### PR TITLE
feat(cli): add --download-archive flag to skip already-downloaded videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest,
 - **Playlists** - Batch downloads with pagination (PornHub)
 - **Cookie support** - Browser extraction (Chrome, Firefox) and Netscape cookie files
 - **Rate limiting** - Global bandwidth throttle with human-readable rates (`1M`, `500K`, `2.5G`)
+- **Download archive** - Skip already-downloaded videos on re-run (`--download-archive`)
 
 ### Supported Sites
 
@@ -71,6 +72,9 @@ rdlp -f "worst" "https://www.redtube.com/12345678"
 # Limit download speed
 rdlp -r 1M "https://www.redtube.com/12345678"
 rdlp --limit-rate 500K "https://www.redtube.com/12345678"
+
+# Skip already-downloaded videos (playlist or repeated runs)
+rdlp --download-archive archive.txt "https://www.pornhub.com/playlist/123456"
 
 # Verbose mode
 rdlp -v "https://www.redtube.com/12345678"
@@ -157,6 +161,21 @@ Rate limit supports binary unit suffixes: `K` (1024), `M` (1048576), `G` (107374
 | `--cookies-from-browser <BROWSER>` | Load cookies from browser (`chrome`, `firefox`) |
 | `--cookies <FILE>` | Load Netscape-format cookies file |
 
+#### Download Archive
+
+| Flag | Description |
+|------|-------------|
+| `--download-archive <FILE>` | Path to archive file (skip already-downloaded videos) |
+
+Records each completed download as `{extractor} {id}` (one per line) in a plain text file. On subsequent runs, videos already in the archive are skipped. Compatible with yt-dlp's archive format. Blank lines and `#` comments are ignored.
+
+```
+# Example archive file
+PornHub ph6abc123def
+RedTube 12345678
+TNAFlix 456789
+```
+
 #### Configuration
 
 | Flag | Description |
@@ -190,12 +209,13 @@ Press **Ctrl+C** during download to pause. Re-run the same command to resume fro
 
 ## Architecture
 
-12-crate workspace with a three-stage pipeline: **Extract** -> **Download** -> **Post-process**.
+13-crate workspace with a three-stage pipeline: **Extract** -> **Download** -> **Post-process**.
 
 ```
 rdlp/
 ├── crates/
 │   ├── rdlp-types/        # Pure data types (Config, Format, InfoDict)
+│   ├── rdlp-table/        # Column layout constants for format selection table
 │   ├── rdlp-core/         # Traits (InfoExtractor, Downloader, PostProcessor)
 │   ├── rdlp-security/     # SSRF protection, URL validation
 │   ├── rdlp-http/         # HTTP client factory

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -122,6 +122,10 @@ struct Args {
     #[arg(long)]
     cookies: Option<PathBuf>,
 
+    /// Path to download archive file (skip already-downloaded videos)
+    #[arg(long)]
+    download_archive: Option<PathBuf>,
+
     // === Config file options ===
     /// Ignore config file (don't load from default location)
     #[arg(long)]
@@ -290,6 +294,9 @@ fn build_config(args: &Args) -> Result<Config> {
     }
     if let Some(ref cookies) = args.cookies {
         config.cookies_file = Some(cookies.clone());
+    }
+    if let Some(ref archive) = args.download_archive {
+        config.download_archive = Some(archive.clone());
     }
 
     // Handle interactive remux selection

--- a/crates/rdlp-cli/src/orchestrator/archive.rs
+++ b/crates/rdlp-cli/src/orchestrator/archive.rs
@@ -1,0 +1,115 @@
+//! Download archive for tracking completed downloads.
+//!
+//! Records completed downloads as `{extractor} {id}` lines in a text file.
+//! On subsequent runs, already-present entries are skipped. Compatible with
+//! yt-dlp's `--download-archive` format.
+
+use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+
+/// Load archive entries from a file into a `HashSet`.
+///
+/// Returns an empty set if the file does not exist. Blank lines and lines
+/// starting with `#` are ignored.
+pub fn load_archive(path: &Path) -> HashSet<String> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return HashSet::new(),
+    };
+
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with('#')
+        })
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+/// Check whether a video is already recorded in the archive.
+pub fn is_in_archive(archive: &HashSet<String>, extractor: &str, id: &str) -> bool {
+    archive.contains(&format!("{extractor} {id}"))
+}
+
+/// Append a completed download entry to the archive file.
+///
+/// Creates the file (and parent directories) if they don't exist.
+pub fn record_in_archive(path: &Path, extractor: &str, id: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let mut file = OpenOptions::new().append(true).create(true).open(path)?;
+
+    writeln!(file, "{extractor} {id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn load_empty_set_when_file_missing() {
+        let archive = load_archive(Path::new("/nonexistent/archive.txt"));
+        assert!(archive.is_empty());
+    }
+
+    #[test]
+    fn load_skips_blank_and_comment_lines() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "# rdlp download archive").unwrap();
+        writeln!(tmp).unwrap();
+        writeln!(tmp, "SiteA abc123").unwrap();
+        writeln!(tmp, "  # another comment  ").unwrap();
+        writeln!(tmp, "SiteB xyz789").unwrap();
+        tmp.flush().unwrap();
+
+        let archive = load_archive(tmp.path());
+        assert_eq!(archive.len(), 2);
+        assert!(archive.contains("SiteA abc123"));
+        assert!(archive.contains("SiteB xyz789"));
+    }
+
+    #[test]
+    fn is_in_archive_checks_extractor_and_id() {
+        let mut archive = HashSet::new();
+        archive.insert("SiteA abc123".to_string());
+
+        assert!(is_in_archive(&archive, "SiteA", "abc123"));
+        assert!(!is_in_archive(&archive, "SiteA", "other"));
+        assert!(!is_in_archive(&archive, "SiteB", "abc123"));
+    }
+
+    #[test]
+    fn record_appends_entry() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        record_in_archive(&path, "SiteA", "abc123").unwrap();
+        record_in_archive(&path, "SiteB", "xyz789").unwrap();
+
+        let archive = load_archive(&path);
+        assert_eq!(archive.len(), 2);
+        assert!(is_in_archive(&archive, "SiteA", "abc123"));
+        assert!(is_in_archive(&archive, "SiteB", "xyz789"));
+    }
+
+    #[test]
+    fn record_creates_file_if_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("archive.txt");
+
+        record_in_archive(&path, "SiteA", "id1").unwrap();
+
+        let archive = load_archive(&path);
+        assert!(is_in_archive(&archive, "SiteA", "id1"));
+    }
+}

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -1,5 +1,6 @@
 //! Orchestrator module for coordinating extraction, download, and post-processing
 
