### PR TITLE
feat(hls): enrich metadata extraction from M3U8 playlists

### DIFF
--- a/crates/rdlp-core/src/codecs.rs
+++ b/crates/rdlp-core/src/codecs.rs
@@ -1,0 +1,163 @@
+//! HLS codec parsing utilities
+//!
+//! Parses the HLS `CODECS` attribute (RFC 6381) from M3U8 playlists
+//! into human-readable video and audio codec names.
+
+/// Parse an HLS `CODECS` attribute string into video and audio codec names.
+///
+/// The CODECS attribute in HLS master playlists uses RFC 6381 format,
+/// e.g., `"avc1.64001f,mp4a.40.2"`. This function splits the string
+/// and maps each codec identifier to a human-readable name.
+///
+/// # Arguments
+/// * `codecs` - The CODECS attribute value (e.g., `"avc1.64001f,mp4a.40.2"`)
+///
+/// # Returns
+/// A tuple of `(video_codec, audio_codec)` where each is `None` if not found.
+///
+/// # Examples
+/// ```
+/// use rdlp_core::codecs::parse_hls_codecs;
+///
+/// let (video, audio) = parse_hls_codecs("avc1.64001f,mp4a.40.2");
+/// assert_eq!(video, Some("h264"));
+/// assert_eq!(audio, Some("aac"));
+///
+/// let (video, audio) = parse_hls_codecs("hvc1.1.6.L93.B0");
+/// assert_eq!(video, Some("hevc"));
+/// assert_eq!(audio, None);
+/// ```
+pub fn parse_hls_codecs(codecs: &str) -> (Option<&'static str>, Option<&'static str>) {
+    let mut video = None;
+    let mut audio = None;
+
+    for codec in codecs.split(',').map(str::trim) {
+        if codec.is_empty() {
+            continue;
+        }
+
+        // Extract the codec family prefix (before the first dot)
+        let prefix = codec.split('.').next().unwrap_or(codec);
+
+        match prefix {
+            // Video codecs
+            "avc1" | "avc3" => video = Some("h264"),
+            "hvc1" | "hev1" => video = Some("hevc"),
+            "vp09" => video = Some("vp9"),
+            "vp8" | "vp08" => video = Some("vp8"),
+            "av01" => video = Some("av1"),
+            // Audio codecs
+            "mp4a" => audio = Some("aac"),
+            "ac-3" => audio = Some("ac3"),
+            "ec-3" => audio = Some("eac3"),
+            "opus" => audio = Some("opus"),
+            "flac" => audio = Some("flac"),
+            "vorbis" => audio = Some("vorbis"),
+            _ => {} // Unknown codec prefix, skip
+        }
+    }
+
+    (video, audio)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_h264_aac() {
+        let (v, a) = parse_hls_codecs("avc1.64001f,mp4a.40.2");
+        assert_eq!(v, Some("h264"));
+        assert_eq!(a, Some("aac"));
+    }
+
+    #[test]
+    fn test_hevc_aac() {
+        let (v, a) = parse_hls_codecs("hvc1.1.6.L93.B0,mp4a.40.2");
+        assert_eq!(v, Some("hevc"));
+        assert_eq!(a, Some("aac"));
+    }
+
+    #[test]
+    fn test_hev1_variant() {
+        let (v, a) = parse_hls_codecs("hev1.1.6.L120.90,mp4a.40.5");
+        assert_eq!(v, Some("hevc"));
+        assert_eq!(a, Some("aac"));
+    }
+
+    #[test]
+    fn test_vp9() {
+        let (v, a) = parse_hls_codecs("vp09.00.10.08");
+        assert_eq!(v, Some("vp9"));
+        assert_eq!(a, None);
+    }
+
+    #[test]
+    fn test_av1_opus() {
+        let (v, a) = parse_hls_codecs("av01.0.08M.08,opus");
+        assert_eq!(v, Some("av1"));
+        assert_eq!(a, Some("opus"));
+    }
+
+    #[test]
+    fn test_audio_only_aac() {
+        let (v, a) = parse_hls_codecs("mp4a.40.2");
+        assert_eq!(v, None);
+        assert_eq!(a, Some("aac"));
+    }
+
+    #[test]
+    fn test_audio_only_ac3() {
+        let (v, a) = parse_hls_codecs("ac-3");
+        assert_eq!(v, None);
+        assert_eq!(a, Some("ac3"));
+    }
+
+    #[test]
+    fn test_audio_only_eac3() {
+        let (v, a) = parse_hls_codecs("ec-3");
+        assert_eq!(v, None);
+        assert_eq!(a, Some("eac3"));
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let (v, a) = parse_hls_codecs("");
+        assert_eq!(v, None);
+        assert_eq!(a, None);
+    }
+
+    #[test]
+    fn test_unknown_codec() {
+        let (v, a) = parse_hls_codecs("unknown.codec");
+        assert_eq!(v, None);
+        assert_eq!(a, None);
+    }
+
+    #[test]
+    fn test_whitespace_handling() {
+        let (v, a) = parse_hls_codecs(" avc1.64001f , mp4a.40.2 ");
+        assert_eq!(v, Some("h264"));
+        assert_eq!(a, Some("aac"));
+    }
+
+    #[test]
+    fn test_avc3_variant() {
+        let (v, _) = parse_hls_codecs("avc3.64001f");
+        assert_eq!(v, Some("h264"));
+    }
+
+    #[test]
+    fn test_vp8() {
+        let (v, a) = parse_hls_codecs("vp8,vorbis");
+        assert_eq!(v, Some("vp8"));
+        assert_eq!(a, Some("vorbis"));
+    }
+
+    #[test]
+    fn test_flac() {
+        let (v, a) = parse_hls_codecs("flac");
+        assert_eq!(v, None);
+        assert_eq!(a, Some("flac"));
+    }
+}

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -26,6 +26,8 @@
 
 #![warn(missing_docs)]
 
