### PR TITLE
feat(cookies): implement cookie system with browser extraction and fi…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +21,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -591,6 +615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -615,6 +640,15 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1061,6 +1095,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1785,6 +1829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +1965,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2088,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2098,7 +2160,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2116,7 +2187,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2156,12 +2227,18 @@ name = "rdlp-cookies"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "aes-gcm",
+ "anyhow",
  "async-trait",
  "base64",
+ "log",
  "rdlp-core",
+ "reqwest",
  "rusqlite",
  "serde_json",
  "tokio",
+ "url",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3196,6 +3273,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ inventory = "0.3"
 
 # Cookie extraction
 aes = "0.8"
+aes-gcm = "0.10"
 base64 = "0.22"
 rusqlite = { version = "0.32", features = ["bundled"] }
 

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -103,6 +103,15 @@ struct Args {
     /// Path to FFmpeg executable (if not in PATH)
     #[arg(long)]
     ffmpeg_location: Option<PathBuf>,
+
+    // === Cookie options ===
+    /// Load cookies from browser (chrome, firefox)
+    #[arg(long)]
+    cookies_from_browser: Option<String>,
+
+    /// Path to Netscape-format cookies file
+    #[arg(long)]
+    cookies: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
@@ -217,6 +226,8 @@ async fn async_main() -> Result<()> {
         remux_container,
         keep_video: args.keep_video,
         ffmpeg_location: args.ffmpeg_location,
+        cookies_from_browser: args.cookies_from_browser,
+        cookies_file: args.cookies,
         ..Default::default()
     };
 
@@ -224,6 +235,9 @@ async fn async_main() -> Result<()> {
 
     // Create orchestrator with shared MultiProgress
     let orchestrator = Orchestrator::new(config, (*multi_progress).clone());
+
+    // Load cookies from file or browser if configured
+    orchestrator.load_cookies().await?;
 
     // List extractors if requested
     if args.list_extractors {

--- a/crates/rdlp-cli/src/orchestrator/errors.rs
+++ b/crates/rdlp-cli/src/orchestrator/errors.rs
@@ -80,6 +80,10 @@ pub enum OrchestratorError {
     /// I/O error
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Configuration error (invalid options, missing files, etc.)
+    #[error("{0}")]
+    Configuration(String),
 }
 
 /// Result type for orchestrator operations

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -18,7 +18,7 @@ pub use errors::{OrchestratorError, Result};
 pub use state::{DownloadPhase, DownloadState};
 
 use indicatif::MultiProgress;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use tracing::instrument;
 use rdlp_cookies::SimpleCookieJar;
 use rdlp_core::{Config, ExtractionContext};
@@ -45,9 +45,10 @@ impl Orchestrator {
     /// Create a new orchestrator with default registries
     #[must_use]
     pub fn new(config: Config, multi_progress: MultiProgress) -> Self {
-        let http_client = HttpClientFactory::from_rdlp_config(&config).build_arc();
-        let js_engine = Arc::new(SimpleJsEngine::new());
         let cookie_jar = Arc::new(SimpleCookieJar::new());
+        let http_client = HttpClientFactory::from_rdlp_config(&config)
+            .build_arc_with_cookies(cookie_jar.jar());
+        let js_engine = Arc::new(SimpleJsEngine::new());
 
         // Wrap config in Arc once and share it
         let config = Arc::new(config);
@@ -108,9 +109,10 @@ impl Orchestrator {
         extractor_registry: Arc<dyn ExtractorRegistryTrait>,
         downloader_registry: Arc<dyn DownloaderRegistryTrait>,
     ) -> Self {
-        let http_client = HttpClientFactory::from_rdlp_config(&config).build_arc();
-        let js_engine = Arc::new(SimpleJsEngine::new());
         let cookie_jar = Arc::new(SimpleCookieJar::new());
+        let http_client = HttpClientFactory::from_rdlp_config(&config)
+            .build_arc_with_cookies(cookie_jar.jar());
+        let js_engine = Arc::new(SimpleJsEngine::new());
 
         let config = Arc::new(config);
 
@@ -132,6 +134,34 @@ impl Orchestrator {
             config,
             multi_progress: MultiProgress::new(),
         }
+    }
+
+    /// Load cookies from file or browser if configured.
+    ///
+    /// Should be called after construction and before any downloads.
+    pub async fn load_cookies(&self) -> Result<()> {
+        let cookie_jar = &self.extraction_context.cookie_jar;
+
+        if let Some(ref path) = self.config.cookies_file {
+            let count = cookie_jar.load_from_file(path).await.map_err(|e| {
+                OrchestratorError::Configuration(format!(
+                    "Failed to load cookies from {}: {e}",
+                    path.display()
+                ))
+            })?;
+            info!(count, file = path.display().to_string().as_str(); "Loaded cookies from file");
+        }
+
+        if let Some(ref browser) = self.config.cookies_from_browser {
+            let count = cookie_jar.load_from_browser(browser).await.map_err(|e| {
+                OrchestratorError::Configuration(format!(
+                    "Failed to load cookies from {browser}: {e}"
+                ))
+            })?;
+            info!(count, browser = browser.as_str(); "Loaded cookies from browser");
+        }
+
+        Ok(())
     }
 
     /// Download a video from URL using state machine pattern

--- a/crates/rdlp-cookies/Cargo.toml
+++ b/crates/rdlp-cookies/Cargo.toml
@@ -11,8 +11,16 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 rusqlite = { workspace = true }
 aes = { workspace = true }
+aes-gcm = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
+reqwest = { workspace = true }
+url = { workspace = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Security_Cryptography", "Win32_Foundation"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/rdlp-cookies/src/chrome.rs
+++ b/crates/rdlp-cookies/src/chrome.rs
@@ -1,0 +1,362 @@
+//! Chrome/Chromium cookie extraction.
+//!
+//! Extracts cookies from Chrome's SQLite database and decrypts them.
+//! On Windows, uses DPAPI + AES-256-GCM (Chrome v80+).
+
+use std::path::{Path, PathBuf};
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use log::{debug, warn};
+use reqwest::cookie::CookieStore;
+use reqwest::header::HeaderValue;
+use url::Url;
+
+/// AES-GCM nonce length (96 bits / 12 bytes).
+const NONCE_LEN: usize = 12;
+
+/// Chrome v10+ encrypted value prefix.
+const V10_PREFIX: &[u8] = b"v10";
+
+/// Extract cookies from Chrome and insert them into the jar.
+///
+/// Returns the number of cookies loaded.
+pub fn extract_cookies(jar: &impl CookieStore) -> Result<usize, std::io::Error> {
+    let cookie_db = find_cookie_db()?;
+    let local_state = find_local_state()?;
+
+    debug!("Chrome cookie DB: {}", cookie_db.display());
+    debug!("Chrome Local State: {}", local_state.display());
+
+    // Get the AES key from Local State (DPAPI-encrypted)
+    let key = load_encryption_key(&local_state)?;
+
+    // Copy the DB to a temp file to avoid locking issues
+    let temp_dir = std::env::temp_dir();
+    let temp_db = temp_dir.join("rdlp_chrome_cookies.db");
+    std::fs::copy(&cookie_db, &temp_db)?;
+
+    let result = read_cookies_from_db(&temp_db, &key, jar);
+
+    // Clean up temp file
+    let _ = std::fs::remove_file(&temp_db);
+
+    result
+}
+
+/// Find Chrome's cookie database path.
+fn find_cookie_db() -> Result<PathBuf, std::io::Error> {
+    let path = chrome_user_data_dir()?.join("Default").join("Cookies");
+    if path.exists() {
+        Ok(path)
+    } else {
+        // Try Network/Cookies (Chrome 96+)
+        let network_path = chrome_user_data_dir()?.join("Default").join("Network").join("Cookies");
+        if network_path.exists() {
+            Ok(network_path)
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Chrome cookie database not found at {} or {}", path.display(), network_path.display()),
+            ))
+        }
+    }
+}
+
+/// Find Chrome's Local State file (contains the encryption key).
+fn find_local_state() -> Result<PathBuf, std::io::Error> {
+    let path = chrome_user_data_dir()?.join("Local State");
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Chrome Local State file not found",
+        ))
+    }
+}
+
+/// Get Chrome's User Data directory.
+fn chrome_user_data_dir() -> Result<PathBuf, std::io::Error> {
+    #[cfg(target_os = "windows")]
+    {
+        let local_app_data = std::env::var("LOCALAPPDATA").map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "LOCALAPPDATA not set")
+        })?;
+        Ok(PathBuf::from(local_app_data)
+            .join("Google")
+            .join("Chrome")
+            .join("User Data"))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let home = std::env::var("HOME").map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "HOME not set")
+        })?;
+        Ok(PathBuf::from(home)
+            .join(".config")
+            .join("google-chrome"))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var("HOME").map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "HOME not set")
+        })?;
+        Ok(PathBuf::from(home)
+            .join("Library")
+            .join("Application Support")
+            .join("Google")
+            .join("Chrome"))
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Chrome cookie extraction not supported on this platform",
+        ))
+    }
+}
+
+/// Load and decrypt the AES encryption key from Local State.
+fn load_encryption_key(local_state_path: &Path) -> Result<Vec<u8>, std::io::Error> {
+    let content = std::fs::read_to_string(local_state_path)?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let encrypted_key_b64 = json
+        .get("os_crypt")
+        .and_then(|o| o.get("encrypted_key"))
+        .and_then(|k| k.as_str())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "No os_crypt.encrypted_key in Local State",
+            )
+        })?;
+
+    // Base64 decode
+    let encrypted_key = BASE64.decode(encrypted_key_b64).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, format!("Base64 decode error: {e}"))
+    })?;
+
+    // Strip "DPAPI" prefix (5 bytes)
+    if encrypted_key.len() < 5 || &encrypted_key[..5] != b"DPAPI" {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Encrypted key missing DPAPI prefix",
+        ));
+    }
+    let dpapi_encrypted = &encrypted_key[5..];
+
+    // Decrypt with platform-specific method
+    decrypt_dpapi_key(dpapi_encrypted)
+}
+
+/// Decrypt a DPAPI-encrypted key.
+#[cfg(target_os = "windows")]
+fn decrypt_dpapi_key(encrypted: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    use windows_sys::Win32::Security::Cryptography::{
+        CryptUnprotectData, CRYPT_INTEGER_BLOB,
+    };
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: encrypted.len() as u32,
+        pbData: encrypted.as_ptr() as *mut u8,
+    };
+
+    let mut output = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+
+    let result = unsafe {
+        CryptUnprotectData(
+            &input,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            &mut output,
+        )
+    };
+
+    if result == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "DPAPI CryptUnprotectData failed — run as the same user who owns the Chrome profile",
+        ));
+    }
+
+    let decrypted = unsafe {
+        let slice = std::slice::from_raw_parts(output.pbData, output.cbData as usize);
+        let vec = slice.to_vec();
+        // Free the DPAPI-allocated memory
+        windows_sys::Win32::Foundation::LocalFree(output.pbData as _);
+        vec
+    };
+
+    Ok(decrypted)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn decrypt_dpapi_key(_encrypted: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Chrome DPAPI decryption is only supported on Windows. Use --cookies with a Netscape cookie file instead.",
+    ))
+}
+
+/// Decrypt a Chrome AES-256-GCM encrypted cookie value.
+fn decrypt_cookie_value(encrypted_value: &[u8], key: &[u8]) -> Option<String> {
+    if encrypted_value.is_empty() {
+        return None;
+    }
+
+    // Check for v10/v11 prefix (Chrome 80+)
+    if encrypted_value.len() < V10_PREFIX.len() + NONCE_LEN + 1 {
+        // Might be plaintext or old format
+        return String::from_utf8(encrypted_value.to_vec()).ok();
+    }
+
+    let prefix = &encrypted_value[..V10_PREFIX.len()];
+    if prefix != V10_PREFIX && prefix != b"v11" {
+        // Not AES-encrypted, try as plaintext
+        return String::from_utf8(encrypted_value.to_vec()).ok();
+    }
+
+    let encrypted_data = &encrypted_value[V10_PREFIX.len()..];
+    if encrypted_data.len() < NONCE_LEN + 1 {
+        return None;
+    }
+
+    let nonce_bytes = &encrypted_data[..NONCE_LEN];
+    let ciphertext = &encrypted_data[NONCE_LEN..];
+
+    let cipher = Aes256Gcm::new_from_slice(key).ok()?;
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let plaintext = cipher.decrypt(nonce, ciphertext).ok()?;
+    String::from_utf8(plaintext).ok()
+}
+
+/// Read cookies from the SQLite database and insert them into the jar.
+fn read_cookies_from_db(
+    db_path: &Path,
+    key: &[u8],
+    jar: &impl CookieStore,
+) -> Result<usize, std::io::Error> {
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT host_key, name, encrypted_value, value, path, is_secure, is_httponly \
+             FROM cookies",
+        )
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    let mut count = 0;
+
+    let rows = stmt
+        .query_map([], |row| {
+            let host_key: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let encrypted_value: Vec<u8> = row.get(2)?;
+            let plaintext_value: String = row.get(3)?;
+            let path: String = row.get(4)?;
+            let is_secure: bool = row.get(5)?;
+            let is_httponly: bool = row.get(6)?;
+            Ok((host_key, name, encrypted_value, plaintext_value, path, is_secure, is_httponly))
+        })
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    for row in rows {
+        let (host_key, name, encrypted_value, plaintext_value, path, is_secure, is_httponly) =
+            match row {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("Failed to read cookie row: {e}");
+                    continue;
+                }
+            };
+
+        // Decrypt the value
+        let value = if !plaintext_value.is_empty() {
+            plaintext_value
+        } else {
+            match decrypt_cookie_value(&encrypted_value, key) {
+                Some(v) => v,
+                None => {
+                    debug!("Failed to decrypt cookie: {name} for {host_key}");
+                    continue;
+                }
+            }
+        };
+
+        if value.is_empty() {
+            continue;
+        }
+
+        // Build URL and Set-Cookie header
+        let scheme = if is_secure { "https" } else { "http" };
+        let host = host_key.trim_start_matches('.');
+        let url_str = format!("{scheme}://{host}{path}");
+
+        let Ok(url) = Url::parse(&url_str) else {
+            continue;
+        };
+
+        let mut set_cookie = format!("{name}={value}; Domain={host_key}; Path={path}");
+        if is_secure {
+            set_cookie.push_str("; Secure");
+        }
+        if is_httponly {
+            set_cookie.push_str("; HttpOnly");
+        }
+
+        if let Ok(val) = HeaderValue::from_str(&set_cookie) {
+            jar.set_cookies(&mut std::iter::once(&val), &url);
+            count += 1;
+        }
+    }
+
+    debug!("Loaded {count} cookies from Chrome");
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decrypt_plaintext_value() {
+        let value = b"plain_value";
+        let result = decrypt_cookie_value(value, &[0u8; 32]);
+        assert_eq!(result, Some("plain_value".to_string()));
+    }
+
+    #[test]
+    fn test_decrypt_empty_value() {
+        let result = decrypt_cookie_value(&[], &[0u8; 32]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_too_short_v10_falls_back_to_plaintext() {
+        // v10 prefix but too short for nonce + ciphertext — falls back to plaintext attempt
+        let mut data = Vec::from(V10_PREFIX);
+        data.extend_from_slice(&[b'x'; 5]);
+        let result = decrypt_cookie_value(&data, &[0u8; 32]);
+        // Falls through to plaintext path since too short for AES-GCM
+        assert_eq!(result, Some("v10xxxxx".to_string()));
+    }
+}

--- a/crates/rdlp-cookies/src/firefox.rs
+++ b/crates/rdlp-cookies/src/firefox.rs
@@ -1,0 +1,310 @@
+//! Firefox cookie extraction.
+//!
+//! Extracts cookies from Firefox's SQLite database.
+//! Firefox stores cookies in plaintext (no encryption needed).
+
+use std::path::{Path, PathBuf};
+
+use log::{debug, warn};
+use reqwest::cookie::CookieStore;
+use reqwest::header::HeaderValue;
+use url::Url;
+
+/// Extract cookies from Firefox and insert them into the jar.
+///
+/// Returns the number of cookies loaded.
+pub fn extract_cookies(jar: &impl CookieStore) -> Result<usize, std::io::Error> {
+    let cookie_db = find_cookie_db()?;
+    debug!("Firefox cookie DB: {}", cookie_db.display());
+
+    // Copy the DB to a temp file to avoid locking issues
+    let temp_dir = std::env::temp_dir();
+    let temp_db = temp_dir.join("rdlp_firefox_cookies.db");
+    std::fs::copy(&cookie_db, &temp_db)?;
+
+    let result = read_cookies_from_db(&temp_db, jar);
+
+    // Clean up temp file
+    let _ = std::fs::remove_file(&temp_db);
+
+    result
+}
+
+/// Find Firefox's cookie database.
+fn find_cookie_db() -> Result<PathBuf, std::io::Error> {
+    let profile_dir = find_default_profile()?;
+    let db_path = profile_dir.join("cookies.sqlite");
+
+    if db_path.exists() {
+        Ok(db_path)
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!(
+                "Firefox cookies.sqlite not found at {}",
+                db_path.display()
+            ),
+        ))
+    }
+}
+
+/// Find the default Firefox profile directory.
+fn find_default_profile() -> Result<PathBuf, std::io::Error> {
+    let profiles_dir = firefox_profiles_dir()?;
+
+    if !profiles_dir.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!(
+                "Firefox profiles directory not found: {}",
+                profiles_dir.display()
+            ),
+        ));
+    }
+
+    // Try profiles.ini first
+    let profiles_ini = profiles_dir.join("profiles.ini");
+    if profiles_ini.exists() {
+        if let Some(profile) = parse_profiles_ini(&profiles_ini, &profiles_dir) {
+            return Ok(profile);
+        }
+    }
+
+    // Fallback: scan directories for preferred profile suffixes, then any profile
+    let suffixes = [".default-release", ".default"];
+    if let Ok(entries) = std::fs::read_dir(&profiles_dir) {
+        let dirs: Vec<_> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_dir() && p.join("cookies.sqlite").exists())
+            .collect();
+
+        // Try preferred suffixes first
+        for suffix in &suffixes {
+            if let Some(dir) = dirs.iter().find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with(suffix))
+            }) {
+                return Ok(dir.clone());
+            }
+        }
+
+        // Any profile with cookies
+        if let Some(dir) = dirs.into_iter().next() {
+            return Ok(dir);
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "No Firefox profile with cookies.sqlite found",
+    ))
+}
+
+/// Parse profiles.ini to find the default profile path.
+fn parse_profiles_ini(ini_path: &Path, profiles_dir: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(ini_path).ok()?;
+
+    let mut current_path: Option<String> = None;
+    let mut current_is_relative = true;
+    let mut current_is_default = false;
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if line.starts_with('[') {
+            // Commit previous section if it was the default
+            if current_is_default {
+                if let Some(ref path) = current_path {
+                    let profile_path = if current_is_relative {
+                        profiles_dir.join(path)
+                    } else {
+                        PathBuf::from(path)
+                    };
+                    if profile_path.join("cookies.sqlite").exists() {
+                        return Some(profile_path);
+                    }
+                }
+            }
+
+            // Reset for new section
+            current_path = None;
+            current_is_relative = true;
+            current_is_default = false;
+            continue;
+        }
+
+        if let Some((key, value)) = line.split_once('=') {
+            match key.trim() {
+                "Path" => current_path = Some(value.trim().to_string()),
+                "IsRelative" => current_is_relative = value.trim() == "1",
+                "Default" => current_is_default = value.trim() == "1",
+                _ => {}
+            }
+        }
+    }
+
+    // Check last section
+    if current_is_default {
+        if let Some(ref path) = current_path {
+            let profile_path = if current_is_relative {
+                profiles_dir.join(path)
+            } else {
+                PathBuf::from(path)
+            };
+            if profile_path.join("cookies.sqlite").exists() {
+                return Some(profile_path);
+            }
+        }
+    }
+
+    None
+}
+
+/// Get Firefox profiles directory.
+fn firefox_profiles_dir() -> Result<PathBuf, std::io::Error> {
+    #[cfg(target_os = "windows")]
+    {
+        let appdata = std::env::var("APPDATA").map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "APPDATA not set")
+        })?;
+        Ok(PathBuf::from(appdata)
+            .join("Mozilla")
+            .join("Firefox")
+            .join("Profiles"))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let home = std::env::var("HOME").map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "HOME not set")
+        })?;
+        Ok(PathBuf::from(home).join(".mozilla").join("firefox"))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var("HOME").map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "HOME not set")
+        })?;
+        Ok(PathBuf::from(home)
+            .join("Library")
+            .join("Application Support")
+            .join("Firefox")
+            .join("Profiles"))
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Firefox cookie extraction not supported on this platform",
+        ))
+    }
+}
+
+/// Read cookies from the SQLite database and insert them into the jar.
+fn read_cookies_from_db(
+    db_path: &Path,
+    jar: &impl CookieStore,
+) -> Result<usize, std::io::Error> {
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT host, name, value, path, isSecure, isHttpOnly \
+             FROM moz_cookies",
+        )
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    let mut count = 0;
+
+    let rows = stmt
+        .query_map([], |row| {
+            let host: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let value: String = row.get(2)?;
+            let path: String = row.get(3)?;
+            let is_secure: bool = row.get(4)?;
+            let is_httponly: bool = row.get(5)?;
+            Ok((host, name, value, path, is_secure, is_httponly))
+        })
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    for row in rows {
+        let (host, name, value, path, is_secure, is_httponly) = match row {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Failed to read Firefox cookie row: {e}");
+                continue;
+            }
+        };
+
+        if name.is_empty() || value.is_empty() {
+            continue;
+        }
+
+        let scheme = if is_secure { "https" } else { "http" };
+        let clean_host = host.trim_start_matches('.');
+        let url_str = format!("{scheme}://{clean_host}{path}");
+
+        let Ok(url) = Url::parse(&url_str) else {
+            continue;
+        };
+
+        let mut set_cookie = format!("{name}={value}; Domain={host}; Path={path}");
+        if is_secure {
+            set_cookie.push_str("; Secure");
+        }
+        if is_httponly {
+            set_cookie.push_str("; HttpOnly");
+        }
+
+        if let Ok(val) = HeaderValue::from_str(&set_cookie) {
+            jar.set_cookies(&mut std::iter::once(&val), &url);
+            count += 1;
+        }
+    }
+
+    debug!("Loaded {count} cookies from Firefox");
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_profiles_ini() {
+        let dir = std::env::temp_dir().join("rdlp_test_firefox_profiles");
+        let _ = std::fs::create_dir_all(&dir);
+
+        // Create a fake profile directory with cookies.sqlite
+        let profile_dir = dir.join("abc123.default-release");
+        let _ = std::fs::create_dir_all(&profile_dir);
+        std::fs::write(profile_dir.join("cookies.sqlite"), b"fake").unwrap();
+
+        // Write a profiles.ini
+        let ini_path = dir.join("profiles.ini");
+        let ini_content = "\
+[Profile0]
+Name=default-release
+IsRelative=1
+Path=abc123.default-release
+Default=1
+";
+        std::fs::write(&ini_path, ini_content).unwrap();
+
+        let result = parse_profiles_ini(&ini_path, &dir);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), profile_dir);
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/rdlp-cookies/src/lib.rs
+++ b/crates/rdlp-cookies/src/lib.rs
@@ -2,26 +2,47 @@
 //!
 //! Browser cookie extraction for rdlp.
 //!
