### PR TITLE
refactor: deduplicate codebase with shared helpers and macros

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -160,6 +160,32 @@ let data = fetch_url(&url)
     .context("Failed to fetch playlist")?;
 ```
 
+## Code Reuse
+
+### Extractor Format Building
+All site extractors **must** use `BaseExtractor::build_format()` to construct `Format` structs. This centralises height/width calculation, format_note, codec defaults, and quality scoring.
+
+```rust
+// Correct — delegate to BaseExtractor, then add site-specific fields
+let mut format = BaseExtractor::build_format(format_id, url, ext, height);
+format.container = Some(container.to_owned()); // site-specific
+format.tbr = extract_bitrate_from_url(&url);   // site-specific
+```
+
+```rust
+// Wrong — duplicating Format construction in each extractor
+let mut format = Format::new(id, url, ext, "https".to_string());
+format.height = Some(h);
+format.width = Some(width_from_height(h));
+format.vcodec = Some("h264".to_string());
+// ...
+```
+
+### Shared Utilities
+- Use `BaseExtractor` methods (`parse_quality_height`, `width_from_height`, `extract_meta_content`, `extract_element_text`, etc.) instead of defining local equivalents.
+- Site-specific helpers belong in the extractor's own module but should compose on top of `BaseExtractor`, not replace it.
+- When adding a new extractor, check `BaseExtractor` and `crate::utils` for existing helpers before writing new ones.
+
 ## API Design
 
 ### Trait Design

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -465,6 +465,57 @@ impl BaseExtractor {
             .filter(|s| !s.is_empty())
     }
 
+    /// Extract content from a meta tag using a CSS selector string.
+    ///
+    /// Convenience wrapper around [`Self::extract_meta_content`] that parses
+    /// the selector from a string. Use this for site-specific selectors that
+    /// are not worth pre-compiling as statics.
+    #[must_use]
+    pub fn extract_meta_content_str(html: &Html, selector_str: &str) -> Option<String> {
+        let selector = Selector::parse(selector_str).ok()?;
+        Self::extract_meta_content(html, &selector)
+    }
+
+    /// Extract text content from an element using a CSS selector string.
+    ///
+    /// Convenience wrapper around [`Self::extract_element_text`] that parses
+    /// the selector from a string. Use this for site-specific selectors that
+    /// are not worth pre-compiling as statics.
+    #[must_use]
+    pub fn extract_element_text_str(html: &Html, selector_str: &str) -> Option<String> {
+        let selector = Selector::parse(selector_str).ok()?;
+        Self::extract_element_text(html, &selector)
+    }
+
+    /// Extract the first href from a list of CSS selector strings.
+    ///
+    /// Tries each selector in order, returning the first non-empty `href`
+    /// attribute found. Relative hrefs starting with `/` are made absolute
+    /// using the provided `base_url`.
+    #[must_use]
+    pub fn extract_first_href(
+        html: &Html,
+        selectors: &[&str],
+        base_url: &str,
+    ) -> Option<String> {
+        for selector_str in selectors {
+            let Ok(selector) = Selector::parse(selector_str) else {
+                continue;
+            };
+            if let Some(element) = html.select(&selector).next() {
+                if let Some(href) = element.value().attr("href") {
+                    if !href.is_empty() {
+                        if href.starts_with('/') {
+                            return Some(format!("{base_url}{href}"));
+                        }
+                        return Some(href.to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Extract title using multiple fallback strategies
     ///
     /// Tries in order:
@@ -688,7 +739,11 @@ impl BaseExtractor {
     // Format Building
     // ========================================================================
 
-    /// Calculate width from height assuming 16:9 aspect ratio
+    /// Calculate width from height assuming 16:9 aspect ratio.
+    ///
+    /// Uses a lookup table for standard resolutions to return the exact
+    /// display width (e.g. 480p → 854, not 853). Falls back to integer
+    /// math for non-standard heights.
     ///
     /// # Arguments
     /// * `height` - Video height in pixels
@@ -698,7 +753,16 @@ impl BaseExtractor {
     #[must_use]
     #[inline]
     pub fn width_from_height(height: u32) -> u32 {
-        (height * 16) / 9
+        match height {
+            240 => 426,
+            360 => 640,
+            480 => 854,
+            720 => 1280,
+            1080 => 1920,
+            1440 => 2560,
+            2160 => 3840,
+            _ => (height * 16) / 9,
+        }
     }
 
     /// Parse quality height from a string (e.g., "720p" -> 720)

--- a/crates/rdlp-extractor/src/base/common/tests.rs
+++ b/crates/rdlp-extractor/src/base/common/tests.rs
@@ -67,9 +67,16 @@ fn test_parse_quality_from_url() {
 
 #[test]
 fn test_width_from_height() {
+    // Standard resolutions (lookup table)
+    assert_eq!(BaseExtractor::width_from_height(240), 426);
+    assert_eq!(BaseExtractor::width_from_height(360), 640);
+    assert_eq!(BaseExtractor::width_from_height(480), 854);
     assert_eq!(BaseExtractor::width_from_height(720), 1280);
     assert_eq!(BaseExtractor::width_from_height(1080), 1920);
-    assert_eq!(BaseExtractor::width_from_height(480), 853);
+    assert_eq!(BaseExtractor::width_from_height(1440), 2560);
+    assert_eq!(BaseExtractor::width_from_height(2160), 3840);
+    // Non-standard height falls back to integer math
+    assert_eq!(BaseExtractor::width_from_height(900), (900 * 16) / 9);
 }
 
 // ========================================================================

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -6,11 +6,11 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Format, RdlpError, Result};
 use serde_json::Value;
 
+use crate::base::common::BaseExtractor;
 use super::patterns::{
     DOWNLOAD_BTN_PATTERN, FLASHVARS_PATTERN, MEDIA_VAR_PATTERN, QUALITY_FROM_URL_PATTERN,
     QUALITY_ITEMS_PATTERN,
 };
-use super::utils::width_from_height;
 use std::collections::HashSet;
 
 /// Extract all formats using multiple strategies
@@ -155,30 +155,17 @@ fn build_format_from_definition(definition: &Value, url: &str, idx: usize) -> Op
     Some(build_format(url, quality, idx))
 }
 
-/// Build a Format struct with common settings
+/// Build a Format struct with common settings.
+///
+/// Delegates to `BaseExtractor::build_format()` for the shared logic
+/// (height/width, format_note, codec defaults, quality score).
 fn build_format(url: &str, quality: Option<u64>, idx: usize) -> Format {
+    let height = quality.map(|q| q as u32);
     let format_id = quality
         .map(|q| format!("{q}p"))
         .unwrap_or_else(|| format!("format_{idx}"));
 
-    let mut format = Format::new(
-        format_id,
-        url.to_string(),
-        "mp4".to_string(),
-        "https".to_string(),
-    );
-
-    if let Some(q) = quality {
-        let height = q as u32;
-        format.height = Some(height);
-        format.width = Some(width_from_height(height));
-        format.format_note = Some(format!("{q}p"));
-    }
-
-    format.vcodec = Some("h264".to_string());
-    format.acodec = Some("aac".to_string());
-
-    format
+    BaseExtractor::build_format(format_id, url.to_string(), "mp4".to_string(), height)
 }
 
 /// Parse quality from JSON value (handles string or number)
@@ -256,16 +243,13 @@ fn extract_from_download_buttons(webpage: &str) -> Vec<Format> {
                 .map(|q| format!("{q}p"))
                 .unwrap_or_else(|| "download".to_string());
 
-            let mut format = Format::new(
+            let height = quality.map(|q| q as u32);
+            let format = BaseExtractor::build_format(
                 format_id.clone(),
                 url.to_string(),
                 "mp4".to_string(),
-                "https".to_string(),
+                height,
             );
-
-            if let Some(q) = quality {
-                format.height = Some(q as u32);
-            }
 
             debug!(format_id:?; "[PornHub] Found format from download button");
 

--- a/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
@@ -5,7 +5,9 @@
 use once_cell::sync::Lazy;
 use rdlp_core::{ExtractionContext, RdlpError, Result};
 use regex::Regex;
-use scraper::{Html, Selector};
+use scraper::Html;
+
+use crate::base::common::BaseExtractor;
 
 /// Age verification cookies required by PornHub
 const AGE_COOKIES: &[&str] = &[
@@ -114,19 +116,25 @@ fn clean_html(text: &str) -> String {
     cleaned.trim().chars().take(200).collect()
 }
 
-/// Extract video title from HTML
+/// PornHub base URL for making relative hrefs absolute.
+const PORNHUB_BASE_URL: &str = "https://www.pornhub.com";
+
+/// Extract video title from HTML.
+///
+/// Uses PornHub-specific strategies first (`h1.title`, `shareTitle` JS var),
+/// then falls back to `BaseExtractor::extract_title_multi_strategy`.
 pub fn extract_title(html: &Html, webpage: &str) -> String {
-    // Strategy 1: twitter:title meta tag
-    if let Some(title) = extract_meta_content(html, "meta[name='twitter:title']") {
+    // Strategy 1: PornHub-specific h1.title element
+    if let Some(title) = BaseExtractor::extract_element_text_str(html, "h1.title") {
         return title;
     }
 
-    // Strategy 2: h1.title element
-    if let Some(title) = extract_element_text(html, "h1.title") {
+    // Strategy 2: generic multi-strategy (og:title, twitter:title, <title>, h1)
+    if let Some(title) = BaseExtractor::extract_title_multi_strategy(html) {
         return title;
     }
 
-    // Strategy 3: shareTitle JavaScript variable
+    // Strategy 3: PornHub-specific shareTitle JavaScript variable
     if let Some(caps) = SHARE_TITLE_PATTERN.captures(webpage) {
         if let Some(m) = caps.get(1) {
             let title = m.as_str().trim();
@@ -139,89 +147,63 @@ pub fn extract_title(html: &Html, webpage: &str) -> String {
     "Untitled".to_string()
 }
 
-/// Extract video description from HTML
+/// Extract video description from HTML.
+///
+/// Delegates to `BaseExtractor::extract_description_multi_strategy`.
 pub fn extract_description(html: &Html) -> Option<String> {
-    extract_meta_content(html, "meta[property='og:description']")
-        .or_else(|| extract_meta_content(html, "meta[name='description']"))
+    BaseExtractor::extract_description_multi_strategy(html)
 }
 
-/// Extract thumbnail URL from HTML
+/// Extract thumbnail URL from HTML.
+///
+/// Delegates to `BaseExtractor::extract_thumbnail_multi_strategy`.
 pub fn extract_thumbnail(html: &Html) -> Option<String> {
-    extract_meta_content(html, "meta[property='og:image']")
-        .or_else(|| extract_meta_content(html, "meta[name='twitter:image']"))
+    BaseExtractor::extract_thumbnail_multi_strategy(html)
 }
 
 /// Extract uploader name from HTML
 pub fn extract_uploader(html: &Html) -> Option<String> {
-    // Try multiple selectors for uploader
-    extract_element_text(html, ".usernameBadgesWrapper a")
-        .or_else(|| extract_element_text(html, ".usernameWrap a"))
-        .or_else(|| extract_element_text(html, ".video-info-row .usernameLink"))
+    BaseExtractor::extract_element_text_str(html, ".usernameBadgesWrapper a")
+        .or_else(|| BaseExtractor::extract_element_text_str(html, ".usernameWrap a"))
+        .or_else(|| BaseExtractor::extract_element_text_str(html, ".video-info-row .usernameLink"))
 }
 
 /// Extract uploader URL from HTML
 pub fn extract_uploader_url(html: &Html) -> Option<String> {
-    let selectors = [
-        ".usernameBadgesWrapper a",
-        ".usernameWrap a",
-        ".video-info-row .usernameLink",
-    ];
-
-    for selector_str in selectors {
-        if let Ok(selector) = Selector::parse(selector_str) {
-            if let Some(element) = html.select(&selector).next() {
-                if let Some(href) = element.value().attr("href") {
-                    if !href.is_empty() {
-                        // Make absolute if relative
-                        if href.starts_with('/') {
-                            return Some(format!("https://www.pornhub.com{href}"));
-                        }
-                        return Some(href.to_string());
-                    }
-                }
-            }
-        }
-    }
-    None
+    BaseExtractor::extract_first_href(
+        html,
+        &[
+            ".usernameBadgesWrapper a",
+            ".usernameWrap a",
+            ".video-info-row .usernameLink",
+        ],
+        PORNHUB_BASE_URL,
+    )
 }
 
 /// Extract channel name (may differ from uploader on some videos)
 pub fn extract_channel(html: &Html) -> Option<String> {
-    extract_element_text(html, ".video-info-row .channel-name a")
-        .or_else(|| extract_element_text(html, ".channel-link"))
+    BaseExtractor::extract_element_text_str(html, ".video-info-row .channel-name a")
+        .or_else(|| BaseExtractor::extract_element_text_str(html, ".channel-link"))
 }
 
 /// Extract channel URL
 pub fn extract_channel_url(html: &Html) -> Option<String> {
-    let selectors = [".video-info-row .channel-name a", ".channel-link"];
-
-    for selector_str in selectors {
-        if let Ok(selector) = Selector::parse(selector_str) {
-            if let Some(element) = html.select(&selector).next() {
-                if let Some(href) = element.value().attr("href") {
-                    if !href.is_empty() {
-                        if href.starts_with('/') {
-                            return Some(format!("https://www.pornhub.com{href}"));
-                        }
-                        return Some(href.to_string());
-                    }
-                }
-            }
-        }
-    }
-    None
+    BaseExtractor::extract_first_href(
+        html,
+        &[".video-info-row .channel-name a", ".channel-link"],
+        PORNHUB_BASE_URL,
+    )
 }
 
 /// Extract view count from HTML
 pub fn extract_view_count(html: &Html) -> Option<u64> {
-    // Try to find view count element
-    if let Some(text) = extract_element_text(html, ".count") {
-        return parse_view_count(&text);
-    }
-    if let Some(text) = extract_element_text(html, ".views") {
-        return parse_view_count(&text);
-    }
-    None
+    BaseExtractor::extract_element_text_str(html, ".count")
+        .and_then(|t| parse_view_count(&t))
+        .or_else(|| {
+            BaseExtractor::extract_element_text_str(html, ".views")
+                .and_then(|t| parse_view_count(&t))
+        })
 }
 
 /// Parse view count string (handles "1.5M", "500K", etc.)
@@ -245,58 +227,9 @@ fn parse_view_count(text: &str) -> Option<u64> {
 
 /// Extract rating percentage from HTML
 pub fn extract_rating(html: &Html) -> Option<f64> {
-    // Try percent element
-    if let Some(text) = extract_element_text(html, ".percent") {
-        let text = text.trim().trim_end_matches('%');
-        return text.parse().ok();
-    }
-    // Try rating-value element
-    if let Some(text) = extract_element_text(html, ".rating-value") {
-        let text = text.trim().trim_end_matches('%');
-        return text.parse().ok();
-    }
-    None
-}
-
-/// Extract content from meta tag
-fn extract_meta_content(html: &Html, selector_str: &str) -> Option<String> {
-    let selector = Selector::parse(selector_str).ok()?;
-    let element = html.select(&selector).next()?;
-    let content = element.value().attr("content")?.trim();
-
-    if content.is_empty() {
-        None
-    } else {
-        Some(content.to_string())
-    }
-}
-
-/// Extract text from element
-fn extract_element_text(html: &Html, selector_str: &str) -> Option<String> {
-    let selector = Selector::parse(selector_str).ok()?;
-    let element = html.select(&selector).next()?;
-    let text: String = element.text().collect();
-    let text = text.trim();
-
-    if text.is_empty() {
-        None
-    } else {
-        Some(text.to_string())
-    }
-}
-
-/// Build width from height assuming 16:9 aspect ratio
-pub fn width_from_height(height: u32) -> u32 {
-    match height {
-        240 => 426,
-        360 => 640,
-        480 => 854,
-        720 => 1280,
-        1080 => 1920,
-        1440 => 2560,
-        2160 => 3840,
-        _ => (height as f32 * 16.0 / 9.0) as u32,
-    }
+    BaseExtractor::extract_element_text_str(html, ".percent")
+        .or_else(|| BaseExtractor::extract_element_text_str(html, ".rating-value"))
+        .and_then(|text| text.trim().trim_end_matches('%').parse().ok())
 }
 
 #[cfg(test)]
@@ -332,12 +265,5 @@ mod tests {
         // Normal video
         let html = r#"<div class="video">Normal content</div>"#;
         assert!(detect_video_unavailable(html).is_none());
-    }
-
-    #[test]
-    fn test_width_from_height() {
-        assert_eq!(width_from_height(1080), 1920);
-        assert_eq!(width_from_height(720), 1280);
-        assert_eq!(width_from_height(480), 854);
     }
 }

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -13,11 +13,6 @@ use crate::utils::{extract_extension_from_url, make_absolute_url};
 
 use super::patterns::{MEDIA_DEF_PATTERN, SOURCES_PATTERN};
 
-// Common codec strings to avoid repeated allocations
-const CODEC_H264: &str = "h264";
-const CODEC_AAC: &str = "aac";
-const PROTOCOL_HTTPS: &str = "https";
-
 /// Extract quality string from JSON value (handles both string and number types)
 pub fn parse_quality(item: &Value) -> String {
     item.get("quality")
@@ -43,31 +38,30 @@ fn extract_bitrate_from_url(url: &str) -> Option<f64> {
         .and_then(|m| m.as_str().parse::<f64>().ok())
 }
 
-/// Build Format from quality string and URL using BaseExtractor utilities
+/// Build Format from quality string and URL using BaseExtractor utilities.
+///
+/// Delegates to `BaseExtractor::build_format()` for shared logic
+/// (height/width, format_note, codec defaults, quality score),
+/// then applies RedTube-specific fields (container, bitrate, fallback format_note).
 pub fn build_format(quality_str: &str, url: String, format_type: &str) -> Format {
     let height = BaseExtractor::parse_quality_height(quality_str);
 
-    let mut format = Format::new(
+    let mut format = BaseExtractor::build_format(
         quality_str.to_owned(),
         url.clone(),
         format_type.to_owned(),
-        PROTOCOL_HTTPS.to_owned(),
+        height,
     );
 
-    if let Some(h) = height {
-        format.height = Some(h);
-        format.width = Some(BaseExtractor::width_from_height(h));
-        format.quality = Some((h / 100) as i32);
-        format.format_note = Some(format!("{h}p"));
-    } else {
+    // RedTube-specific: set format_note to raw quality string when height is unknown
+    if height.is_none() {
         format.format_note = Some(quality_str.to_owned());
     }
 
-    format.vcodec = Some(CODEC_H264.to_owned());
-    format.acodec = Some(CODEC_AAC.to_owned());
+    // RedTube-specific: container field
     format.container = Some(format_type.to_owned());
 
-    // Extract bitrate from URL if available (e.g., "4000K" = 4000 kbps)
+    // RedTube-specific: extract bitrate from URL (e.g., "4000K" = 4000 kbps)
     if let Some(bitrate) = extract_bitrate_from_url(&url) {
         format.tbr = Some(bitrate);
     }

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -295,6 +295,24 @@ impl FFmpegRunner {
         Self::new()
     }
 
+    /// Run a blocking FFmpeg operation on a background thread.
+    ///
+    /// All FFmpeg library calls are synchronous and must not run on the
+    /// Tokio runtime. This helper wraps `tokio::task::spawn_blocking`
+    /// with uniform error mapping.
+    async fn spawn_blocking<F, T>(task_name: &str, f: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let name = task_name.to_string();
+        tokio::task::spawn_blocking(f)
+            .await
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("{name} task join error: {e}"),
+            })?
+    }
+
     /// Probe a media file using the FFmpeg library and return its information.
     pub async fn probe(&self, path: impl AsRef<Path>) -> Result<MediaInfo> {
         let path = path.as_ref().to_path_buf();
@@ -303,11 +321,7 @@ impl FFmpegRunner {
             return Err(PostProcessError::InputNotFound { path });
         }
 
-        tokio::task::spawn_blocking(move || Self::probe_sync(&path))
-            .await
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("probe task join error: {e}"),
-            })?
+        Self::spawn_blocking("probe", move || Self::probe_sync(&path)).await
     }
 
     /// Probe a media file synchronously using ffmpeg-the-third library.
@@ -463,11 +477,7 @@ impl FFmpegRunner {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        tokio::task::spawn_blocking(move || Self::remux_sync(&input, &output, &opts))
-            .await
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("remux task join error: {e}"),
-            })?
+        Self::spawn_blocking("remux", move || Self::remux_sync(&input, &output, &opts)).await
     }
 
     /// Remux a single input file synchronously (stream copy).
@@ -584,13 +594,10 @@ impl FFmpegRunner {
         let audio_input = audio_input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        tokio::task::spawn_blocking(move || {
+        Self::spawn_blocking("merge", move || {
             Self::merge_sync(&video_input, &audio_input, &output, &opts)
         })
         .await
-        .map_err(|e| PostProcessError::FFmpegLibraryError {
-            message: format!("merge task join error: {e}"),
-        })?
     }
 
     /// Merge separate video and audio files synchronously (stream copy).
@@ -773,11 +780,10 @@ impl FFmpegRunner {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        tokio::task::spawn_blocking(move || Self::extract_audio_sync(&input, &output, &opts))
-            .await
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("extract_audio task join error: {e}"),
-            })?
+        Self::spawn_blocking("extract_audio", move || {
+            Self::extract_audio_sync(&input, &output, &opts)
+        })
+        .await
     }
 
     /// Extract audio synchronously (dispatches to copy or transcode).
@@ -1209,13 +1215,10 @@ impl FFmpegRunner {
         let output = output.as_ref().to_path_buf();
         let metadata = metadata.clone();
         let chapters: Vec<ChapterEntry> = chapters.to_vec();
-        tokio::task::spawn_blocking(move || {
+        Self::spawn_blocking("embed_metadata", move || {
             Self::embed_metadata_sync(&input, &output, &metadata, &chapters)
         })
         .await
-        .map_err(|e| PostProcessError::FFmpegLibraryError {
-            message: format!("embed_metadata task join error: {e}"),
-        })?
     }
 
     /// Embed metadata and chapters synchronously.
@@ -1355,13 +1358,10 @@ impl FFmpegRunner {
         let thumbnail = thumbnail.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let container = container.to_string();
-        tokio::task::spawn_blocking(move || {
+        Self::spawn_blocking("embed_thumbnail", move || {
             Self::embed_thumbnail_sync(&media, &thumbnail, &output, &container)
         })
         .await
-        .map_err(|e| PostProcessError::FFmpegLibraryError {
-            message: format!("embed_thumbnail task join error: {e}"),
-        })?
     }
 
     /// Embed thumbnail synchronously.
@@ -1589,11 +1589,10 @@ impl FFmpegRunner {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        tokio::task::spawn_blocking(move || Self::convert_video_sync(&input, &output, &opts))
-            .await
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("convert_video task join error: {e}"),
-            })?
+        Self::spawn_blocking("convert_video", move || {
+            Self::convert_video_sync(&input, &output, &opts)
+        })
+        .await
     }
 
     /// Convert video synchronously (dispatches to remux or transcode).

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -9,13 +9,10 @@
 //! - FLAC/OGG/Opus: Video stream with `ATTACHED_PIC` disposition
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
-
-use crate::ffmpeg::FFmpegRunner;
 
 /// Supported thumbnail formats.
 const THUMBNAIL_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
@@ -25,25 +22,19 @@ const SUPPORTED_CONTAINERS: &[&str] = &[
     "mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac", "ogg", "opus",
 ];
 
-/// Post-processor that embeds thumbnails into media files.
-///
-/// # Priority
-/// This processor has priority 20 (runs after most other processing).
-///
-/// # When it runs
-/// - When `embed_thumbnail` is true in config
-/// - When a thumbnail file exists alongside the media file
-pub struct EmbedThumbnail {
-    ffmpeg: Arc<FFmpegRunner>,
-}
+ffmpeg_processor!(
+    EmbedThumbnail,
+    "EmbedThumbnail",
+    20,
+    "Post-processor that embeds thumbnails into media files.\n\n\
+     # Priority\n\
+     This processor has priority 20 (runs after most other processing).\n\n\
+     # When it runs\n\
+     - When `embed_thumbnail` is true in config\n\
+     - When a thumbnail file exists alongside the media file"
+);
 
 impl EmbedThumbnail {
-    /// Create a new thumbnail embedding processor.
-    #[must_use]
-    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
-        Self { ffmpeg }
-    }
-
     /// Find a thumbnail file for the given media file.
     fn find_thumbnail(media_file: &Path) -> Option<PathBuf> {
         let stem = media_file.file_stem()?.to_str()?;
@@ -70,11 +61,11 @@ impl EmbedThumbnail {
 #[async_trait]
 impl PostProcessor for EmbedThumbnail {
     fn name(&self) -> &str {
-        "EmbedThumbnail"
+        self.processor_name()
     }
 
     fn priority(&self) -> i32 {
-        20 // Near the end
+        self.processor_priority()
     }
 
     fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -5,34 +5,27 @@
 //! Supports various output formats including MP3, AAC, Opus, FLAC, etc.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use crate::error::PostProcessError;
-use crate::ffmpeg::{get_audio_codec, AudioCodecConfig, AudioExtractOptions, FFmpegRunner};
+use crate::ffmpeg::{get_audio_codec, AudioCodecConfig, AudioExtractOptions};
 
-/// Post-processor that extracts audio from video files.
-///
-/// # Priority
-/// This processor has priority 50 (runs after merging).
-///
-/// # When it runs
-/// - When `extract_audio` is true in config
-/// - Optionally converts to specified `audio_format`
-pub struct FFmpegExtractAudio {
-    ffmpeg: Arc<FFmpegRunner>,
-}
+ffmpeg_processor!(
+    FFmpegExtractAudio,
+    "FFmpegExtractAudio",
+    50,
+    "Post-processor that extracts audio from video files.\n\n\
+     # Priority\n\
+     This processor has priority 50 (runs after merging).\n\n\
+     # When it runs\n\
+     - When `extract_audio` is true in config\n\
+     - Optionally converts to specified `audio_format`"
+);
 
 impl FFmpegExtractAudio {
-    /// Create a new audio extraction processor.
-    #[must_use]
-    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
-        Self { ffmpeg }
-    }
-
     /// Build extraction options from codec config and quality string.
     fn build_extract_options(
         codec_config: &AudioCodecConfig,
@@ -73,11 +66,11 @@ impl FFmpegExtractAudio {
 #[async_trait]
 impl PostProcessor for FFmpegExtractAudio {
     fn name(&self) -> &str {
-        "FFmpegExtractAudio"
+        self.processor_name()
     }
 
     fn priority(&self) -> i32 {
-        50 // After merging
+        self.processor_priority()
     }
 
     fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -6,34 +6,27 @@
 //! video and audio separately (like HLS/DASH streams).
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
-use crate::ffmpeg::{FFmpegRunner, RemuxOptions};
+use crate::ffmpeg::RemuxOptions;
 
-/// Post-processor that merges video and audio streams.
-///
-/// # Priority
-/// This processor has priority 100 (runs first) because other
-/// processors need a merged file to work with.
-///
-/// # When it runs
-/// - When there are multiple input files (video + audio)
-/// - When `requested_formats` contains multiple formats
-pub struct FFmpegMerger {
-    ffmpeg: Arc<FFmpegRunner>,
-}
+ffmpeg_processor!(
+    FFmpegMerger,
+    "FFmpegMerger",
+    100,
+    "Post-processor that merges video and audio streams.\n\n\
+     # Priority\n\
+     This processor has priority 100 (runs first) because other\n\
+     processors need a merged file to work with.\n\n\
+     # When it runs\n\
+     - When there are multiple input files (video + audio)\n\
+     - When `requested_formats` contains multiple formats"
+);
 
 impl FFmpegMerger {
-    /// Create a new merger processor.
-    #[must_use]
-    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
-        Self { ffmpeg }
-    }
-
     /// Determine the output format based on config and input formats.
     fn determine_output_format(
         &self,
@@ -66,11 +59,11 @@ impl FFmpegMerger {
 #[async_trait]
 impl PostProcessor for FFmpegMerger {
     fn name(&self) -> &str {
-        "FFmpegMerger"
+        self.processor_name()
     }
 
     fn priority(&self) -> i32 {
-        100 // High priority - runs first
+        self.processor_priority()
     }
 
     fn should_run(&self, info: &InfoDict, _config: &PostProcessConfig) -> bool {
@@ -158,7 +151,10 @@ impl PostProcessor for FFmpegMerger {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::ffmpeg::FFmpegRunner;
 
     #[test]
     fn test_determine_output_format() {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -6,37 +6,29 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::info;
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
-use crate::ffmpeg::{ChapterEntry, FFmpegRunner};
+use crate::ffmpeg::ChapterEntry;
 
-/// Post-processor that embeds metadata into media files.
-///
-/// # Priority
-/// This processor has priority 30 (runs after merging and conversion).
-///
-/// # When it runs
-/// - When `embed_metadata` is true in config
-///
-/// # Supported metadata
-/// - title, artist, album, date, description
-/// - genre, track, comment
-/// - Chapters (if available in InfoDict)
-pub struct FFmpegMetadata {
-    ffmpeg: Arc<FFmpegRunner>,
-}
+ffmpeg_processor!(
+    FFmpegMetadata,
+    "FFmpegMetadata",
+    30,
+    "Post-processor that embeds metadata into media files.\n\n\
+     # Priority\n\
+     This processor has priority 30 (runs after merging and conversion).\n\n\
+     # When it runs\n\
+     - When `embed_metadata` is true in config\n\n\
+     # Supported metadata\n\
+     - title, artist, album, date, description\n\
+     - genre, track, comment\n\
+     - Chapters (if available in InfoDict)"
+);
 
 impl FFmpegMetadata {
-    /// Create a new metadata embedding processor.
-    #[must_use]
-    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
-        Self { ffmpeg }
-    }
-
     /// Build a metadata `HashMap` from `InfoDict`.
     fn build_metadata(info: &InfoDict) -> HashMap<String, String> {
         let mut meta = HashMap::new();
@@ -126,11 +118,11 @@ impl FFmpegMetadata {
 #[async_trait]
 impl PostProcessor for FFmpegMetadata {
     fn name(&self) -> &str {
-        "FFmpegMetadata"
+        self.processor_name()
     }
 
     fn priority(&self) -> i32 {
-        30 // After merging and conversion
+        self.processor_priority()
     }
 
     fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -5,47 +5,31 @@
 //! a centralized index.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use crate::error::PostProcessError;
-use crate::ffmpeg::{FFmpegRunner, RemuxOptions};
+use crate::ffmpeg::RemuxOptions;
 
 /// Supported remux target containers.
 const SUPPORTED_CONTAINERS: &[&str] = &["mp4", "mkv", "webm", "mov", "avi", "ts"];
 
-/// Post-processor that remuxes video files to a different container.
-///
-/// This performs stream copy (no re-encoding) for fast container conversion.
-/// Primary use case: remux MPEG-TS (.ts) to MP4 or MKV for better seeking.
-///
-/// # Priority
-/// This processor has priority 45 (runs after merging, before video conversion).
-///
-/// # When it runs
-/// When `remux_container` is specified in config.
-///
-/// # Supported Containers
-/// - **MP4**: Best compatibility, faststart for streaming
-/// - **MKV**: Supports all codecs, efficient cues index
-/// - **WebM**: Web-optimized (VP8/VP9/AV1 + Opus/Vorbis)
-/// - **MOV**: Apple QuickTime, good for editing
-/// - **AVI**: Legacy format, wide support
-/// - **TS**: MPEG-TS for broadcast/streaming
-pub struct FFmpegRemuxer {
-    ffmpeg: Arc<FFmpegRunner>,
-}
+ffmpeg_processor!(
+    FFmpegRemuxer,
+    "FFmpegRemuxer",
+    45,
+    "Post-processor that remuxes video files to a different container.\n\n\
+     This performs stream copy (no re-encoding) for fast container conversion.\n\
+     Primary use case: remux MPEG-TS (.ts) to MP4 or MKV for better seeking.\n\n\
+     # Priority\n\
+     This processor has priority 45 (runs after merging, before video conversion).\n\n\
+     # When it runs\n\
+     When `remux_container` is specified in config."
+);
 
 impl FFmpegRemuxer {
-    /// Create a new remuxer processor.
-    #[must_use]
-    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
-        Self { ffmpeg }
-    }
-
     /// Check if the format is a supported container for remuxing.
     fn is_supported_container(format: &str) -> bool {
         SUPPORTED_CONTAINERS.contains(&format.to_lowercase().as_str())
@@ -55,11 +39,11 @@ impl FFmpegRemuxer {
 #[async_trait]
 impl PostProcessor for FFmpegRemuxer {
     fn name(&self) -> &str {
-        "FFmpegRemuxer"
+        self.processor_name()
     }
 
     fn priority(&self) -> i32 {
-        45 // After merging (100), before video conversion (40)
+        self.processor_priority()
     }
 
     fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {
@@ -151,7 +135,10 @@ impl PostProcessor for FFmpegRemuxer {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::ffmpeg::FFmpegRunner;
 
     #[test]
     fn test_supported_containers() {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -4,14 +4,13 @@
 //! containers using `ffmpeg-the-third` library bindings (no CLI process spawning).
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use crate::error::PostProcessError;
-use crate::ffmpeg::{FFmpegRunner, VideoConvertOptions};
+use crate::ffmpeg::VideoConvertOptions;
 
 /// Supported video container formats.
 const SUPPORTED_CONTAINERS: &[&str] = &["mp4", "mkv", "webm", "mov", "avi", "flv", "ts"];
@@ -26,25 +25,19 @@ const VIDEO_CODECS: &[(&str, &str)] = &[
     ("av1", "libaom-av1"),
 ];
 
-/// Post-processor that converts or remuxes video files.
-///
-/// # Priority
-/// This processor has priority 40 (runs after merging, before metadata).
-///
-/// # When it runs
-/// - When `recode_video` is specified in config (full transcode)
-/// - When container change is needed
-pub struct FFmpegVideoConvertor {
-    ffmpeg: Arc<FFmpegRunner>,
-}
+ffmpeg_processor!(
+    FFmpegVideoConvertor,
+    "FFmpegVideoConvertor",
+    40,
+    "Post-processor that converts or remuxes video files.\n\n\
+     # Priority\n\
+     This processor has priority 40 (runs after merging, before metadata).\n\n\
+     # When it runs\n\
+     - When `recode_video` is specified in config (full transcode)\n\
+     - When container change is needed"
+);
 
 impl FFmpegVideoConvertor {
-    /// Create a new video converter processor.
-    #[must_use]
-    pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self {
-        Self { ffmpeg }
-    }
-
     /// Check if the format is a supported container.
     fn is_supported_container(format: &str) -> bool {
         SUPPORTED_CONTAINERS.contains(&format.to_lowercase().as_str())
@@ -114,11 +107,11 @@ impl FFmpegVideoConvertor {
 #[async_trait]
 impl PostProcessor for FFmpegVideoConvertor {
     fn name(&self) -> &str {
-        "FFmpegVideoConvertor"
+        self.processor_name()
     }
 
     fn priority(&self) -> i32 {
-        40 // After merging
+        self.processor_priority()
     }
 
     fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {

--- a/crates/rdlp-postprocess/src/processors/mod.rs
+++ b/crates/rdlp-postprocess/src/processors/mod.rs
@@ -9,6 +9,59 @@
 //! - [`FFmpegMetadata`]: Embed metadata into files
 //! - [`EmbedThumbnail`]: Embed thumbnail images
 
+/// Declare an FFmpeg-backed post-processor struct with standard boilerplate.
+///
+/// Generates:
+/// - `pub struct $name { ffmpeg: Arc<FFmpegRunner> }`
+/// - `impl $name { pub fn new(ffmpeg: Arc<FFmpegRunner>) -> Self }`
+/// - `fn name()` and `fn priority()` inside the `PostProcessor` trait impl
+///
+/// The caller must still provide the `should_run` and `process` methods
+/// (and an `#[async_trait]` attribute) — see usage in each processor file.
+///
+/// # Example
+/// ```ignore
+/// ffmpeg_processor!(FFmpegRemuxer, "FFmpegRemuxer", 45, "Remuxes containers.");
+/// ```
+macro_rules! ffmpeg_processor {
+    ($name:ident, $display_name:expr, $priority:expr, $doc:expr) => {
+        #[doc = $doc]
+        pub struct $name {
+            ffmpeg: std::sync::Arc<crate::ffmpeg::FFmpegRunner>,
+        }
+
+        impl $name {
+            /// Create a new processor.
+            #[must_use]
+            pub fn new(ffmpeg: std::sync::Arc<crate::ffmpeg::FFmpegRunner>) -> Self {
+                Self { ffmpeg }
+            }
+        }
+
+        // Provide `name()` and `priority()` via a helper trait impl.
+        // The file that uses this macro must still write the full
+        // `#[async_trait] impl PostProcessor for $name { … }` block
+        // containing `should_run` and `process`, and can call
+        // `self.processor_name()` / `self.processor_priority()` to
+        // delegate.  However, since PostProcessor::name/priority are
+        // simple, each file just inlines the constants via the two
+        // helper methods below — no extra trait needed.
+        impl $name {
+            /// Processor display name (used by `PostProcessor::name`).
+            #[inline]
+            fn processor_name(&self) -> &str {
+                $display_name
+            }
+
+            /// Processor priority (used by `PostProcessor::priority`).
+            #[inline]
+            fn processor_priority(&self) -> i32 {
+                $priority
+            }
+        }
+    };
+}
+
 mod embed_thumbnail;
 mod ffmpeg_extract_audio;
 mod ffmpeg_merger;


