### PR TITLE
Refactor/must use attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,6 @@ bytes = "1.9"
 # Testing
 mockito = "1.5"
 tempfile = "3.14"
+
+[workspace.lints.clippy]
+must_use_candidate = "warn"

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -39,3 +39,6 @@ mockito = "1.7"
 wiremock = "0.6"
 async-trait = { workspace = true }
 regex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -43,6 +43,7 @@ pub struct Orchestrator {
 
 impl Orchestrator {
     /// Create a new orchestrator with default registries
+    #[must_use]
     pub fn new(config: Config, multi_progress: MultiProgress) -> Self {
         let http_client = HttpClientFactory::from_rdlp_config(&config).build_arc();
         let js_engine = Arc::new(SimpleJsEngine::new());
@@ -185,11 +186,13 @@ impl Orchestrator {
     }
 
     /// List all available extractors
+    #[must_use]
     pub fn list_extractors(&self) -> Vec<String> {
         self.extractor_registry.list_extractors()
     }
 
     /// List all available download protocols
+    #[must_use]
     pub fn list_downloaders(&self) -> Vec<String> {
         self.downloader_registry.list_downloaders()
     }

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -18,6 +18,7 @@ pub enum DownloadState {
 
 impl DownloadState {
     /// Get the resume offset (0 for fresh downloads)
+    #[must_use]
     pub fn offset(&self) -> u64 {
         match self {
             Self::Fresh => 0,

--- a/crates/rdlp-cookies/Cargo.toml
+++ b/crates/rdlp-cookies/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/rdlp-cookies/src/lib.rs
+++ b/crates/rdlp-cookies/src/lib.rs
@@ -19,6 +19,7 @@ pub struct SimpleCookieJar {
 
 impl SimpleCookieJar {
     /// Create a new empty cookie jar
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }

--- a/crates/rdlp-core/Cargo.toml
+++ b/crates/rdlp-core/Cargo.toml
@@ -22,3 +22,6 @@ backon = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/rdlp-core/src/retry.rs
+++ b/crates/rdlp-core/src/retry.rs
@@ -24,6 +24,7 @@ pub struct RetryConfig {
 
 impl RetryConfig {
     /// Create a new retry configuration
+    #[must_use]
     pub fn new(
         max_retries: usize,
         initial_delay: Duration,
@@ -40,6 +41,7 @@ impl RetryConfig {
     }
 
     /// Create default retry configuration (10 retries, 1s-60s backoff, jitter enabled)
+    #[must_use]
     pub fn default_config() -> Self {
         Self {
             max_retries: 10,
@@ -77,6 +79,7 @@ impl RetryConfig {
     ///         .await;
     /// }
     /// ```
+    #[must_use]
     pub fn to_backoff(&self) -> ExponentialBuilder {
         let mut builder = ExponentialBuilder::default()
             .with_min_delay(self.initial_delay)
@@ -118,6 +121,7 @@ impl Default for RetryConfig {
 ///         .await;
 /// }
 /// ```
+#[must_use]
 pub fn is_retryable_error(error: &RdlpError) -> bool {
     match error {
         // Network errors are generally retryable

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -144,6 +144,7 @@ pub struct DownloadProgress {
 
 impl DownloadProgress {
     /// Create a new progress update
+    #[must_use]
     pub fn new(bytes_downloaded: u64, total_bytes: Option<u64>, speed: f64) -> Self {
         let percentage = total_bytes.map(|total| {
             if total > 0 {
@@ -176,6 +177,7 @@ impl DownloadProgress {
     }
 
     /// Create a new segment-based progress update (for HLS downloads)
+    #[must_use]
     pub fn new_with_segments(
         bytes_downloaded: u64,
         speed: f64,
@@ -219,6 +221,7 @@ impl DownloadProgress {
     ///
     /// Uses stream duration for more accurate progress/ETA than segment count,
     /// since segments can have variable lengths.
+    #[must_use]
     pub fn new_with_duration(
         bytes_downloaded: u64,
         speed: f64,
@@ -263,21 +266,25 @@ impl DownloadProgress {
     }
 
     /// Check if this is a segment-based progress (HLS)
+    #[must_use]
     pub fn is_segmented(&self) -> bool {
         self.total_segments.is_some()
     }
 
     /// Format speed as human-readable string (e.g., "1.5 MB/s")
+    #[must_use]
     pub fn speed_string(&self) -> String {
         format_bytes_per_second(self.speed)
     }
 
     /// Format bytes downloaded as human-readable string (e.g., "15.3 MB")
+    #[must_use]
     pub fn bytes_string(&self) -> String {
         format_bytes(self.bytes_downloaded)
     }
 
     /// Format total size as human-readable string (e.g., "100.0 MB")
+    #[must_use]
     pub fn total_string(&self) -> String {
         self.total_bytes
             .map(format_bytes)
@@ -321,6 +328,7 @@ pub struct DownloadStats {
 
 impl DownloadStats {
     /// Create new download statistics
+    #[must_use]
     pub fn new(bytes_downloaded: u64, duration: Duration, retries: usize) -> Self {
         let average_speed = if duration.as_secs_f64() > 0.0 {
             bytes_downloaded as f64 / duration.as_secs_f64()
@@ -338,17 +346,20 @@ impl DownloadStats {
     }
 
     /// Create new stats with fragment information
+    #[must_use]
     pub fn with_fragments(mut self, fragments: usize) -> Self {
         self.fragments = Some(fragments);
         self
     }
 
     /// Format average speed as human-readable string
+    #[must_use]
     pub fn speed_string(&self) -> String {
         format_bytes_per_second(self.average_speed)
     }
 
     /// Format bytes downloaded as human-readable string
+    #[must_use]
     pub fn bytes_string(&self) -> String {
         format_bytes(self.bytes_downloaded)
     }

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -62,6 +62,7 @@ pub struct PostProcessResult {
 
 impl PostProcessResult {
     /// Create a new post-process result
+    #[must_use]
     pub fn new(info: InfoDict, files: Vec<PathBuf>) -> Self {
         Self {
             info,
@@ -71,6 +72,7 @@ impl PostProcessResult {
     }
 
     /// Add temporary files that can be cleaned up
+    #[must_use]
     pub fn with_temp_files(mut self, temp_files: Vec<PathBuf>) -> Self {
         self.temp_files = temp_files;
         self

--- a/crates/rdlp-downloader/Cargo.toml
+++ b/crates/rdlp-downloader/Cargo.toml
@@ -29,3 +29,6 @@ tokio = { workspace = true, features = ["test-util"] }
 mockito = { workspace = true }
 tempfile = { workspace = true }
 proptest = "1.4"
+
+[lints]
+workspace = true

--- a/crates/rdlp-downloader/src/chunking.rs
+++ b/crates/rdlp-downloader/src/chunking.rs
@@ -79,6 +79,7 @@ impl fmt::Display for ChunkSizeStrategy {
 /// assert_eq!(chunk_size_for_file(1024 * 1024 * 1024), 1024 * 1024);   // 1 GB → 1 MB
 /// assert_eq!(chunk_size_for_file(5 * 1024 * 1024 * 1024), 8 * 1024 * 1024); // 5 GB → 8 MB
 /// ```
+#[must_use]
 pub fn chunk_size_for_file(file_size: u64) -> usize {
     const MIN_CHUNK: u64 = 64 * 1024; // 64 KB (NTFS cluster size)
     const MAX_CHUNK: u64 = 8 * 1024 * 1024; // 8 MB (reasonable upper bound)
@@ -96,6 +97,7 @@ pub fn chunk_size_for_file(file_size: u64) -> usize {
 /// Calculate chunk information for a file
 ///
 /// Returns (chunk_size, total_chunks)
+#[must_use]
 pub fn calculate_chunks(file_size: u64, strategy: ChunkSizeStrategy) -> (usize, usize) {
     let chunk_size = match strategy {
         ChunkSizeStrategy::Auto => chunk_size_for_file(file_size),
@@ -230,7 +232,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "must be power of two")]
     fn test_calculate_chunks_fixed_non_power_of_two() {
-        calculate_chunks(1024 * 1024, ChunkSizeStrategy::Fixed(1000)); // Not power of two
+        let _ = calculate_chunks(1024 * 1024, ChunkSizeStrategy::Fixed(1000)); // Not power of two
     }
 
     #[test]

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -81,6 +81,7 @@ pub struct HlsDownloader {
 
 impl HlsDownloader {
     /// Create a new HLS downloader with default settings
+    #[must_use]
     pub fn new() -> Self {
         Self {
             http_downloader: HttpDownloader::new(),

--- a/crates/rdlp-downloader/src/hls_state.rs
+++ b/crates/rdlp-downloader/src/hls_state.rs
@@ -62,6 +62,7 @@ impl HlsDownloadState {
     ///
     /// The playlist URL is normalized (query parameters stripped) to handle
     /// dynamic tokens that change on each request.
+    #[must_use]
     pub fn new(playlist_url: String, segment_count: usize) -> Self {
         let now = Utc::now();
         Self {
@@ -76,6 +77,7 @@ impl HlsDownloadState {
     }
 
     /// Get the state file path for a given output path
+    #[must_use]
     pub fn state_file_path(output_path: &Path) -> PathBuf {
         let mut state_path = output_path.to_path_buf();
         let filename = state_path
@@ -193,11 +195,13 @@ impl HlsDownloadState {
     }
 
     /// Check if a segment is already completed
+    #[must_use]
     pub fn is_completed(&self, segment_index: usize) -> bool {
         self.completed_segments.contains(&segment_index)
     }
 
     /// Get list of segments that still need to be downloaded
+    #[must_use]
     pub fn pending_segments(&self) -> Vec<usize> {
         (0..self.segment_count)
             .filter(|idx| !self.completed_segments.contains(idx))
@@ -205,6 +209,7 @@ impl HlsDownloadState {
     }
 
     /// Get progress as a fraction (0.0 to 1.0)
+    #[must_use]
     pub fn progress(&self) -> f64 {
         if self.segment_count == 0 {
             return 1.0;

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -37,11 +37,13 @@ pub struct HttpDownloader {
 
 impl HttpDownloader {
     /// Create a new HTTP downloader
+    #[must_use]
     pub fn new() -> Self {
         Self::with_client(reqwest::Client::new())
     }
 
     /// Create with custom client
+    #[must_use]
     pub fn with_client(client: reqwest::Client) -> Self {
         Self {
             client,
@@ -50,6 +52,7 @@ impl HttpDownloader {
     }
 
     /// Get reference to the HTTP client
+    #[must_use]
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -274,11 +274,13 @@ pub struct DownloaderRegistry {
 
 impl DownloaderRegistry {
     /// Create a new registry with default downloaders
+    #[must_use]
     pub fn new() -> Self {
         Self::with_config(&Config::default())
     }
 
     /// Create a new registry with custom configuration
+    #[must_use]
     pub fn with_config(config: &Config) -> Self {
         let mut registry = Self {
             downloaders: Vec::new(),
@@ -333,6 +335,7 @@ impl DownloaderRegistry {
     /// let downloader = registry.find_downloader("https://example.com/video.mp4");
     /// assert!(downloader.is_some());
     /// ```
+    #[must_use]
     pub fn find_downloader(&self, url: &str) -> Option<Arc<dyn Downloader>> {
         self.downloaders.iter().find(|d| d.supports(url)).cloned()
     }
@@ -341,6 +344,7 @@ impl DownloaderRegistry {
     ///
     /// # Returns
     /// A vector of protocol names (e.g., ["http", "hls", "dash"])
+    #[must_use]
     pub fn list_downloaders(&self) -> Vec<String> {
         self.downloaders
             .iter()

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -17,6 +17,7 @@ pub struct ProgressGuard(Option<tokio::task::JoinHandle<()>>);
 
 impl ProgressGuard {
     /// Create a new progress guard wrapping an optional task handle.
+    #[must_use]
     pub fn new(task: Option<tokio::task::JoinHandle<()>>) -> Self {
         Self(task)
     }
@@ -88,6 +89,7 @@ pub struct ProgressReporterConfig {
 
 impl ProgressReporterConfig {
     /// Create config for HTTP byte-based progress.
+    #[must_use]
     pub fn http(start_time: Instant, total_size: u64, resume_from: u64) -> Self {
         Self {
             start_time,
@@ -100,6 +102,7 @@ impl ProgressReporterConfig {
     }
 
     /// Create config for HLS duration-based progress.
+    #[must_use]
     pub fn hls(start_time: Instant, total_segments: u64, total_duration: f64) -> Self {
         Self {
             start_time,
@@ -123,6 +126,7 @@ impl ProgressReporterConfig {
 ///
 /// # Returns
 /// A `ProgressGuard` that manages the spawned task's lifecycle.
+#[must_use]
 pub fn spawn_progress_reporter(
     callback: Option<Box<dyn ProgressCallback>>,
     metrics: ProgressMetrics,

--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -25,3 +25,6 @@ futures = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 mockito = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -361,6 +361,7 @@ impl BaseExtractor {
     ///
     /// let id = BaseExtractor::extract_id_from_url(url, &VIDEO_PATTERN, "id");
     /// ```
+    #[must_use]
     pub fn extract_id_from_url(url: &str, pattern: &Regex, group_name: &str) -> Option<String> {
         pattern
             .captures(url)
@@ -391,6 +392,7 @@ impl BaseExtractor {
     ///
     /// let id = BaseExtractor::extract_id_positional(url, &PATTERN, &[1, 2]);
     /// ```
+    #[must_use]
     pub fn extract_id_positional(
         url: &str,
         pattern: &Regex,
@@ -421,6 +423,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// The content attribute value if found and non-empty
+    #[must_use]
     pub fn extract_meta_content(html: &Html, selector: &Selector) -> Option<String> {
         html.select(selector)
             .next()
@@ -437,6 +440,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// The href attribute value if found and non-empty
+    #[must_use]
     pub fn extract_link_href(html: &Html, selector: &Selector) -> Option<String> {
         html.select(selector)
             .next()
@@ -453,6 +457,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// The text content if found and non-empty
+    #[must_use]
     pub fn extract_element_text(html: &Html, selector: &Selector) -> Option<String> {
         html.select(selector)
             .next()
@@ -473,6 +478,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Title from the first successful strategy, `None` if all fail
+    #[must_use]
     pub fn extract_title_multi_strategy(html: &Html) -> Option<String> {
         // Strategy 1: Open Graph
         if let Some(title) = Self::extract_meta_content(html, &OG_TITLE_SELECTOR) {
@@ -505,6 +511,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Description from the first successful strategy, `None` if all fail
+    #[must_use]
     pub fn extract_description_multi_strategy(html: &Html) -> Option<String> {
         // Strategy 1: Open Graph
         if let Some(desc) = Self::extract_meta_content(html, &OG_DESCRIPTION_SELECTOR) {
@@ -527,6 +534,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Thumbnail URL from the first successful strategy, `None` if all fail
+    #[must_use]
     pub fn extract_thumbnail_multi_strategy(html: &Html) -> Option<String> {
         // Strategy 1: Open Graph
         if let Some(thumb) = Self::extract_meta_content(html, &OG_IMAGE_SELECTOR) {
@@ -687,6 +695,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Calculated width in pixels
+    #[must_use]
     #[inline]
     pub fn width_from_height(height: u32) -> u32 {
         (height * 16) / 9
@@ -699,6 +708,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Parsed height as u32, `None` if parsing fails
+    #[must_use]
     pub fn parse_quality_height(quality_str: &str) -> Option<u32> {
         quality_str.trim_end_matches(['p', 'P']).parse::<u32>().ok()
     }
@@ -731,6 +741,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// A Format struct with quality metadata populated
+    #[must_use]
     pub fn build_format(
         format_id: String,
         url: String,
@@ -820,6 +831,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Truncated string (or original if already shorter)
+    #[must_use]
     pub fn truncate_string(s: String, max_len: usize) -> String {
         if s.chars().count() <= max_len {
             s
@@ -839,6 +851,7 @@ impl BaseExtractor {
     ///
     /// # Returns
     /// Sanitized string with sensitive data redacted
+    #[must_use]
     pub fn sanitize_for_logging(s: &str) -> String {
         rdlp_security::sanitize_for_logging(s)
     }

--- a/crates/rdlp-extractor/src/base/tnaflix_network/mod.rs
+++ b/crates/rdlp-extractor/src/base/tnaflix_network/mod.rs
@@ -114,6 +114,7 @@ pub struct TnaFlixNetworkBase;
 
 impl TnaFlixNetworkBase {
     /// Create a new base extractor
+    #[must_use]
     pub fn new() -> Self {
         Self
     }
@@ -322,6 +323,7 @@ impl TnaFlixNetworkBase {
     /// assert_eq!(base.parse_iso8601_duration("PT30M"), Some(1800.0));
     /// assert_eq!(base.parse_iso8601_duration("PT45S"), Some(45.0));
     /// ```
+    #[must_use]
     pub fn parse_iso8601_duration(&self, duration_str: &str) -> Option<f64> {
         if !duration_str.starts_with("PT") {
             return None;
@@ -370,6 +372,7 @@ impl TnaFlixNetworkBase {
     /// assert_eq!(base.parse_iso8601_date("2024-01-15"), Some("20240115".to_string()));
     /// assert_eq!(base.parse_iso8601_date("2024-01-15T10:30:00Z"), Some("20240115".to_string()));
     /// ```
+    #[must_use]
     pub fn parse_iso8601_date(&self, date_str: &str) -> Option<String> {
         let date_part = date_str.split('T').next().unwrap_or(date_str);
         let parts: Vec<&str> = date_part.split('-').collect();

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -50,6 +50,7 @@ pub struct PornHubExtractor;
 
 impl PornHubExtractor {
     /// Create a new PornHub extractor
+    #[must_use]
     pub fn new() -> Self {
         Self
     }

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -34,6 +34,7 @@ pub struct RedTubeExtractor {
 
 impl RedTubeExtractor {
     /// Create a new RedTube extractor
+    #[must_use]
     pub fn new() -> Self {
         Self {
             base: TnaFlixNetworkBase::new(),

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -33,6 +33,7 @@ pub struct TNAFlixExtractor {
 
 impl TNAFlixExtractor {
     /// Create extractor for TNAFlix
+    #[must_use]
     pub fn tnaflix() -> Self {
         Self {
             name: "TNAFlix".to_string(),
@@ -42,6 +43,7 @@ impl TNAFlixExtractor {
     }
 
     /// Create extractor for EMPFlix
+    #[must_use]
     pub fn empflix() -> Self {
         Self {
             name: "EMPFlix".to_string(),
@@ -51,6 +53,7 @@ impl TNAFlixExtractor {
     }
 
     /// Create extractor for MovieFap
+    #[must_use]
     pub fn moviefap() -> Self {
         Self {
             name: "MovieFap".to_string(),

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -120,6 +120,7 @@ impl HlsSizeDetector {
     /// # Arguments
     /// * `http_client` - Shared HTTP client for making requests
     /// * `verbose` - Enable detailed logging
+    #[must_use]
     pub fn new(http_client: Arc<reqwest::Client>, verbose: bool) -> Self {
         Self {
             http_client,

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -64,6 +64,7 @@ pub struct ExtractorRegistry {
 
 impl ExtractorRegistry {
     /// Create a new registry with default extractors
+    #[must_use]
     pub fn new() -> Self {
         let mut registry = Self {
             extractors: Vec::new(),
@@ -110,6 +111,7 @@ impl ExtractorRegistry {
     /// let extractor = registry.find_extractor("https://www.tnaflix.com/video/123");
     /// assert!(extractor.is_some());
     /// ```
+    #[must_use]
     pub fn find_extractor(&self, url: &str) -> Option<Arc<dyn InfoExtractor>> {
         self.extractors
             .iter()
@@ -122,6 +124,7 @@ impl ExtractorRegistry {
     ///
     /// # Returns
     /// A vector of extractor names (e.g., ["TNAFlix", "EMPFlix", "MovieFap"])
+    #[must_use]
     pub fn list_extractors(&self) -> Vec<String> {
         self.extractors
             .iter()

--- a/crates/rdlp-extractor/src/utils.rs
+++ b/crates/rdlp-extractor/src/utils.rs
@@ -217,6 +217,7 @@ pub fn decode_html_entities(text: &str) -> String {
 /// assert_eq!(extract_extension_from_url("https://example.com/video.mp4?token=abc"), Some("mp4".to_string()));
 /// assert_eq!(extract_extension_from_url("https://example.com/video"), None);
 /// ```
+#[must_use]
 pub fn extract_extension_from_url(url: &str) -> Option<String> {
     // Parse URL to get path
     let parsed = url::Url::parse(url).ok()?;
@@ -259,6 +260,7 @@ pub fn extract_extension_from_url(url: &str) -> Option<String> {
 /// );
 /// assert_eq!(abs, "https://example.com/video/segment001.ts");
 /// ```
+#[must_use]
 pub fn make_absolute_url(base_url: &str, relative_url: &str) -> String {
     // If already absolute, return as-is
     if relative_url.starts_with("http://") || relative_url.starts_with("https://") {
@@ -299,6 +301,7 @@ pub fn make_absolute_url(base_url: &str, relative_url: &str) -> String {
 /// assert_eq!(format_filesize(1024 * 1024), "1.0 MiB");
 /// assert_eq!(format_filesize(1536 * 1024 * 1024), "1.5 GiB");
 /// ```
+#[must_use]
 pub fn format_filesize(bytes: u64) -> String {
     const KIB: u64 = 1024;
     const MIB: u64 = KIB * 1024;
@@ -324,6 +327,7 @@ pub fn format_filesize(bytes: u64) -> String {
 ///
 /// # Returns
 /// Formatted string (e.g., "1.5 GB", "256 MB", "128 KB")
+#[must_use]
 pub fn format_filesize_decimal(bytes: u64) -> String {
     const KB: u64 = 1000;
     const MB: u64 = KB * 1000;
@@ -357,6 +361,7 @@ pub fn format_filesize_decimal(bytes: u64) -> String {
 /// assert_eq!(format_duration(330.0), "5:30");
 /// assert_eq!(format_duration(5445.0), "1:30:45");
 /// ```
+#[must_use]
 pub fn format_duration(seconds: f64) -> String {
     let total_secs = seconds as u64;
     let hours = total_secs / 3600;

--- a/crates/rdlp-http/Cargo.toml
+++ b/crates/rdlp-http/Cargo.toml
@@ -9,3 +9,6 @@ license.workspace = true
 rdlp-types = { path = "../rdlp-types" }
 reqwest = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rdlp-http/src/client.rs
+++ b/crates/rdlp-http/src/client.rs
@@ -29,11 +29,13 @@ pub struct HttpClientFactory {
 
 impl HttpClientFactory {
     /// Create a new factory with default configuration
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Create a factory from an HttpClientConfig
+    #[must_use]
     pub fn from_config(config: &HttpClientConfig) -> Self {
         Self {
             config: config.clone(),
@@ -41,6 +43,7 @@ impl HttpClientFactory {
     }
 
     /// Create a factory from rdlp-types Config
+    #[must_use]
     pub fn from_rdlp_config(config: &rdlp_types::Config) -> Self {
         Self {
             config: HttpClientConfig::from_rdlp_config(config),
@@ -48,6 +51,7 @@ impl HttpClientFactory {
     }
 
     /// Build a reqwest::Client with the configured settings
+    #[must_use]
     pub fn build(&self) -> reqwest::Client {
         let mut builder = reqwest::Client::builder()
             .user_agent(&self.config.user_agent)
@@ -68,6 +72,7 @@ impl HttpClientFactory {
     }
 
     /// Build and wrap in Arc for sharing across async tasks
+    #[must_use]
     pub fn build_arc(&self) -> Arc<reqwest::Client> {
         Arc::new(self.build())
     }

--- a/crates/rdlp-http/src/config.rs
+++ b/crates/rdlp-http/src/config.rs
@@ -50,11 +50,13 @@ impl Default for HttpClientConfig {
 
 impl HttpClientConfig {
     /// Create a new config with default values
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Create config from rdlp-types Config
+    #[must_use]
     pub fn from_rdlp_config(config: &rdlp_types::Config) -> Self {
         let mut http_config = Self::default();
 
@@ -80,36 +82,42 @@ impl HttpClientConfig {
     }
 
     /// Set the connection timeout in seconds
+    #[must_use]
     pub fn with_connect_timeout_secs(mut self, secs: u64) -> Self {
         self.connect_timeout_secs = secs;
         self
     }
 
     /// Set the read timeout in seconds
+    #[must_use]
     pub fn with_read_timeout_secs(mut self, secs: u64) -> Self {
         self.read_timeout_secs = secs;
         self
     }
 
     /// Set the maximum idle connections per host
+    #[must_use]
     pub fn with_pool_max_idle_per_host(mut self, count: usize) -> Self {
         self.pool_max_idle_per_host = count;
         self
     }
 
     /// Set the idle connection timeout in seconds
+    #[must_use]
     pub fn with_pool_idle_timeout_secs(mut self, secs: u64) -> Self {
         self.pool_idle_timeout_secs = secs;
         self
     }
 
     /// Set the TCP keepalive interval in seconds
+    #[must_use]
     pub fn with_tcp_keepalive_secs(mut self, secs: u64) -> Self {
         self.tcp_keepalive_secs = secs;
         self
     }
 
     /// Enable or disable TCP_NODELAY
+    #[must_use]
     pub fn with_tcp_nodelay(mut self, enabled: bool) -> Self {
         self.tcp_nodelay = enabled;
         self

--- a/crates/rdlp-jsinterp/Cargo.toml
+++ b/crates/rdlp-jsinterp/Cargo.toml
@@ -15,3 +15,6 @@ once_cell = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/rdlp-jsinterp/src/lib.rs
+++ b/crates/rdlp-jsinterp/src/lib.rs
@@ -17,6 +17,7 @@ pub struct SimpleJsEngine {
 
 impl SimpleJsEngine {
     /// Create a new JavaScript engine instance
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }

--- a/crates/rdlp-plugin/Cargo.toml
+++ b/crates/rdlp-plugin/Cargo.toml
@@ -10,3 +10,6 @@ rdlp-core = { path = "../rdlp-core" }
 libloading = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -21,3 +21,6 @@ ffmpeg-the-third = "4.0"
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -151,6 +151,7 @@ pub static AUDIO_CODECS: &[(&str, AudioCodecConfig)] = &[
 ];
 
 /// Get audio codec configuration by name.
+#[must_use]
 pub fn get_audio_codec(name: &str) -> Option<&'static AudioCodecConfig> {
     AUDIO_CODECS
         .iter()
@@ -2142,6 +2143,7 @@ impl FFmpegRunner {
 
 impl MediaInfo {
     /// Get a resolution string (e.g., "1920x1080").
+    #[must_use]
     pub fn resolution_string(&self) -> Option<String> {
         match (self.width, self.height) {
             (Some(w), Some(h)) => Some(format!("{w}x{h}")),
@@ -2150,11 +2152,13 @@ impl MediaInfo {
     }
 
     /// Get the video stream info.
+    #[must_use]
     pub fn video_stream(&self) -> Option<&StreamInfo> {
         self.streams.iter().find(|s| s.codec_type == "video")
     }
 
     /// Get the audio stream info.
+    #[must_use]
     pub fn audio_stream(&self) -> Option<&StreamInfo> {
         self.streams.iter().find(|s| s.codec_type == "audio")
     }

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -39,6 +39,7 @@ pub struct EmbedThumbnail {
 
 impl EmbedThumbnail {
     /// Create a new thumbnail embedding processor.
+    #[must_use]
     pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
         Self { ffmpeg }
     }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -28,6 +28,7 @@ pub struct FFmpegExtractAudio {
 
 impl FFmpegExtractAudio {
     /// Create a new audio extraction processor.
+    #[must_use]
     pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
         Self { ffmpeg }
     }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -29,6 +29,7 @@ pub struct FFmpegMerger {
 
 impl FFmpegMerger {
     /// Create a new merger processor.
+    #[must_use]
     pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
         Self { ffmpeg }
     }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -32,6 +32,7 @@ pub struct FFmpegMetadata {
 
 impl FFmpegMetadata {
     /// Create a new metadata embedding processor.
+    #[must_use]
     pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
         Self { ffmpeg }
     }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -41,6 +41,7 @@ pub struct FFmpegRemuxer {
 
 impl FFmpegRemuxer {
     /// Create a new remuxer processor.
+    #[must_use]
     pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
         Self { ffmpeg }
     }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -40,6 +40,7 @@ pub struct FFmpegVideoConvertor {
 
 impl FFmpegVideoConvertor {
     /// Create a new video converter processor.
+    #[must_use]
     pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
         Self { ffmpeg }
     }

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -138,6 +138,7 @@ impl PostProcessorRegistry {
     }
 
     /// Get the FFmpeg runner.
+    #[must_use]
     pub fn ffmpeg(&self) -> &Arc<FFmpegRunner> {
         &self.ffmpeg
     }

--- a/crates/rdlp-security/Cargo.toml
+++ b/crates/rdlp-security/Cargo.toml
@@ -10,3 +10,6 @@ thiserror = "2.0"
 log = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/rdlp-security/src/lib.rs
+++ b/crates/rdlp-security/src/lib.rs
@@ -175,6 +175,7 @@ pub fn validate_url_security(url: &str) -> Result<()> {
 /// assert!(!is_private_host("example.com"));
 /// assert!(!is_private_host("8.8.8.8"));
 /// ```
+#[must_use]
 pub fn is_private_host(host: &str) -> bool {
     // Check for localhost variants
     if host == "localhost" || host == "127.0.0.1" || host == "::1" {
@@ -249,6 +250,7 @@ pub fn is_private_host(host: &str) -> bool {
 ///     "https://example.com/video.m3u8"
 /// );
 /// ```
+#[must_use]
 pub fn normalize_url(url: &str) -> String {
     match url::Url::parse(url) {
         Ok(mut parsed) => {
@@ -292,6 +294,7 @@ pub fn normalize_url(url: &str) -> String {
 ///     "/hls/video.m3u8"
 /// );
 /// ```
+#[must_use]
 pub fn extract_url_path(url: &str) -> String {
     match url::Url::parse(url) {
         Ok(parsed) => parsed.path().to_string(),
@@ -339,6 +342,7 @@ pub fn extract_url_path(url: &str) -> String {
 /// let safe = sanitize_for_logging(multi);
 /// assert_eq!(safe, "url?key=***&password=***");
 /// ```
+#[must_use]
 pub fn sanitize_for_logging(s: &str) -> String {
     // Common patterns to redact
     let patterns = [

--- a/crates/rdlp-types/Cargo.toml
+++ b/crates/rdlp-types/Cargo.toml
@@ -13,3 +13,6 @@ url = { workspace = true }
 regex = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/rdlp-types/src/format.rs
+++ b/crates/rdlp-types/src/format.rs
@@ -200,6 +200,7 @@ impl fmt::Debug for Format {
 
 impl Format {
     /// Create a new format with required fields
+    #[must_use]
     pub fn new(format_id: String, url: String, ext: String, protocol: String) -> Self {
         Self {
             format_id,
@@ -503,6 +504,7 @@ impl FormatSelector {
     }
 
     /// Get the expression string
+    #[must_use]
     pub fn expression(&self) -> &str {
         &self.expression
     }

--- a/crates/rdlp-types/src/info_dict.rs
+++ b/crates/rdlp-types/src/info_dict.rs
@@ -178,6 +178,7 @@ pub struct InfoDict {
 
 impl InfoDict {
     /// Create a new InfoDict with required fields
+    #[must_use]
     pub fn new(id: String, title: String, extractor: String, webpage_url: String) -> Self {
         Self {
             id,
@@ -224,6 +225,7 @@ impl InfoDict {
     }
 
     /// Get the best format (highest quality video with audio, or best video+audio)
+    #[must_use]
     pub fn best_format(&self) -> Option<&Format> {
         self.formats
             .iter()
@@ -242,6 +244,7 @@ impl InfoDict {
     }
 
     /// Get the best video-only format
+    #[must_use]
     pub fn best_video(&self) -> Option<&Format> {
         self.formats
             .iter()
@@ -259,6 +262,7 @@ impl InfoDict {
     }
 
     /// Get the best audio-only format
+    #[must_use]
     pub fn best_audio(&self) -> Option<&Format> {
         self.formats
             .iter()


### PR DESCRIPTION
This pull request introduces a consistent application of the `#[must_use]` attribute to constructors and important methods across multiple crates, helping catch potential bugs where return values are ignored. Additionally, it standardizes workspace-level lint configuration for Clippy and enables workspace lints in all crates. These changes improve code safety and maintainability.

**Lints and Workspace Configuration:**

* Added `[lints] workspace = true` to all crate `Cargo.toml` files, enabling workspace-wide lint settings. [[1]](diffhunk://#diff-3b3b3254bd5e775b69d74fe464b6b6f1d0921e6a936c6ca3342f4dc224647126R42-R44) [[2]](diffhunk://#diff-a2fdf524fa53bc2455faf9c0d4fcb1d1b96b998f73a77ed76736176efd6c3a1dR19-R21) [[3]](diffhunk://#diff-016d50c1c05407659e5de93bc80134959e10a7273b50881b566a9b1113904e98R25-R27) [[4]](diffhunk://#diff-73674e4cb6704b3bb5f72fa2d3051c7587a000bd8a0bc6ffaad78a2b23d305d0R32-R34) [[5]](diffhunk://#diff-c94e74c802710db3a681f02eb11a71da343c56bed03039bb9c0455a9a9e328edR28-R30)
* Added `[workspace.lints.clippy] must_use_candidate = "warn"` to the root `Cargo.toml`, ensuring Clippy warns when potentially important return values are not used.

**API and Code Safety Improvements:**

* Added `#[must_use]` to constructors and key methods (e.g., `new`, `with_config`, `list_downloaders`, `speed_string`, etc.) across many types in `rdlp-core`, `rdlp-downloader`, `rdlp-cli`, and `rdlp-cookies` to prevent accidental ignoring of important results. [[1]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R46) [[2]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R189-R195) [[3]](diffhunk://#diff-40d2f40928ab42c5c5d19cedf5960225b16c7ed91ab2aa49551209642935904cR21) [[4]](diffhunk://#diff-d4e0da146149d427ab7c4393110d7d869c54e7565dce2f420d362ad7601cf896R22) [[5]](diffhunk://#diff-2dbf2f9576e3a3edb03eaaf24dadd13941dbf27c5f7c5be3df8e96008e9fd12dR27) [[6]](diffhunk://#diff-2dbf2f9576e3a3edb03eaaf24dadd13941dbf27c5f7c5be3df8e96008e9fd12dR44) [[7]](diffhunk://#diff-2dbf2f9576e3a3edb03eaaf24dadd13941dbf27c5f7c5be3df8e96008e9fd12dR82) [[8]](diffhunk://#diff-2dbf2f9576e3a3edb03eaaf24dadd13941dbf27c5f7c5be3df8e96008e9fd12dR124) [[9]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R147) [[10]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R180) [[11]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R224) [[12]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R269-R287) [[13]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R331) [[14]](diffhunk://#diff-8010e0b245ab3cad95ad202866adb3ad927a4a488bcc974f0505aa88eb91b3e2R349-R362) [[15]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R65) [[16]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R75) [[17]](diffhunk://#diff-804278a59fb03b721d2d8b177fb988ca48251d24e7167aabe2c74c1cd2c5a208R82) [[18]](diffhunk://#diff-804278a59fb03b721d2d8b177fb988ca48251d24e7167aabe2c74c1cd2c5a208R100) [[19]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R84) [[20]](diffhunk://#diff-3b5497e2da3b22e65a8c990fb2c9ee0c998ee3dbdd7d7a4a3ba36d1bf57fb2d4R65) [[21]](diffhunk://#diff-3b5497e2da3b22e65a8c990fb2c9ee0c998ee3dbdd7d7a4a3ba36d1bf57fb2d4R80) [[22]](diffhunk://#diff-3b5497e2da3b22e65a8c990fb2c9ee0c998ee3dbdd7d7a4a3ba36d1bf57fb2d4R198-R212) [[23]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR40-R46) [[24]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR55) [[25]](diffhunk://#diff-5c9fff48c1ce99dcf82b93711c7aa517889443f91bc938eb20efdb005eac21ebR277-R283) [[26]](diffhunk://#diff-5c9fff48c1ce99dcf82b93711c7aa517889443f91bc938eb20efdb005eac21ebR338) [[27]](diffhunk://#diff-5c9fff48c1ce99dcf82b93711c7aa517889443f91bc938eb20efdb005eac21ebR347) [[28]](diffhunk://#diff-59d8bef7ea446d697a7d015c319ff59a908ea9f8bc5eb89a5d8ce4a54654d755R20) [[29]](diffhunk://#diff-59d8bef7ea446d697a7d015c319ff59a908ea9f8bc5eb89a5d8ce4a54654d755R92) [[30]](diffhunk://#diff-59d8bef7ea446d697a7d015c319ff59a908ea9f8bc5eb89a5d8ce4a54654d755R105) [[31]](diffhunk://#diff-59d8bef7ea446d697a7d015c319ff59a908ea9f8bc5eb89a5d8ce4a54654d755R129)

**Testing and Minor Fixes:**

* Minor test adjustment: explicitly assigns the result of a function call in a test to avoid unused result warnings.

These changes collectively improve code quality by enforcing best practices and reducing the likelihood of subtle bugs due to ignored return values.