### PR TITLE
Feature/ffmpeg library migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Thumbs.db
 *.tmp
 *.temp
 
+# Machine-specific Cargo config (contains local paths)
+.cargo/config.toml
+
 # Plugin build artifacts
 plugins/*/target/
 docs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,12 +765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,13 +2269,10 @@ dependencies = [
  "ffmpeg-the-third",
  "log",
  "rdlp-core",
- "regex",
  "serde",
- "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
- "which",
 ]
 
 [[package]]
@@ -3418,17 +3409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
-dependencies = [
- "env_home",
- "rustix",
- "winsafe",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,12 +3640,6 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,7 +223,7 @@ dependencies = [
  "boa_string",
  "indexmap",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -235,7 +255,7 @@ dependencies = [
  "icu_normalizer",
  "indexmap",
  "intrusive-collections",
- "itertools",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -244,7 +264,7 @@ dependencies = [
  "portable-atomic",
  "rand",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
@@ -282,7 +302,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "static_assertions",
 ]
 
@@ -315,7 +335,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -327,7 +347,7 @@ dependencies = [
  "fast-float2",
  "itoa",
  "paste",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "static_assertions",
 ]
@@ -375,6 +395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +437,27 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
+dependencies = [
+ "clang-sys",
+ "libc",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -781,6 +831,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ffmpeg-sys-the-third"
+version = "4.0.0+ffmpeg-8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc211d0448e9ba775923b7cac39c19d350b47b4994b658f096cd0232d09ef97"
+dependencies = [
+ "bindgen",
+ "cc",
+ "clang",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ffmpeg-the-third"
+version = "4.0.1+ffmpeg-8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b90ff7c38b228afb4d1abaf9fce9336acb7c0674f7c99fdb4aee157820bb"
+dependencies = [
+ "bitflags",
+ "ffmpeg-sys-the-third",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1068,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -1393,6 +1474,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1421,6 +1511,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -1932,7 +2028,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror",
@@ -1952,7 +2048,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2176,11 +2272,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "ffmpeg-the-third",
  "log",
  "rdlp-core",
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "which",
@@ -2327,6 +2425,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -2462,7 +2566,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "servo_arc",
  "smallvec",
 ]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 - **🚀 Performance** - 37x faster downloads (10.5 MB/s) with 7-layer optimization stack
 - **🔒 Memory Safety** - No segfaults or data races guaranteed by Rust
-- **🧩 Extensibility** - Modular 8-crate workspace architecture with plugin support
+- **🧩 Extensibility** - Modular 11-crate workspace architecture with plugin support
 - **📦 Small Binary** - ~8MB release binary with no runtime dependencies
 - **⚡ Async Everything** - Built on tokio for efficient I/O operations
 - **⚖️ ToS Compliance** - Only supports sites with permissive Terms of Service
@@ -40,8 +40,8 @@
 | **Reliability** | Auto-resume • Ctrl+C interrupt handling • Backward-compatible chunks |
 | **Site Support** | 5 sites • TNAFlix • EMPFlix • MovieFap • RedTube • PornHub (with playlists) |
 | **User Experience** | Interactive format selection • Segment-based progress bars • Verbose mode |
-| **Post-Processing** | FFmpeg integration • Audio extraction • Metadata embedding • Thumbnail embedding |
-| **Code Quality** | 100% Rust • 213+ tests • 0 unsafe code • 0 compiler warnings |
+| **Post-Processing** | FFmpeg library bindings • Audio extraction • Metadata embedding • Thumbnail embedding |
+| **Code Quality** | 100% Rust • 270+ tests • unsafe only in FFmpeg FFI • 0 compiler warnings |
 
 ### ⚙️ Current Status
 
@@ -335,9 +335,9 @@ Quality      | Resolution | Size            | Type | Codecs
 | Metric | Value | Notes |
 |--------|-------|-------|
 | **Build Status** | ✅ Passing | Zero compiler warnings (release builds) |
-| **Test Coverage** | 213+ tests | All passing (unit + integration tests) |
-| **Architecture** | 8 crates | Clean separation of concerns |
-| **Type Safety** | 100% | No unsafe code |
+| **Test Coverage** | 270+ tests | All passing (unit + integration + property tests) |
+| **Architecture** | 11 crates | Clean separation of concerns |
+| **Type Safety** | 100% | `unsafe` only in FFmpeg FFI (18 sites, all documented) |
 | **Documentation** | Full | Inline docs + comprehensive guides |
 | **Rust Files** | 50+ files | Pure Rust (2024 Edition) |
 
@@ -345,16 +345,19 @@ Quality      | Resolution | Size            | Type | Codecs
 
 ### Workspace Structure
 
-rdlp uses a modular workspace with 8 specialized crates:
+rdlp uses a modular workspace with 11 specialized crates:
 
 ```
 rdlp/
 ├── crates/
-│   ├── rdlp-core/         # Foundation: traits, types, errors
+│   ├── rdlp-types/        # Pure data types (no I/O) - Foundation
+│   ├── rdlp-core/         # Traits, errors - Contracts
+│   ├── rdlp-security/     # SSRF protection, URL validation
+│   ├── rdlp-http/         # Centralized HTTP client factory
 │   ├── rdlp-extractor/    # Site-specific extractors
-│   ├── rdlp-downloader/   # Protocol handlers (HTTP, HLS, DASH)
+│   ├── rdlp-downloader/   # Protocol handlers (HTTP, HLS)
 │   ├── rdlp-jsinterp/     # JavaScript execution (boa)
-│   ├── rdlp-postprocess/  # FFmpeg integration
+│   ├── rdlp-postprocess/  # FFmpeg library bindings pipeline
 │   ├── rdlp-cookies/      # Browser cookie extraction
 │   ├── rdlp-plugin/       # Dynamic plugin loading
 │   └── rdlp-cli/          # User-facing CLI
@@ -366,7 +369,7 @@ rdlp/
 ```
 URL → Extraction → Download → Post-Processing → Video File
       ↓            ↓           ↓
-      Metadata     Streaming   FFmpeg (future)
+      Metadata     Streaming   FFmpeg library bindings
 ```
 
 **Extraction Stage:**
@@ -551,9 +554,18 @@ cargo doc --no-deps --open
 - [x] FFmpegMetadata - Embed title, artist, chapters
 - [x] EmbedThumbnail - Cover art for MP4/MKV/MP3
 - [x] Priority-based processor registry
-- [x] **Status**: Production-ready, 25 tests passing
+- [x] **Status**: Production-ready, 26 tests passing
 
-### Phases 8-10: Future
+### Phase 8: FFmpeg Library Migration ✅ COMPLETE (2026-01-28)
+- [x] Migrated all FFmpeg operations from CLI process spawning to `ffmpeg-the-third` v4.0 library bindings
+- [x] Replaced `ffprobe` CLI with library-based `probe_sync()`
+- [x] Replaced all 5 processor CLI invocations with library calls (remux, audio extract, video convert, metadata, thumbnail)
+- [x] Removed `which`, `regex`, `serde_json` CLI dependencies
+- [x] Fixed 5 bugs during migration (config ignored, unconditional AAC BSF, MP3 thumbnail, description truncation, lost InfoDict)
+- [x] Post-migration quality fixes: unwrap panic elimination (28 sites), async I/O correctness, download timeouts, resilience improvements
+- [x] **Status**: Production-ready, 270+ tests passing, 0 clippy warnings
+
+### Phases 9-11: Future
 - Additional site extractors (Vimeo, Dailymotion, Archive.org)
 - Enhanced CLI features
 - Format selection DSL parser
@@ -579,7 +591,7 @@ overwrite = false
 # Download options
 format = "best"
 concurrent_fragments = 5
-buffer_size = 8192
+buffer_size = 2097152  # 2 MB
 
 # Display options
 quiet = false
@@ -695,7 +707,7 @@ All downloads use streaming to maintain constant memory usage regardless of vide
 
 Perfect for newcomers to the Rust ecosystem:
 
-- [ ] Add retry logic with exponential backoff (`rdlp-downloader`)
+- [x] ~~Add retry logic with exponential backoff~~ (done — `backon` crate)
 - [ ] Add rate limiting to HTTP downloader (`rdlp-downloader`)
 - [ ] Improve error messages with suggestions (`rdlp-core`)
 - [ ] Add more unit tests for edge cases (all crates)
@@ -1003,11 +1015,11 @@ We take security seriously and will respond within 48 hours.
 
 ### Security Features
 
-- ✅ No unsafe code (100% safe Rust)
+- ✅ Minimal unsafe (only FFmpeg FFI in `ffmpeg.rs`, all with SAFETY comments)
 - ✅ Input validation on all URLs
 - ✅ Sanitized filenames (no path traversal)
 - ✅ HTTPS by default (rustls)
-- ✅ No shell command execution (except FFmpeg when added)
+- ✅ No shell command execution (FFmpeg uses library bindings, not CLI)
 - ✅ Dependency auditing with `cargo audit`
 
 ## 📜 License
@@ -1049,19 +1061,19 @@ This project wouldn't be possible without these amazing open source projects:
 |--------|-------|
 | **Language** | 100% Rust (2024 Edition) |
 | **Rust Files** | 50+ source files |
-| **Crates** | 8 (modular workspace) |
-| **Dependencies** | 26 (workspace-level, including m3u8-rs, futures) |
-| **Tests** | 213+ tests (all passing) |
+| **Crates** | 11 (modular workspace) |
+| **Dependencies** | 30+ (workspace-level, including ffmpeg-the-third, m3u8-rs, futures) |
+| **Tests** | 270+ tests (all passing) |
 | **Build Time** | ~10s (clean release), ~2s (incremental) |
 | **Binary Size** | ~8 MB (release, no runtime dependencies) |
-| **Unsafe Code** | 0% (100% safe Rust) |
+| **Unsafe Code** | FFmpeg FFI only (18 sites in `ffmpeg.rs`, all SAFETY-documented) |
 | **Download Speed** | 10.5 MB/s (37x faster than baseline) |
 | **Status** | Alpha (Production-ready for 5 sites) |
 
 ## 🗺️ Roadmap
 
-### ✅ Completed (2026-01-24)
-- **Phase 1: Foundation** - Core traits, error handling, 8-crate workspace architecture
+### ✅ Completed (2026-01-28)
+- **Phase 1: Foundation** - Core traits, error handling, 11-crate workspace architecture
 - **Phase 2: TNAFlix Support** - HTTP downloader, streaming, resume, progress tracking
 - **Phase 2.5: Power-of-Two Chunking** - 37x faster downloads with memory-aligned chunks
 - **Phase 3: Resume Compatibility** - Backward-compatible with old chunk format
@@ -1069,14 +1081,15 @@ This project wouldn't be possible without these amazing open source projects:
 - **Phase 5: PornHub Playlist Support** - Full playlist extraction with pagination
 - **Phase 6: CLI Playlist Integration** - Batch downloads with [N/total] progress
 - **Phase 6.5: HLS Progress & Segment Counting** - Fast segment counting, segment-based progress
-- **Phase 7: Post-Processing Pipeline** - FFmpeg integration (remux, audio, metadata, thumbnails)
+- **Phase 7: Post-Processing Pipeline** - FFmpeg library bindings (remux, audio, metadata, thumbnails)
+- **Phase 8: FFmpeg Library Migration** - Replaced all CLI FFmpeg with `ffmpeg-the-third` library calls
+- **Quality Fixes** - Unwrap elimination, async I/O correctness, download timeouts, resilience improvements
 - **TNAFlix Network** - Support for TNAFlix, EMPFlix, MovieFap (MP4 downloads)
 - **RedTube Support** - HLS + MP4 formats with segment counting
 - **PornHub Support** - HLS streaming with full playlist support
 - **Interactive CLI** - Format selection with arrow keys + ESC cancellation
 - **Smart Filesize** - HEAD/Range request detection with CDN fallback
 - **Performance Optimizations** - 7-layer optimization stack (10.5 MB/s downloads)
-- **FFmpeg Post-Processing** - Remux HLS→MP4, audio extraction, metadata embedding
 
 ### 📅 Planned
 - **More Extractors** - Vimeo, Dailymotion, Archive.org, and more

--- a/crates/rdlp-cli/src/orchestrator/extraction.rs
+++ b/crates/rdlp-cli/src/orchestrator/extraction.rs
@@ -36,21 +36,21 @@ impl Orchestrator {
         info!("Title: {}", info.title);
 
         if let Some(ref uploader) = info.uploader {
-            info!("Uploader: {}", uploader);
+            info!("Uploader: {uploader}");
         }
         if let Some(ref channel) = info.channel {
-            info!("Channel: {}", channel);
+            info!("Channel: {channel}");
         }
         if let Some(duration) = info.duration {
             let mins = (duration / 60.0) as u32;
             let secs = (duration % 60.0) as u32;
-            info!("Duration: {}:{:02}", mins, secs);
+            info!("Duration: {mins}:{secs:02}");
         }
         if let Some(views) = info.view_count {
-            info!("Views: {}", views);
+            info!("Views: {views}");
         }
         if let Some(rating) = info.average_rating {
-            info!("Rating: {:.0}%", rating);
+            info!("Rating: {rating:.0}%");
         }
         if let Some(ref tags) = info.tags {
             if !tags.is_empty() {
@@ -104,7 +104,7 @@ impl Orchestrator {
                 .playlist_title
                 .as_deref()
                 .unwrap_or("Unnamed Playlist");
-            info!("Playlist: {}", playlist_title);
+            info!("Playlist: {playlist_title}");
             info!("Found {} videos", infos.len());
         }
 

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -66,7 +66,7 @@ impl Orchestrator {
 
         // Check for existing files (resume detection)
         let (existing_files, partial_count) =
-            self.detect_existing_playlist_files(&playlist_dir, &infos);
+            self.detect_existing_playlist_files(&playlist_dir, &infos).await;
         let already_downloaded = existing_files.len();
         let remaining = total - already_downloaded;
 
@@ -105,11 +105,15 @@ impl Orchestrator {
                 format!("Download {total} videos to '{playlist_folder_name}'?")
             };
 
-            let proceed = Confirm::new()
-                .with_prompt(prompt)
-                .default(true)
-                .interact()
-                .unwrap_or(false);
+            let proceed = tokio::task::spawn_blocking(move || {
+                Confirm::new()
+                    .with_prompt(prompt)
+                    .default(true)
+                    .interact()
+                    .unwrap_or(false)
+            })
+            .await
+            .unwrap_or(false);
 
             if !proceed {
                 println!("Cancelled by user");
@@ -120,7 +124,7 @@ impl Orchestrator {
 
         // Create playlist directory if it doesn't exist
         if !playlist_dir.exists() {
-            std::fs::create_dir_all(&playlist_dir).map_err(|e| {
+            tokio::fs::create_dir_all(&playlist_dir).await.map_err(|e| {
                 OrchestratorError::IoError(format!(
                     "Failed to create playlist folder '{}': {e}",
                     playlist_dir.display()
@@ -241,7 +245,7 @@ impl Orchestrator {
     ///
     /// Since HLS segments are cleaned up before each download, we just report
     /// the count for user information.
-    pub(super) fn detect_existing_playlist_files(
+    pub(super) async fn detect_existing_playlist_files(
         &self,
         playlist_dir: &std::path::Path,
         infos: &[rdlp_core::InfoDict],
@@ -254,16 +258,18 @@ impl Orchestrator {
         }
 
         // Get all files in the playlist directory
-        let dir_entries = match std::fs::read_dir(playlist_dir) {
+        let mut dir_entries = match tokio::fs::read_dir(playlist_dir).await {
             Ok(entries) => entries,
             Err(_) => return (completed, partial_count),
         };
 
-        let files: Vec<PathBuf> = dir_entries
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.is_file())
-            .collect();
+        let mut files: Vec<PathBuf> = Vec::new();
+        while let Ok(Some(entry)) = dir_entries.next_entry().await {
+            let path = entry.path();
+            if path.is_file() {
+                files.push(path);
+            }
+        }
 
         // Check each video in the playlist
         for info in infos {
@@ -344,7 +350,7 @@ impl Orchestrator {
         output_dir: &std::path::Path,
     ) -> Result<Option<PathBuf>> {
         // Select format
-        let format = match self.select_format(&info.formats, interactive)? {
+        let format = match self.select_format(&info.formats, interactive).await? {
             Some(format) => format,
             None => return Ok(None),
         };

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -124,7 +124,7 @@ impl Orchestrator {
 
     /// Run FFmpeg remux on downloaded files to fix container format
     ///
-    /// This performs a stream copy (no re-encoding) to:
+    /// This performs a stream copy (no re-encoding) via library bindings to:
     /// - Move moov atom to beginning of file (faststart)
     /// - Fix timestamps
     /// - Ensure proper MP4 container structure
@@ -132,8 +132,8 @@ impl Orchestrator {
     /// Applied to both HLS and HTTP downloads for consistent output quality.
     pub(super) async fn ffmpeg_remux(&self, files: &[PathBuf]) -> Option<Vec<PathBuf>> {
         let registry = self.postprocessor_registry.as_ref()?;
-        let ffmpeg = registry.list_processors(); // Just to verify FFmpeg is available
-        if ffmpeg.is_empty() {
+        let processors = registry.list_processors();
+        if processors.is_empty() {
             return None;
         }
 
@@ -143,27 +143,9 @@ impl Orchestrator {
             let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
             let temp_path = file.with_extension(format!("fixed.{ext}"));
 
-            // Run FFmpeg remux: -c copy -movflags +faststart
-            let result = tokio::process::Command::new("ffmpeg")
-                .args([
-                    "-y", // Overwrite output
-                    "-i",
-                    &file.to_string_lossy(),
-                    "-c",
-                    "copy", // Stream copy (no re-encoding)
-                    "-movflags",
-                    "+faststart", // Move moov atom to start
-                    "-f",
-                    "mp4", // Force MP4 format
-                    &temp_path.to_string_lossy(),
-                ])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::piped())
-                .output()
-                .await;
-
-            match result {
-                Ok(output) if output.status.success() => {
+            // Remux using library bindings (stream copy + faststart)
+            match registry.remux_faststart(file, &temp_path).await {
+                Ok(()) => {
                     // Replace original with fixed file
                     if let Err(e) = tokio::fs::remove_file(file).await {
                         warn!("Could not remove original file: {e}");
@@ -176,15 +158,10 @@ impl Orchestrator {
                         output_files.push(file.clone());
                     }
                 }
-                Ok(output) => {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    debug!("FFmpeg remux failed: {stderr}");
+                Err(e) => {
+                    debug!("FFmpeg remux failed: {e}");
                     // Clean up temp file
                     let _ = tokio::fs::remove_file(&temp_path).await;
-                    output_files.push(file.clone());
-                }
-                Err(e) => {
-                    debug!("FFmpeg not available: {e}");
                     output_files.push(file.clone());
                 }
             }

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -246,13 +246,13 @@ impl Orchestrator {
             return;
         }
 
-        let entries = match std::fs::read_dir(dir) {
+        let mut entries = match tokio::fs::read_dir(dir).await {
             Ok(entries) => entries,
             Err(_) => return,
         };
 
         let mut deleted = 0;
-        for entry in entries.filter_map(|e| e.ok()) {
+        while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
             if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
                 // Match pattern: base_name.part{number}
@@ -261,7 +261,7 @@ impl Orchestrator {
                     if let Some(part_idx) = filename.rfind(".part") {
                         let suffix = &filename[part_idx + 5..];
                         if suffix.chars().all(|c| c.is_ascii_digit())
-                            && std::fs::remove_file(&path).is_ok()
+                            && tokio::fs::remove_file(&path).await.is_ok()
                         {
                             deleted += 1;
                         }

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -14,13 +14,13 @@ impl Orchestrator {
     /// Returns an error if:
     /// - Format selector string is invalid
     /// - No suitable format is found (automatic mode)
-    pub(super) fn select_format(
+    pub(super) async fn select_format(
         &self,
         formats: &[Format],
         interactive: bool,
     ) -> Result<Option<Format>> {
         let format = if interactive {
-            match self.select_format_interactive(formats)? {
+            match self.select_format_interactive(formats).await? {
                 Some(format) => format,
                 None => {
                     info!("Selection cancelled by user");
@@ -48,7 +48,7 @@ impl Orchestrator {
     /// Displays a menu of available formats and lets the user select one.
     ///
     /// Returns Ok(Some(format)) if format selected, Ok(None) if user cancelled (ESC pressed)
-    pub(super) fn select_format_interactive(&self, formats: &[Format]) -> Result<Option<Format>> {
+    pub(super) async fn select_format_interactive(&self, formats: &[Format]) -> Result<Option<Format>> {
         if formats.is_empty() {
             return Err(OrchestratorError::NoFormat);
         }
@@ -63,12 +63,16 @@ impl Orchestrator {
         );
         println!("{}", "-".repeat(79));
 
-        let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt("Select a format to download (ESC to cancel)")
-            .items(&items)
-            .default(0)
-            .interact_opt()
-            .map_err(|e| OrchestratorError::Io(e.into()))?;
+        let selection = tokio::task::spawn_blocking(move || {
+            Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Select a format to download (ESC to cancel)")
+                .items(&items)
+                .default(0)
+                .interact_opt()
+        })
+        .await
+        .map_err(|e| OrchestratorError::Io(std::io::Error::other(e)))?
+        .map_err(|e| OrchestratorError::Io(e.into()))?;
 
         match selection {
             Some(index) => Ok(Some(formats[index].clone())),

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -137,7 +137,7 @@ impl DownloadPhase {
             }
 
             Self::SelectingFormat { info } => {
-                let format = match orchestrator.select_format(&info.formats, interactive)? {
+                let format = match orchestrator.select_format(&info.formats, interactive).await? {
                     Some(format) => format,
                     None => return Ok(Self::Cancelled),
                 };

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -232,7 +232,7 @@ impl DownloadPhase {
                 // Report success
                 info!("Downloaded successfully!");
                 info!("   File: {}", output_path.display());
-                info!("   Stats: {:?}", stats);
+                info!("   Stats: {stats:?}");
 
                 // Run post-processing (automatic for HLS, optional for others)
                 let final_path = orchestrator

--- a/crates/rdlp-cli/src/orchestrator/tests.rs
+++ b/crates/rdlp-cli/src/orchestrator/tests.rs
@@ -224,8 +224,8 @@ fn test_generate_output_path_hls_extension() {
     );
 }
 
-#[test]
-fn test_select_format_automatic_mode() {
+#[tokio::test]
+async fn test_select_format_automatic_mode() {
     let orchestrator = create_test_orchestrator();
     let formats = vec![
         create_test_format("360p", "360p", Some(500000)),
@@ -234,7 +234,7 @@ fn test_select_format_automatic_mode() {
     ];
 
     // Non-interactive mode should use format selector
-    let result = orchestrator.select_format(&formats, false);
+    let result = orchestrator.select_format(&formats, false).await;
     assert!(result.is_ok());
     let selected = result.unwrap();
     assert!(selected.is_some());
@@ -243,13 +243,13 @@ fn test_select_format_automatic_mode() {
     assert_eq!(format.format_id, "1080p");
 }
 
-#[test]
-fn test_select_format_empty_formats() {
+#[tokio::test]
+async fn test_select_format_empty_formats() {
     let orchestrator = create_test_orchestrator();
     let formats = vec![];
 
     // Should fail with empty formats in automatic mode
-    let result = orchestrator.select_format(&formats, false);
+    let result = orchestrator.select_format(&formats, false).await;
     assert!(result.is_err());
 }
 

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -17,10 +17,16 @@ pub trait PostProcessor: Send + Sync {
     /// # Arguments
     /// * `info` - Video metadata
     /// * `files` - List of downloaded file paths to process
+    /// * `config` - Post-processing configuration
     ///
     /// # Returns
     /// Updated InfoDict and potentially new file paths after processing
-    async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult>;
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        config: &PostProcessConfig,
+    ) -> Result<PostProcessResult>;
 
     /// Check if this post-processor should run based on config
     ///

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -61,6 +61,10 @@ pub struct HlsDownloader {
     retry_config: Arc<RetryConfig>,
     /// Expected total size for progress reporting (set externally)
     expected_size: Option<u64>,
+    /// Total download timeout (entire operation must complete within this)
+    download_timeout: Duration,
+    /// Merge operation timeout (segment merge must complete within this)
+    merge_timeout: Duration,
 }
 
 impl HlsDownloader {
@@ -72,6 +76,8 @@ impl HlsDownloader {
             buffer_size: 2 * 1024 * 1024, // 2 MB buffer for merging
             retry_config: Arc::new(RetryConfig::default_config()),
             expected_size: None,
+            download_timeout: Duration::from_secs(3600), // 1 hour
+            merge_timeout: Duration::from_secs(1800),    // 30 min
         }
     }
 
@@ -110,6 +116,20 @@ impl HlsDownloader {
     #[must_use = "builder methods consume self and return a new instance"]
     pub fn with_expected_size(mut self, size: u64) -> Self {
         self.expected_size = Some(size);
+        self
+    }
+
+    /// Set total download timeout
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_download_timeout(mut self, timeout: Duration) -> Self {
+        self.download_timeout = timeout;
+        self
+    }
+
+    /// Set merge operation timeout
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_merge_timeout(mut self, timeout: Duration) -> Self {
+        self.merge_timeout = timeout;
         self
     }
 
@@ -493,36 +513,46 @@ impl HlsDownloader {
     /// * `Ok(u64)` - Total bytes written
     /// * `Err(_)` - I/O error during merge
     async fn merge_segments(&self, segment_paths: Vec<PathBuf>, output_path: &Path) -> Result<u64> {
-        info!(segments = segment_paths.len(); "Merging segments into final file");
+        let merge_timeout = self.merge_timeout;
+        tokio::time::timeout(merge_timeout, async {
+            info!(segments = segment_paths.len(); "Merging segments into final file");
 
-        let final_file = File::create(output_path).await.map_err(RdlpError::Io)?;
+            let final_file = File::create(output_path).await.map_err(RdlpError::Io)?;
 
-        let mut writer = BufWriter::with_capacity(self.buffer_size, final_file);
-        let mut total_bytes = 0u64;
+            let mut writer = BufWriter::with_capacity(self.buffer_size, final_file);
+            let mut total_bytes = 0u64;
 
-        for (idx, segment_path) in segment_paths.iter().enumerate() {
-            let mut segment_file = File::open(segment_path).await.map_err(RdlpError::Io)?;
+            for (idx, segment_path) in segment_paths.iter().enumerate() {
+                let mut segment_file = File::open(segment_path).await.map_err(RdlpError::Io)?;
 
-            let bytes = tokio::io::copy(&mut segment_file, &mut writer)
-                .await
-                .map_err(RdlpError::Io)?;
+                let bytes = tokio::io::copy(&mut segment_file, &mut writer)
+                    .await
+                    .map_err(RdlpError::Io)?;
 
-            total_bytes += bytes;
+                total_bytes += bytes;
 
-            if (idx + 1) % 100 == 0 || idx == segment_paths.len() - 1 {
-                debug!(
-                    merged = idx + 1,
-                    total = segment_paths.len(),
-                    mb = total_bytes / (1024 * 1024);
-                    "Merge progress"
-                );
+                if (idx + 1) % 100 == 0 || idx == segment_paths.len() - 1 {
+                    debug!(
+                        merged = idx + 1,
+                        total = segment_paths.len(),
+                        mb = total_bytes / (1024 * 1024);
+                        "Merge progress"
+                    );
+                }
             }
-        }
 
-        writer.flush().await.map_err(RdlpError::Io)?;
-        info!(mb = total_bytes / (1024 * 1024); "Merge complete");
+            writer.flush().await.map_err(RdlpError::Io)?;
+            info!(mb = total_bytes / (1024 * 1024); "Merge complete");
 
-        Ok(total_bytes)
+            Ok(total_bytes)
+        })
+        .await
+        .map_err(|_| {
+            RdlpError::Download(format!(
+                "Merge timed out after {}s",
+                merge_timeout.as_secs()
+            ))
+        })?
     }
 
     /// Clean up temporary segment files
@@ -574,141 +604,151 @@ impl Downloader for HlsDownloader {
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
-        let start_time = Instant::now();
+        let timeout = self.download_timeout;
+        tokio::time::timeout(timeout, async {
+            let start_time = Instant::now();
 
-        // Step 1: Parse playlist
-        let segment_urls = self.parse_playlist(url).await?;
-        let total_segments = segment_urls.len();
-        info!(segments = total_segments; "Parsed HLS playlist");
+            // Step 1: Parse playlist
+            let segment_urls = self.parse_playlist(url).await?;
+            let total_segments = segment_urls.len();
+            info!(segments = total_segments; "Parsed HLS playlist");
 
-        // Step 2: Load or create state for resume support
-        let state = match HlsDownloadState::load(path, url, total_segments).await {
-            Some(existing_state) => {
-                let completed = existing_state.completed_segments.len();
-                let remaining = total_segments - completed;
-                info!(
-                    completed,
-                    total = total_segments,
-                    remaining;
-                    "Resuming HLS download"
-                );
-                Arc::new(Mutex::new(existing_state))
-            }
-            None => {
-                info!("Starting fresh HLS download");
-                Arc::new(Mutex::new(HlsDownloadState::new(
-                    url.to_string(),
-                    total_segments,
-                )))
-            }
-        };
+            // Step 2: Load or create state for resume support
+            let state = match HlsDownloadState::load(path, url, total_segments).await {
+                Some(existing_state) => {
+                    let completed = existing_state.completed_segments.len();
+                    let remaining = total_segments - completed;
+                    info!(
+                        completed,
+                        total = total_segments,
+                        remaining;
+                        "Resuming HLS download"
+                    );
+                    Arc::new(Mutex::new(existing_state))
+                }
+                None => {
+                    info!("Starting fresh HLS download");
+                    Arc::new(Mutex::new(HlsDownloadState::new(
+                        url.to_string(),
+                        total_segments,
+                    )))
+                }
+            };
 
-        // Step 3: Setup progress tracking
-        let downloaded = Arc::new(AtomicU64::new(state.lock().await.total_bytes_downloaded));
-        let segments_completed = Arc::new(AtomicU64::new(
-            state.lock().await.completed_segments.len() as u64,
-        ));
-        let total_segments_u64 = total_segments as u64;
+            // Step 3: Setup progress tracking
+            let downloaded = Arc::new(AtomicU64::new(state.lock().await.total_bytes_downloaded));
+            let segments_completed = Arc::new(AtomicU64::new(
+                state.lock().await.completed_segments.len() as u64,
+            ));
+            let total_segments_u64 = total_segments as u64;
 
-        // Spawn progress reporter task with segment-based progress
-        let progress_task = if let Some(callback) = progress {
-            let downloaded_clone = downloaded.clone();
-            let segments_clone = segments_completed.clone();
-            let start_time_clone = start_time;
-            Some(tokio::spawn(async move {
-                let mut last_update = Instant::now();
-                let update_interval = Duration::from_millis(100);
+            // Spawn progress reporter task with segment-based progress
+            let progress_task = if let Some(callback) = progress {
+                let downloaded_clone = downloaded.clone();
+                let segments_clone = segments_completed.clone();
+                let start_time_clone = start_time;
+                Some(tokio::spawn(async move {
+                    let mut last_update = Instant::now();
+                    let update_interval = Duration::from_millis(100);
 
-                loop {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    let now = Instant::now();
-                    if now.duration_since(last_update) >= update_interval {
-                        let bytes = downloaded_clone.load(Ordering::Relaxed);
-                        let segments = segments_clone.load(Ordering::Relaxed);
-                        let elapsed = now.duration_since(start_time_clone).as_secs_f64();
-                        let speed = if elapsed > 0.0 {
-                            bytes as f64 / elapsed
-                        } else {
-                            0.0
-                        };
+                    loop {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        let now = Instant::now();
+                        if now.duration_since(last_update) >= update_interval {
+                            let bytes = downloaded_clone.load(Ordering::Relaxed);
+                            let segments = segments_clone.load(Ordering::Relaxed);
+                            let elapsed = now.duration_since(start_time_clone).as_secs_f64();
+                            let speed = if elapsed > 0.0 {
+                                bytes as f64 / elapsed
+                            } else {
+                                0.0
+                            };
 
-                        // Use segment-based progress for HLS
-                        let progress_info = DownloadProgress::new_with_segments(
-                            bytes,
-                            speed,
-                            segments,
-                            total_segments_u64,
-                        );
-                        callback.on_progress(&progress_info);
-                        last_update = now;
+                            // Use segment-based progress for HLS
+                            let progress_info = DownloadProgress::new_with_segments(
+                                bytes,
+                                speed,
+                                segments,
+                                total_segments_u64,
+                            );
+                            callback.on_progress(&progress_info);
+                            last_update = now;
+                        }
                     }
-                }
-            }))
-        } else {
-            None
-        };
+                }))
+            } else {
+                None
+            };
 
-        // Step 4: Download segments (with resume support)
-        let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        let base_filename = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("download");
+            // Step 4: Download segments (with resume support)
+            let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
+            let base_filename = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("download");
 
-        let segment_paths = match self
-            .download_segments_with_resume(
-                segment_urls.clone(),
-                temp_dir,
-                base_filename,
-                downloaded.clone(),
-                segments_completed.clone(),
-                state.clone(),
-                path,
-            )
-            .await
-        {
-            Ok(paths) => paths,
-            Err(e) => {
-                // Save state on error (so we can resume later)
-                let snapshot = state.lock().await.clone();
-                if let Err(save_err) = snapshot.save(path).await {
-                    warn!("Failed to save HLS state: {save_err}");
+            let segment_paths = match self
+                .download_segments_with_resume(
+                    segment_urls.clone(),
+                    temp_dir,
+                    base_filename,
+                    downloaded.clone(),
+                    segments_completed.clone(),
+                    state.clone(),
+                    path,
+                )
+                .await
+            {
+                Ok(paths) => paths,
+                Err(e) => {
+                    // Save state on error (so we can resume later)
+                    let snapshot = state.lock().await.clone();
+                    if let Err(save_err) = snapshot.save(path).await {
+                        warn!("Failed to save HLS state: {save_err}");
+                    }
+                    if let Some(task) = progress_task {
+                        task.abort();
+                    }
+                    return Err(e);
                 }
-                if let Some(task) = progress_task {
-                    task.abort();
-                }
-                return Err(e);
+            };
+
+            // Stop progress reporter
+            if let Some(task) = progress_task {
+                task.abort();
             }
-        };
 
-        // Stop progress reporter
-        if let Some(task) = progress_task {
-            task.abort();
-        }
+            // Step 5: Merge segments
+            let total_bytes = self.merge_segments(segment_paths.clone(), path).await?;
 
-        // Step 5: Merge segments
-        let total_bytes = self.merge_segments(segment_paths.clone(), path).await?;
+            // Step 6: Cleanup segments and state file
+            self.cleanup_segments(segment_paths).await;
+            if let Err(e) = HlsDownloadState::delete(path).await {
+                warn!("Failed to delete HLS state file: {e}");
+            }
 
-        // Step 6: Cleanup segments and state file
-        self.cleanup_segments(segment_paths).await;
-        if let Err(e) = HlsDownloadState::delete(path).await {
-            warn!("Failed to delete HLS state file: {e}");
-        }
+            // Step 7: Return statistics
+            let duration = start_time.elapsed();
+            let stats = DownloadStats::new(total_bytes, duration, 0).with_fragments(total_segments);
 
-        // Step 7: Return statistics
-        let duration = start_time.elapsed();
-        let stats = DownloadStats::new(total_bytes, duration, 0).with_fragments(total_segments);
+            let duration_secs = duration.as_secs_f64();
+            let speed_mbps = (total_bytes as f64 / duration_secs) / (1024.0 * 1024.0);
+            info!(
+                mb = total_bytes / (1024 * 1024),
+                duration_secs:? = duration_secs,
+                speed_mbps:? = speed_mbps;
+                "HLS download complete"
+            );
 
-        let duration_secs = duration.as_secs_f64();
-        let speed_mbps = (total_bytes as f64 / duration_secs) / (1024.0 * 1024.0);
-        info!(
-            mb = total_bytes / (1024 * 1024),
-            duration_secs:? = duration_secs,
-            speed_mbps:? = speed_mbps;
-            "HLS download complete"
-        );
-
-        Ok(stats)
+            Ok(stats)
+        })
+        .await
+        .map_err(|_| {
+            RdlpError::Download(format!(
+                "Download timed out after {}s",
+                timeout.as_secs()
+            ))
+        })?
     }
 }
 

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -402,13 +402,19 @@ impl HlsDownloader {
 
                     match &result {
                         Ok((_, _, bytes)) => {
-                            // Update state on success
-                            let mut state_guard = state.lock().await;
-                            state_guard.mark_completed(idx, *bytes);
-
-                            // Save state every 50 segments for crash recovery
-                            if state_guard.completed_segments.len() % 50 == 0 {
-                                if let Err(e) = state_guard.save(&output_path).await {
+                            // Update state on success; clone if periodic save needed
+                            let snapshot = {
+                                let mut guard = state.lock().await;
+                                guard.mark_completed(idx, *bytes);
+                                if guard.completed_segments.len() % 50 == 0 {
+                                    Some(guard.clone())
+                                } else {
+                                    None
+                                }
+                            };
+                            // Save outside the lock to avoid holding it across I/O
+                            if let Some(snapshot) = snapshot {
+                                if let Err(e) = snapshot.save(&output_path).await {
                                     warn!("Failed to save HLS state: {e}");
                                 }
                             }
@@ -417,7 +423,8 @@ impl HlsDownloader {
                         }
                         Err(e) => {
                             // Save state on error before propagating
-                            if let Err(save_err) = state.lock().await.save(&output_path).await {
+                            let snapshot = state.lock().await.clone();
+                            if let Err(save_err) = snapshot.save(&output_path).await {
                                 warn!("Failed to save HLS state on error: {save_err}");
                             }
                             warn!(segment = idx; "Segment download failed: {e}");
@@ -431,8 +438,9 @@ impl HlsDownloader {
             .try_collect()
             .await?;
 
-        // Save final state
-        if let Err(e) = state.lock().await.save(output_path).await {
+        // Save final state (clone under lock, then save outside lock)
+        let snapshot = state.lock().await.clone();
+        if let Err(e) = snapshot.save(output_path).await {
             warn!("Failed to save final HLS state: {e}");
         }
 
@@ -662,7 +670,8 @@ impl Downloader for HlsDownloader {
             Ok(paths) => paths,
             Err(e) => {
                 // Save state on error (so we can resume later)
-                if let Err(save_err) = state.lock().await.save(path).await {
+                let snapshot = state.lock().await.clone();
+                if let Err(save_err) = snapshot.save(path).await {
                     warn!("Failed to save HLS state: {save_err}");
                 }
                 if let Some(task) = progress_task {

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use backon::Retryable;
-use futures::stream::{self, StreamExt, TryStreamExt};
+use futures::stream::{self, StreamExt};
 use log::{debug, info, warn};
 use tracing::instrument;
 use rdlp_core::{
@@ -65,6 +65,8 @@ pub struct HlsDownloader {
     download_timeout: Duration,
     /// Merge operation timeout (segment merge must complete within this)
     merge_timeout: Duration,
+    /// Maximum number of segment failures before aborting the download
+    max_segment_failures: usize,
 }
 
 impl HlsDownloader {
@@ -78,6 +80,7 @@ impl HlsDownloader {
             expected_size: None,
             download_timeout: Duration::from_secs(3600), // 1 hour
             merge_timeout: Duration::from_secs(1800),    // 30 min
+            max_segment_failures: 3,
         }
     }
 
@@ -130,6 +133,13 @@ impl HlsDownloader {
     #[must_use = "builder methods consume self and return a new instance"]
     pub fn with_merge_timeout(mut self, timeout: Duration) -> Self {
         self.merge_timeout = timeout;
+        self
+    }
+
+    /// Set maximum number of segment failures before aborting
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_max_segment_failures(mut self, max: usize) -> Self {
+        self.max_segment_failures = max;
         self
     }
 
@@ -378,7 +388,8 @@ impl HlsDownloader {
         let base_filename_owned = base_filename.to_string();
         let output_path_owned = output_path.to_path_buf();
 
-        let results: Vec<(usize, PathBuf, u64)> = stream::iter(to_download.into_iter())
+        let max_failures = self.max_segment_failures;
+        let mut stream = stream::iter(to_download.into_iter())
             .map(|(idx, url)| {
                 let segment_path = temp_dir_owned.join(format!("{base_filename_owned}.part{idx}"));
                 let downloader = downloader.clone();
@@ -388,25 +399,23 @@ impl HlsDownloader {
                 let output_path = output_path_owned.clone();
 
                 async move {
-                    // Check if segment file already exists and is non-empty
-                    if segment_path.exists() {
-                        if let Ok(meta) = tokio::fs::metadata(&segment_path).await {
-                            if meta.len() > 0 {
-                                debug!(
-                                    segment = idx,
-                                    bytes = meta.len();
-                                    "Segment already exists, skipping"
-                                );
-                                let bytes = meta.len();
-                                // Mark as completed in state
-                                {
-                                    let mut state_guard = state.lock().await;
-                                    state_guard.mark_completed(idx, bytes);
-                                }
-                                segments.fetch_add(1, Ordering::Relaxed);
-                                progress.fetch_add(bytes, Ordering::Relaxed);
-                                return Ok((idx, segment_path, bytes));
+                    // Check if segment file already exists and is non-empty (single async stat)
+                    if let Ok(meta) = tokio::fs::metadata(&segment_path).await {
+                        if meta.len() > 0 {
+                            debug!(
+                                segment = idx,
+                                bytes = meta.len();
+                                "Segment already exists, skipping"
+                            );
+                            let bytes = meta.len();
+                            // Mark as completed in state
+                            {
+                                let mut state_guard = state.lock().await;
+                                state_guard.mark_completed(idx, bytes);
                             }
+                            segments.fetch_add(1, Ordering::Relaxed);
+                            progress.fetch_add(bytes, Ordering::Relaxed);
+                            return Ok((idx, segment_path, bytes));
                         }
                     }
 
@@ -454,9 +463,35 @@ impl HlsDownloader {
                     result
                 }
             })
-            .buffer_unordered(self.concurrent_segments)
-            .try_collect()
-            .await?;
+            .buffer_unordered(self.concurrent_segments);
+
+        // Collect results, tolerating up to max_segment_failures errors
+        let mut results: Vec<(usize, PathBuf, u64)> = Vec::new();
+        let mut segment_failures = 0usize;
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(item) => results.push(item),
+                Err(e) => {
+                    segment_failures += 1;
+                    warn!(
+                        failures = segment_failures,
+                        max = max_failures;
+                        "Segment failed: {e}"
+                    );
+                    if segment_failures >= max_failures {
+                        let snapshot = state.lock().await.clone();
+                        let _ = snapshot.save(output_path).await;
+                        return Err(RdlpError::Download(format!(
+                            "Too many segment failures ({segment_failures}), aborting"
+                        )));
+                    }
+                }
+            }
+        }
+        if segment_failures > 0 {
+            warn!(failures = segment_failures; "Completed with segment failures");
+        }
 
         // Save final state (clone under lock, then save outside lock)
         let snapshot = state.lock().await.clone();
@@ -483,11 +518,12 @@ impl HlsDownloader {
         // Sort by index for correct merge order
         all_segment_paths.sort_by_key(|(idx, _)| *idx);
 
-        // Verify we have all segments
+        // Verify we have the expected number of segments (accounting for tolerated failures)
+        let expected_count = total_segments - segment_failures;
         let actual_count = all_segment_paths.len();
-        if actual_count != total_segments {
+        if actual_count != expected_count {
             return Err(RdlpError::Download(format!(
-                "Missing segments: expected {total_segments}, got {actual_count}"
+                "Missing segments: expected {expected_count}, got {actual_count}"
             )));
         }
 

--- a/crates/rdlp-downloader/src/hls_state.rs
+++ b/crates/rdlp-downloader/src/hls_state.rs
@@ -166,8 +166,8 @@ impl HlsDownloadState {
         let state_path = Self::state_file_path(output_path);
         let temp_path = state_path.with_extension("json.tmp");
 
-        // Serialize to JSON
-        let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
+        // Serialize to compact JSON (saved every 50 segments, not human-read during operation)
+        let json = serde_json::to_string(self).map_err(std::io::Error::other)?;
 
         // Write to temp file
         let mut file = File::create(&temp_path).await?;

--- a/crates/rdlp-downloader/src/http/config.rs
+++ b/crates/rdlp-downloader/src/http/config.rs
@@ -5,6 +5,7 @@
 
 use crate::chunking::ChunkSizeStrategy;
 use rdlp_core::RetryConfig;
+use std::time::Duration;
 
 /// Downloader configuration (shared across clones via Arc)
 ///
@@ -21,6 +22,12 @@ pub(crate) struct DownloaderConfig {
     pub retry_config: RetryConfig,
     pub concurrent_fragments: usize,
     pub chunk_strategy: ChunkSizeStrategy,
+    /// Per-read idle timeout (no data received for this long = abort)
+    pub read_timeout: Duration,
+    /// Total download timeout (entire operation must complete within this)
+    pub download_timeout: Duration,
+    /// Merge operation timeout (chunk/segment merge must complete within this)
+    pub merge_timeout: Duration,
 }
 
 impl Default for DownloaderConfig {
@@ -37,10 +44,13 @@ impl Default for DownloaderConfig {
             .unwrap_or(4);
 
         Self {
-            buffer_size: 8192,
+            buffer_size: 2 * 1024 * 1024, // 2 MB
             retry_config: RetryConfig::default_config(),
             concurrent_fragments,
             chunk_strategy: ChunkSizeStrategy::Auto,
+            read_timeout: Duration::from_secs(60),
+            download_timeout: Duration::from_secs(3600), // 1 hour
+            merge_timeout: Duration::from_secs(1800),    // 30 min
         }
     }
 }

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -82,6 +82,27 @@ impl HttpDownloader {
         self
     }
 
+    /// Set per-read idle timeout
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_read_timeout(mut self, timeout: Duration) -> Self {
+        Arc::make_mut(&mut self.config).read_timeout = timeout;
+        self
+    }
+
+    /// Set total download timeout
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_download_timeout(mut self, timeout: Duration) -> Self {
+        Arc::make_mut(&mut self.config).download_timeout = timeout;
+        self
+    }
+
+    /// Set merge operation timeout
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_merge_timeout(mut self, timeout: Duration) -> Self {
+        Arc::make_mut(&mut self.config).merge_timeout = timeout;
+        self
+    }
+
     /// Check if server supports range requests
     async fn supports_ranges(&self, url: &str) -> Result<bool> {
         let client = self.client.clone();
@@ -154,8 +175,17 @@ impl HttpDownloader {
 
         let mut stream = response.bytes_stream();
         let mut downloaded = 0u64;
+        let read_timeout = self.config.read_timeout;
 
-        while let Some(chunk_result) = stream.next().await {
+        while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
+            .await
+            .map_err(|_| {
+                RdlpError::Network(format!(
+                    "Read timed out (no data for {}s)",
+                    read_timeout.as_secs()
+                ))
+            })?
+        {
             let chunk = chunk_result
                 .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
 
@@ -212,8 +242,17 @@ impl HttpDownloader {
         let mut downloaded: u64 = 0;
         let mut last_update = Instant::now();
         let update_interval = Duration::from_millis(100);
+        let read_timeout = self.config.read_timeout;
 
-        while let Some(chunk_result) = stream.next().await {
+        while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
+            .await
+            .map_err(|_| {
+                RdlpError::Network(format!(
+                    "Read timed out (no data for {}s)",
+                    read_timeout.as_secs()
+                ))
+            })?
+        {
             let chunk = chunk_result
                 .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
 
@@ -268,99 +307,109 @@ impl Downloader for HttpDownloader {
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
-        let size = self.get_size(url).await.ok().flatten();
-        let supports_ranges = self.supports_ranges(url).await.unwrap_or(false);
+        let timeout = self.config.download_timeout;
+        tokio::time::timeout(timeout, async {
+            let size = self.get_size(url).await.ok().flatten();
+            let supports_ranges = self.supports_ranges(url).await.unwrap_or(false);
 
-        debug!(
-            "Download analysis: size={} MB, concurrent={}, ranges={}",
-            size.map(|s| s / 1024 / 1024).unwrap_or(0),
-            self.config.concurrent_fragments,
-            supports_ranges
-        );
+            debug!(
+                "Download analysis: size={} MB, concurrent={}, ranges={}",
+                size.map(|s| s / 1024 / 1024).unwrap_or(0),
+                self.config.concurrent_fragments,
+                supports_ranges
+            );
 
-        // Try Range request if HEAD didn't return size
-        let size = if (size.is_none() || size == Some(0)) && supports_ranges {
-            debug!("HEAD didn't return valid size, trying Range request...");
-            let client = self.client.clone();
-            let url_string = url.to_string();
-            let backoff = self.config.retry_config.to_backoff();
+            // Try Range request if HEAD didn't return size
+            let size = if (size.is_none() || size == Some(0)) && supports_ranges {
+                debug!("HEAD didn't return valid size, trying Range request...");
+                let client = self.client.clone();
+                let url_string = url.to_string();
+                let backoff = self.config.retry_config.to_backoff();
 
-            match (|| {
-                let client = client.clone();
-                let url = url_string.clone();
-                async move {
-                    client
-                        .get(&url)
-                        .header("Range", "bytes=0-0")
-                        .send()
-                        .await
-                        .map_err(|e| RdlpError::Network(format!("Size check failed: {e}")))
-                }
-            })
-            .retry(backoff)
-            .when(is_retryable_error)
-            .notify(|err, dur| {
-                warn!(delay:? = dur; "HTTP GET (size check) failed, retrying: {err}");
-            })
-            .await
-            {
-                Ok(response) => {
-                    if let Some(content_range) = response.headers().get("content-range") {
-                        if let Ok(range_str) = content_range.to_str() {
-                            if let Some(total_str) = range_str.split('/').nth(1) {
-                                let detected_size = total_str.parse::<u64>().ok();
-                                debug!(
-                                    "Detected size from Range: {} MB",
-                                    detected_size.map(|s| s / 1024 / 1024).unwrap_or(0)
-                                );
-                                detected_size
+                match (|| {
+                    let client = client.clone();
+                    let url = url_string.clone();
+                    async move {
+                        client
+                            .get(&url)
+                            .header("Range", "bytes=0-0")
+                            .send()
+                            .await
+                            .map_err(|e| RdlpError::Network(format!("Size check failed: {e}")))
+                    }
+                })
+                .retry(backoff)
+                .when(is_retryable_error)
+                .notify(|err, dur| {
+                    warn!(delay:? = dur; "HTTP GET (size check) failed, retrying: {err}");
+                })
+                .await
+                {
+                    Ok(response) => {
+                        if let Some(content_range) = response.headers().get("content-range") {
+                            if let Ok(range_str) = content_range.to_str() {
+                                if let Some(total_str) = range_str.split('/').nth(1) {
+                                    let detected_size = total_str.parse::<u64>().ok();
+                                    debug!(
+                                        "Detected size from Range: {} MB",
+                                        detected_size.map(|s| s / 1024 / 1024).unwrap_or(0)
+                                    );
+                                    detected_size
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
                             }
                         } else {
                             None
                         }
-                    } else {
-                        None
                     }
+                    Err(_) => None,
                 }
-                Err(_) => None,
-            }
-        } else {
-            size
-        };
-
-        let use_parallel = match size {
-            Some(s) if s > 10 * 1024 * 1024 => {
-                self.config.concurrent_fragments > 1 && supports_ranges
-            }
-            _ => false,
-        };
-
-        if use_parallel {
-            info!(
-                "Using parallel download mode ({} connections)",
-                self.config.concurrent_fragments
-            );
-            return self
-                .download_parallel(url, path, size.unwrap(), progress)
-                .await;
-        } else {
-            let reason = match size {
-                None | Some(0) => "could not detect file size",
-                Some(s) if s <= 10 * 1024 * 1024 => "file too small for parallel",
-                Some(_) if self.config.concurrent_fragments <= 1 => "concurrent_fragments <= 1",
-                Some(_) if !supports_ranges => "server doesn't support ranges",
-                Some(_) => "unknown reason",
+            } else {
+                size
             };
-            warn!(
-                "Using sequential download - reason: {reason} (size: {:?} MB, fragments: {}, ranges: {supports_ranges})",
-                size.map(|s| s / 1024 / 1024),
-                self.config.concurrent_fragments
-            );
-        }
 
-        self.download_sequential(url, path, progress).await
+            let use_parallel = match size {
+                Some(s) if s > 10 * 1024 * 1024 => {
+                    self.config.concurrent_fragments > 1 && supports_ranges
+                }
+                _ => false,
+            };
+
+            if use_parallel {
+                info!(
+                    "Using parallel download mode ({} connections)",
+                    self.config.concurrent_fragments
+                );
+                return self
+                    .download_parallel(url, path, size.unwrap(), progress)
+                    .await;
+            } else {
+                let reason = match size {
+                    None | Some(0) => "could not detect file size",
+                    Some(s) if s <= 10 * 1024 * 1024 => "file too small for parallel",
+                    Some(_) if self.config.concurrent_fragments <= 1 => "concurrent_fragments <= 1",
+                    Some(_) if !supports_ranges => "server doesn't support ranges",
+                    Some(_) => "unknown reason",
+                };
+                warn!(
+                    "Using sequential download - reason: {reason} (size: {:?} MB, fragments: {}, ranges: {supports_ranges})",
+                    size.map(|s| s / 1024 / 1024),
+                    self.config.concurrent_fragments
+                );
+            }
+
+            self.download_sequential(url, path, progress).await
+        })
+        .await
+        .map_err(|_| {
+            RdlpError::Download(format!(
+                "Download timed out after {}s",
+                timeout.as_secs()
+            ))
+        })?
     }
 
     fn supports(&self, url: &str) -> bool {
@@ -400,150 +449,169 @@ impl Downloader for HttpDownloader {
         resume_from: u64,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
-        let start_time = Instant::now();
-        let client = self.client.clone();
-        let url_string = url.to_string();
-        let backoff = self.config.retry_config.to_backoff();
+        let timeout = self.config.download_timeout;
+        tokio::time::timeout(timeout, async {
+            let start_time = Instant::now();
+            let client = self.client.clone();
+            let url_string = url.to_string();
+            let backoff = self.config.retry_config.to_backoff();
 
-        let response = (|| {
-            let client = client.clone();
-            let url = url_string.clone();
-            async move {
-                let response = client
-                    .get(&url)
-                    .header("Range", format!("bytes={resume_from}-"))
-                    .send()
-                    .await
-                    .map_err(|e| RdlpError::Network(format!("Resume request failed: {e}")))?;
+            let response = (|| {
+                let client = client.clone();
+                let url = url_string.clone();
+                async move {
+                    let response = client
+                        .get(&url)
+                        .header("Range", format!("bytes={resume_from}-"))
+                        .send()
+                        .await
+                        .map_err(|e| RdlpError::Network(format!("Resume request failed: {e}")))?;
 
-                if response.status().as_u16() != 206 {
-                    return Err(RdlpError::Download(format!(
-                        "Server does not support resume (expected HTTP 206, got {}). \
-                         Cannot continue download without overwriting existing data. \
-                         Please delete the partial file and restart the download.",
-                        response.status()
-                    )));
+                    if response.status().as_u16() != 206 {
+                        return Err(RdlpError::Download(format!(
+                            "Server does not support resume (expected HTTP 206, got {}). \
+                             Cannot continue download without overwriting existing data. \
+                             Please delete the partial file and restart the download.",
+                            response.status()
+                        )));
+                    }
+
+                    Ok(response)
                 }
+            })
+            .retry(backoff)
+            .when(is_retryable_error)
+            .notify(|err, dur| {
+                warn!(delay:? = dur; "HTTP GET (resume) failed, retrying: {err}");
+            })
+            .await?;
 
-                Ok(response)
-            }
-        })
-        .retry(backoff)
-        .when(is_retryable_error)
-        .notify(|err, dur| {
-            warn!(delay:? = dur; "HTTP GET (resume) failed, retrying: {err}");
-        })
-        .await?;
-
-        let total_size = if let Some(content_range) = response.headers().get("content-range") {
-            if let Ok(range_str) = content_range.to_str() {
-                if let Some(total_str) = range_str.split('/').nth(1) {
-                    total_str.parse::<u64>().ok()
+            let total_size = if let Some(content_range) = response.headers().get("content-range") {
+                if let Ok(range_str) = content_range.to_str() {
+                    if let Some(total_str) = range_str.split('/').nth(1) {
+                        total_str.parse::<u64>().ok()
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
             } else {
-                None
-            }
-        } else {
-            response.content_length().map(|size| size + resume_from)
-        };
+                response.content_length().map(|size| size + resume_from)
+            };
 
-        // Check for parallel resume
-        if let Some(total) = total_size {
-            let progress_pct = (resume_from as f64 / total as f64) * 100.0;
-            let remaining_size = total - resume_from;
-            let supports_ranges = response
-                .headers()
-                .get("accept-ranges")
-                .and_then(|v| v.to_str().ok())
-                .map(|v| v != "none")
-                .unwrap_or(true);
+            // Check for parallel resume
+            if let Some(total) = total_size {
+                let progress_pct = (resume_from as f64 / total as f64) * 100.0;
+                let remaining_size = total - resume_from;
+                let supports_ranges = response
+                    .headers()
+                    .get("accept-ranges")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|v| v != "none")
+                    .unwrap_or(true);
 
-            debug!(
-                "Resume analysis: {:.1}% ({} MB / {} MB), remaining={} MB, concurrent={}, ranges={}",
-                progress_pct,
-                resume_from / 1024 / 1024,
-                total / 1024 / 1024,
-                remaining_size / 1024 / 1024,
-                self.config.concurrent_fragments,
-                supports_ranges
-            );
-
-            let can_parallel = remaining_size > 10 * 1024 * 1024
-                && self.config.concurrent_fragments > 1
-                && supports_ranges;
-
-            if can_parallel {
-                info!(
-                    "Using parallel resume mode ({} connections), keeping {} MB, parallelizing {} MB",
-                    self.config.concurrent_fragments,
+                debug!(
+                    "Resume analysis: {:.1}% ({} MB / {} MB), remaining={} MB, concurrent={}, ranges={}",
+                    progress_pct,
                     resume_from / 1024 / 1024,
-                    remaining_size / 1024 / 1024
-                );
-
-                drop(response);
-                return self
-                    .download_parallel_resume(url, path, resume_from, total, progress)
-                    .await;
-            } else if !can_parallel {
-                warn!(
-                    "Parallel resume not available (remaining: {} MB, concurrent: {}, ranges: {}), using sequential",
+                    total / 1024 / 1024,
                     remaining_size / 1024 / 1024,
                     self.config.concurrent_fragments,
                     supports_ranges
                 );
-            }
-        }
 
-        let content_length = response.content_length();
-        let total_size = total_size.or_else(|| content_length.map(|size| size + resume_from));
+                let can_parallel = remaining_size > 10 * 1024 * 1024
+                    && self.config.concurrent_fragments > 1
+                    && supports_ranges;
 
-        let file = tokio::fs::OpenOptions::new()
-            .append(true)
-            .open(path)
-            .await
-            .map_err(RdlpError::Io)?;
-        let mut writer = BufWriter::with_capacity(self.config.buffer_size, file);
+                if can_parallel {
+                    info!(
+                        "Using parallel resume mode ({} connections), keeping {} MB, parallelizing {} MB",
+                        self.config.concurrent_fragments,
+                        resume_from / 1024 / 1024,
+                        remaining_size / 1024 / 1024
+                    );
 
-        let mut stream = response.bytes_stream();
-        let mut downloaded = resume_from;
-        let mut last_update = Instant::now();
-        let update_interval = Duration::from_millis(100);
-
-        while let Some(chunk_result) = stream.next().await {
-            let chunk = chunk_result
-                .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
-
-            writer.write_all(&chunk).await.map_err(RdlpError::Io)?;
-            downloaded += chunk.len() as u64;
-
-            if let Some(ref callback) = progress {
-                let now = Instant::now();
-                if now.duration_since(last_update) >= update_interval {
-                    let elapsed = now.duration_since(start_time).as_secs_f64();
-                    let speed = if elapsed > 0.0 {
-                        (downloaded - resume_from) as f64 / elapsed
-                    } else {
-                        0.0
-                    };
-
-                    let progress_info = DownloadProgress::new(downloaded, total_size, speed);
-                    callback.on_progress(&progress_info);
-                    last_update = now;
+                    drop(response);
+                    return self
+                        .download_parallel_resume(url, path, resume_from, total, progress)
+                        .await;
+                } else if !can_parallel {
+                    warn!(
+                        "Parallel resume not available (remaining: {} MB, concurrent: {}, ranges: {}), using sequential",
+                        remaining_size / 1024 / 1024,
+                        self.config.concurrent_fragments,
+                        supports_ranges
+                    );
                 }
             }
-        }
 
-        writer.flush().await.map_err(RdlpError::Io)?;
+            let content_length = response.content_length();
+            let total_size = total_size.or_else(|| content_length.map(|size| size + resume_from));
 
-        let duration = start_time.elapsed();
-        let stats = DownloadStats::new(downloaded, duration, 0);
+            let file = tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(path)
+                .await
+                .map_err(RdlpError::Io)?;
+            let mut writer = BufWriter::with_capacity(self.config.buffer_size, file);
 
-        if let Some(callback) = progress {
-            callback.on_complete(&stats);
-        }
+            let mut stream = response.bytes_stream();
+            let mut downloaded = resume_from;
+            let mut last_update = Instant::now();
+            let update_interval = Duration::from_millis(100);
+            let read_timeout = self.config.read_timeout;
 
-        Ok(stats)
+            while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
+                .await
+                .map_err(|_| {
+                    RdlpError::Network(format!(
+                        "Read timed out (no data for {}s)",
+                        read_timeout.as_secs()
+                    ))
+                })?
+            {
+                let chunk = chunk_result
+                    .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
+
+                writer.write_all(&chunk).await.map_err(RdlpError::Io)?;
+                downloaded += chunk.len() as u64;
+
+                if let Some(ref callback) = progress {
+                    let now = Instant::now();
+                    if now.duration_since(last_update) >= update_interval {
+                        let elapsed = now.duration_since(start_time).as_secs_f64();
+                        let speed = if elapsed > 0.0 {
+                            (downloaded - resume_from) as f64 / elapsed
+                        } else {
+                            0.0
+                        };
+
+                        let progress_info = DownloadProgress::new(downloaded, total_size, speed);
+                        callback.on_progress(&progress_info);
+                        last_update = now;
+                    }
+                }
+            }
+
+            writer.flush().await.map_err(RdlpError::Io)?;
+
+            let duration = start_time.elapsed();
+            let stats = DownloadStats::new(downloaded, duration, 0);
+
+            if let Some(callback) = progress {
+                callback.on_complete(&stats);
+            }
+
+            Ok(stats)
+        })
+        .await
+        .map_err(|_| {
+            RdlpError::Download(format!(
+                "Download timed out after {}s",
+                timeout.as_secs()
+            ))
+        })?
     }
 }

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -363,30 +363,40 @@ async fn merge_chunks(
     total_chunks: usize,
     config: &DownloaderConfig,
 ) -> Result<()> {
-    info!(chunks = total_chunks; "Merging chunks into final file");
-    let final_file = File::create(path).await.map_err(RdlpError::Io)?;
-    let mut writer = BufWriter::with_capacity(config.buffer_size, final_file);
+    let merge_timeout = config.merge_timeout;
+    tokio::time::timeout(merge_timeout, async {
+        info!(chunks = total_chunks; "Merging chunks into final file");
+        let final_file = File::create(path).await.map_err(RdlpError::Io)?;
+        let mut writer = BufWriter::with_capacity(config.buffer_size, final_file);
 
-    let mut deleted_chunks = 0;
-    for chunk_id in 0..total_chunks {
-        let chunk_path = temp_dir.join(format!("{filename}.{download_id}.part{chunk_id}"));
-        let mut chunk_file = File::open(&chunk_path).await.map_err(RdlpError::Io)?;
-        tokio::io::copy(&mut chunk_file, &mut writer)
-            .await
-            .map_err(RdlpError::Io)?;
+        let mut deleted_chunks = 0;
+        for chunk_id in 0..total_chunks {
+            let chunk_path = temp_dir.join(format!("{filename}.{download_id}.part{chunk_id}"));
+            let mut chunk_file = File::open(&chunk_path).await.map_err(RdlpError::Io)?;
+            tokio::io::copy(&mut chunk_file, &mut writer)
+                .await
+                .map_err(RdlpError::Io)?;
 
-        if tokio::fs::remove_file(&chunk_path).await.is_ok() {
-            deleted_chunks += 1;
+            if tokio::fs::remove_file(&chunk_path).await.is_ok() {
+                deleted_chunks += 1;
+            }
+
+            if (chunk_id + 1) % 100 == 0 || chunk_id == total_chunks - 1 {
+                debug!(merged = chunk_id + 1, total = total_chunks; "Merge progress");
+            }
         }
+        debug!(deleted = deleted_chunks; "Chunk cleanup complete");
 
-        if (chunk_id + 1) % 100 == 0 || chunk_id == total_chunks - 1 {
-            debug!(merged = chunk_id + 1, total = total_chunks; "Merge progress");
-        }
-    }
-    debug!(deleted = deleted_chunks; "Chunk cleanup complete");
-
-    writer.flush().await.map_err(RdlpError::Io)?;
-    Ok(())
+        writer.flush().await.map_err(RdlpError::Io)?;
+        Ok(())
+    })
+    .await
+    .map_err(|_| {
+        RdlpError::Download(format!(
+            "Merge timed out after {}s",
+            merge_timeout.as_secs()
+        ))
+    })?
 }
 
 /// Append chunks to existing file (for resume)
@@ -398,32 +408,42 @@ async fn append_chunks(
     total_chunks: usize,
     config: &DownloaderConfig,
 ) -> Result<()> {
-    let file = tokio::fs::OpenOptions::new()
-        .append(true)
-        .open(path)
-        .await
-        .map_err(RdlpError::Io)?;
-    let mut writer = BufWriter::with_capacity(config.buffer_size, file);
-
-    info!(chunks = total_chunks; "Appending chunks to existing file");
-    let mut deleted_chunks = 0;
-    for chunk_id in 0..total_chunks {
-        let chunk_path = temp_dir.join(format!("{filename}.{download_id}.resume{chunk_id}"));
-        let mut chunk_file = File::open(&chunk_path).await.map_err(RdlpError::Io)?;
-        tokio::io::copy(&mut chunk_file, &mut writer)
+    let merge_timeout = config.merge_timeout;
+    tokio::time::timeout(merge_timeout, async {
+        let file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(path)
             .await
             .map_err(RdlpError::Io)?;
+        let mut writer = BufWriter::with_capacity(config.buffer_size, file);
 
-        if tokio::fs::remove_file(&chunk_path).await.is_ok() {
-            deleted_chunks += 1;
+        info!(chunks = total_chunks; "Appending chunks to existing file");
+        let mut deleted_chunks = 0;
+        for chunk_id in 0..total_chunks {
+            let chunk_path = temp_dir.join(format!("{filename}.{download_id}.resume{chunk_id}"));
+            let mut chunk_file = File::open(&chunk_path).await.map_err(RdlpError::Io)?;
+            tokio::io::copy(&mut chunk_file, &mut writer)
+                .await
+                .map_err(RdlpError::Io)?;
+
+            if tokio::fs::remove_file(&chunk_path).await.is_ok() {
+                deleted_chunks += 1;
+            }
+
+            if (chunk_id + 1) % 100 == 0 || chunk_id == total_chunks - 1 {
+                debug!(appended = chunk_id + 1, total = total_chunks; "Append progress");
+            }
         }
+        debug!(deleted = deleted_chunks; "Chunk cleanup complete");
 
-        if (chunk_id + 1) % 100 == 0 || chunk_id == total_chunks - 1 {
-            debug!(appended = chunk_id + 1, total = total_chunks; "Append progress");
-        }
-    }
-    debug!(deleted = deleted_chunks; "Chunk cleanup complete");
-
-    writer.flush().await.map_err(RdlpError::Io)?;
-    Ok(())
+        writer.flush().await.map_err(RdlpError::Io)?;
+        Ok(())
+    })
+    .await
+    .map_err(|_| {
+        RdlpError::Download(format!(
+            "Merge timed out after {}s",
+            merge_timeout.as_secs()
+        ))
+    })?
 }

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -104,7 +104,7 @@ impl HttpDownloader {
 
         let url_shared: Arc<str> = Arc::from(url);
 
-        let chunk_results: Vec<u64> = stream::iter(0..total_chunks)
+        let chunk_results: Vec<u64> = match stream::iter(0..total_chunks)
             .map(|chunk_id| {
                 let start = chunk_id as u64 * chunk_size as u64;
                 let end = if chunk_id == total_chunks - 1 {
@@ -138,17 +138,14 @@ impl HttpDownloader {
             .buffer_unordered(self.config.concurrent_fragments)
             .try_collect::<Vec<_>>()
             .await
-            .inspect_err(|e| {
+        {
+            Ok(results) => results.into_iter().map(|(_, bytes, _)| bytes).collect(),
+            Err(e) => {
                 error!("Download failed: {e}");
-                let temp_dir = temp_dir.to_path_buf();
-                let filename = filename.clone();
-                tokio::spawn(async move {
-                    cleanup_chunk_files(&temp_dir, &filename, download_id, total_chunks).await;
-                });
-            })?
-            .into_iter()
-            .map(|(_, bytes, _)| bytes)
-            .collect();
+                cleanup_chunk_files(temp_dir, &filename, download_id, total_chunks).await;
+                return Err(e);
+            }
+        };
 
         let total_downloaded: u64 = chunk_results.iter().sum();
         info!(
@@ -228,7 +225,7 @@ impl HttpDownloader {
 
         let url_shared: Arc<str> = Arc::from(url);
 
-        let chunk_results: Vec<u64> = stream::iter(0..total_chunks)
+        let chunk_results: Vec<u64> = match stream::iter(0..total_chunks)
             .map(|chunk_id| {
                 let start = resume_from + (chunk_id as u64 * chunk_size as u64);
                 let end = if chunk_id == total_chunks - 1 {
@@ -262,20 +259,17 @@ impl HttpDownloader {
             .buffer_unordered(self.config.concurrent_fragments)
             .try_collect::<Vec<_>>()
             .await
-            .inspect_err(|e| {
+        {
+            Ok(results) => results.into_iter().map(|(_, bytes, _)| bytes).collect(),
+            Err(e) => {
                 error!("Resume failed: {e}");
                 if let Some(task) = &progress_task {
                     task.abort();
                 }
-                let temp_dir = temp_dir.to_path_buf();
-                let filename = filename.clone();
-                tokio::spawn(async move {
-                    cleanup_chunk_files(&temp_dir, &filename, download_id, total_chunks).await;
-                });
-            })?
-            .into_iter()
-            .map(|(_, bytes, _)| bytes)
-            .collect();
+                cleanup_chunk_files(temp_dir, &filename, download_id, total_chunks).await;
+                return Err(e);
+            }
+        };
 
         let newly_downloaded: u64 = chunk_results.iter().sum();
         info!(

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -20,7 +20,9 @@ log = { workspace = true }
 # For finding executables in PATH
 which = "8.0.0"
 
+# FFmpeg library bindings (FFmpeg 5-8)
+ffmpeg-the-third = "4.0"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
-ffmpeg-the-third = "4.0"
 tempfile = { workspace = true }

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -22,3 +22,5 @@ which = "8.0.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+ffmpeg-the-third = "4.0"
+tempfile = { workspace = true }

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -9,16 +9,11 @@ description = "Post-processing pipeline for rdlp (FFmpeg operations, metadata em
 [dependencies]
 rdlp-core = { path = "../rdlp-core" }
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["process", "fs", "io-util"] }
+tokio = { workspace = true, features = ["fs", "io-util"] }
 serde = { workspace = true }
-serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-regex = { workspace = true }
 log = { workspace = true }
-
-# For finding executables in PATH
-which = "8.0.0"
 
 # FFmpeg library bindings (FFmpeg 5-8)
 ffmpeg-the-third = "4.0"

--- a/crates/rdlp-postprocess/build.rs
+++ b/crates/rdlp-postprocess/build.rs
@@ -1,0 +1,171 @@
+//! Build script for rdlp-postprocess.
+//!
+//! Auto-detects FFmpeg shared builds on Windows for the `ffmpeg-the-third`
+//! dev-dependency. Sets `FFMPEG_DETECTED_DIR` so the crate can locate FFmpeg
+//! at compile time.
+//!
+//! # FFmpeg resolution order
+//!
+//! 1. `FFMPEG_DIR` environment variable (explicit override)
+//! 2. WinGet package paths (`Gyan.FFmpeg.Shared`)
+//! 3. Chocolatey FFmpeg installation
+//! 4. Derive from `ffmpeg.exe` found in `PATH`
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=FFMPEG_DIR");
+
+    if let Some(dir) = detect_ffmpeg() {
+        let dir_str = dir.to_string_lossy();
+        println!("cargo:rustc-env=FFMPEG_DETECTED_DIR={dir_str}");
+        // Also set FFMPEG_DIR so ffmpeg-sys-the-third picks it up
+        // (only works if this build script runs before ffmpeg-sys-the-third,
+        //  which it doesn't - use .cargo/config.toml for that)
+        println!("cargo:ffmpeg_dir={dir_str}");
+    }
+}
+
+/// Detect FFmpeg shared build directory.
+///
+/// Returns the path to a directory containing `include/` and `lib/` subdirs.
+fn detect_ffmpeg() -> Option<PathBuf> {
+    // 1. Explicit FFMPEG_DIR takes priority
+    if let Ok(dir) = std::env::var("FFMPEG_DIR") {
+        let path = PathBuf::from(&dir);
+        if is_valid_ffmpeg_dir(&path) {
+            return Some(path);
+        }
+        println!("cargo:warning=FFMPEG_DIR={dir} is set but missing include/ or lib/");
+    }
+
+    // 2. Search common installation paths (Windows)
+    if cfg!(target_os = "windows") {
+        if let Some(dir) = search_windows_paths() {
+            println!(
+                "cargo:warning=Auto-detected FFmpeg at: {}",
+                dir.display()
+            );
+            return Some(dir);
+        }
+    }
+
+    // 3. Derive from ffmpeg.exe in PATH
+    if let Some(dir) = derive_from_path() {
+        println!(
+            "cargo:warning=Derived FFmpeg dir from PATH: {}",
+            dir.display()
+        );
+        return Some(dir);
+    }
+
+    println!("cargo:warning=FFmpeg shared build not found. Set FFMPEG_DIR or install via: winget install Gyan.FFmpeg.Shared");
+    None
+}
+
+/// Check if a directory has the expected FFmpeg structure (include/ + lib/).
+fn is_valid_ffmpeg_dir(path: &Path) -> bool {
+    path.join("include").join("libavcodec").is_dir() && path.join("lib").is_dir()
+}
+
+/// Search common Windows installation paths for FFmpeg shared builds.
+fn search_windows_paths() -> Option<PathBuf> {
+    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
+
+    // WinGet: Gyan.FFmpeg.Shared
+    let winget_base = PathBuf::from(&local_app_data)
+        .join("Microsoft")
+        .join("WinGet")
+        .join("Packages");
+
+    if winget_base.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&winget_base) {
+            // Look for Gyan.FFmpeg.Shared_* directories
+            let mut ffmpeg_dirs: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("Gyan.FFmpeg.Shared"))
+                })
+                .collect();
+
+            // Sort to get newest version last
+            ffmpeg_dirs.sort();
+
+            for winget_dir in ffmpeg_dirs.iter().rev() {
+                // Inside WinGet dir, find the ffmpeg-*-shared subdirectory
+                if let Ok(inner) = std::fs::read_dir(winget_dir) {
+                    for entry in inner.filter_map(|e| e.ok()) {
+                        let path = entry.path();
+                        if path.is_dir() && is_valid_ffmpeg_dir(&path) {
+                            return Some(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Chocolatey: C:\ProgramData\chocolatey\lib\ffmpeg-shared
+    let choco_paths = [
+        PathBuf::from(r"C:\ProgramData\chocolatey\lib\ffmpeg-shared\tools\ffmpeg"),
+        PathBuf::from(r"C:\ProgramData\chocolatey\lib\ffmpeg\tools\ffmpeg"),
+    ];
+    for path in &choco_paths {
+        if is_valid_ffmpeg_dir(path) {
+            return Some(path.clone());
+        }
+    }
+
+    // Program Files
+    let program_files = [
+        std::env::var("ProgramFiles").unwrap_or_default(),
+        std::env::var("ProgramFiles(x86)").unwrap_or_default(),
+    ];
+    for pf in &program_files {
+        if pf.is_empty() {
+            continue;
+        }
+        let ffmpeg_dir = PathBuf::from(pf).join("FFmpeg");
+        if is_valid_ffmpeg_dir(&ffmpeg_dir) {
+            return Some(ffmpeg_dir);
+        }
+    }
+
+    None
+}
+
+/// Try to find ffmpeg.exe in PATH and derive the shared build directory.
+///
+/// If ffmpeg.exe is at `.../bin/ffmpeg.exe`, check if `../` has include/ and lib/.
+fn derive_from_path() -> Option<PathBuf> {
+    let path_var = std::env::var("PATH").ok()?;
+    let separator = if cfg!(target_os = "windows") {
+        ';'
+    } else {
+        ':'
+    };
+
+    for dir in path_var.split(separator) {
+        let ffmpeg_exe = PathBuf::from(dir).join(if cfg!(target_os = "windows") {
+            "ffmpeg.exe"
+        } else {
+            "ffmpeg"
+        });
+
+        if ffmpeg_exe.is_file() {
+            // Go from .../bin/ffmpeg.exe -> .../
+            if let Some(bin_dir) = ffmpeg_exe.parent() {
+                if let Some(parent) = bin_dir.parent() {
+                    if is_valid_ffmpeg_dir(parent) {
+                        return Some(parent.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/crates/rdlp-postprocess/src/error.rs
+++ b/crates/rdlp-postprocess/src/error.rs
@@ -8,29 +8,13 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[allow(missing_docs)] // Field names are self-explanatory, variant docs describe them
 pub enum PostProcessError {
-    /// FFmpeg executable not found
-    #[error(
-        "FFmpeg not found. Please install FFmpeg and ensure it's in your PATH, or specify the location with --ffmpeg-location"
-    )]
-    FFmpegNotFound,
-
-    /// FFprobe executable not found
-    #[error(
-        "FFprobe not found. Please install FFmpeg (includes FFprobe) and ensure it's in your PATH"
-    )]
-    FFprobeNotFound,
-
-    /// FFmpeg execution failed
+    /// FFmpeg operation failed
     #[error("FFmpeg failed: {message}")]
     FFmpegFailed {
         message: String,
         #[source]
         source: Option<std::io::Error>,
     },
-
-    /// FFmpeg returned non-zero exit code
-    #[error("FFmpeg exited with code {code}: {stderr}")]
-    FFmpegExitCode { code: i32, stderr: String },
 
     /// Input file not found
     #[error("Input file not found: {}", path.display())]
@@ -88,10 +72,6 @@ pub enum PostProcessError {
     #[error("FFmpeg library error: {message}")]
     FFmpegLibraryError { message: String },
 
-    /// Failed to parse FFprobe output
-    #[error("Failed to parse media info: {message}")]
-    ParseError { message: String },
-
     /// Post-processor not found in registry
     #[error("Post-processor not found: {name}")]
     ProcessorNotFound { name: String },
@@ -111,14 +91,6 @@ impl PostProcessError {
         Self::FFmpegFailed {
             message: message.into(),
             source: None,
-        }
-    }
-
-    /// Create an FFmpeg failed error with source
-    pub fn ffmpeg_failed_with_source(message: impl Into<String>, source: std::io::Error) -> Self {
-        Self::FFmpegFailed {
-            message: message.into(),
-            source: Some(source),
         }
     }
 
@@ -147,10 +119,7 @@ impl From<ffmpeg_the_third::Error> for PostProcessError {
 impl From<PostProcessError> for RdlpError {
     fn from(error: PostProcessError) -> Self {
         match error {
-            PostProcessError::FFmpegNotFound
-            | PostProcessError::FFprobeNotFound
-            | PostProcessError::FFmpegFailed { .. }
-            | PostProcessError::FFmpegExitCode { .. }
+            PostProcessError::FFmpegFailed { .. }
             | PostProcessError::FFmpegInitFailed { .. }
             | PostProcessError::FFmpegLibraryError { .. } => RdlpError::FFmpeg(error.to_string()),
 

--- a/crates/rdlp-postprocess/src/error.rs
+++ b/crates/rdlp-postprocess/src/error.rs
@@ -134,6 +134,15 @@ impl PostProcessError {
 /// Result type for post-processing operations.
 pub type Result<T> = std::result::Result<T, PostProcessError>;
 
+/// Convert ffmpeg-the-third errors into PostProcessError.
+impl From<ffmpeg_the_third::Error> for PostProcessError {
+    fn from(e: ffmpeg_the_third::Error) -> Self {
+        PostProcessError::FFmpegLibraryError {
+            message: e.to_string(),
+        }
+    }
+}
+
 /// Convert PostProcessError to RdlpError for use at trait boundaries.
 impl From<PostProcessError> for RdlpError {
     fn from(error: PostProcessError) -> Self {

--- a/crates/rdlp-postprocess/src/error.rs
+++ b/crates/rdlp-postprocess/src/error.rs
@@ -80,6 +80,14 @@ pub enum PostProcessError {
         source: std::io::Error,
     },
 
+    /// FFmpeg library initialization failed
+    #[error("FFmpeg library initialization failed: {message}")]
+    FFmpegInitFailed { message: String },
+
+    /// FFmpeg library operation failed
+    #[error("FFmpeg library error: {message}")]
+    FFmpegLibraryError { message: String },
+
     /// Failed to parse FFprobe output
     #[error("Failed to parse media info: {message}")]
     ParseError { message: String },
@@ -133,7 +141,9 @@ impl From<PostProcessError> for RdlpError {
             PostProcessError::FFmpegNotFound
             | PostProcessError::FFprobeNotFound
             | PostProcessError::FFmpegFailed { .. }
-            | PostProcessError::FFmpegExitCode { .. } => RdlpError::FFmpeg(error.to_string()),
+            | PostProcessError::FFmpegExitCode { .. }
+            | PostProcessError::FFmpegInitFailed { .. }
+            | PostProcessError::FFmpegLibraryError { .. } => RdlpError::FFmpeg(error.to_string()),
 
             PostProcessError::InputNotFound { .. }
             | PostProcessError::OutputExists { .. }

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -210,13 +210,14 @@ pub struct StreamInfo {
     pub metadata: HashMap<String, String>,
 }
 
-/// FFmpeg/FFprobe runner.
+/// FFmpeg runner.
+///
+/// Provides media probing via `ffmpeg-the-third` library bindings and
+/// CLI execution for operations not yet migrated to library calls.
 #[derive(Debug, Clone)]
 pub struct FFmpegRunner {
-    /// Path to FFmpeg executable
+    /// Path to FFmpeg executable (used for CLI operations not yet migrated)
     ffmpeg_path: PathBuf,
-    /// Path to FFprobe executable
-    ffprobe_path: PathBuf,
     /// FFmpeg version string
     version: Option<String>,
 }
@@ -230,30 +231,23 @@ impl FFmpegRunner {
     /// Create a new FFmpeg runner with a custom location.
     ///
     /// If `location` is `Some`, it should be either:
-    /// - A path to a directory containing ffmpeg and ffprobe
-    /// - A path to the ffmpeg executable (ffprobe will be in the same directory)
+    /// - A path to a directory containing ffmpeg
+    /// - A path to the ffmpeg executable
     pub fn with_location(location: Option<&Path>) -> Result<Self> {
-        let (ffmpeg_path, ffprobe_path) = Self::find_executables(location)?;
+        let ffmpeg_path = Self::find_ffmpeg(location)?;
 
         Ok(Self {
             ffmpeg_path,
-            ffprobe_path,
             version: None,
         })
     }
 
-    /// Find FFmpeg and FFprobe executables.
-    fn find_executables(location: Option<&Path>) -> Result<(PathBuf, PathBuf)> {
+    /// Find the FFmpeg executable.
+    fn find_ffmpeg(location: Option<&Path>) -> Result<PathBuf> {
         let ffmpeg_names = if cfg!(windows) {
             vec!["ffmpeg.exe", "ffmpeg"]
         } else {
             vec!["ffmpeg"]
-        };
-
-        let ffprobe_names = if cfg!(windows) {
-            vec!["ffprobe.exe", "ffprobe"]
-        } else {
-            vec!["ffprobe"]
         };
 
         let ffmpeg_path = if let Some(loc) = location {
@@ -262,27 +256,9 @@ impl FFmpegRunner {
             Self::find_in_path(&ffmpeg_names).ok_or(PostProcessError::FFmpegNotFound)?
         };
 
-        let ffprobe_path = if let Some(loc) = location {
-            Self::find_in_location(loc, &ffprobe_names)?
-        } else {
-            // Try to find ffprobe in same directory as ffmpeg first
-            let ffmpeg_dir = ffmpeg_path.parent();
-            let in_ffmpeg_dir = ffmpeg_dir.and_then(|dir| {
-                ffprobe_names
-                    .iter()
-                    .map(|name| dir.join(name))
-                    .find(|p| p.exists())
-            });
-
-            in_ffmpeg_dir
-                .or_else(|| Self::find_in_path(&ffprobe_names))
-                .ok_or(PostProcessError::FFprobeNotFound)?
-        };
-
         debug!(path:? = ffmpeg_path.display(); "Found FFmpeg");
-        debug!(path:? = ffprobe_path.display(); "Found FFprobe");
 
-        Ok((ffmpeg_path, ffprobe_path))
+        Ok(ffmpeg_path)
     }
 
     /// Find executable in a specific location.
@@ -333,7 +309,7 @@ impl FFmpegRunner {
 
     /// Check if FFmpeg is available.
     pub fn available(&self) -> bool {
-        self.ffmpeg_path.exists() && self.ffprobe_path.exists()
+        self.ffmpeg_path.exists()
     }
 
     /// Get the FFmpeg version.
@@ -369,196 +345,157 @@ impl FFmpegRunner {
         &self.ffmpeg_path
     }
 
-    /// Get the path to the FFprobe executable.
-    pub fn ffprobe_path(&self) -> &Path {
-        &self.ffprobe_path
-    }
-
-    /// Probe a media file and return its information.
+    /// Probe a media file using the FFmpeg library and return its information.
     pub async fn probe(&self, path: impl AsRef<Path>) -> Result<MediaInfo> {
-        let path = path.as_ref();
+        let path = path.as_ref().to_path_buf();
 
         if !path.exists() {
-            return Err(PostProcessError::InputNotFound {
-                path: path.to_path_buf(),
-            });
+            return Err(PostProcessError::InputNotFound { path });
         }
 
-        let output = Command::new(&self.ffprobe_path)
-            .args([
-                "-v",
-                "quiet",
-                "-print_format",
-                "json",
-                "-show_format",
-                "-show_streams",
-            ])
-            .arg(path)
-            .output()
+        tokio::task::spawn_blocking(move || Self::probe_sync(&path))
             .await
-            .map_err(|e| PostProcessError::ffmpeg_failed_with_source("Failed to run FFprobe", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(PostProcessError::FFmpegExitCode {
-                code: output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
-            });
-        }
-
-        let json_str = String::from_utf8_lossy(&output.stdout);
-        self.parse_probe_output(path, &json_str)
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("probe task join error: {e}"),
+            })?
     }
 
-    /// Parse FFprobe JSON output into MediaInfo.
-    fn parse_probe_output(&self, path: &Path, json: &str) -> Result<MediaInfo> {
-        let data: serde_json::Value =
-            serde_json::from_str(json).map_err(|e| PostProcessError::ParseError {
-                message: format!("Invalid JSON from FFprobe: {e}"),
-            })?;
+    /// Probe a media file synchronously using ffmpeg-the-third library.
+    fn probe_sync(path: &Path) -> Result<MediaInfo> {
+        ensure_init()?;
+
+        let ictx = ffmpeg_the_third::format::input(path).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open {}: {e}", path.display()),
+            }
+        })?;
 
         let mut info = MediaInfo {
             path: path.to_path_buf(),
             ..Default::default()
         };
 
-        // Parse format information
-        if let Some(format) = data.get("format") {
-            info.format = format
-                .get("format_name")
-                .and_then(|v| v.as_str())
-                .map(|s| s.split(',').next().unwrap_or(s).to_string());
+        // Duration (stored in AV_TIME_BASE units)
+        let duration_ts = ictx.duration();
+        if duration_ts > 0 {
+            info.duration =
+                Some(duration_ts as f64 / f64::from(ffmpeg_the_third::ffi::AV_TIME_BASE));
+        }
 
-            info.duration = format
-                .get("duration")
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse().ok());
+        // Format name
+        if let Some(fmt) = ictx.format().name().split(',').next() {
+            info.format = Some(fmt.to_string());
+        }
 
-            info.bitrate = format
-                .get("bit_rate")
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse::<u64>().ok())
-                .map(|b| (b / 1000) as u32);
+        // Bit rate
+        let bit_rate = ictx.bit_rate();
+        if bit_rate > 0 {
+            info.bitrate = Some((bit_rate as u64 / 1000) as u32);
+        }
 
-            info.filesize = format
-                .get("size")
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse().ok());
+        // File size from metadata or filesystem
+        info.filesize = std::fs::metadata(path).ok().map(|m| m.len());
 
-            // Parse format metadata
-            if let Some(tags) = format.get("tags").and_then(|t| t.as_object()) {
-                for (key, value) in tags {
-                    if let Some(v) = value.as_str() {
-                        info.metadata.insert(key.to_lowercase(), v.to_string());
-                    }
-                }
-            }
+        // Format-level metadata
+        for (key, value) in ictx.metadata().iter() {
+            info.metadata.insert(key.to_lowercase(), value.to_string());
         }
 
         // Parse streams
-        if let Some(streams) = data.get("streams").and_then(|s| s.as_array()) {
-            info.stream_count = streams.len();
+        info.stream_count = ictx.streams().count();
 
-            for (i, stream) in streams.iter().enumerate() {
-                let codec_type = stream
-                    .get("codec_type")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
+        for stream in ictx.streams() {
+            let params = stream.parameters();
+            let medium = params.medium();
 
-                let codec_name = stream
-                    .get("codec_name")
-                    .and_then(|v| v.as_str())
-                    .map(String::from);
+            let codec_name = stream.parameters().id().name().to_string();
+            let codec_type_str = match medium {
+                ffmpeg_the_third::media::Type::Video => "video",
+                ffmpeg_the_third::media::Type::Audio => "audio",
+                ffmpeg_the_third::media::Type::Subtitle => "subtitle",
+                ffmpeg_the_third::media::Type::Data => "data",
+                _ => "unknown",
+            };
 
-                let mut stream_info = StreamInfo {
-                    index: i,
-                    codec_type: codec_type.to_string(),
-                    codec_name: codec_name.clone(),
-                    metadata: HashMap::new(),
-                };
+            let mut stream_info = StreamInfo {
+                index: stream.index(),
+                codec_type: codec_type_str.to_string(),
+                codec_name: Some(codec_name.clone()),
+                metadata: HashMap::new(),
+            };
 
-                // Parse stream metadata
-                if let Some(tags) = stream.get("tags").and_then(|t| t.as_object()) {
-                    for (key, value) in tags {
-                        if let Some(v) = value.as_str() {
-                            stream_info
-                                .metadata
-                                .insert(key.to_lowercase(), v.to_string());
-                        }
-                    }
-                }
-
-                match codec_type {
-                    "video" => {
-                        info.has_video = true;
-                        info.video_codec = codec_name;
-                        info.width = stream
-                            .get("width")
-                            .and_then(|v| v.as_u64())
-                            .map(|v| v as u32);
-                        info.height = stream
-                            .get("height")
-                            .and_then(|v| v.as_u64())
-                            .map(|v| v as u32);
-
-                        // Parse frame rate (could be "30/1" or "29.97")
-                        if let Some(fps_str) = stream.get("r_frame_rate").and_then(|v| v.as_str()) {
-                            info.fps = Self::parse_frame_rate(fps_str);
-                        }
-
-                        info.video_bitrate = stream
-                            .get("bit_rate")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse::<u64>().ok())
-                            .map(|b| (b / 1000) as u32);
-                    }
-                    "audio" => {
-                        info.has_audio = true;
-                        if info.audio_codec.is_none() {
-                            info.audio_codec = codec_name;
-                        }
-
-                        info.sample_rate = stream
-                            .get("sample_rate")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse().ok());
-
-                        info.channels = stream
-                            .get("channels")
-                            .and_then(|v| v.as_u64())
-                            .map(|c| c as u8);
-
-                        if info.audio_bitrate.is_none() {
-                            info.audio_bitrate = stream
-                                .get("bit_rate")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse::<u64>().ok())
-                                .map(|b| (b / 1000) as u32);
-                        }
-                    }
-                    _ => {}
-                }
-
-                info.streams.push(stream_info);
+            // Stream-level metadata
+            for (key, value) in stream.metadata().iter() {
+                stream_info
+                    .metadata
+                    .insert(key.to_lowercase(), value.to_string());
             }
+
+            match medium {
+                ffmpeg_the_third::media::Type::Video => {
+                    info.has_video = true;
+                    if info.video_codec.is_none() {
+                        info.video_codec = Some(codec_name);
+                    }
+
+                    if let Ok(codec_ctx) =
+                        ffmpeg_the_third::codec::context::Context::from_parameters(params)
+                    {
+                        if let Ok(video) = codec_ctx.decoder().video() {
+                            info.width = Some(video.width());
+                            info.height = Some(video.height());
+                        }
+                    }
+
+                    // Frame rate from avg_frame_rate
+                    let rate = stream.avg_frame_rate();
+                    if rate.denominator() > 0 {
+                        let fps =
+                            rate.numerator() as f64 / rate.denominator() as f64;
+                        if fps > 0.0 && fps < 1000.0 {
+                            info.fps = Some(fps);
+                        }
+                    }
+
+                    // Video bitrate from stream metadata
+                    if let Some(br_str) = stream_info.metadata.get("bps") {
+                        if let Ok(bps) = br_str.parse::<u64>() {
+                            info.video_bitrate = Some((bps / 1000) as u32);
+                        }
+                    }
+                }
+                ffmpeg_the_third::media::Type::Audio => {
+                    info.has_audio = true;
+                    if info.audio_codec.is_none() {
+                        info.audio_codec = Some(codec_name);
+                    }
+
+                    if let Ok(codec_ctx) =
+                        ffmpeg_the_third::codec::context::Context::from_parameters(params)
+                    {
+                        if let Ok(audio) = codec_ctx.decoder().audio() {
+                            info.sample_rate = Some(audio.rate());
+                            info.channels =
+                                Some(audio.ch_layout().channels() as u8);
+                        }
+                    }
+
+                    // Audio bitrate from stream metadata
+                    if info.audio_bitrate.is_none() {
+                        if let Some(br_str) = stream_info.metadata.get("bps") {
+                            if let Ok(bps) = br_str.parse::<u64>() {
+                                info.audio_bitrate = Some((bps / 1000) as u32);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            info.streams.push(stream_info);
         }
 
         Ok(info)
-    }
-
-    /// Parse frame rate string like "30/1" or "29.97".
-    fn parse_frame_rate(fps_str: &str) -> Option<f64> {
-        if fps_str.contains('/') {
-            let parts: Vec<&str> = fps_str.split('/').collect();
-            if parts.len() == 2 {
-                let num: f64 = parts[0].parse().ok()?;
-                let den: f64 = parts[1].parse().ok()?;
-                if den > 0.0 {
-                    return Some(num / den);
-                }
-            }
-        }
-        fps_str.parse().ok()
     }
 
     /// Run FFmpeg with the given arguments.
@@ -706,17 +643,6 @@ mod tests {
         let flac = get_audio_codec("flac").unwrap();
         assert!(flac.encoder.is_none()); // Native codec
         assert!(flac.bitrate_range.is_none()); // Lossless
-    }
-
-    #[test]
-    fn test_parse_frame_rate() {
-        assert_eq!(FFmpegRunner::parse_frame_rate("30/1"), Some(30.0));
-        assert_eq!(
-            FFmpegRunner::parse_frame_rate("30000/1001"),
-            Some(29.97002997002997)
-        );
-        assert_eq!(FFmpegRunner::parse_frame_rate("24"), Some(24.0));
-        assert!(FFmpegRunner::parse_frame_rate("invalid").is_none());
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -27,6 +27,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Output;
+use std::sync::OnceLock;
 
 use log::{debug, trace};
 use regex::Regex;
@@ -34,6 +35,27 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
 use crate::error::{PostProcessError, Result};
+
+/// Global initialization state for the FFmpeg library.
+/// Ensures `ffmpeg_the_third::init()` is called exactly once.
+static FFMPEG_INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
+
+/// Initialize the FFmpeg library (idempotent).
+///
+/// This must be called before any `ffmpeg-the-third` library operations.
+/// Safe to call multiple times — only the first call performs initialization.
+pub fn ensure_init() -> Result<()> {
+    let result = FFMPEG_INIT.get_or_init(|| {
+        ffmpeg_the_third::init().map_err(|e| format!("ffmpeg_the_third::init() failed: {e}"))
+    });
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(msg) => Err(PostProcessError::FFmpegInitFailed {
+            message: msg.clone(),
+        }),
+    }
+}
 
 /// Audio codec configuration for extraction/conversion.
 #[derive(Debug, Clone)]

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -1453,6 +1453,251 @@ impl FFmpegRunner {
         Ok(())
     }
 
+    /// Embed a thumbnail image into a media file via stream copy (remux).
+    ///
+    /// Opens both the media file and thumbnail image, copies all media streams,
+    /// and adds the thumbnail as a video stream with `ATTACHED_PIC` disposition.
+    /// Container-specific handling for MKV (attachment) and MP3 (ID3v2).
+    pub async fn embed_thumbnail(
+        &self,
+        media: impl AsRef<Path>,
+        thumbnail: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        container: &str,
+    ) -> Result<()> {
+        let media = media.as_ref().to_path_buf();
+        let thumbnail = thumbnail.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let container = container.to_string();
+        tokio::task::spawn_blocking(move || {
+            Self::embed_thumbnail_sync(&media, &thumbnail, &output, &container)
+        })
+        .await
+        .map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("embed_thumbnail task join error: {e}"),
+        })?
+    }
+
+    /// Embed thumbnail synchronously.
+    ///
+    /// Strategy varies by container:
+    /// - **MP4/MOV/M4A/M4V**: Map all streams + thumbnail as video with `ATTACHED_PIC`
+    /// - **MKV/MKA**: Map all streams + thumbnail as attachment with mimetype metadata
+    /// - **MP3**: Map audio only + thumbnail as video with ID3v2 metadata
+    /// - **FLAC/OGG/Opus**: Map all streams + thumbnail with `ATTACHED_PIC`
+    fn embed_thumbnail_sync(
+        media: &Path,
+        thumbnail: &Path,
+        output: &Path,
+        container: &str,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        // Open media input
+        let mut ictx = ffmpeg_the_third::format::input(media).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open media input {}: {e}", media.display()),
+            }
+        })?;
+
+        // Open thumbnail input
+        let mut thumb_ictx = ffmpeg_the_third::format::input(thumbnail).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open thumbnail {}: {e}", thumbnail.display()),
+            }
+        })?;
+
+        // Create output
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        let is_mp3 = container.eq_ignore_ascii_case("mp3");
+        let is_mkv = matches!(
+            container.to_lowercase().as_str(),
+            "mkv" | "mka"
+        );
+
+        // Map media streams to output
+        let stream_count = ictx.streams().count();
+        let mut stream_mapping: Vec<i32> = vec![-1; stream_count];
+        let mut ist_time_bases = vec![ffmpeg_the_third::Rational(0, 1); stream_count];
+        let mut ost_index: i32 = 0;
+
+        for (ist_index, ist) in ictx.streams().enumerate() {
+            let medium = ist.parameters().medium();
+
+            // For MP3: only map audio streams (thumbnail replaces any video)
+            if is_mp3 && medium != ffmpeg_the_third::media::Type::Audio {
+                continue;
+            }
+
+            if medium != ffmpeg_the_third::media::Type::Video
+                && medium != ffmpeg_the_third::media::Type::Audio
+            {
+                continue;
+            }
+
+            stream_mapping[ist_index] = ost_index;
+            ist_time_bases[ist_index] = ist.time_base();
+            ost_index += 1;
+
+            let mut ost = octx
+                .add_stream(ffmpeg_the_third::encoder::find(
+                    ffmpeg_the_third::codec::Id::None,
+                ))
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add output stream: {e}"),
+                })?;
+            ost.set_parameters(ist.parameters());
+            unsafe {
+                (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                    .codec_tag = 0;
+            }
+        }
+
+        // Add thumbnail stream
+        let thumb_ist = thumb_ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Video)
+            .ok_or(PostProcessError::ffmpeg_failed(
+                "no video stream found in thumbnail",
+            ))?;
+        let thumb_ist_index = thumb_ist.index();
+        let thumb_ist_time_base = thumb_ist.time_base();
+        let thumb_params = thumb_ist.parameters();
+
+        let thumb_ost_index;
+        if is_mkv {
+            // MKV: add as attachment stream
+            let mut ost = octx
+                .add_stream(ffmpeg_the_third::encoder::find(
+                    ffmpeg_the_third::codec::Id::None,
+                ))
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add thumbnail attachment stream: {e}"),
+                })?;
+            thumb_ost_index = ost.index();
+            // Set codec parameters from thumbnail
+            ost.set_parameters(thumb_params);
+            // Override to attachment type for MKV
+            unsafe {
+                let codecpar =
+                    ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters;
+                (*codecpar).codec_type =
+                    ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_ATTACHMENT;
+                (*codecpar).codec_tag = 0;
+            }
+            // Set attachment metadata
+            {
+                let mut dict = ffmpeg_the_third::Dictionary::new();
+                dict.set("mimetype", Self::thumbnail_mimetype(thumbnail));
+                dict.set("filename", "cover.jpg");
+                ost.set_metadata(dict);
+            }
+        } else {
+            // All other containers: add as video stream with ATTACHED_PIC
+            let mut ost = octx
+                .add_stream(ffmpeg_the_third::encoder::find(
+                    ffmpeg_the_third::codec::Id::None,
+                ))
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add thumbnail stream: {e}"),
+                })?;
+            thumb_ost_index = ost.index();
+            ost.set_parameters(thumb_params);
+            unsafe {
+                let stream_ptr = ost.as_mut_ptr();
+                (*stream_ptr).disposition =
+                    ffmpeg_the_third::ffi::AV_DISPOSITION_ATTACHED_PIC;
+                (*((*stream_ptr).codecpar)).codec_tag = 0;
+            }
+
+            // For MP3: set ID3v2 metadata on the thumbnail stream
+            if is_mp3 {
+                let mut dict = ffmpeg_the_third::Dictionary::new();
+                dict.set("title", "Album cover");
+                dict.set("comment", "Cover (front)");
+                ost.set_metadata(dict);
+            }
+        }
+
+        // Copy format-level metadata from media input
+        octx.set_metadata(ictx.metadata().to_owned());
+
+        // Write header
+        octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output header: {e}"),
+        })?;
+
+        // Copy media packets
+        for result in ictx.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read media packet: {e}"),
+                }
+            })?;
+            let ist_index = stream.index();
+            let ost_idx = stream_mapping[ist_index];
+            if ost_idx < 0 {
+                continue;
+            }
+            let ost_idx = ost_idx as usize;
+            let ost_time_base = octx.stream(ost_idx).unwrap().time_base();
+            packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
+            packet.set_position(-1);
+            packet.set_stream(ost_idx);
+            packet.write_interleaved(&mut octx).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write media packet: {e}"),
+                }
+            })?;
+        }
+
+        // Copy thumbnail packet(s)
+        let thumb_ost_time_base = octx.stream(thumb_ost_index).unwrap().time_base();
+        for result in thumb_ictx.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read thumbnail packet: {e}"),
+                }
+            })?;
+            if stream.index() == thumb_ist_index {
+                packet.rescale_ts(thumb_ist_time_base, thumb_ost_time_base);
+                packet.set_position(-1);
+                packet.set_stream(thumb_ost_index);
+                packet.write_interleaved(&mut octx).map_err(|e| {
+                    PostProcessError::FFmpegLibraryError {
+                        message: format!("failed to write thumbnail packet: {e}"),
+                    }
+                })?;
+            }
+        }
+
+        octx.write_trailer().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output trailer: {e}"),
+        })?;
+
+        Ok(())
+    }
+
+    /// Determine MIME type from thumbnail file extension.
+    fn thumbnail_mimetype(path: &Path) -> &'static str {
+        match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase()
+            .as_str()
+        {
+            "png" => "image/png",
+            "webp" => "image/webp",
+            _ => "image/jpeg",
+        }
+    }
+
     /// Convert a video file, either by remuxing or transcoding.
     ///
     /// Uses `opts.remux_only` to determine whether to stream-copy or transcode.

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -154,6 +154,15 @@ pub fn get_audio_codec(name: &str) -> Option<&'static AudioCodecConfig> {
         .map(|(_, config)| config)
 }
 
+/// Options for remux and merge operations.
+#[derive(Debug, Clone, Default)]
+pub struct RemuxOptions {
+    /// Enable MP4 faststart (moov atom at beginning of file).
+    pub faststart: bool,
+    /// Force output format (e.g., "mp4", "mkv").
+    pub output_format: Option<String>,
+}
+
 /// Media file information from FFprobe.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MediaInfo {
@@ -496,6 +505,324 @@ impl FFmpegRunner {
         }
 
         Ok(info)
+    }
+
+    /// Remux a file (stream copy, no re-encoding) with optional faststart.
+    ///
+    /// This performs a container-level copy without transcoding, useful for:
+    /// - Moving the moov atom to the start of MP4 files (faststart)
+    /// - Fixing timestamps and container structure
+    /// - Converting between container formats
+    pub async fn remux(
+        &self,
+        input: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        opts: &RemuxOptions,
+    ) -> Result<()> {
+        let input = input.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let opts = opts.clone();
+        tokio::task::spawn_blocking(move || Self::remux_sync(&input, &output, &opts))
+            .await
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("remux task join error: {e}"),
+            })?
+    }
+
+    /// Remux a single input file synchronously (stream copy).
+    fn remux_sync(input: &Path, output: &Path, opts: &RemuxOptions) -> Result<()> {
+        ensure_init()?;
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        let stream_count = ictx.streams().count();
+        let mut stream_mapping: Vec<i32> = vec![-1; stream_count];
+        let mut ist_time_bases =
+            vec![ffmpeg_the_third::Rational(0, 1); stream_count];
+        let mut ost_index: i32 = 0;
+
+        for (ist_index, ist) in ictx.streams().enumerate() {
+            let medium = ist.parameters().medium();
+            if medium != ffmpeg_the_third::media::Type::Video
+                && medium != ffmpeg_the_third::media::Type::Audio
+            {
+                continue;
+            }
+
+            stream_mapping[ist_index] = ost_index;
+            ist_time_bases[ist_index] = ist.time_base();
+            ost_index += 1;
+
+            let mut ost = octx
+                .add_stream(ffmpeg_the_third::encoder::find(
+                    ffmpeg_the_third::codec::Id::None,
+                ))
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add output stream: {e}"),
+                })?;
+            ost.set_parameters(ist.parameters());
+            // Reset codec tag for container compatibility
+            unsafe {
+                (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                    .codec_tag = 0;
+            }
+        }
+
+        // Copy format-level metadata
+        octx.set_metadata(ictx.metadata().to_owned());
+
+        // Write header (with faststart if requested)
+        if opts.faststart {
+            let mut dict = ffmpeg_the_third::Dictionary::new();
+            dict.set("movflags", "+faststart");
+            octx.write_header_with(dict).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write output header: {e}"),
+                }
+            })?;
+        } else {
+            octx.write_header().map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write output header: {e}"),
+                }
+            })?;
+        }
+
+        // Copy packets
+        for result in ictx.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read packet: {e}"),
+                }
+            })?;
+            let ist_index = stream.index();
+            let ost_idx = stream_mapping[ist_index];
+            if ost_idx < 0 {
+                continue;
+            }
+            let ost_idx = ost_idx as usize;
+            let ost_time_base = octx.stream(ost_idx).unwrap().time_base();
+            packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
+            packet.set_position(-1);
+            packet.set_stream(ost_idx);
+            packet.write_interleaved(&mut octx).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write packet: {e}"),
+                }
+            })?;
+        }
+
+        octx.write_trailer().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output trailer: {e}"),
+        })?;
+
+        Ok(())
+    }
+
+    /// Merge separate video and audio files into a single container (stream copy).
+    ///
+    /// Takes two input files (one containing video, one containing audio) and
+    /// combines them into a single output file without re-encoding.
+    /// The MP4 muxer automatically handles AAC ADTS→ASC conversion when needed.
+    pub async fn merge(
+        &self,
+        video_input: impl AsRef<Path>,
+        audio_input: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        opts: &RemuxOptions,
+    ) -> Result<()> {
+        let video_input = video_input.as_ref().to_path_buf();
+        let audio_input = audio_input.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let opts = opts.clone();
+        tokio::task::spawn_blocking(move || {
+            Self::merge_sync(&video_input, &audio_input, &output, &opts)
+        })
+        .await
+        .map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("merge task join error: {e}"),
+        })?
+    }
+
+    /// Merge separate video and audio files synchronously (stream copy).
+    fn merge_sync(
+        video_input: &Path,
+        audio_input: &Path,
+        output: &Path,
+        opts: &RemuxOptions,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        let mut ictx_video =
+            ffmpeg_the_third::format::input(video_input).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "failed to open video input {}: {e}",
+                        video_input.display()
+                    ),
+                }
+            })?;
+
+        let mut ictx_audio =
+            ffmpeg_the_third::format::input(audio_input).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "failed to open audio input {}: {e}",
+                        audio_input.display()
+                    ),
+                }
+            })?;
+
+        let mut octx =
+            ffmpeg_the_third::format::output(output).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "failed to create output {}: {e}",
+                        output.display()
+                    ),
+                }
+            })?;
+
+        // Find best video stream from video input
+        let video_ist_index = ictx_video
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Video)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoVideoStream)?;
+
+        let video_ist_time_base = ictx_video
+            .stream(video_ist_index)
+            .unwrap()
+            .time_base();
+
+        let mut ost_video = octx
+            .add_stream(ffmpeg_the_third::encoder::find(
+                ffmpeg_the_third::codec::Id::None,
+            ))
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add video output stream: {e}"),
+            })?;
+        ost_video.set_parameters(
+            ictx_video
+                .stream(video_ist_index)
+                .unwrap()
+                .parameters(),
+        );
+        unsafe {
+            (*(ost_video.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                    .codec_tag = 0;
+        }
+        let video_ost_index = ost_video.index();
+
+        // Find best audio stream from audio input
+        let audio_ist_index = ictx_audio
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let audio_ist_time_base = ictx_audio
+            .stream(audio_ist_index)
+            .unwrap()
+            .time_base();
+
+        let mut ost_audio = octx
+            .add_stream(ffmpeg_the_third::encoder::find(
+                ffmpeg_the_third::codec::Id::None,
+            ))
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add audio output stream: {e}"),
+            })?;
+        ost_audio.set_parameters(
+            ictx_audio
+                .stream(audio_ist_index)
+                .unwrap()
+                .parameters(),
+        );
+        unsafe {
+            (*(ost_audio.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                    .codec_tag = 0;
+        }
+        let audio_ost_index = ost_audio.index();
+
+        // Write header (with faststart if requested)
+        if opts.faststart {
+            let mut dict = ffmpeg_the_third::Dictionary::new();
+            dict.set("movflags", "+faststart");
+            octx.write_header_with(dict).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write output header: {e}"),
+                }
+            })?;
+        } else {
+            octx.write_header().map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write output header: {e}"),
+                }
+            })?;
+        }
+
+        // Copy video packets
+        for result in ictx_video.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read video packet: {e}"),
+                }
+            })?;
+            if stream.index() != video_ist_index {
+                continue;
+            }
+            let ost_time_base =
+                octx.stream(video_ost_index).unwrap().time_base();
+            packet.rescale_ts(video_ist_time_base, ost_time_base);
+            packet.set_position(-1);
+            packet.set_stream(video_ost_index);
+            packet.write_interleaved(&mut octx).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write video packet: {e}"),
+                }
+            })?;
+        }
+
+        // Copy audio packets
+        for result in ictx_audio.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read audio packet: {e}"),
+                }
+            })?;
+            if stream.index() != audio_ist_index {
+                continue;
+            }
+            let ost_time_base =
+                octx.stream(audio_ost_index).unwrap().time_base();
+            packet.rescale_ts(audio_ist_time_base, ost_time_base);
+            packet.set_position(-1);
+            packet.set_stream(audio_ost_index);
+            packet.write_interleaved(&mut octx).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write audio packet: {e}"),
+                }
+            })?;
+        }
+
+        octx.write_trailer().map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to write output trailer: {e}"),
+            }
+        })?;
+
+        Ok(())
     }
 
     /// Run FFmpeg with the given arguments.

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -1,9 +1,14 @@
-//! FFmpeg and FFprobe integration.
+//! FFmpeg integration via `ffmpeg-the-third` library bindings.
 //!
 //! This module provides utilities for:
-//! - Detecting FFmpeg/FFprobe executables
-//! - Running FFmpeg commands with proper argument handling
 //! - Probing media files for codec and format information
+//! - Remuxing and merging streams (stream copy)
+//! - Audio extraction and transcoding
+//! - Video conversion and transcoding
+//! - Metadata and chapter embedding
+//! - Thumbnail embedding (container-specific strategies)
+//!
+//! All FFmpeg operations use direct library calls (no CLI process spawning).
 //!
 //! # Example
 //!
@@ -17,22 +22,17 @@
 //! let info = ffmpeg.probe("video.mp4").await?;
 //! println!("Duration: {:?}", info.duration);
 //! println!("Video codec: {:?}", info.video_codec);
-//!
-//! // Run FFmpeg command
-//! ffmpeg.run(&["-i", "input.mp4", "-c:v", "copy", "output.mkv"]).await?;
+//! println!("Resolution: {:?}", info.resolution_string());
 //! # Ok(())
 //! # }
 //! ```
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Output;
 use std::sync::OnceLock;
 
-use log::{debug, trace};
-use regex::Regex;
+use log::debug;
 use serde::{Deserialize, Serialize};
-use tokio::process::Command;
 
 use crate::error::{PostProcessError, Result};
 
@@ -265,137 +265,29 @@ pub struct StreamInfo {
 
 /// FFmpeg runner.
 ///
-/// Provides media probing via `ffmpeg-the-third` library bindings and
-/// CLI execution for operations not yet migrated to library calls.
+/// Provides media operations via `ffmpeg-the-third` library bindings:
+/// probing, remuxing, merging, audio extraction, video conversion,
+/// metadata embedding, and thumbnail embedding.
 #[derive(Debug, Clone)]
-pub struct FFmpegRunner {
-    /// Path to FFmpeg executable (used for CLI operations not yet migrated)
-    ffmpeg_path: PathBuf,
-    /// FFmpeg version string
-    version: Option<String>,
-}
+pub struct FFmpegRunner;
 
 impl FFmpegRunner {
-    /// Create a new FFmpeg runner, auto-detecting executables from PATH.
+    /// Create a new FFmpeg runner.
+    ///
+    /// Initializes the FFmpeg library (idempotent — safe to call multiple times).
     pub fn new() -> Result<Self> {
-        Self::with_location(None)
+        ensure_init()?;
+        debug!("FFmpeg library initialized");
+        Ok(Self)
     }
 
     /// Create a new FFmpeg runner with a custom location.
     ///
-    /// If `location` is `Some`, it should be either:
-    /// - A path to a directory containing ffmpeg
-    /// - A path to the ffmpeg executable
-    pub fn with_location(location: Option<&Path>) -> Result<Self> {
-        let ffmpeg_path = Self::find_ffmpeg(location)?;
-
-        Ok(Self {
-            ffmpeg_path,
-            version: None,
-        })
-    }
-
-    /// Find the FFmpeg executable.
-    fn find_ffmpeg(location: Option<&Path>) -> Result<PathBuf> {
-        let ffmpeg_names = if cfg!(windows) {
-            vec!["ffmpeg.exe", "ffmpeg"]
-        } else {
-            vec!["ffmpeg"]
-        };
-
-        let ffmpeg_path = if let Some(loc) = location {
-            Self::find_in_location(loc, &ffmpeg_names)?
-        } else {
-            Self::find_in_path(&ffmpeg_names).ok_or(PostProcessError::FFmpegNotFound)?
-        };
-
-        debug!(path:? = ffmpeg_path.display(); "Found FFmpeg");
-
-        Ok(ffmpeg_path)
-    }
-
-    /// Find executable in a specific location.
-    fn find_in_location(location: &Path, names: &[&str]) -> Result<PathBuf> {
-        // If location is a file, check if it's one of the executables
-        if location.is_file() {
-            if let Some(name) = location.file_name().and_then(|n| n.to_str()) {
-                if names
-                    .iter()
-                    .any(|n| name.contains(n.trim_end_matches(".exe")))
-                {
-                    return Ok(location.to_path_buf());
-                }
-            }
-            // If it's a file but not the right one, check its directory
-            if let Some(dir) = location.parent() {
-                for name in names {
-                    let path = dir.join(name);
-                    if path.exists() {
-                        return Ok(path);
-                    }
-                }
-            }
-        }
-
-        // If location is a directory, search in it
-        if location.is_dir() {
-            for name in names {
-                let path = location.join(name);
-                if path.exists() {
-                    return Ok(path);
-                }
-            }
-        }
-
-        Err(PostProcessError::FFmpegNotFound)
-    }
-
-    /// Find executable in PATH.
-    fn find_in_path(names: &[&str]) -> Option<PathBuf> {
-        for name in names {
-            if let Ok(path) = which::which(name) {
-                return Some(path);
-            }
-        }
-        None
-    }
-
-    /// Check if FFmpeg is available.
-    pub fn available(&self) -> bool {
-        self.ffmpeg_path.exists()
-    }
-
-    /// Get the FFmpeg version.
-    pub async fn version(&mut self) -> Result<&str> {
-        if self.version.is_none() {
-            let output = Command::new(&self.ffmpeg_path)
-                .arg("-version")
-                .output()
-                .await
-                .map_err(|e| {
-                    PostProcessError::ffmpeg_failed_with_source("Failed to get version", e)
-                })?;
-
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let version = stdout
-                .lines()
-                .next()
-                .and_then(|line| {
-                    // Parse "ffmpeg version N.N.N ..." or "ffmpeg version N.N ..."
-                    let re = Regex::new(r"ffmpeg version (\S+)").ok()?;
-                    re.captures(line).map(|c| c[1].to_string())
-                })
-                .unwrap_or_else(|| "unknown".to_string());
-
-            self.version = Some(version);
-        }
-
-        Ok(self.version.as_ref().unwrap())
-    }
-
-    /// Get the path to the FFmpeg executable.
-    pub fn ffmpeg_path(&self) -> &Path {
-        &self.ffmpeg_path
+    /// The `location` parameter is accepted for API compatibility but is
+    /// ignored — all operations use `ffmpeg-the-third` library bindings
+    /// which link against system FFmpeg shared libraries.
+    pub fn with_location(_location: Option<&Path>) -> Result<Self> {
+        Self::new()
     }
 
     /// Probe a media file using the FFmpeg library and return its information.
@@ -2135,107 +2027,6 @@ impl FFmpegRunner {
         Ok(())
     }
 
-    /// Run FFmpeg with the given arguments.
-    ///
-    /// This method automatically adds `-y` (overwrite) and sets an appropriate loglevel.
-    pub async fn run(&self, args: &[&str]) -> Result<Output> {
-        self.run_with_options(args, true, "error").await
-    }
-
-    /// Run FFmpeg with custom options.
-    pub async fn run_with_options(
-        &self,
-        args: &[&str],
-        overwrite: bool,
-        loglevel: &str,
-    ) -> Result<Output> {
-        let mut cmd = Command::new(&self.ffmpeg_path);
-
-        if overwrite {
-            cmd.arg("-y");
-        }
-
-        cmd.args(["-loglevel", loglevel]);
-        cmd.args(args);
-
-        trace!(
-            "Running FFmpeg: {} {}",
-            self.ffmpeg_path.display(),
-            args.join(" ")
-        );
-
-        let output = cmd
-            .output()
-            .await
-            .map_err(|e| PostProcessError::ffmpeg_failed_with_source("Failed to run FFmpeg", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(PostProcessError::FFmpegExitCode {
-                code: output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
-            });
-        }
-
-        Ok(output)
-    }
-
-    /// Run FFmpeg with input and output file paths.
-    ///
-    /// Handles special characters in filenames by using the `file:` protocol.
-    pub async fn run_with_files(
-        &self,
-        inputs: &[&Path],
-        output: &Path,
-        opts: &[&str],
-    ) -> Result<Output> {
-        let mut args = Vec::new();
-
-        // Add input files
-        for input in inputs {
-            args.push("-i".to_string());
-            args.push(Self::filename_arg(input));
-        }
-
-        // Add options
-        args.extend(opts.iter().map(|s| s.to_string()));
-
-        // Add output
-        args.push(Self::filename_arg(output));
-
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        self.run(&args_refs).await
-    }
-
-    /// Create a filename argument with proper escaping.
-    fn filename_arg(path: &Path) -> String {
-        let path_str = path.to_string_lossy();
-
-        // Use file: protocol for paths that might contain special characters
-        if path_str.starts_with('-') || path_str.contains(':') && !path_str.starts_with("file:") {
-            format!("file:{path_str}")
-        } else {
-            path_str.to_string()
-        }
-    }
-
-    /// Get the audio codec from a file.
-    pub async fn get_audio_codec(&self, path: impl AsRef<Path>) -> Result<Option<String>> {
-        let info = self.probe(path).await?;
-        Ok(info.audio_codec)
-    }
-
-    /// Check if a file has an audio stream.
-    pub async fn has_audio(&self, path: impl AsRef<Path>) -> Result<bool> {
-        let info = self.probe(path).await?;
-        Ok(info.has_audio)
-    }
-
-    /// Check if a file has a video stream.
-    pub async fn has_video(&self, path: impl AsRef<Path>) -> Result<bool> {
-        let info = self.probe(path).await?;
-        Ok(info.has_video)
-    }
 }
 
 impl MediaInfo {
@@ -2280,21 +2071,6 @@ mod tests {
         let flac = get_audio_codec("flac").unwrap();
         assert!(flac.encoder.is_none()); // Native codec
         assert!(flac.bitrate_range.is_none()); // Lossless
-    }
-
-    #[test]
-    fn test_filename_arg() {
-        // Normal path
-        assert_eq!(
-            FFmpegRunner::filename_arg(Path::new("video.mp4")),
-            "video.mp4"
-        );
-
-        // Path starting with dash
-        assert_eq!(
-            FFmpegRunner::filename_arg(Path::new("-output.mp4")),
-            "file:-output.mp4"
-        );
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -163,6 +163,22 @@ pub struct RemuxOptions {
     pub output_format: Option<String>,
 }
 
+/// Options for audio extraction and transcoding.
+#[derive(Debug, Clone, Default)]
+pub struct AudioExtractOptions {
+    /// Encoder name (e.g., "libmp3lame", "aac", "libopus").
+    /// If None, uses the default encoder for the output format.
+    pub encoder_name: Option<String>,
+    /// If true, copy audio stream without re-encoding.
+    pub copy: bool,
+    /// Target bitrate in kbps (e.g., 192 for 192kbps).
+    pub bitrate_kbps: Option<u32>,
+    /// VBR quality scale value (codec-specific).
+    /// For MP3: 0 (best) to 9 (worst).
+    /// For Vorbis: 0 (worst) to 10 (best).
+    pub quality_scale: Option<i32>,
+}
+
 /// Media file information from FFprobe.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MediaInfo {
@@ -822,6 +838,442 @@ impl FFmpegRunner {
             }
         })?;
 
+        Ok(())
+    }
+
+    /// Extract audio from a media file, either by stream copy or transcoding.
+    ///
+    /// Uses `opts.copy` to determine whether to copy or transcode.
+    /// For transcoding, supports bitrate (CBR) and quality scale (VBR) modes.
+    pub async fn extract_audio(
+        &self,
+        input: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        opts: &AudioExtractOptions,
+    ) -> Result<()> {
+        let input = input.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let opts = opts.clone();
+        tokio::task::spawn_blocking(move || Self::extract_audio_sync(&input, &output, &opts))
+            .await
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("extract_audio task join error: {e}"),
+            })?
+    }
+
+    /// Extract audio synchronously (dispatches to copy or transcode).
+    fn extract_audio_sync(input: &Path, output: &Path, opts: &AudioExtractOptions) -> Result<()> {
+        if opts.copy {
+            Self::extract_audio_copy_sync(input, output)
+        } else {
+            Self::extract_audio_transcode_sync(input, output, opts)
+        }
+    }
+
+    /// Extract audio by stream copy (no re-encoding).
+    ///
+    /// Maps only the best audio stream from input to output without transcoding.
+    fn extract_audio_copy_sync(input: &Path, output: &Path) -> Result<()> {
+        ensure_init()?;
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        // Find best audio stream
+        let ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let ist_time_base = ictx.stream(ist_index).unwrap().time_base();
+
+        // Add output stream (stream copy mode)
+        let mut ost = octx
+            .add_stream(ffmpeg_the_third::encoder::find(
+                ffmpeg_the_third::codec::Id::None,
+            ))
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add output stream: {e}"),
+            })?;
+        ost.set_parameters(ictx.stream(ist_index).unwrap().parameters());
+        unsafe {
+            (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                .codec_tag = 0;
+        }
+
+        octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output header: {e}"),
+        })?;
+
+        // Copy only audio packets
+        for result in ictx.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read packet: {e}"),
+                }
+            })?;
+            if stream.index() != ist_index {
+                continue;
+            }
+            let ost_time_base = octx.stream(0).unwrap().time_base();
+            packet.rescale_ts(ist_time_base, ost_time_base);
+            packet.set_position(-1);
+            packet.set_stream(0);
+            packet.write_interleaved(&mut octx).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write packet: {e}"),
+                }
+            })?;
+        }
+
+        octx.write_trailer().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output trailer: {e}"),
+        })?;
+
+        Ok(())
+    }
+
+    /// Extract audio by transcoding to a target codec.
+    ///
+    /// Decodes the input audio, optionally converts sample format/rate through
+    /// a filter graph, and encodes to the target codec.
+    fn extract_audio_transcode_sync(
+        input: &Path,
+        output: &Path,
+        opts: &AudioExtractOptions,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        // Open input and find audio stream
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let ist_time_base = ictx.stream(ist_index).unwrap().time_base();
+
+        // Create decoder (bind stream to extend its lifetime for parameters())
+        let ist = ictx.stream(ist_index).unwrap();
+        let decoder_ctx =
+            ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())?;
+        let mut decoder = decoder_ctx.decoder().audio()?;
+
+        // Open output
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        // Find encoder codec
+        let enc_codec = if let Some(ref name) = opts.encoder_name {
+            ffmpeg_the_third::encoder::find_by_name(name).ok_or_else(|| {
+                PostProcessError::UnsupportedCodec {
+                    codec: name.clone(),
+                    operation: "audio extraction".into(),
+                }
+            })?
+        } else {
+            let codec_id = octx
+                .format()
+                .codec(output, ffmpeg_the_third::media::Type::Audio);
+            ffmpeg_the_third::encoder::find(codec_id).ok_or_else(|| {
+                PostProcessError::ffmpeg_failed("no default encoder for output format")
+            })?
+        };
+
+        // Check global header flag BEFORE taking mutable stream borrow
+        let needs_global_header = octx
+            .format()
+            .flags()
+            .contains(ffmpeg_the_third::format::Flags::GLOBAL_HEADER);
+
+        // Add output stream and create encoder context (scoped to release octx borrow)
+        let ost_index;
+        let enc_context;
+        {
+            let ost = octx.add_stream(enc_codec).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add output stream: {e}"),
+                }
+            })?;
+            ost_index = ost.index();
+            enc_context =
+                ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
+        }
+        // ost dropped — octx no longer mutably borrowed
+
+        // Configure encoder
+        let mut audio_encoder = enc_context.encoder().audio()?;
+
+        let target_format = Self::pick_audio_sample_format(&enc_codec, decoder.format());
+        audio_encoder.set_format(target_format);
+        audio_encoder.set_rate(decoder.rate() as i32);
+        audio_encoder.set_time_base(ffmpeg_the_third::Rational(1, decoder.rate() as i32));
+
+        // Set channel layout from decoder (default layout matching channel count)
+        let channels = decoder.ch_layout().channels();
+        unsafe {
+            ffmpeg_the_third::ffi::av_channel_layout_default(
+                &mut (*audio_encoder.as_mut_ptr()).ch_layout,
+                channels as i32,
+            );
+        }
+
+        // Set bitrate (CBR)
+        if let Some(br_kbps) = opts.bitrate_kbps {
+            audio_encoder.set_bit_rate((br_kbps as usize) * 1000);
+        }
+
+        // Set VBR quality
+        if let Some(quality) = opts.quality_scale {
+            unsafe {
+                let ctx = audio_encoder.as_mut_ptr();
+                (*ctx).flags |= ffmpeg_the_third::ffi::AV_CODEC_FLAG_QSCALE as i32;
+                (*ctx).global_quality = quality * ffmpeg_the_third::ffi::FF_QP2LAMBDA;
+            }
+        }
+
+        // Set global header flag if required by output format
+        if needs_global_header {
+            unsafe {
+                (*audio_encoder.as_mut_ptr()).flags |=
+                    ffmpeg_the_third::ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
+            }
+        }
+
+        // Open encoder
+        let mut audio_encoder = audio_encoder.open_as(enc_codec).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open audio encoder: {e}"),
+            }
+        })?;
+
+        // Copy encoder parameters back to output stream via FFI
+        unsafe {
+            let stream_ptr = *(*octx.as_mut_ptr()).streams.add(ost_index);
+            ffmpeg_the_third::ffi::avcodec_parameters_from_context(
+                (*stream_ptr).codecpar,
+                audio_encoder.as_ptr(),
+            );
+        }
+
+        octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output header: {e}"),
+        })?;
+
+        // Build filter graph for sample format/rate conversion
+        let mut filter_graph =
+            Self::build_audio_filter(&decoder, &audio_encoder, ist_time_base)?;
+
+        // Transcode loop: read → decode → filter → encode → write
+        for result in ictx.packets() {
+            let (stream, packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read packet: {e}"),
+                }
+            })?;
+            if stream.index() != ist_index {
+                continue;
+            }
+            decoder.send_packet(&packet)?;
+            Self::receive_and_process_audio(
+                &mut decoder,
+                &mut filter_graph,
+                &mut audio_encoder,
+                &mut octx,
+                ost_index,
+            )?;
+        }
+
+        // Flush decoder
+        decoder.send_eof()?;
+        Self::receive_and_process_audio(
+            &mut decoder,
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            ost_index,
+        )?;
+
+        // Flush filter graph (signal EOF to source)
+        filter_graph.get("in").unwrap().source().flush()?;
+        Self::drain_filter_to_encoder(
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            ost_index,
+        )?;
+
+        // Flush encoder
+        audio_encoder.send_eof()?;
+        Self::drain_encoder_packets(&mut audio_encoder, &mut octx, ost_index)?;
+
+        octx.write_trailer().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output trailer: {e}"),
+        })?;
+
+        Ok(())
+    }
+
+    /// Pick a sample format supported by the encoder, preferring the decoder's format.
+    fn pick_audio_sample_format(
+        codec: &ffmpeg_the_third::Codec,
+        preferred: ffmpeg_the_third::format::Sample,
+    ) -> ffmpeg_the_third::format::Sample {
+        // Check codec's supported sample formats
+        unsafe {
+            let ptr = codec.as_ptr();
+            let sample_fmts = (*ptr).sample_fmts;
+            if sample_fmts.is_null() {
+                // Codec accepts any format
+                return preferred;
+            }
+
+            let mut i = 0;
+            let mut first = None;
+            loop {
+                let fmt = *sample_fmts.offset(i);
+                if fmt == ffmpeg_the_third::ffi::AVSampleFormat::AV_SAMPLE_FMT_NONE {
+                    break;
+                }
+                let sample = ffmpeg_the_third::format::Sample::from(fmt);
+                if first.is_none() {
+                    first = Some(sample);
+                }
+                if sample == preferred {
+                    return preferred;
+                }
+                i += 1;
+            }
+
+            first.unwrap_or(preferred)
+        }
+    }
+
+    /// Build an audio filter graph for sample format/rate/channel conversion.
+    ///
+    /// Uses `abuffer` → `anull` → `abuffersink` to let FFmpeg handle any
+    /// necessary sample format, sample rate, or channel layout conversions.
+    fn build_audio_filter(
+        decoder: &ffmpeg_the_third::decoder::Audio,
+        encoder: &ffmpeg_the_third::encoder::audio::Audio,
+        ist_time_base: ffmpeg_the_third::Rational,
+    ) -> Result<ffmpeg_the_third::filter::Graph> {
+        let mut graph = ffmpeg_the_third::filter::Graph::new();
+
+        let abuffer = ffmpeg_the_third::filter::find("abuffer").ok_or_else(|| {
+            PostProcessError::ffmpeg_failed("abuffer filter not found")
+        })?;
+        let abuffersink = ffmpeg_the_third::filter::find("abuffersink").ok_or_else(|| {
+            PostProcessError::ffmpeg_failed("abuffersink filter not found")
+        })?;
+
+        // Build abuffer args with decoder's output parameters
+        let channels = decoder.ch_layout().channels();
+        let args = format!(
+            "time_base={}/{}:sample_rate={}:sample_fmt={}:chlayout={}c",
+            ist_time_base.numerator(),
+            ist_time_base.denominator(),
+            decoder.rate(),
+            decoder.format().name(),
+            channels,
+        );
+
+        graph.add(&abuffer, "in", &args).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add abuffer filter: {e}"),
+            }
+        })?;
+        graph.add(&abuffersink, "out", "").map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add abuffersink filter: {e}"),
+            }
+        })?;
+
+        // Build aformat spec to convert to encoder's expected format
+        let enc_channels = encoder.ch_layout().channels();
+        let aformat_spec = format!(
+            "aformat=sample_fmts={}:sample_rates={}:channel_layouts={}c",
+            encoder.format().name(),
+            encoder.rate(),
+            enc_channels,
+        );
+
+        graph
+            .output("out", 0)?
+            .input("in", 0)?
+            .parse(&aformat_spec)?;
+        graph.validate()?;
+
+        Ok(graph)
+    }
+
+    /// Receive decoded frames from decoder, push through filter, encode, and write.
+    fn receive_and_process_audio(
+        decoder: &mut ffmpeg_the_third::decoder::Audio,
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        while decoder.receive_frame(&mut frame).is_ok() {
+            filter.get("in").unwrap().source().add(&frame)?;
+            Self::drain_filter_to_encoder(filter, encoder, octx, ost_index)?;
+        }
+        Ok(())
+    }
+
+    /// Pull filtered frames from filter graph, encode, and write.
+    fn drain_filter_to_encoder(
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut filtered = ffmpeg_the_third::frame::Audio::empty();
+        while filter
+            .get("out")
+            .unwrap()
+            .sink()
+            .frame(&mut filtered)
+            .is_ok()
+        {
+            encoder.send_frame(&filtered)?;
+            Self::drain_encoder_packets(encoder, octx, ost_index)?;
+        }
+        Ok(())
+    }
+
+    /// Receive encoded packets from encoder and write to output.
+    fn drain_encoder_packets(
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut packet = ffmpeg_the_third::Packet::empty();
+        while encoder.receive_packet(&mut packet).is_ok() {
+            packet.set_stream(ost_index);
+            packet.write_interleaved(octx)?;
+        }
         Ok(())
     }
 

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -511,11 +511,7 @@ impl FFmpegRunner {
                     message: format!("failed to add output stream: {e}"),
                 })?;
             ost.set_parameters(ist.parameters());
-            // Reset codec tag for container compatibility
-            unsafe {
-                (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                    .codec_tag = 0;
-            }
+            Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 
         // Copy format-level metadata
@@ -551,7 +547,9 @@ impl FFmpegRunner {
                 continue;
             }
             let ost_idx = ost_idx as usize;
-            let ost_time_base = octx.stream(ost_idx).unwrap().time_base();
+            let ost_time_base = octx.stream(ost_idx)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("output stream {ost_idx} not found")))?
+                .time_base();
             packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
             packet.set_position(-1);
             packet.set_stream(ost_idx);
@@ -642,7 +640,7 @@ impl FFmpegRunner {
 
         let video_ist_time_base = ictx_video
             .stream(video_ist_index)
-            .unwrap()
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("video input stream {video_ist_index} not found")))?
             .time_base();
 
         let mut ost_video = octx
@@ -655,13 +653,10 @@ impl FFmpegRunner {
         ost_video.set_parameters(
             ictx_video
                 .stream(video_ist_index)
-                .unwrap()
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("video input stream {video_ist_index} not found")))?
                 .parameters(),
         );
-        unsafe {
-            (*(ost_video.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                    .codec_tag = 0;
-        }
+        Self::clear_codec_tag(ost_video.parameters().as_ptr());
         let video_ost_index = ost_video.index();
 
         // Find best audio stream from audio input
@@ -673,7 +668,7 @@ impl FFmpegRunner {
 
         let audio_ist_time_base = ictx_audio
             .stream(audio_ist_index)
-            .unwrap()
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {audio_ist_index} not found")))?
             .time_base();
 
         let mut ost_audio = octx
@@ -686,13 +681,10 @@ impl FFmpegRunner {
         ost_audio.set_parameters(
             ictx_audio
                 .stream(audio_ist_index)
-                .unwrap()
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {audio_ist_index} not found")))?
                 .parameters(),
         );
-        unsafe {
-            (*(ost_audio.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                    .codec_tag = 0;
-        }
+        Self::clear_codec_tag(ost_audio.parameters().as_ptr());
         let audio_ost_index = ost_audio.index();
 
         // Write header (with faststart if requested)
@@ -722,8 +714,9 @@ impl FFmpegRunner {
             if stream.index() != video_ist_index {
                 continue;
             }
-            let ost_time_base =
-                octx.stream(video_ost_index).unwrap().time_base();
+            let ost_time_base = octx.stream(video_ost_index)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("video output stream {video_ost_index} not found")))?
+                .time_base();
             packet.rescale_ts(video_ist_time_base, ost_time_base);
             packet.set_position(-1);
             packet.set_stream(video_ost_index);
@@ -744,8 +737,9 @@ impl FFmpegRunner {
             if stream.index() != audio_ist_index {
                 continue;
             }
-            let ost_time_base =
-                octx.stream(audio_ost_index).unwrap().time_base();
+            let ost_time_base = octx.stream(audio_ost_index)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio output stream {audio_ost_index} not found")))?
+                .time_base();
             packet.rescale_ts(audio_ist_time_base, ost_time_base);
             packet.set_position(-1);
             packet.set_stream(audio_ost_index);
@@ -819,7 +813,9 @@ impl FFmpegRunner {
             .map(|s| s.index())
             .ok_or(PostProcessError::NoAudioStream)?;
 
-        let ist_time_base = ictx.stream(ist_index).unwrap().time_base();
+        let ist_time_base = ictx.stream(ist_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {ist_index} not found")))?
+            .time_base();
 
         // Add output stream (stream copy mode)
         let mut ost = octx
@@ -829,11 +825,12 @@ impl FFmpegRunner {
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to add output stream: {e}"),
             })?;
-        ost.set_parameters(ictx.stream(ist_index).unwrap().parameters());
-        unsafe {
-            (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                .codec_tag = 0;
-        }
+        ost.set_parameters(
+            ictx.stream(ist_index)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {ist_index} not found")))?
+                .parameters(),
+        );
+        Self::clear_codec_tag(ost.parameters().as_ptr());
 
         octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
             message: format!("failed to write output header: {e}"),
@@ -849,7 +846,9 @@ impl FFmpegRunner {
             if stream.index() != ist_index {
                 continue;
             }
-            let ost_time_base = octx.stream(0).unwrap().time_base();
+            let ost_time_base = octx.stream(0)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("output stream 0 not found"))?
+                .time_base();
             packet.rescale_ts(ist_time_base, ost_time_base);
             packet.set_position(-1);
             packet.set_stream(0);
@@ -891,10 +890,13 @@ impl FFmpegRunner {
             .map(|s| s.index())
             .ok_or(PostProcessError::NoAudioStream)?;
 
-        let ist_time_base = ictx.stream(ist_index).unwrap().time_base();
+        let ist_time_base = ictx.stream(ist_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {ist_index} not found")))?
+            .time_base();
 
         // Create decoder (bind stream to extend its lifetime for parameters())
-        let ist = ictx.stream(ist_index).unwrap();
+        let ist = ictx.stream(ist_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {ist_index} not found")))?;
         let decoder_ctx =
             ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())?;
         let mut decoder = decoder_ctx.decoder().audio()?;
@@ -954,12 +956,8 @@ impl FFmpegRunner {
 
         // Set channel layout from decoder (default layout matching channel count)
         let channels = decoder.ch_layout().channels();
-        unsafe {
-            ffmpeg_the_third::ffi::av_channel_layout_default(
-                &mut (*audio_encoder.as_mut_ptr()).ch_layout,
-                channels as i32,
-            );
-        }
+        // SAFETY: audio_encoder is a valid pre-open encoder context.
+        Self::set_default_channel_layout(unsafe { audio_encoder.as_mut_ptr() }, channels as i32);
 
         // Set bitrate (CBR)
         if let Some(br_kbps) = opts.bitrate_kbps {
@@ -968,19 +966,14 @@ impl FFmpegRunner {
 
         // Set VBR quality
         if let Some(quality) = opts.quality_scale {
-            unsafe {
-                let ctx = audio_encoder.as_mut_ptr();
-                (*ctx).flags |= ffmpeg_the_third::ffi::AV_CODEC_FLAG_QSCALE as i32;
-                (*ctx).global_quality = quality * ffmpeg_the_third::ffi::FF_QP2LAMBDA;
-            }
+            // SAFETY: audio_encoder is a valid pre-open encoder context.
+            Self::set_vbr_quality(unsafe { audio_encoder.as_mut_ptr() }, quality);
         }
 
         // Set global header flag if required by output format
         if needs_global_header {
-            unsafe {
-                (*audio_encoder.as_mut_ptr()).flags |=
-                    ffmpeg_the_third::ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
-            }
+            // SAFETY: audio_encoder is a valid pre-open encoder context.
+            Self::set_global_header_flag(unsafe { audio_encoder.as_mut_ptr() });
         }
 
         // Open encoder
@@ -990,14 +983,9 @@ impl FFmpegRunner {
             }
         })?;
 
-        // Copy encoder parameters back to output stream via FFI
-        unsafe {
-            let stream_ptr = *(*octx.as_mut_ptr()).streams.add(ost_index);
-            ffmpeg_the_third::ffi::avcodec_parameters_from_context(
-                (*stream_ptr).codecpar,
-                audio_encoder.as_ptr(),
-            );
-        }
+        // Copy encoder parameters back to output stream
+        // SAFETY: audio_encoder is a valid opened encoder context.
+        Self::copy_encoder_params_to_stream(&mut octx, ost_index, unsafe { audio_encoder.as_ptr() });
 
         octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
             message: format!("failed to write output header: {e}"),
@@ -1038,7 +1026,9 @@ impl FFmpegRunner {
         )?;
 
         // Flush filter graph (signal EOF to source)
-        filter_graph.get("in").unwrap().source().flush()?;
+        filter_graph.get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+            .source().flush()?;
         Self::drain_filter_to_encoder(
             &mut filter_graph,
             &mut audio_encoder,
@@ -1160,7 +1150,9 @@ impl FFmpegRunner {
     ) -> Result<()> {
         let mut frame = ffmpeg_the_third::frame::Audio::empty();
         while decoder.receive_frame(&mut frame).is_ok() {
-            filter.get("in").unwrap().source().add(&frame)?;
+            filter.get("in")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                .source().add(&frame)?;
             Self::drain_filter_to_encoder(filter, encoder, octx, ost_index)?;
         }
         Ok(())
@@ -1174,13 +1166,12 @@ impl FFmpegRunner {
         ost_index: usize,
     ) -> Result<()> {
         let mut filtered = ffmpeg_the_third::frame::Audio::empty();
-        while filter
-            .get("out")
-            .unwrap()
-            .sink()
-            .frame(&mut filtered)
-            .is_ok()
-        {
+        loop {
+            let mut out_node = filter.get("out")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'out' not found"))?;
+            if out_node.sink().frame(&mut filtered).is_err() {
+                break;
+            }
             encoder.send_frame(&filtered)?;
             Self::drain_encoder_packets(encoder, octx, ost_index)?;
         }
@@ -1277,11 +1268,7 @@ impl FFmpegRunner {
                     message: format!("failed to add output stream: {e}"),
                 })?;
             ost.set_parameters(ist.parameters());
-            // Reset codec tag for container compatibility
-            unsafe {
-                (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                    .codec_tag = 0;
-            }
+            Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 
         // Build metadata dictionary from input metadata + provided overrides
@@ -1331,7 +1318,9 @@ impl FFmpegRunner {
                 continue;
             }
             let ost_idx = ost_idx as usize;
-            let ost_time_base = octx.stream(ost_idx).unwrap().time_base();
+            let ost_time_base = octx.stream(ost_idx)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("output stream {ost_idx} not found")))?
+                .time_base();
             packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
             packet.set_position(-1);
             packet.set_stream(ost_idx);
@@ -1448,10 +1437,7 @@ impl FFmpegRunner {
                     message: format!("failed to add output stream: {e}"),
                 })?;
             ost.set_parameters(ist.parameters());
-            unsafe {
-                (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                    .codec_tag = 0;
-            }
+            Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 
         // Add thumbnail stream
@@ -1479,13 +1465,7 @@ impl FFmpegRunner {
             // Set codec parameters from thumbnail
             ost.set_parameters(thumb_params);
             // Override to attachment type for MKV
-            unsafe {
-                let codecpar =
-                    ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters;
-                (*codecpar).codec_type =
-                    ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_ATTACHMENT;
-                (*codecpar).codec_tag = 0;
-            }
+            Self::set_stream_as_attachment(ost.parameters().as_ptr());
             // Set attachment metadata
             {
                 let mut dict = ffmpeg_the_third::Dictionary::new();
@@ -1504,12 +1484,8 @@ impl FFmpegRunner {
                 })?;
             thumb_ost_index = ost.index();
             ost.set_parameters(thumb_params);
-            unsafe {
-                let stream_ptr = ost.as_mut_ptr();
-                (*stream_ptr).disposition =
-                    ffmpeg_the_third::ffi::AV_DISPOSITION_ATTACHED_PIC;
-                (*((*stream_ptr).codecpar)).codec_tag = 0;
-            }
+            // SAFETY: ost is a valid output stream in a live output context.
+            Self::set_attached_pic_disposition(unsafe { ost.as_mut_ptr() });
 
             // For MP3: set ID3v2 metadata on the thumbnail stream
             if is_mp3 {
@@ -1541,7 +1517,9 @@ impl FFmpegRunner {
                 continue;
             }
             let ost_idx = ost_idx as usize;
-            let ost_time_base = octx.stream(ost_idx).unwrap().time_base();
+            let ost_time_base = octx.stream(ost_idx)
+                .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("output stream {ost_idx} not found")))?
+                .time_base();
             packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
             packet.set_position(-1);
             packet.set_stream(ost_idx);
@@ -1553,7 +1531,9 @@ impl FFmpegRunner {
         }
 
         // Copy thumbnail packet(s)
-        let thumb_ost_time_base = octx.stream(thumb_ost_index).unwrap().time_base();
+        let thumb_ost_time_base = octx.stream(thumb_ost_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("thumbnail output stream {thumb_ost_index} not found")))?
+            .time_base();
         for result in thumb_ictx.packets() {
             let (stream, mut packet) = result.map_err(|e| {
                 PostProcessError::FFmpegLibraryError {
@@ -1669,13 +1649,23 @@ impl FFmpegRunner {
             .map(|s| s.index());
 
         // Capture stream time bases before any mutable borrows
-        let video_ist_time_base = ictx.stream(video_ist_index).unwrap().time_base();
-        let video_ist_frame_rate = ictx.stream(video_ist_index).unwrap().avg_frame_rate();
-        let audio_ist_time_base =
-            audio_ist_index.map(|i| ictx.stream(i).unwrap().time_base());
+        let video_ist_time_base = ictx.stream(video_ist_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("video input stream {video_ist_index} not found")))?
+            .time_base();
+        let video_ist_frame_rate = ictx.stream(video_ist_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("video input stream {video_ist_index} not found")))?
+            .avg_frame_rate();
+        let audio_ist_time_base = audio_ist_index
+            .map(|i| {
+                ictx.stream(i)
+                    .map(|s| s.time_base())
+                    .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {i} not found")))
+            })
+            .transpose()?;
 
         // Create video decoder
-        let video_ist = ictx.stream(video_ist_index).unwrap();
+        let video_ist = ictx.stream(video_ist_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("video input stream {video_ist_index} not found")))?;
         let video_dec_ctx =
             ffmpeg_the_third::codec::context::Context::from_parameters(video_ist.parameters())?;
         let mut video_decoder = video_dec_ctx.decoder().video()?;
@@ -1740,10 +1730,8 @@ impl FFmpegRunner {
         video_encoder.set_frame_rate(Some(video_ist_frame_rate));
 
         if needs_global_header {
-            unsafe {
-                (*video_encoder.as_mut_ptr()).flags |=
-                    ffmpeg_the_third::ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
-            }
+            // SAFETY: video_encoder is a valid pre-open encoder context.
+            Self::set_global_header_flag(unsafe { video_encoder.as_mut_ptr() });
         }
 
         // Open encoder with preset/CRF options
@@ -1767,13 +1755,8 @@ impl FFmpegRunner {
         )?;
 
         // Copy encoder parameters back to output stream
-        unsafe {
-            let stream_ptr = *(*octx.as_mut_ptr()).streams.add(video_ost_index);
-            ffmpeg_the_third::ffi::avcodec_parameters_from_context(
-                (*stream_ptr).codecpar,
-                video_encoder.as_ptr(),
-            );
-        }
+        // SAFETY: video_encoder is a valid opened encoder context.
+        Self::copy_encoder_params_to_stream(&mut octx, video_ost_index, unsafe { video_encoder.as_ptr() });
 
         // Add audio output stream (stream copy) if audio exists and copy requested
         let audio_ost_index = if opts.audio_copy {
@@ -1787,13 +1770,13 @@ impl FFmpegRunner {
                         .map_err(|e| PostProcessError::FFmpegLibraryError {
                             message: format!("failed to add audio output stream: {e}"),
                         })?;
-                    ost.set_parameters(ictx.stream(audio_idx).unwrap().parameters());
+                    ost.set_parameters(
+                        ictx.stream(audio_idx)
+                            .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio input stream {audio_idx} not found")))?
+                            .parameters(),
+                    );
                     audio_ost_idx = ost.index();
-                    unsafe {
-                        (*(ost.parameters().as_ptr()
-                            as *mut ffmpeg_the_third::ffi::AVCodecParameters))
-                            .codec_tag = 0;
-                    }
+                    Self::clear_codec_tag(ost.parameters().as_ptr());
                 }
                 Some(audio_ost_idx)
             } else {
@@ -1833,8 +1816,12 @@ impl FFmpegRunner {
             } else if Some(ist_index) == audio_ist_index {
                 // Audio: stream copy
                 if let Some(audio_ost_idx) = audio_ost_index {
-                    let ost_time_base = octx.stream(audio_ost_idx).unwrap().time_base();
-                    packet.rescale_ts(audio_ist_time_base.unwrap(), ost_time_base);
+                    let ost_time_base = octx.stream(audio_ost_idx)
+                        .ok_or_else(|| PostProcessError::ffmpeg_failed(format!("audio output stream {audio_ost_idx} not found")))?
+                        .time_base();
+                    let audio_tb = audio_ist_time_base
+                        .ok_or_else(|| PostProcessError::ffmpeg_failed("audio input time base not available"))?;
+                    packet.rescale_ts(audio_tb, ost_time_base);
                     packet.set_position(-1);
                     packet.set_stream(audio_ost_idx);
                     packet.write_interleaved(&mut octx).map_err(|e| {
@@ -1857,7 +1844,9 @@ impl FFmpegRunner {
         )?;
 
         // Flush video filter graph
-        filter_graph.get("in").unwrap().source().flush()?;
+        filter_graph.get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("video filter node 'in' not found"))?
+            .source().flush()?;
         Self::drain_video_filter_to_encoder(
             &mut filter_graph,
             &mut video_encoder,
@@ -1990,7 +1979,9 @@ impl FFmpegRunner {
     ) -> Result<()> {
         let mut frame = ffmpeg_the_third::frame::Video::empty();
         while decoder.receive_frame(&mut frame).is_ok() {
-            filter.get("in").unwrap().source().add(&frame)?;
+            filter.get("in")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("video filter node 'in' not found"))?
+                .source().add(&frame)?;
             Self::drain_video_filter_to_encoder(filter, encoder, octx, ost_index)?;
         }
         Ok(())
@@ -2004,13 +1995,12 @@ impl FFmpegRunner {
         ost_index: usize,
     ) -> Result<()> {
         let mut filtered = ffmpeg_the_third::frame::Video::empty();
-        while filter
-            .get("out")
-            .unwrap()
-            .sink()
-            .frame(&mut filtered)
-            .is_ok()
-        {
+        loop {
+            let mut out_node = filter.get("out")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("video filter node 'out' not found"))?;
+            if out_node.sink().frame(&mut filtered).is_err() {
+                break;
+            }
             encoder.send_frame(&filtered)?;
             Self::drain_video_encoder_packets(encoder, octx, ost_index)?;
         }
@@ -2031,6 +2021,123 @@ impl FFmpegRunner {
         Ok(())
     }
 
+    // -----------------------------------------------------------------------
+    // FFI helper functions
+    //
+    // These encapsulate all `unsafe` FFI operations that lack safe wrappers
+    // in `ffmpeg-the-third`, providing safe call-site signatures. The `unsafe`
+    // blocks are limited to these well-documented helpers.
+    // -----------------------------------------------------------------------
+
+    /// Reset the codec tag to 0 for container compatibility.
+    ///
+    /// When remuxing between containers, the source codec tag may not be valid
+    /// in the target container. Setting it to 0 lets FFmpeg auto-select.
+    fn clear_codec_tag(params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters) {
+        // SAFETY: `params_ptr` points to a valid AVCodecParameters allocated by FFmpeg.
+        // Setting codec_tag to 0 is always valid — it tells FFmpeg to auto-select.
+        unsafe {
+            (*(params_ptr as *mut ffmpeg_the_third::ffi::AVCodecParameters)).codec_tag = 0;
+        }
+    }
+
+    /// Copy encoder parameters back to an output stream.
+    ///
+    /// After opening an encoder, its parameters (codec, dimensions, sample rate,
+    /// etc.) must be copied to the corresponding output stream before writing
+    /// the header.
+    fn copy_encoder_params_to_stream(
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        stream_index: usize,
+        encoder_ptr: *const ffmpeg_the_third::ffi::AVCodecContext,
+    ) {
+        // SAFETY: `octx` owns the output context with a valid stream array.
+        // `stream_index` was obtained from a stream added to this context.
+        // `encoder_ptr` points to a valid, opened encoder context.
+        unsafe {
+            let stream_ptr = *(*octx.as_mut_ptr()).streams.add(stream_index);
+            ffmpeg_the_third::ffi::avcodec_parameters_from_context(
+                (*stream_ptr).codecpar,
+                encoder_ptr,
+            );
+        }
+    }
+
+    /// Set the default channel layout for the given number of channels.
+    fn set_default_channel_layout(
+        encoder_ptr: *mut ffmpeg_the_third::ffi::AVCodecContext,
+        channels: i32,
+    ) {
+        // SAFETY: `encoder_ptr` is a valid, pre-open encoder context.
+        // `av_channel_layout_default` populates the ch_layout field in-place.
+        unsafe {
+            ffmpeg_the_third::ffi::av_channel_layout_default(
+                &mut (*encoder_ptr).ch_layout,
+                channels,
+            );
+        }
+    }
+
+    /// Enable VBR (variable bitrate) quality mode on an encoder.
+    fn set_vbr_quality(
+        encoder_ptr: *mut ffmpeg_the_third::ffi::AVCodecContext,
+        quality: i32,
+    ) {
+        // SAFETY: `encoder_ptr` is a valid, pre-open encoder context.
+        // Setting QSCALE flag + global_quality is the standard way to enable VBR.
+        unsafe {
+            (*encoder_ptr).flags |= ffmpeg_the_third::ffi::AV_CODEC_FLAG_QSCALE as i32;
+            (*encoder_ptr).global_quality = quality * ffmpeg_the_third::ffi::FF_QP2LAMBDA;
+        }
+    }
+
+    /// Set the global header flag on an encoder.
+    ///
+    /// Required when the output format needs codec parameters in the container
+    /// header rather than in each packet (e.g., MP4, MKV).
+    fn set_global_header_flag(encoder_ptr: *mut ffmpeg_the_third::ffi::AVCodecContext) {
+        // SAFETY: `encoder_ptr` is a valid, pre-open encoder context.
+        // This flag is required by certain container formats.
+        unsafe {
+            (*encoder_ptr).flags |=
+                ffmpeg_the_third::ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
+        }
+    }
+
+    /// Configure a stream as an MKV attachment (for embedded thumbnails).
+    ///
+    /// Sets the codec type to `ATTACHMENT` and clears the codec tag.
+    fn set_stream_as_attachment(
+        params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters,
+    ) {
+        // SAFETY: `params_ptr` points to a valid AVCodecParameters for an output stream.
+        // Setting codec_type to ATTACHMENT and clearing codec_tag is the standard
+        // way to embed attachments in Matroska containers.
+        unsafe {
+            let codecpar = params_ptr as *mut ffmpeg_the_third::ffi::AVCodecParameters;
+            (*codecpar).codec_type =
+                ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_ATTACHMENT;
+            (*codecpar).codec_tag = 0;
+        }
+    }
+
+    /// Configure a stream with `ATTACHED_PIC` disposition (for cover art).
+    ///
+    /// Sets the stream disposition and clears the codec tag. Used for MP4,
+    /// FLAC, OGG, and other containers that embed cover art as a video stream
+    /// with special disposition.
+    fn set_attached_pic_disposition(
+        stream_ptr: *mut ffmpeg_the_third::ffi::AVStream,
+    ) {
+        // SAFETY: `stream_ptr` is a valid output stream pointer from a live
+        // output context. Setting disposition and clearing codec_tag configures
+        // the stream as cover art.
+        unsafe {
+            (*stream_ptr).disposition =
+                ffmpeg_the_third::ffi::AV_DISPOSITION_ATTACHED_PIC;
+            (*((*stream_ptr).codecpar)).codec_tag = 0;
+        }
+    }
 }
 
 impl MediaInfo {

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -179,6 +179,21 @@ pub struct AudioExtractOptions {
     pub quality_scale: Option<i32>,
 }
 
+/// Options for video conversion/transcoding.
+#[derive(Debug, Clone, Default)]
+pub struct VideoConvertOptions {
+    /// If true, remux only (stream copy, no re-encoding).
+    pub remux_only: bool,
+    /// Video encoder name (e.g., "libx264", "libx265", "libvpx-vp9").
+    pub video_codec: Option<String>,
+    /// Encoder preset (e.g., "medium", "fast", "slow").
+    pub preset: Option<String>,
+    /// Constant Rate Factor for quality-based encoding.
+    pub crf: Option<u32>,
+    /// If true, copy audio stream without re-encoding.
+    pub audio_copy: bool,
+}
+
 /// Media file information from FFprobe.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MediaInfo {
@@ -1266,6 +1281,443 @@ impl FFmpegRunner {
     /// Receive encoded packets from encoder and write to output.
     fn drain_encoder_packets(
         encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut packet = ffmpeg_the_third::Packet::empty();
+        while encoder.receive_packet(&mut packet).is_ok() {
+            packet.set_stream(ost_index);
+            packet.write_interleaved(octx)?;
+        }
+        Ok(())
+    }
+
+    /// Convert a video file, either by remuxing or transcoding.
+    ///
+    /// Uses `opts.remux_only` to determine whether to stream-copy or transcode.
+    /// For transcoding, encodes video with the specified codec while optionally
+    /// copying the audio stream unchanged.
+    pub async fn convert_video(
+        &self,
+        input: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        opts: &VideoConvertOptions,
+    ) -> Result<()> {
+        let input = input.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let opts = opts.clone();
+        tokio::task::spawn_blocking(move || Self::convert_video_sync(&input, &output, &opts))
+            .await
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("convert_video task join error: {e}"),
+            })?
+    }
+
+    /// Convert video synchronously (dispatches to remux or transcode).
+    fn convert_video_sync(
+        input: &Path,
+        output: &Path,
+        opts: &VideoConvertOptions,
+    ) -> Result<()> {
+        if opts.remux_only {
+            // Determine if output is MP4/MOV for faststart
+            let ext = output
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            let remux_opts = RemuxOptions {
+                faststart: ext.eq_ignore_ascii_case("mp4") || ext.eq_ignore_ascii_case("mov"),
+                ..Default::default()
+            };
+            Self::remux_sync(input, output, &remux_opts)
+        } else {
+            Self::convert_video_transcode_sync(input, output, opts)
+        }
+    }
+
+    /// Transcode video to a target codec, optionally copying audio.
+    ///
+    /// Decodes video frames, converts pixel format through a filter graph,
+    /// and encodes with the target video codec. Audio is stream-copied if
+    /// `opts.audio_copy` is true.
+    fn convert_video_transcode_sync(
+        input: &Path,
+        output: &Path,
+        opts: &VideoConvertOptions,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        // Open input
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        // Find video and audio stream indices
+        let video_ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Video)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoVideoStream)?;
+
+        let audio_ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index());
+
+        // Capture stream time bases before any mutable borrows
+        let video_ist_time_base = ictx.stream(video_ist_index).unwrap().time_base();
+        let video_ist_frame_rate = ictx.stream(video_ist_index).unwrap().avg_frame_rate();
+        let audio_ist_time_base =
+            audio_ist_index.map(|i| ictx.stream(i).unwrap().time_base());
+
+        // Create video decoder
+        let video_ist = ictx.stream(video_ist_index).unwrap();
+        let video_dec_ctx =
+            ffmpeg_the_third::codec::context::Context::from_parameters(video_ist.parameters())?;
+        let mut video_decoder = video_dec_ctx.decoder().video()?;
+
+        // Open output
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        // Find video encoder
+        let video_codec_name = opts.video_codec.as_deref().unwrap_or("libx264");
+        let video_enc_codec =
+            ffmpeg_the_third::encoder::find_by_name(video_codec_name).ok_or_else(|| {
+                PostProcessError::UnsupportedCodec {
+                    codec: video_codec_name.to_string(),
+                    operation: "video conversion".into(),
+                }
+            })?;
+
+        // Check global header flag before mutable stream borrows
+        let needs_global_header = octx
+            .format()
+            .flags()
+            .contains(ffmpeg_the_third::format::Flags::GLOBAL_HEADER);
+
+        // Add video output stream (scoped to release octx borrow)
+        let video_ost_index;
+        let video_enc_context;
+        {
+            let ost = octx.add_stream(video_enc_codec).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add video output stream: {e}"),
+                }
+            })?;
+            video_ost_index = ost.index();
+            video_enc_context =
+                ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
+        }
+
+        // Configure video encoder
+        let mut video_encoder = video_enc_context.encoder().video()?;
+        video_encoder.set_width(video_decoder.width());
+        video_encoder.set_height(video_decoder.height());
+
+        let target_pix_fmt =
+            Self::pick_video_pixel_format(&video_enc_codec, video_decoder.format());
+        video_encoder.set_format(target_pix_fmt);
+
+        // Set time base from frame rate (inverse of fps)
+        if video_ist_frame_rate.numerator() > 0 && video_ist_frame_rate.denominator() > 0 {
+            video_encoder.set_time_base(ffmpeg_the_third::Rational(
+                video_ist_frame_rate.denominator(),
+                video_ist_frame_rate.numerator(),
+            ));
+        } else {
+            video_encoder.set_time_base(video_ist_time_base);
+        }
+
+        // Set frame rate
+        video_encoder.set_frame_rate(Some(video_ist_frame_rate));
+
+        if needs_global_header {
+            unsafe {
+                (*video_encoder.as_mut_ptr()).flags |=
+                    ffmpeg_the_third::ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
+            }
+        }
+
+        // Open encoder with preset/CRF options
+        let mut enc_opts = ffmpeg_the_third::Dictionary::new();
+        if let Some(ref preset) = opts.preset {
+            enc_opts.set("preset", preset);
+        }
+        if let Some(crf) = opts.crf {
+            enc_opts.set("crf", &crf.to_string());
+        }
+
+        // For VP9: set bitrate to 0 for pure CRF mode
+        if video_codec_name.contains("vpx") && opts.crf.is_some() {
+            video_encoder.set_bit_rate(0);
+        }
+
+        let mut video_encoder = video_encoder.open_as_with(video_enc_codec, enc_opts).map_err(
+            |e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open video encoder: {e}"),
+            },
+        )?;
+
+        // Copy encoder parameters back to output stream
+        unsafe {
+            let stream_ptr = *(*octx.as_mut_ptr()).streams.add(video_ost_index);
+            ffmpeg_the_third::ffi::avcodec_parameters_from_context(
+                (*stream_ptr).codecpar,
+                video_encoder.as_ptr(),
+            );
+        }
+
+        // Add audio output stream (stream copy) if audio exists and copy requested
+        let audio_ost_index = if opts.audio_copy {
+            if let Some(audio_idx) = audio_ist_index {
+                let audio_ost_idx;
+                {
+                    let mut ost = octx
+                        .add_stream(ffmpeg_the_third::encoder::find(
+                            ffmpeg_the_third::codec::Id::None,
+                        ))
+                        .map_err(|e| PostProcessError::FFmpegLibraryError {
+                            message: format!("failed to add audio output stream: {e}"),
+                        })?;
+                    ost.set_parameters(ictx.stream(audio_idx).unwrap().parameters());
+                    audio_ost_idx = ost.index();
+                    unsafe {
+                        (*(ost.parameters().as_ptr()
+                            as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                            .codec_tag = 0;
+                    }
+                }
+                Some(audio_ost_idx)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output header: {e}"),
+        })?;
+
+        // Build video filter graph for pixel format conversion
+        let mut filter_graph =
+            Self::build_video_filter(&video_decoder, &video_encoder, video_ist_time_base)?;
+
+        // Process packets: video → decode/filter/encode, audio → copy
+        for result in ictx.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read packet: {e}"),
+                }
+            })?;
+            let ist_index = stream.index();
+
+            if ist_index == video_ist_index {
+                // Video: decode → filter → encode → write
+                video_decoder.send_packet(&packet)?;
+                Self::receive_and_process_video(
+                    &mut video_decoder,
+                    &mut filter_graph,
+                    &mut video_encoder,
+                    &mut octx,
+                    video_ost_index,
+                )?;
+            } else if Some(ist_index) == audio_ist_index {
+                // Audio: stream copy
+                if let Some(audio_ost_idx) = audio_ost_index {
+                    let ost_time_base = octx.stream(audio_ost_idx).unwrap().time_base();
+                    packet.rescale_ts(audio_ist_time_base.unwrap(), ost_time_base);
+                    packet.set_position(-1);
+                    packet.set_stream(audio_ost_idx);
+                    packet.write_interleaved(&mut octx).map_err(|e| {
+                        PostProcessError::FFmpegLibraryError {
+                            message: format!("failed to write audio packet: {e}"),
+                        }
+                    })?;
+                }
+            }
+        }
+
+        // Flush video decoder
+        video_decoder.send_eof()?;
+        Self::receive_and_process_video(
+            &mut video_decoder,
+            &mut filter_graph,
+            &mut video_encoder,
+            &mut octx,
+            video_ost_index,
+        )?;
+
+        // Flush video filter graph
+        filter_graph.get("in").unwrap().source().flush()?;
+        Self::drain_video_filter_to_encoder(
+            &mut filter_graph,
+            &mut video_encoder,
+            &mut octx,
+            video_ost_index,
+        )?;
+
+        // Flush video encoder
+        video_encoder.send_eof()?;
+        Self::drain_video_encoder_packets(&mut video_encoder, &mut octx, video_ost_index)?;
+
+        octx.write_trailer().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output trailer: {e}"),
+        })?;
+
+        Ok(())
+    }
+
+    /// Pick a pixel format supported by the video encoder, preferring the decoder's format.
+    fn pick_video_pixel_format(
+        codec: &ffmpeg_the_third::Codec,
+        preferred: ffmpeg_the_third::format::Pixel,
+    ) -> ffmpeg_the_third::format::Pixel {
+        unsafe {
+            let ptr = codec.as_ptr();
+            let pix_fmts = (*ptr).pix_fmts;
+            if pix_fmts.is_null() {
+                return preferred;
+            }
+
+            let mut i = 0;
+            let mut first = None;
+            loop {
+                let fmt = *pix_fmts.offset(i);
+                if fmt == ffmpeg_the_third::ffi::AVPixelFormat::AV_PIX_FMT_NONE {
+                    break;
+                }
+                let pixel = ffmpeg_the_third::format::Pixel::from(fmt);
+                if first.is_none() {
+                    first = Some(pixel);
+                }
+                if pixel == preferred {
+                    return preferred;
+                }
+                i += 1;
+            }
+
+            first.unwrap_or(preferred)
+        }
+    }
+
+    /// Build a video filter graph for pixel format conversion.
+    ///
+    /// Uses `buffer` → `format` → `buffersink` to convert pixel format
+    /// from decoder output to encoder input format.
+    fn build_video_filter(
+        decoder: &ffmpeg_the_third::decoder::Video,
+        encoder: &ffmpeg_the_third::encoder::video::Video,
+        ist_time_base: ffmpeg_the_third::Rational,
+    ) -> Result<ffmpeg_the_third::filter::Graph> {
+        let mut graph = ffmpeg_the_third::filter::Graph::new();
+
+        let buffer = ffmpeg_the_third::filter::find("buffer").ok_or_else(|| {
+            PostProcessError::ffmpeg_failed("buffer filter not found")
+        })?;
+        let buffersink = ffmpeg_the_third::filter::find("buffersink").ok_or_else(|| {
+            PostProcessError::ffmpeg_failed("buffersink filter not found")
+        })?;
+
+        // Pixel aspect ratio (default 1:1 if unknown)
+        let sar = decoder.aspect_ratio();
+        let sar_num = if sar.numerator() > 0 {
+            sar.numerator()
+        } else {
+            1
+        };
+        let sar_den = if sar.denominator() > 0 {
+            sar.denominator()
+        } else {
+            1
+        };
+
+        let args = format!(
+            "video_size={}x{}:pix_fmt={}:time_base={}/{}:pixel_aspect={}/{}",
+            decoder.width(),
+            decoder.height(),
+            decoder.format() as i32,
+            ist_time_base.numerator(),
+            ist_time_base.denominator(),
+            sar_num,
+            sar_den,
+        );
+
+        graph.add(&buffer, "in", &args).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add buffer filter: {e}"),
+            }
+        })?;
+        graph.add(&buffersink, "out", "").map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add buffersink filter: {e}"),
+            }
+        })?;
+
+        // Convert pixel format to match encoder's requirement
+        let enc_pix_fmt_name = encoder
+            .format()
+            .descriptor()
+            .map(|d| d.name().to_string())
+            .unwrap_or_else(|| "yuv420p".to_string());
+
+        let format_spec = format!("format=pix_fmts={enc_pix_fmt_name}");
+
+        graph
+            .output("out", 0)?
+            .input("in", 0)?
+            .parse(&format_spec)?;
+        graph.validate()?;
+
+        Ok(graph)
+    }
+
+    /// Receive decoded video frames, push through filter, encode, and write.
+    fn receive_and_process_video(
+        decoder: &mut ffmpeg_the_third::decoder::Video,
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::video::Video,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut frame = ffmpeg_the_third::frame::Video::empty();
+        while decoder.receive_frame(&mut frame).is_ok() {
+            filter.get("in").unwrap().source().add(&frame)?;
+            Self::drain_video_filter_to_encoder(filter, encoder, octx, ost_index)?;
+        }
+        Ok(())
+    }
+
+    /// Pull filtered video frames from filter graph, encode, and write.
+    fn drain_video_filter_to_encoder(
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::video::Video,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut filtered = ffmpeg_the_third::frame::Video::empty();
+        while filter
+            .get("out")
+            .unwrap()
+            .sink()
+            .frame(&mut filtered)
+            .is_ok()
+        {
+            encoder.send_frame(&filtered)?;
+            Self::drain_video_encoder_packets(encoder, octx, ost_index)?;
+        }
+        Ok(())
+    }
+
+    /// Receive encoded video packets from encoder and write to output.
+    fn drain_video_encoder_packets(
+        encoder: &mut ffmpeg_the_third::encoder::video::Video,
         octx: &mut ffmpeg_the_third::format::context::Output,
         ost_index: usize,
     ) -> Result<()> {

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -194,6 +194,19 @@ pub struct VideoConvertOptions {
     pub audio_copy: bool,
 }
 
+/// A chapter entry for metadata embedding.
+#[derive(Debug, Clone)]
+pub struct ChapterEntry {
+    /// Chapter ID (unique, typically sequential starting from 0).
+    pub id: i64,
+    /// Start time in milliseconds.
+    pub start_ms: i64,
+    /// End time in milliseconds.
+    pub end_ms: i64,
+    /// Chapter title.
+    pub title: String,
+}
+
 /// Media file information from FFprobe.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MediaInfo {
@@ -1289,6 +1302,154 @@ impl FFmpegRunner {
             packet.set_stream(ost_index);
             packet.write_interleaved(octx)?;
         }
+        Ok(())
+    }
+
+    /// Embed metadata and chapters into a media file via stream copy (remux).
+    ///
+    /// Copies all streams without re-encoding, sets format-level metadata via
+    /// `Dictionary`, and adds chapters via `add_chapter()`. No temporary
+    /// FFMETADATA1 file is needed.
+    pub async fn embed_metadata(
+        &self,
+        input: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        metadata: &HashMap<String, String>,
+        chapters: &[ChapterEntry],
+    ) -> Result<()> {
+        let input = input.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let metadata = metadata.clone();
+        let chapters: Vec<ChapterEntry> = chapters.to_vec();
+        tokio::task::spawn_blocking(move || {
+            Self::embed_metadata_sync(&input, &output, &metadata, &chapters)
+        })
+        .await
+        .map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("embed_metadata task join error: {e}"),
+        })?
+    }
+
+    /// Embed metadata and chapters synchronously.
+    ///
+    /// Remuxes (stream copies) the input to output while:
+    /// - Setting format-level metadata from the provided `HashMap`
+    /// - Adding chapters with millisecond precision (time_base = 1/1000)
+    fn embed_metadata_sync(
+        input: &Path,
+        output: &Path,
+        metadata: &HashMap<String, String>,
+        chapters: &[ChapterEntry],
+    ) -> Result<()> {
+        ensure_init()?;
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        // Map all streams (stream copy)
+        let stream_count = ictx.streams().count();
+        let mut stream_mapping: Vec<i32> = vec![-1; stream_count];
+        let mut ist_time_bases = vec![ffmpeg_the_third::Rational(0, 1); stream_count];
+        let mut ost_index: i32 = 0;
+
+        for (ist_index, ist) in ictx.streams().enumerate() {
+            let medium = ist.parameters().medium();
+            if medium != ffmpeg_the_third::media::Type::Video
+                && medium != ffmpeg_the_third::media::Type::Audio
+            {
+                continue;
+            }
+
+            stream_mapping[ist_index] = ost_index;
+            ist_time_bases[ist_index] = ist.time_base();
+            ost_index += 1;
+
+            let mut ost = octx
+                .add_stream(ffmpeg_the_third::encoder::find(
+                    ffmpeg_the_third::codec::Id::None,
+                ))
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to add output stream: {e}"),
+                })?;
+            ost.set_parameters(ist.parameters());
+            // Reset codec tag for container compatibility
+            unsafe {
+                (*(ost.parameters().as_ptr() as *mut ffmpeg_the_third::ffi::AVCodecParameters))
+                    .codec_tag = 0;
+            }
+        }
+
+        // Build metadata dictionary from input metadata + provided overrides
+        let mut dict = ffmpeg_the_third::Dictionary::new();
+
+        // Copy existing metadata from input first
+        for (k, v) in ictx.metadata().iter() {
+            dict.set(k, v);
+        }
+
+        // Apply provided metadata (overrides existing keys)
+        for (k, v) in metadata {
+            dict.set(k, v);
+        }
+
+        octx.set_metadata(dict);
+
+        // Add chapters (time_base = 1/1000 for millisecond precision)
+        for ch in chapters {
+            octx.add_chapter(
+                ch.id,
+                ffmpeg_the_third::Rational(1, 1000),
+                ch.start_ms,
+                ch.end_ms,
+                &ch.title,
+            )
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add chapter '{}': {e}", ch.title),
+            })?;
+        }
+
+        // Write header
+        octx.write_header().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output header: {e}"),
+        })?;
+
+        // Copy packets
+        for result in ictx.packets() {
+            let (stream, mut packet) = result.map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read packet: {e}"),
+                }
+            })?;
+            let ist_index = stream.index();
+            let ost_idx = stream_mapping[ist_index];
+            if ost_idx < 0 {
+                continue;
+            }
+            let ost_idx = ost_idx as usize;
+            let ost_time_base = octx.stream(ost_idx).unwrap().time_base();
+            packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
+            packet.set_position(-1);
+            packet.set_stream(ost_idx);
+            packet.write_interleaved(&mut octx).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write packet: {e}"),
+                }
+            })?;
+        }
+
+        octx.write_trailer().map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output trailer: {e}"),
+        })?;
+
         Ok(())
     }
 

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -46,7 +46,11 @@ static FFMPEG_INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
 /// Safe to call multiple times — only the first call performs initialization.
 pub fn ensure_init() -> Result<()> {
     let result = FFMPEG_INIT.get_or_init(|| {
-        ffmpeg_the_third::init().map_err(|e| format!("ffmpeg_the_third::init() failed: {e}"))
+        ffmpeg_the_third::init().map_err(|e| format!("ffmpeg_the_third::init() failed: {e}"))?;
+        // Suppress FFmpeg's internal diagnostic messages (e.g. mpegts stream timing warnings).
+        // Only show actual errors — we handle logging ourselves.
+        ffmpeg_the_third::log::set_level(ffmpeg_the_third::log::Level::Error);
+        Ok(())
     });
 
     match result {

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -137,7 +137,8 @@ pub mod registry;
 // Re-export main types
 pub use error::{PostProcessError, Result};
 pub use ffmpeg::{
-    AudioExtractOptions, FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo, VideoConvertOptions,
+    AudioExtractOptions, ChapterEntry, FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo,
+    VideoConvertOptions,
 };
 pub use registry::{PostProcessorRegistry, PostProcessorRegistryTrait};
 

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -136,7 +136,7 @@ pub mod registry;
 
 // Re-export main types
 pub use error::{PostProcessError, Result};
-pub use ffmpeg::{FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo};
+pub use ffmpeg::{AudioExtractOptions, FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo};
 pub use registry::{PostProcessorRegistry, PostProcessorRegistryTrait};
 
 // Re-export processor types

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -136,7 +136,7 @@ pub mod registry;
 
 // Re-export main types
 pub use error::{PostProcessError, Result};
-pub use ffmpeg::{FFmpegRunner, MediaInfo, StreamInfo};
+pub use ffmpeg::{FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo};
 pub use registry::{PostProcessorRegistry, PostProcessorRegistryTrait};
 
 // Re-export processor types

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -82,7 +82,7 @@
 //!
 //! ## FFmpeg Integration
 //!
-//! The crate provides a comprehensive FFmpeg wrapper:
+//! The crate provides comprehensive FFmpeg operations via library bindings:
 //!
 //! ```no_run
 //! use rdlp_postprocess::ffmpeg::FFmpegRunner;
@@ -96,9 +96,6 @@
 //! println!("Video codec: {:?}", info.video_codec);
 //! println!("Audio codec: {:?}", info.audio_codec);
 //! println!("Resolution: {:?}", info.resolution_string());
-//!
-//! // Run custom FFmpeg command
-//! ffmpeg.run(&["-i", "input.mp4", "-c:v", "copy", "-an", "video_only.mp4"]).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -122,7 +119,9 @@
 //!
 //! fn example() -> Result<()> {
 //!     // Errors are descriptive and actionable
-//!     Err(PostProcessError::FFmpegNotFound)
+//!     Err(PostProcessError::FFmpegInitFailed {
+//!         message: "FFmpeg library not available".to_string(),
+//!     })
 //! }
 //! ```
 

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -136,7 +136,9 @@ pub mod registry;
 
 // Re-export main types
 pub use error::{PostProcessError, Result};
-pub use ffmpeg::{AudioExtractOptions, FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo};
+pub use ffmpeg::{
+    AudioExtractOptions, FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo, VideoConvertOptions,
+};
 pub use registry::{PostProcessorRegistry, PostProcessorRegistryTrait};
 
 // Re-export processor types

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -73,7 +73,7 @@
 //!         true
 //!     }
 //!
-//!     async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult> {
+//!     async fn process(&self, info: &InfoDict, files: Vec<PathBuf>, _config: &PostProcessConfig) -> Result<PostProcessResult> {
 //!         // Custom processing logic
 //!         Ok(PostProcessResult::new(info.clone(), files))
 //!     }

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -173,7 +173,12 @@ impl PostProcessor for EmbedThumbnail {
         config.embed_thumbnail
     }
 
-    async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult> {
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        _config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
         }

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -1,10 +1,12 @@
 //! Thumbnail embedding post-processor.
 //!
-//! Embeds thumbnail images into media files. Supports different embedding
-//! methods based on the container format:
-//! - MP4/M4A: Uses FFmpeg with cover art disposition
-//! - MKV/MKA: Uses FFmpeg attachment
-//! - MP3: Uses FFmpeg with ID3v2 tags
+//! Embeds thumbnail images into media files using `ffmpeg-the-third` library
+//! bindings (no CLI process spawning). Supports different embedding methods
+//! based on the container format:
+//! - MP4/M4A/MOV: Cover art with `ATTACHED_PIC` disposition
+//! - MKV/MKA: Attachment stream with mimetype metadata
+//! - MP3: Video stream with ID3v2 metadata
+//! - FLAC/OGG/Opus: Video stream with `ATTACHED_PIC` disposition
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -42,7 +44,7 @@ impl EmbedThumbnail {
     }
 
     /// Find a thumbnail file for the given media file.
-    fn find_thumbnail(&self, media_file: &Path) -> Option<PathBuf> {
+    fn find_thumbnail(media_file: &Path) -> Option<PathBuf> {
         let stem = media_file.file_stem()?.to_str()?;
         let parent = media_file.parent()?;
 
@@ -61,101 +63,6 @@ impl EmbedThumbnail {
         SUPPORTED_CONTAINERS
             .iter()
             .any(|c| c.eq_ignore_ascii_case(extension))
-    }
-
-    /// Build FFmpeg arguments for embedding thumbnail.
-    fn build_embed_args(
-        &self,
-        media_file: &Path,
-        thumbnail_file: &Path,
-        output_file: &Path,
-        container: &str,
-    ) -> Vec<String> {
-        // Input files
-        let mut args = vec![
-            "-i".to_string(),
-            media_file.to_string_lossy().to_string(),
-            "-i".to_string(),
-            thumbnail_file.to_string_lossy().to_string(),
-        ];
-
-        match container.to_lowercase().as_str() {
-            // MP4/M4A/MOV - use cover art
-            "mp4" | "m4a" | "m4v" | "mov" => {
-                args.push("-map".to_string());
-                args.push("0".to_string());
-                args.push("-map".to_string());
-                args.push("1".to_string());
-                args.push("-c".to_string());
-                args.push("copy".to_string());
-                args.push("-c:v:1".to_string());
-                args.push("mjpeg".to_string()); // Convert to JPEG for compatibility
-                args.push("-disposition:v:1".to_string());
-                args.push("attached_pic".to_string());
-            }
-            // MKV/MKA - use attachment
-            "mkv" | "mka" => {
-                args.push("-map".to_string());
-                args.push("0".to_string());
-                args.push("-c".to_string());
-                args.push("copy".to_string());
-                args.push("-attach".to_string());
-                args.push(thumbnail_file.to_string_lossy().to_string());
-                args.push("-metadata:s:t".to_string());
-                args.push("mimetype=image/jpeg".to_string());
-                args.push("-metadata:s:t".to_string());
-                args.push("filename=cover.jpg".to_string());
-            }
-            // MP3 - use ID3v2 APIC frame
-            "mp3" => {
-                args.push("-i".to_string());
-                args.push(thumbnail_file.to_string_lossy().to_string());
-                // Remove the duplicate -i we added above
-                args.remove(args.len() - 1);
-                args.remove(args.len() - 1);
-                args.push("-i".to_string());
-                args.push(thumbnail_file.to_string_lossy().to_string());
-
-                args.push("-map".to_string());
-                args.push("0:a".to_string());
-                args.push("-map".to_string());
-                args.push("1:v".to_string());
-                args.push("-c:a".to_string());
-                args.push("copy".to_string());
-                args.push("-c:v".to_string());
-                args.push("mjpeg".to_string());
-                args.push("-id3v2_version".to_string());
-                args.push("3".to_string());
-                args.push("-metadata:s:v".to_string());
-                args.push("title=Album cover".to_string());
-                args.push("-metadata:s:v".to_string());
-                args.push("comment=Cover (front)".to_string());
-            }
-            // FLAC/OGG/Opus - use metadata picture
-            "flac" | "ogg" | "opus" => {
-                args.push("-map".to_string());
-                args.push("0".to_string());
-                args.push("-map".to_string());
-                args.push("1".to_string());
-                args.push("-c".to_string());
-                args.push("copy".to_string());
-                args.push("-disposition:v".to_string());
-                args.push("attached_pic".to_string());
-            }
-            _ => {
-                // Fallback - try attachment method
-                args.push("-map".to_string());
-                args.push("0".to_string());
-                args.push("-c".to_string());
-                args.push("copy".to_string());
-                args.push("-attach".to_string());
-                args.push(thumbnail_file.to_string_lossy().to_string());
-            }
-        }
-
-        args.push(output_file.to_string_lossy().to_string());
-
-        args
     }
 }
 
@@ -196,7 +103,7 @@ impl PostProcessor for EmbedThumbnail {
         }
 
         // Find thumbnail file
-        let thumbnail_file = match self.find_thumbnail(media_file) {
+        let thumbnail_file = match Self::find_thumbnail(media_file) {
             Some(path) => path,
             None => {
                 debug!(file:? = media_file.display(); "No thumbnail file found");
@@ -213,12 +120,13 @@ impl PostProcessor for EmbedThumbnail {
         // Create temp output file
         let temp_output = media_file.with_extension(format!("thumb.{extension}"));
 
-        // Build and run FFmpeg command
-        let args = self.build_embed_args(media_file, &thumbnail_file, &temp_output, extension);
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        match self.ffmpeg.run(&args_refs).await {
-            Ok(_) => {
+        // Embed via library bindings
+        match self
+            .ffmpeg
+            .embed_thumbnail(media_file, &thumbnail_file, &temp_output, extension)
+            .await
+        {
+            Ok(()) => {
                 // Replace original with temp
                 tokio::fs::rename(&temp_output, media_file).await?;
                 info!(file:? = media_file.display(); "Thumbnail embedded");
@@ -252,41 +160,10 @@ mod tests {
         assert!(EmbedThumbnail::supports_thumbnail("MP4"));
         assert!(EmbedThumbnail::supports_thumbnail("mkv"));
         assert!(EmbedThumbnail::supports_thumbnail("mp3"));
+        assert!(EmbedThumbnail::supports_thumbnail("flac"));
+        assert!(EmbedThumbnail::supports_thumbnail("ogg"));
+        assert!(EmbedThumbnail::supports_thumbnail("opus"));
         assert!(!EmbedThumbnail::supports_thumbnail("txt"));
         assert!(!EmbedThumbnail::supports_thumbnail("avi"));
-    }
-
-    #[test]
-    fn test_build_embed_args_mp4() {
-        if let Ok(ffmpeg) = FFmpegRunner::new() {
-            let processor = EmbedThumbnail::new(Arc::new(ffmpeg));
-
-            let args = processor.build_embed_args(
-                Path::new("video.mp4"),
-                Path::new("video.jpg"),
-                Path::new("output.mp4"),
-                "mp4",
-            );
-
-            assert!(args.contains(&"-disposition:v:1".to_string()));
-            assert!(args.contains(&"attached_pic".to_string()));
-        }
-    }
-
-    #[test]
-    fn test_build_embed_args_mkv() {
-        if let Ok(ffmpeg) = FFmpegRunner::new() {
-            let processor = EmbedThumbnail::new(Arc::new(ffmpeg));
-
-            let args = processor.build_embed_args(
-                Path::new("video.mkv"),
-                Path::new("video.jpg"),
-                Path::new("output.mkv"),
-                "mkv",
-            );
-
-            assert!(args.contains(&"-attach".to_string()));
-            assert!(args.iter().any(|a| a.contains("mimetype=")));
-        }
     }
 }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -86,7 +86,12 @@ impl PostProcessor for FFmpegExtractAudio {
         config.extract_audio
     }
 
-    async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult> {
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
         }
@@ -100,7 +105,6 @@ impl PostProcessor for FFmpegExtractAudio {
         }
 
         // Determine target format
-        let config = PostProcessConfig::default();
         let target_format = config.audio_format.as_deref().unwrap_or("mp3");
         let codec_config =
             get_audio_codec(target_format).ok_or_else(|| PostProcessError::UnsupportedFormat {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -1,6 +1,7 @@
 //! FFmpeg audio extraction post-processor.
 //!
-//! Extracts and optionally converts audio from video files.
+//! Extracts and optionally converts audio from video files using
+//! `ffmpeg-the-third` library bindings (no CLI process spawning).
 //! Supports various output formats including MP3, AAC, Opus, FLAC, etc.
 
 use std::path::PathBuf;
@@ -11,7 +12,7 @@ use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use crate::error::PostProcessError;
-use crate::ffmpeg::{FFmpegRunner, get_audio_codec};
+use crate::ffmpeg::{get_audio_codec, AudioCodecConfig, AudioExtractOptions, FFmpegRunner};
 
 /// Post-processor that extracts audio from video files.
 ///
@@ -31,44 +32,40 @@ impl FFmpegExtractAudio {
         Self { ffmpeg }
     }
 
-    /// Build quality arguments for the specified codec.
-    fn build_quality_args(&self, codec: &str, quality: Option<&str>) -> Vec<String> {
-        let mut args = Vec::new();
-
-        let codec_config = match get_audio_codec(codec) {
-            Some(c) => c,
-            None => return args,
+    /// Build extraction options from codec config and quality string.
+    fn build_extract_options(
+        codec_config: &AudioCodecConfig,
+        can_copy: bool,
+        quality: Option<&str>,
+    ) -> AudioExtractOptions {
+        let mut opts = AudioExtractOptions {
+            encoder_name: codec_config.encoder.map(String::from),
+            copy: can_copy,
+            ..Default::default()
         };
 
-        let quality = match quality {
-            Some(q) => q,
-            None => return args,
-        };
-
-        // Parse quality as number
-        if let Ok(q_num) = quality.parse::<u32>() {
-            // If it's a bitrate (e.g., "192" for 192kbps)
-            if let Some((min, max)) = codec_config.bitrate_range {
-                let bitrate = q_num.clamp(min, max);
-                args.push("-b:a".to_string());
-                args.push(format!("{bitrate}k"));
-            }
-        } else if let Some((worst, best)) = codec_config.quality_scale {
-            // Quality scale (VBR)
-            // Map quality string to scale
-            let scale = match quality.to_lowercase().as_str() {
-                "best" | "0" => best,
-                "worst" | "9" | "10" => worst,
-                _ => {
-                    // Try to parse as scale value
-                    quality.parse().unwrap_or((worst + best) / 2)
-                }
-            };
-            args.push("-q:a".to_string());
-            args.push(scale.to_string());
+        if can_copy {
+            return opts;
         }
 
-        args
+        if let Some(q) = quality {
+            // Try to parse as numeric bitrate (e.g., "192" for 192kbps)
+            if let Ok(q_num) = q.parse::<u32>() {
+                if let Some((min, max)) = codec_config.bitrate_range {
+                    opts.bitrate_kbps = Some(q_num.clamp(min, max));
+                }
+            } else if let Some((worst, best)) = codec_config.quality_scale {
+                // Non-numeric = VBR quality string (e.g., "best", "worst")
+                let scale = match q.to_lowercase().as_str() {
+                    "best" | "0" => best,
+                    "worst" | "9" | "10" => worst,
+                    _ => q.parse().unwrap_or((worst + best) / 2),
+                };
+                opts.quality_scale = Some(scale as i32);
+            }
+        }
+
+        opts
     }
 }
 
@@ -124,38 +121,24 @@ impl PostProcessor for FFmpegExtractAudio {
             .as_ref()
             .is_some_and(|c| c == target_format || (c == "aac" && target_format == "m4a"));
 
+        if can_copy {
+            debug!(format:? = target_format; "Audio codec matches target, copying stream");
+        }
+
         // Build output path
         let output_path = input_file.with_extension(codec_config.extension);
 
-        // Build FFmpeg arguments
-        let mut args = vec![
-            "-i".to_string(),
-            input_file.to_string_lossy().to_string(),
-            "-vn".to_string(), // No video
-        ];
+        // Build extraction options
+        let opts = Self::build_extract_options(
+            codec_config,
+            can_copy,
+            config.audio_quality.as_deref(),
+        );
 
-        if can_copy {
-            debug!(format:? = target_format; "Audio codec matches target, copying stream");
-            args.push("-c:a".to_string());
-            args.push("copy".to_string());
-        } else {
-            // Transcode
-            if let Some(encoder) = codec_config.encoder {
-                args.push("-c:a".to_string());
-                args.push(encoder.to_string());
-            }
-
-            // Add quality arguments
-            let quality_args =
-                self.build_quality_args(target_format, config.audio_quality.as_deref());
-            args.extend(quality_args);
-        }
-
-        args.push(output_path.to_string_lossy().to_string());
-
-        // Run FFmpeg
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        self.ffmpeg.run(&args_refs).await?;
+        // Extract audio via library bindings
+        self.ffmpeg
+            .extract_audio(input_file, &output_path, &opts)
+            .await?;
 
         info!(output:? = output_path.display(); "Audio extracted");
 
@@ -179,31 +162,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_quality_args_mp3() {
-        if let Ok(ffmpeg) = FFmpegRunner::new() {
-            let extractor = FFmpegExtractAudio::new(Arc::new(ffmpeg));
-
-            // Bitrate
-            let args = extractor.build_quality_args("mp3", Some("192"));
-            assert!(args.contains(&"-b:a".to_string()));
-            assert!(args.contains(&"192k".to_string()));
-
-            // VBR quality
-            let args = extractor.build_quality_args("mp3", Some("best"));
-            assert!(args.contains(&"-q:a".to_string()));
-            assert!(args.contains(&"0".to_string())); // Best quality for MP3
-        }
+    fn test_build_extract_options_mp3_bitrate() {
+        let codec_config = get_audio_codec("mp3").unwrap();
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, false, Some("192"));
+        assert_eq!(opts.bitrate_kbps, Some(192));
+        assert_eq!(opts.quality_scale, None);
+        assert!(!opts.copy);
     }
 
     #[test]
-    fn test_build_quality_args_opus() {
-        if let Ok(ffmpeg) = FFmpegRunner::new() {
-            let extractor = FFmpegExtractAudio::new(Arc::new(ffmpeg));
+    fn test_build_extract_options_mp3_vbr() {
+        let codec_config = get_audio_codec("mp3").unwrap();
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, false, Some("best"));
+        assert_eq!(opts.quality_scale, Some(0)); // Best quality for MP3 = 0
+        assert_eq!(opts.bitrate_kbps, None);
+    }
 
-            // Opus uses bitrate only
-            let args = extractor.build_quality_args("opus", Some("128"));
-            assert!(args.contains(&"-b:a".to_string()));
-            assert!(args.contains(&"128k".to_string()));
-        }
+    #[test]
+    fn test_build_extract_options_copy() {
+        let codec_config = get_audio_codec("mp3").unwrap();
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, true, Some("192"));
+        assert!(opts.copy);
+        // Quality settings should be ignored when copying
+        assert_eq!(opts.bitrate_kbps, None);
+        assert_eq!(opts.quality_scale, None);
+    }
+
+    #[test]
+    fn test_build_extract_options_opus_bitrate() {
+        let codec_config = get_audio_codec("opus").unwrap();
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, false, Some("128"));
+        assert_eq!(opts.bitrate_kbps, Some(128));
+        assert_eq!(opts.quality_scale, None); // Opus has no quality scale
+    }
+
+    #[test]
+    fn test_build_extract_options_bitrate_clamping() {
+        let codec_config = get_audio_codec("mp3").unwrap();
+        // Over max (320)
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, false, Some("999"));
+        assert_eq!(opts.bitrate_kbps, Some(320));
+        // Under min (32)
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, false, Some("1"));
+        assert_eq!(opts.bitrate_kbps, Some(32));
+    }
+
+    #[test]
+    fn test_build_extract_options_no_quality() {
+        let codec_config = get_audio_codec("mp3").unwrap();
+        let opts = FFmpegExtractAudio::build_extract_options(codec_config, false, None);
+        assert_eq!(opts.bitrate_kbps, None);
+        assert_eq!(opts.quality_scale, None);
+        assert_eq!(opts.encoder_name, Some("libmp3lame".to_string()));
     }
 }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -122,7 +122,12 @@ impl PostProcessor for FFmpegMerger {
         false
     }
 
-    async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult> {
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
         if files.len() < 2 {
             // Nothing to merge
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -160,8 +165,7 @@ impl PostProcessor for FFmpegMerger {
         // Determine output format
         let video_ext = video_file.extension().and_then(|e| e.to_str());
         let audio_ext = audio_file.extension().and_then(|e| e.to_str());
-        let config = PostProcessConfig::default();
-        let output_format = self.determine_output_format(&config, video_ext, audio_ext);
+        let output_format = self.determine_output_format(config, video_ext, audio_ext);
 
         // Create output filename
         let output_path = video_file.with_extension(output_format);

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -1,17 +1,18 @@
 //! FFmpeg merger post-processor.
 //!
-//! Merges separate video and audio streams into a single container.
+//! Merges separate video and audio streams into a single container
+//! using `ffmpeg-the-third` library bindings (no CLI process spawning).
 //! This is typically needed when downloading from sites that serve
 //! video and audio separately (like HLS/DASH streams).
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
-use crate::ffmpeg::FFmpegRunner;
+use crate::ffmpeg::{FFmpegRunner, RemuxOptions};
 
 /// Post-processor that merges video and audio streams.
 ///
@@ -59,44 +60,6 @@ impl FFmpegMerger {
             _ => "mp4",
         }
     }
-
-    /// Build FFmpeg arguments for merging.
-    fn build_merge_args<'a>(
-        &self,
-        inputs: &[&'a Path],
-        output: &'a Path,
-        video_index: usize,
-        audio_index: usize,
-    ) -> Vec<String> {
-        let mut args = Vec::new();
-
-        // Add input files
-        for input in inputs {
-            args.push("-i".to_string());
-            args.push(input.to_string_lossy().to_string());
-        }
-
-        // Map video from first input
-        args.push("-map".to_string());
-        args.push(format!("{video_index}:v:0"));
-
-        // Map audio from second input (or first if only one input)
-        args.push("-map".to_string());
-        args.push(format!("{audio_index}:a:0"));
-
-        // Copy streams without re-encoding
-        args.push("-c".to_string());
-        args.push("copy".to_string());
-
-        // Handle AAC in MPEG-TS (HLS) - needs ADTS to ASC conversion
-        args.push("-bsf:a".to_string());
-        args.push("aac_adtstoasc".to_string());
-
-        // Output file
-        args.push(output.to_string_lossy().to_string());
-
-        args
-    }
 }
 
 #[async_trait]
@@ -136,24 +99,24 @@ impl PostProcessor for FFmpegMerger {
         info!(streams = files.len(); "Merging streams into single file");
 
         // Determine which file is video and which is audio
-        let (video_file, audio_file, video_idx, audio_idx) = if files.len() == 2 {
+        let (video_file, audio_file) = if files.len() == 2 {
             // Probe files to determine which is which
             let info1 = self.ffmpeg.probe(&files[0]).await?;
             let info2 = self.ffmpeg.probe(&files[1]).await?;
 
             if info1.has_video && !info1.has_audio && info2.has_audio {
-                (&files[0], &files[1], 0, 1)
+                (&files[0], &files[1])
             } else if info2.has_video && !info2.has_audio && info1.has_audio {
-                (&files[1], &files[0], 1, 0)
+                (&files[1], &files[0])
             } else if info1.has_video {
                 // Both have video, prefer first as video
-                (&files[0], &files[1], 0, 1)
+                (&files[0], &files[1])
             } else {
-                (&files[1], &files[0], 1, 0)
+                (&files[1], &files[0])
             }
         } else {
             // More than 2 files - assume first is video, second is audio
-            (&files[0], &files[1], 0, 1)
+            (&files[0], &files[1])
         };
 
         debug!(
@@ -170,13 +133,16 @@ impl PostProcessor for FFmpegMerger {
         // Create output filename
         let output_path = video_file.with_extension(output_format);
 
-        // Build merge command
-        let inputs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
-        let args = self.build_merge_args(&inputs, &output_path, video_idx, audio_idx);
-
-        // Run FFmpeg
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        self.ffmpeg.run(&args_refs).await?;
+        // Merge using library bindings (stream copy, no re-encoding).
+        // The MP4 muxer automatically handles AAC ADTS→ASC conversion,
+        // so we no longer need the unconditional aac_adtstoasc BSF.
+        let opts = RemuxOptions {
+            faststart: output_format == "mp4" || output_format == "mov",
+            ..Default::default()
+        };
+        self.ffmpeg
+            .merge(video_file, audio_file, &output_path, &opts)
+            .await?;
 
         info!(output:? = output_path.display(); "Merged output");
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -143,7 +143,12 @@ impl PostProcessor for FFmpegMetadata {
         config.embed_metadata
     }
 
-    async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult> {
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        _config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
         }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -1,17 +1,18 @@
 //! FFmpeg metadata embedding post-processor.
 //!
 //! Embeds metadata (title, artist, album, etc.) and chapters into media files
-//! using FFmpeg's metadata capabilities.
+//! using `ffmpeg-the-third` library bindings (no CLI process spawning).
+//! No temporary FFMETADATA1 file is needed.
 
-use std::io::Write;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::info;
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
-use crate::ffmpeg::FFmpegRunner;
+use crate::ffmpeg::{ChapterEntry, FFmpegRunner};
 
 /// Post-processor that embeds metadata into media files.
 ///
@@ -35,33 +36,28 @@ impl FFmpegMetadata {
         Self { ffmpeg }
     }
 
-    /// Build FFmpeg metadata arguments from InfoDict.
-    fn build_metadata_args(&self, info: &InfoDict) -> Vec<String> {
-        let mut args = Vec::new();
+    /// Build a metadata `HashMap` from `InfoDict`.
+    fn build_metadata(info: &InfoDict) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
 
         // Title
-        args.push("-metadata".to_string());
-        args.push(format!("title={}", info.title));
+        meta.insert("title".to_string(), info.title.clone());
 
         // Artist/Uploader
         if let Some(ref artist) = info.artist {
-            args.push("-metadata".to_string());
-            args.push(format!("artist={artist}"));
+            meta.insert("artist".to_string(), artist.clone());
         } else if let Some(ref uploader) = info.uploader {
-            args.push("-metadata".to_string());
-            args.push(format!("artist={uploader}"));
+            meta.insert("artist".to_string(), uploader.clone());
         }
 
         // Album
         if let Some(ref album) = info.album {
-            args.push("-metadata".to_string());
-            args.push(format!("album={album}"));
+            meta.insert("album".to_string(), album.clone());
         }
 
         // Track
         if let Some(ref track) = info.track {
-            args.push("-metadata".to_string());
-            args.push(format!("track={track}"));
+            meta.insert("track".to_string(), track.clone());
         }
 
         // Date
@@ -72,60 +68,57 @@ impl FFmpegMetadata {
             } else {
                 date.clone()
             };
-            args.push("-metadata".to_string());
-            args.push(format!("date={formatted}"));
+            meta.insert("date".to_string(), formatted);
         }
 
         // Year
         if let Some(year) = info.release_year {
-            args.push("-metadata".to_string());
-            args.push(format!("year={year}"));
+            meta.insert("year".to_string(), year.to_string());
         }
 
-        // Description/Comment
+        // Description/Comment — truncate safely at UTF-8 char boundary
         if let Some(ref description) = info.description {
-            // Truncate very long descriptions
             let desc = if description.len() > 1000 {
-                format!("{}...", &description[..997])
+                let truncated = match description.char_indices().nth(997) {
+                    Some((byte_idx, _)) => &description[..byte_idx],
+                    None => description, // fewer than 997 chars, no truncation needed
+                };
+                format!("{truncated}...")
             } else {
                 description.clone()
             };
-            args.push("-metadata".to_string());
-            args.push(format!("comment={desc}"));
-
-            args.push("-metadata".to_string());
-            args.push(format!("description={desc}"));
+            meta.insert("comment".to_string(), desc.clone());
+            meta.insert("description".to_string(), desc);
         }
 
         // Webpage URL
-        args.push("-metadata".to_string());
-        args.push(format!("purl={}", info.webpage_url));
+        meta.insert("purl".to_string(), info.webpage_url.clone());
 
         // Extractor
-        args.push("-metadata".to_string());
-        args.push(format!("encoder=rdlp via {}", info.extractor));
+        meta.insert(
+            "encoder".to_string(),
+            format!("rdlp via {}", info.extractor),
+        );
 
-        args
+        meta
     }
 
-    /// Generate FFMETADATA1 format file content for chapters.
-    fn generate_chapters_metadata(&self, info: &InfoDict) -> Option<String> {
-        let chapters = info.chapters.as_ref()?;
-        if chapters.is_empty() {
-            return None;
-        }
+    /// Build chapter entries from `InfoDict`.
+    fn build_chapters(info: &InfoDict) -> Vec<ChapterEntry> {
+        let Some(chapters) = info.chapters.as_ref() else {
+            return Vec::new();
+        };
 
-        let mut content = String::from(";FFMETADATA1\n");
-
-        for chapter in chapters {
-            content.push_str("\n[CHAPTER]\n");
-            content.push_str("TIMEBASE=1/1000\n");
-            content.push_str(&format!("START={}\n", (chapter.start_time * 1000.0) as i64));
-            content.push_str(&format!("END={}\n", (chapter.end_time * 1000.0) as i64));
-            content.push_str(&format!("title={}\n", chapter.title));
-        }
-
-        Some(content)
+        chapters
+            .iter()
+            .enumerate()
+            .map(|(i, ch)| ChapterEntry {
+                id: i as i64,
+                start_ms: (ch.start_time * 1000.0) as i64,
+                end_ms: (ch.end_time * 1000.0) as i64,
+                title: ch.title.clone(),
+            })
+            .collect()
     }
 }
 
@@ -164,49 +157,17 @@ impl PostProcessor for FFmpegMetadata {
         // Create temp output file
         let temp_output = input_file.with_extension(format!("temp.{extension}"));
 
-        // Build base arguments
-        let mut args = vec!["-i".to_string(), input_file.to_string_lossy().to_string()];
+        // Build metadata and chapters
+        let metadata = Self::build_metadata(info);
+        let chapters = Self::build_chapters(info);
 
-        // Handle chapters if present
-        let mut temp_metadata_file = None;
-        if let Some(chapters_content) = self.generate_chapters_metadata(info) {
-            debug!("Generating chapter metadata file");
-
-            // Write chapters to temp file
-            let chapters_path = input_file.with_extension("ffmetadata");
-            let mut file = std::fs::File::create(&chapters_path)?;
-            file.write_all(chapters_content.as_bytes())?;
-
-            args.push("-i".to_string());
-            args.push(chapters_path.to_string_lossy().to_string());
-            args.push("-map_metadata".to_string());
-            args.push("1".to_string());
-
-            temp_metadata_file = Some(chapters_path);
-        }
-
-        // Add metadata arguments
-        let metadata_args = self.build_metadata_args(info);
-        args.extend(metadata_args);
-
-        // Copy streams
-        args.push("-c".to_string());
-        args.push("copy".to_string());
-
-        // Output
-        args.push(temp_output.to_string_lossy().to_string());
-
-        // Run FFmpeg
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        self.ffmpeg.run(&args_refs).await?;
+        // Embed via library bindings (stream copy + metadata + chapters)
+        self.ffmpeg
+            .embed_metadata(input_file, &temp_output, &metadata, &chapters)
+            .await?;
 
         // Replace original with temp
         tokio::fs::rename(&temp_output, input_file).await?;
-
-        // Cleanup chapter metadata file
-        if let Some(chapters_file) = temp_metadata_file {
-            let _ = tokio::fs::remove_file(&chapters_file).await;
-        }
 
         info!(file:? = input_file.display(); "Metadata embedded");
 
@@ -219,60 +180,118 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_metadata_args() {
-        if let Ok(ffmpeg) = FFmpegRunner::new() {
-            let processor = FFmpegMetadata::new(Arc::new(ffmpeg));
+    fn test_build_metadata() {
+        let mut info = InfoDict::new(
+            "test123".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com/video".to_string(),
+        );
+        info.artist = Some("Test Artist".to_string());
+        info.upload_date = Some("20240115".to_string());
 
-            let mut info = InfoDict::new(
-                "test123".to_string(),
-                "Test Video".to_string(),
-                "TestExtractor".to_string(),
-                "https://example.com/video".to_string(),
-            );
-            info.artist = Some("Test Artist".to_string());
-            info.upload_date = Some("20240115".to_string());
+        let meta = FFmpegMetadata::build_metadata(&info);
 
-            let args = processor.build_metadata_args(&info);
-
-            assert!(args.contains(&"-metadata".to_string()));
-            assert!(args.iter().any(|a| a.starts_with("title=")));
-            assert!(args.iter().any(|a| a.starts_with("artist=")));
-            assert!(args.iter().any(|a| a.starts_with("date=")));
-        }
+        assert_eq!(meta.get("title").unwrap(), "Test Video");
+        assert_eq!(meta.get("artist").unwrap(), "Test Artist");
+        assert_eq!(meta.get("date").unwrap(), "2024-01-15");
+        assert_eq!(meta.get("purl").unwrap(), "https://example.com/video");
+        assert!(meta.get("encoder").unwrap().contains("TestExtractor"));
     }
 
     #[test]
-    fn test_generate_chapters_metadata() {
-        if let Ok(ffmpeg) = FFmpegRunner::new() {
-            let processor = FFmpegMetadata::new(Arc::new(ffmpeg));
+    fn test_build_metadata_description_truncation() {
+        let mut info = InfoDict::new(
+            "test".to_string(),
+            "Test".to_string(),
+            "Test".to_string(),
+            "https://example.com".to_string(),
+        );
+        // Create a long description (> 1000 chars)
+        info.description = Some("a".repeat(2000));
 
-            let mut info = InfoDict::new(
-                "test".to_string(),
-                "Test".to_string(),
-                "Test".to_string(),
-                "https://example.com".to_string(),
-            );
-            info.chapters = Some(vec![
-                rdlp_core::Chapter {
-                    title: "Intro".to_string(),
-                    start_time: 0.0,
-                    end_time: 30.0,
-                },
-                rdlp_core::Chapter {
-                    title: "Main".to_string(),
-                    start_time: 30.0,
-                    end_time: 120.0,
-                },
-            ]);
+        let meta = FFmpegMetadata::build_metadata(&info);
+        let desc = meta.get("description").unwrap();
+        assert!(desc.len() <= 1003); // 997 chars + "..."
+        assert!(desc.ends_with("..."));
+    }
 
-            let metadata = processor.generate_chapters_metadata(&info);
-            assert!(metadata.is_some());
+    #[test]
+    fn test_build_metadata_description_utf8_safe() {
+        let mut info = InfoDict::new(
+            "test".to_string(),
+            "Test".to_string(),
+            "Test".to_string(),
+            "https://example.com".to_string(),
+        );
+        // Use multi-byte UTF-8 characters (each '日' is 3 bytes)
+        info.description = Some("日".repeat(500)); // 1500 bytes, 500 chars
 
-            let content = metadata.unwrap();
-            assert!(content.contains(";FFMETADATA1"));
-            assert!(content.contains("[CHAPTER]"));
-            assert!(content.contains("title=Intro"));
-            assert!(content.contains("title=Main"));
-        }
+        let meta = FFmpegMetadata::build_metadata(&info);
+        let desc = meta.get("description").unwrap();
+        // Should truncate at char boundary, not byte boundary
+        assert!(desc.ends_with("..."));
+        // Verify it's valid UTF-8 (would panic if not)
+        let _ = desc.chars().count();
+    }
+
+    #[test]
+    fn test_build_metadata_uploader_fallback() {
+        let mut info = InfoDict::new(
+            "test".to_string(),
+            "Test".to_string(),
+            "Test".to_string(),
+            "https://example.com".to_string(),
+        );
+        info.uploader = Some("Uploader Name".to_string());
+
+        let meta = FFmpegMetadata::build_metadata(&info);
+        assert_eq!(meta.get("artist").unwrap(), "Uploader Name");
+    }
+
+    #[test]
+    fn test_build_chapters() {
+        let mut info = InfoDict::new(
+            "test".to_string(),
+            "Test".to_string(),
+            "Test".to_string(),
+            "https://example.com".to_string(),
+        );
+        info.chapters = Some(vec![
+            rdlp_core::Chapter {
+                title: "Intro".to_string(),
+                start_time: 0.0,
+                end_time: 30.0,
+            },
+            rdlp_core::Chapter {
+                title: "Main".to_string(),
+                start_time: 30.0,
+                end_time: 120.0,
+            },
+        ]);
+
+        let chapters = FFmpegMetadata::build_chapters(&info);
+        assert_eq!(chapters.len(), 2);
+        assert_eq!(chapters[0].id, 0);
+        assert_eq!(chapters[0].start_ms, 0);
+        assert_eq!(chapters[0].end_ms, 30000);
+        assert_eq!(chapters[0].title, "Intro");
+        assert_eq!(chapters[1].id, 1);
+        assert_eq!(chapters[1].start_ms, 30000);
+        assert_eq!(chapters[1].end_ms, 120000);
+        assert_eq!(chapters[1].title, "Main");
+    }
+
+    #[test]
+    fn test_build_chapters_none() {
+        let info = InfoDict::new(
+            "test".to_string(),
+            "Test".to_string(),
+            "Test".to_string(),
+            "https://example.com".to_string(),
+        );
+
+        let chapters = FFmpegMetadata::build_chapters(&info);
+        assert!(chapters.is_empty());
     }
 }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -92,13 +92,17 @@ impl PostProcessor for FFmpegVideoConvertor {
         config.recode_video.is_some()
     }
 
-    async fn process(&self, info: &InfoDict, files: Vec<PathBuf>) -> Result<PostProcessResult> {
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
         }
 
         let input_file = &files[0];
-        let config = PostProcessConfig::default();
 
         let target_format = config.recode_video.as_deref().unwrap_or("mp4");
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -1,7 +1,7 @@
 //! FFmpeg video conversion/remuxing post-processor.
 //!
 //! Converts video files to different formats or remuxes them to different
-//! containers without re-encoding.
+//! containers using `ffmpeg-the-third` library bindings (no CLI process spawning).
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,7 +11,7 @@ use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use crate::error::PostProcessError;
-use crate::ffmpeg::FFmpegRunner;
+use crate::ffmpeg::{FFmpegRunner, VideoConvertOptions};
 
 /// Supported video container formats.
 const SUPPORTED_CONTAINERS: &[&str] = &["mp4", "mkv", "webm", "mov", "avi", "flv", "ts"];
@@ -73,6 +73,39 @@ impl FFmpegVideoConvertor {
             // Same container - can copy
             _ if input_ext.eq_ignore_ascii_case(output_ext) => true,
             _ => false,
+        }
+    }
+
+    /// Build `VideoConvertOptions` from the target format and remux decision.
+    fn build_convert_options(target_format: &str, can_remux: bool) -> VideoConvertOptions {
+        if can_remux {
+            return VideoConvertOptions {
+                remux_only: true,
+                audio_copy: true,
+                ..Default::default()
+            };
+        }
+
+        // Determine target codec from container
+        let target_codec = match target_format {
+            "webm" => "vp9",
+            "mp4" | "mov" | "mkv" => "h264",
+            _ => "h264",
+        };
+
+        let encoder = Self::get_encoder(target_codec);
+        let (preset, crf) = match target_codec {
+            "h264" | "h265" | "hevc" => (Some("medium".to_string()), Some(23)),
+            "vp9" => (None, Some(30)),
+            _ => (None, None),
+        };
+
+        VideoConvertOptions {
+            remux_only: false,
+            video_codec: encoder.map(String::from),
+            preset,
+            crf,
+            audio_copy: true,
         }
     }
 }
@@ -140,61 +173,22 @@ impl PostProcessor for FFmpegVideoConvertor {
         let can_remux =
             Self::can_remux(input_ext, target_format, media_info.video_codec.as_deref());
 
+        if can_remux {
+            debug!("Remuxing (stream copy)");
+        } else {
+            debug!("Transcoding video");
+        }
+
         // Build output path
         let output_path = input_file.with_extension(target_format);
 
-        // Build FFmpeg arguments
-        let mut args = vec!["-i".to_string(), input_file.to_string_lossy().to_string()];
+        // Build conversion options
+        let opts = Self::build_convert_options(target_format, can_remux);
 
-        if can_remux {
-            debug!("Remuxing (stream copy)");
-            args.push("-c".to_string());
-            args.push("copy".to_string());
-        } else {
-            debug!("Transcoding video");
-
-            // Get appropriate encoder
-            let target_codec = match target_format {
-                "webm" => "vp9",
-                "mp4" | "mov" | "mkv" => "h264",
-                _ => "h264",
-            };
-
-            if let Some(encoder) = Self::get_encoder(target_codec) {
-                args.push("-c:v".to_string());
-                args.push(encoder.to_string());
-
-                // Add reasonable default encoding settings
-                match target_codec {
-                    "h264" | "h265" | "hevc" => {
-                        args.push("-preset".to_string());
-                        args.push("medium".to_string());
-                        args.push("-crf".to_string());
-                        args.push("23".to_string());
-                    }
-                    "vp9" => {
-                        args.push("-crf".to_string());
-                        args.push("30".to_string());
-                        args.push("-b:v".to_string());
-                        args.push("0".to_string());
-                    }
-                    _ => {}
-                }
-            }
-
-            // Copy audio stream
-            args.push("-c:a".to_string());
-            args.push("copy".to_string());
-        }
-
-        // Add any custom FFmpeg args
-        args.extend(config.ffmpeg_args.iter().cloned());
-
-        args.push(output_path.to_string_lossy().to_string());
-
-        // Run FFmpeg
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        self.ffmpeg.run(&args_refs).await?;
+        // Convert via library bindings
+        self.ffmpeg
+            .convert_video(input_file, &output_path, &opts)
+            .await?;
 
         info!(output:? = output_path.display(); "Converted");
 
@@ -246,5 +240,33 @@ mod tests {
         // Anything to MKV - can remux
         assert!(FFmpegVideoConvertor::can_remux("mp4", "mkv", Some("h264")));
         assert!(FFmpegVideoConvertor::can_remux("webm", "mkv", Some("vp9")));
+    }
+
+    #[test]
+    fn test_build_convert_options_remux() {
+        let opts = FFmpegVideoConvertor::build_convert_options("mp4", true);
+        assert!(opts.remux_only);
+        assert!(opts.audio_copy);
+        assert!(opts.video_codec.is_none());
+    }
+
+    #[test]
+    fn test_build_convert_options_transcode_mp4() {
+        let opts = FFmpegVideoConvertor::build_convert_options("mp4", false);
+        assert!(!opts.remux_only);
+        assert_eq!(opts.video_codec, Some("libx264".to_string()));
+        assert_eq!(opts.preset, Some("medium".to_string()));
+        assert_eq!(opts.crf, Some(23));
+        assert!(opts.audio_copy);
+    }
+
+    #[test]
+    fn test_build_convert_options_transcode_webm() {
+        let opts = FFmpegVideoConvertor::build_convert_options("webm", false);
+        assert!(!opts.remux_only);
+        assert_eq!(opts.video_codec, Some("libvpx-vp9".to_string()));
+        assert_eq!(opts.preset, None); // VP9 has no preset
+        assert_eq!(opts.crf, Some(30));
+        assert!(opts.audio_copy);
     }
 }

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -99,14 +99,15 @@ impl PostProcessorRegistry {
     }
 
     /// Create a registry without FFmpeg (for testing or non-FFmpeg operations).
+    ///
+    /// Note: FFmpeg library initialization will still be attempted.
+    /// Operations will fail at runtime if the library is not available.
     pub fn without_ffmpeg() -> Self {
         Self {
             processors: Vec::new(),
-            ffmpeg: Arc::new(FFmpegRunner::new().unwrap_or_else(|_| {
-                // Create a dummy runner that will fail if used
-                FFmpegRunner::with_location(Some(std::path::Path::new("/nonexistent")))
-                    .unwrap_or_else(|_| panic!("Cannot create FFmpeg runner"))
-            })),
+            ffmpeg: Arc::new(
+                FFmpegRunner::new().unwrap_or_else(|_| panic!("Cannot initialize FFmpeg library")),
+            ),
         }
     }
 
@@ -255,9 +256,8 @@ mod tests {
 
     #[test]
     fn test_registry_creation() {
-        // This test only works if FFmpeg is installed
-        if which::which("ffmpeg").is_ok() {
-            let registry = PostProcessorRegistry::new().unwrap();
+        // This test only works if FFmpeg library is available
+        if let Ok(registry) = PostProcessorRegistry::new() {
             let processors = registry.list_processors();
             assert!(!processors.is_empty());
         }
@@ -265,8 +265,7 @@ mod tests {
 
     #[test]
     fn test_processor_priority_order() {
-        if which::which("ffmpeg").is_ok() {
-            let registry = PostProcessorRegistry::new().unwrap();
+        if let Ok(registry) = PostProcessorRegistry::new() {
             let sorted = registry.sorted_processors();
 
             // Verify processors are sorted by priority (highest first)

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -165,7 +165,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
             info!(name:? = processor.name(); "Running post-processor");
 
             match processor
-                .process(&current_info, current_files.clone())
+                .process(&current_info, current_files.clone(), config)
                 .await
             {
                 Ok(result) => {

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -102,13 +102,11 @@ impl PostProcessorRegistry {
     ///
     /// Note: FFmpeg library initialization will still be attempted.
     /// Operations will fail at runtime if the library is not available.
-    pub fn without_ffmpeg() -> Self {
-        Self {
+    pub fn without_ffmpeg() -> Result<Self> {
+        Ok(Self {
             processors: Vec::new(),
-            ffmpeg: Arc::new(
-                FFmpegRunner::new().unwrap_or_else(|_| panic!("Cannot initialize FFmpeg library")),
-            ),
-        }
+            ffmpeg: Arc::new(FFmpegRunner::new()?),
+        })
     }
 
     /// Register default post-processors.

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -33,7 +33,7 @@
 //! # }
 //! ```
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -41,7 +41,7 @@ use log::{debug, info, warn};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor};
 
 use crate::error::Result;
-use crate::ffmpeg::FFmpegRunner;
+use crate::ffmpeg::{FFmpegRunner, RemuxOptions};
 use crate::processors::*;
 
 /// Trait for post-processor registry operations.
@@ -54,6 +54,12 @@ pub trait PostProcessorRegistryTrait: Send + Sync {
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
     ) -> anyhow::Result<PostProcessResult>;
+
+    /// Remux a file with faststart enabled (stream copy, no re-encoding).
+    ///
+    /// Moves the moov atom to the beginning of the file for progressive
+    /// playback and fixes container structure/timestamps.
+    async fn remux_faststart(&self, input: &Path, output: &Path) -> anyhow::Result<()>;
 
     /// List all registered post-processors.
     fn list_processors(&self) -> Vec<String>;
@@ -206,6 +212,17 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
             files: current_files,
             temp_files: Vec::new(), // Already cleaned up
         })
+    }
+
+    async fn remux_faststart(&self, input: &Path, output: &Path) -> anyhow::Result<()> {
+        let opts = RemuxOptions {
+            faststart: true,
+            ..Default::default()
+        };
+        self.ffmpeg
+            .remux(input, output, &opts)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))
     }
 
     fn list_processors(&self) -> Vec<String> {

--- a/crates/rdlp-postprocess/tests/ffmpeg_next_probe.rs
+++ b/crates/rdlp-postprocess/tests/ffmpeg_next_probe.rs
@@ -1,0 +1,112 @@
+//! Small test to verify ffmpeg-the-third bindings work for media probing.
+//!
+//! Generates a synthetic test video with ffmpeg CLI, then probes it
+//! using the ffmpeg Rust bindings to extract stream info.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Generate a 1-second test video using ffmpeg CLI (lavfi source).
+fn generate_test_video(path: &Path) {
+    let status = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=duration=1:size=320x240:rate=25",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-c:a",
+            "aac",
+            "-shortest",
+        ])
+        .arg(path)
+        .output()
+        .expect("ffmpeg CLI must be available");
+
+    assert!(
+        status.status.success(),
+        "ffmpeg failed to generate test video"
+    );
+}
+
+#[test]
+fn test_ffmpeg_probe() {
+    ffmpeg_the_third::init().expect("ffmpeg init failed");
+
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let video_path = dir.path().join("test.mp4");
+
+    generate_test_video(&video_path);
+
+    let ctx = ffmpeg_the_third::format::input(&video_path).expect("failed to open test video");
+
+    // Check duration (~1 second)
+    let duration_secs =
+        ctx.duration() as f64 / f64::from(ffmpeg_the_third::ffi::AV_TIME_BASE);
+    assert!(
+        duration_secs > 0.5 && duration_secs < 2.0,
+        "unexpected duration: {duration_secs}"
+    );
+
+    // Should have at least 2 streams (video + audio)
+    let stream_count = ctx.streams().count();
+    assert!(
+        stream_count >= 2,
+        "expected >= 2 streams, got {stream_count}"
+    );
+
+    // Find video stream
+    let video_stream = ctx
+        .streams()
+        .best(ffmpeg_the_third::media::Type::Video)
+        .expect("no video stream found");
+
+    let video_codec =
+        ffmpeg_the_third::codec::context::Context::from_parameters(video_stream.parameters())
+            .expect("failed to get video codec context");
+
+    assert_eq!(video_codec.medium(), ffmpeg_the_third::media::Type::Video);
+
+    if let Ok(video) = video_codec.decoder().video() {
+        assert_eq!(video.width(), 320);
+        assert_eq!(video.height(), 240);
+        println!(
+            "Video: {}x{}, format: {:?}",
+            video.width(),
+            video.height(),
+            video.format()
+        );
+    }
+
+    // Find audio stream
+    let audio_stream = ctx
+        .streams()
+        .best(ffmpeg_the_third::media::Type::Audio)
+        .expect("no audio stream found");
+
+    let audio_codec =
+        ffmpeg_the_third::codec::context::Context::from_parameters(audio_stream.parameters())
+            .expect("failed to get audio codec context");
+
+    assert_eq!(audio_codec.medium(), ffmpeg_the_third::media::Type::Audio);
+
+    if let Ok(audio) = audio_codec.decoder().audio() {
+        assert!(audio.rate() > 0, "audio sample rate should be > 0");
+        println!(
+            "Audio: {} Hz, channel_layout: {:?}, format: {:?}",
+            audio.rate(),
+            audio.ch_layout(),
+            audio.format()
+        );
+    }
+
+    println!("ffmpeg probe test passed");
+}

--- a/crates/rdlp-types/src/format.rs
+++ b/crates/rdlp-types/src/format.rs
@@ -344,7 +344,7 @@ impl Format {
             if let Some(ref fragments) = self.fragments {
                 let _ = write!(buf, "{} segments", fragments.len());
             } else if let Some(segment_count) = self.filesize_approx {
-                let _ = write!(buf, "{} segments", segment_count);
+                let _ = write!(buf, "{segment_count} segments");
             } else {
                 buf.push_str("HLS stream");
             }


### PR DESCRIPTION
This pull request brings significant improvements to both the codebase and documentation for the project. The most notable changes are the migration of all FFmpeg operations from CLI process spawning to library bindings, a refactor of the CLI orchestrator to use asynchronous I/O for all filesystem operations, and updates to the documentation to reflect the expanded architecture and improved test coverage. Additionally, user prompts and playlist handling are now fully async, and the documentation has been updated to clarify the use of `unsafe` code and the new crate structure.

**Major architectural and codebase improvements:**

* Migrated all FFmpeg operations in the post-processing pipeline from CLI process spawning to the `ffmpeg-the-third` library bindings, eliminating shell command execution and updating all relevant orchestrator methods to use async library calls instead of spawning processes. [[1]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL127-R136) [[2]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL146-R148) [[3]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL179-L189)
* Refactored the CLI orchestrator (`rdlp-cli/src/orchestrator/playlist.rs`, `postprocess.rs`, `selection.rs`) to use asynchronous I/O for all filesystem operations, including directory creation, reading, and file removal, improving performance and reliability. [[1]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L69-R69) [[2]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L123-R127) [[3]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L244-R248) [[4]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L257-R272) [[5]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL272-R255) [[6]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL287-R264) [[7]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158L17-R23)
* Updated user interaction prompts (e.g., playlist download confirmation) to run in a non-blocking way using `tokio::task::spawn_blocking`, ensuring the CLI remains responsive.

**Documentation and project metadata updates:**

* Updated `README.md` to reflect the expanded modular architecture (11 crates instead of 8), increased test coverage (270+ tests), clarified the use of `unsafe` code (now only in FFmpeg FFI with SAFETY comments), and documented the completed migration to FFmpeg library bindings. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R44) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L338-R360) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L369-R372) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L554-R568) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L582-R594) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L698-R710) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1006-R1022) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1052-L1079)
* Increased default buffer size in the example config for better performance.

**Minor code quality and ergonomic improvements:**

* Modernized logging output by using Rust's inline formatting in `info!` macros for better readability. [[1]](diffhunk://#diff-4b442a8cd00a843061d8f64391af72ca8fb401e64e7433fc8c62ba724a9da5cdL39-R53) [[2]](diffhunk://#diff-4b442a8cd00a843061d8f64391af72ca8fb401e64e7433fc8c62ba724a9da5cdL107-R107)

These changes collectively modernize the codebase, improve performance and reliability, and bring the documentation up to date with the current state of the project.