### PR TITLE
fix(cli): dynamically align format selection table columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
  "rdlp-plugin",
  "rdlp-postprocess",
  "rdlp-ratelimit",
+ "rdlp-types",
  "regex",
  "reqwest",
  "serde_json",

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -10,6 +10,7 @@ name = "rdlp"
 path = "src/main.rs"
 
 [dependencies]
+rdlp-types = { path = "../rdlp-types" }
 rdlp-core = { path = "../rdlp-core" }
 rdlp-http = { path = "../rdlp-http" }
 rdlp-extractor = { path = "../rdlp-extractor" }

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -4,6 +4,7 @@ use super::{Orchestrator, errors::*};
 use dialoguer::{Select, theme::ColorfulTheme};
 use log::{info, warn};
 use rdlp_core::{Format, FormatSelector, InfoDict};
+use rdlp_types::format::table;
 
 impl Orchestrator {
     /// Select format from available formats
@@ -73,15 +74,29 @@ impl Orchestrator {
             warn!("LIVE stream detected — download may be incomplete");
         }
 
+        // Compute dynamic size column width from actual content
+        let size_width = formats
+            .iter()
+            .map(|f| f.size_text().len())
+            .max()
+            .unwrap_or(4) // "Size".len()
+            .max(4);
+
         // Build menu items with format details
-        let items: Vec<String> = formats.iter().map(|f| f.table_row()).collect();
+        let items: Vec<String> = formats.iter().map(|f| f.table_row(size_width)).collect();
 
         info!("Available formats:");
         info!(
-            "{:<12} | {:<10} | {:<12} | {:<6} | Codecs",
-            "Quality", "Resolution", "Size", "Type"
+            "{:<qw$} | {:<rw$} | {:<size_width$} | {:<tw$} | Codecs",
+            "Quality",
+            "Resolution",
+            "Size",
+            "Type",
+            qw = table::QUALITY_WIDTH,
+            rw = table::RESOLUTION_WIDTH,
+            tw = table::TYPE_WIDTH,
         );
-        info!("{}", "-".repeat(79));
+        info!("{}", "-".repeat(table::separator_width(size_width)));
 
         let selection = tokio::task::spawn_blocking(move || {
             Select::with_theme(&ColorfulTheme::default())

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -1,6 +1,7 @@
 //! Format types for video/audio streams
 
 pub mod selector;
+pub mod table;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -326,53 +327,14 @@ impl Format {
         })
     }
 
-    /// Format as table row for interactive selection UI
+    /// Returns the size column text for this format (e.g. `"837.9 MB"`, `"50:16 (754 seg)"`)
     ///
-    /// Returns a formatted string suitable for display in selection menus:
-    /// `"720p         | 1280x720   | 245.3 MB     | MP4    | h264/aac"`
-    ///
-    /// Optimized to minimize heap allocations using pre-allocated buffer.
-    pub fn table_row(&self) -> String {
-        // Pre-allocate buffer for typical row length (~80 chars)
-        let mut buf = String::with_capacity(80);
-
-        // Quality column: append fps when non-standard (e.g. "1080p60")
-        let quality_base = self.format_note.as_deref().unwrap_or("unknown");
-        match self.fps {
-            Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => {
-                let _ = write!(buf, "{quality_base}{fps:.0}");
-                let col_len = quality_base.len() + format!("{fps:.0}").len();
-                for _ in col_len..12 {
-                    buf.push(' ');
-                }
-                buf.push_str(" | ");
-            }
-            _ => {
-                let _ = write!(buf, "{quality_base:<12} | ");
-            }
-        }
-
-        // Resolution: avoid intermediate String allocation
-        match (self.width, self.height) {
-            (Some(w), Some(h)) => {
-                let _ = write!(buf, "{w}x{h}");
-                // Pad to 10 chars
-                let len = buf.len() - 15; // account for "quality | "
-                for _ in len..10 {
-                    buf.push(' ');
-                }
-            }
-            _ => buf.push_str("N/A       "),
-        }
-        buf.push_str(" | ");
-
-        // Check if this is an HLS format (also check URL for .m3u8)
+    /// Call this on every format to compute `max` width, then pass that to [`Self::table_row`].
+    #[must_use]
+    pub fn size_text(&self) -> String {
         let is_hls = self.is_hls() || self.url.contains(".m3u8");
 
-        // Size column: write directly to buffer
-        let size_start = buf.len();
         if is_hls {
-            // For HLS: show duration + segment count when available
             let seg_count = self
                 .fragments
                 .as_ref()
@@ -383,35 +345,81 @@ impl Format {
                 (Some(dur), Some(segs)) => {
                     let mins = dur as u64 / 60;
                     let secs = dur as u64 % 60;
-                    let _ = write!(buf, "{mins}:{secs:02} ({segs} seg)");
+                    format!("{mins}:{secs:02} ({segs} seg)")
                 }
                 (Some(dur), None) => {
                     let mins = dur as u64 / 60;
                     let secs = dur as u64 % 60;
-                    let _ = write!(buf, "{mins}:{secs:02}");
+                    format!("{mins}:{secs:02}")
                 }
-                (None, Some(segs)) => {
-                    let _ = write!(buf, "{segs} segments");
-                }
-                (None, None) => {
-                    buf.push_str("HLS stream");
-                }
+                (None, Some(segs)) => format!("{segs} segments"),
+                (None, None) => "HLS stream".to_string(),
             }
         } else if let Some(filesize) = self.filesize {
-            let _ = write!(buf, "{:.1} MB", filesize as f64 / (1024.0 * 1024.0));
+            format!("{:.1} MB", filesize as f64 / (1024.0 * 1024.0))
         } else if let Some(filesize_approx) = self.filesize_approx {
-            let _ = write!(buf, "~{:.0} MB", filesize_approx as f64 / (1024.0 * 1024.0));
+            format!("~{:.0} MB", filesize_approx as f64 / (1024.0 * 1024.0))
         } else {
-            buf.push_str("Unknown");
+            "Unknown".to_string()
         }
-        // Pad size to 12 chars
+    }
+
+    /// Format as table row for interactive selection UI
+    ///
+    /// Returns a formatted string suitable for display in selection menus:
+    /// `"720p         | 1280x720   | 245.3 MB     | MP4    | h264/aac"`
+    ///
+    /// `size_width` controls the size column padding (use [`Self::size_text`] across
+    /// all formats to compute the appropriate value).
+    ///
+    /// Optimized to minimize heap allocations using pre-allocated buffer.
+    pub fn table_row(&self, size_width: usize) -> String {
+        // Pre-allocate buffer for typical row length (~80 chars)
+        let mut buf = String::with_capacity(80);
+
+        // Quality column: append fps when non-standard (e.g. "1080p60")
+        let quality_base = self.format_note.as_deref().unwrap_or("unknown");
+        match self.fps {
+            Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => {
+                let _ = write!(buf, "{quality_base}{fps:.0}");
+                let col_len = quality_base.len() + format!("{fps:.0}").len();
+                for _ in col_len..table::QUALITY_WIDTH {
+                    buf.push(' ');
+                }
+                buf.push_str(" | ");
+            }
+            _ => {
+                let _ = write!(buf, "{quality_base:<w$} | ", w = table::QUALITY_WIDTH);
+            }
+        }
+
+        // Resolution: avoid intermediate String allocation
+        match (self.width, self.height) {
+            (Some(w), Some(h)) => {
+                let res_start = buf.len();
+                let _ = write!(buf, "{w}x{h}");
+                let res_len = buf.len() - res_start;
+                for _ in res_len..table::RESOLUTION_WIDTH {
+                    buf.push(' ');
+                }
+            }
+            _ => {
+                let _ = write!(buf, "{:<w$}", "N/A", w = table::RESOLUTION_WIDTH);
+            }
+        }
+        buf.push_str(" | ");
+
+        // Size column: write directly, pad to dynamic width
+        let size_start = buf.len();
+        buf.push_str(&self.size_text());
         let size_len = buf.len() - size_start;
-        for _ in size_len..12 {
+        for _ in size_len..size_width {
             buf.push(' ');
         }
         buf.push_str(" | ");
 
         // Format type column: avoid to_uppercase() allocation for HLS
+        let is_hls = self.is_hls() || self.url.contains(".m3u8");
         let format_start = buf.len();
         if is_hls {
             buf.push_str("HLS");
@@ -421,9 +429,8 @@ impl Format {
                 buf.push(c.to_ascii_uppercase());
             }
         }
-        // Pad to 6 chars
         let format_len = buf.len() - format_start;
-        for _ in format_len..6 {
+        for _ in format_len..table::TYPE_WIDTH {
             buf.push(' ');
         }
         buf.push_str(" | ");

--- a/crates/rdlp-types/src/format/table.rs
+++ b/crates/rdlp-types/src/format/table.rs
@@ -1,0 +1,32 @@
+//! Column layout constants for the interactive format selection table.
+//!
+//! Shared between `Format::table_row()` and the CLI header so both stay in sync.
+
+/// Width of the Quality column (e.g. `"1080p60     "`).
+pub const QUALITY_WIDTH: usize = 12;
+
+/// Width of the Resolution column (e.g. `"1920x1080 "`).
+pub const RESOLUTION_WIDTH: usize = 10;
+
+/// Width of the Type column (e.g. `"HLS   "`).
+pub const TYPE_WIDTH: usize = 6;
+
+/// Width of the column separator `" | "`.
+pub const SEP_WIDTH: usize = 3;
+
+/// Approximate width of the trailing Codecs label used in the separator line.
+const CODECS_LABEL_WIDTH: usize = 6;
+
+/// Compute the total separator line width given a dynamic size column width.
+#[must_use]
+pub const fn separator_width(size_width: usize) -> usize {
+    QUALITY_WIDTH
+        + SEP_WIDTH
+        + RESOLUTION_WIDTH
+        + SEP_WIDTH
+        + size_width
+        + SEP_WIDTH
+        + TYPE_WIDTH
+        + SEP_WIDTH
+        + CODECS_LABEL_WIDTH
+}


### PR DESCRIPTION
This pull request improves the format selection UI in the CLI by making the table column widths more consistent and dynamic. The main changes include refactoring how table rows are rendered for format selection, introducing a new module for table layout constants, and ensuring that the size column adapts its width based on the actual data.

**Table layout and formatting improvements:**

* Added a new `table` module (`crates/rdlp-types/src/format/table.rs`) that defines constants for column widths and a function to compute the separator line width, ensuring consistent table formatting between the CLI header and table rows. [[1]](diffhunk://#diff-a638c81a801be5f2e5677e68c9db361289303c7c124611438503d46b438a9d0fR1-R32) [[2]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592R4)
* Updated `Format::table_row` to accept a dynamic `size_width` parameter and use the new `table` constants for padding, so columns (especially the size column) are aligned regardless of content length. [[1]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592R330-R376) [[2]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592L345-R422) [[3]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592L424-R433)
* Added a new `Format::size_text` method to compute the display text for the size column, handling both file sizes and HLS stream info, and used this to determine the maximum width needed for the size column.

**CLI integration:**

* Updated the format selection logic in `crates/rdlp-cli/src/orchestrator/selection.rs` to compute the appropriate `size_width` dynamically from the actual formats, and to use the new table layout constants for printing the table header and separator. [[1]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158R7) [[2]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158R77-R99)

**Dependency management:**

* Added `rdlp-types` as a dependency in `rdlp-cli` to access the new table module and formatting utilities.Extract column width constants into format::table module so header and rows share one source of truth. Size column width is now computed from actual content, fixing overflow for HLS duration strings.