### PR TITLE
Feature/hls metadata surface

### DIFF
--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -153,17 +153,17 @@ async fn async_main() -> Result<()> {
 
     // List extractors if requested
     if args.list_extractors {
-        println!("Available extractors:");
+        info!("Available extractors:");
         for extractor in orchestrator.list_extractors() {
-            println!("  - {extractor}");
+            info!("  - {extractor}");
         }
         return Ok(());
     }
 
     if args.list_downloaders {
-        println!("Available download protocols:");
+        info!("Available download protocols:");
         for downloader in orchestrator.list_downloaders() {
-            println!("  - {downloader}");
+            info!("  - {downloader}");
         }
         return Ok(());
     }

--- a/crates/rdlp-cli/src/orchestrator/paths.rs
+++ b/crates/rdlp-cli/src/orchestrator/paths.rs
@@ -25,34 +25,21 @@ impl Orchestrator {
 
     /// Determine the actual file extension for a format
     ///
-    /// For streaming protocols (HLS, DASH), detects the actual container format
-    /// from the format metadata or segment URLs.
+    /// For streaming protocols (HLS, DASH), uses the detected container format
+    /// from segment metadata. Falls back to URL-based detection if not available.
     pub(super) fn determine_file_extension(&self, format: &rdlp_core::Format) -> String {
-        // Priority 1: Use container field if explicitly set
+        // Priority 1: Use container field from HLS/DASH metadata
         if let Some(ref container) = format.container {
-            // Clean up container names (e.g., "mp4_dash" -> "mp4")
-            return container.split('_').next().unwrap_or(container).to_string();
+            return match container.as_str() {
+                "m4s" | "m4v" | "m4a" => "mp4".to_string(), // fMP4 variants → mp4
+                other => other.split('_').next().unwrap_or(other).to_string(),
+            };
         }
 
-        // Priority 2: For HLS/DASH, detect from URL or default to mp4
+        // Priority 2: Fallback for formats without detected container
         match format.ext.as_str() {
-            "hls" | "m3u8" => {
-                // Try to detect from URL (e.g., .../segment.ts)
-                if format.url.contains(".ts") {
-                    "ts".to_string() // MPEG-TS segments
-                } else {
-                    "mp4".to_string() // fMP4 segments (.m4s/.mp4) or default
-                }
-            }
-            "dash" | "mpd" => {
-                // DASH typically uses fMP4
-                if format.url.contains(".webm") {
-                    "webm".to_string()
-                } else {
-                    "mp4".to_string() // Default to MP4 for DASH
-                }
-            }
-            ext => ext.to_string(), // Use extension as-is for direct formats
+            "hls" | "m3u8" | "dash" | "mpd" => "mp4".to_string(),
+            ext => ext.to_string(),
         }
     }
 

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -70,7 +70,7 @@ impl Orchestrator {
         let already_downloaded = existing_files.len();
         let remaining = total - already_downloaded;
 
-        println!("\n{}", "=".repeat(60));
+        info!("{}", "=".repeat(60));
         info!(title:? = playlist_title; "Playlist");
         info!(path:? = playlist_dir.display(); "Folder");
         info!(total; "Total videos");
@@ -85,8 +85,7 @@ impl Orchestrator {
             info!(remaining; "Remaining");
         }
 
-        println!("{}", "=".repeat(60));
-        println!();
+        info!("{}", "=".repeat(60));
 
         // If all videos are already downloaded, return early
         if remaining == 0 {
@@ -116,10 +115,9 @@ impl Orchestrator {
             .unwrap_or(false);
 
             if !proceed {
-                println!("Cancelled by user");
+                info!("Cancelled by user");
                 return Ok(None);
             }
-            println!();
         }
 
         // Create playlist directory if it doesn't exist
@@ -155,9 +153,9 @@ impl Orchestrator {
                 continue;
             }
 
-            println!("\n{}", "─".repeat(60));
+            info!("{}", "─".repeat(60));
             info!(position, total, title:? = info.title; "Downloading");
-            println!("{}", "─".repeat(60));
+            info!("{}", "─".repeat(60));
 
             // Race download against Ctrl+C signal
             tokio::select! {
@@ -201,7 +199,7 @@ impl Orchestrator {
         info!(downloaded = downloaded.len(), total; "Total downloaded");
 
         if already_downloaded > 0 {
-            println!("   (previously: {already_downloaded}, this session: {newly_downloaded})");
+            info!("   (previously: {already_downloaded}, this session: {newly_downloaded})");
         }
 
         if !failed.is_empty() {
@@ -219,7 +217,7 @@ impl Orchestrator {
             info!("Run the same command again to resume");
         }
 
-        println!("{}", "=".repeat(60));
+        info!("{}", "=".repeat(60));
 
         if downloaded.is_empty() {
             Err(OrchestratorError::ExtractionFailed(

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -350,7 +350,7 @@ impl Orchestrator {
         output_dir: &std::path::Path,
     ) -> Result<Option<PathBuf>> {
         // Select format
-        let format = match self.select_format(&info.formats, interactive).await? {
+        let format = match self.select_format(info, interactive).await? {
             Some(format) => format,
             None => return Ok(None),
         };

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -87,7 +87,7 @@ impl Orchestrator {
 
         if self.config.verbose {
             let processors = registry.list_processors();
-            println!("   Available processors: {}", processors.join(", "));
+            debug!("Available processors: {}", processors.join(", "));
         }
 
         // Run FFmpeg remux to fix container (faststart, timestamps)

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -2,8 +2,8 @@
 
 use super::{Orchestrator, errors::*};
 use dialoguer::{Select, theme::ColorfulTheme};
-use log::info;
-use rdlp_core::{Format, FormatSelector};
+use log::{info, warn};
+use rdlp_core::{Format, FormatSelector, InfoDict};
 
 impl Orchestrator {
     /// Select format from available formats
@@ -16,11 +16,12 @@ impl Orchestrator {
     /// - No suitable format is found (automatic mode)
     pub(super) async fn select_format(
         &self,
-        formats: &[Format],
+        info: &InfoDict,
         interactive: bool,
     ) -> Result<Option<Format>> {
+        let formats = &info.formats;
         let format = if interactive {
-            match self.select_format_interactive(formats).await? {
+            match self.select_format_interactive(info).await? {
                 Some(format) => format,
                 None => {
                     info!("Selection cancelled by user");
@@ -48,9 +49,16 @@ impl Orchestrator {
     /// Displays a menu of available formats and lets the user select one.
     ///
     /// Returns Ok(Some(format)) if format selected, Ok(None) if user cancelled (ESC pressed)
-    pub(super) async fn select_format_interactive(&self, formats: &[Format]) -> Result<Option<Format>> {
+    pub(super) async fn select_format_interactive(&self, info: &InfoDict) -> Result<Option<Format>> {
+        let formats = &info.formats;
         if formats.is_empty() {
             return Err(OrchestratorError::NoFormat);
+        }
+
+        // Warn about live streams before showing format table
+        if info.is_live == Some(true) {
+            warn!("This appears to be a LIVE stream — download may be incomplete");
+            println!();
         }
 
         // Build menu items with format details

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -56,20 +56,19 @@ impl Orchestrator {
         }
 
         // Warn about live streams before showing format table
-        if info.is_live == Some(true) {
-            warn!("This appears to be a LIVE stream — download may be incomplete");
-            println!();
+        if info.is_live.unwrap_or(false) {
+            warn!("LIVE stream detected — download may be incomplete");
         }
 
         // Build menu items with format details
         let items: Vec<String> = formats.iter().map(|f| f.table_row()).collect();
 
         info!("Available formats:");
-        println!(
+        info!(
             "{:<12} | {:<10} | {:<12} | {:<6} | Codecs",
             "Quality", "Resolution", "Size", "Type"
         );
-        println!("{}", "-".repeat(79));
+        info!("{}", "-".repeat(79));
 
         let selection = tokio::task::spawn_blocking(move || {
             Select::with_theme(&ColorfulTheme::default())

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -137,7 +137,7 @@ impl DownloadPhase {
             }
 
             Self::SelectingFormat { info } => {
-                let format = match orchestrator.select_format(&info.formats, interactive).await? {
+                let format = match orchestrator.select_format(&info, interactive).await? {
                     Some(format) => format,
                     None => return Ok(Self::Cancelled),
                 };

--- a/crates/rdlp-cli/src/orchestrator/tests.rs
+++ b/crates/rdlp-cli/src/orchestrator/tests.rs
@@ -1,13 +1,25 @@
 //! Tests for the orchestrator module
 
 use super::*;
-use rdlp_core::{Config, Format};
+use rdlp_core::{Config, Format, InfoDict};
 use std::path::Path;
 
 /// Helper function to create a test orchestrator
 pub(crate) fn create_test_orchestrator() -> Orchestrator {
     let config = Config::default();
     Orchestrator::new(config)
+}
+
+/// Helper function to wrap formats in an InfoDict for testing
+fn create_test_info_dict(formats: Vec<Format>) -> InfoDict {
+    let mut info = InfoDict::new(
+        "test_id".to_string(),
+        "Test Video".to_string(),
+        "TestExtractor".to_string(),
+        "https://example.com/video".to_string(),
+    );
+    info.formats = formats;
+    info
 }
 
 /// Helper function to create a test format
@@ -232,9 +244,10 @@ async fn test_select_format_automatic_mode() {
         create_test_format("720p", "720p", Some(1000000)),
         create_test_format("1080p", "1080p", Some(2000000)),
     ];
+    let info = create_test_info_dict(formats);
 
     // Non-interactive mode should use format selector
-    let result = orchestrator.select_format(&formats, false).await;
+    let result = orchestrator.select_format(&info, false).await;
     assert!(result.is_ok());
     let selected = result.unwrap();
     assert!(selected.is_some());
@@ -246,10 +259,10 @@ async fn test_select_format_automatic_mode() {
 #[tokio::test]
 async fn test_select_format_empty_formats() {
     let orchestrator = create_test_orchestrator();
-    let formats = vec![];
+    let info = create_test_info_dict(vec![]);
 
     // Should fail with empty formats in automatic mode
-    let result = orchestrator.select_format(&formats, false).await;
+    let result = orchestrator.select_format(&info, false).await;
     assert!(result.is_err());
 }
 

--- a/crates/rdlp-cli/src/orchestrator/tests.rs
+++ b/crates/rdlp-cli/src/orchestrator/tests.rs
@@ -210,8 +210,8 @@ fn test_generate_output_path_hls_extension() {
         "HLS Test Video.mp4"
     );
 
-    // HLS with MPEG-TS segments (detected from URL)
-    format.url = "https://example.com/segment0.ts".to_string();
+    // HLS with MPEG-TS segments (detected from segment metadata)
+    format.container = Some("ts".to_string());
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),

--- a/crates/rdlp-cli/tests/test_utils.rs
+++ b/crates/rdlp-cli/tests/test_utils.rs
@@ -169,6 +169,8 @@ impl Downloader for MockDownloader {
                 percentage: Some(100.0),
                 segments_downloaded: None,
                 total_segments: None,
+                duration_downloaded: None,
+                total_duration: None,
             };
             callback.on_progress(&progress);
         }
@@ -226,6 +228,8 @@ impl Downloader for MockDownloader {
                 percentage: Some(100.0),
                 segments_downloaded: None,
                 total_segments: None,
+                duration_downloaded: None,
+                total_duration: None,
             };
             callback.on_progress(&progress);
         }

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -134,6 +134,12 @@ pub struct DownloadProgress {
 
     /// Total segments (for HLS/segmented downloads)
     pub total_segments: Option<u64>,
+
+    /// Duration downloaded in seconds (for HLS with duration tracking)
+    pub duration_downloaded: Option<f64>,
+
+    /// Total stream duration in seconds (for HLS with duration tracking)
+    pub total_duration: Option<f64>,
 }
 
 impl DownloadProgress {
@@ -164,6 +170,8 @@ impl DownloadProgress {
             percentage,
             segments_downloaded: None,
             total_segments: None,
+            duration_downloaded: None,
+            total_duration: None,
         }
     }
 
@@ -202,6 +210,55 @@ impl DownloadProgress {
             percentage,
             segments_downloaded: Some(segments_downloaded),
             total_segments: Some(total_segments),
+            duration_downloaded: None,
+            total_duration: None,
+        }
+    }
+
+    /// Create a new duration-based progress update (for HLS with duration tracking)
+    ///
+    /// Uses stream duration for more accurate progress/ETA than segment count,
+    /// since segments can have variable lengths.
+    pub fn new_with_duration(
+        bytes_downloaded: u64,
+        speed: f64,
+        segments_downloaded: u64,
+        total_segments: u64,
+        duration_downloaded: f64,
+        total_duration: f64,
+    ) -> Self {
+        let percentage = if total_duration > 0.0 {
+            Some((duration_downloaded / total_duration) * 100.0)
+        } else {
+            None
+        };
+
+        let eta = if speed > 0.0 && total_duration > 0.0 && duration_downloaded < total_duration {
+            // Estimate remaining bytes based on duration ratio and current progress
+            let remaining_duration = total_duration - duration_downloaded;
+            let duration_ratio = if duration_downloaded > 0.0 {
+                remaining_duration / duration_downloaded
+            } else {
+                1.0
+            };
+            let estimated_remaining_bytes = (bytes_downloaded as f64 * duration_ratio) as u64;
+            Some(Duration::from_secs_f64(
+                estimated_remaining_bytes as f64 / speed,
+            ))
+        } else {
+            None
+        };
+
+        Self {
+            bytes_downloaded,
+            total_bytes: None,
+            speed,
+            eta,
+            percentage,
+            segments_downloaded: Some(segments_downloaded),
+            total_segments: Some(total_segments),
+            duration_downloaded: Some(duration_downloaded),
+            total_duration: Some(total_duration),
         }
     }
 

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -18,6 +18,15 @@ use tokio::sync::Mutex;
 use crate::hls_state::HlsDownloadState;
 use crate::http::HttpDownloader;
 
+/// Information about an HLS segment including its duration
+#[derive(Clone, Debug)]
+struct SegmentInfo {
+    /// Segment URL
+    url: String,
+    /// Segment duration in seconds (from EXTINF)
+    duration: f64,
+}
+
 /// HLS (HTTP Live Streaming) downloader
 ///
 /// Downloads HLS streams by parsing m3u8 playlists and downloading segments
@@ -244,9 +253,9 @@ impl HlsDownloader {
     /// * `m3u8_url` - URL of the m3u8 playlist
     ///
     /// # Returns
-    /// * `Ok(Vec<String>)` - List of segment URLs
+    /// * `Ok(Vec<SegmentInfo>)` - List of segment URLs with durations
     /// * `Err(_)` - Network error, parse error, or empty playlist
-    async fn parse_playlist(&self, m3u8_url: &str) -> Result<Vec<String>> {
+    async fn parse_playlist(&self, m3u8_url: &str) -> Result<Vec<SegmentInfo>> {
         // Fetch playlist text
         let playlist_text = self
             .http_downloader
@@ -274,19 +283,23 @@ impl HlsDownloader {
                     warn!("HLS stream appears to be live (no EXT-X-ENDLIST) — may not download completely");
                 }
 
-                // Direct media playlist - extract segments
+                // Direct media playlist - extract segments with durations
                 let base_url = url::Url::parse(m3u8_url)
                     .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
 
-                let segments: Vec<String> = media
+                let segments: Vec<SegmentInfo> = media
                     .segments
                     .iter()
                     .map(|seg| {
                         // Join relative URLs with base URL
-                        base_url
+                        let url = base_url
                             .join(&seg.uri)
                             .map(|u| u.to_string())
-                            .unwrap_or_else(|_| seg.uri.clone())
+                            .unwrap_or_else(|_| seg.uri.clone());
+                        SegmentInfo {
+                            url,
+                            duration: seg.duration as f64,
+                        }
                     })
                     .collect();
 
@@ -342,11 +355,12 @@ impl HlsDownloader {
     /// Saves state periodically for crash recovery.
     ///
     /// # Arguments
-    /// * `segment_urls` - List of segment URLs to download
+    /// * `segments` - List of segments with URLs and durations
     /// * `temp_dir` - Directory to save temporary segment files
     /// * `base_filename` - Base filename for temporary files
     /// * `progress_counter` - Shared atomic counter for bytes downloaded
     /// * `segments_counter` - Shared atomic counter for segments completed
+    /// * `duration_counter` - Shared atomic counter for duration completed (in centiseconds for precision)
     /// * `state` - Shared download state for resume tracking
     /// * `output_path` - Final output path (for state file location)
     ///
@@ -354,27 +368,37 @@ impl HlsDownloader {
     /// * `Ok(Vec<PathBuf>)` - Paths to ALL segment files (in order, including pre-existing)
     /// * `Err(_)` - Download error (network, I/O, etc.)
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(self, segment_urls, progress_counter, segments_counter, state), fields(segments = segment_urls.len()))]
+    #[instrument(skip(self, segments, progress_counter, segments_counter, duration_counter, state), fields(segments = segments.len()))]
     async fn download_segments_with_resume(
         &self,
-        segment_urls: Vec<String>,
+        segments: Vec<SegmentInfo>,
         temp_dir: &Path,
         base_filename: &str,
         progress_counter: Arc<AtomicU64>,
         segments_counter: Arc<AtomicU64>,
+        duration_counter: Arc<AtomicU64>,
         state: Arc<Mutex<HlsDownloadState>>,
         output_path: &Path,
     ) -> Result<Vec<PathBuf>> {
-        let total_segments = segment_urls.len();
+        let total_segments = segments.len();
 
         // Get already completed segments
         let completed: HashSet<usize> = state.lock().await.completed_segments.clone();
-        let to_download: Vec<(usize, String)> = segment_urls
+        let to_download: Vec<(usize, SegmentInfo)> = segments
             .iter()
             .enumerate()
             .filter(|(idx, _)| !completed.contains(idx))
-            .map(|(idx, url)| (idx, url.clone()))
+            .map(|(idx, seg)| (idx, seg.clone()))
             .collect();
+
+        // Calculate duration already downloaded from completed segments
+        let completed_duration: f64 = segments
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| completed.contains(idx))
+            .map(|(_, seg)| seg.duration)
+            .sum();
+        duration_counter.store((completed_duration * 100.0) as u64, Ordering::Relaxed);
 
         let already_downloaded = completed.len();
         let remaining = to_download.len();
@@ -399,13 +423,16 @@ impl HlsDownloader {
 
         let max_failures = self.max_segment_failures;
         let mut stream = stream::iter(to_download.into_iter())
-            .map(|(idx, url)| {
+            .map(|(idx, seg)| {
                 let segment_path = temp_dir_owned.join(format!("{base_filename_owned}.part{idx}"));
                 let downloader = downloader.clone();
                 let progress = progress_counter.clone();
                 let segments = segments_counter.clone();
+                let duration = duration_counter.clone();
                 let state = state.clone();
                 let output_path = output_path_owned.clone();
+                let seg_duration = seg.duration;
+                let seg_url = seg.url;
 
                 async move {
                     // Check if segment file already exists and is non-empty (single async stat)
@@ -424,6 +451,7 @@ impl HlsDownloader {
                             }
                             segments.fetch_add(1, Ordering::Relaxed);
                             progress.fetch_add(bytes, Ordering::Relaxed);
+                            duration.fetch_add((seg_duration * 100.0) as u64, Ordering::Relaxed);
                             return Ok((idx, segment_path, bytes));
                         }
                     }
@@ -432,7 +460,7 @@ impl HlsDownloader {
                     let result = downloader
                         .download_segment_with_retry(
                             idx,
-                            url,
+                            seg_url,
                             segment_path.clone(),
                             progress.clone(),
                         )
@@ -458,6 +486,7 @@ impl HlsDownloader {
                             }
 
                             segments.fetch_add(1, Ordering::Relaxed);
+                            duration.fetch_add((seg_duration * 100.0) as u64, Ordering::Relaxed);
                         }
                         Err(e) => {
                             // Save state on error before propagating
@@ -654,9 +683,14 @@ impl Downloader for HlsDownloader {
             let start_time = Instant::now();
 
             // Step 1: Parse playlist
-            let segment_urls = self.parse_playlist(url).await?;
-            let total_segments = segment_urls.len();
-            info!(segments = total_segments; "Parsed HLS playlist");
+            let segments = self.parse_playlist(url).await?;
+            let total_segments = segments.len();
+            let total_duration: f64 = segments.iter().map(|s| s.duration).sum();
+            info!(
+                segments = total_segments,
+                duration_secs = total_duration;
+                "Parsed HLS playlist"
+            );
 
             // Step 2: Load or create state for resume support
             let state = match HlsDownloadState::load(path, url, total_segments).await {
@@ -685,12 +719,15 @@ impl Downloader for HlsDownloader {
             let segments_completed = Arc::new(AtomicU64::new(
                 state.lock().await.completed_segments.len() as u64,
             ));
+            // Duration in centiseconds for atomic precision (f64 -> u64)
+            let duration_completed = Arc::new(AtomicU64::new(0));
             let total_segments_u64 = total_segments as u64;
 
-            // Spawn progress reporter task with segment-based progress
+            // Spawn progress reporter task with duration-based progress
             let progress_task = if let Some(callback) = progress {
                 let downloaded_clone = downloaded.clone();
                 let segments_clone = segments_completed.clone();
+                let duration_clone = duration_completed.clone();
                 let start_time_clone = start_time;
                 Some(tokio::spawn(async move {
                     let mut last_update = Instant::now();
@@ -702,6 +739,8 @@ impl Downloader for HlsDownloader {
                         if now.duration_since(last_update) >= update_interval {
                             let bytes = downloaded_clone.load(Ordering::Relaxed);
                             let segments = segments_clone.load(Ordering::Relaxed);
+                            let dur_centis = duration_clone.load(Ordering::Relaxed);
+                            let dur_downloaded = dur_centis as f64 / 100.0;
                             let elapsed = now.duration_since(start_time_clone).as_secs_f64();
                             let speed = if elapsed > 0.0 {
                                 bytes as f64 / elapsed
@@ -709,12 +748,14 @@ impl Downloader for HlsDownloader {
                                 0.0
                             };
 
-                            // Use segment-based progress for HLS
-                            let progress_info = DownloadProgress::new_with_segments(
+                            // Use duration-based progress for more accurate percentage/ETA
+                            let progress_info = DownloadProgress::new_with_duration(
                                 bytes,
                                 speed,
                                 segments,
                                 total_segments_u64,
+                                dur_downloaded,
+                                total_duration,
                             );
                             callback.on_progress(&progress_info);
                             last_update = now;
@@ -734,11 +775,12 @@ impl Downloader for HlsDownloader {
 
             let segment_paths = match self
                 .download_segments_with_resume(
-                    segment_urls.clone(),
+                    segments.clone(),
                     temp_dir,
                     base_filename,
                     downloaded.clone(),
                     segments_completed.clone(),
+                    duration_completed.clone(),
                     state.clone(),
                     path,
                 )

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -115,7 +115,7 @@ impl InfoExtractor for PornHubExtractor {
         }
 
         // Detect file sizes and segment counts
-        let formats_with_size = detect_format_sizes(formats, ctx, self.name()).await;
+        let (formats_with_size, hls_flags) = detect_format_sizes(formats, ctx, self.name()).await;
 
         // Build InfoDict with all metadata
         let mut info = InfoDict::new(video_id, title, self.name().to_string(), url.to_string());
@@ -129,6 +129,11 @@ impl InfoExtractor for PornHubExtractor {
         info.average_rating = average_rating;
         info.age_limit = Some(18);
         info.formats = formats_with_size;
+
+        // Set stream-level flags from HLS detection
+        if hls_flags.is_live {
+            info.is_live = Some(true);
+        }
 
         Ok(info)
     }

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -112,7 +112,7 @@ impl InfoExtractor for RedTubeExtractor {
         }
 
         // Fetch sizes/segments for all formats in parallel
-        formats = detect_format_sizes(formats, ctx, self.name()).await;
+        let (formats, hls_flags) = detect_format_sizes(formats, ctx, self.name()).await;
 
         // Build InfoDict with all extracted metadata
         let mut info = InfoDict::new(
@@ -139,6 +139,11 @@ impl InfoExtractor for RedTubeExtractor {
         info.categories = metadata.categories;
         info.age_limit = Some(18); // RedTube is adult content
         info.formats = formats;
+
+        // Set stream-level flags from HLS detection
+        if hls_flags.is_live {
+            info.is_live = Some(true);
+        }
 
         Ok(info)
     }

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -85,6 +85,8 @@ pub struct HlsInfo {
     pub is_live: bool,
     /// Whether any segment uses encryption (EXT-X-KEY)
     pub has_encryption: bool,
+    /// Detected segment container format (e.g., "ts", "mp4", "m4s")
+    pub segment_container: Option<String>,
 }
 
 /// Media playlist metadata extracted without additional HTTP requests
@@ -93,6 +95,15 @@ struct MediaPlaylistInfo {
     total_duration: f64,
     is_live: bool,
     has_encryption: bool,
+    segment_container: Option<String>,
+}
+
+/// Detect container format from segment URL extension
+fn detect_segment_container(segment_uri: &str) -> Option<String> {
+    let path = segment_uri.split('?').next().unwrap_or(segment_uri);
+    path.rfind('.')
+        .map(|pos| path[pos + 1..].to_lowercase())
+        .filter(|ext| !ext.is_empty())
 }
 
 /// HLS playlist size detector
@@ -240,6 +251,9 @@ impl HlsSizeDetector {
 
         let segment_count = segment_urls.len();
 
+        // Detect container from first segment URL
+        let segment_container = segment_urls.first().and_then(|url| detect_segment_container(url));
+
         // Step 2: Calculate total size from all segments
         let total_size = match self.sum_segment_sizes(segment_urls).await {
             Ok(size) => size,
@@ -274,6 +288,7 @@ impl HlsSizeDetector {
             average_bandwidth: None,
             is_live: false,
             has_encryption: false,
+            segment_container,
         }))
     }
 
@@ -378,6 +393,7 @@ impl HlsSizeDetector {
                             average_bandwidth,
                             is_live: false,
                             has_encryption: false,
+                            segment_container: None,
                         }));
                     }
                 };
@@ -394,6 +410,7 @@ impl HlsSizeDetector {
                     average_bandwidth,
                     is_live: media_info.is_live,
                     has_encryption: media_info.has_encryption,
+                    segment_container: media_info.segment_container,
                 }))
             }
             m3u8_rs::Playlist::MediaPlaylist(media) => {
@@ -421,6 +438,7 @@ impl HlsSizeDetector {
                     average_bandwidth: None,
                     is_live: info.is_live,
                     has_encryption: info.has_encryption,
+                    segment_container: info.segment_container,
                 }))
             }
         }
@@ -475,11 +493,18 @@ impl HlsSizeDetector {
         let is_live = !media.end_list;
         let has_encryption = media.segments.iter().any(|s| s.key.is_some());
 
+        // Detect container from first segment URL
+        let segment_container = media
+            .segments
+            .first()
+            .and_then(|seg| detect_segment_container(&seg.uri));
+
         MediaPlaylistInfo {
             segment_count,
             total_duration,
             is_live,
             has_encryption,
+            segment_container,
         }
     }
 
@@ -827,6 +852,9 @@ pub async fn detect_format_sizes(
                             if info.has_encryption {
                                 format.has_drm = Some(true);
                             }
+                            if let Some(container) = info.segment_container {
+                                format.container = Some(container);
+                            }
 
                             // Capture stream-level flags for aggregation
                             detected_is_live = Some(info.is_live);
@@ -879,10 +907,10 @@ pub async fn detect_format_sizes(
 
     for (format, is_live, has_encryption) in results {
         formats.push(format);
-        if is_live == Some(true) {
+        if is_live.unwrap_or(false) {
             flags.is_live = true;
         }
-        if has_encryption == Some(true) {
+        if has_encryption.unwrap_or(false) {
             flags.has_any_drm = true;
         }
     }

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -804,6 +804,9 @@ pub async fn detect_format_sizes(
                             if let Some(bw) = info.average_bandwidth.or(info.bandwidth) {
                                 format.tbr = Some(bw as f64 / 1000.0);
                             }
+                            if let Some(dur) = info.total_duration {
+                                format.duration = Some(dur);
+                            }
                             if info.has_encryption {
                                 format.has_drm = Some(true);
                             }

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -47,6 +47,19 @@ const MAX_SEGMENTS: usize = 10_000;
 /// Default number of concurrent HTTP requests
 const DEFAULT_CONCURRENCY: usize = 8;
 
+/// Stream-level flags aggregated from HLS format detection
+///
+/// These flags represent properties of the entire stream, not individual formats.
+/// They are aggregated during `detect_format_sizes()` and can be used to set
+/// `InfoDict.is_live` or warn users about encrypted content.
+#[derive(Debug, Clone, Default)]
+pub struct HlsStreamFlags {
+    /// True if any HLS format is a live stream (no EXT-X-ENDLIST tag)
+    pub is_live: bool,
+    /// True if any HLS format uses encryption (EXT-X-KEY)
+    pub has_any_drm: bool,
+}
+
 /// Information about an HLS stream
 #[derive(Debug, Clone)]
 pub struct HlsInfo {
@@ -748,12 +761,12 @@ impl HlsSizeDetector {
 /// * `extractor_name` - Name of the extractor for logging (e.g., "PornHub", "RedTube")
 ///
 /// # Returns
-/// Vector of formats with sizes/segment counts populated
+/// Tuple of (formats with sizes/segment counts populated, stream-level flags)
 pub async fn detect_format_sizes(
     formats: Vec<rdlp_core::Format>,
     ctx: &rdlp_core::ExtractionContext,
     extractor_name: &str,
-) -> Vec<rdlp_core::Format> {
+) -> (Vec<rdlp_core::Format>, HlsStreamFlags) {
     use futures::future::join_all;
     use std::time::Duration;
     use tokio::time::timeout;
@@ -774,6 +787,10 @@ pub async fn detect_format_sizes(
                 let mut format = format;
                 let url = format.url.clone();
                 let is_hls = format.ext == "hls" || url.contains(".m3u8") || url.contains("/hls/");
+
+                // Track stream-level flags from HLS detection
+                let mut detected_is_live = None;
+                let mut detected_has_encryption = None;
 
                 if is_hls {
                     // Detect HLS metadata (segment count, codecs, resolution, etc.)
@@ -811,6 +828,10 @@ pub async fn detect_format_sizes(
                                 format.has_drm = Some(true);
                             }
 
+                            // Capture stream-level flags for aggregation
+                            detected_is_live = Some(info.is_live);
+                            detected_has_encryption = Some(info.has_encryption);
+
                             if verbose {
                                 debug!(
                                     extractor:? = extractor_name,
@@ -820,7 +841,8 @@ pub async fn detect_format_sizes(
                                     video_codec:? = format.vcodec,
                                     audio_codec:? = format.acodec,
                                     fps:? = format.fps,
-                                    tbr:? = format.tbr;
+                                    tbr:? = format.tbr,
+                                    is_live = info.is_live;
                                     "HLS metadata detected"
                                 );
                             }
@@ -844,12 +866,28 @@ pub async fn detect_format_sizes(
                     }
                 }
 
-                format
+                (format, detected_is_live, detected_has_encryption)
             }
         })
         .collect();
 
-    join_all(detection_futures).await
+    let results = join_all(detection_futures).await;
+
+    // Separate formats from flags and aggregate stream-level properties
+    let mut formats = Vec::with_capacity(results.len());
+    let mut flags = HlsStreamFlags::default();
+
+    for (format, is_live, has_encryption) in results {
+        formats.push(format);
+        if is_live == Some(true) {
+            flags.is_live = true;
+        }
+        if has_encryption == Some(true) {
+            flags.has_any_drm = true;
+        }
+    }
+
+    (formats, flags)
 }
 
 #[cfg(test)]

--- a/crates/rdlp-types/src/format.rs
+++ b/crates/rdlp-types/src/format.rs
@@ -431,7 +431,7 @@ impl Format {
             (None, None) => buf.push_str("Unknown"),
         }
 
-        if self.has_drm == Some(true) {
+        if self.has_drm.unwrap_or(false) {
             buf.push_str(" [DRM]");
         }
 
@@ -518,7 +518,7 @@ impl FormatSelector {
                 // Ranking: quality > height > tbr > fps
                 if let Some(best) = formats
                     .iter()
-                    .filter(|f| f.has_video() && f.has_audio() && f.has_drm != Some(true))
+                    .filter(|f| f.has_video() && f.has_audio() && !f.has_drm.unwrap_or(false))
                     .max_by(|a, b| {
                         a.quality
                             .cmp(&b.quality)
@@ -544,7 +544,7 @@ impl FormatSelector {
                 // Ranking: height > vbr > fps
                 if let Some(best) = formats
                     .iter()
-                    .filter(|f| f.has_video() && f.has_drm != Some(true))
+                    .filter(|f| f.has_video() && !f.has_drm.unwrap_or(false))
                     .max_by(|a, b| {
                         a.height
                             .cmp(&b.height)
@@ -568,7 +568,7 @@ impl FormatSelector {
             "bestaudio" => {
                 if let Some(best) = formats
                     .iter()
-                    .filter(|f| f.has_audio() && f.has_drm != Some(true))
+                    .filter(|f| f.has_audio() && !f.has_drm.unwrap_or(false))
                     .max_by(|a, b| {
                     a.abr
                         .partial_cmp(&b.abr)
@@ -584,7 +584,7 @@ impl FormatSelector {
                 // Ranking: quality > height > tbr > fps
                 if let Some(best) = formats
                     .iter()
-                    .filter(|f| f.has_drm != Some(true))
+                    .filter(|f| !f.has_drm.unwrap_or(false))
                     .max_by(|a, b| {
                         a.quality
                             .cmp(&b.quality)

--- a/crates/rdlp-types/src/format.rs
+++ b/crates/rdlp-types/src/format.rs
@@ -515,6 +515,7 @@ impl FormatSelector {
         match self.expression.as_str() {
             "best" => {
                 // Find best format with both video and audio, excluding DRM
+                // Ranking: quality > height > tbr > fps
                 if let Some(best) = formats
                     .iter()
                     .filter(|f| f.has_video() && f.has_audio() && f.has_drm != Some(true))
@@ -527,6 +528,11 @@ impl FormatSelector {
                                     .partial_cmp(&b.tbr)
                                     .unwrap_or(std::cmp::Ordering::Equal),
                             )
+                            .then(
+                                a.fps
+                                    .partial_cmp(&b.fps)
+                                    .unwrap_or(std::cmp::Ordering::Equal),
+                            )
                     })
                 {
                     vec![best]
@@ -535,16 +541,25 @@ impl FormatSelector {
                 }
             }
             "bestvideo" => {
+                // Ranking: height > vbr > fps
                 if let Some(best) = formats
                     .iter()
                     .filter(|f| f.has_video() && f.has_drm != Some(true))
                     .max_by(|a, b| {
-                    a.height.cmp(&b.height).then(
-                        a.vbr
-                            .partial_cmp(&b.vbr)
-                            .unwrap_or(std::cmp::Ordering::Equal),
-                    )
-                }) {
+                        a.height
+                            .cmp(&b.height)
+                            .then(
+                                a.vbr
+                                    .partial_cmp(&b.vbr)
+                                    .unwrap_or(std::cmp::Ordering::Equal),
+                            )
+                            .then(
+                                a.fps
+                                    .partial_cmp(&b.fps)
+                                    .unwrap_or(std::cmp::Ordering::Equal),
+                            )
+                    })
+                {
                     vec![best]
                 } else {
                     Vec::new()
@@ -566,19 +581,26 @@ impl FormatSelector {
             }
             _ => {
                 // Default: return best format, excluding DRM
+                // Ranking: quality > height > tbr > fps
                 if let Some(best) = formats
                     .iter()
                     .filter(|f| f.has_drm != Some(true))
                     .max_by(|a, b| {
-                    a.quality
-                        .cmp(&b.quality)
-                        .then(a.height.cmp(&b.height))
-                        .then(
-                            a.tbr
-                                .partial_cmp(&b.tbr)
-                                .unwrap_or(std::cmp::Ordering::Equal),
-                        )
-                }) {
+                        a.quality
+                            .cmp(&b.quality)
+                            .then(a.height.cmp(&b.height))
+                            .then(
+                                a.tbr
+                                    .partial_cmp(&b.tbr)
+                                    .unwrap_or(std::cmp::Ordering::Equal),
+                            )
+                            .then(
+                                a.fps
+                                    .partial_cmp(&b.fps)
+                                    .unwrap_or(std::cmp::Ordering::Equal),
+                            )
+                    })
+                {
                     vec![best]
                 } else {
                     Vec::new()

--- a/crates/rdlp-types/src/format.rs
+++ b/crates/rdlp-types/src/format.rs
@@ -113,6 +113,10 @@ pub struct Format {
     /// Whether format has DRM protection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_drm: Option<bool>,
+
+    /// Total duration in seconds (for HLS: sum of segment durations)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f64>,
 }
 
 impl fmt::Debug for Format {
@@ -186,6 +190,9 @@ impl fmt::Debug for Format {
         if let Some(v) = &self.has_drm {
             d.field("has_drm", v);
         }
+        if let Some(v) = &self.duration {
+            d.field("duration", v);
+        }
 
         d.finish()
     }
@@ -220,6 +227,7 @@ impl Format {
             dynamic_range: None,
             cached_description: OnceLock::new(),
             has_drm: None,
+            duration: None,
         }
     }
 
@@ -317,8 +325,21 @@ impl Format {
         // Pre-allocate buffer for typical row length (~80 chars)
         let mut buf = String::with_capacity(80);
 
-        let quality = self.format_note.as_deref().unwrap_or("unknown");
-        let _ = write!(buf, "{quality:<12} | ");
+        // Quality column: append fps when non-standard (e.g. "1080p60")
+        let quality_base = self.format_note.as_deref().unwrap_or("unknown");
+        match self.fps {
+            Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => {
+                let _ = write!(buf, "{quality_base}{fps:.0}");
+                let col_len = quality_base.len() + format!("{fps:.0}").len();
+                for _ in col_len..12 {
+                    buf.push(' ');
+                }
+                buf.push_str(" | ");
+            }
+            _ => {
+                let _ = write!(buf, "{quality_base:<12} | ");
+            }
+        }
 
         // Resolution: avoid intermediate String allocation
         match (self.width, self.height) {
@@ -340,13 +361,30 @@ impl Format {
         // Size column: write directly to buffer
         let size_start = buf.len();
         if is_hls {
-            // For HLS: show segment count if available (stored in filesize_approx)
-            if let Some(ref fragments) = self.fragments {
-                let _ = write!(buf, "{} segments", fragments.len());
-            } else if let Some(segment_count) = self.filesize_approx {
-                let _ = write!(buf, "{segment_count} segments");
-            } else {
-                buf.push_str("HLS stream");
+            // For HLS: show duration + segment count when available
+            let seg_count = self
+                .fragments
+                .as_ref()
+                .map(|f| f.len() as u64)
+                .or(self.filesize_approx);
+
+            match (self.duration, seg_count) {
+                (Some(dur), Some(segs)) => {
+                    let mins = dur as u64 / 60;
+                    let secs = dur as u64 % 60;
+                    let _ = write!(buf, "{mins}:{secs:02} ({segs} seg)");
+                }
+                (Some(dur), None) => {
+                    let mins = dur as u64 / 60;
+                    let secs = dur as u64 % 60;
+                    let _ = write!(buf, "{mins}:{secs:02}");
+                }
+                (None, Some(segs)) => {
+                    let _ = write!(buf, "{segs} segments");
+                }
+                (None, None) => {
+                    buf.push_str("HLS stream");
+                }
             }
         } else if let Some(filesize) = self.filesize {
             let _ = write!(buf, "{:.1} MB", filesize as f64 / (1024.0 * 1024.0));
@@ -391,6 +429,10 @@ impl Format {
                 let _ = write!(buf, "{a} (audio only)");
             }
             (None, None) => buf.push_str("Unknown"),
+        }
+
+        if self.has_drm == Some(true) {
+            buf.push_str(" [DRM]");
         }
 
         buf
@@ -472,10 +514,10 @@ impl FormatSelector {
     pub fn select<'a>(&self, formats: &'a [Format]) -> Vec<&'a Format> {
         match self.expression.as_str() {
             "best" => {
-                // Find best format with both video and audio
+                // Find best format with both video and audio, excluding DRM
                 if let Some(best) = formats
                     .iter()
-                    .filter(|f| f.has_video() && f.has_audio())
+                    .filter(|f| f.has_video() && f.has_audio() && f.has_drm != Some(true))
                     .max_by(|a, b| {
                         a.quality
                             .cmp(&b.quality)
@@ -493,7 +535,10 @@ impl FormatSelector {
                 }
             }
             "bestvideo" => {
-                if let Some(best) = formats.iter().filter(|f| f.has_video()).max_by(|a, b| {
+                if let Some(best) = formats
+                    .iter()
+                    .filter(|f| f.has_video() && f.has_drm != Some(true))
+                    .max_by(|a, b| {
                     a.height.cmp(&b.height).then(
                         a.vbr
                             .partial_cmp(&b.vbr)
@@ -506,7 +551,10 @@ impl FormatSelector {
                 }
             }
             "bestaudio" => {
-                if let Some(best) = formats.iter().filter(|f| f.has_audio()).max_by(|a, b| {
+                if let Some(best) = formats
+                    .iter()
+                    .filter(|f| f.has_audio() && f.has_drm != Some(true))
+                    .max_by(|a, b| {
                     a.abr
                         .partial_cmp(&b.abr)
                         .unwrap_or(std::cmp::Ordering::Equal)
@@ -517,8 +565,11 @@ impl FormatSelector {
                 }
             }
             _ => {
-                // Default: return best format
-                if let Some(best) = formats.iter().max_by(|a, b| {
+                // Default: return best format, excluding DRM
+                if let Some(best) = formats
+                    .iter()
+                    .filter(|f| f.has_drm != Some(true))
+                    .max_by(|a, b| {
                     a.quality
                         .cmp(&b.quality)
                         .then(a.height.cmp(&b.height))


### PR DESCRIPTION
This pull request introduces support for duration-based progress tracking in HLS downloads, improving the accuracy of progress and ETA reporting, especially for streams with variable segment lengths. It also refactors the format selection logic to use the full `InfoDict` structure instead of just a formats slice, and adds warnings for live streams. Several test and utility updates are included to support these changes.

**HLS Downloader: Duration-based Progress Tracking**
- Added `duration_downloaded` and `total_duration` fields to `DownloadProgress`, along with a new constructor `new_with_duration` for accurate progress/ETA based on stream duration rather than segment count. [[1]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R137-R142) [[2]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R213-R261)
- Updated the HLS downloader to parse segment durations from playlists, track cumulative downloaded duration, and report progress in centiseconds for atomic precision. [[1]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R21-R29) [[2]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L247-R258) [[3]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L277-R302) [[4]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L345-R402) [[5]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L402-R435) [[6]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R454) [[7]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L435-R463) [[8]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R489) [[9]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L657-R693) [[10]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R722-R730)

**Format Selection Refactor and Live Stream Warning**
- Refactored format selection methods to accept the full `InfoDict` instead of a formats slice, enabling more context-aware selection and easier future extensibility. [[1]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L353-R353) [[2]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158L5-R6) [[3]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158L19-R24) [[4]](diffhunk://#diff-40d2f40928ab42c5c5d19cedf5960225b16c7ed91ab2aa49551209642935904cL140-R140)
- Added a warning message in the interactive format selector when a live stream is detected, improving user awareness.

**Testing and Utilities**
- Updated tests to use the new `InfoDict`-based format selection, and added a helper to create test `InfoDict` instances. [[1]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL4-R4) [[2]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aR13-R24) [[3]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aR247-R250) [[4]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL249-R265)
- Adjusted mock downloader and progress reporting in tests to include the new duration-based progress fields. [[1]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78R172-R173) [[2]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78R231-R232) [[3]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R173-R174)