### PR TITLE
refactor(types): replace stringly-typed fields with type-safe enums

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -40,6 +40,9 @@ This document establishes the core coding standards for the rdlp video downloade
 - Document public APIs with **rustdoc** (`///` comments)
 - Add `#![warn(missing_docs)]` to all crates
 - Prefer `impl Into<T>` for flexible function parameters
+- Use **typed enums** for fixed-set values (never raw strings for container formats, protocols, etc.)
+- Derive `PartialEq` (and `Eq` where no floats) on all value types for testability
+- Prefer `eq_ignore_ascii_case()` over `to_lowercase()` comparisons (avoids allocation)
 
 ### Async Patterns
 - Use `async_trait` for async trait methods
@@ -127,6 +130,44 @@ cargo test test_name                 # Specific test
 cargo test -- --nocapture            # Show println output
 ```
 
+## Type Safety
+
+### Strongly-Typed Enums
+Use the following enums from `rdlp-types` instead of raw strings. All are `Serialize`/`Deserialize` compatible and implement `Display`/`FromStr`.
+
+| Enum | Use For | Variants |
+|------|---------|----------|
+| `ContainerFormat` | Container/remux/recode config | Mp4, Mkv, WebM, Mov, Ts, Flv, Avi, Ogg, M4a |
+| `AudioFormat` | Audio extraction format | Mp3, Aac, M4a, Opus, Vorbis, Flac, Alac, Wav |
+| `BrowserType` | Cookie browser selection | Chrome, Firefox |
+| `DownloadProtocol` | Format download protocol | Http, Https, M3u8, M3u8Native, HttpDashSegments, Other(String) |
+| `SubtitleFormat` | Subtitle format config | Srt, Vtt, Ass, Ssa, Lrc |
+
+```rust
+// Correct — use typed enums
+config.remux_container = Some(ContainerFormat::Mp4);
+config.audio_format = Some(AudioFormat::Mp3);
+let format = Format::new("hd", url, "mp4", DownloadProtocol::Https);
+
+// Wrong — raw strings for fixed-set values
+config.remux_container = Some("mp4".to_string());  // DON'T
+```
+
+Parse CLI string inputs at the boundary:
+```rust
+let container: ContainerFormat = user_input.parse().map_err(|e| anyhow::anyhow!(e))?;
+```
+
+### Structured Errors
+- `Config::validate()` returns `Result<(), ConfigValidationError>` (not `String`)
+- `RdlpError::Http { status, reason }` for HTTP errors (not `Network` with status in string)
+- `is_retryable_error()` matches on `RdlpError::Http { status, .. }` for 429/5xx
+
+### Derive Guidelines
+- Add `PartialEq` to all value types (enables `assert_eq!` in tests)
+- Add `Eq` where there are no `f64` fields
+- Add `Copy` to small enums without heap data
+
 ## Error Handling
 
 ### Error Types
@@ -174,7 +215,7 @@ format.tbr = extract_bitrate_from_url(&url);   // site-specific
 
 ```rust
 // Wrong — duplicating Format construction in each extractor
-let mut format = Format::new(id, url, ext, "https".to_string());
+let mut format = Format::new(id, url, ext, DownloadProtocol::Https);
 format.height = Some(h);
 format.width = Some(width_from_height(h));
 format.vcodec = Some("h264".to_string());

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use dialoguer::{Select, theme::ColorfulTheme};
 use indicatif::MultiProgress;
 use rdlp_cli::Orchestrator;
-use rdlp_core::{Config, config_io};
+use rdlp_core::{AudioFormat, BrowserType, Config, ContainerFormat, config_io};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -143,19 +143,28 @@ fn main() -> Result<()> {
 }
 
 /// Interactive remux container selection
