### PR TITLE
Feature/container formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest,
 
 - **Performance** - 10+ MB/s downloads with parallel chunking and power-of-two sizing
 - **HLS support** - Full streaming with duration-based progress, DRM detection, live stream warnings
-- **Post-processing** - FFmpeg library bindings for remux, audio extraction, metadata/thumbnail embedding
+- **Post-processing** - FFmpeg library bindings for remux, audio extraction, video conversion, metadata/thumbnail embedding
+- **28 container formats** - MP4, MKV, WebM, MOV, AVI, TS, FLV, 3GP, MPG, ASF/WMV, MXF, VOB, IVF, and audio containers (MP3, FLAC, WAV, Opus, AAC, AIFF, etc.)
+- **16 video codecs** - H.264, H.265, VP8, VP9, AV1, VVC/H.266, MPEG-1/2/4, ProRes, DNxHD, Theora, FFV1, Xvid, WMV2
+- **14 audio codecs** - MP3, AAC, M4A, Opus, Vorbis, FLAC, ALAC, WAV, AC-3, E-AC-3, DTS, MP2, WavPack, TTA
 - **Resume** - Ctrl+C to pause, re-run to resume automatically
 - **Format selection** - yt-dlp-compatible DSL with filters, merge (`+`), and fallback chains (`/`)
 - **Interactive** - Arrow-key format selection, container remux menu
