### PR TITLE
Feature/remux postprocessor

### DIFF
--- a/.cargo/config.toml.example
+++ b/.cargo/config.toml.example
@@ -1,0 +1,14 @@
+# Cargo configuration template
+#
+# Copy this file to config.toml and adjust paths for your machine.
+#   cp .cargo/config.toml.example .cargo/config.toml
+
+[env]
+# Path to FFmpeg shared build with include/ and lib/ subdirectories.
+# Required for building the ffmpeg-the-third dev-dependency (used in tests).
+#
+# Windows (WinGet):  winget install Gyan.FFmpeg.Shared
+# Windows (Choco):   choco install ffmpeg-shared
+#
+# Then set the path below to the directory containing include/ and lib/:
+FFMPEG_DIR = "C:/path/to/ffmpeg-shared"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | Category | Features |
 |----------|----------|
 | **Performance** | 37x faster • 10.5 MB/s downloads • Power-of-two chunking • Fine-grained parallelism |
-| **Protocols** | HTTP/HTTPS • HLS streaming with segment progress • DASH (planned) |
+| **Protocols** | HTTP/HTTPS • HLS with duration/fps/DRM metadata • DASH (planned) |
 | **Reliability** | Auto-resume • Ctrl+C interrupt handling • Backward-compatible chunks |
 | **Site Support** | 5 sites • TNAFlix • EMPFlix • MovieFap • RedTube • PornHub (with playlists) |
 | **User Experience** | Interactive format selection • Segment-based progress bars • Verbose mode |
@@ -171,6 +171,45 @@ Supported extractors:
 Total: 5 extractors
 ```
 
+### 📦 Container Remux
+
+MPEG-TS (.ts) files from HLS streams have poor seeking. Use `--remux` to convert to a container with better seeking support:
+
+```bash
+# Interactive container selection
+rdlp --remux "https://www.redtube.com/12345678"
+
+# Direct: remux to MP4 (best compatibility, faststart)
+rdlp --remux=mp4 "https://www.redtube.com/12345678"
+
+# Direct: remux to MKV (supports all codecs)
+rdlp --remux=mkv "https://www.redtube.com/12345678"
+
+# Combine with interactive format selection
+rdlp -i --remux "https://www.redtube.com/12345678"
+```
+
+**Interactive menu:**
+```
+? Select remux container (ESC to cancel)
+> mp4    Best compatibility, faststart for streaming
+  mkv    Supports all codecs, efficient cues index
+  webm   Web-optimized, VP8/VP9/AV1 + Opus/Vorbis
+  mov    Apple QuickTime, good for editing
+  avi    Legacy format, wide support
+  ts     MPEG-TS, broadcast/streaming
+```
+
+**Supported containers:**
+| Container | Seeking | Use Case |
+|-----------|---------|----------|
+| **MP4** | Excellent (moov atom) | Best compatibility, streaming |
+| **MKV** | Excellent (cues index) | All codecs, editing |
+| **WebM** | Good | Web browsers, VP9/AV1 |
+| **MOV** | Excellent | Apple ecosystem, editing |
+| **AVI** | Fair | Legacy compatibility |
+| **TS** | Poor | Broadcast, live streaming |
+
 ### 📋 Playlist Downloads
 
 ```bash
@@ -280,15 +319,31 @@ Quality      | Resolution | Size         | Codecs       | Protocol
   ...
 ```
 
-**Example: RedTube/PornHub (HLS formats with segment counting)**
+**Example: RedTube/PornHub (HLS formats with duration and fps)**
 ```
 📋 Available formats:
 Quality      | Resolution | Size            | Type | Codecs
 -------------------------------------------------------------------------
