### PR TITLE
Feature/rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,7 @@ dependencies = [
  "rdlp-jsinterp",
  "rdlp-plugin",
  "rdlp-postprocess",
+ "rdlp-ratelimit",
  "regex",
  "reqwest",
  "serde_json",
@@ -2276,6 +2277,7 @@ dependencies = [
  "proptest",
  "rdlp-core",
  "rdlp-http",
+ "rdlp-ratelimit",
  "rdlp-security",
  "reqwest",
  "serde",
@@ -2350,6 +2352,13 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "rdlp-ratelimit"
+version = "0.1.0"
+dependencies = [
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/rdlp-jsinterp",
     "crates/rdlp-postprocess",
     "crates/rdlp-cookies",
+    "crates/rdlp-ratelimit",
     "crates/rdlp-plugin",
     "crates/rdlp-cli",
 ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest,
 - **Interactive** - Arrow-key format selection, container remux menu
 - **Playlists** - Batch downloads with pagination (PornHub)
 - **Cookie support** - Browser extraction (Chrome, Firefox) and Netscape cookie files
+- **Rate limiting** - Global bandwidth throttle with human-readable rates (`1M`, `500K`, `2.5G`)
 
 ### Supported Sites
 
@@ -67,6 +68,10 @@ rdlp -f "bv[height<=720]+ba" "https://www.redtube.com/12345678"
 rdlp -f "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]" "https://www.redtube.com/12345678"
 rdlp -f "worst" "https://www.redtube.com/12345678"
 
+# Limit download speed
+rdlp -r 1M "https://www.redtube.com/12345678"
+rdlp --limit-rate 500K "https://www.redtube.com/12345678"
+
 # Verbose mode
 rdlp -v "https://www.redtube.com/12345678"
 ```
@@ -103,13 +108,62 @@ rdlp -f "ba[abr>=128]"                  # Best audio with bitrate >= 128kbps
 rdlp -f "bv[ext=mp4]+ba[ext=m4a]/b"    # MP4 video + M4A audio, fallback to best
 ```
 
+### CLI Reference
+
+```
+rdlp [OPTIONS] [URL]
+```
+
+#### General
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output <DIR>` | `-o` | Output directory (default: `.`) |
+| `--format <FMT>` | `-f` | Format selection, yt-dlp syntax (default: `best`) |
+| `--interactive` | `-i` | Interactive format selection with arrow keys |
+| `--simulate` | `-s` | Simulate only, don't download |
+| `--quiet` | `-q` | Minimal output |
+| `--verbose` | `-v` | Detailed debug output |
+| `--list-extractors` | | List all supported site extractors |
+| `--list-downloaders` | | List all supported download protocols |
+
+#### Network
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--limit-rate <RATE>` | `-r` | Limit download speed (e.g., `1M`, `500K`, `2.5G`) |
+| `--proxy <URL>` | | HTTP/HTTPS/SOCKS proxy (e.g., `socks5://127.0.0.1:1080`) |
+
+Rate limit supports binary unit suffixes: `K` (1024), `M` (1048576), `G` (1073741824). Decimal values work (e.g., `2.5M`). Plain numbers are bytes/s.
+
+#### Post-processing
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--extract-audio` | `-x` | Extract audio only (requires FFmpeg) |
+| `--audio-format <FMT>` | | Audio format: `mp3`, `m4a`, `opus`, `flac`, `wav` (default: `mp3`) |
+| `--audio-quality <Q>` | | VBR level 0-9 or bitrate like `192K` |
+| `--embed-metadata` | | Embed title, artist, etc. in the file |
+| `--embed-thumbnail` | | Embed thumbnail in the file (requires FFmpeg) |
+| `--recode-video <FMT>` | | Re-encode video to format: `mp4`, `mkv`, `webm` |
+| `--remux[=FMT]` | | Remux to container without re-encoding. Use `--remux` for interactive, `--remux=mp4` for direct |
+| `--keep-video` | | Keep original file after post-processing |
+| `--ffmpeg-location <PATH>` | | Path to FFmpeg if not in PATH |
+
+#### Cookies
+
+| Flag | Description |
+|------|-------------|
+| `--cookies-from-browser <BROWSER>` | Load cookies from browser (`chrome`, `firefox`) |
+| `--cookies <FILE>` | Load Netscape-format cookies file |
+
 ### Resume
 
 Press **Ctrl+C** during download to pause. Re-run the same command to resume from where you left off.
 
 ## Architecture
 
-11-crate workspace with a three-stage pipeline: **Extract** -> **Download** -> **Post-process**.
+12-crate workspace with a three-stage pipeline: **Extract** -> **Download** -> **Post-process**.
 
 ```
 rdlp/
@@ -118,6 +172,7 @@ rdlp/
 │   ├── rdlp-core/         # Traits (InfoExtractor, Downloader, PostProcessor)
 │   ├── rdlp-security/     # SSRF protection, URL validation
 │   ├── rdlp-http/         # HTTP client factory
+│   ├── rdlp-ratelimit/    # Async token-bucket rate limiter
 │   ├── rdlp-extractor/    # Site extractors
 │   ├── rdlp-downloader/   # HTTP + HLS downloaders
 │   ├── rdlp-postprocess/  # FFmpeg library bindings pipeline

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -18,6 +18,7 @@ rdlp-jsinterp = { path = "../rdlp-jsinterp" }
 rdlp-postprocess = { path = "../rdlp-postprocess" }
 rdlp-cookies = { path = "../rdlp-cookies" }
 rdlp-plugin = { path = "../rdlp-plugin" }
+rdlp-ratelimit = { path = "../rdlp-ratelimit" }
 
 tokio = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -109,6 +109,10 @@ struct Args {
     #[arg(long)]
     proxy: Option<String>,
 
+    /// Limit download speed (e.g., "1M", "500K", "10M", "2.5M")
+    #[arg(long, short = 'r')]
+    limit_rate: Option<String>,
+
     // === Cookie options ===
     /// Load cookies from browser (chrome, firefox)
     #[arg(long)]
@@ -202,6 +206,16 @@ async fn async_main() -> Result<()> {
             .init();
     }
 
+    // Parse rate limit
+    let rate_limit = match args.limit_rate {
+        Some(ref rate_str) => {
+            let bps = rdlp_ratelimit::parse_rate_limit(rate_str).map_err(|e| anyhow::anyhow!(e))?;
+            info!("Rate limit: {} bytes/s ({rate_str})", bps);
+            Some(bps)
+        }
+        None => None,
+    };
+
     // Handle interactive remux selection
     let remux_container = match args.remux.as_deref() {
         Some("interactive") => select_remux_container()?,
@@ -232,6 +246,7 @@ async fn async_main() -> Result<()> {
         keep_video: args.keep_video,
         ffmpeg_location: args.ffmpeg_location,
         proxy: args.proxy,
+        rate_limit,
         cookies_from_browser: args.cookies_from_browser,
         cookies_file: args.cookies,
         ..Default::default()

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -65,7 +65,7 @@ impl Orchestrator {
 
         Self {
             extractor_registry: Arc::new(ExtractorRegistry::new()),
-            downloader_registry: Arc::new(DownloaderRegistry::new()),
+            downloader_registry: Arc::new(DownloaderRegistry::with_config(&config)),
             postprocessor_registry,
             extraction_context,
             config,

--- a/crates/rdlp-downloader/Cargo.toml
+++ b/crates/rdlp-downloader/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 rdlp-core = { path = "../rdlp-core" }
 rdlp-http = { path = "../rdlp-http" }
+rdlp-ratelimit = { path = "../rdlp-ratelimit" }
 rdlp-security = { path = "../rdlp-security" }
 async-trait = { workspace = true }
 tokio = { workspace = true }

--- a/crates/rdlp-downloader/src/hls.rs
+++ b/crates/rdlp-downloader/src/hls.rs
@@ -174,6 +174,7 @@ impl HlsDownloader {
         progress: Arc<AtomicU64>,
     ) -> Result<(usize, PathBuf, u64)> {
         let http_client = self.http_downloader.client().clone();
+        let rate_limiter = self.http_downloader.rate_limiter.clone();
         let buffer_size = self.buffer_size;
         let backoff = self.retry_config.to_backoff();
 
@@ -183,6 +184,7 @@ impl HlsDownloader {
             let url = url.clone();
             let segment_path = segment_path.clone();
             let progress = progress.clone();
+            let rate_limiter = rate_limiter.clone();
 
             async move {
                 // Download segment to file
@@ -225,6 +227,10 @@ impl HlsDownloader {
 
                     // Update shared progress counter (lock-free atomic)
                     progress.fetch_add(chunk.len() as u64, Ordering::Relaxed);
+
+                    if let Some(ref limiter) = rate_limiter {
+                        limiter.acquire(chunk.len()).await;
+                    }
                 }
 
                 writer.flush().await.map_err(RdlpError::Io)?;

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -25,6 +25,7 @@ use tokio::io::{AsyncWriteExt, BufWriter};
 
 use crate::chunking::ChunkSizeStrategy;
 use config::DownloaderConfig;
+use rdlp_ratelimit::RateLimiter;
 
 /// HTTP/HTTPS downloader
 ///
@@ -33,6 +34,7 @@ use config::DownloaderConfig;
 pub struct HttpDownloader {
     client: reqwest::Client,
     pub(crate) config: Arc<DownloaderConfig>,
+    pub(crate) rate_limiter: Option<Arc<RateLimiter>>,
 }
 
 impl HttpDownloader {
@@ -48,6 +50,7 @@ impl HttpDownloader {
         Self {
             client,
             config: Arc::new(DownloaderConfig::default()),
+            rate_limiter: None,
         }
     }
 
@@ -103,6 +106,13 @@ impl HttpDownloader {
     #[must_use = "builder methods consume self and return a new instance"]
     pub fn with_merge_timeout(mut self, timeout: Duration) -> Self {
         Arc::make_mut(&mut self.config).merge_timeout = timeout;
+        self
+    }
+
+    /// Set the rate limiter for bandwidth throttling
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_rate_limiter(mut self, limiter: Option<Arc<RateLimiter>>) -> Self {
+        self.rate_limiter = limiter;
         self
     }
 
@@ -198,6 +208,10 @@ impl HttpDownloader {
             if let Some(ref counter) = progress_counter {
                 counter.fetch_add(chunk.len() as u64, std::sync::atomic::Ordering::Relaxed);
             }
+
+            if let Some(ref limiter) = self.rate_limiter {
+                limiter.acquire(chunk.len()).await;
+            }
         }
 
         writer.flush().await.map_err(RdlpError::Io)?;
@@ -276,6 +290,10 @@ impl HttpDownloader {
                     callback.on_progress(&progress_info);
                     last_update = now;
                 }
+            }
+
+            if let Some(ref limiter) = self.rate_limiter {
+                limiter.acquire(chunk.len()).await;
             }
         }
 
@@ -595,6 +613,10 @@ impl Downloader for HttpDownloader {
                         callback.on_progress(&progress_info);
                         last_update = now;
                     }
+                }
+
+                if let Some(ref limiter) = self.rate_limiter {
+                    limiter.acquire(chunk.len()).await;
                 }
             }
 

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -258,6 +258,7 @@ pub use progress::{
 
 use rdlp_core::{Config, Downloader};
 use rdlp_http::HttpClientFactory;
+use rdlp_ratelimit::RateLimiter;
 use std::sync::Arc;
 
 /// Trait for downloader registries to enable mocking in tests
@@ -291,10 +292,14 @@ impl DownloaderRegistry {
         // Create optimized HTTP client using shared factory
         let client = HttpClientFactory::from_rdlp_config(config).build();
 
+        // Create rate limiter if configured
+        let rate_limiter = config.rate_limit.map(|bps| Arc::new(RateLimiter::new(bps)));
+
         // Create HTTP downloader with optimized settings
         let http_downloader = HttpDownloader::with_client(client.clone())
             .with_buffer_size(config.buffer_size)
-            .with_concurrent_fragments(config.concurrent_fragments);
+            .with_concurrent_fragments(config.concurrent_fragments)
+            .with_rate_limiter(rate_limiter);
 
         // Register HLS downloader FIRST (more specific matcher for .m3u8 URLs)
         let hls_downloader = HlsDownloader::new()

--- a/crates/rdlp-ratelimit/Cargo.toml
+++ b/crates/rdlp-ratelimit/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rdlp-ratelimit"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+tokio = { workspace = true, features = ["sync", "time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/rdlp-ratelimit/src/lib.rs
+++ b/crates/rdlp-ratelimit/src/lib.rs
@@ -1,0 +1,24 @@
+//! Async token-bucket rate limiter for download bandwidth throttling.
+//!
+//! Provides a global rate limit shared across all parallel connections.
+//! Uses a token-bucket algorithm with async sleep for precise throttling.
+//!
+//! # Example
+//!
+//! ```rust
+//! use rdlp_ratelimit::{RateLimiter, parse_rate_limit};
+//!
+//! let bps = parse_rate_limit("1M").unwrap();
+//! assert_eq!(bps, 1_048_576);
+//!
+//! let limiter = RateLimiter::new(bps);
+//! // limiter.acquire(16384).await; // throttle before next read
+//! ```
+
+#![warn(missing_docs)]
+
+mod limiter;
+mod parse;
+
+pub use limiter::RateLimiter;
+pub use parse::parse_rate_limit;

--- a/crates/rdlp-ratelimit/src/limiter.rs
+++ b/crates/rdlp-ratelimit/src/limiter.rs
@@ -1,0 +1,119 @@
+//! Token-bucket rate limiter implementation.
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant};
+
+/// Internal mutable state for the token bucket.
+struct TokenBucketState {
+    /// Available tokens (bytes). Can go negative to represent debt.
+    tokens: f64,
+    /// Last time tokens were refilled.
+    last_refill: Instant,
+}
+
+/// Async token-bucket rate limiter for bandwidth throttling.
+///
+/// Shared across all parallel connections via `Arc` internally.
+/// When rate limiting is active, each chunk write calls [`acquire`](Self::acquire)
+/// which sleeps if the byte budget is exhausted.
+///
+/// # Design
+///
+/// - Tokens (bytes) refill at `bytes_per_second` rate
+/// - Burst capacity: up to 1 second of data
+/// - One instance shared by all HTTP and HLS connections
+/// - Zero overhead when wrapped in `Option<Arc<RateLimiter>>`
+#[derive(Clone)]
+pub struct RateLimiter {
+    bytes_per_second: f64,
+    state: Arc<Mutex<TokenBucketState>>,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter with the given bytes-per-second limit.
+    #[must_use]
+    pub fn new(bytes_per_second: u64) -> Self {
+        let bps = bytes_per_second as f64;
+        Self {
+            bytes_per_second: bps,
+            state: Arc::new(Mutex::new(TokenBucketState {
+                tokens: bps, // Start with full bucket (1-second burst)
+                last_refill: Instant::now(),
+            })),
+        }
+    }
+
+    /// Acquire permission to transfer `bytes` bytes.
+    ///
+    /// If insufficient tokens are available, sleeps until enough accumulate.
+    /// The mutex is released before sleeping so other tasks are not blocked.
+    pub async fn acquire(&self, bytes: usize) {
+        let sleep_duration = {
+            let mut state = self.state.lock().await;
+            let now = Instant::now();
+            let elapsed = now.duration_since(state.last_refill).as_secs_f64();
+
+            // Refill tokens based on elapsed time
+            state.tokens += elapsed * self.bytes_per_second;
+            // Cap at burst size (1 second worth)
+            if state.tokens > self.bytes_per_second {
+                state.tokens = self.bytes_per_second;
+            }
+            state.last_refill = now;
+
+            // Consume tokens
+            state.tokens -= bytes as f64;
+
+            // If tokens went negative, calculate sleep time for the deficit
+            if state.tokens < 0.0 {
+                let deficit = -state.tokens;
+                Some(Duration::from_secs_f64(deficit / self.bytes_per_second))
+            } else {
+                None
+            }
+        }; // Mutex released here — before sleeping
+
+        if let Some(duration) = sleep_duration {
+            tokio::time::sleep(duration).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_no_delay_within_burst() {
+        let limiter = RateLimiter::new(1_000_000); // 1 MB/s
+        let start = Instant::now();
+
+        // 500 KB is within burst capacity (1 MB), should be near-instant
+        limiter.acquire(500_000).await;
+
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() < 100,
+            "Should be near-instant within burst: {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_throttle_beyond_burst() {
+        let limiter = RateLimiter::new(100_000); // 100 KB/s
+        let start = Instant::now();
+
+        // Consume initial burst (100KB) + 100KB extra = need ~1s sleep
+        for _ in 0..20 {
+            limiter.acquire(10_000).await; // 10 KB each, 200 KB total
+        }
+
+        let elapsed = start.elapsed();
+        assert!(elapsed.as_millis() > 800, "Should throttle: {elapsed:?}");
+        assert!(
+            elapsed.as_millis() < 1500,
+            "Should not over-throttle: {elapsed:?}"
+        );
+    }
+}

--- a/crates/rdlp-ratelimit/src/parse.rs
+++ b/crates/rdlp-ratelimit/src/parse.rs
@@ -24,23 +24,11 @@ pub fn parse_rate_limit(rate_str: &str) -> Result<u64, String> {
         return Err("Rate limit string is empty".to_string());
     }
 
-    let (number_part, multiplier) = if let Some(num) = rate_str
-        .strip_suffix('G')
-        .or_else(|| rate_str.strip_suffix('g'))
-    {
-        (num, 1024u64 * 1024 * 1024)
-    } else if let Some(num) = rate_str
-        .strip_suffix('M')
-        .or_else(|| rate_str.strip_suffix('m'))
-    {
-        (num, 1024u64 * 1024)
-    } else if let Some(num) = rate_str
-        .strip_suffix('K')
-        .or_else(|| rate_str.strip_suffix('k'))
-    {
-        (num, 1024u64)
-    } else {
-        (rate_str, 1u64)
+    let (number_part, multiplier) = match rate_str.as_bytes().last() {
+        Some(b'G' | b'g') => (&rate_str[..rate_str.len() - 1], 1024u64 * 1024 * 1024),
+        Some(b'M' | b'm') => (&rate_str[..rate_str.len() - 1], 1024u64 * 1024),
+        Some(b'K' | b'k') => (&rate_str[..rate_str.len() - 1], 1024u64),
+        _ => (rate_str, 1u64),
     };
 
     let value: f64 = number_part

--- a/crates/rdlp-ratelimit/src/parse.rs
+++ b/crates/rdlp-ratelimit/src/parse.rs
@@ -1,0 +1,91 @@
+//! Human-readable rate string parsing.
+
+/// Parse a human-readable rate string into bytes per second.
+///
+/// Supports suffixes: `K` (kilobytes), `M` (megabytes), `G` (gigabytes).
+/// Case-insensitive. Decimal values supported (e.g., `2.5M`).
+/// Plain numbers are treated as bytes per second.
+///
+/// Uses binary units: 1K = 1024, 1M = 1048576, 1G = 1073741824.
+///
+/// # Examples
+///
+/// ```
+/// use rdlp_ratelimit::parse_rate_limit;
+///
+/// assert_eq!(parse_rate_limit("1M").unwrap(), 1_048_576);
+/// assert_eq!(parse_rate_limit("500K").unwrap(), 512_000);
+/// assert_eq!(parse_rate_limit("2.5M").unwrap(), 2_621_440);
+/// assert_eq!(parse_rate_limit("1048576").unwrap(), 1_048_576);
+/// ```
+pub fn parse_rate_limit(rate_str: &str) -> Result<u64, String> {
+    let rate_str = rate_str.trim();
+    if rate_str.is_empty() {
+        return Err("Rate limit string is empty".to_string());
+    }
+
+    let (number_part, multiplier) = if let Some(num) = rate_str
+        .strip_suffix('G')
+        .or_else(|| rate_str.strip_suffix('g'))
+    {
+        (num, 1024u64 * 1024 * 1024)
+    } else if let Some(num) = rate_str
+        .strip_suffix('M')
+        .or_else(|| rate_str.strip_suffix('m'))
+    {
+        (num, 1024u64 * 1024)
+    } else if let Some(num) = rate_str
+        .strip_suffix('K')
+        .or_else(|| rate_str.strip_suffix('k'))
+    {
+        (num, 1024u64)
+    } else {
+        (rate_str, 1u64)
+    };
+
+    let value: f64 = number_part
+        .parse()
+        .map_err(|e| format!("Invalid rate limit '{rate_str}': {e}"))?;
+
+    if value <= 0.0 {
+        return Err(format!("Rate limit must be positive, got '{rate_str}'"));
+    }
+
+    Ok((value * multiplier as f64) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_megabytes() {
+        assert_eq!(parse_rate_limit("1M").unwrap(), 1_048_576);
+        assert_eq!(parse_rate_limit("2.5M").unwrap(), 2_621_440);
+        assert_eq!(parse_rate_limit("10m").unwrap(), 10_485_760);
+    }
+
+    #[test]
+    fn test_parse_kilobytes() {
+        assert_eq!(parse_rate_limit("500K").unwrap(), 512_000);
+        assert_eq!(parse_rate_limit("1k").unwrap(), 1024);
+    }
+
+    #[test]
+    fn test_parse_gigabytes() {
+        assert_eq!(parse_rate_limit("1G").unwrap(), 1_073_741_824);
+    }
+
+    #[test]
+    fn test_parse_plain_number() {
+        assert_eq!(parse_rate_limit("1048576").unwrap(), 1_048_576);
+    }
+
+    #[test]
+    fn test_parse_errors() {
+        assert!(parse_rate_limit("").is_err());
+        assert!(parse_rate_limit("abc").is_err());
+        assert!(parse_rate_limit("-1M").is_err());
+        assert!(parse_rate_limit("0M").is_err());
+    }
+}


### PR DESCRIPTION
This pull request introduces a configurable global download rate limiter to the project, enabling users to throttle download bandwidth using a new command-line option. The rate limiter is implemented as a reusable async token-bucket and is integrated into both HTTP and HLS downloaders. The implementation includes human-readable rate string parsing (e.g., "2.5M", "500K") and ensures throttling is shared across all parallel downloads. The main changes are grouped below:

**New Rate Limiting Feature:**

* Added a new crate, `rdlp-ratelimit`, which provides an async token-bucket rate limiter (`RateLimiter`) and a parser for human-readable rate strings (`parse_rate_limit`). This enables precise, global bandwidth throttling across all parallel downloads. [[1]](diffhunk://#diff-6eeb08736ad63403214c40b772e7506d6ad1b2e6cb8db4d3ae12cb4b512795c9R1-R15) [[2]](diffhunk://#diff-e1e015d24b710a77fcf6171a29cbab6d2c1c270f49eb7d6b98205d518cce66c6R1-R24) [[3]](diffhunk://#diff-194442ceab888beef33b083fb7ef9793c1a55967a0c3ea88960bd11029221906R1-R119) [[4]](diffhunk://#diff-d22e485bcc557968ca5faaceaf0f31f415c1b4be4d5adc7ba2d03b942b003291R1-R79)
* Integrated the rate limiter into the HTTP and HLS downloaders. After each chunk write, downloads will now respect the configured bandwidth limit by calling `acquire()` on the shared rate limiter. [[1]](diffhunk://#diff-73674e4cb6704b3bb5f72fa2d3051c7587a000bd8a0bc6ffaad78a2b23d305d0R11) [[2]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R177) [[3]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R187) [[4]](diffhunk://#diff-6470c405900cc9076208dc64e10e4195889427a627e6742abbdf0fad95ec9744R230-R233) [[5]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR28) [[6]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR37) [[7]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR53) [[8]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR112-R118) [[9]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR211-R214) [[10]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR294-R297) [[11]](diffhunk://#diff-4f84e8b5237eed5c1fc9635a1e8d191ad3cbc819d9c7edb8f81efa47bac26edaR617-R620) [[12]](diffhunk://#diff-5c9fff48c1ce99dcf82b93711c7aa517889443f91bc938eb20efdb005eac21ebR261) [[13]](diffhunk://#diff-5c9fff48c1ce99dcf82b93711c7aa517889443f91bc938eb20efdb005eac21ebR295-R302)

**CLI and Configuration Updates:**

* Added a new CLI option `--limit-rate` (short: `-r`) to `rdlp-cli`, allowing users to specify a download speed limit (e.g., "1M", "500K"). The argument is parsed and passed through the system to the downloader configuration. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R112-R115) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R209-R218) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R249) [[4]](diffhunk://#diff-3b3b3254bd5e775b69d74fe464b6b6f1d0921e6a936c6ca3342f4dc224647126R21)
* Updated the workspace configuration and dependencies to include the new `rdlp-ratelimit` crate. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R12) [[2]](diffhunk://#diff-73674e4cb6704b3bb5f72fa2d3051c7587a000bd8a0bc6ffaad78a2b23d305d0R11)

**Internal Registry and Initialization Changes:**

* Modified the downloader registry to create and share a single `RateLimiter` instance (if configured) across all downloaders, ensuring consistent throttling for all parallel downloads. [[1]](diffhunk://#diff-5c9fff48c1ce99dcf82b93711c7aa517889443f91bc938eb20efdb005eac21ebR295-R302) [[2]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L68-R68)
* Updated the orchestrator to pass the new configuration through to the downloader registry.

These changes collectively enable users to control bandwidth usage for downloads, improving flexibility and resource management.