### PR TITLE
Feature/json dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest,
 - **Cookie support** - Browser extraction (Chrome, Firefox) and Netscape cookie files
 - **Rate limiting** - Global bandwidth throttle with human-readable rates (`1M`, `500K`, `2.5G`)
 - **Download archive** - Skip already-downloaded videos on re-run (`--download-archive`)
+- **JSON metadata** - `--dump-json` and `--print` for scripting (`rdlp --dump-json URL | jq .title`)
 
 ### Supported Sites
 
@@ -90,6 +91,14 @@ rdlp --list-codecs
 # Skip already-downloaded videos (playlist or repeated runs)
 rdlp --download-archive archive.txt "https://www.pornhub.com/playlist/123456"
 
+# Dump metadata as JSON (no download)
+rdlp --dump-json "https://www.redtube.com/12345678"
+rdlp --dump-json "https://www.redtube.com/12345678" | jq .title
+
+# Print specific fields
+rdlp --print title "https://www.redtube.com/12345678"
+rdlp --print "id,title,extractor" "https://www.redtube.com/12345678"
+
 # Verbose mode
 rdlp -v "https://www.redtube.com/12345678"
 ```
@@ -139,7 +148,9 @@ rdlp [OPTIONS] [URL]
 | `--output <DIR>` | `-o` | Output directory (default: `.`) |
 | `--format <FMT>` | `-f` | Format selection, yt-dlp syntax (default: `best`) |
 | `--interactive` | `-i` | Interactive format selection with arrow keys |
-| `--simulate` | `-s` | Simulate only, don't download |
+| `--dump-json` | `-j` | Dump full metadata as JSON to stdout (no download) |
+| `--print <FIELDS>` | | Print specific metadata field(s), comma-separated (no download) |
+| `--simulate` | `-s` | Simulate only, show metadata summary |
 | `--quiet` | `-q` | Minimal output |
 | `--verbose` | `-v` | Detailed debug output |
 | `--list-extractors` | | List all supported site extractors |

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -7,10 +7,10 @@ use clap::Parser;
 use dialoguer::{Select, theme::ColorfulTheme};
 use indicatif::MultiProgress;
 use rdlp_cli::Orchestrator;
-use rdlp_core::{AudioFormat, BrowserType, Config, ContainerFormat, config_io};
+use rdlp_core::{AudioFormat, BrowserType, Config, ContainerFormat, InfoDict, config_io};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -62,9 +62,18 @@ struct Args {
     #[arg(long)]
     list_codecs: bool,
 
-    /// Simulate (don't actually download)
+    /// Simulate (don't actually download, shows extraction summary)
     #[arg(short = 's', long)]
     simulate: bool,
+
+    /// Dump full metadata as JSON to stdout (no download)
+    #[arg(short = 'j', long)]
+    dump_json: bool,
+
+    /// Print specific field(s) from metadata (no download)
+    /// e.g., --print title or --print "id,title,extractor"
+    #[arg(long)]
+    print: Option<String>,
 
     /// Interactive format selection
     #[arg(short = 'i', long)]
@@ -322,6 +331,29 @@ fn print_codecs() {
     }
 }
 
+/// Print specific fields from an InfoDict
+fn print_fields(info: &InfoDict, fields: &str) -> Result<()> {
+    let value = serde_json::to_value(info)?;
+    let map = value.as_object().expect("InfoDict serializes to object");
+
+    for field in fields.split(',') {
+        let field = field.trim();
+        if field.is_empty() {
+            continue;
+        }
+        match map.get(field) {
+            Some(serde_json::Value::String(s)) => println!("{field}: {s}"),
+            Some(serde_json::Value::Null) => println!("{field}:"),
+            Some(v) => println!("{field}: {v}"),
+            None => {
+                warn!("Unknown field: {field}");
+                eprintln!("Warning: unknown field '{field}'");
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Writer that suspends progress bars while writing to prevent visual duplication
 #[derive(Clone)]
 struct SuspendingWriter {
@@ -545,10 +577,35 @@ async fn async_main() -> Result<()> {
         .url
         .ok_or_else(|| anyhow::anyhow!("No URL provided. Use --help for usage information."))?;
 
-    // Download the video
-    if args.simulate {
-        info!("[Simulate] No actual download will occur");
-        info!("URL: {url}");
+    // Metadata-only modes: --dump-json, --print, --simulate
+    if args.dump_json || args.print.is_some() || args.simulate {
+        let infos = orchestrator.extract_info(&url).await?;
+
+        if args.dump_json {
+            for info in &infos {
+                let json = serde_json::to_string_pretty(info)?;
+                println!("{json}");
+            }
+        }
+
+        if let Some(ref fields) = args.print {
+            for info in &infos {
+                print_fields(info, fields)?;
+            }
+        }
+
+        if args.simulate && !args.dump_json && args.print.is_none() {
+            for info in &infos {
+                info!(
+                    "[Simulate] {} | id={} | extractor={} | {} format(s)",
+                    info.title,
+                    info.id,
+                    info.extractor,
+                    info.formats.len()
+                );
+            }
+        }
+
         return Ok(());
     }
 

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -238,6 +238,11 @@ impl Orchestrator {
         }
     }
 
+    /// Extract metadata without downloading (for --dump-json / --print / --simulate)
+    pub async fn extract_info(&self, url: &str) -> Result<Vec<rdlp_core::InfoDict>> {
+        self.extract_playlist_info(url).await
+    }
+
     /// List all available extractors
     #[must_use]
     pub fn list_extractors(&self) -> Vec<&str> {


### PR DESCRIPTION
This pull request adds new options for metadata extraction and printing to the CLI, including `--dump-json` and `--print`, and updates the documentation and codebase to support these features. The main changes focus on enabling users to extract and print video metadata without downloading, improving scripting and automation capabilities.

**New metadata extraction features:**

* Added `--dump-json` (`-j`) flag to output full video metadata as JSON to stdout without downloading the video. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L65-R77) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L548-R608) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R153)
* Added `--print` flag to print specific metadata fields (comma-separated) from the extracted info, also without downloading. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L65-R77) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R334-R356) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L548-R608) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R153)
* Updated the `--simulate` flag to show a metadata summary instead of just skipping download. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L65-R77) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L548-R608) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R153)

**Documentation updates:**

* Updated the `README.md` to document the new `--dump-json` and `--print` options, including usage examples and option descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R101) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R153)

**Internal code changes:**

* Added a new `extract_info` method to `Orchestrator` for extracting metadata without downloading, used by the new CLI options.
* Refactored imports and logging to support the new features.