@@ -145,12 +148,12 @@ Rate limit supports binary unit suffixes: `K` (1024), `M` (1048576), `G` (107374
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--extract-audio` | `-x` | Extract audio only (requires FFmpeg) |
-| `--audio-format <FMT>` | | Audio format: `mp3`, `m4a`, `opus`, `flac`, `wav` (default: `mp3`) |
+| `--audio-format <FMT>` | | Audio format: `mp3`, `aac`, `m4a`, `opus`, `vorbis`, `flac`, `alac`, `wav`, `ac3`, `eac3`, `dts`, `mp2`, `wavpack`, `tta` (default: `mp3`) |
 | `--audio-quality <Q>` | | VBR level 0-9 or bitrate like `192K` |
 | `--embed-metadata` | | Embed title, artist, etc. in the file |
 | `--embed-thumbnail` | | Embed thumbnail in the file (requires FFmpeg) |
-| `--recode-video <FMT>` | | Re-encode video to format: `mp4`, `mkv`, `webm` |
-| `--remux[=FMT]` | | Remux to container without re-encoding. Use `--remux` for interactive, `--remux=mp4` for direct |
+| `--recode-video <FMT>` | | Re-encode video to format: `mp4`, `mkv`, `webm`, `mov`, `avi`, `ts`, `flv`, `3gp`, `mpg`, `asf`, and more |
+| `--remux[=FMT]` | | Remux to container without re-encoding (28 formats). Use `--remux` for interactive, `--remux=mp4` for direct |
 | `--keep-video` | | Keep original file after post-processing |
 | `--ffmpeg-location <PATH>` | | Path to FFmpeg if not in PATH |
 
@@ -235,7 +238,7 @@ rdlp/
 
 ```bash
 cargo build --release      # Optimized build
-cargo test                 # Run all tests (270+)
+cargo test                 # Run all tests (400+)
 cargo clippy               # Lint check
 cargo fmt                  # Format code
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ rdlp -f "worst" "https://www.redtube.com/12345678"
 rdlp -r 1M "https://www.redtube.com/12345678"
 rdlp --limit-rate 500K "https://www.redtube.com/12345678"
 
+# Extract audio (interactive format selection)
+rdlp -x --audio-format "https://www.redtube.com/12345678"
+rdlp -x --audio-format=flac "https://www.redtube.com/12345678"
+
+# Re-encode video (interactive codec selection)
+rdlp --recode-video "https://www.redtube.com/12345678"
+rdlp --recode-video=webm "https://www.redtube.com/12345678"
+
+# List supported codecs
+rdlp --list-codecs
+
 # Skip already-downloaded videos (playlist or repeated runs)
 rdlp --download-archive archive.txt "https://www.pornhub.com/playlist/123456"
 
@@ -133,6 +144,7 @@ rdlp [OPTIONS] [URL]
 | `--verbose` | `-v` | Detailed debug output |
 | `--list-extractors` | | List all supported site extractors |
 | `--list-downloaders` | | List all supported download protocols |
+| `--list-codecs` | | List all supported audio and video codecs |
 
 #### Network
 
@@ -148,11 +160,11 @@ Rate limit supports binary unit suffixes: `K` (1024), `M` (1048576), `G` (107374
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--extract-audio` | `-x` | Extract audio only (requires FFmpeg) |
-| `--audio-format <FMT>` | | Audio format: `mp3`, `aac`, `m4a`, `opus`, `vorbis`, `flac`, `alac`, `wav`, `ac3`, `eac3`, `dts`, `mp2`, `wavpack`, `tta` (default: `mp3`) |
+| `--audio-format[=FMT]` | | Audio format (14 codecs). Use `--audio-format` for interactive, `--audio-format=mp3` for direct |
 | `--audio-quality <Q>` | | VBR level 0-9 or bitrate like `192K` |
 | `--embed-metadata` | | Embed title, artist, etc. in the file |
 | `--embed-thumbnail` | | Embed thumbnail in the file (requires FFmpeg) |
-| `--recode-video <FMT>` | | Re-encode video to format: `mp4`, `mkv`, `webm`, `mov`, `avi`, `ts`, `flv`, `3gp`, `mpg`, `asf`, and more |
+| `--recode-video[=FMT]` | | Re-encode video (16 codecs). Use `--recode-video` for interactive, `--recode-video=mp4` for direct |
 | `--remux[=FMT]` | | Remux to container without re-encoding (28 formats). Use `--remux` for interactive, `--remux=mp4` for direct |
 | `--keep-video` | | Keep original file after post-processing |
 | `--ffmpeg-location <PATH>` | | Path to FFmpeg if not in PATH |

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -164,6 +164,8 @@ fn select_remux_container() -> Result<Option<ContainerFormat>> {
         (ContainerFormat::Mov, "Apple QuickTime, good for editing"),
         (ContainerFormat::Avi, "Legacy format, wide support"),
         (ContainerFormat::Ts, "MPEG-TS, broadcast/streaming"),
+        (ContainerFormat::Mp3, "Audio only, MPEG Layer 3"),
+        (ContainerFormat::Flac, "Audio only, lossless"),
     ];
 
     let items: Vec<String> = containers

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -58,6 +58,10 @@ struct Args {
     #[arg(long)]
     list_downloaders: bool,
 
+    /// List all supported audio and video codecs
+    #[arg(long)]
+    list_codecs: bool,
+
     /// Simulate (don't actually download)
     #[arg(short = 's', long)]
     simulate: bool,
@@ -71,8 +75,9 @@ struct Args {
     #[arg(short = 'x', long)]
     extract_audio: bool,
 
-    /// Audio format for extraction (mp3, m4a, opus, flac, wav)
-    #[arg(long)]
+    /// Audio format for extraction
+    /// Use --audio-format for interactive, --audio-format=mp3 for direct
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
     audio_format: Option<String>,
 
     /// Audio quality (VBR level 0-9 or bitrate like "192K")
@@ -87,8 +92,9 @@ struct Args {
     #[arg(long)]
     embed_thumbnail: bool,
 
-    /// Convert video to specified format (mp4, mkv, webm)
-    #[arg(long)]
+    /// Convert video to specified format
+    /// Use --recode-video for interactive, --recode-video=mp4 for direct
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
     recode_video: Option<String>,
 
     /// Remux to container for better seeking - no re-encoding
@@ -207,6 +213,115 @@ fn select_remux_container() -> Result<Option<ContainerFormat>> {
     Ok(selection.map(|idx| containers[idx].0))
 }
 
+/// Interactive audio format selection
+fn select_audio_format() -> Result<Option<AudioFormat>> {
+    let formats = [
+        (AudioFormat::Mp3, "MPEG Layer 3, most compatible"),
+        (AudioFormat::Aac, "Advanced Audio Coding"),
+        (AudioFormat::M4a, "AAC in M4A container"),
+        (AudioFormat::Opus, "Opus codec, excellent quality/size"),
+        (AudioFormat::Vorbis, "Ogg Vorbis"),
+        (AudioFormat::Flac, "Free Lossless Audio Codec"),
+        (AudioFormat::Alac, "Apple Lossless"),
+        (AudioFormat::Wav, "PCM waveform, uncompressed"),
+        (AudioFormat::Ac3, "Dolby Digital"),
+        (AudioFormat::Eac3, "Dolby Digital Plus"),
+        (AudioFormat::Dts, "DTS Coherent Acoustics"),
+        (AudioFormat::Mp2, "MPEG Layer 2"),
+        (AudioFormat::WavPack, "WavPack lossless"),
+        (AudioFormat::Tta, "True Audio lossless"),
+    ];
+
+    let items: Vec<String> = formats
+        .iter()
+        .map(|(fmt, desc)| format!("{:<8} {desc}", fmt.as_ext()))
+        .collect();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select audio format (ESC to cancel)")
+        .items(&items)
+        .default(0)
+        .interact_opt()?;
+
+    Ok(selection.map(|idx| formats[idx].0))
+}
+
+/// Interactive video recode format selection
+fn select_recode_video() -> Result<Option<ContainerFormat>> {
+    let formats = [
+        (ContainerFormat::Mp4, "h264", "Best compatibility, H.264"),
+        (ContainerFormat::Mkv, "h264", "Matroska, H.264"),
+        (ContainerFormat::WebM, "vp9", "Web-optimized, VP9"),
+        (ContainerFormat::Mov, "h264", "Apple QuickTime, H.264"),
+        (ContainerFormat::Avi, "h264", "Legacy AVI, H.264"),
+        (ContainerFormat::Mpg, "mpeg2", "MPEG program stream, MPEG-2"),
+        (ContainerFormat::Ts, "h264", "MPEG-TS, H.264"),
+        (ContainerFormat::ThreeGp, "h264", "3GPP mobile, H.264"),
+        (ContainerFormat::Flv, "h264", "Flash Video, H.264"),
+        (ContainerFormat::Asf, "wmv2", "Windows Media, WMV2"),
+    ];
+
+    let items: Vec<String> = formats
+        .iter()
+        .map(|(fmt, codec, desc)| format!("{:<6} [{codec}] {desc}", fmt.as_ext()))
+        .collect();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select video format (ESC to cancel)")
+        .items(&items)
+        .default(0)
+        .interact_opt()?;
+
+    Ok(selection.map(|idx| formats[idx].0))
+}
+
+/// Print all supported codecs
+fn print_codecs() {
+    println!("Audio codecs (14):");
+    let audio_codecs = [
+        ("mp3", "libmp3lame", "MPEG Layer 3"),
+        ("aac", "aac", "Advanced Audio Coding"),
+        ("m4a", "aac", "AAC in M4A container"),
+        ("opus", "libopus", "Opus codec"),
+        ("vorbis", "libvorbis", "Ogg Vorbis"),
+        ("flac", "flac", "Free Lossless Audio Codec"),
+        ("alac", "alac", "Apple Lossless"),
+        ("wav", "pcm_s16le", "PCM waveform"),
+        ("ac3", "ac3", "Dolby Digital"),
+        ("eac3", "eac3", "Dolby Digital Plus"),
+        ("dts", "dca", "DTS Coherent Acoustics"),
+        ("mp2", "mp2", "MPEG Layer 2"),
+        ("wavpack", "wavpack", "WavPack lossless"),
+        ("tta", "tta", "True Audio lossless"),
+    ];
+    for (name, encoder, desc) in audio_codecs {
+        println!("  {name:<10} [{encoder}]  {desc}");
+    }
+
+    println!();
+    println!("Video codecs (16):");
+    let video_codecs = [
+        ("h264", "libx264", "H.264 / AVC"),
+        ("h265", "libx265", "H.265 / HEVC"),
+        ("vp9", "libvpx-vp9", "VP9"),
+        ("vp8", "libvpx", "VP8"),
+        ("av1", "libaom-av1", "AV1"),
+        ("vvc", "libvvenc", "H.266 / VVC"),
+        ("mpeg1", "mpeg1video", "MPEG-1 Video"),
+        ("mpeg2", "mpeg2video", "MPEG-2 Video"),
+        ("mpeg4", "mpeg4", "MPEG-4 Part 2"),
+        ("theora", "libtheora", "Theora"),
+        ("prores", "prores_ks", "Apple ProRes"),
+        ("dnxhd", "dnxhd", "Avid DNxHD"),
+        ("wmv2", "wmv2", "Windows Media Video 8"),
+        ("ffv1", "ffv1", "FFV1 lossless archival"),
+        ("xvid", "libxvid", "Xvid (MPEG-4 ASP)"),
+    ];
+    for (name, encoder, desc) in video_codecs {
+        println!("  {name:<10} [{encoder}]  {desc}");
+    }
+}
+
 /// Writer that suspends progress bars while writing to prevent visual duplication
 #[derive(Clone)]
 struct SuspendingWriter {
@@ -276,12 +391,18 @@ fn build_config(args: &Args) -> Result<Config> {
     if args.extract_audio {
         config.extract_audio = true;
     }
-    if let Some(ref audio_format) = args.audio_format {
-        config.audio_format = Some(
-            audio_format
-                .parse::<AudioFormat>()
-                .map_err(|e| anyhow::anyhow!(e))?,
-        );
+    match args.audio_format.as_deref() {
+        Some("interactive") => {
+            config.audio_format = select_audio_format()?;
+        }
+        Some(audio_format) => {
+            config.audio_format = Some(
+                audio_format
+                    .parse::<AudioFormat>()
+                    .map_err(|e| anyhow::anyhow!(e))?,
+            );
+        }
+        None => {}
     }
     if let Some(ref audio_quality) = args.audio_quality {
         config.audio_quality = Some(audio_quality.clone());
@@ -292,12 +413,18 @@ fn build_config(args: &Args) -> Result<Config> {
     if args.embed_thumbnail {
         config.embed_thumbnail = true;
     }
-    if let Some(ref recode_video) = args.recode_video {
-        config.recode_video = Some(
-            recode_video
-                .parse::<ContainerFormat>()
-                .map_err(|e| anyhow::anyhow!(e))?,
-        );
+    match args.recode_video.as_deref() {
+        Some("interactive") => {
+            config.recode_video = select_recode_video()?;
+        }
+        Some(recode_video) => {
+            config.recode_video = Some(
+                recode_video
+                    .parse::<ContainerFormat>()
+                    .map_err(|e| anyhow::anyhow!(e))?,
+            );
+        }
+        None => {}
     }
     if args.keep_video {
         config.keep_video = true;
@@ -405,6 +532,11 @@ async fn async_main() -> Result<()> {
         for downloader in orchestrator.list_downloaders() {
             info!("  - {downloader}");
         }
+        return Ok(());
+    }
+
+    if args.list_codecs {
+        print_codecs();
         return Ok(());
     }
 

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -149,6 +149,7 @@ fn main() -> Result<()> {
 /// Interactive remux container selection
 fn select_remux_container() -> Result<Option<ContainerFormat>> {
     let containers = [
+        // Video containers
         (
             ContainerFormat::Mp4,
             "Best compatibility, faststart for streaming",
@@ -164,8 +165,32 @@ fn select_remux_container() -> Result<Option<ContainerFormat>> {
         (ContainerFormat::Mov, "Apple QuickTime, good for editing"),
         (ContainerFormat::Avi, "Legacy format, wide support"),
         (ContainerFormat::Ts, "MPEG-TS, broadcast/streaming"),
+        (ContainerFormat::Flv, "Flash Video, legacy"),
+        (ContainerFormat::ThreeGp, "3GPP mobile video"),
+        (ContainerFormat::Mpg, "MPEG-1/2 program stream"),
+        (ContainerFormat::F4v, "Flash Video (MP4 variant)"),
+        (ContainerFormat::Asf, "Windows Media / ASF"),
+        (
+            ContainerFormat::Mxf,
+            "Material eXchange, broadcast/professional",
+        ),
+        (ContainerFormat::Vob, "DVD Video Object"),
+        (ContainerFormat::Dv, "Digital Video"),
+        (ContainerFormat::Nut, "NUT (FFmpeg native container)"),
+        (ContainerFormat::Ivf, "On2 IVF (VP8/VP9/AV1 raw)"),
+        // Audio containers
         (ContainerFormat::Mp3, "Audio only, MPEG Layer 3"),
         (ContainerFormat::Flac, "Audio only, lossless"),
+        (ContainerFormat::Wav, "Audio only, PCM waveform"),
+        (ContainerFormat::Ogg, "Audio only, Ogg container"),
+        (ContainerFormat::M4a, "Audio only, MPEG-4 Audio"),
+        (ContainerFormat::Opus, "Audio only, Ogg Opus"),
+        (ContainerFormat::Aac, "Audio only, raw ADTS AAC"),
+        (ContainerFormat::Aiff, "Audio only, Apple AIFF"),
+        (ContainerFormat::Mka, "Audio only, Matroska Audio"),
+        (ContainerFormat::Wv, "Audio only, WavPack lossless"),
+        (ContainerFormat::Caf, "Audio only, Core Audio Format"),
+        (ContainerFormat::Ac3, "Audio only, Dolby AC-3"),
     ];
 
     let items: Vec<String> = containers

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -148,6 +148,60 @@ pub static AUDIO_CODECS: &[(&str, AudioCodecConfig)] = &[
             bitrate_range: None,
         },
     ),
+    (
+        "ac3",
+        AudioCodecConfig {
+            encoder: Some("ac3"),
+            extension: "ac3",
+            quality_scale: None,
+            bitrate_range: Some((64, 640)),
+        },
+    ),
+    (
+        "eac3",
+        AudioCodecConfig {
+            encoder: Some("eac3"),
+            extension: "eac3",
+            quality_scale: None,
+            bitrate_range: Some((32, 6144)),
+        },
+    ),
+    (
+        "dts",
+        AudioCodecConfig {
+            encoder: Some("dca"),
+            extension: "dts",
+            quality_scale: None,
+            bitrate_range: Some((32, 3840)),
+        },
+    ),
+    (
+        "mp2",
+        AudioCodecConfig {
+            encoder: Some("mp2"),
+            extension: "mp2",
+            quality_scale: None,
+            bitrate_range: Some((32, 384)),
+        },
+    ),
+    (
+        "wavpack",
+        AudioCodecConfig {
+            encoder: Some("wavpack"),
+            extension: "wv",
+            quality_scale: None,
+            bitrate_range: None, // Lossless
+        },
+    ),
+    (
+        "tta",
+        AudioCodecConfig {
+            encoder: Some("tta"),
+            extension: "tta",
+            quality_scale: None,
+            bitrate_range: None, // Lossless
+        },
+    ),
 ];
 
 /// Get audio codec configuration by name.

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -139,8 +139,13 @@ mod tests {
         assert!(FFmpegRemuxer::is_supported_container("ts"));
         assert!(FFmpegRemuxer::is_supported_container("flv"));
 
+        // Aliases
+        assert!(FFmpegRemuxer::is_supported_container("wmv"));
+        assert!(FFmpegRemuxer::is_supported_container("3gp"));
+        assert!(FFmpegRemuxer::is_supported_container("flac"));
+
         // Unsupported
-        assert!(!FFmpegRemuxer::is_supported_container("wmv"));
+        assert!(!FFmpegRemuxer::is_supported_container("xyz"));
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -22,6 +22,17 @@ const VIDEO_CODECS: &[(&str, &str)] = &[
     ("vp9", "libvpx-vp9"),
     ("vp8", "libvpx"),
     ("av1", "libaom-av1"),
+    ("vvc", "libvvenc"),
+    ("h266", "libvvenc"),
+    ("mpeg1", "mpeg1video"),
+    ("mpeg2", "mpeg2video"),
+    ("mpeg4", "mpeg4"),
+    ("theora", "libtheora"),
+    ("prores", "prores_ks"),
+    ("dnxhd", "dnxhd"),
+    ("wmv2", "wmv2"),
+    ("ffv1", "ffv1"),
+    ("xvid", "libxvid"),
 ];
 
 ffmpeg_processor!(
@@ -54,15 +65,33 @@ impl FFmpegVideoConvertor {
     fn can_remux(input_ext: &str, output_ext: &str, video_codec: Option<&str>) -> bool {
         // Check if the codec is compatible with the target container
         match (output_ext.to_lowercase().as_str(), video_codec) {
-            // MP4 supports H.264, H.265, MPEG-4
-            ("mp4", Some(c)) => matches!(
+            // MP4/F4v supports H.264, H.265, MPEG-4, AV1
+            ("mp4" | "f4v", Some(c)) => matches!(
                 c.to_lowercase().as_str(),
-                "h264" | "avc" | "h265" | "hevc" | "mpeg4"
+                "h264" | "avc" | "h265" | "hevc" | "mpeg4" | "av1"
             ),
-            // MKV supports almost everything
-            ("mkv", _) => true,
+            // MKV, MKA, NUT, MXF accept almost everything
+            ("mkv" | "mka" | "nut" | "mxf", _) => true,
             // WebM supports VP8, VP9, AV1
             ("webm", Some(c)) => matches!(c.to_lowercase().as_str(), "vp8" | "vp9" | "av1"),
+            // IVF supports VP8, VP9, AV1
+            ("ivf", Some(c)) => matches!(c.to_lowercase().as_str(), "vp8" | "vp9" | "av1"),
+            // 3GP supports H.264, H.263, MPEG-4
+            ("3gp", Some(c)) => {
+                matches!(c.to_lowercase().as_str(), "h264" | "avc" | "h263" | "mpeg4")
+            }
+            // ASF/WMV supports WMV, H.264, MPEG-4
+            ("asf", Some(c)) => matches!(
+                c.to_lowercase().as_str(),
+                "wmv1" | "wmv2" | "h264" | "avc" | "mpeg4"
+            ),
+            // MPEG/VOB supports MPEG-1, MPEG-2, MPEG-4
+            ("mpg" | "vob", Some(c)) => matches!(
+                c.to_lowercase().as_str(),
+                "mpeg1" | "mpeg1video" | "mpeg2" | "mpeg2video" | "mpeg4"
+            ),
+            // AVI supports most codecs
+            ("avi", _) => true,
             // Same container - can copy
             _ if input_ext.eq_ignore_ascii_case(output_ext) => true,
             _ => false,
@@ -82,14 +111,18 @@ impl FFmpegVideoConvertor {
         // Determine target codec from container
         let target_codec = match target_format {
             "webm" => "vp9",
-            "mp4" | "mov" | "mkv" => "h264",
+            "ivf" => "vp9",
+            "ogg" => "theora",
+            "mpg" | "vob" => "mpeg2",
             _ => "h264",
         };
 
         let encoder = Self::get_encoder(target_codec);
         let (preset, crf) = match target_codec {
-            "h264" | "h265" | "hevc" => (Some("medium".to_string()), Some(23)),
-            "vp9" => (None, Some(30)),
+            "h264" | "h265" | "hevc" | "vvc" | "h266" => (Some("medium".to_string()), Some(23)),
+            "vp9" | "vp8" => (None, Some(30)),
+            "av1" => (None, Some(28)),
+            "mpeg2" | "mpeg4" | "theora" => (None, None),
             _ => (None, None),
         };
 

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -24,6 +24,18 @@ pub enum AudioFormat {
     Alac,
     /// Waveform Audio File Format (PCM)
     Wav,
+    /// Dolby Digital (AC-3)
+    Ac3,
+    /// Dolby Digital Plus (Enhanced AC-3)
+    Eac3,
+    /// DTS Coherent Acoustics
+    Dts,
+    /// MPEG Audio Layer 2
+    Mp2,
+    /// WavPack lossless
+    WavPack,
+    /// True Audio lossless
+    Tta,
 }
 
 impl AudioFormat {
@@ -39,6 +51,12 @@ impl AudioFormat {
             Self::Flac => "flac",
             Self::Alac => "m4a",
             Self::Wav => "wav",
+            Self::Ac3 => "ac3",
+            Self::Eac3 => "eac3",
+            Self::Dts => "dts",
+            Self::Mp2 => "mp2",
+            Self::WavPack => "wv",
+            Self::Tta => "tta",
         }
     }
 
@@ -54,6 +72,12 @@ impl AudioFormat {
             Self::Flac => "flac",
             Self::Alac => "alac",
             Self::Wav => "wav",
+            Self::Ac3 => "ac3",
+            Self::Eac3 => "eac3",
+            Self::Dts => "dts",
+            Self::Mp2 => "mp2",
+            Self::WavPack => "wavpack",
+            Self::Tta => "tta",
         }
     }
 }
@@ -77,6 +101,12 @@ impl FromStr for AudioFormat {
             "flac" => Ok(Self::Flac),
             "alac" => Ok(Self::Alac),
             "wav" => Ok(Self::Wav),
+            "ac3" => Ok(Self::Ac3),
+            "eac3" | "e-ac-3" | "e-ac3" => Ok(Self::Eac3),
+            "dts" | "dca" => Ok(Self::Dts),
+            "mp2" => Ok(Self::Mp2),
+            "wavpack" | "wv" => Ok(Self::WavPack),
+            "tta" => Ok(Self::Tta),
             _ => Err(format!("unsupported audio format: {s}")),
         }
     }
@@ -97,11 +127,26 @@ mod tests {
             AudioFormat::Flac,
             AudioFormat::Alac,
             AudioFormat::Wav,
+            AudioFormat::Ac3,
+            AudioFormat::Eac3,
+            AudioFormat::Dts,
+            AudioFormat::Mp2,
+            AudioFormat::WavPack,
+            AudioFormat::Tta,
         ] {
             let s = fmt.to_string();
             let parsed: AudioFormat = s.parse().unwrap();
-            assert_eq!(fmt, parsed);
+            assert_eq!(fmt, parsed, "roundtrip failed for {s}");
         }
+    }
+
+    #[test]
+    fn test_alias_parsing() {
+        assert_eq!("ogg".parse::<AudioFormat>().unwrap(), AudioFormat::Vorbis);
+        assert_eq!("e-ac-3".parse::<AudioFormat>().unwrap(), AudioFormat::Eac3);
+        assert_eq!("e-ac3".parse::<AudioFormat>().unwrap(), AudioFormat::Eac3);
+        assert_eq!("dca".parse::<AudioFormat>().unwrap(), AudioFormat::Dts);
+        assert_eq!("wv".parse::<AudioFormat>().unwrap(), AudioFormat::WavPack);
     }
 
     #[test]

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -10,9 +10,10 @@ use std::str::FromStr;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ContainerFormat {
-    /// MPEG-4 Part 14 - best compatibility, supports faststart
+    // === Video containers ===
+    /// MPEG-4 Part 14 — best compatibility, supports faststart
     Mp4,
-    /// Matroska - supports all codecs, efficient cues index
+    /// Matroska — supports all codecs, efficient cues index
     Mkv,
     /// Web-optimized, VP8/VP9/AV1 + Opus/Vorbis
     WebM,
@@ -24,10 +25,50 @@ pub enum ContainerFormat {
     Flv,
     /// Audio Video Interleave, legacy format
     Avi,
+    /// 3GPP mobile video
+    ThreeGp,
+    /// MPEG-1/2 program stream
+    Mpg,
+    /// Flash Video (MP4 variant)
+    F4v,
+    /// Advanced Streaming Format / Windows Media
+    Asf,
+    /// Material eXchange Format (broadcast/professional)
+    Mxf,
+    /// DVD Video Object
+    Vob,
+    /// Digital Video
+    Dv,
+    /// NUT (FFmpeg native container)
+    Nut,
+    /// On2 IVF (VP8/VP9/AV1 raw)
+    Ivf,
+
+    // === Audio containers ===
     /// Ogg container
     Ogg,
     /// MPEG-4 Audio (audio-only container)
     M4a,
+    /// MPEG Audio Layer 3
+    Mp3,
+    /// Waveform Audio (PCM)
+    Wav,
+    /// Free Lossless Audio Codec
+    Flac,
+    /// Ogg Opus
+    Opus,
+    /// Raw ADTS AAC
+    Aac,
+    /// Audio Interchange File Format (Apple)
+    Aiff,
+    /// Matroska Audio
+    Mka,
+    /// WavPack lossless
+    Wv,
+    /// Core Audio Format (Apple)
+    Caf,
+    /// Dolby AC-3
+    Ac3,
 }
 
 impl ContainerFormat {
@@ -42,15 +83,54 @@ impl ContainerFormat {
             Self::Ts => "ts",
             Self::Flv => "flv",
             Self::Avi => "avi",
+            Self::ThreeGp => "3gp",
+            Self::Mpg => "mpg",
+            Self::F4v => "f4v",
+            Self::Asf => "asf",
+            Self::Mxf => "mxf",
+            Self::Vob => "vob",
+            Self::Dv => "dv",
+            Self::Nut => "nut",
+            Self::Ivf => "ivf",
             Self::Ogg => "ogg",
             Self::M4a => "m4a",
+            Self::Mp3 => "mp3",
+            Self::Wav => "wav",
+            Self::Flac => "flac",
+            Self::Opus => "opus",
+            Self::Aac => "aac",
+            Self::Aiff => "aiff",
+            Self::Mka => "mka",
+            Self::Wv => "wv",
+            Self::Caf => "caf",
+            Self::Ac3 => "ac3",
         }
     }
 
     /// Whether this container supports faststart (moov atom at beginning).
     #[must_use]
     pub fn supports_faststart(&self) -> bool {
-        matches!(self, Self::Mp4 | Self::Mov)
+        matches!(self, Self::Mp4 | Self::Mov | Self::F4v)
+    }
+
+    /// Whether this is an audio-only container format.
+    #[must_use]
+    pub fn is_audio_only(&self) -> bool {
+        matches!(
+            self,
+            Self::Ogg
+                | Self::M4a
+                | Self::Mp3
+                | Self::Wav
+                | Self::Flac
+                | Self::Opus
+                | Self::Aac
+                | Self::Aiff
+                | Self::Mka
+                | Self::Wv
+                | Self::Caf
+                | Self::Ac3
+        )
     }
 }
 
@@ -72,8 +152,27 @@ impl FromStr for ContainerFormat {
             "ts" | "mpegts" => Ok(Self::Ts),
             "flv" => Ok(Self::Flv),
             "avi" => Ok(Self::Avi),
+            "3gp" | "3gpp" => Ok(Self::ThreeGp),
+            "mpg" | "mpeg" => Ok(Self::Mpg),
+            "f4v" => Ok(Self::F4v),
+            "asf" | "wmv" | "wma" => Ok(Self::Asf),
+            "mxf" => Ok(Self::Mxf),
+            "vob" => Ok(Self::Vob),
+            "dv" => Ok(Self::Dv),
+            "nut" => Ok(Self::Nut),
+            "ivf" => Ok(Self::Ivf),
             "ogg" => Ok(Self::Ogg),
             "m4a" => Ok(Self::M4a),
+            "mp3" => Ok(Self::Mp3),
+            "wav" | "wave" => Ok(Self::Wav),
+            "flac" => Ok(Self::Flac),
+            "opus" => Ok(Self::Opus),
+            "aac" | "adts" => Ok(Self::Aac),
+            "aiff" | "aif" => Ok(Self::Aiff),
+            "mka" => Ok(Self::Mka),
+            "wv" | "wavpack" => Ok(Self::Wv),
+            "caf" => Ok(Self::Caf),
+            "ac3" => Ok(Self::Ac3),
             _ => Err(format!("unsupported container format: {s}")),
         }
     }
@@ -83,23 +182,93 @@ impl FromStr for ContainerFormat {
 mod tests {
     use super::*;
 
+    /// All variants for exhaustive testing.
+    const ALL_FORMATS: [ContainerFormat; 28] = [
+        ContainerFormat::Mp4,
+        ContainerFormat::Mkv,
+        ContainerFormat::WebM,
+        ContainerFormat::Mov,
+        ContainerFormat::Ts,
+        ContainerFormat::Flv,
+        ContainerFormat::Avi,
+        ContainerFormat::ThreeGp,
+        ContainerFormat::Mpg,
+        ContainerFormat::F4v,
+        ContainerFormat::Asf,
+        ContainerFormat::Mxf,
+        ContainerFormat::Vob,
+        ContainerFormat::Dv,
+        ContainerFormat::Nut,
+        ContainerFormat::Ivf,
+        ContainerFormat::Ogg,
+        ContainerFormat::M4a,
+        ContainerFormat::Mp3,
+        ContainerFormat::Wav,
+        ContainerFormat::Flac,
+        ContainerFormat::Opus,
+        ContainerFormat::Aac,
+        ContainerFormat::Aiff,
+        ContainerFormat::Mka,
+        ContainerFormat::Wv,
+        ContainerFormat::Caf,
+        ContainerFormat::Ac3,
+    ];
+
     #[test]
     fn test_display_roundtrip() {
-        for fmt in [
-            ContainerFormat::Mp4,
-            ContainerFormat::Mkv,
-            ContainerFormat::WebM,
-            ContainerFormat::Mov,
-            ContainerFormat::Ts,
-            ContainerFormat::Flv,
-            ContainerFormat::Avi,
-            ContainerFormat::Ogg,
-            ContainerFormat::M4a,
-        ] {
+        for fmt in ALL_FORMATS {
             let s = fmt.to_string();
             let parsed: ContainerFormat = s.parse().unwrap();
-            assert_eq!(fmt, parsed);
+            assert_eq!(fmt, parsed, "roundtrip failed for {s}");
         }
+    }
+
+    #[test]
+    fn test_alias_parsing() {
+        assert_eq!(
+            "matroska".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Mkv
+        );
+        assert_eq!(
+            "quicktime".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Mov
+        );
+        assert_eq!(
+            "mpegts".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Ts
+        );
+        assert_eq!(
+            "3gpp".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::ThreeGp
+        );
+        assert_eq!(
+            "mpeg".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Mpg
+        );
+        assert_eq!(
+            "wmv".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Asf
+        );
+        assert_eq!(
+            "wma".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Asf
+        );
+        assert_eq!(
+            "wave".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Wav
+        );
+        assert_eq!(
+            "adts".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Aac
+        );
+        assert_eq!(
+            "aif".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Aiff
+        );
+        assert_eq!(
+            "wavpack".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Wv
+        );
     }
 
     #[test]
@@ -113,8 +282,12 @@ mod tests {
             ContainerFormat::Mkv
         );
         assert_eq!(
-            "Matroska".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Mkv
+            "WMV".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Asf
+        );
+        assert_eq!(
+            "FLAC".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::Flac
         );
     }
 
@@ -131,6 +304,27 @@ mod tests {
     fn test_faststart() {
         assert!(ContainerFormat::Mp4.supports_faststart());
         assert!(ContainerFormat::Mov.supports_faststart());
+        assert!(ContainerFormat::F4v.supports_faststart());
         assert!(!ContainerFormat::Mkv.supports_faststart());
+        assert!(!ContainerFormat::Avi.supports_faststart());
+    }
+
+    #[test]
+    fn test_is_audio_only() {
+        // Audio containers
+        assert!(ContainerFormat::Mp3.is_audio_only());
+        assert!(ContainerFormat::Wav.is_audio_only());
+        assert!(ContainerFormat::Flac.is_audio_only());
+        assert!(ContainerFormat::Opus.is_audio_only());
+        assert!(ContainerFormat::Aac.is_audio_only());
+        assert!(ContainerFormat::M4a.is_audio_only());
+        assert!(ContainerFormat::Ogg.is_audio_only());
+        assert!(ContainerFormat::Mka.is_audio_only());
+        assert!(ContainerFormat::Ac3.is_audio_only());
+
+        // Video containers
+        assert!(!ContainerFormat::Mp4.is_audio_only());
+        assert!(!ContainerFormat::Mkv.is_audio_only());
+        assert!(!ContainerFormat::Avi.is_audio_only());
     }
 }


### PR DESCRIPTION
This pull request significantly expands and improves codec and container format support, enhances the CLI with interactive and listing features, and updates documentation to reflect these capabilities. Key changes include support for 14 audio codecs and 16 video codecs, interactive format selection for audio and video, and a new `--list-codecs` command. The documentation and tests have also been updated to match the expanded functionality.

**Major feature expansions:**

* Added support for 14 audio codecs (including AC-3, E-AC-3, DTS, MP2, WavPack, TTA) and 16 video codecs (including AV1, VVC/H.266, ProRes, DNxHD, Theora, FFV1, Xvid, WMV2) throughout the codebase. (`crates/rdlp-types/src/audio_format.rs`, `crates/rdlp-postprocess/src/ffmpeg.rs`, `crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs`, `README.md`) [[1]](diffhunk://#diff-5cb27dac9b97552e1532b36421b160b2e68b21192121af8a924a860ebf9df030R27-R38) [[2]](diffhunk://#diff-5cb27dac9b97552e1532b36421b160b2e68b21192121af8a924a860ebf9df030R54-R59) [[3]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249R151-R204) [[4]](diffhunk://#diff-4df8b54e729fb72feca279d7e10c70603af36ed139715c87e4710826d5498906R25-R35) [[5]](diffhunk://#diff-4df8b54e729fb72feca279d7e10c70603af36ed139715c87e4710826d5498906L57-R94) [[6]](diffhunk://#diff-4df8b54e729fb72feca279d7e10c70603af36ed139715c87e4710826d5498906L85-R125) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R18)
* Greatly expanded supported container formats (now 28), including legacy and pro formats, and improved remuxing compatibility logic. (`crates/rdlp-cli/src/main.rs`, `crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs`, `README.md`) [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R158) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R174-R199) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R18)

**CLI and user experience improvements:**

* Added interactive selection for audio extraction format (`--audio-format`) and video recoding format (`--recode-video`), as well as a new `--list-codecs` command to display all supported codecs. (`crates/rdlp-cli/src/main.rs`, `README.md`) [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L74-R80) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L90-R97) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R216-R324) [[4]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R538-R542) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R89) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R168)
* Updated CLI argument handling to support interactive and direct codec selection for audio and video, with improved help texts and argument parsing. (`crates/rdlp-cli/src/main.rs`, `README.md`) [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L74-R80) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L90-R97) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R168)

**Documentation and test updates:**

* Updated `README.md` to document all new codecs, containers, CLI options, and usage examples. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R89) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R168) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L238-R253)
* Expanded and corrected tests for supported containers and aliases. (`crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs`)

These changes make the tool much more versatile for advanced users, while also improving usability for common workflows.