+mod archive;
 mod errors;
 mod execution;
 mod extraction;
@@ -26,6 +27,7 @@ use rdlp_extractor::{ExtractorRegistry, ExtractorRegistryTrait};
 use rdlp_http::HttpClientFactory;
 use rdlp_jsinterp::SimpleJsEngine;
 use rdlp_postprocess::{PostProcessorRegistry, PostProcessorRegistryTrait};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::instrument;
@@ -191,12 +193,28 @@ impl Orchestrator {
         // Try playlist extraction first to check if this is a playlist
         let infos = self.extract_playlist_info(url).await?;
 
+        // Load archive once at start
+        let archive = self.load_archive_if_configured();
+
         // If multiple videos found, this is a playlist
         if infos.len() > 1 {
             return self
-                .download_playlist_internal(infos, interactive)
+                .download_playlist_internal(infos, interactive, archive)
                 .await
                 .map(|opt| opt.and_then(|paths| paths.into_iter().next()));
+        }
+
+        // Single video — check archive before downloading
+        if let Some(ref archive_set) = archive {
+            let info = &infos[0];
+            if archive::is_in_archive(archive_set, &info.extractor, &info.id) {
+                info!(
+                    id = info.id.as_str(),
+                    extractor = info.extractor.as_str();
+                    "Already in archive, skipping"
+                );
+                return Ok(None);
+            }
         }
 
         // Single video - use existing state machine
@@ -208,7 +226,12 @@ impl Orchestrator {
             phase = phase.advance(self, interactive).await?;
 
             match phase {
-                DownloadPhase::Complete { path } => return Ok(Some(path)),
+                DownloadPhase::Complete { ref path } => {
+                    let result_path = path.clone();
+                    // Record in archive after successful download
+                    self.record_in_archive(&infos[0].extractor, &infos[0].id);
+                    return Ok(Some(result_path));
+                }
                 DownloadPhase::Cancelled => return Ok(None),
                 _ => continue, // Keep advancing through phases
             }
@@ -225,5 +248,22 @@ impl Orchestrator {
     #[must_use]
     pub fn list_downloaders(&self) -> Vec<&str> {
         self.downloader_registry.list_downloaders()
+    }
+
+    /// Load archive if configured, returning `None` if not configured.
+    fn load_archive_if_configured(&self) -> Option<HashSet<String>> {
+        self.config
+            .download_archive
+            .as_ref()
+            .map(|path| archive::load_archive(path))
+    }
+
+    /// Record a completed download in the archive (no-op if not configured).
+    fn record_in_archive(&self, extractor: &str, id: &str) {
+        if let Some(ref path) = self.config.download_archive {
+            if let Err(e) = archive::record_in_archive(path, extractor, id) {
+                warn!("Failed to write to download archive: {e}");
+            }
+        }
     }
 }

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -3,9 +3,9 @@
 //! Provides batch download support with progress tracking, resume capability,
 //! and graceful degradation for failed videos.
 
-use super::{Orchestrator, OrchestratorError, Result};
+use super::{Orchestrator, OrchestratorError, Result, archive};
 use log::{error, info};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 impl Orchestrator {
@@ -38,7 +38,9 @@ impl Orchestrator {
                 .map(|opt| opt.map(|path| vec![path]));
         }
 
-        self.download_playlist_internal(infos, interactive).await
+        let archive = self.load_archive_if_configured();
+        self.download_playlist_internal(infos, interactive, archive)
+            .await
     }
 
     /// Internal playlist download logic
@@ -53,6 +55,7 @@ impl Orchestrator {
         &self,
         infos: Vec<rdlp_core::InfoDict>,
         interactive: bool,
+        archive: Option<HashSet<String>>,
     ) -> Result<Option<Vec<PathBuf>>> {
         let total = infos.len();
         let playlist_title = infos[0]
@@ -156,6 +159,14 @@ impl Orchestrator {
                 continue;
             }
 
+            // Check download archive
+            if let Some(ref archive_set) = archive {
+                if archive::is_in_archive(archive_set, &info.extractor, &info.id) {
+                    info!(position, total, title:? = info.title; "Already in archive, skipping");
+                    continue;
+                }
+            }
+
             info!("{}", "─".repeat(60));
             info!(position, total, title:? = info.title; "Downloading");
             info!("{}", "─".repeat(60));
@@ -168,6 +179,7 @@ impl Orchestrator {
                         Ok(Some(path)) => {
                             info!(position, total, path:? = path.display(); "Saved");
                             downloaded.push(path);
+                            self.record_in_archive(&info.extractor, &info.id);
                         }
                         Ok(None) => {
                             info!(position, total; "Skipped by user");

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -225,6 +225,10 @@ pub struct Config {
     /// Path to cookies file (Netscape format)
     pub cookies_file: Option<PathBuf>,
 
+    // === Archive ===
+    /// Path to download archive file (logs completed downloads to skip on re-run)
+    pub download_archive: Option<PathBuf>,
+
     // === Plugin system ===
     /// Directories to search for plugins
     pub plugin_directories: Vec<PathBuf>,
@@ -316,6 +320,9 @@ impl Default for Config {
             // Cookies
             cookies_from_browser: None,
             cookies_file: None,
+
+            // Archive
+            download_archive: None,
 
             // Plugin system
             plugin_directories: Vec::new(),


### PR DESCRIPTION
This pull request adds support for a "download archive" feature to the project, allowing users to skip already-downloaded videos on repeated runs by specifying the `--download-archive` flag. The implementation is compatible with yt-dlp's archive format and integrates with both single video and playlist downloads. The changes include updates to the CLI, configuration, orchestrator logic, and documentation.

**Download Archive Feature:**

* Added a new CLI flag `--download-archive <FILE>` to specify an archive file for tracking completed downloads, with documentation and usage examples in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R178) [[4]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R125-R128)
* Updated the configuration struct `Config` to include an optional `download_archive` field, and ensured CLI arguments are correctly mapped to configuration. [[1]](diffhunk://#diff-8d6dabb2c50be56e467f3836a33c2e3b0d846d1b3ad9c2d88089ed32ab3007c3R228-R231) [[2]](diffhunk://#diff-8d6dabb2c50be56e467f3836a33c2e3b0d846d1b3ad9c2d88089ed32ab3007c3R324-R326) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R298-R300)

**Archive Management Implementation:**

* Introduced a new module `orchestrator/archive.rs` with functions to load, check, and record entries in the archive file, including tests for edge cases and compatibility with yt-dlp format.
* Integrated archive checking and recording into the orchestrator logic for both single video and playlist downloads, ensuring videos present in the archive are skipped and newly completed downloads are recorded. [[1]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R196-R219) [[2]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21L211-R234) [[3]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R252-R268) [[4]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L41-R43) [[5]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341R58) [[6]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341R162-R169) [[7]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341R182)

**Documentation and Workspace Updates:**

* Updated the workspace description in `README.md` to reflect the addition of the new crate `rdlp-table`.Records completed downloads as `{extractor} {id}` lines in a plain text file. On re-run, already-present entries are skipped via O(1) HashSet lookup. Works for both single videos and playlists. Compatible with yt-dlp's archive format.