-1080p        | 1920x1080  | 754 segments    | HLS  | h264/aac
-720p         | 1280x720   | 612 segments    | HLS  | h264/aac
-480p         | 854x480    | 398 segments    | HLS  | h264/aac
-240p         | 426x240    | 198 segments    | HLS  | h264/aac
+1080p60      | 1920x1080  | 16:39 (250 seg) | HLS  | h264/aac
+720p30       | 1280x720   | 16:39 (250 seg) | HLS  | h264/aac
+480p30       | 854x480    | 16:39 (250 seg) | HLS  | h264/aac
+240p30       | 426x240    | 16:39 (250 seg) | HLS  | h264/aac
+```
+
+**Example: DRM-protected stream**
+```
+Quality      | Resolution | Size            | Type | Codecs
+-------------------------------------------------------------------------
+1080p60      | 1920x1080  | 16:39 (250 seg) | HLS  | h264/aac [DRM]
+```
+
+**Example: Live stream warning**
+```
+⚠ LIVE stream detected — download may be incomplete
+
+Quality      | Resolution | Size            | Type | Codecs
+-------------------------------------------------------------------------
+1080p        | 1920x1080  | LIVE            | HLS  | h264/aac
 ```
 
 **Controls:**
@@ -307,8 +362,8 @@ Quality      | Resolution | Size            | Type | Codecs
 | **Power-of-Two Chunking** | Memory-aligned chunks (64 KB - 8 MB) targeting ~1024 chunks | ✅ |
 | **Fine-Grained Parallelism** | Up to 591 concurrent chunks processed 4 at a time | ✅ |
 | **37x Faster Downloads** | 590 MB in 56.4s (10.5 MB/s) with 7-layer optimization stack | ✅ |
-| **HLS Streaming** | Full HLS downloads with segment-based progress tracking | ✅ |
-| **Fast Segment Counting** | M3U8 parsing in ~100-500ms (no size fetching) | ✅ |
+| **HLS Streaming** | Full HLS with duration-based progress and rich metadata | ✅ |
+| **HLS Metadata** | Duration, fps, DRM badge, live detection, container detection | ✅ |
 | **Playlist Support** | Batch downloads with pagination and progress tracking | ✅ |
 | **Multi-Quality** | Automatic detection of 144p to 1080p formats | ✅ |
 | **Smart Filesize** | HEAD/Range requests with CDN fallback | ✅ |
@@ -323,6 +378,7 @@ Quality      | Resolution | Size            | Type | Codecs
 | Feature | Description | Example |
 |---------|-------------|---------|
 | **Interactive Menu** | Arrow keys to select, ESC to cancel | `-i` |
+| **Remux Container** | Convert to MP4/MKV for better seeking | `--remux` or `--remux=mp4` |
 | **Verbose Mode** | Shows HEAD requests, debug info | `-v` |
 | **Quiet Mode** | Minimal output for scripts | `-q` |
 | **Simulate Mode** | Test extraction without downloading | `-s` |
@@ -388,10 +444,11 @@ URL → Extraction → Download → Post-Processing → Video File
 
 **Post-Processing Stage:**
 - Remux HLS segments to MP4 container (automatic for HLS downloads)
+- Container remux for better seeking (TS → MP4/MKV/WebM/MOV/AVI)
 - Extract audio to MP3/AAC/Opus/FLAC/WAV
 - Embed metadata (title, artist, date, chapters)
 - Embed thumbnail as cover art (MP4/MKV/MP3/FLAC)
-- Priority-based processor pipeline (100→50→40→30→20)
+- Priority-based processor pipeline (100→50→45→40→30→20)
 
 ### Key Design Decisions
 
@@ -565,7 +622,19 @@ cargo doc --no-deps --open
 - [x] Post-migration quality fixes: unwrap panic elimination (28 sites), async I/O correctness, download timeouts, resilience improvements
 - [x] **Status**: Production-ready, 270+ tests passing, 0 clippy warnings
 
-### Phases 9-11: Future
+### Phase 9: HLS Metadata Surface ✅ COMPLETE (2026-01-28)
+- [x] Duration field with mm:ss display alongside segment count
+- [x] FPS in quality column (e.g., 1080p60) for non-standard frame rates
+- [x] DRM badge [DRM] for encrypted streams
+- [x] DRM formats filtered from automatic "best" selection
+- [x] LIVE stream warning before format selection
+- [x] is_live flag propagation from M3U8 to InfoDict
+- [x] Duration-based progress tracking (more accurate than segment count)
+- [x] FPS as fourth-tier ranking tiebreaker (quality > height > bitrate > fps)
+- [x] Container detection from segment URLs (ts/mp4/m4s)
+- [x] **Status**: Production-ready, 270+ tests passing
+
+### Phases 10-12: Future
 - Additional site extractors (Vimeo, Dailymotion, Archive.org)
 - Enhanced CLI features
 - Format selection DSL parser
@@ -921,17 +990,20 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 ### Does rdlp support HLS/DASH?
 
 **Full HLS support**:
-- ✅ **HLS Streaming** - Complete download with segment-based progress (Phase 5-6.5)
-- ✅ **Fast Segment Counting** - M3U8 parsing in ~100-500ms (no size fetching)
-- ✅ **FFmpeg Remux** - Automatic HLS→MP4 conversion (Phase 7)
+- ✅ **HLS Streaming** - Complete download with duration-based progress
+- ✅ **Rich Metadata** - Duration (mm:ss), fps, DRM badge, live stream detection
+- ✅ **Smart Format Selection** - Ranking: quality > height > bitrate > fps
+- ✅ **Container Detection** - Automatic detection from segment URLs (ts/mp4/m4s)
+- ✅ **FFmpeg Remux** - Automatic HLS→MP4 conversion
 - ❌ **DASH** - Not yet supported (planned for future phases)
 
 **Current capabilities:**
 - RedTube and PornHub extractors with full HLS download support
-- Segment-based progress tracking (195/198 segments)
-- Format table shows segment count for HLS formats
-- Automatic FFmpeg remux to MP4 container after download
-- Fast detection (~100-500ms per format)
+- Duration-based progress tracking with accurate ETA
+- Format table shows duration, fps, and DRM status
+- LIVE stream warning before download
+- DRM formats filtered from automatic "best" selection
+- Automatic container detection from segment metadata
 
 **Coming soon:** DASH/MPD support, AES-128 decryption
 
@@ -1083,6 +1155,7 @@ This project wouldn't be possible without these amazing open source projects:
 - **Phase 6.5: HLS Progress & Segment Counting** - Fast segment counting, segment-based progress
 - **Phase 7: Post-Processing Pipeline** - FFmpeg library bindings (remux, audio, metadata, thumbnails)
 - **Phase 8: FFmpeg Library Migration** - Replaced all CLI FFmpeg with `ffmpeg-the-third` library calls
+- **Phase 9: HLS Metadata Surface** - Duration, fps, DRM badge, live warning, container detection
 - **Quality Fixes** - Unwrap elimination, async I/O correctness, download timeouts, resilience improvements
 - **TNAFlix Network** - Support for TNAFlix, EMPFlix, MovieFap (MP4 downloads)
 - **RedTube Support** - HLS + MP4 formats with segment counting

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use clap::Parser;
+use dialoguer::{Select, theme::ColorfulTheme};
 use rdlp_cli::Orchestrator;
 use rdlp_core::Config;
 use std::path::PathBuf;
@@ -86,6 +87,11 @@ struct Args {
     #[arg(long)]
     recode_video: Option<String>,
 
+    /// Remux to container for better seeking - no re-encoding
+    /// Use --remux for interactive, --remux=mp4 for direct
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
+    remux: Option<String>,
+
     /// Keep original video file after post-processing
     #[arg(long)]
     keep_video: bool,
@@ -105,6 +111,31 @@ fn main() -> Result<()> {
     runtime.block_on(async_main())
 }
 
+/// Interactive remux container selection
+fn select_remux_container() -> Result<Option<String>> {
+    let containers = vec![
+        ("mp4", "Best compatibility, faststart for streaming"),
+        ("mkv", "Supports all codecs, efficient cues index"),
+        ("webm", "Web-optimized, VP8/VP9/AV1 + Opus/Vorbis"),
+        ("mov", "Apple QuickTime, good for editing"),
+        ("avi", "Legacy format, wide support"),
+        ("ts", "MPEG-TS, broadcast/streaming"),
+    ];
+
+    let items: Vec<String> = containers
+        .iter()
+        .map(|(name, desc)| format!("{name:<6} {desc}"))
+        .collect();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select remux container (ESC to cancel)")
+        .items(&items)
+        .default(0)
+        .interact_opt()?;
+
+    Ok(selection.map(|idx| containers[idx].0.to_string()))
+}
+
 async fn async_main() -> Result<()> {
     let args = Args::parse();
 
@@ -121,6 +152,13 @@ async fn async_main() -> Result<()> {
             .with_target(true)
             .init();
     }
+
+    // Handle interactive remux selection
+    let remux_container = match args.remux.as_deref() {
+        Some("interactive") => select_remux_container()?,
+        Some(container) => Some(container.to_string()),
+        None => None,
+    };
 
     // Create configuration
     let config = Config {
@@ -141,6 +179,7 @@ async fn async_main() -> Result<()> {
         embed_metadata: args.embed_metadata,
         embed_thumbnail: args.embed_thumbnail,
         recode_video: args.recode_video,
+        remux_container,
         keep_video: args.keep_video,
         ffmpeg_location: args.ffmpeg_location,
         ..Default::default()

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -15,6 +15,7 @@ impl Orchestrator {
             audio_format: self.config.audio_format.clone(),
             audio_quality: self.config.audio_quality.clone(),
             recode_video: self.config.recode_video.clone(),
+            remux_container: self.config.remux_container.clone(),
             merge_output_format: self.config.merge_output_format.clone(),
             embed_thumbnail: self.config.embed_thumbnail,
             embed_metadata: self.config.embed_metadata,
@@ -31,6 +32,7 @@ impl Orchestrator {
             || self.config.embed_metadata
             || self.config.embed_thumbnail
             || self.config.recode_video.is_some()
+            || self.config.remux_container.is_some()
     }
 
     /// Run post-processing pipeline on downloaded file(s)

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -92,6 +92,10 @@ pub struct PostProcessConfig {
     /// Video format to recode to
     pub recode_video: Option<String>,
 
+    /// Remux to container format (stream copy, no re-encoding)
+    /// Use "mp4" or "mkv" for better seeking than TS
+    pub remux_container: Option<String>,
+
     /// Merge output format (when combining video+audio)
     pub merge_output_format: Option<String>,
 
@@ -121,6 +125,7 @@ impl Default for PostProcessConfig {
             audio_format: None,
             audio_quality: None,
             recode_video: None,
+            remux_container: None,
             merge_output_format: Some("mp4".to_string()),
             embed_thumbnail: false,
             embed_metadata: false,

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -106,6 +106,7 @@
 //! |-----------|----------|-------------|
 //! | `FFmpegMerger` | 100 | Merge video + audio streams |
 //! | `FFmpegExtractAudio` | 50 | Extract and convert audio |
+//! | `FFmpegRemuxer` | 45 | Remux to MP4/MKV for better seeking |
 //! | `FFmpegVideoConvertor` | 40 | Convert/remux video formats |
 //! | `FFmpegMetadata` | 30 | Embed metadata and chapters |
 //! | `EmbedThumbnail` | 20 | Embed cover art/thumbnails |
@@ -143,7 +144,8 @@ pub use registry::{PostProcessorRegistry, PostProcessorRegistryTrait};
 
 // Re-export processor types
 pub use processors::{
-    EmbedThumbnail, FFmpegExtractAudio, FFmpegMerger, FFmpegMetadata, FFmpegVideoConvertor,
+    EmbedThumbnail, FFmpegExtractAudio, FFmpegMerger, FFmpegMetadata, FFmpegRemuxer,
+    FFmpegVideoConvertor,
 };
 
 // Re-export core types for convenience

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -1,0 +1,180 @@
+//! FFmpeg container remuxer post-processor.
+//!
+//! Remuxes video files to different containers (MP4, MKV) using stream copy
+//! (no re-encoding). Improves seeking for formats like MPEG-TS which lack
+//! a centralized index.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use log::{debug, info};
+use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+
+use crate::error::PostProcessError;
+use crate::ffmpeg::{FFmpegRunner, RemuxOptions};
+
+/// Supported remux target containers.
+const SUPPORTED_CONTAINERS: &[&str] = &["mp4", "mkv", "webm", "mov", "avi", "ts"];
+
+/// Post-processor that remuxes video files to a different container.
+///
+/// This performs stream copy (no re-encoding) for fast container conversion.
+/// Primary use case: remux MPEG-TS (.ts) to MP4 or MKV for better seeking.
+///
+/// # Priority
+/// This processor has priority 45 (runs after merging, before video conversion).
+///
+/// # When it runs
+/// When `remux_container` is specified in config.
+///
+/// # Supported Containers
+/// - **MP4**: Best compatibility, faststart for streaming
+/// - **MKV**: Supports all codecs, efficient cues index
+/// - **WebM**: Web-optimized (VP8/VP9/AV1 + Opus/Vorbis)
+/// - **MOV**: Apple QuickTime, good for editing
+/// - **AVI**: Legacy format, wide support
+/// - **TS**: MPEG-TS for broadcast/streaming
+pub struct FFmpegRemuxer {
+    ffmpeg: Arc<FFmpegRunner>,
+}
+
+impl FFmpegRemuxer {
+    /// Create a new remuxer processor.
+    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
+        Self { ffmpeg }
+    }
+
+    /// Check if the format is a supported container for remuxing.
+    fn is_supported_container(format: &str) -> bool {
+        SUPPORTED_CONTAINERS.contains(&format.to_lowercase().as_str())
+    }
+}
+
+#[async_trait]
+impl PostProcessor for FFmpegRemuxer {
+    fn name(&self) -> &str {
+        "FFmpegRemuxer"
+    }
+
+    fn priority(&self) -> i32 {
+        45 // After merging (100), before video conversion (40)
+    }
+
+    fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {
+        config.remux_container.is_some()
+    }
+
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
+        if files.is_empty() {
+            return Ok(PostProcessResult::new(info.clone(), files));
+        }
+
+        let input_file = &files[0];
+        let target_container = config
+            .remux_container
+            .as_deref()
+            .unwrap_or("mp4")
+            .to_lowercase();
+
+        // Validate target container
+        if !Self::is_supported_container(&target_container) {
+            return Err(PostProcessError::UnsupportedFormat {
+                format: target_container,
+                operation: "remux".to_string(),
+            }
+            .into());
+        }
+
+        let input_ext = input_file
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        // Skip if already in target container
+        if input_ext == target_container {
+            debug!(
+                container = target_container.as_str();
+                "File already in target container, skipping remux"
+            );
+            return Ok(PostProcessResult::new(info.clone(), files));
+        }
+
+        info!(
+            file = input_file.display().to_string().as_str(),
+            from = input_ext.as_str(),
+            to = target_container.as_str();
+            "Remuxing to improve seeking"
+        );
+
+        // Build output path
+        let output_path = input_file.with_extension(&target_container);
+
+        // Configure remux options
+        // MP4/MOV: enable faststart for progressive playback (moov atom at beginning)
+        // MKV: cues written at end, but seeking is still excellent
+        // WebM: similar to MKV (Matroska-based)
+        let opts = RemuxOptions {
+            faststart: matches!(target_container.as_str(), "mp4" | "mov"),
+            output_format: Some(target_container.clone()),
+        };
+
+        // Perform remux via library bindings
+        self.ffmpeg.remux(input_file, &output_path, &opts).await?;
+
+        info!(
+            output = output_path.display().to_string().as_str();
+            "Remuxed successfully"
+        );
+
+        // Keep or delete original
+        let temp_files = if config.keep_video {
+            Vec::new()
+        } else {
+            files.clone()
+        };
+
+        Ok(PostProcessResult {
+            info: info.clone(),
+            files: vec![output_path],
+            temp_files,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supported_containers() {
+        // All supported containers
+        assert!(FFmpegRemuxer::is_supported_container("mp4"));
+        assert!(FFmpegRemuxer::is_supported_container("MP4"));
+        assert!(FFmpegRemuxer::is_supported_container("mkv"));
+        assert!(FFmpegRemuxer::is_supported_container("MKV"));
+        assert!(FFmpegRemuxer::is_supported_container("webm"));
+        assert!(FFmpegRemuxer::is_supported_container("mov"));
+        assert!(FFmpegRemuxer::is_supported_container("avi"));
+        assert!(FFmpegRemuxer::is_supported_container("ts"));
+
+        // Unsupported
+        assert!(!FFmpegRemuxer::is_supported_container("flv"));
+        assert!(!FFmpegRemuxer::is_supported_container("wmv"));
+    }
+
+    #[test]
+    fn test_priority() {
+        if let Ok(ffmpeg) = FFmpegRunner::new() {
+            let remuxer = FFmpegRemuxer::new(Arc::new(ffmpeg));
+            // Should run after merger (100) but before video convertor (40)
+            assert_eq!(remuxer.priority(), 45);
+        }
+    }
+}

--- a/crates/rdlp-postprocess/src/processors/mod.rs
+++ b/crates/rdlp-postprocess/src/processors/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! - [`FFmpegMerger`]: Merge video and audio streams
 //! - [`FFmpegExtractAudio`]: Extract and convert audio
+//! - [`FFmpegRemuxer`]: Remux to different container (MP4/MKV) for better seeking
 //! - [`FFmpegVideoConvertor`]: Convert video formats
 //! - [`FFmpegMetadata`]: Embed metadata into files
 //! - [`EmbedThumbnail`]: Embed thumbnail images
@@ -12,10 +13,12 @@ mod embed_thumbnail;
 mod ffmpeg_extract_audio;
 mod ffmpeg_merger;
 mod ffmpeg_metadata;
+mod ffmpeg_remuxer;
 mod ffmpeg_video_convertor;
 
 pub use embed_thumbnail::EmbedThumbnail;
 pub use ffmpeg_extract_audio::FFmpegExtractAudio;
 pub use ffmpeg_merger::FFmpegMerger;
 pub use ffmpeg_metadata::FFmpegMetadata;
+pub use ffmpeg_remuxer::FFmpegRemuxer;
 pub use ffmpeg_video_convertor::FFmpegVideoConvertor;

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -118,6 +118,9 @@ impl PostProcessorRegistry {
         // Priority 50: Extract audio
         self.register(Arc::new(FFmpegExtractAudio::new(self.ffmpeg.clone())));
 
+        // Priority 45: Container remuxing (TS → MP4/MKV for better seeking)
+        self.register(Arc::new(FFmpegRemuxer::new(self.ffmpeg.clone())));
+
         // Priority 40: Video conversion/remuxing
         self.register(Arc::new(FFmpegVideoConvertor::new(self.ffmpeg.clone())));
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -92,6 +92,9 @@ pub struct Config {
     /// Video format to recode to
     pub recode_video: Option<String>,
 
+    /// Remux to container format for better seeking (mp4, mkv)
+    pub remux_container: Option<String>,
+
     /// Embed thumbnail in video file
     pub embed_thumbnail: bool,
 
@@ -227,6 +230,7 @@ impl Default for Config {
             audio_format: None,
             audio_quality: None,
             recode_video: None,
+            remux_container: None,
             embed_thumbnail: false,
             embed_metadata: false,
             embed_subtitles: false,


### PR DESCRIPTION
This pull request introduces a new feature to allow users to remux downloaded videos into different container formats (such as MP4, MKV, etc.) for improved seeking and compatibility, without re-encoding. It adds both an interactive and direct CLI option for remuxing, updates the post-processing pipeline to support this, and extensively updates the documentation to describe the new capabilities and recent improvements to HLS metadata handling.

**Remux Container Feature:**

- Added a `--remux` CLI option (with interactive menu or direct value) to select a target container format (e.g., mp4, mkv, webm, mov, avi, ts) for remuxing downloaded videos, improving seeking and compatibility. The interactive menu uses the `dialoguer` crate for user selection. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R7) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R90-R94) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R114-R138) [[4]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R156-R162)
- Updated the post-processing pipeline and configuration to support the new `remux_container` option, ensuring remuxing is triggered as part of post-processing when requested. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R182) [[2]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afR18) [[3]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afR35) [[4]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R95-R98) [[5]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R128) [[6]](diffhunk://#diff-7b4418e9bd5710302a90f3dd1ec5012b5531835447a20a4f301e1dfcee4a8242R109) [[7]](diffhunk://#diff-7b4418e9bd5710302a90f3dd1ec5012b5531835447a20a4f301e1dfcee4a8242L146-R148)

**Documentation and Metadata Improvements:**

- Expanded the `README.md` with detailed documentation and usage examples for the new remux feature, including an interactive selection menu, supported containers, and guidance for users. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174-R212) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R381) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R447-R451)
- Updated feature tables and examples in the `README.md` to reflect richer HLS metadata (duration, fps, DRM badge, live detection, and container detection), and clarified the progress tracking now uses duration instead of segment count. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L283-R346) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L310-R366) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L568-R637) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L924-R1006) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1158)

**Build and Configuration:**

- Added a `.cargo/config.toml.example` template with instructions for setting up FFmpeg dependencies required for development and testing.

These changes improve user experience by enabling better playback seeking, providing more accurate and informative metadata, and making advanced post-processing accessible through a simple CLI interface.