-//! This crate provides cookie extraction from various browsers:
+//! This crate provides cookie storage and extraction from various browsers:
 //! - Chrome/Chromium
 //! - Firefox
 //! - Safari (macOS)
 
 #![warn(missing_docs)]
 
-use async_trait::async_trait;
-use rdlp_core::{CookieJar, Result};
+mod chrome;
+mod firefox;
+mod netscape;
 
-/// Simple cookie jar implementation (stub for now)
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use log::{debug, warn};
+use rdlp_core::{CookieJar, Result};
+use reqwest::cookie::CookieStore;
+use url::Url;
+
+/// Cookie jar backed by `reqwest::cookie::Jar`.
+///
+/// Cookies added via `add_cookie()` are automatically sent by any
+/// `reqwest::Client` that was built with this jar's `cookie_provider()`.
 pub struct SimpleCookieJar {
-    // Will be implemented in Phase 8
+    jar: Arc<reqwest::cookie::Jar>,
 }
 
 impl SimpleCookieJar {
-    /// Create a new empty cookie jar
+    /// Create a new empty cookie jar.
     #[must_use]
     pub fn new() -> Self {
-        Self {}
+        Self {
+            jar: Arc::new(reqwest::cookie::Jar::default()),
+        }
+    }
+
+    /// Get the underlying `reqwest::cookie::Jar` for use with `cookie_provider()`.
+    #[must_use]
+    pub fn jar(&self) -> Arc<reqwest::cookie::Jar> {
+        Arc::clone(&self.jar)
     }
 }
 