-fn select_remux_container() -> Result<Option<String>> {
+fn select_remux_container() -> Result<Option<ContainerFormat>> {
     let containers = [
-        ("mp4", "Best compatibility, faststart for streaming"),
-        ("mkv", "Supports all codecs, efficient cues index"),
-        ("webm", "Web-optimized, VP8/VP9/AV1 + Opus/Vorbis"),
-        ("mov", "Apple QuickTime, good for editing"),
-        ("avi", "Legacy format, wide support"),
-        ("ts", "MPEG-TS, broadcast/streaming"),
+        (
+            ContainerFormat::Mp4,
+            "Best compatibility, faststart for streaming",
+        ),
+        (
+            ContainerFormat::Mkv,
+            "Supports all codecs, efficient cues index",
+        ),
+        (
+            ContainerFormat::WebM,
+            "Web-optimized, VP8/VP9/AV1 + Opus/Vorbis",
+        ),
+        (ContainerFormat::Mov, "Apple QuickTime, good for editing"),
+        (ContainerFormat::Avi, "Legacy format, wide support"),
+        (ContainerFormat::Ts, "MPEG-TS, broadcast/streaming"),
     ];
 
     let items: Vec<String> = containers
         .iter()
-        .map(|(name, desc)| format!("{name:<6} {desc}"))
+        .map(|(fmt, desc)| format!("{:<6} {desc}", fmt.as_ext()))
         .collect();
 
     let selection = Select::with_theme(&ColorfulTheme::default())
@@ -164,7 +173,7 @@ fn select_remux_container() -> Result<Option<String>> {
         .default(0)
         .interact_opt()?;
 
-    Ok(selection.map(|idx| containers[idx].0.to_string()))
+    Ok(selection.map(|idx| containers[idx].0))
 }
 
 /// Writer that suspends progress bars while writing to prevent visual duplication
@@ -237,7 +246,11 @@ fn build_config(args: &Args) -> Result<Config> {
         config.extract_audio = true;
     }
     if let Some(ref audio_format) = args.audio_format {
-        config.audio_format = Some(audio_format.clone());
+        config.audio_format = Some(
+            audio_format
+                .parse::<AudioFormat>()
+                .map_err(|e| anyhow::anyhow!(e))?,
+        );
     }
     if let Some(ref audio_quality) = args.audio_quality {
         config.audio_quality = Some(audio_quality.clone());
@@ -249,7 +262,11 @@ fn build_config(args: &Args) -> Result<Config> {
         config.embed_thumbnail = true;
     }
     if let Some(ref recode_video) = args.recode_video {
-        config.recode_video = Some(recode_video.clone());
+        config.recode_video = Some(
+            recode_video
+                .parse::<ContainerFormat>()
+                .map_err(|e| anyhow::anyhow!(e))?,
+        );
     }
     if args.keep_video {
         config.keep_video = true;
@@ -265,7 +282,11 @@ fn build_config(args: &Args) -> Result<Config> {
         config.rate_limit = Some(bps);
     }
     if let Some(ref browser) = args.cookies_from_browser {
-        config.cookies_from_browser = Some(browser.clone());
+        config.cookies_from_browser = Some(
+            browser
+                .parse::<BrowserType>()
+                .map_err(|e| anyhow::anyhow!(e))?,
+        );
     }
     if let Some(ref cookies) = args.cookies {
         config.cookies_file = Some(cookies.clone());
@@ -277,7 +298,11 @@ fn build_config(args: &Args) -> Result<Config> {
             config.remux_container = select_remux_container()?;
         }
         Some(container) => {
-            config.remux_container = Some(container.to_string());
+            config.remux_container = Some(
+                container
+                    .parse::<ContainerFormat>()
+                    .map_err(|e| anyhow::anyhow!(e))?,
+            );
         }
         None => {}
     }
@@ -287,7 +312,7 @@ fn build_config(args: &Args) -> Result<Config> {
 
     // Set audio_format when extract_audio is set but no explicit format
     if config.extract_audio && config.audio_format.is_none() {
-        config.audio_format = Some("mp3".to_string());
+        config.audio_format = Some(AudioFormat::Mp3);
     }
 
     Ok(config)

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -152,13 +152,13 @@ impl Orchestrator {
             info!(count, file = path.display().to_string().as_str(); "Loaded cookies from file");
         }
 
-        if let Some(ref browser) = self.config.cookies_from_browser {
+        if let Some(browser) = self.config.cookies_from_browser {
             let count = cookie_jar.load_from_browser(browser).await.map_err(|e| {
                 OrchestratorError::Configuration(format!(
                     "Failed to load cookies from {browser}: {e}"
                 ))
             })?;
-            info!(count, browser = browser.as_str(); "Loaded cookies from browser");
+            info!(count, browser = browser.to_string().as_str(); "Loaded cookies from browser");
         }
 
         Ok(())
@@ -217,13 +217,13 @@ impl Orchestrator {
 
     /// List all available extractors
     #[must_use]
-    pub fn list_extractors(&self) -> Vec<String> {
+    pub fn list_extractors(&self) -> Vec<&str> {
         self.extractor_registry.list_extractors()
     }
 
     /// List all available download protocols
     #[must_use]
-    pub fn list_downloaders(&self) -> Vec<String> {
+    pub fn list_downloaders(&self) -> Vec<&str> {
         self.downloader_registry.list_downloaders()
     }
 }

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -12,11 +12,11 @@ impl Orchestrator {
     pub(super) fn to_postprocess_config(&self) -> PostProcessConfig {
         PostProcessConfig {
             extract_audio: self.config.extract_audio,
-            audio_format: self.config.audio_format.clone(),
+            audio_format: self.config.audio_format,
             audio_quality: self.config.audio_quality.clone(),
-            recode_video: self.config.recode_video.clone(),
-            remux_container: self.config.remux_container.clone(),
-            merge_output_format: self.config.merge_output_format.clone(),
+            recode_video: self.config.recode_video,
+            remux_container: self.config.remux_container,
+            merge_output_format: self.config.merge_output_format,
             embed_thumbnail: self.config.embed_thumbnail,
             embed_metadata: self.config.embed_metadata,
             embed_subtitles: self.config.embed_subtitles,
@@ -82,7 +82,7 @@ impl Orchestrator {
         if is_hls && pp_config.recode_video.is_none() && !pp_config.extract_audio {
             // Set merge_output_format to trigger FFmpeg remux for container fixup
             // This ensures proper moov atom placement and timestamp fixing
-            pp_config.merge_output_format = Some("mp4".to_string());
+            pp_config.merge_output_format = Some(rdlp_core::ContainerFormat::Mp4);
         }
 
         info!("Running post-processing pipeline...");

--- a/crates/rdlp-cli/src/orchestrator/tests.rs
+++ b/crates/rdlp-cli/src/orchestrator/tests.rs
@@ -28,7 +28,7 @@ fn create_test_format(format_id: &str, quality: &str, filesize: Option<u64>) -> 
         format_id.to_string(),
         "https://example.com/video.mp4".to_string(),
         "mp4".to_string(),
-        "https".to_string(),
+        rdlp_core::DownloadProtocol::Https,
     );
     format.format_note = Some(quality.to_string());
     format.filesize = filesize;
@@ -325,9 +325,9 @@ fn test_list_extractors() {
     // Should have at least the TNAFlix network extractors
     assert!(!extractors.is_empty());
     assert!(
-        extractors.contains(&"TNAFlix".to_string())
-            || extractors.contains(&"EMPFlix".to_string())
-            || extractors.contains(&"MovieFap".to_string()),
+        extractors.contains(&"TNAFlix")
+            || extractors.contains(&"EMPFlix")
+            || extractors.contains(&"MovieFap"),
         "Expected to find at least one TNAFlix network extractor, found: {extractors:?}"
     );
 }

--- a/crates/rdlp-cli/tests/test_utils.rs
+++ b/crates/rdlp-cli/tests/test_utils.rs
@@ -102,11 +102,8 @@ impl ExtractorRegistryTrait for MockExtractorRegistry {
             .cloned()
     }
 
-    fn list_extractors(&self) -> Vec<String> {
-        self.extractors
-            .iter()
-            .map(|e| e.name().to_string())
-            .collect()
+    fn list_extractors(&self) -> Vec<&str> {
+        self.extractors.iter().map(|e| e.name()).collect()
     }
 }
 
@@ -270,11 +267,8 @@ impl DownloaderRegistryTrait for MockDownloaderRegistry {
         self.downloaders.iter().find(|d| d.supports(url)).cloned()
     }
 
-    fn list_downloaders(&self) -> Vec<String> {
-        self.downloaders
-            .iter()
-            .map(|d| d.protocol().to_string())
-            .collect()
+    fn list_downloaders(&self) -> Vec<&str> {
+        self.downloaders.iter().map(|d| d.protocol()).collect()
     }
 }
 
@@ -285,13 +279,13 @@ pub fn create_test_info_dict(title: impl Into<String>, url: impl Into<String>) -
             "1".to_string(),
             "mock://example.com/video1.mp4".to_string(),
             "mp4".to_string(),
-            "mock".to_string(),
+            rdlp_core::DownloadProtocol::Other("mock".to_string()),
         ),
         Format::new(
             "2".to_string(),
             "mock://example.com/video2.mp4".to_string(),
             "mp4".to_string(),
-            "mock".to_string(),
+            rdlp_core::DownloadProtocol::Other("mock".to_string()),
         ),
     ];
 

--- a/crates/rdlp-cookies/src/lib.rs
+++ b/crates/rdlp-cookies/src/lib.rs
@@ -16,7 +16,7 @@ mod util;
 
 use async_trait::async_trait;
 use log::{debug, warn};
-use rdlp_core::{CookieJar, Result};
+use rdlp_core::{BrowserType, CookieJar, Result};
 use reqwest::cookie::CookieStore;
 use std::path::Path;
 use std::sync::Arc;
@@ -88,20 +88,12 @@ impl CookieJar for SimpleCookieJar {
         Ok(())
     }
 
-    async fn load_from_browser(&self, browser: &str) -> Result<usize> {
+    async fn load_from_browser(&self, browser: BrowserType) -> Result<usize> {
         let jar = Arc::clone(&self.jar);
-        let browser_name = browser.to_lowercase();
 
-        let count = tokio::task::spawn_blocking(move || match browser_name.as_str() {
-            "chrome" | "chromium" | "google-chrome" => chrome::extract_cookies(&*jar),
-            "firefox" | "mozilla" => firefox::extract_cookies(&*jar),
-            _ => {
-                warn!("Unsupported browser for cookie extraction: {browser_name}");
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    format!("Unsupported browser: {browser_name}. Supported: chrome, firefox"),
-                ))
-            }
+        let count = tokio::task::spawn_blocking(move || match browser {
+            BrowserType::Chrome => chrome::extract_cookies(&*jar),
+            BrowserType::Firefox => firefox::extract_cookies(&*jar),
         })
         .await
         .map_err(|e| std::io::Error::other(e.to_string()))??;

--- a/crates/rdlp-core/src/config_io.rs
+++ b/crates/rdlp-core/src/config_io.rs
@@ -63,7 +63,9 @@ pub fn to_toml_file(config: &Config, path: impl AsRef<Path>) -> Result<()> {
 
 /// Validate configuration, returning RdlpError on failure
 pub fn validate(config: &Config) -> Result<()> {
-    config.validate().map_err(RdlpError::Config)
+    config
+        .validate()
+        .map_err(|e| RdlpError::Config(e.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/rdlp-core/src/error.rs
+++ b/crates/rdlp-core/src/error.rs
@@ -7,6 +7,15 @@ pub enum RdlpError {
     #[error("Network error: {0}")]
     Network(String),
 
+    /// HTTP response error with status code
+    #[error("HTTP error {status}: {reason}")]
+    Http {
+        /// HTTP status code
+        status: u16,
+        /// Human-readable reason
+        reason: String,
+    },
+
     /// Extraction errors
     #[error("Extraction failed: {0}")]
     Extraction(String),
@@ -96,11 +105,14 @@ pub type Result<T> = std::result::Result<T, RdlpError>;
 /// ```
 pub fn check_http_response(response: &reqwest::Response) -> Result<()> {
     if !response.status().is_success() {
-        return Err(RdlpError::Network(format!(
-            "HTTP error {}: {}",
-            response.status().as_u16(),
-            response.status().canonical_reason().unwrap_or("Unknown")
-        )));
+        return Err(RdlpError::Http {
+            status: response.status().as_u16(),
+            reason: response
+                .status()
+                .canonical_reason()
+                .unwrap_or("Unknown")
+                .to_string(),
+        });
     }
     Ok(())
 }

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -39,7 +39,8 @@ pub mod traits;
 
 // Re-export types from rdlp-types for convenience
 pub use rdlp_types::{
-    Chapter, Config, Format, FormatSelector, Fragment, InfoDict, Subtitle, Thumbnail,
+    AudioFormat, BrowserType, Chapter, Config, ContainerFormat, DownloadProtocol, Format,
+    FormatSelector, Fragment, InfoDict, Subtitle, SubtitleFormat, Thumbnail,
 };
 
 // Re-export codec utilities

--- a/crates/rdlp-core/src/retry.rs
+++ b/crates/rdlp-core/src/retry.rs
@@ -8,7 +8,7 @@ pub use backon::{ExponentialBuilder, Retryable};
 ///
 /// This struct provides user-facing configuration that can be converted
 /// to a backon `ExponentialBuilder` for actual retry execution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts
     pub max_retries: usize,
@@ -124,14 +124,15 @@ impl Default for RetryConfig {
 #[must_use]
 pub fn is_retryable_error(error: &RdlpError) -> bool {
     match error {
-        // Network errors are generally retryable
-        RdlpError::Network(msg) => {
-            // Don't retry HTTP 4xx client errors (except 429 rate limit)
-            if msg.contains("HTTP error 4") && !msg.contains("429") {
-                return false;
+        // Structured HTTP errors: retry 5xx and 429, not other 4xx
+        RdlpError::Http { status, .. } => {
+            if *status == 429 || *status >= 500 {
+                return true;
             }
-            true
+            false
         }
+        // Legacy network errors are generally retryable
+        RdlpError::Network(_) => true,
         // I/O errors might be retryable (disk full, temp failure)
         RdlpError::Io(_) => true,
         // Other errors are not retryable
@@ -171,23 +172,35 @@ mod tests {
 
     #[test]
     fn test_is_retryable_error() {
-        // Network errors are retryable
+        // HTTP 5xx errors are retryable
+        assert!(is_retryable_error(&RdlpError::Http {
+            status: 503,
+            reason: "Service Unavailable".to_string(),
+        }));
+        assert!(is_retryable_error(&RdlpError::Http {
+            status: 500,
+            reason: "Internal Server Error".to_string(),
+        }));
+
+        // HTTP 429 (rate limit) is retryable
+        assert!(is_retryable_error(&RdlpError::Http {
+            status: 429,
+            reason: "Too Many Requests".to_string(),
+        }));
+
+        // HTTP 4xx client errors (except 429) are not retryable
+        assert!(!is_retryable_error(&RdlpError::Http {
+            status: 404,
+            reason: "Not Found".to_string(),
+        }));
+        assert!(!is_retryable_error(&RdlpError::Http {
+            status: 403,
+            reason: "Forbidden".to_string(),
+        }));
+
+        // Legacy network errors are retryable
         assert!(is_retryable_error(&RdlpError::Network(
             "timeout".to_string()
-        )));
-        assert!(is_retryable_error(&RdlpError::Network(
-            "HTTP error 503".to_string()
-        )));
-        assert!(is_retryable_error(&RdlpError::Network(
-            "HTTP error 429".to_string()
-        )));
-
-        // 4xx client errors (except 429) are not retryable
-        assert!(!is_retryable_error(&RdlpError::Network(
-            "HTTP error 404".to_string()
-        )));
-        assert!(!is_retryable_error(&RdlpError::Network(
-            "HTTP error 403".to_string()
         )));
 
         // I/O errors are retryable
@@ -282,7 +295,10 @@ mod tests {
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
                 // Return a non-retryable error (404)
-                Err(RdlpError::Network("HTTP error 404 Not Found".to_string()))
+                Err(RdlpError::Http {
+                    status: 404,
+                    reason: "Not Found".to_string(),
+                })
             }
         })
         .retry(config.to_backoff())
@@ -342,7 +358,10 @@ mod tests {
                     Err(RdlpError::Network("timeout".to_string()))
                 } else {
                     // Third attempt: permanent error
-                    Err(RdlpError::Network("HTTP error 403 Forbidden".to_string()))
+                    Err(RdlpError::Http {
+                        status: 403,
+                        reason: "Forbidden".to_string(),
+                    })
                 }
             }
         })

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -112,7 +112,7 @@ pub trait ProgressCallback: Send + Sync {
 }
 
 /// Current download progress information
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DownloadProgress {
     /// Bytes downloaded so far
     pub bytes_downloaded: u64,
@@ -308,7 +308,7 @@ impl fmt::Display for DownloadProgress {
 }
 
 /// Download statistics after completion
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DownloadStats {
     /// Total bytes downloaded
     pub bytes_downloaded: u64,

--- a/crates/rdlp-core/src/traits/extractor.rs
+++ b/crates/rdlp-core/src/traits/extractor.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use regex::Regex;
 use std::sync::Arc;
 
-use crate::{Config, InfoDict, Result};
+use crate::{BrowserType, Config, InfoDict, Result};
 
 /// Core trait for all site extractors
 ///
@@ -265,11 +265,11 @@ pub trait CookieJar: Send + Sync {
     /// Load cookies from a browser
     ///
     /// # Arguments
-    /// * `browser` - Browser name ("chrome", "firefox", "safari", etc.)
+    /// * `browser` - Browser type to extract cookies from
     ///
     /// # Returns
     /// Number of cookies loaded
-    async fn load_from_browser(&self, browser: &str) -> Result<usize>;
+    async fn load_from_browser(&self, browser: BrowserType) -> Result<usize>;
 
     /// Load cookies from a Netscape-format cookies file
     ///

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::path::PathBuf;
 
-use crate::{InfoDict, Result};
+use crate::{AudioFormat, ContainerFormat, InfoDict, Result};
 
 /// Post-processing operations on downloaded files
 ///
@@ -85,21 +85,20 @@ pub struct PostProcessConfig {
     /// Extract audio only
     pub extract_audio: bool,
 
-    /// Audio format to convert to ("mp3", "m4a", "opus", etc.)
-    pub audio_format: Option<String>,
+    /// Audio format to convert to
+    pub audio_format: Option<AudioFormat>,
 
     /// Audio quality (VBR level or bitrate)
     pub audio_quality: Option<String>,
 
     /// Video format to recode to
-    pub recode_video: Option<String>,
+    pub recode_video: Option<ContainerFormat>,
 
     /// Remux to container format (stream copy, no re-encoding)
-    /// Use "mp4" or "mkv" for better seeking than TS
-    pub remux_container: Option<String>,
+    pub remux_container: Option<ContainerFormat>,
 
     /// Merge output format (when combining video+audio)
-    pub merge_output_format: Option<String>,
+    pub merge_output_format: Option<ContainerFormat>,
 
     /// Embed thumbnail in video file
     pub embed_thumbnail: bool,
@@ -128,7 +127,7 @@ impl Default for PostProcessConfig {
             audio_quality: None,
             recode_video: None,
             remux_container: None,
-            merge_output_format: Some("mp4".to_string()),
+            merge_output_format: Some(ContainerFormat::Mp4),
             embed_thumbnail: false,
             embed_metadata: false,
             embed_subtitles: false,

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -190,8 +190,8 @@ async fn test_parallel_download_error_propagation() {
 
     let err = result.unwrap_err();
     assert!(
-        matches!(err, RdlpError::Network(_)),
-        "Should be a network error"
+        matches!(err, RdlpError::Http { .. } | RdlpError::Network(_)),
+        "Should be an HTTP or network error, got: {err:?}"
     );
 
     // Verify mocks were called appropriately

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -267,7 +267,7 @@ pub trait DownloaderRegistryTrait: Send + Sync {
     fn find_downloader(&self, url: &str) -> Option<Arc<dyn Downloader>>;
 
     /// Get all registered downloader protocol names
-    fn list_downloaders(&self) -> Vec<String>;
+    fn list_downloaders(&self) -> Vec<&str>;
 }
 
 /// Registry for managing downloaders
@@ -352,11 +352,8 @@ impl DownloaderRegistry {
     /// # Returns
     /// A vector of protocol names (e.g., ["http", "hls", "dash"])
     #[must_use]
-    pub fn list_downloaders(&self) -> Vec<String> {
-        self.downloaders
-            .iter()
-            .map(|d| d.protocol().to_string())
-            .collect()
+    pub fn list_downloaders(&self) -> Vec<&str> {
+        self.downloaders.iter().map(|d| d.protocol()).collect()
     }
 }
 
@@ -371,7 +368,7 @@ impl DownloaderRegistryTrait for DownloaderRegistry {
         self.find_downloader(url)
     }
 
-    fn list_downloaders(&self) -> Vec<String> {
+    fn list_downloaders(&self) -> Vec<&str> {
         self.list_downloaders()
     }
 }
@@ -384,7 +381,7 @@ mod tests {
     fn test_registry_creation() {
         let registry = DownloaderRegistry::new();
         let downloaders = registry.list_downloaders();
-        assert!(downloaders.contains(&"http".to_string()));
+        assert!(downloaders.contains(&"http"));
     }
 
     #[test]
@@ -396,7 +393,7 @@ mod tests {
 
         let registry = DownloaderRegistry::with_config(&config);
         let downloaders = registry.list_downloaders();
-        assert!(downloaders.contains(&"http".to_string()));
+        assert!(downloaders.contains(&"http"));
 
         // Verify the downloader was created with config settings
         let downloader = registry.find_downloader("https://example.com/video.mp4");
@@ -424,8 +421,8 @@ mod tests {
         let registry = DownloaderRegistry::new();
         let downloaders = registry.list_downloaders();
 
-        assert!(downloaders.contains(&"http".to_string()));
-        assert!(downloaders.contains(&"hls".to_string()));
+        assert!(downloaders.contains(&"http"));
+        assert!(downloaders.contains(&"hls"));
         assert_eq!(downloaders.len(), 2);
     }
 }

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -808,7 +808,12 @@ impl BaseExtractor {
         ext: String,
         height: Option<u32>,
     ) -> Format {
-        let mut format = Format::new(format_id, url, ext.clone(), "https".to_string());
+        let mut format = Format::new(
+            format_id,
+            url,
+            ext.clone(),
+            rdlp_core::DownloadProtocol::Https,
+        );
 
         if let Some(h) = height {
             format.height = Some(h);

--- a/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
+++ b/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
@@ -138,7 +138,7 @@ pub(crate) fn parse_moviefap_xml(xml_text: &str) -> Vec<VideoMetadata> {
 // Common codec strings to avoid repeated allocations
 const CODEC_H264: &str = "h264";
 const CODEC_AAC: &str = "aac";
-const PROTOCOL_HTTPS: &str = "https";
+use rdlp_core::DownloadProtocol;
 
 /// Build format list from video metadata and fetch filesizes
 pub(crate) async fn build_formats(
@@ -152,7 +152,7 @@ pub(crate) async fn build_formats(
             format_id,
             video_url.clone(),
             ext.clone(),
-            PROTOCOL_HTTPS.to_owned(),
+            DownloadProtocol::Https,
         );
 
         format.height = height;

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -54,7 +54,7 @@ pub trait ExtractorRegistryTrait: Send + Sync {
     fn find_extractor(&self, url: &str) -> Option<Arc<dyn InfoExtractor>>;
 
     /// Get all registered extractor names
-    fn list_extractors(&self) -> Vec<String>;
+    fn list_extractors(&self) -> Vec<&str>;
 }
 
 /// Registry for managing extractors
@@ -125,11 +125,8 @@ impl ExtractorRegistry {
     /// # Returns
     /// A vector of extractor names (e.g., ["TNAFlix", "EMPFlix", "MovieFap"])
     #[must_use]
-    pub fn list_extractors(&self) -> Vec<String> {
-        self.extractors
-            .iter()
-            .map(|e| e.name().to_string())
-            .collect()
+    pub fn list_extractors(&self) -> Vec<&str> {
+        self.extractors.iter().map(|e| e.name()).collect()
     }
 }
 
@@ -144,7 +141,7 @@ impl ExtractorRegistryTrait for ExtractorRegistry {
         self.find_extractor(url)
     }
 
-    fn list_extractors(&self) -> Vec<String> {
+    fn list_extractors(&self) -> Vec<&str> {
         self.list_extractors()
     }
 }
@@ -157,11 +154,11 @@ mod tests {
     fn test_registry_creation() {
         let registry = ExtractorRegistry::new();
         let extractors = registry.list_extractors();
-        assert!(extractors.contains(&"TNAFlix".to_string()));
-        assert!(extractors.contains(&"EMPFlix".to_string()));
-        assert!(extractors.contains(&"MovieFap".to_string()));
-        assert!(extractors.contains(&"RedTube".to_string()));
-        assert!(extractors.contains(&"PornHub".to_string()));
+        assert!(extractors.contains(&"TNAFlix"));
+        assert!(extractors.contains(&"EMPFlix"));
+        assert!(extractors.contains(&"MovieFap"));
+        assert!(extractors.contains(&"RedTube"));
+        assert!(extractors.contains(&"PornHub"));
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -62,7 +62,7 @@ pub fn ensure_init() -> Result<()> {
 }
 
 /// Audio codec configuration for extraction/conversion.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AudioCodecConfig {
     /// FFmpeg encoder name (e.g., "libmp3lame", "aac")
     pub encoder: Option<&'static str>,
@@ -155,12 +155,12 @@ pub static AUDIO_CODECS: &[(&str, AudioCodecConfig)] = &[
 pub fn get_audio_codec(name: &str) -> Option<&'static AudioCodecConfig> {
     AUDIO_CODECS
         .iter()
-        .find(|(n, _)| *n == name.to_lowercase())
+        .find(|(n, _)| n.eq_ignore_ascii_case(name))
         .map(|(_, config)| config)
 }
 
 /// Options for remux and merge operations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RemuxOptions {
     /// Enable MP4 faststart (moov atom at beginning of file).
     pub faststart: bool,
@@ -169,7 +169,7 @@ pub struct RemuxOptions {
 }
 
 /// Options for audio extraction and transcoding.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AudioExtractOptions {
     /// Encoder name (e.g., "libmp3lame", "aac", "libopus").
     /// If None, uses the default encoder for the output format.
@@ -185,7 +185,7 @@ pub struct AudioExtractOptions {
 }
 
 /// Options for video conversion/transcoding.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VideoConvertOptions {
     /// If true, remux only (stream copy, no re-encoding).
     pub remux_only: bool,
@@ -200,7 +200,7 @@ pub struct VideoConvertOptions {
 }
 
 /// A chapter entry for metadata embedding.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChapterEntry {
     /// Chapter ID (unique, typically sequential starting from 0).
     pub id: i64,

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -96,7 +96,7 @@ impl PostProcessor for FFmpegExtractAudio {
         }
 
         // Determine target format
-        let target_format = config.audio_format.as_deref().unwrap_or("mp3");
+        let target_format = config.audio_format.map(|f| f.codec_name()).unwrap_or("mp3");
         let codec_config =
             get_audio_codec(target_format).ok_or_else(|| PostProcessError::UnsupportedFormat {
                 format: target_format.to_string(),

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -35,14 +35,8 @@ impl FFmpegMerger {
         audio_ext: Option<&str>,
     ) -> &'static str {
         // Use configured merge format if specified
-        if let Some(ref format) = config.merge_output_format {
-            match format.as_str() {
-                "mp4" => return "mp4",
-                "mkv" => return "mkv",
-                "webm" => return "webm",
-                "mov" => return "mov",
-                _ => {}
-            }
+        if let Some(format) = config.merge_output_format {
+            return format.as_ext();
         }
 
         // Determine based on file extensions
@@ -131,7 +125,7 @@ impl PostProcessor for FFmpegMerger {
         // The MP4 muxer automatically handles AAC ADTS→ASC conversion,
         // so we no longer need the unconditional aac_adtstoasc BSF.
         let opts = RemuxOptions {
-            faststart: output_format == "mp4" || output_format == "mov",
+            faststart: matches!(output_format, "mp4" | "mov"),
             ..Default::default()
         };
         self.ffmpeg
@@ -175,7 +169,7 @@ mod tests {
             // Without explicit format, uses codec-based detection
             let config_no_format = PostProcessConfig {
                 merge_output_format: None,
-                ..Default::default()
+                ..PostProcessConfig::default()
             };
             assert_eq!(
                 merger.determine_output_format(&config_no_format, Some("webm"), Some("opus")),

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -10,11 +10,9 @@ use async_trait::async_trait;
 use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
-use crate::error::PostProcessError;
 use crate::ffmpeg::RemuxOptions;
 
-/// Supported remux target containers.
-const SUPPORTED_CONTAINERS: &[&str] = &["mp4", "mkv", "webm", "mov", "avi", "ts"];
+use rdlp_core::ContainerFormat;
 
 ffmpeg_processor!(
     FFmpegRemuxer,
@@ -31,8 +29,9 @@ ffmpeg_processor!(
 
 impl FFmpegRemuxer {
     /// Check if the format is a supported container for remuxing.
+    #[cfg(test)]
     fn is_supported_container(format: &str) -> bool {
-        SUPPORTED_CONTAINERS.contains(&format.to_lowercase().as_str())
+        format.parse::<ContainerFormat>().is_ok()
     }
 }
 
@@ -61,20 +60,7 @@ impl PostProcessor for FFmpegRemuxer {
         }
 
         let input_file = &files[0];
-        let target_container = config
-            .remux_container
-            .as_deref()
-            .unwrap_or("mp4")
-            .to_lowercase();
-
-        // Validate target container
-        if !Self::is_supported_container(&target_container) {
-            return Err(PostProcessError::UnsupportedFormat {
-                format: target_container,
-                operation: "remux".to_string(),
-            }
-            .into());
-        }
+        let target_container = config.remux_container.unwrap_or(ContainerFormat::Mp4);
 
         let input_ext = input_file
             .extension()
@@ -83,9 +69,9 @@ impl PostProcessor for FFmpegRemuxer {
             .to_lowercase();
 
         // Skip if already in target container
-        if input_ext == target_container {
+        if input_ext == target_container.as_ext() {
             debug!(
-                container = target_container.as_str();
+                container = target_container.as_ext();
                 "File already in target container, skipping remux"
             );
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -94,20 +80,20 @@ impl PostProcessor for FFmpegRemuxer {
         info!(
             file = input_file.display().to_string().as_str(),
             from = input_ext.as_str(),
-            to = target_container.as_str();
+            to = target_container.as_ext();
             "Remuxing to improve seeking"
         );
 
         // Build output path
-        let output_path = input_file.with_extension(&target_container);
+        let output_path = input_file.with_extension(target_container.as_ext());
 
         // Configure remux options
         // MP4/MOV: enable faststart for progressive playback (moov atom at beginning)
         // MKV: cues written at end, but seeking is still excellent
         // WebM: similar to MKV (Matroska-based)
         let opts = RemuxOptions {
-            faststart: matches!(target_container.as_str(), "mp4" | "mov"),
-            output_format: Some(target_container.clone()),
+            faststart: target_container.supports_faststart(),
+            output_format: Some(target_container.to_string()),
         };
 
         // Perform remux via library bindings
@@ -151,9 +137,9 @@ mod tests {
         assert!(FFmpegRemuxer::is_supported_container("mov"));
         assert!(FFmpegRemuxer::is_supported_container("avi"));
         assert!(FFmpegRemuxer::is_supported_container("ts"));
+        assert!(FFmpegRemuxer::is_supported_container("flv"));
 
         // Unsupported
-        assert!(!FFmpegRemuxer::is_supported_container("flv"));
         assert!(!FFmpegRemuxer::is_supported_container("wmv"));
     }
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -12,8 +12,7 @@ use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, R
 use crate::error::PostProcessError;
 use crate::ffmpeg::VideoConvertOptions;
 
-/// Supported video container formats.
-const SUPPORTED_CONTAINERS: &[&str] = &["mp4", "mkv", "webm", "mov", "avi", "flv", "ts"];
+use rdlp_core::ContainerFormat;
 
 /// Supported video codecs for transcoding.
 const VIDEO_CODECS: &[(&str, &str)] = &[
@@ -40,7 +39,7 @@ ffmpeg_processor!(
 impl FFmpegVideoConvertor {
     /// Check if the format is a supported container.
     fn is_supported_container(format: &str) -> bool {
-        SUPPORTED_CONTAINERS.contains(&format.to_lowercase().as_str())
+        format.parse::<ContainerFormat>().is_ok()
     }
 
     /// Get the FFmpeg encoder for a codec.
@@ -131,7 +130,7 @@ impl PostProcessor for FFmpegVideoConvertor {
 
         let input_file = &files[0];
 
-        let target_format = config.recode_video.as_deref().unwrap_or("mp4");
+        let target_format = config.recode_video.map(|c| c.as_ext()).unwrap_or("mp4");
 
         // Validate target format
         if !Self::is_supported_container(target_format) {

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -1,0 +1,115 @@
+//! Audio format types for extraction and conversion
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Supported audio formats for extraction and conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AudioFormat {
+    /// MPEG Audio Layer 3
+    Mp3,
+    /// Advanced Audio Coding
+    Aac,
+    /// MPEG-4 Audio (AAC in M4A container)
+    M4a,
+    /// Opus codec
+    Opus,
+    /// Vorbis codec
+    Vorbis,
+    /// Free Lossless Audio Codec
+    Flac,
+    /// Apple Lossless Audio Codec
+    Alac,
+    /// Waveform Audio File Format (PCM)
+    Wav,
+}
+
+impl AudioFormat {
+    /// File extension for this audio format.
+    #[must_use]
+    pub fn as_ext(&self) -> &'static str {
+        match self {
+            Self::Mp3 => "mp3",
+            Self::Aac => "aac",
+            Self::M4a => "m4a",
+            Self::Opus => "opus",
+            Self::Vorbis => "ogg",
+            Self::Flac => "flac",
+            Self::Alac => "m4a",
+            Self::Wav => "wav",
+        }
+    }
+
+    /// Codec lookup name (matches AUDIO_CODECS keys in ffmpeg.rs).
+    #[must_use]
+    pub fn codec_name(&self) -> &'static str {
+        match self {
+            Self::Mp3 => "mp3",
+            Self::Aac => "aac",
+            Self::M4a => "m4a",
+            Self::Opus => "opus",
+            Self::Vorbis => "vorbis",
+            Self::Flac => "flac",
+            Self::Alac => "alac",
+            Self::Wav => "wav",
+        }
+    }
+}
+
+impl fmt::Display for AudioFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.codec_name())
+    }
+}
+
+impl FromStr for AudioFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "mp3" => Ok(Self::Mp3),
+            "aac" => Ok(Self::Aac),
+            "m4a" => Ok(Self::M4a),
+            "opus" => Ok(Self::Opus),
+            "vorbis" | "ogg" => Ok(Self::Vorbis),
+            "flac" => Ok(Self::Flac),
+            "alac" => Ok(Self::Alac),
+            "wav" => Ok(Self::Wav),
+            _ => Err(format!("unsupported audio format: {s}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_roundtrip() {
+        for fmt in [
+            AudioFormat::Mp3,
+            AudioFormat::Aac,
+            AudioFormat::M4a,
+            AudioFormat::Opus,
+            AudioFormat::Vorbis,
+            AudioFormat::Flac,
+            AudioFormat::Alac,
+            AudioFormat::Wav,
+        ] {
+            let s = fmt.to_string();
+            let parsed: AudioFormat = s.parse().unwrap();
+            assert_eq!(fmt, parsed);
+        }
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let fmt = AudioFormat::Mp3;
+        let json = serde_json::to_string(&fmt).unwrap();
+        assert_eq!(json, "\"mp3\"");
+        let parsed: AudioFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(fmt, parsed);
+    }
+}

--- a/crates/rdlp-types/src/browser_type.rs
+++ b/crates/rdlp-types/src/browser_type.rs
@@ -1,0 +1,85 @@
+//! Browser type for cookie extraction
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Supported browsers for cookie extraction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BrowserType {
+    /// Google Chrome / Chromium
+    Chrome,
+    /// Mozilla Firefox
+    Firefox,
+}
+
+impl BrowserType {
+    /// Canonical name for display and matching.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Chrome => "chrome",
+            Self::Firefox => "firefox",
+        }
+    }
+}
+
+impl fmt::Display for BrowserType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for BrowserType {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "chrome" | "chromium" | "google-chrome" => Ok(Self::Chrome),
+            "firefox" | "mozilla" => Ok(Self::Firefox),
+            _ => Err(format!(
+                "unsupported browser: {s}. Supported: chrome, firefox"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_variants() {
+        assert_eq!(
+            "chrome".parse::<BrowserType>().unwrap(),
+            BrowserType::Chrome
+        );
+        assert_eq!(
+            "chromium".parse::<BrowserType>().unwrap(),
+            BrowserType::Chrome
+        );
+        assert_eq!(
+            "google-chrome".parse::<BrowserType>().unwrap(),
+            BrowserType::Chrome
+        );
+        assert_eq!(
+            "firefox".parse::<BrowserType>().unwrap(),
+            BrowserType::Firefox
+        );
+        assert_eq!(
+            "mozilla".parse::<BrowserType>().unwrap(),
+            BrowserType::Firefox
+        );
+        assert!("safari".parse::<BrowserType>().is_err());
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let b = BrowserType::Chrome;
+        let json = serde_json::to_string(&b).unwrap();
+        assert_eq!(json, "\"chrome\"");
+        let parsed: BrowserType = serde_json::from_str(&json).unwrap();
+        assert_eq!(b, parsed);
+    }
+}

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -1,7 +1,51 @@
 //! Application configuration types
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::path::PathBuf;
+
+use crate::audio_format::AudioFormat;
+use crate::browser_type::BrowserType;
+use crate::container::ContainerFormat;
+use crate::subtitle_format::SubtitleFormat;
+
+/// Errors from configuration validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigValidationError {
+    /// `concurrent_fragments` must be at least 1
+    InvalidConcurrentFragments,
+    /// `buffer_size` must be at least 1
+    InvalidBufferSize,
+    /// `playlist_start` must be at least 1
+    InvalidPlaylistStart,
+    /// `playlist_end` must be >= `playlist_start`
+    InvalidPlaylistRange {
+        /// Configured start
+        start: usize,
+        /// Configured end
+        end: usize,
+    },
+}
+
+impl fmt::Display for ConfigValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConcurrentFragments => {
+                write!(f, "concurrent_fragments must be at least 1")
+            }
+            Self::InvalidBufferSize => write!(f, "buffer_size must be at least 1"),
+            Self::InvalidPlaylistStart => write!(f, "playlist_start must be at least 1"),
+            Self::InvalidPlaylistRange { start, end } => {
+                write!(
+                    f,
+                    "playlist_end ({end}) must be >= playlist_start ({start})"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigValidationError {}
 
 /// Application configuration
 ///
@@ -36,8 +80,8 @@ pub struct Config {
     /// Format selection expression (default: "bestvideo*+bestaudio/best")
     pub format: String,
 
-    /// Merge output format when combining video+audio (e.g., "mp4", "mkv")
-    pub merge_output_format: Option<String>,
+    /// Merge output format when combining video+audio
+    pub merge_output_format: Option<ContainerFormat>,
 
     // === Download options ===
     /// Number of concurrent fragments to download
@@ -84,17 +128,17 @@ pub struct Config {
     /// Extract audio only
     pub extract_audio: bool,
 
-    /// Audio format to convert to ("mp3", "m4a", "opus", etc.)
-    pub audio_format: Option<String>,
+    /// Audio format to convert to
+    pub audio_format: Option<AudioFormat>,
 
     /// Audio quality (VBR level or bitrate, e.g., "192K")
     pub audio_quality: Option<String>,
 
     /// Video format to recode to
-    pub recode_video: Option<String>,
+    pub recode_video: Option<ContainerFormat>,
 
-    /// Remux to container format for better seeking (mp4, mkv)
-    pub remux_container: Option<String>,
+    /// Remux to container format for better seeking
+    pub remux_container: Option<ContainerFormat>,
 
     /// Embed thumbnail in video file
     pub embed_thumbnail: bool,
@@ -124,8 +168,8 @@ pub struct Config {
     /// Subtitle languages to download (e.g., ["en", "es"])
     pub subtitle_langs: Vec<String>,
 
-    /// Subtitle format ("srt", "vtt", "ass", etc.)
-    pub subtitle_format: Option<String>,
+    /// Subtitle format
+    pub subtitle_format: Option<SubtitleFormat>,
 
     // === Thumbnail ===
     /// Write thumbnail image to disk
@@ -175,8 +219,8 @@ pub struct Config {
     pub netrc: bool,
 
     // === Cookies ===
-    /// Browser to extract cookies from ("chrome", "firefox", "safari", etc.)
-    pub cookies_from_browser: Option<String>,
+    /// Browser to extract cookies from
+    pub cookies_from_browser: Option<BrowserType>,
 
     /// Path to cookies file (Netscape format)
     pub cookies_file: Option<PathBuf>,
@@ -205,7 +249,7 @@ impl Default for Config {
 
             // Format selection
             format: "bestvideo*+bestaudio/best".to_string(),
-            merge_output_format: Some("mp4".to_string()),
+            merge_output_format: Some(ContainerFormat::Mp4),
 
             // Download options
             concurrent_fragments: 4,
@@ -282,32 +326,25 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Validate configuration and return errors if invalid
-    ///
-    /// Returns Ok(()) if valid, Err with description if invalid.
-    pub fn validate(&self) -> Result<(), String> {
-        // Validate concurrent_fragments
+    /// Validate configuration and return errors if invalid.
+    pub fn validate(&self) -> Result<(), ConfigValidationError> {
         if self.concurrent_fragments == 0 {
-            return Err("concurrent_fragments must be at least 1".to_string());
+            return Err(ConfigValidationError::InvalidConcurrentFragments);
         }
-
-        // Validate buffer_size
         if self.buffer_size == 0 {
-            return Err("buffer_size must be at least 1".to_string());
+            return Err(ConfigValidationError::InvalidBufferSize);
         }
-
-        // Validate playlist_start
         if self.playlist_start == 0 {
-            return Err("playlist_start must be at least 1".to_string());
+            return Err(ConfigValidationError::InvalidPlaylistStart);
         }
-
-        // Validate playlist_end
         if let Some(end) = self.playlist_end {
             if end < self.playlist_start {
-                return Err("playlist_end must be >= playlist_start".to_string());
+                return Err(ConfigValidationError::InvalidPlaylistRange {
+                    start: self.playlist_start,
+                    end,
+                });
             }
         }
-
         Ok(())
     }
 }

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -1,0 +1,136 @@
+//! Container format types for video/audio files
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Supported container formats for video/audio files.
+///
+/// Used for merge output, remux targets, and video recode targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainerFormat {
+    /// MPEG-4 Part 14 - best compatibility, supports faststart
+    Mp4,
+    /// Matroska - supports all codecs, efficient cues index
+    Mkv,
+    /// Web-optimized, VP8/VP9/AV1 + Opus/Vorbis
+    WebM,
+    /// Apple QuickTime, good for editing
+    Mov,
+    /// MPEG Transport Stream, broadcast/streaming
+    Ts,
+    /// Flash Video, legacy format
+    Flv,
+    /// Audio Video Interleave, legacy format
+    Avi,
+    /// Ogg container
+    Ogg,
+    /// MPEG-4 Audio (audio-only container)
+    M4a,
+}
+
+impl ContainerFormat {
+    /// File extension for this container format.
+    #[must_use]
+    pub fn as_ext(&self) -> &'static str {
+        match self {
+            Self::Mp4 => "mp4",
+            Self::Mkv => "mkv",
+            Self::WebM => "webm",
+            Self::Mov => "mov",
+            Self::Ts => "ts",
+            Self::Flv => "flv",
+            Self::Avi => "avi",
+            Self::Ogg => "ogg",
+            Self::M4a => "m4a",
+        }
+    }
+
+    /// Whether this container supports faststart (moov atom at beginning).
+    #[must_use]
+    pub fn supports_faststart(&self) -> bool {
+        matches!(self, Self::Mp4 | Self::Mov)
+    }
+}
+
+impl fmt::Display for ContainerFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ext())
+    }
+}
+
+impl FromStr for ContainerFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "mp4" => Ok(Self::Mp4),
+            "mkv" | "matroska" => Ok(Self::Mkv),
+            "webm" => Ok(Self::WebM),
+            "mov" | "quicktime" => Ok(Self::Mov),
+            "ts" | "mpegts" => Ok(Self::Ts),
+            "flv" => Ok(Self::Flv),
+            "avi" => Ok(Self::Avi),
+            "ogg" => Ok(Self::Ogg),
+            "m4a" => Ok(Self::M4a),
+            _ => Err(format!("unsupported container format: {s}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_roundtrip() {
+        for fmt in [
+            ContainerFormat::Mp4,
+            ContainerFormat::Mkv,
+            ContainerFormat::WebM,
+            ContainerFormat::Mov,
+            ContainerFormat::Ts,
+            ContainerFormat::Flv,
+            ContainerFormat::Avi,
+            ContainerFormat::Ogg,
+            ContainerFormat::M4a,
+        ] {
+            let s = fmt.to_string();
+            let parsed: ContainerFormat = s.parse().unwrap();
+            assert_eq!(fmt, parsed);
+        }
+    }
+
+    #[test]
+    fn test_case_insensitive_parse() {
+        assert_eq!(
+            "MP4".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Mp4
+        );
+        assert_eq!(
+            "MKV".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Mkv
+        );
+        assert_eq!(
+            "Matroska".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Mkv
+        );
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let fmt = ContainerFormat::Mp4;
+        let json = serde_json::to_string(&fmt).unwrap();
+        assert_eq!(json, "\"mp4\"");
+        let parsed: ContainerFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(fmt, parsed);
+    }
+
+    #[test]
+    fn test_faststart() {
+        assert!(ContainerFormat::Mp4.supports_faststart());
+        assert!(ContainerFormat::Mov.supports_faststart());
+        assert!(!ContainerFormat::Mkv.supports_faststart());
+    }
+}

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::sync::OnceLock;
 
+use crate::protocol::DownloadProtocol;
+
 pub use selector::FormatSelector;
 
 /// Video/audio format information
@@ -71,8 +73,8 @@ pub struct Format {
     pub format_note: Option<String>,
 
     // === Protocol ===
-    /// Download protocol (e.g., "https", "http", "m3u8", "m3u8_native", "http_dash_segments")
-    pub protocol: String,
+    /// Download protocol
+    pub protocol: DownloadProtocol,
 
     /// Container format (e.g., "mp4", "webm", "mp4_dash")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -131,7 +133,7 @@ impl fmt::Debug for Format {
         d.field("format_id", &self.format_id);
         d.field("url", &self.url);
         d.field("ext", &self.ext);
-        d.field("protocol", &self.protocol);
+        d.field("protocol", &self.protocol.as_str());
 
         // Only show optional fields that have values
         if let Some(v) = &self.quality {
@@ -205,10 +207,15 @@ impl fmt::Debug for Format {
 impl Format {
     /// Create a new format with required fields
     #[must_use]
-    pub fn new(format_id: String, url: String, ext: String, protocol: String) -> Self {
+    pub fn new(
+        format_id: impl Into<String>,
+        url: impl Into<String>,
+        ext: impl Into<String>,
+        protocol: DownloadProtocol,
+    ) -> Self {
         Self {
-            format_id,
-            url,
+            format_id: format_id.into(),
+            url: url.into(),
             quality: None,
             width: None,
             height: None,
@@ -219,7 +226,7 @@ impl Format {
             asr: None,
             vcodec: None,
             acodec: None,
-            ext,
+            ext: ext.into(),
             format_note: None,
             protocol,
             container: None,
@@ -273,13 +280,12 @@ impl Format {
 
     /// Check if this is a DASH format
     pub fn is_dash(&self) -> bool {
-        self.protocol.contains("dash")
-            || self.container.as_ref().is_some_and(|c| c.contains("dash"))
+        self.protocol.is_dash() || self.container.as_ref().is_some_and(|c| c.contains("dash"))
     }
 
     /// Check if this is an HLS format
     pub fn is_hls(&self) -> bool {
-        self.protocol.contains("m3u8")
+        self.protocol.is_hls()
     }
 
     /// Get a human-readable format description
@@ -471,7 +477,7 @@ impl fmt::Display for Format {
 }
 
 /// Fragment of a segmented download
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fragment {
     /// Fragment URL (absolute or relative to fragment_base_url)
     pub url: String,
@@ -513,7 +519,7 @@ mod tests {
             "137".to_string(),
             "https://example.com/video".to_string(),
             "mp4".to_string(),
-            "https".to_string(),
+            DownloadProtocol::Https,
         );
         format.vcodec = Some("h264".to_string());
         format.acodec = Some("none".to_string());
@@ -528,7 +534,7 @@ mod tests {
             "140".to_string(),
             "https://example.com/audio".to_string(),
             "m4a".to_string(),
-            "https".to_string(),
+            DownloadProtocol::Https,
         );
         format.vcodec = Some("none".to_string());
         format.acodec = Some("aac".to_string());

--- a/crates/rdlp-types/src/format/selector.rs
+++ b/crates/rdlp-types/src/format/selector.rs
@@ -383,7 +383,7 @@ fn matches_filter(filter: &Filter, f: &Format) -> bool {
             Some(v) => compare_str(v, &filter.op, &filter.value),
             None => false,
         },
-        FilterField::Protocol => compare_str(&f.protocol, &filter.op, &filter.value),
+        FilterField::Protocol => compare_str(f.protocol.as_str(), &filter.op, &filter.value),
         FilterField::FormatId => compare_str(&f.format_id, &filter.op, &filter.value),
     }
 }
@@ -502,6 +502,7 @@ fn rank_formats(base: &BaseSelector, a: &Format, b: &Format) -> std::cmp::Orderi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::DownloadProtocol;
 
     // ---- Test helpers ----
 
@@ -510,7 +511,7 @@ mod tests {
             id.to_string(),
             format!("url_{id}"),
             ext.to_string(),
-            "https".to_string(),
+            DownloadProtocol::Https,
         );
         f.vcodec = Some("h264".to_string());
         f.acodec = Some("aac".to_string());
@@ -526,7 +527,7 @@ mod tests {
             id.to_string(),
             format!("url_{id}"),
             ext.to_string(),
-            "https".to_string(),
+            DownloadProtocol::Https,
         );
         f.vcodec = Some("h264".to_string());
         f.acodec = Some("none".to_string());
@@ -541,7 +542,7 @@ mod tests {
             id.to_string(),
             format!("url_{id}"),
             ext.to_string(),
-            "https".to_string(),
+            DownloadProtocol::Https,
         );
         f.vcodec = Some("none".to_string());
         f.acodec = Some("aac".to_string());

--- a/crates/rdlp-types/src/info_dict.rs
+++ b/crates/rdlp-types/src/info_dict.rs
@@ -179,12 +179,17 @@ pub struct InfoDict {
 impl InfoDict {
     /// Create a new InfoDict with required fields
     #[must_use]
-    pub fn new(id: String, title: String, extractor: String, webpage_url: String) -> Self {
+    pub fn new(
+        id: impl Into<String>,
+        title: impl Into<String>,
+        extractor: impl Into<String>,
+        webpage_url: impl Into<String>,
+    ) -> Self {
         Self {
-            id,
-            title,
-            extractor,
-            webpage_url,
+            id: id.into(),
+            title: title.into(),
+            extractor: extractor.into(),
+            webpage_url: webpage_url.into(),
             description: None,
             duration: None,
             thumbnail: None,
@@ -276,7 +281,7 @@ impl InfoDict {
 }
 
 /// Thumbnail information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Thumbnail {
     /// Thumbnail URL
     pub url: String,
@@ -299,7 +304,7 @@ pub struct Thumbnail {
 }
 
 /// Subtitle information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Subtitle {
     /// Subtitle URL
     pub url: String,
@@ -313,7 +318,7 @@ pub struct Subtitle {
 }
 
 /// Chapter information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Chapter {
     /// Chapter title
     pub title: String,

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -23,11 +23,21 @@
 
 #![warn(missing_docs)]
 
+pub mod audio_format;
+pub mod browser_type;
 pub mod config;
+pub mod container;
 pub mod format;
 pub mod info_dict;
+pub mod protocol;
+pub mod subtitle_format;
 
 // Re-export main types
-pub use config::Config;
+pub use audio_format::AudioFormat;
+pub use browser_type::BrowserType;
+pub use config::{Config, ConfigValidationError};
+pub use container::ContainerFormat;
 pub use format::{Format, FormatSelector, Fragment};
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
+pub use protocol::DownloadProtocol;
+pub use subtitle_format::SubtitleFormat;

--- a/crates/rdlp-types/src/protocol.rs
+++ b/crates/rdlp-types/src/protocol.rs
@@ -1,0 +1,142 @@
+//! Download protocol types
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Download protocol for a format stream.
+///
+/// Determines which downloader handles the stream.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DownloadProtocol {
+    /// Plain HTTP
+    Http,
+    /// HTTPS
+    Https,
+    /// HLS (M3U8) playlist
+    M3u8,
+    /// Native HLS implementation
+    M3u8Native,
+    /// DASH segments over HTTP
+    HttpDashSegments,
+    /// Other/unknown protocol
+    Other(String),
+}
+
+impl DownloadProtocol {
+    /// Check if this is an HLS protocol.
+    #[must_use]
+    pub fn is_hls(&self) -> bool {
+        matches!(self, Self::M3u8 | Self::M3u8Native)
+    }
+
+    /// Check if this is a DASH protocol.
+    #[must_use]
+    pub fn is_dash(&self) -> bool {
+        matches!(self, Self::HttpDashSegments)
+    }
+
+    /// Get the protocol as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Http => "http",
+            Self::Https => "https",
+            Self::M3u8 => "m3u8",
+            Self::M3u8Native => "m3u8_native",
+            Self::HttpDashSegments => "http_dash_segments",
+            Self::Other(s) => s,
+        }
+    }
+}
+
+impl fmt::Display for DownloadProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for DownloadProtocol {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(match s.to_ascii_lowercase().as_str() {
+            "http" => Self::Http,
+            "https" => Self::Https,
+            "m3u8" => Self::M3u8,
+            "m3u8_native" => Self::M3u8Native,
+            "http_dash_segments" => Self::HttpDashSegments,
+            _ => Self::Other(s.to_string()),
+        })
+    }
+}
+
+impl From<String> for DownloadProtocol {
+    fn from(s: String) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "http" => Self::Http,
+            "https" => Self::Https,
+            "m3u8" => Self::M3u8,
+            "m3u8_native" => Self::M3u8Native,
+            "http_dash_segments" => Self::HttpDashSegments,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+impl From<&str> for DownloadProtocol {
+    fn from(s: &str) -> Self {
+        s.parse().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_hls() {
+        assert!(DownloadProtocol::M3u8.is_hls());
+        assert!(DownloadProtocol::M3u8Native.is_hls());
+        assert!(!DownloadProtocol::Https.is_hls());
+        assert!(!DownloadProtocol::HttpDashSegments.is_hls());
+    }
+
+    #[test]
+    fn test_is_dash() {
+        assert!(DownloadProtocol::HttpDashSegments.is_dash());
+        assert!(!DownloadProtocol::Https.is_dash());
+    }
+
+    #[test]
+    fn test_parse_roundtrip() {
+        for proto in [
+            DownloadProtocol::Http,
+            DownloadProtocol::Https,
+            DownloadProtocol::M3u8,
+            DownloadProtocol::M3u8Native,
+            DownloadProtocol::HttpDashSegments,
+        ] {
+            let s = proto.to_string();
+            let parsed: DownloadProtocol = s.parse().unwrap();
+            assert_eq!(proto, parsed);
+        }
+    }
+
+    #[test]
+    fn test_unknown_protocol() {
+        let proto: DownloadProtocol = "rtmp".parse().unwrap();
+        assert_eq!(proto, DownloadProtocol::Other("rtmp".to_string()));
+        assert_eq!(proto.as_str(), "rtmp");
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let proto = DownloadProtocol::M3u8Native;
+        let json = serde_json::to_string(&proto).unwrap();
+        assert_eq!(json, "\"m3u8_native\"");
+        let parsed: DownloadProtocol = serde_json::from_str(&json).unwrap();
+        assert_eq!(proto, parsed);
+    }
+}

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -1,0 +1,85 @@
+//! Subtitle format types
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Supported subtitle formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SubtitleFormat {
+    /// SubRip Text
+    Srt,
+    /// Web Video Text Tracks
+    Vtt,
+    /// Advanced SubStation Alpha
+    Ass,
+    /// SubStation Alpha
+    Ssa,
+    /// LRC lyrics format
+    Lrc,
+}
+
+impl SubtitleFormat {
+    /// File extension for this subtitle format.
+    #[must_use]
+    pub fn as_ext(&self) -> &'static str {
+        match self {
+            Self::Srt => "srt",
+            Self::Vtt => "vtt",
+            Self::Ass => "ass",
+            Self::Ssa => "ssa",
+            Self::Lrc => "lrc",
+        }
+    }
+}
+
+impl fmt::Display for SubtitleFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ext())
+    }
+}
+
+impl FromStr for SubtitleFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "srt" => Ok(Self::Srt),
+            "vtt" | "webvtt" => Ok(Self::Vtt),
+            "ass" => Ok(Self::Ass),
+            "ssa" => Ok(Self::Ssa),
+            "lrc" => Ok(Self::Lrc),
+            _ => Err(format!("unsupported subtitle format: {s}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_roundtrip() {
+        for fmt in [
+            SubtitleFormat::Srt,
+            SubtitleFormat::Vtt,
+            SubtitleFormat::Ass,
+            SubtitleFormat::Ssa,
+            SubtitleFormat::Lrc,
+        ] {
+            let s = fmt.to_string();
+            let parsed: SubtitleFormat = s.parse().unwrap();
+            assert_eq!(fmt, parsed);
+        }
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let fmt = SubtitleFormat::Srt;
+        let json = serde_json::to_string(&fmt).unwrap();
+        assert_eq!(json, "\"srt\"");
+        let parsed: SubtitleFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(fmt, parsed);
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive migration from raw string usage to strongly-typed enums for key configuration values in the rdlp video downloader, improving type safety, code clarity, and testability across the codebase. It also updates error handling for HTTP responses, enhances documentation and coding standards, and updates interfaces and tests to reflect these changes.

**Type Safety and Enum Migration**
- Replaces raw strings with enums such as `ContainerFormat`, `AudioFormat`, `BrowserType`, `DownloadProtocol`, and `SubtitleFormat` throughout the CLI, core, and cookie modules, as well as in tests. This includes parsing CLI string inputs into enums and updating function signatures and logic accordingly. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L10-R10) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L146-R167) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L167-R176) [[4]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L240-R253) [[5]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L252-R269) [[6]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L268-R289) [[7]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L280-R305) [[8]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L290-R315) [[9]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L155-R161) [[10]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L220-R226) [[11]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL15-R19) [[12]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL85-R85) [[13]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL31-R31) [[14]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL328-R330) [[15]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78L105-R106) [[16]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78L273-R271) [[17]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78L288-R288) [[18]](diffhunk://#diff-d4e0da146149d427ab7c4393110d7d869c54e7565dce2f420d362ad7601cf896L19-R19) [[19]](diffhunk://#diff-d4e0da146149d427ab7c4393110d7d869c54e7565dce2f420d362ad7601cf896L91-R96) [[20]](diffhunk://#diff-125ce9aaf01ea46ff81f122a046514bd45e3ef52e9d63bd4e6e314ec8e9a751dL42-R43)

**Error Handling Improvements**
- Introduces a new `RdlpError::Http` variant for HTTP errors, replacing generic network errors with a structured error containing status and reason. Updates HTTP response checking logic to use this new error type. [[1]](diffhunk://#diff-8f72c1de401a777ca8352bb228143a35c1b8d614d3c87fbba462db704f01de75R10-R18) [[2]](diffhunk://#diff-8f72c1de401a777ca8352bb228143a35c1b8d614d3c87fbba462db704f01de75L99-R115)
- Updates config validation error mapping to ensure errors are converted to strings for consistent error reporting.

**Documentation and Coding Standards**
- Expands the `CODING_RULES.md` with a new section on type safety, including a table of recommended enums, guidelines on parsing, structured error handling, and deriving traits like `PartialEq`, `Eq`, and `Copy` for value types. [[1]](diffhunk://#diff-2e0115a404a3b2dedeef597c87114a412c291208799840e8dceb73d39ac82fc8R43-R45) [[2]](diffhunk://#diff-2e0115a404a3b2dedeef597c87114a412c291208799840e8dceb73d39ac82fc8R133-R170) [[3]](diffhunk://#diff-2e0115a404a3b2dedeef597c87114a412c291208799840e8dceb73d39ac82fc8L177-R218)

**Trait and Interface Updates**
- Updates trait methods and registry interfaces to use enums and references instead of strings, improving API clarity and consistency. [[1]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L220-R226) [[2]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78L105-R106) [[3]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78L273-R271)

**Test and Utility Adjustments**
- Refactors tests and test utilities to use the new enums, ensuring coverage and correctness with the updated types. [[1]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL31-R31) [[2]](diffhunk://#diff-4268138cdf279e465c43d4e1ecf7cbb76dd95b2eb2cf8042a996a376668a696aL328-R330) [[3]](diffhunk://#diff-586ec28d434e23b2258551c269f9934ac9feca344499e6c5690fcb3b67865a78L288-R288)

These changes collectively enforce better type safety, reduce runtime errors, and clarify code intent, especially around configuration and protocol handling.Introduce 5 strongly-typed enums (ContainerFormat, AudioFormat, BrowserType, DownloadProtocol, SubtitleFormat) replacing Option<String> fields across Config, Format, and PostProcessConfig. Add ConfigValidationError enum and structured RdlpError::Http variant. Add PartialEq/Eq derives to 13 value types. Update constructors to accept impl Into<String> and registry methods to return Vec<&str>.

All tests pass, clippy clean, formatted.