### PR TITLE
refactor: extract table layout constants into rdlp-table crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ dependencies = [
  "rdlp-plugin",
  "rdlp-postprocess",
  "rdlp-ratelimit",
- "rdlp-types",
+ "rdlp-table",
  "regex",
  "reqwest",
  "serde_json",
@@ -2412,9 +2412,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdlp-table"
+version = "0.1.0"
+
+[[package]]
 name = "rdlp-types"
 version = "0.1.0"
 dependencies = [
+ "rdlp-table",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/rdlp-postprocess",
     "crates/rdlp-cookies",
     "crates/rdlp-ratelimit",
+    "crates/rdlp-table",
     "crates/rdlp-plugin",
     "crates/rdlp-cli",
 ]

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -10,7 +10,7 @@ name = "rdlp"
 path = "src/main.rs"
 
 [dependencies]
-rdlp-types = { path = "../rdlp-types" }
+rdlp-table = { path = "../rdlp-table" }
 rdlp-core = { path = "../rdlp-core" }
 rdlp-http = { path = "../rdlp-http" }
 rdlp-extractor = { path = "../rdlp-extractor" }

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -4,7 +4,7 @@ use super::{Orchestrator, errors::*};
 use dialoguer::{Select, theme::ColorfulTheme};
 use log::{info, warn};
 use rdlp_core::{Format, FormatSelector, InfoDict};
-use rdlp_types::format::table;
+use rdlp_table;
 
 impl Orchestrator {
     /// Select format from available formats
@@ -92,11 +92,11 @@ impl Orchestrator {
             "Resolution",
             "Size",
             "Type",
-            qw = table::QUALITY_WIDTH,
-            rw = table::RESOLUTION_WIDTH,
-            tw = table::TYPE_WIDTH,
+            qw = rdlp_table::QUALITY_WIDTH,
+            rw = rdlp_table::RESOLUTION_WIDTH,
+            tw = rdlp_table::TYPE_WIDTH,
         );
-        info!("{}", "-".repeat(table::separator_width(size_width)));
+        info!("{}", "-".repeat(rdlp_table::separator_width(size_width)));
 
         let selection = tokio::task::spawn_blocking(move || {
             Select::with_theme(&ColorfulTheme::default())

--- a/crates/rdlp-table/Cargo.toml
+++ b/crates/rdlp-table/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rdlp-table"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/rdlp-table/src/lib.rs
+++ b/crates/rdlp-table/src/lib.rs
@@ -1,6 +1,9 @@
 //! Column layout constants for the interactive format selection table.
 //!
-//! Shared between `Format::table_row()` and the CLI header so both stay in sync.
+//! Shared between `Format::table_row()` (in `rdlp-types`) and the CLI header
+//! (in `rdlp-cli`) so both stay in sync.
+
+#![warn(missing_docs)]
 
 /// Width of the Quality column (e.g. `"1080p60     "`).
 pub const QUALITY_WIDTH: usize = 12;

--- a/crates/rdlp-types/Cargo.toml
+++ b/crates/rdlp-types/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Pure domain types for rdlp (no I/O dependencies)"
 
 [dependencies]
+rdlp-table = { path = "../rdlp-table" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -1,7 +1,6 @@
 //! Format types for video/audio streams
 
 pub mod selector;
-pub mod table;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -383,13 +382,13 @@ impl Format {
             Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => {
                 let _ = write!(buf, "{quality_base}{fps:.0}");
                 let col_len = quality_base.len() + format!("{fps:.0}").len();
-                for _ in col_len..table::QUALITY_WIDTH {
+                for _ in col_len..rdlp_table::QUALITY_WIDTH {
                     buf.push(' ');
                 }
                 buf.push_str(" | ");
             }
             _ => {
-                let _ = write!(buf, "{quality_base:<w$} | ", w = table::QUALITY_WIDTH);
+                let _ = write!(buf, "{quality_base:<w$} | ", w = rdlp_table::QUALITY_WIDTH);
             }
         }
 
@@ -399,12 +398,12 @@ impl Format {
                 let res_start = buf.len();
                 let _ = write!(buf, "{w}x{h}");
                 let res_len = buf.len() - res_start;
-                for _ in res_len..table::RESOLUTION_WIDTH {
+                for _ in res_len..rdlp_table::RESOLUTION_WIDTH {
                     buf.push(' ');
                 }
             }
             _ => {
-                let _ = write!(buf, "{:<w$}", "N/A", w = table::RESOLUTION_WIDTH);
+                let _ = write!(buf, "{:<w$}", "N/A", w = rdlp_table::RESOLUTION_WIDTH);
             }
         }
         buf.push_str(" | ");
@@ -430,7 +429,7 @@ impl Format {
             }
         }
         let format_len = buf.len() - format_start;
-        for _ in format_len..table::TYPE_WIDTH {
+        for _ in format_len..rdlp_table::TYPE_WIDTH {
             buf.push(' ');
         }
         buf.push_str(" | ");


### PR DESCRIPTION
This pull request introduces a new crate, `rdlp-table`, to centralize table layout constants used for formatting output in both the CLI and core types. The change removes duplication by extracting these constants from `rdlp-types` and updating all dependent code to use the new crate. This improves maintainability and ensures consistency across the project.

**Crate extraction and dependency updates:**

* Introduced a new crate, `rdlp-table`, containing shared table layout constants and added it to the workspace (`Cargo.toml`, `crates/rdlp-table/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R13) [[2]](diffhunk://#diff-0a4058d03509c8ad751e1aae34dfd13a27106669ec4430cf72c7a7f28701fc05R1-R11).
* Updated dependencies in `rdlp-types` and `rdlp-cli` to use `rdlp-table` instead of the previous local module (`crates/rdlp-types/Cargo.toml`, `crates/rdlp-cli/Cargo.toml`) [[1]](diffhunk://#diff-d2741be08106380bb8563c16fbe0ea09335c15314d66ab477ea914eafd0f0f76R10) [[2]](diffhunk://#diff-3b3b3254bd5e775b69d74fe464b6b6f1d0921e6a936c6ca3342f4dc224647126L13-R13).

**Code refactoring to use new crate:**

* Removed the `table` module from `rdlp-types` and updated all references in `rdlp-types` and `rdlp-cli` to use `rdlp_table` instead of the old path (`crates/rdlp-types/src/format/mod.rs`, `crates/rdlp-cli/src/orchestrator/selection.rs`) [[1]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592L4) [[2]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158L7-R7) [[3]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592L386-R391) [[4]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592L402-R406) [[5]](diffhunk://#diff-84a27c03c29fe71ee07f425e90a4d7e8911a6939805dd2134547c6e21ac07592L433-R432) [[6]](diffhunk://#diff-d65695ab037855dedb33a6d8f1464726b94c10a4d92a34a19036afa299a7b158L95-R99).

**File moves and documentation:**

* Moved the table constants source file from `crates/rdlp-types/src/format/table.rs` to `crates/rdlp-table/src/lib.rs` and updated documentation to clarify its shared usage.

These changes collectively improve code organization and reduce the risk of inconsistencies in table formatting logic across the project.Move column width constants and separator_width() from the format::table submodule in rdlp-types into a standalone rdlp-table crate so both rdlp-types and rdlp-cli depend on it directly.