@@ -33,18 +54,142 @@ impl Default for SimpleCookieJar {
 
 #[async_trait]
 impl CookieJar for SimpleCookieJar {
-    async fn get_cookies(&self, _url: &str) -> Result<Vec<String>> {
-        // Stub implementation - returns empty cookies
-        Ok(Vec::new())
+    async fn get_cookies(&self, url: &str) -> Result<Vec<String>> {
+        let parsed = match Url::parse(url) {
+            Ok(u) => u,
+            Err(_) => return Ok(Vec::new()),
+        };
+
+        // reqwest::cookie::Jar returns cookies as a single header value
+        match self.jar.cookies(&parsed) {
+            Some(header_value) => {
+                let cookie_str = header_value.to_str().unwrap_or("");
+                Ok(cookie_str
+                    .split("; ")
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .collect())
+            }
+            None => Ok(Vec::new()),
+        }
     }
 
-    async fn add_cookie(&self, _url: &str, _cookie: &str) -> Result<()> {
-        // Stub implementation
+    async fn add_cookie(&self, url: &str, cookie: &str) -> Result<()> {
+        let parsed = match Url::parse(url) {
+            Ok(u) => u,
+            Err(e) => {
+                warn!("Invalid URL for cookie: {e}");
+                return Ok(());
+            }
+        };
+
+        debug!(cookie, url; "Adding cookie");
+        self.jar.add_cookie_str(cookie, &parsed);
         Ok(())
     }
 
-    async fn load_from_browser(&self, _browser: &str) -> Result<usize> {
-        // Stub implementation - returns 0 cookies loaded
-        Ok(0)
+    async fn load_from_browser(&self, browser: &str) -> Result<usize> {
+        let jar = Arc::clone(&self.jar);
+        let browser_name = browser.to_lowercase();
+
+        let count = tokio::task::spawn_blocking(move || match browser_name.as_str() {
+            "chrome" | "chromium" | "google-chrome" => chrome::extract_cookies(&*jar),
+            "firefox" | "mozilla" => firefox::extract_cookies(&*jar),
+            _ => {
+                warn!("Unsupported browser for cookie extraction: {browser_name}");
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    format!("Unsupported browser: {browser_name}. Supported: chrome, firefox"),
+                ))
+            }
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+        ?;
+
+        debug!("Loaded {count} cookies from browser: {browser}");
+        Ok(count)
+    }
+
+    async fn load_from_file(&self, path: &Path) -> Result<usize> {
+        let jar = Arc::clone(&self.jar);
+        let path = path.to_path_buf();
+        let count = tokio::task::spawn_blocking(move || {
+            netscape::load_cookie_file(&path, &*jar)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+        ?;
+
+        debug!(count; "Loaded cookies from file");
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_add_and_get_cookie() {
+        let jar = SimpleCookieJar::new();
+        jar.add_cookie("https://example.com", "session=abc123")
+            .await
+            .unwrap();
+
+        let cookies = jar.get_cookies("https://example.com").await.unwrap();
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0], "session=abc123");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_cookies() {
+        let jar = SimpleCookieJar::new();
+        jar.add_cookie("https://example.com", "a=1").await.unwrap();
+        jar.add_cookie("https://example.com", "b=2").await.unwrap();
+
+        let cookies = jar.get_cookies("https://example.com").await.unwrap();
+        assert_eq!(cookies.len(), 2);
+        assert!(cookies.contains(&"a=1".to_string()));
+        assert!(cookies.contains(&"b=2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_cookies_scoped_by_domain() {
+        let jar = SimpleCookieJar::new();
+        jar.add_cookie("https://example.com", "a=1").await.unwrap();
+        jar.add_cookie("https://other.com", "b=2").await.unwrap();
+
+        let cookies = jar.get_cookies("https://example.com").await.unwrap();
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0], "a=1");
+    }
+
+    #[tokio::test]
+    async fn test_empty_jar() {
+        let jar = SimpleCookieJar::new();
+        let cookies = jar.get_cookies("https://example.com").await.unwrap();
+        assert!(cookies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_url() {
+        let jar = SimpleCookieJar::new();
+        // Should not panic, just return empty
+        let cookies = jar.get_cookies("not-a-url").await.unwrap();
+        assert!(cookies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_jar_accessor() {
+        let jar = SimpleCookieJar::new();
+        let inner = jar.jar();
+        // Verify it's the same jar by adding via inner and reading via trait
+        let url = Url::parse("https://example.com").unwrap();
+        inner.add_cookie_str("test=value", &url);
+
+        let cookies = jar.get_cookies("https://example.com").await.unwrap();
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0], "test=value");
     }
 }

--- a/crates/rdlp-cookies/src/netscape.rs
+++ b/crates/rdlp-cookies/src/netscape.rs
@@ -1,0 +1,213 @@
+//! Netscape/Mozilla cookie file parser.
+//!
+//! Parses the standard Netscape cookie format used by browsers and tools
+//! like `curl`, `wget`, and browser cookie export extensions.
+//!
+//! Format: `domain\tinclude_subdomains\tpath\tsecure\texpiry\tname\tvalue`
+
+use std::path::Path;
+
+use log::{debug, warn};
+use reqwest::cookie::CookieStore;
+use url::Url;
+
+/// A parsed cookie from a Netscape cookie file.
+#[derive(Debug)]
+struct NetscapeCookie {
+    domain: String,
+    _include_subdomains: bool,
+    path: String,
+    secure: bool,
+    _expiry: u64,
+    name: String,
+    value: String,
+}
+
+/// Parse a Netscape-format cookie file and insert cookies into the jar.
+///
+/// Returns the number of cookies successfully loaded.
+pub fn load_cookie_file(
+    path: &Path,
+    jar: &impl CookieStore,
+) -> Result<usize, std::io::Error> {
+    let content = std::fs::read_to_string(path)?;
+    Ok(load_cookie_string(&content, jar))
+}
+
+/// Parse cookie string content and insert into jar.
+///
+/// Returns the number of cookies loaded.
+pub fn load_cookie_string(content: &str, jar: &impl CookieStore) -> usize {
+    let mut count = 0;
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        // Skip empty lines
+        if line.is_empty() {
+            continue;
+        }
+
+        // Handle #HttpOnly_ prefix (valid cookie with httponly flag)
+        let line = if let Some(stripped) = line.strip_prefix("#HttpOnly_") {
+            stripped
+        } else if line.starts_with('#') {
+            // Regular comment
+            continue;
+        } else {
+            line
+        };
+
+        match parse_cookie_line(line) {
+            Some(cookie) => {
+                if insert_cookie(&cookie, jar) {
+                    count += 1;
+                }
+            }
+            None => {
+                debug!("Skipping malformed cookie line: {line}");
+            }
+        }
+    }
+
+    count
+}
+
+/// Parse a single Netscape cookie line.
+fn parse_cookie_line(line: &str) -> Option<NetscapeCookie> {
+    let fields: Vec<&str> = line.split('\t').collect();
+    if fields.len() < 7 {
+        return None;
+    }
+
+    let domain = fields[0].to_string();
+    let include_subdomains = fields[1].eq_ignore_ascii_case("TRUE");
+    let path = fields[2].to_string();
+    let secure = fields[3].eq_ignore_ascii_case("TRUE");
+    let expiry = fields[4].parse().unwrap_or(0);
+    let name = fields[5].to_string();
+    let value = fields[6].to_string();
+
+    // Skip empty names
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(NetscapeCookie {
+        domain,
+        _include_subdomains: include_subdomains,
+        path,
+        secure,
+        _expiry: expiry,
+        name,
+        value,
+    })
+}
+
+/// Insert a parsed cookie into the reqwest jar.
+fn insert_cookie(cookie: &NetscapeCookie, jar: &impl CookieStore) -> bool {
+    let scheme = if cookie.secure { "https" } else { "http" };
+
+    // Build a URL from the cookie domain for the jar
+    let host = cookie.domain.trim_start_matches('.');
+    let url_str = format!("{scheme}://{host}{}", cookie.path);
+
+    let Ok(url) = Url::parse(&url_str) else {
+        warn!("Invalid URL from cookie domain: {url_str}");
+        return false;
+    };
+
+    // Build Set-Cookie header string
+    let mut set_cookie = format!("{}={}", cookie.name, cookie.value);
+    set_cookie.push_str(&format!("; Domain={}", cookie.domain));
+    set_cookie.push_str(&format!("; Path={}", cookie.path));
+    if cookie.secure {
+        set_cookie.push_str("; Secure");
+    }
+
+    // Use set_cookies to insert (same interface as HTTP response headers)
+    let header_value = reqwest::header::HeaderValue::from_str(&set_cookie);
+    match header_value {
+        Ok(val) => {
+            jar.set_cookies(&mut std::iter::once(&val), &url);
+            true
+        }
+        Err(e) => {
+            warn!("Invalid cookie header value for {}: {e}", cookie.name);
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn make_jar() -> Arc<reqwest::cookie::Jar> {
+        Arc::new(reqwest::cookie::Jar::default())
+    }
+
+    #[test]
+    fn test_parse_basic_cookie() {
+        let jar = make_jar();
+        let content = ".example.com\tTRUE\t/\tTRUE\t0\tsession\tabc123";
+        let count = load_cookie_string(content, &*jar);
+        assert_eq!(count, 1);
+
+        let url = Url::parse("https://example.com/").unwrap();
+        let cookies = jar.cookies(&url);
+        assert!(cookies.is_some());
+        let cookie_str = cookies.unwrap();
+        assert!(cookie_str.to_str().unwrap().contains("session=abc123"));
+    }
+
+    #[test]
+    fn test_skip_comments_and_empty_lines() {
+        let jar = make_jar();
+        let content = "# Netscape HTTP Cookie File\n\n# comment\n.example.com\tTRUE\t/\tFALSE\t0\tname\tvalue\n";
+        let count = load_cookie_string(content, &*jar);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_multiple_cookies() {
+        let jar = make_jar();
+        let content = "\
+.example.com\tTRUE\t/\tTRUE\t0\ta\t1
+.example.com\tTRUE\t/\tTRUE\t0\tb\t2
+.other.com\tTRUE\t/\tFALSE\t0\tc\t3";
+        let count = load_cookie_string(content, &*jar);
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_malformed_line_skipped() {
+        let jar = make_jar();
+        let content = "not\tenough\tfields";
+        let count = load_cookie_string(content, &*jar);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_empty_name_skipped() {
+        let jar = make_jar();
+        let content = ".example.com\tTRUE\t/\tFALSE\t0\t\tvalue";
+        let count = load_cookie_string(content, &*jar);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_httponly_prefix() {
+        let jar = make_jar();
+        // Some exporters use #HttpOnly_ prefix on the domain
+        let content = "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t0\thttponly_cookie\tsecret";
+        let count = load_cookie_string(content, &*jar);
+        assert_eq!(count, 1);
+
+        let url = Url::parse("https://example.com/").unwrap();
+        let cookies = jar.cookies(&url);
+        assert!(cookies.is_some());
+        assert!(cookies.unwrap().to_str().unwrap().contains("httponly_cookie=secret"));
+    }
+}

--- a/crates/rdlp-core/src/traits/extractor.rs
+++ b/crates/rdlp-core/src/traits/extractor.rs
@@ -270,4 +270,13 @@ pub trait CookieJar: Send + Sync {
     /// # Returns
     /// Number of cookies loaded
     async fn load_from_browser(&self, browser: &str) -> Result<usize>;
+
+    /// Load cookies from a Netscape-format cookies file
+    ///
+    /// # Arguments
+    /// * `path` - Path to the cookies file
+    ///
+    /// # Returns
+    /// Number of cookies loaded
+    async fn load_from_file(&self, path: &std::path::Path) -> Result<usize>;
 }

--- a/crates/rdlp-http/src/client.rs
+++ b/crates/rdlp-http/src/client.rs
@@ -53,6 +53,25 @@ impl HttpClientFactory {
     /// Build a reqwest::Client with the configured settings
     #[must_use]
     pub fn build(&self) -> reqwest::Client {
+        self.build_inner(None)
+    }
+
+    /// Build a reqwest::Client with a cookie provider.
+    ///
+    /// Cookies in the jar are automatically sent with every request and
+    /// `Set-Cookie` response headers are stored back into the jar.
+    #[must_use]
+    pub fn build_with_cookies(
+        &self,
+        jar: Arc<reqwest::cookie::Jar>,
+    ) -> reqwest::Client {
+        self.build_inner(Some(jar))
+    }
+
+    fn build_inner(
+        &self,
+        cookie_jar: Option<Arc<reqwest::cookie::Jar>>,
+    ) -> reqwest::Client {
         let mut builder = reqwest::Client::builder()
             .user_agent(&self.config.user_agent)
             .pool_max_idle_per_host(self.config.pool_max_idle_per_host)
@@ -61,6 +80,10 @@ impl HttpClientFactory {
             .tcp_nodelay(self.config.tcp_nodelay)
             .connect_timeout(Duration::from_secs(self.config.connect_timeout_secs))
             .read_timeout(Duration::from_secs(self.config.read_timeout_secs));
+
+        if let Some(jar) = cookie_jar {
+            builder = builder.cookie_provider(jar);
+        }
 
         if let Some(ref proxy_url) = self.config.proxy {
             if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
@@ -75,6 +98,15 @@ impl HttpClientFactory {
     #[must_use]
     pub fn build_arc(&self) -> Arc<reqwest::Client> {
         Arc::new(self.build())
+    }
+
+    /// Build with cookie provider and wrap in Arc for sharing across async tasks
+    #[must_use]
+    pub fn build_arc_with_cookies(
+        &self,
+        jar: Arc<reqwest::cookie::Jar>,
+    ) -> Arc<reqwest::Client> {
+        Arc::new(self.build_with_cookies(jar))
     }
 }
 


### PR DESCRIPTION
This pull request adds support for loading cookies from Chrome and Netscape-format files, enabling the application to authenticate downloads using browser-stored cookies. It introduces new CLI options for specifying cookie sources, implements Chrome cookie extraction and decryption (Windows only), and refactors the orchestrator to load cookies before starting downloads. Additionally, it updates dependencies and error handling to support these features.

**New cookie extraction features:**

* Added support for extracting and decrypting cookies from Chrome's SQLite database on Windows, including DPAPI and AES-256-GCM decryption, in the new `chrome.rs` module (`crates/rdlp-cookies/src/chrome.rs`).
* Added new CLI options `--cookies-from-browser` and `--cookies` to specify loading cookies from Chrome/Firefox or a Netscape-format file, respectively (`crates/rdlp-cli/src/main.rs`) [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R106-R114) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R229-R230).

**Orchestrator and configuration changes:**

* Refactored the `Orchestrator` to support loading cookies from browser or file before downloads, and to pass cookie configuration from CLI (`crates/rdlp-cli/src/orchestrator/mod.rs`, `crates/rdlp-cli/src/main.rs`) [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R239-R241) [[2]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L48-R51) [[3]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L111-R115) [[4]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R139-R166).
* Improved error handling by adding a `Configuration` error variant for better diagnostics when loading cookies fails (`crates/rdlp-cli/src/orchestrator/errors.rs`).

**Dependency updates:**

* Added new dependencies required for Chrome cookie extraction and decryption, including `aes-gcm`, `reqwest`, `url`, `log`, `anyhow`, and platform-specific dependencies for Windows (`Cargo.toml`, `crates/rdlp-cookies/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R69) [[2]](diffhunk://#diff-a2fdf524fa53bc2455faf9c0d4fcb1d1b96b998f73a77ed76736176efd6c3a1dR14-R23).

**Logging improvements:**

* Enhanced logging to provide more informative messages when cookies are loaded from a file or browser (`crates/rdlp-cli/src/orchestrator/mod.rs`).

These changes collectively enable more seamless authentication for downloads by leveraging browser cookies, especially for sites requiring login.…le loading

Wire SimpleCookieJar to reqwest::cookie::Jar so cookies are actually stored and sent with HTTP requests. This fixes PornHub 403 errors caused by age verification cookies being silently discarded.

- Replace stub SimpleCookieJar with reqwest::cookie::Jar backing store
- Add cookie_provider() support to HttpClientFactory
- Add --cookies-from-browser and --cookies CLI flags
- Implement Netscape cookie file parser with #HttpOnly_ support
- Implement Chrome cookie extraction (SQLite + AES-256-GCM/DPAPI)
- Implement Firefox cookie extraction (SQLite, no decryption needed)
- Add load_from_file() to CookieJar trait
- Add Configuration error variant to OrchestratorError