### PR TITLE
Feature/thumbnail download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mp4ameta"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453e991b2efe96c288cbc2d03a19e353504294559ecb6c03067fff5bd824616d"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2393,7 @@ dependencies = [
  "async-trait",
  "ffmpeg-the-third",
  "log",
+ "mp4ameta",
  "rdlp-core",
  "serde",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest,
 
 - **Performance** - 10+ MB/s downloads with parallel chunking and power-of-two sizing
 - **HLS support** - Full streaming with duration-based progress, DRM detection, live stream warnings
-- **Post-processing** - FFmpeg library bindings for remux, audio extraction, video conversion, metadata/thumbnail embedding
+- **Post-processing** - FFmpeg library bindings for remux, audio extraction, video conversion, metadata embedding
+- **Thumbnails** - Auto-download and embed cover art; MP4 uses iTunes `covr` atom for Windows Explorer visibility
 - **28 container formats** - MP4, MKV, WebM, MOV, AVI, TS, FLV, 3GP, MPG, ASF/WMV, MXF, VOB, IVF, and audio containers (MP3, FLAC, WAV, Opus, AAC, AIFF, etc.)
 - **16 video codecs** - H.264, H.265, VP8, VP9, AV1, VVC/H.266, MPEG-1/2/4, ProRes, DNxHD, Theora, FFV1, Xvid, WMV2
 - **14 audio codecs** - MP3, AAC, M4A, Opus, Vorbis, FLAC, ALAC, WAV, AC-3, E-AC-3, DTS, MP2, WavPack, TTA
@@ -87,6 +88,10 @@ rdlp --recode-video=webm "https://www.redtube.com/12345678"
 
 # List supported codecs
 rdlp --list-codecs
+
+# Thumbnail control
+rdlp --no-thumbnail "https://www.redtube.com/12345678"       # Skip thumbnail download/embed
+rdlp --write-thumbnail "https://www.redtube.com/12345678"     # Keep thumbnail file on disk
 
 # Skip already-downloaded videos (playlist or repeated runs)
 rdlp --download-archive archive.txt "https://www.pornhub.com/playlist/123456"
@@ -174,7 +179,9 @@ Rate limit supports binary unit suffixes: `K` (1024), `M` (1048576), `G` (107374
 | `--audio-format[=FMT]` | | Audio format (14 codecs). Use `--audio-format` for interactive, `--audio-format=mp3` for direct |
 | `--audio-quality <Q>` | | VBR level 0-9 or bitrate like `192K` |
 | `--embed-metadata` | | Embed title, artist, etc. in the file |
-| `--embed-thumbnail` | | Embed thumbnail in the file (requires FFmpeg) |
+| `--embed-thumbnail` | | Embed thumbnail in the file (default: on). MP4 writes both `attached_pic` stream and iTunes `covr` atom |
+| `--no-thumbnail` | | Disable automatic thumbnail download and embedding |
+| `--write-thumbnail` | | Keep thumbnail image file on disk alongside media file |
 | `--recode-video[=FMT]` | | Re-encode video (16 codecs). Use `--recode-video` for interactive, `--recode-video=mp4` for direct |
 | `--remux[=FMT]` | | Remux to container without re-encoding (28 formats). Use `--remux` for interactive, `--remux=mp4` for direct |
 | `--keep-video` | | Keep original file after post-processing |

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -97,9 +97,13 @@ struct Args {
     #[arg(long)]
     embed_metadata: bool,
 
-    /// Embed thumbnail in the file (requires FFmpeg)
+    /// Disable automatic thumbnail download and embedding
     #[arg(long)]
-    embed_thumbnail: bool,
+    no_thumbnail: bool,
+
+    /// Write thumbnail image to disk alongside media file
+    #[arg(long)]
+    write_thumbnail: bool,
 
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
@@ -442,8 +446,11 @@ fn build_config(args: &Args) -> Result<Config> {
     if args.embed_metadata {
         config.embed_metadata = true;
     }
-    if args.embed_thumbnail {
-        config.embed_thumbnail = true;
+    if args.no_thumbnail {
+        config.embed_thumbnail = false;
+    }
+    if args.write_thumbnail {
+        config.write_thumbnail = true;
     }
     match args.recode_video.as_deref() {
         Some("interactive") => {

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -10,6 +10,7 @@ mod postprocess;
 mod resume;
 mod selection;
 mod state;
+mod thumbnail;
 
 #[cfg(test)]
 mod tests;

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -435,6 +435,11 @@ impl Orchestrator {
         info!(path:? = output_path.display(); "   File");
         info!(stats:?; "   Stats");
 
+        // Download thumbnail if needed (before post-processing so embed can find it)
+        if self.config.embed_thumbnail || self.config.write_thumbnail {
+            self.download_thumbnail(info, &output_path).await;
+        }
+
         // Run post-processing if configured (or automatic for HLS)
         let final_files = self
             .run_postprocessing(info, vec![output_path.clone()], is_hls)

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -18,6 +18,7 @@ impl Orchestrator {
             remux_container: self.config.remux_container,
             merge_output_format: self.config.merge_output_format,
             embed_thumbnail: self.config.embed_thumbnail,
+            write_thumbnail: self.config.write_thumbnail,
             embed_metadata: self.config.embed_metadata,
             embed_subtitles: self.config.embed_subtitles,
             keep_video: self.config.keep_video,
@@ -182,6 +183,7 @@ impl Orchestrator {
     /// Also runs user-requested post-processing (extract audio, embed metadata, etc.)
     pub(super) async fn run_postprocessing_for_state_machine(
         &self,
+        info: &rdlp_core::InfoDict,
         output_path: &Path,
         is_hls: bool,
     ) -> Result<PathBuf> {
@@ -191,19 +193,8 @@ impl Orchestrator {
             if let Some(fixed_path) = fixed_files.into_iter().next() {
                 // If user also requested additional post-processing, run it
                 if self.needs_postprocessing() {
-                    let info = rdlp_core::InfoDict::new(
-                        "unknown".to_string(),
-                        fixed_path
-                            .file_stem()
-                            .and_then(|s| s.to_str())
-                            .unwrap_or("Unknown")
-                            .to_string(),
-                        "unknown".to_string(),
-                        "unknown".to_string(),
-                    );
-
                     let result = self
-                        .run_postprocessing(&info, vec![fixed_path.clone()], is_hls)
+                        .run_postprocessing(info, vec![fixed_path.clone()], is_hls)
                         .await?;
                     if let Some(path) = result.into_iter().next() {
                         return Ok(path);
@@ -215,20 +206,8 @@ impl Orchestrator {
 
         // If FFmpeg remux failed, check if user requested any post-processing
         if self.needs_postprocessing() {
-            // Create a minimal InfoDict for post-processing
-            let info = rdlp_core::InfoDict::new(
-                "unknown".to_string(),
-                output_path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("Unknown")
-                    .to_string(),
-                "unknown".to_string(),
-                "unknown".to_string(),
-            );
-
             let result = self
-                .run_postprocessing(&info, vec![output_path.to_path_buf()], is_hls)
+                .run_postprocessing(info, vec![output_path.to_path_buf()], is_hls)
                 .await?;
             if let Some(path) = result.into_iter().next() {
                 return Ok(path);

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -70,6 +70,8 @@ pub enum DownloadPhase {
     },
     /// Downloading with progress tracking
     Downloading {
+        /// Extracted video metadata (for post-processing and thumbnail)
+        info: Box<rdlp_core::InfoDict>,
         /// Path where the file will be saved
         output_path: PathBuf,
         /// Selected format being downloaded
@@ -172,6 +174,7 @@ impl DownloadPhase {
                 };
 
                 Ok(Self::Downloading {
+                    info,
                     output_path,
                     format,
                     state,
@@ -179,6 +182,7 @@ impl DownloadPhase {
             }
 
             Self::Downloading {
+                info,
                 output_path,
                 format,
                 state,
@@ -235,9 +239,15 @@ impl DownloadPhase {
                 info!("   File: {}", output_path.display());
                 info!("   Stats: {stats:?}");
 
+                // Download thumbnail for embedding or standalone use
+                // Skipped only when --no-thumbnail is set (embed_thumbnail=false && write_thumbnail=false)
+                if orchestrator.config.embed_thumbnail || orchestrator.config.write_thumbnail {
+                    orchestrator.download_thumbnail(&info, &output_path).await;
+                }
+
                 // Run post-processing (automatic for HLS, optional for others)
                 let final_path = orchestrator
-                    .run_postprocessing_for_state_machine(&output_path, is_hls)
+                    .run_postprocessing_for_state_machine(&info, &output_path, is_hls)
                     .await?;
 
                 Ok(Self::Complete { path: final_path })

--- a/crates/rdlp-cli/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-cli/src/orchestrator/thumbnail.rs
@@ -1,0 +1,111 @@
+//! Thumbnail download support
+//!
+//! Downloads thumbnail images from extracted metadata URLs and saves them
+//! alongside media files for embedding or standalone use.
+
+use super::Orchestrator;
+use log::{debug, info, warn};
+use std::path::{Path, PathBuf};
+
+impl Orchestrator {
+    /// Download thumbnail image from URL and save alongside media file.
+    ///
+    /// Saves as `{media_stem}.{ext}` in the same directory as the media file.
+    /// The extension is inferred from the thumbnail URL (defaults to `jpg`).
+    ///
+    /// This is non-fatal: logs a warning and returns `None` on any error.
+    /// The `EmbedThumbnail` post-processor will then skip embedding gracefully.
+    ///
+    /// # Returns
+    ///
+    /// - `Some(path)` — thumbnail downloaded successfully
+    /// - `None` — no thumbnail URL available or download failed
+    pub(super) async fn download_thumbnail(
+        &self,
+        info: &rdlp_core::InfoDict,
+        media_file: &Path,
+    ) -> Option<PathBuf> {
+        // Get best thumbnail URL
+        let thumbnail_url = info.thumbnail.as_deref().or_else(|| {
+            info.thumbnails
+                .as_ref()
+                .and_then(|thumbs| thumbs.first())
+                .map(|t| t.url.as_str())
+        })?;
+
+        debug!(url = thumbnail_url; "Downloading thumbnail");
+
+        // Determine extension from URL (default to jpg)
+        let ext = thumbnail_url
+            .rsplit('/')
+            .next()
+            .and_then(|filename| {
+                // Strip query string
+                let filename = filename.split('?').next().unwrap_or(filename);
+                filename.rsplit('.').next()
+            })
+            .and_then(|ext| {
+                let ext = ext.to_lowercase();
+                match ext.as_str() {
+                    "jpg" | "jpeg" | "png" | "webp" => Some(ext),
+                    _ => None,
+                }
+            })
+            .unwrap_or_else(|| "jpg".to_string());
+
+        // Build output path: {media_stem}.{ext}
+        let stem = media_file.file_stem()?.to_str()?;
+        let parent = media_file.parent()?;
+        let thumbnail_path = parent.join(format!("{stem}.{ext}"));
+
+        // Download using the shared HTTP client
+        let response = match self
+            .extraction_context
+            .http_client
+            .get(thumbnail_url)
+            .send()
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                warn!("Failed to download thumbnail: {e}");
+                return None;
+            }
+        };
+
+        if !response.status().is_success() {
+            warn!(
+                status = response.status().as_u16();
+                "Thumbnail download returned non-success status"
+            );
+            return None;
+        }
+
+        let bytes = match response.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("Failed to read thumbnail response: {e}");
+                return None;
+            }
+        };
+
+        if bytes.is_empty() {
+            warn!("Thumbnail response was empty");
+            return None;
+        }
+
+        // Write to disk
+        if let Err(e) = tokio::fs::write(&thumbnail_path, &bytes).await {
+            warn!("Failed to write thumbnail file: {e}");
+            return None;
+        }
+
+        info!(
+            path = thumbnail_path.display().to_string().as_str(),
+            size = bytes.len();
+            "Thumbnail downloaded"
+        );
+
+        Some(thumbnail_path)
+    }
+}

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -103,6 +103,9 @@ pub struct PostProcessConfig {
     /// Embed thumbnail in video file
     pub embed_thumbnail: bool,
 
+    /// Write thumbnail image to disk (keep after embedding)
+    pub write_thumbnail: bool,
+
     /// Embed metadata (title, artist, etc.)
     pub embed_metadata: bool,
 
@@ -129,6 +132,7 @@ impl Default for PostProcessConfig {
             remux_container: None,
             merge_output_format: Some(ContainerFormat::Mp4),
             embed_thumbnail: false,
+            write_thumbnail: false,
             embed_metadata: false,
             embed_subtitles: false,
             keep_video: false,

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -18,6 +18,9 @@ log = { workspace = true }
 # FFmpeg library bindings (FFmpeg 5-8)
 ffmpeg-the-third = "4.0"
 
+# MP4 iTunes metadata (covr atom for Windows Explorer thumbnails)
+mp4ameta = "0.13"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = { workspace = true }

--- a/crates/rdlp-postprocess/src/ffmpeg.rs
+++ b/crates/rdlp-postprocess/src/ffmpeg.rs
@@ -1530,6 +1530,13 @@ impl FFmpegRunner {
         let thumb_ost_index;
         if is_mkv {
             // MKV: add as attachment stream
+            // Matroska attachments are written during write_header() via extradata,
+            // not via packet writing (which fails with "Invalid argument").
+            let thumb_bytes =
+                std::fs::read(thumbnail).map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read thumbnail file: {e}"),
+                })?;
+
             let mut ost = octx
                 .add_stream(ffmpeg_the_third::encoder::find(
                     ffmpeg_the_third::codec::Id::None,
@@ -1542,11 +1549,13 @@ impl FFmpegRunner {
             ost.set_parameters(thumb_params);
             // Override to attachment type for MKV
             Self::set_stream_as_attachment(ost.parameters().as_ptr());
+            // Set the thumbnail data as extradata — Matroska muxer reads this during write_header()
+            Self::set_extradata(ost.parameters().as_ptr(), &thumb_bytes);
             // Set attachment metadata
             {
                 let mut dict = ffmpeg_the_third::Dictionary::new();
                 dict.set("mimetype", Self::thumbnail_mimetype(thumbnail));
-                dict.set("filename", "cover.jpg");
+                dict.set("filename", Self::thumbnail_attachment_filename(thumbnail));
                 ost.set_metadata(dict);
             }
         } else {
@@ -1567,7 +1576,7 @@ impl FFmpegRunner {
             if is_mp3 {
                 let mut dict = ffmpeg_the_third::Dictionary::new();
                 dict.set("title", "Album cover");
-                dict.set("comment", "Cover (front)");
+                dict.set("comment", "Cover (Front)");
                 ost.set_metadata(dict);
             }
         }
@@ -1575,11 +1584,39 @@ impl FFmpegRunner {
         // Copy format-level metadata from media input
         octx.set_metadata(ictx.metadata().to_owned());
 
-        // Write header
-        octx.write_header()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+        // Write header (with faststart for MP4/MOV so moov atom is at start —
+        // required for Windows Explorer and many players to show the thumbnail)
+        let is_mp4_mov = matches!(
+            container.to_lowercase().as_str(),
+            "mp4" | "m4a" | "m4v" | "mov"
+        );
+        if is_mp4_mov {
+            let mut dict = ffmpeg_the_third::Dictionary::new();
+            dict.set("movflags", "+faststart");
+            octx.write_header_with(dict).map(|_| ())
+        } else {
+            octx.write_header()
+        }
+        .map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to write output header: {e}"),
+        })?;
+
+        // For FLAC/OGG/Opus: write thumbnail packets BEFORE media packets.
+        // These formats store picture metadata in the file header (METADATA_BLOCK_PICTURE
+        // for FLAC, Vorbis comment for OGG/Opus), so the muxer needs picture data before
+        // audio frames are flushed. For other formats (MP4, MP3), order doesn't matter.
+        let is_header_picture_format =
+            matches!(container.to_lowercase().as_str(), "flac" | "ogg" | "opus");
+
+        if !is_mkv && is_header_picture_format {
+            Self::write_thumbnail_packets(
+                &mut thumb_ictx,
+                &mut octx,
+                thumb_ist_index,
+                thumb_ist_time_base,
+                thumb_ost_index,
+            )?;
+        }
 
         // Copy media packets
         for result in ictx.packets() {
@@ -1609,30 +1646,16 @@ impl FFmpegRunner {
             })?;
         }
 
-        // Copy thumbnail packet(s)
-        let thumb_ost_time_base = octx
-            .stream(thumb_ost_index)
-            .ok_or_else(|| {
-                PostProcessError::ffmpeg_failed(format!(
-                    "thumbnail output stream {thumb_ost_index} not found"
-                ))
-            })?
-            .time_base();
-        for result in thumb_ictx.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read thumbnail packet: {e}"),
-                })?;
-            if stream.index() == thumb_ist_index {
-                packet.rescale_ts(thumb_ist_time_base, thumb_ost_time_base);
-                packet.set_position(-1);
-                packet.set_stream(thumb_ost_index);
-                packet.write_interleaved(&mut octx).map_err(|e| {
-                    PostProcessError::FFmpegLibraryError {
-                        message: format!("failed to write thumbnail packet: {e}"),
-                    }
-                })?;
-            }
+        // Copy thumbnail packet(s) for formats that don't need them in the header.
+        // MKV: already embedded via extradata. FLAC/OGG/Opus: already written above.
+        if !is_mkv && !is_header_picture_format {
+            Self::write_thumbnail_packets(
+                &mut thumb_ictx,
+                &mut octx,
+                thumb_ist_index,
+                thumb_ist_time_base,
+                thumb_ost_index,
+            )?;
         }
 
         octx.write_trailer()
@@ -1655,6 +1678,21 @@ impl FFmpegRunner {
             "png" => "image/png",
             "webp" => "image/webp",
             _ => "image/jpeg",
+        }
+    }
+
+    /// Determine attachment filename from thumbnail file extension (for MKV).
+    fn thumbnail_attachment_filename(path: &Path) -> &'static str {
+        match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase()
+            .as_str()
+        {
+            "png" => "cover.png",
+            "webp" => "cover.webp",
+            _ => "cover.jpg",
         }
     }
 
@@ -2200,6 +2238,72 @@ impl FFmpegRunner {
         // This flag is required by certain container formats.
         unsafe {
             (*encoder_ptr).flags |= ffmpeg_the_third::ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
+        }
+    }
+
+    /// Write thumbnail packets from the thumbnail input to the output context.
+    fn write_thumbnail_packets(
+        thumb_ictx: &mut ffmpeg_the_third::format::context::Input,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        thumb_ist_index: usize,
+        thumb_ist_time_base: ffmpeg_the_third::Rational,
+        thumb_ost_index: usize,
+    ) -> Result<()> {
+        let thumb_ost_time_base = octx
+            .stream(thumb_ost_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!(
+                    "thumbnail output stream {thumb_ost_index} not found"
+                ))
+            })?
+            .time_base();
+        for result in thumb_ictx.packets() {
+            let (stream, mut packet) =
+                result.map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to read thumbnail packet: {e}"),
+                })?;
+            if stream.index() == thumb_ist_index {
+                packet.rescale_ts(thumb_ist_time_base, thumb_ost_time_base);
+                packet.set_position(-1);
+                packet.set_stream(thumb_ost_index);
+                packet.write_interleaved(octx).map_err(|e| {
+                    PostProcessError::FFmpegLibraryError {
+                        message: format!("failed to write thumbnail packet: {e}"),
+                    }
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Set extradata on codec parameters (used for MKV attachment data).
+    ///
+    /// The Matroska muxer reads attachment data from `extradata` during `write_header()`,
+    /// so the thumbnail bytes must be set here rather than written as packets.
+    ///
+    /// Follows FFmpeg's `ff_alloc_extradata` convention: allocate
+    /// `size + AV_INPUT_BUFFER_PADDING_SIZE` bytes via `av_malloc`, zero the padding.
+    fn set_extradata(params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters, data: &[u8]) {
+        const PADDING: usize = ffmpeg_the_third::ffi::AV_INPUT_BUFFER_PADDING_SIZE as usize;
+
+        // SAFETY: `params_ptr` points to a valid AVCodecParameters for an output stream.
+        // We allocate extradata via av_malloc (required by FFmpeg) and copy the thumbnail bytes.
+        // FFmpeg takes ownership and frees the buffer when the context is closed.
+        unsafe {
+            let codecpar = params_ptr as *mut ffmpeg_the_third::ffi::AVCodecParameters;
+            // Free any existing extradata
+            if !(*codecpar).extradata.is_null() {
+                ffmpeg_the_third::ffi::av_free((*codecpar).extradata as *mut _);
+            }
+            let alloc_size = data.len() + PADDING;
+            let buf = ffmpeg_the_third::ffi::av_malloc(alloc_size) as *mut u8;
+            if !buf.is_null() {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
+                // Zero the padding bytes (required by FFmpeg bitstream readers)
+                std::ptr::write_bytes(buf.add(data.len()), 0, PADDING);
+                (*codecpar).extradata = buf;
+                (*codecpar).extradata_size = data.len() as i32;
+            }
         }
     }
 

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -3,10 +3,14 @@
 //! Embeds thumbnail images into media files using `ffmpeg-the-third` library
 //! bindings (no CLI process spawning). Supports different embedding methods
 //! based on the container format:
-//! - MP4/M4A/MOV: Cover art with `ATTACHED_PIC` disposition
+//! - MP4/M4A/MOV: Cover art with `ATTACHED_PIC` disposition + iTunes `covr` atom
 //! - MKV/MKA: Attachment stream with mimetype metadata
 //! - MP3: Video stream with ID3v2 metadata
 //! - FLAC/OGG/Opus: Video stream with `ATTACHED_PIC` disposition
+//!
+//! For MP4 containers, a second pass writes the thumbnail into the iTunes `covr`
+//! metadata atom using `mp4ameta`. This is needed because Windows Explorer reads
+//! cover art from the `covr` atom, not from `attached_pic` streams.
 
 use std::path::{Path, PathBuf};
 
@@ -56,6 +60,51 @@ impl EmbedThumbnail {
             .iter()
             .any(|c| c.eq_ignore_ascii_case(extension))
     }
+
+    /// Check if the container is an MP4-family format (supports covr atom).
+    fn is_mp4_family(extension: &str) -> bool {
+        matches!(
+            extension.to_lowercase().as_str(),
+            "mp4" | "m4a" | "m4v" | "mov"
+        )
+    }
+
+    /// Write the iTunes `covr` metadata atom for Windows Explorer thumbnail visibility.
+    ///
+    /// This is a second pass after FFmpeg embedding. Non-fatal: logs a warning on failure.
+    async fn write_covr_atom(media_file: &Path, thumbnail_file: &Path) {
+        let media = media_file.to_path_buf();
+        let thumb = thumbnail_file.to_path_buf();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let cover_bytes = std::fs::read(&thumb)?;
+
+            let img = match thumb
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("")
+                .to_lowercase()
+                .as_str()
+            {
+                "png" => mp4ameta::Img::png(cover_bytes),
+                _ => mp4ameta::Img::jpeg(cover_bytes),
+            };
+
+            let mut tag = mp4ameta::Tag::read_from_path(&media)
+                .unwrap_or_else(|_| mp4ameta::Tag::default());
+            tag.set_artwork(img);
+            tag.write_to_path(&media)?;
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .await;
+
+        match result {
+            Ok(Ok(())) => info!("MP4 covr atom written for Windows Explorer"),
+            Ok(Err(e)) => warn!("Failed to write MP4 covr atom: {e}"),
+            Err(e) => warn!("covr atom task panicked: {e}"),
+        }
+    }
 }
 
 #[async_trait]
@@ -76,7 +125,7 @@ impl PostProcessor for EmbedThumbnail {
         &self,
         info: &InfoDict,
         files: Vec<PathBuf>,
-        _config: &PostProcessConfig,
+        config: &PostProcessConfig,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -121,13 +170,23 @@ impl PostProcessor for EmbedThumbnail {
             Ok(()) => {
                 // Replace original with temp
                 tokio::fs::rename(&temp_output, media_file).await?;
-                info!(file:? = media_file.display(); "Thumbnail embedded");
+                info!(file:? = media_file.display(); "Thumbnail embedded via FFmpeg");
 
-                // Return thumbnail as temp file for cleanup
+                // For MP4-family: write covr atom so Windows Explorer shows the thumbnail
+                if Self::is_mp4_family(extension) {
+                    Self::write_covr_atom(media_file, &thumbnail_file).await;
+                }
+
+                // Clean up thumbnail unless --write-thumbnail was requested
+                let temp_files = if config.write_thumbnail {
+                    Vec::new()
+                } else {
+                    vec![thumbnail_file]
+                };
                 Ok(PostProcessResult {
                     info: info.clone(),
                     files,
-                    temp_files: vec![thumbnail_file],
+                    temp_files,
                 })
             }
             Err(e) => {

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -280,7 +280,7 @@ impl Default for Config {
             audio_quality: None,
             recode_video: None,
             remux_container: None,
-            embed_thumbnail: false,
+            embed_thumbnail: true,
             embed_metadata: false,
             embed_subtitles: false,
             keep_video: false,


### PR DESCRIPTION
This pull request introduces enhanced thumbnail handling for downloads, giving users more control over how thumbnails are downloaded, embedded, and saved. It adds new CLI options, improves documentation, and refactors the codebase to support these features, including robust support for embedding thumbnails in various formats and writing them to disk.

**User-facing features and CLI options:**

- Added `--no-thumbnail` and `--write-thumbnail` CLI flags to control thumbnail downloading and saving. `--embed-thumbnail` is now enabled by default and provides better MP4 support by writing both an `attached_pic` stream and iTunes `covr` atom for improved Windows Explorer compatibility. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L100-R106) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R184) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R95) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R16)
- Updated documentation in `README.md` to clearly explain the new thumbnail options and their effects. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R95) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R184)

**Core implementation and refactoring:**

- Implemented a new `download_thumbnail` method in `orchestrator/thumbnail.rs`, which downloads the thumbnail image before post-processing, saving it alongside the media file for embedding or standalone use. [[1]](diffhunk://#diff-5b57e64e44e71667a346dbcd9cb71eab7a9c11fb2f35c94a0a5703b1a9aa9704R1-R111) [[2]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341R438-R442) [[3]](diffhunk://#diff-40d2f40928ab42c5c5d19cedf5960225b16c7ed91ab2aa49551209642935904cR242-R250)
- Refactored orchestrator state and post-processing logic to ensure video metadata (`InfoDict`) is available during download and post-processing, enabling correct thumbnail handling throughout the workflow. [[1]](diffhunk://#diff-40d2f40928ab42c5c5d19cedf5960225b16c7ed91ab2aa49551209642935904cR73-R74) [[2]](diffhunk://#diff-40d2f40928ab42c5c5d19cedf5960225b16c7ed91ab2aa49551209642935904cR177-R185) [[3]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afR186) [[4]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL194-R197) [[5]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afL218-R210)

**Post-processing and format support:**

- Enhanced FFmpeg-based post-processing to properly embed thumbnails for MP4, MKV, FLAC, OGG, Opus, and MP3 formats, including correct handling of Matroska attachments and iTunes `covr` atom for MP4. Also, added support for writing thumbnails to disk if requested. [[1]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249R1533-R1539) [[2]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249R1552-R1558) [[3]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249L1570-R1620) [[4]](diffhunk://#diff-f1e92ff38d833070ebd1f986834593f86a9cd9bebff5a7e10b68fcf305de3249L1612-R1658) [[5]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R106-R108) [[6]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R135) [[7]](diffhunk://#diff-1dbba72396a00929ea0d7a7709d55285376ae099f04e54f2af28562f5fc8d1d8R21-R23)

These changes provide users with more flexibility and reliability when working with thumbnails, and ensure better compatibility with popular media players and file managers.