### PR TITLE
feat(cli): add --proxy flag for HTTP/HTTPS/SOCKS proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "rdlp-types",
  "reqwest",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -104,6 +104,11 @@ struct Args {
     #[arg(long)]
     ffmpeg_location: Option<PathBuf>,
 
+    // === Network options ===
+    /// HTTP/HTTPS/SOCKS proxy URL (e.g., socks5://127.0.0.1:1080)
+    #[arg(long)]
+    proxy: Option<String>,
+
     // === Cookie options ===
     /// Load cookies from browser (chrome, firefox)
     #[arg(long)]
@@ -226,6 +231,7 @@ async fn async_main() -> Result<()> {
         remux_container,
         keep_video: args.keep_video,
         ffmpeg_location: args.ffmpeg_location,
+        proxy: args.proxy,
         cookies_from_browser: args.cookies_from_browser,
         cookies_file: args.cookies,
         ..Default::default()

--- a/crates/rdlp-http/Cargo.toml
+++ b/crates/rdlp-http/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 rdlp-types = { path = "../rdlp-types" }
 reqwest = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rdlp-http/src/client.rs
+++ b/crates/rdlp-http/src/client.rs
@@ -86,8 +86,9 @@ impl HttpClientFactory {
         }
 
         if let Some(ref proxy_url) = self.config.proxy {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                builder = builder.proxy(proxy);
+            match reqwest::Proxy::all(proxy_url) {
+                Ok(proxy) => builder = builder.proxy(proxy),
+                Err(e) => tracing::warn!("Invalid proxy URL '{}': {}", proxy_url, e),
             }
         }
 


### PR DESCRIPTION
This pull request adds support for configuring an HTTP/HTTPS/SOCKS proxy via a new CLI option and improves error handling for invalid proxy URLs. It also introduces the `tracing` crate to enable logging of warnings.

Network configuration enhancements:

* Added a `--proxy` command-line option to `rdlp-cli` for specifying an HTTP/HTTPS/SOCKS proxy URL (e.g., `socks5://127.0.0.1:1080`) in `main.rs`, and passed this value to the HTTP client configuration. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R107-R111) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R234)
* Improved error handling in `HttpClientFactory` to log a warning using `tracing` if the provided proxy URL is invalid, instead of silently ignoring it.

Dependency updates:

* Added the `tracing` crate as a dependency in `rdlp-http` to support logging.Wire existing Config.proxy field to CLI via --proxy flag. Add tracing warning for invalid proxy URLs instead of silent failure.