+/// HLS codec parsing utilities
+pub mod codecs;
 /// Configuration file I/O utilities
 pub mod config_io;
 /// Error types and result aliases
@@ -39,6 +41,9 @@ pub mod traits;
 pub use rdlp_types::{
     Chapter, Config, Format, FormatSelector, Fragment, InfoDict, Subtitle, Thumbnail,
 };
+
+// Re-export codec utilities
+pub use codecs::parse_hls_codecs;
 
 // Re-export error types and utilities
 pub use error::{RdlpError, Result, check_http_response};

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -265,6 +265,15 @@ impl HlsDownloader {
 
         match playlist {
             m3u8_rs::Playlist::MediaPlaylist(media) => {
+                // Warn about encryption (not yet supported)
+                if media.segments.iter().any(|s| s.key.is_some()) {
+                    warn!("HLS stream uses encryption (AES-128/SAMPLE-AES) — decryption not yet supported");
+                }
+                // Warn about live streams
+                if !media.end_list {
+                    warn!("HLS stream appears to be live (no EXT-X-ENDLIST) — may not download completely");
+                }
+
                 // Direct media playlist - extract segments
                 let base_url = url::Url::parse(m3u8_url)
                     .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -54,6 +54,32 @@ pub struct HlsInfo {
     pub total_size: Option<u64>,
     /// Number of segments in the playlist
     pub segment_count: usize,
+    /// Total duration in seconds (sum of segment durations)
+    pub total_duration: Option<f64>,
+    /// Video resolution (width, height) from master playlist variant
+    pub resolution: Option<(u64, u64)>,
+    /// Parsed video codec name (e.g., "h264", "hevc", "vp9")
+    pub video_codec: Option<String>,
+    /// Parsed audio codec name (e.g., "aac", "ac3", "opus")
+    pub audio_codec: Option<String>,
+    /// Frame rate from master playlist variant
+    pub frame_rate: Option<f64>,
+    /// Peak bandwidth in bits per second from variant
+    pub bandwidth: Option<u64>,
+    /// Average bandwidth in bits per second from variant
+    pub average_bandwidth: Option<u64>,
+    /// Whether the stream is live (no EXT-X-ENDLIST tag)
+    pub is_live: bool,
+    /// Whether any segment uses encryption (EXT-X-KEY)
+    pub has_encryption: bool,
+}
+
+/// Media playlist metadata extracted without additional HTTP requests
+struct MediaPlaylistInfo {
+    segment_count: usize,
+    total_duration: f64,
+    is_live: bool,
+    has_encryption: bool,
 }
 
 /// HLS playlist size detector
@@ -226,7 +252,222 @@ impl HlsSizeDetector {
         Ok(Some(HlsInfo {
             total_size: Some(total_size),
             segment_count,
+            total_duration: None,
+            resolution: None,
+            video_codec: None,
+            audio_codec: None,
+            frame_rate: None,
+            bandwidth: None,
+            average_bandwidth: None,
+            is_live: false,
+            has_encryption: false,
         }))
+    }
+
+    /// Detect comprehensive HLS metadata from an M3U8 playlist
+    ///
+    /// Fetches and parses the M3U8 playlist, extracting all available metadata:
+    /// - From master playlists: resolution, codecs, frame rate, bandwidth
+    /// - From media playlists: segment count, total duration, live/VOD, encryption
+    ///
+    /// This is more comprehensive than `count_segments()` but does not fetch segment
+    /// sizes (no HEAD requests). Performance is similar: 1-2 HTTP requests.
+    ///
+    /// # Arguments
+    /// * `m3u8_url` - URL of the HLS m3u8 playlist
+    ///
+    /// # Returns
+    /// * `Ok(Some(HlsInfo))` - Metadata extracted from the playlist
+    /// * `Ok(None)` - Metadata could not be determined (non-fatal)
+    /// * `Err(_)` - Fatal error (network failure, invalid playlist, etc.)
+    pub async fn detect_hls_metadata(&self, m3u8_url: &str) -> Result<Option<HlsInfo>> {
+        BaseExtractor::validate_url_security(m3u8_url)?;
+
+        if self.verbose {
+            debug!(url:? = m3u8_url; "HLS detecting metadata");
+        }
+
+        let playlist_text = match self.fetch_playlist_text(m3u8_url).await {
+            Ok(text) => text,
+            Err(e) => {
+                if self.verbose {
+                    debug!("HLS failed to fetch playlist: {e}");
+                }
+                return Ok(None);
+            }
+        };
+
+        let playlist = match m3u8_rs::parse_playlist_res(playlist_text.as_bytes()) {
+            Ok(p) => p,
+            Err(e) => {
+                if self.verbose {
+                    debug!("HLS failed to parse playlist: {e:?}");
+                }
+                return Ok(None);
+            }
+        };
+
+        match playlist {
+            m3u8_rs::Playlist::MasterPlaylist(master) => {
+                if master.variants.is_empty() {
+                    return Ok(None);
+                }
+
+                let variant = &master.variants[0];
+
+                // Extract variant metadata
+                let resolution = variant.resolution.as_ref().map(|r| (r.width, r.height));
+                let (video_codec, audio_codec) = variant
+                    .codecs
+                    .as_deref()
+                    .map(rdlp_core::parse_hls_codecs)
+                    .unwrap_or((None, None));
+                let frame_rate = variant.frame_rate;
+                let bandwidth = Some(variant.bandwidth);
+                let average_bandwidth = variant.average_bandwidth;
+
+                if self.verbose {
+                    debug!(
+                        variants = master.variants.len(),
+                        bandwidth = variant.bandwidth,
+                        resolution:? = resolution,
+                        codecs:? = variant.codecs,
+                        frame_rate:? = frame_rate;
+                        "HLS master playlist metadata extracted"
+                    );
+                }
+
+                // Resolve and fetch the media playlist for segment info
+                let base_url = url::Url::parse(m3u8_url)
+                    .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+                let media_url = base_url
+                    .join(&variant.uri)
+                    .map_err(|e| {
+                        RdlpError::Extraction(format!("Failed to join media playlist URL: {e}"))
+                    })?
+                    .to_string();
+
+                BaseExtractor::validate_url_security(&media_url)?;
+
+                let media_info = match self.fetch_and_extract_media_info(&media_url).await {
+                    Ok(Some(info)) => info,
+                    Ok(None) | Err(_) => {
+                        // Return what we have from the master playlist
+                        return Ok(Some(HlsInfo {
+                            total_size: None,
+                            segment_count: 0,
+                            total_duration: None,
+                            resolution,
+                            video_codec: video_codec.map(String::from),
+                            audio_codec: audio_codec.map(String::from),
+                            frame_rate,
+                            bandwidth,
+                            average_bandwidth,
+                            is_live: false,
+                            has_encryption: false,
+                        }));
+                    }
+                };
+
+                Ok(Some(HlsInfo {
+                    total_size: None,
+                    segment_count: media_info.segment_count,
+                    total_duration: Some(media_info.total_duration),
+                    resolution,
+                    video_codec: video_codec.map(String::from),
+                    audio_codec: audio_codec.map(String::from),
+                    frame_rate,
+                    bandwidth,
+                    average_bandwidth,
+                    is_live: media_info.is_live,
+                    has_encryption: media_info.has_encryption,
+                }))
+            }
+            m3u8_rs::Playlist::MediaPlaylist(media) => {
+                let info = Self::extract_media_playlist_info(&media);
+
+                if self.verbose {
+                    debug!(
+                        segments = info.segment_count,
+                        duration = info.total_duration,
+                        is_live = info.is_live,
+                        encrypted = info.has_encryption;
+                        "HLS media playlist metadata extracted"
+                    );
+                }
+
+                Ok(Some(HlsInfo {
+                    total_size: None,
+                    segment_count: info.segment_count,
+                    total_duration: Some(info.total_duration),
+                    resolution: None,
+                    video_codec: None,
+                    audio_codec: None,
+                    frame_rate: None,
+                    bandwidth: None,
+                    average_bandwidth: None,
+                    is_live: info.is_live,
+                    has_encryption: info.has_encryption,
+                }))
+            }
+        }
+    }
+
+    /// Fetch M3U8 playlist text from a URL
+    async fn fetch_playlist_text(&self, m3u8_url: &str) -> Result<String> {
+        let response = self.http_client.get(m3u8_url).send().await.map_err(|e| {
+            if e.is_timeout() {
+                RdlpError::Network(format!("Timeout fetching playlist: {m3u8_url}"))
+            } else if e.is_connect() {
+                RdlpError::Network(format!("Connection failed for playlist: {m3u8_url}: {e}"))
+            } else {
+                RdlpError::Network(format!("Failed to fetch playlist: {e}"))
+            }
+        })?;
+
+        if !response.status().is_success() {
+            return Err(RdlpError::Network(format!(
+                "HTTP {} for playlist: {m3u8_url}",
+                response.status()
+            )));
+        }
+
+        response
+            .text()
+            .await
+            .map_err(|e| RdlpError::Network(format!("Failed to read playlist response: {e}")))
+    }
+
+    /// Fetch a media playlist and extract its metadata
+    async fn fetch_and_extract_media_info(
+        &self,
+        media_url: &str,
+    ) -> Result<Option<MediaPlaylistInfo>> {
+        let text = self.fetch_playlist_text(media_url).await?;
+        let playlist = m3u8_rs::parse_playlist_res(text.as_bytes())
+            .map_err(|e| RdlpError::Extraction(format!("M3U8 parse error: {e:?}")))?;
+
+        match playlist {
+            m3u8_rs::Playlist::MediaPlaylist(media) => {
+                Ok(Some(Self::extract_media_playlist_info(&media)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Extract metadata from a parsed media playlist (no HTTP requests)
+    fn extract_media_playlist_info(media: &m3u8_rs::MediaPlaylist) -> MediaPlaylistInfo {
+        let segment_count = media.segments.len();
+        let total_duration = media.segments.iter().map(|s| s.duration as f64).sum();
+        let is_live = !media.end_list;
+        let has_encryption = media.segments.iter().any(|s| s.key.is_some());
+
+        MediaPlaylistInfo {
+            segment_count,
+            total_duration,
+            is_live,
+            has_encryption,
+        }
     }
 
     /// Parse m3u8 playlist and extract segment URLs
@@ -245,28 +486,7 @@ impl HlsSizeDetector {
             debug!(url:? = m3u8_url; "HLS fetching playlist");
         }
 
-        // Fetch playlist text
-        let response = self.http_client.get(m3u8_url).send().await.map_err(|e| {
-            if e.is_timeout() {
-                RdlpError::Network(format!("Timeout fetching playlist: {m3u8_url}"))
-            } else if e.is_connect() {
-                RdlpError::Network(format!("Connection failed for playlist: {m3u8_url}: {e}"))
-            } else {
-                RdlpError::Network(format!("Failed to fetch playlist: {e}"))
-            }
-        })?;
-
-        if !response.status().is_success() {
-            return Err(RdlpError::Network(format!(
-                "HTTP {} for playlist: {m3u8_url}",
-                response.status()
-            )));
-        }
-
-        let playlist_text = response
-            .text()
-            .await
-            .map_err(|e| RdlpError::Network(format!("Failed to read playlist response: {e}")))?;
+        let playlist_text = self.fetch_playlist_text(m3u8_url).await?;
 
         if self.verbose {
             debug!(bytes = playlist_text.len(); "HLS playlist size");
@@ -556,30 +776,55 @@ pub async fn detect_format_sizes(
                 let is_hls = format.ext == "hls" || url.contains(".m3u8") || url.contains("/hls/");
 
                 if is_hls {
-                    // Fast segment count only (parses m3u8, no size fetching)
-                    // Store segment count in filesize_approx for display in Size column
-                    // (negative value convention: segment count, not bytes)
-                    let result =
-                        timeout(Duration::from_secs(5), hls_detector.count_segments(&url)).await;
+                    // Detect HLS metadata (segment count, codecs, resolution, etc.)
+                    let result = timeout(
+                        Duration::from_secs(5),
+                        hls_detector.detect_hls_metadata(&url),
+                    )
+                    .await;
 
                     match result {
-                        Ok(Ok(Some(segment_count))) => {
-                            // Use a special marker: store segment count as approx size
-                            // The table_row() method will detect HLS and show "X segments"
-                            format.filesize_approx = Some(segment_count as u64);
+                        Ok(Ok(Some(info))) => {
+                            format.filesize_approx = Some(info.segment_count as u64);
+
+                            // Enrich format with M3U8 metadata (overrides hardcoded values)
+                            if let Some((w, h)) = info.resolution {
+                                format.width = Some(w as u32);
+                                format.height = Some(h as u32);
+                            }
+                            if let Some(vc) = info.video_codec {
+                                format.vcodec = Some(vc);
+                            }
+                            if let Some(ac) = info.audio_codec {
+                                format.acodec = Some(ac);
+                            }
+                            if let Some(fr) = info.frame_rate {
+                                format.fps = Some(fr);
+                            }
+                            if let Some(bw) = info.average_bandwidth.or(info.bandwidth) {
+                                format.tbr = Some(bw as f64 / 1000.0);
+                            }
+                            if info.has_encryption {
+                                format.has_drm = Some(true);
+                            }
 
                             if verbose {
                                 debug!(
                                     extractor:? = extractor_name,
                                     format:? = format.format_id,
-                                    segments = segment_count;
-                                    "HLS segment count detected"
+                                    segments = info.segment_count,
+                                    resolution:? = info.resolution,
+                                    video_codec:? = format.vcodec,
+                                    audio_codec:? = format.acodec,
+                                    fps:? = format.fps,
+                                    tbr:? = format.tbr;
+                                    "HLS metadata detected"
                                 );
                             }
                         }
                         Ok(Ok(None)) | Ok(Err(_)) | Err(_) => {
                             if verbose {
-                                debug!(extractor:? = extractor_name, url:? = url; "Could not count HLS segments");
+                                debug!(extractor:? = extractor_name, url:? = url; "Could not detect HLS metadata");
                             }
                         }
                     }


### PR DESCRIPTION
Add comprehensive HLS metadata extraction from M3U8 playlists using fields already available in m3u8-rs but previously ignored. HLS formats now get real codec, resolution, fps, and bitrate values from the M3U8 CODECS/RESOLUTION/FRAME-RATE attributes instead of hardcoded defaults.

- Add RFC 6381 codec parser (codecs.rs) supporting h264, hevc, vp9, vp8, av1, aac, ac3, eac3, opus, flac, vorbis
- Extend HlsInfo with 9 new fields: total_duration, resolution, video_codec, audio_codec, frame_rate, bandwidth, average_bandwidth, is_live, has_encryption
- Add detect_hls_metadata() to HlsSizeDetector for full M3U8 metadata extraction from both master and media playlists
- Update detect_format_sizes() to populate Format fields with real M3U8 metadata, overriding hardcoded h264/aac values
- Add encryption and live stream warnings in downloader