### PR TITLE
Refactor/consolidate progress reporter

### DIFF
--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -5,11 +5,15 @@
 use anyhow::Result;
 use clap::Parser;
 use dialoguer::{Select, theme::ColorfulTheme};
+use indicatif::MultiProgress;
 use rdlp_cli::Orchestrator;
 use rdlp_core::Config;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 /// Get optimal number of worker threads for I/O-heavy workloads
 fn optimal_worker_threads() -> usize {
@@ -113,7 +117,7 @@ fn main() -> Result<()> {
 
 /// Interactive remux container selection
 fn select_remux_container() -> Result<Option<String>> {
-    let containers = vec![
+    let containers = [
         ("mp4", "Best compatibility, faststart for streaming"),
         ("mkv", "Supports all codecs, efficient cues index"),
         ("webm", "Web-optimized, VP8/VP9/AV1 + Opus/Vorbis"),
@@ -136,20 +140,51 @@ fn select_remux_container() -> Result<Option<String>> {
     Ok(selection.map(|idx| containers[idx].0.to_string()))
 }
 
+/// Writer that suspends progress bars while writing to prevent visual duplication
+#[derive(Clone)]
+struct SuspendingWriter {
+    multi_progress: Arc<MultiProgress>,
+}
+
+impl std::io::Write for SuspendingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.multi_progress.suspend(|| std::io::stderr().write(buf))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        std::io::stderr().flush()
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SuspendingWriter {
+    type Writer = SuspendingWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
 async fn async_main() -> Result<()> {
     let args = Args::parse();
 
-    // Initialize tracing subscriber
-    // Use RUST_LOG environment variable or default based on verbose/quiet flags
+    // Create shared MultiProgress for managing progress bars with log output
+    let multi_progress = Arc::new(MultiProgress::new());
+
     if !args.quiet {
         let default_level = if args.verbose { "debug" } else { "info" };
 
         let filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new(default_level));
 
-        tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_target(true)
+        // Use SuspendingWriter to properly handle logs while progress bars are active
+        // This prevents progress bar duplication caused by log messages
+        let writer = SuspendingWriter {
+            multi_progress: Arc::clone(&multi_progress),
+        };
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer().with_writer(writer))
             .init();
     }
 
@@ -187,8 +222,8 @@ async fn async_main() -> Result<()> {
 
     let interactive = args.interactive;
 
-    // Create orchestrator
-    let orchestrator = Orchestrator::new(config);
+    // Create orchestrator with shared MultiProgress
+    let orchestrator = Orchestrator::new(config, (*multi_progress).clone());
 
     // List extractors if requested
     if args.list_extractors {

--- a/crates/rdlp-cli/src/orchestrator/execution.rs
+++ b/crates/rdlp-cli/src/orchestrator/execution.rs
@@ -1,7 +1,7 @@
 //! Download execution and progress tracking
 
 use super::{Orchestrator, errors::*};
-use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use rdlp_core::{DownloadProgress, DownloadStats, Downloader, ProgressCallback};
 use std::path::Path;
@@ -79,6 +79,7 @@ impl Orchestrator {
     /// Create a progress bar for download tracking
     ///
     /// Uses steady tick for smooth animation regardless of download speed.
+    /// Progress bar is added to MultiProgress for proper log integration.
     ///
     /// # Errors
     /// Returns an error if progress bar template is invalid
@@ -91,8 +92,12 @@ impl Orchestrator {
             return Ok(None);
         }
 
-        // Use higher refresh rate (30 fps) for smoother animation
-        let pb = ProgressBar::with_draw_target(filesize, ProgressDrawTarget::stderr_with_hz(30));
+        // Create progress bar and add to MultiProgress for proper log handling
+        let pb = self.multi_progress.add(ProgressBar::new(filesize.unwrap_or(0)));
+        if let Some(size) = filesize {
+            pb.set_length(size);
+        }
+
         pb.set_style(
             ProgressStyle::default_bar()
                 .template(
@@ -117,6 +122,7 @@ impl Orchestrator {
     /// Unlike byte-based progress bars, this tracks segment completion.
     /// The message shows bytes and speed, while the bar shows segment progress.
     /// Uses steady tick for smooth animation between segment completions.
+    /// Progress bar is added to MultiProgress for proper log integration.
     ///
     /// # Errors
     /// Returns an error if progress bar template is invalid
@@ -125,11 +131,9 @@ impl Orchestrator {
             return Ok(None);
         }
 
-        // Use higher refresh rate (30 fps) for smoother animation
-        let pb = ProgressBar::with_draw_target(
-            Some(0), // Will be set when we know total segments
-            ProgressDrawTarget::stderr_with_hz(30),
-        );
+        // Create progress bar and add to MultiProgress for proper log handling
+        let pb = self.multi_progress.add(ProgressBar::new(0));
+
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {msg}")

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -17,6 +17,7 @@ mod tests;
 pub use errors::{OrchestratorError, Result};
 pub use state::{DownloadPhase, DownloadState};
 
+use indicatif::MultiProgress;
 use log::{debug, warn};
 use tracing::instrument;
 use rdlp_cookies::SimpleCookieJar;
@@ -36,11 +37,13 @@ pub struct Orchestrator {
     pub(super) postprocessor_registry: Option<Arc<dyn PostProcessorRegistryTrait>>,
     pub(super) extraction_context: Arc<ExtractionContext>,
     pub(super) config: Arc<Config>,
+    /// MultiProgress for managing progress bars with log output
+    pub(super) multi_progress: MultiProgress,
 }
 
 impl Orchestrator {
     /// Create a new orchestrator with default registries
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, multi_progress: MultiProgress) -> Self {
         let http_client = HttpClientFactory::from_rdlp_config(&config).build_arc();
         let js_engine = Arc::new(SimpleJsEngine::new());
         let cookie_jar = Arc::new(SimpleCookieJar::new());
@@ -64,6 +67,7 @@ impl Orchestrator {
             postprocessor_registry,
             extraction_context,
             config,
+            multi_progress,
         }
     }
 
@@ -125,6 +129,7 @@ impl Orchestrator {
             postprocessor_registry,
             extraction_context,
             config,
+            multi_progress: MultiProgress::new(),
         }
     }
 

--- a/crates/rdlp-cli/src/orchestrator/tests.rs
+++ b/crates/rdlp-cli/src/orchestrator/tests.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 /// Helper function to create a test orchestrator
 pub(crate) fn create_test_orchestrator() -> Orchestrator {
     let config = Config::default();
-    Orchestrator::new(config)
+    Orchestrator::new(config, MultiProgress::new())
 }
 
 /// Helper function to wrap formats in an InfoDict for testing
@@ -272,7 +272,7 @@ fn test_create_progress_bar_disabled() {
         progress: false,
         ..Default::default()
     };
-    let orchestrator = Orchestrator::new(config);
+    let orchestrator = Orchestrator::new(config, MultiProgress::new());
 
     let result = orchestrator.create_progress_bar(Some(1000000), 0);
     assert!(result.is_ok());
@@ -285,7 +285,7 @@ fn test_create_progress_bar_enabled() {
         progress: true,
         ..Default::default()
     };
-    let orchestrator = Orchestrator::new(config);
+    let orchestrator = Orchestrator::new(config, MultiProgress::new());
 
     let result = orchestrator.create_progress_bar(Some(1000000), 0);
     assert!(result.is_ok());
@@ -298,7 +298,7 @@ fn test_create_progress_bar_with_resume() {
         progress: true,
         ..Default::default()
     };
-    let orchestrator = Orchestrator::new(config);
+    let orchestrator = Orchestrator::new(config, MultiProgress::new());
 
     let result = orchestrator.create_progress_bar(Some(1000000), 500000);
     assert!(result.is_ok());

--- a/crates/rdlp-cli/tests/orchestrator_integration.rs
+++ b/crates/rdlp-cli/tests/orchestrator_integration.rs
@@ -4,6 +4,7 @@
 
 mod test_utils;
 
+use indicatif::MultiProgress;
 use rdlp_cli::Orchestrator;
 use rdlp_core::Config;
 use std::sync::Arc;
@@ -29,7 +30,7 @@ fn test_orchestrator_creation() {
     let config = create_test_config(&temp_dir);
 
     // Create orchestrator
-    let orch = Orchestrator::new(config);
+    let orch = Orchestrator::new(config, MultiProgress::new());
 
     // Verify orchestrator was created successfully
     // The orchestrator should have registered extractors
@@ -44,7 +45,7 @@ fn test_orchestrator_creation() {
 fn test_list_extractors() {
     let temp_dir = tempfile::tempdir().unwrap();
     let config = create_test_config(&temp_dir);
-    let orch = Orchestrator::new(config);
+    let orch = Orchestrator::new(config, MultiProgress::new());
 
     let extractors = orch.list_extractors();
 
@@ -104,7 +105,7 @@ fn test_orchestrator_with_custom_config() {
     assert!(!config.progress);
 
     // Create orchestrator with custom config
-    let orch = Orchestrator::new(config);
+    let orch = Orchestrator::new(config, MultiProgress::new());
 
     // Verify orchestrator works with custom config
     assert!(!orch.list_extractors().is_empty());
@@ -119,8 +120,8 @@ fn test_multiple_orchestrators() {
     let config1 = create_test_config(&temp_dir1);
     let config2 = create_test_config(&temp_dir2);
 
-    let orch1 = Orchestrator::new(config1);
-    let orch2 = Orchestrator::new(config2);
+    let orch1 = Orchestrator::new(config1, MultiProgress::new());
+    let orch2 = Orchestrator::new(config2, MultiProgress::new());
 
     // Both should work independently
     assert!(!orch1.list_extractors().is_empty());

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -4,7 +4,7 @@ use futures::stream::{self, StreamExt};
 use log::{debug, info, warn};
 use tracing::instrument;
 use rdlp_core::{
-    DownloadProgress, DownloadStats, Downloader, ProgressCallback, RdlpError, Result, RetryConfig,
+    DownloadStats, Downloader, ProgressCallback, RdlpError, Result, RetryConfig,
 };
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -17,6 +17,7 @@ use tokio::sync::Mutex;
 
 use crate::hls_state::HlsDownloadState;
 use crate::http::HttpDownloader;
+use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 
 /// Information about an HLS segment including its duration
 #[derive(Clone, Debug)]
@@ -724,47 +725,15 @@ impl Downloader for HlsDownloader {
             let total_segments_u64 = total_segments as u64;
 
             // Spawn progress reporter task with duration-based progress
-            let progress_task = if let Some(callback) = progress {
-                let downloaded_clone = downloaded.clone();
-                let segments_clone = segments_completed.clone();
-                let duration_clone = duration_completed.clone();
-                let start_time_clone = start_time;
-                Some(tokio::spawn(async move {
-                    let mut last_update = Instant::now();
-                    let update_interval = Duration::from_millis(100);
-
-                    loop {
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                        let now = Instant::now();
-                        if now.duration_since(last_update) >= update_interval {
-                            let bytes = downloaded_clone.load(Ordering::Relaxed);
-                            let segments = segments_clone.load(Ordering::Relaxed);
-                            let dur_centis = duration_clone.load(Ordering::Relaxed);
-                            let dur_downloaded = dur_centis as f64 / 100.0;
-                            let elapsed = now.duration_since(start_time_clone).as_secs_f64();
-                            let speed = if elapsed > 0.0 {
-                                bytes as f64 / elapsed
-                            } else {
-                                0.0
-                            };
-
-                            // Use duration-based progress for more accurate percentage/ETA
-                            let progress_info = DownloadProgress::new_with_duration(
-                                bytes,
-                                speed,
-                                segments,
-                                total_segments_u64,
-                                dur_downloaded,
-                                total_duration,
-                            );
-                            callback.on_progress(&progress_info);
-                            last_update = now;
-                        }
-                    }
-                }))
-            } else {
-                None
-            };
+            let mut progress_guard = spawn_progress_reporter(
+                progress,
+                ProgressMetrics::with_duration(
+                    downloaded.clone(),
+                    segments_completed.clone(),
+                    duration_completed.clone(),
+                ),
+                ProgressReporterConfig::hls(start_time, total_segments_u64, total_duration),
+            );
 
             // Step 4: Download segments (with resume support)
             let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
@@ -793,17 +762,13 @@ impl Downloader for HlsDownloader {
                     if let Err(save_err) = snapshot.save(path).await {
                         warn!("Failed to save HLS state: {save_err}");
                     }
-                    if let Some(task) = progress_task {
-                        task.abort();
-                    }
+                    progress_guard.abort();
                     return Err(e);
                 }
             };
 
-            // Stop progress reporter
-            if let Some(task) = progress_task {
-                task.abort();
-            }
+            // Progress guard will be dropped and abort the task automatically
+            drop(progress_guard);
 
             // Step 5: Merge segments
             let total_bytes = self.merge_segments(segment_paths.clone(), path).await?;

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -4,40 +4,21 @@
 
 use futures::stream::{self, StreamExt, TryStreamExt};
 use log::{debug, error, info};
-use rdlp_core::{DownloadProgress, DownloadStats, RdlpError, Result};
+use rdlp_core::{DownloadStats, RdlpError, Result};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
 
 use super::HttpDownloader;
 use super::config::DownloaderConfig;
 use crate::chunking::calculate_chunks;
+use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 
 /// Global atomic counter for generating unique download IDs
 pub(super) static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// RAII guard for progress reporter tasks
-///
-/// Ensures the progress reporter task is aborted when the guard goes out of scope,
-/// preventing task leaks on early returns or errors.
-pub(super) struct ProgressGuard(pub Option<tokio::task::JoinHandle<()>>);
-
-impl ProgressGuard {
-    pub fn new(task: Option<tokio::task::JoinHandle<()>>) -> Self {
-        Self(task)
-    }
-}
-
-impl Drop for ProgressGuard {
-    fn drop(&mut self) {
-        if let Some(task) = self.0.take() {
-            task.abort();
-        }
-    }
-}
 
 /// Cleanup chunk files on error
 pub(super) async fn cleanup_chunk_files(
@@ -89,13 +70,11 @@ impl HttpDownloader {
 
         let downloaded = Arc::new(AtomicU64::new(0));
 
-        let _progress_guard = ProgressGuard::new(create_progress_reporter(
+        let _progress_guard = spawn_progress_reporter(
             progress,
-            downloaded.clone(),
-            start_time,
-            total_size,
-            0,
-        ));
+            ProgressMetrics::bytes_only(downloaded.clone()),
+            ProgressReporterConfig::http(start_time, total_size, 0),
+        );
 
         info!(
             "Starting parallel download with {} concurrent connections",
@@ -210,12 +189,10 @@ impl HttpDownloader {
 
         let downloaded = Arc::new(AtomicU64::new(resume_from));
 
-        let progress_task = create_progress_reporter(
+        let mut progress_guard = spawn_progress_reporter(
             progress,
-            downloaded.clone(),
-            start_time,
-            total_size,
-            resume_from,
+            ProgressMetrics::bytes_only(downloaded.clone()),
+            ProgressReporterConfig::http(start_time, total_size, resume_from),
         );
 
         info!(
@@ -263,9 +240,7 @@ impl HttpDownloader {
             Ok(results) => results.into_iter().map(|(_, bytes, _)| bytes).collect(),
             Err(e) => {
                 error!("Resume failed: {e}");
-                if let Some(task) = &progress_task {
-                    task.abort();
-                }
+                progress_guard.abort();
                 cleanup_chunk_files(temp_dir, &filename, download_id, total_chunks).await;
                 return Err(e);
             }
@@ -278,9 +253,7 @@ impl HttpDownloader {
             newly_downloaded / 1024 / 1024
         );
 
-        if let Some(task) = progress_task {
-            task.abort();
-        }
+        // Progress guard will be dropped and abort the task automatically
 
         // Append chunks to existing file
         append_chunks(
@@ -307,45 +280,6 @@ impl HttpDownloader {
 
         Ok(stats)
     }
-}
-
-/// Create a progress reporter task
-fn create_progress_reporter(
-    callback: Option<Box<dyn rdlp_core::ProgressCallback>>,
-    downloaded: Arc<AtomicU64>,
-    start_time: Instant,
-    total_size: u64,
-    resume_from: u64,
-) -> Option<tokio::task::JoinHandle<()>> {
-    callback.map(|cb| {
-        tokio::spawn(async move {
-            let mut last_update = Instant::now();
-            let update_interval = Duration::from_millis(100);
-
-            loop {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                let now = Instant::now();
-                if now.duration_since(last_update) >= update_interval {
-                    let bytes_downloaded = downloaded.load(Ordering::Relaxed);
-                    let elapsed = now.duration_since(start_time).as_secs_f64();
-                    let speed = if elapsed > 0.0 {
-                        (bytes_downloaded - resume_from) as f64 / elapsed
-                    } else {
-                        0.0
-                    };
-
-                    let progress_info =
-                        DownloadProgress::new(bytes_downloaded, Some(total_size), speed);
-                    cb.on_progress(&progress_info);
-                    last_update = now;
-
-                    if bytes_downloaded >= total_size {
-                        break;
-                    }
-                }
-            }
-        })
-    })
 }
 
 /// Merge chunks into final file

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -246,10 +246,13 @@ pub mod hls;
 pub mod hls_state;
 /// HTTP/HTTPS downloader with parallel chunk support
 pub mod http;
+/// Shared progress reporting infrastructure
+pub mod progress;
 
 pub use chunking::{ChunkSizeStrategy, calculate_chunks, chunk_size_for_file};
 pub use hls::HlsDownloader;
 pub use http::HttpDownloader;
+pub use progress::{ProgressGuard, ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 
 use rdlp_core::{Config, Downloader};
 use rdlp_http::HttpClientFactory;

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -1,0 +1,262 @@
+//! Shared progress reporting infrastructure for downloaders.
+//!
+//! This module provides a unified progress reporter that works for both
+//! HTTP (byte-based) and HLS (duration-based) downloads, eliminating
+//! duplicate progress tracking code.
+
+use rdlp_core::{DownloadProgress, ProgressCallback};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// RAII guard for progress reporter tasks.
+///
+/// Ensures the progress reporter task is aborted when the guard goes out of scope,
+/// preventing task leaks on early returns or errors.
+pub struct ProgressGuard(Option<tokio::task::JoinHandle<()>>);
+
+impl ProgressGuard {
+    /// Create a new progress guard wrapping an optional task handle.
+    pub fn new(task: Option<tokio::task::JoinHandle<()>>) -> Self {
+        Self(task)
+    }
+
+    /// Abort the task explicitly (also happens on drop).
+    pub fn abort(&mut self) {
+        if let Some(task) = self.0.take() {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for ProgressGuard {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+/// Progress metrics tracked atomically across parallel downloads.
+#[derive(Clone)]
+pub struct ProgressMetrics {
+    /// Bytes downloaded so far
+    pub downloaded: Arc<AtomicU64>,
+    /// Segments completed (HLS only)
+    pub segments_completed: Option<Arc<AtomicU64>>,
+    /// Duration completed in centiseconds (HLS only, for f64 precision)
+    pub duration_completed: Option<Arc<AtomicU64>>,
+}
+
+impl ProgressMetrics {
+    /// Create metrics for byte-based progress (HTTP downloads).
+    pub fn bytes_only(downloaded: Arc<AtomicU64>) -> Self {
+        Self {
+            downloaded,
+            segments_completed: None,
+            duration_completed: None,
+        }
+    }
+
+    /// Create metrics for duration-based progress (HLS downloads).
+    pub fn with_duration(
+        downloaded: Arc<AtomicU64>,
+        segments_completed: Arc<AtomicU64>,
+        duration_completed: Arc<AtomicU64>,
+    ) -> Self {
+        Self {
+            downloaded,
+            segments_completed: Some(segments_completed),
+            duration_completed: Some(duration_completed),
+        }
+    }
+}
+
+/// Configuration for the progress reporter.
+pub struct ProgressReporterConfig {
+    /// Start time for speed calculation
+    pub start_time: Instant,
+    /// Bytes already downloaded (for resume)
+    pub resume_from: u64,
+    /// Total expected size in bytes (None for unknown/streaming)
+    pub total_size: Option<u64>,
+    /// Total segments (HLS only)
+    pub total_segments: Option<u64>,
+    /// Total duration in seconds (HLS only)
+    pub total_duration: Option<f64>,
+    /// Update interval (default: 100ms)
+    pub update_interval: Duration,
+}
+
+impl ProgressReporterConfig {
+    /// Create config for HTTP byte-based progress.
+    pub fn http(start_time: Instant, total_size: u64, resume_from: u64) -> Self {
+        Self {
+            start_time,
+            resume_from,
+            total_size: Some(total_size),
+            total_segments: None,
+            total_duration: None,
+            update_interval: Duration::from_millis(100),
+        }
+    }
+
+    /// Create config for HLS duration-based progress.
+    pub fn hls(start_time: Instant, total_segments: u64, total_duration: f64) -> Self {
+        Self {
+            start_time,
+            resume_from: 0,
+            total_size: None,
+            total_segments: Some(total_segments),
+            total_duration: Some(total_duration),
+            update_interval: Duration::from_millis(100),
+        }
+    }
+}
+
+/// Spawn a progress reporter task that periodically reports download progress.
+///
+/// Returns a `ProgressGuard` that automatically aborts the task on drop.
+///
+/// # Arguments
+/// * `callback` - Optional progress callback to receive updates
+/// * `metrics` - Atomic counters for tracking progress
+/// * `config` - Configuration for the reporter
+///
+/// # Returns
+/// A `ProgressGuard` that manages the spawned task's lifecycle.
+pub fn spawn_progress_reporter(
+    callback: Option<Box<dyn ProgressCallback>>,
+    metrics: ProgressMetrics,
+    config: ProgressReporterConfig,
+) -> ProgressGuard {
+    let task = callback.map(|cb| {
+        tokio::spawn(async move {
+            let mut last_update = Instant::now();
+
+            loop {
+                tokio::time::sleep(config.update_interval).await;
+                let now = Instant::now();
+
+                if now.duration_since(last_update) >= config.update_interval {
+                    let bytes = metrics.downloaded.load(Ordering::Relaxed);
+                    let elapsed = now.duration_since(config.start_time).as_secs_f64();
+                    let speed = if elapsed > 0.0 {
+                        (bytes - config.resume_from) as f64 / elapsed
+                    } else {
+                        0.0
+                    };
+
+                    let progress_info = if let (Some(segments_counter), Some(duration_counter)) =
+                        (&metrics.segments_completed, &metrics.duration_completed)
+                    {
+                        // HLS: duration-based progress
+                        let segments = segments_counter.load(Ordering::Relaxed);
+                        let dur_centis = duration_counter.load(Ordering::Relaxed);
+                        let dur_downloaded = dur_centis as f64 / 100.0;
+
+                        DownloadProgress::new_with_duration(
+                            bytes,
+                            speed,
+                            segments,
+                            config.total_segments.unwrap_or(0),
+                            dur_downloaded,
+                            config.total_duration.unwrap_or(0.0),
+                        )
+                    } else {
+                        // HTTP: byte-based progress
+                        DownloadProgress::new(bytes, config.total_size, speed)
+                    };
+
+                    cb.on_progress(&progress_info);
+                    last_update = now;
+
+                    // Exit when download is complete (HTTP only - has known total)
+                    if let Some(total) = config.total_size {
+                        if bytes >= total {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+    });
+
+    ProgressGuard::new(task)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_guard_abort() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let handle = tokio::spawn(async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            });
+
+            let mut guard = ProgressGuard::new(Some(handle));
+            guard.abort();
+
+            // Task should be aborted
+            assert!(guard.0.is_none());
+        });
+    }
+
+    #[test]
+    fn test_progress_metrics_bytes_only() {
+        let downloaded = Arc::new(AtomicU64::new(1000));
+        let metrics = ProgressMetrics::bytes_only(downloaded.clone());
+
+        assert_eq!(metrics.downloaded.load(Ordering::Relaxed), 1000);
+        assert!(metrics.segments_completed.is_none());
+        assert!(metrics.duration_completed.is_none());
+    }
+
+    #[test]
+    fn test_progress_metrics_with_duration() {
+        let downloaded = Arc::new(AtomicU64::new(1000));
+        let segments = Arc::new(AtomicU64::new(10));
+        let duration = Arc::new(AtomicU64::new(500)); // 5.0 seconds in centiseconds
+
+        let metrics =
+            ProgressMetrics::with_duration(downloaded.clone(), segments.clone(), duration.clone());
+
+        assert_eq!(metrics.downloaded.load(Ordering::Relaxed), 1000);
+        assert_eq!(
+            metrics
+                .segments_completed
+                .as_ref()
+                .unwrap()
+                .load(Ordering::Relaxed),
+            10
+        );
+        assert_eq!(
+            metrics
+                .duration_completed
+                .as_ref()
+                .unwrap()
+                .load(Ordering::Relaxed),
+            500
+        );
+    }
+
+    #[test]
+    fn test_config_http() {
+        let config = ProgressReporterConfig::http(Instant::now(), 1_000_000, 100_000);
+
+        assert_eq!(config.total_size, Some(1_000_000));
+        assert_eq!(config.resume_from, 100_000);
+        assert!(config.total_segments.is_none());
+        assert!(config.total_duration.is_none());
+    }
+
+    #[test]
+    fn test_config_hls() {
+        let config = ProgressReporterConfig::hls(Instant::now(), 100, 600.0);
+
+        assert!(config.total_size.is_none());
+        assert_eq!(config.total_segments, Some(100));
+        assert_eq!(config.total_duration, Some(600.0));
+    }
+}


### PR DESCRIPTION
This pull request significantly improves progress bar and logging integration in the CLI and downloader components. The main changes introduce a shared `MultiProgress` object to manage progress bars, ensuring clean log output even during active downloads, and refactor progress reporting to be more robust and less error-prone. The orchestrator and downloader APIs are updated to support these changes, and tests are updated accordingly.

**Progress Bar and Logging Integration:**
- Introduced a shared `MultiProgress` instance to the `Orchestrator` for unified management of progress bars and logging output, preventing visual duplication and ensuring smooth user experience. This includes a new `SuspendingWriter` to suspend progress bars during log writes. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R8-R16) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R143-R187) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L190-R226) [[4]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R20) [[5]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R40-R46) [[6]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R70) [[7]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R132)

**Progress Bar Creation and Usage:**
- Refactored progress bar creation in the orchestrator to always use `MultiProgress`, ensuring that all progress bars are properly managed and integrated with logging. Removed deprecated or unnecessary code, and updated comments to reflect the new approach. [[1]](diffhunk://#diff-832c2dac90a4ead435838b59fc4e686bb088e2069ef48df776a9278971d4ebe3L4-R4) [[2]](diffhunk://#diff-832c2dac90a4ead435838b59fc4e686bb088e2069ef48df776a9278971d4ebe3R82) [[3]](diffhunk://#diff-832c2dac90a4ead435838b59fc4e686bb088e2069ef48df776a9278971d4ebe3L94-R100) [[4]](diffhunk://#diff-832c2dac90a4ead435838b59fc4e686bb088e2069ef48df776a9278971d4ebe3R125) [[5]](diffhunk://#diff-832c2dac90a4ead435838b59fc4e686bb088e2069ef48df776a9278971d4ebe3L128-R136)

**Downloader Progress Reporting Refactor:**
- Replaced ad-hoc progress reporter tasks in the HLS and HTTP downloaders with a unified `spawn_progress_reporter` utility and associated configuration/metrics types, simplifying code and ensuring correct task cleanup via RAII. Removed the custom `ProgressGuard` in favor of this new approach. [[1]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L7-R7) [[2]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R20) [[3]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L727-L767) [[4]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744L796-R771) [[5]](diffhunk://#diff-dbc733da4cfe4fae6bd51d539341fe2abcf90075af99c03c9a0de51d615762c1L7-L41)

**API and Test Updates:**
- Updated all `Orchestrator::new` calls throughout the codebase and tests to require a `MultiProgress` parameter, ensuring consistency and correctness. [[1]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL10-R10) [[2]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL275-R275) [[3]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL288-R288) [[4]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL301-R301) [[5]](diffhunk://#diff-ac263294641bd03f63b8d4cda6a6b59e144d919478040159fe4c2b247c5eccddR7) [[6]](diffhunk://#diff-ac263294641bd03f63b8d4cda6a6b59e144d919478040159fe4c2b247c5eccddL32-R33) [[7]](diffhunk://#diff-ac263294641bd03f63b8d4cda6a6b59e144d919478040159fe4c2b247c5eccddL47-R48) [[8]](diffhunk://#diff-ac263294641bd03f63b8d4cda6a6b59e144d919478040159fe4c2b247c5eccddL107-R108) [[9]](diffhunk://#diff-ac263294641bd03f63b8d4cda6a6b59e144d919478040159fe4c2b247c5eccddL122-R124)

These changes make progress bar handling more robust, prevent log/progress bar interference, and simplify progress reporting throughout the CLI and downloader modules.