### PR DESCRIPTION
This pull request introduces significant improvements to code reuse, maintainability, and consistency across site extractors, especially for PornHub and RedTube. The main changes include centralizing format construction logic in `BaseExtractor`, refactoring site-specific utilities to use shared helpers, and enhancing utility methods for HTML extraction. Additionally, there are improvements to the FFmpeg runner for safer asynchronous processing.

**Code reuse and extractor consistency:**

* All site extractors are now required to use `BaseExtractor::build_format()` for constructing `Format` structs, centralizing logic for height/width calculation, codec defaults, and quality scoring. This eliminates duplicated code and ensures consistency. (`CODING_RULES.md` update)
* PornHub and RedTube format extraction functions have been refactored to delegate format construction to `BaseExtractor::build_format()`, removing local logic and reducing code duplication. [[1]](diffhunk://#diff-bc1cbc4691819cc315eb6b7d7b0f6181255d4cb58af54a006cb0a37561c84011L158-R168) [[2]](diffhunk://#diff-bc1cbc4691819cc315eb6b7d7b0f6181255d4cb58af54a006cb0a37561c84011L259-L269) [[3]](diffhunk://#diff-ff2bb28c4dcd9d552d3d9c2481ab07dccc385e75cf1d984fc82922dc99d76bfdL46-R64)

**Shared utility enhancements:**

* Introduced new convenience methods in `BaseExtractor`: `extract_meta_content_str`, `extract_element_text_str`, and `extract_first_href`, which simplify extraction of content/text/URLs from HTML using selector strings.
* Refactored PornHub extractor utilities to use these new `BaseExtractor` methods for extracting titles, descriptions, thumbnails, uploader info, and channel info, further reducing site-specific boilerplate. [[1]](diffhunk://#diff-515a8bc4d07e0153ba5f9991b5c9c4b9b6a700de5ab81200fcf54a56f15d1e12L117-R137) [[2]](diffhunk://#diff-515a8bc4d07e0153ba5f9991b5c9c4b9b6a700de5ab81200fcf54a56f15d1e12L142-R206) [[3]](diffhunk://#diff-515a8bc4d07e0153ba5f9991b5c9c4b9b6a700de5ab81200fcf54a56f15d1e12L248-R232)

**Format width calculation improvements:**

* `BaseExtractor::width_from_height()` now uses a lookup table for standard video resolutions (e.g., 480p → 854), ensuring more accurate width values. Tests have been updated to reflect this change. [[1]](diffhunk://#diff-58c36e96644a703545f14b052f94efa92a4dcbb51420f79bcdc0dc22d5d195a5L701-R765) [[2]](diffhunk://#diff-ef7aa8f868d4f72dde4fa15296c6920ce8cf0fa871079ec9a649c809a1d412ddR70-R79)

**FFmpeg runner improvements:**

* Added a helper method `spawn_blocking` to `FFmpegRunner` to standardize and safely run blocking FFmpeg operations on background threads, improving error handling and preventing accidental blocking of the Tokio runtime. [[1]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249R298-R315) [[2]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249L306-R324)

These changes collectively improve code quality, reduce duplication, and make it easier to add or maintain site extractors in the future.Consolidate duplicated code across extractors and post-processors:
- Delegate format building to BaseExtractor::build_format() (PornHub, RedTube)
- Reuse BaseExtractor metadata helpers in PornHub utils, add string-accepting convenience methods and extract_first_href()
- Replace width_from_height integer math with lookup table for standard resolutions
- Add FFmpegRunner::spawn_blocking helper, refactor all 7 async FFmpeg methods
- Add ffmpeg_processor! macro to eliminate struct/constructor boilerplate in all 6 post-processors
- Update CODING_RULES.md with code reuse guidelines