### PR TITLE
feat(extractor): add XTits (KVS) extractor with direct MP4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest,
 | MovieFap | MP4 | Multi-quality (144p-720p) |
 | RedTube | HLS + MP4 | Segment-based progress |
 | PornHub | HLS | Playlist support |
+| XTits | MP4 | Direct download, multi-quality (480p-720p) |
 
 ## Installation
 
@@ -276,17 +277,6 @@ cargo fmt                  # Format code
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for adding extractors, code style, and development workflow.
 See [CODING_RULES.md](CODING_RULES.md) for coding standards.
-
-## Performance
-
-Tested on Windows 11, Intel Core i7, 1 Gbps connection:
-
-| Config | Speed | Notes |
-|--------|-------|-------|
-| Baseline (8KB, single) | ~360 KB/s | 1x |
-| Power-of-two chunking | **10.5 MB/s** | **37x** (590 MB in 56s) |
-
-Memory usage stays under 20 MB regardless of video size (streaming I/O).
 
 ## Legal
 

--- a/crates/rdlp-extractor/src/extractors/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/mod.rs
@@ -1,7 +1,9 @@
 pub mod pornhub;
 pub mod redtube;
 pub mod tnaflix;
+pub mod xtits;
 
 pub use pornhub::PornHubExtractor;
 pub use redtube::RedTubeExtractor;
 pub use tnaflix::TNAFlixExtractor;
+pub use xtits::XTitsExtractor;

--- a/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
@@ -174,16 +174,12 @@ pub fn extract_thumbnail(html: &Html, webpage: &str) -> Option<String> {
 ///
 /// yt-dlp uses `flashvars.video_duration` for accurate duration.
 pub fn extract_duration(webpage: &str) -> Option<f64> {
-    extract_flashvar_string(webpage, "video_duration")
-        .and_then(|s| s.parse::<f64>().ok())
+    extract_flashvar_string(webpage, "video_duration").and_then(|s| s.parse::<f64>().ok())
 }
 
 /// Extract a string value from the flashvars JSON object.
 fn extract_flashvar_string(webpage: &str, key: &str) -> Option<String> {
-    let json_str = FLASHVARS_PATTERN
-        .captures(webpage)?
-        .get(1)?
-        .as_str();
+    let json_str = FLASHVARS_PATTERN.captures(webpage)?.get(1)?.as_str();
     let flashvars: serde_json::Value = serde_json::from_str(json_str).ok()?;
     flashvars.get(key)?.as_str().map(|s| s.to_string())
 }

--- a/crates/rdlp-extractor/src/extractors/xtits/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/formats.rs
@@ -1,0 +1,242 @@
+//! Format extraction for XTits (KVS player)
+//!
+//! XTits uses Kernel Video Sharing (KVS) which embeds video URLs directly
+//! in a `flashvars` JavaScript object. Videos are direct MP4 downloads
+//! (no HLS). Typical fields:
+//!
+//! - `video_url` + `video_url_text` — primary quality (e.g. "480p")
+//! - `video_alt_url` + `video_alt_url_text` — alternate quality (e.g. "720p")
+
+use log::debug;
+use once_cell::sync::Lazy;
+use rdlp_core::Format;
+use regex::Regex;
+
+use crate::base::common::BaseExtractor;
+
+/// Pattern to extract a single KVS flashvar value (string).
+///
+/// Matches: `key: 'value'` anywhere in the flashvars block.
+/// No line-start anchor because KVS sites often emit all entries on one line.
+static KVS_STRING_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(\w+)\s*:\s*'([^']*)'").expect("Valid KVS string pattern"));
+
+/// Extract all flashvar key-value pairs from the flashvars block content.
+fn parse_flashvars(flashvars_content: &str) -> Vec<(String, String)> {
+    KVS_STRING_PATTERN
+        .captures_iter(flashvars_content)
+        .map(|caps| {
+            (
+                caps.get(1).unwrap().as_str().to_string(),
+                caps.get(2).unwrap().as_str().to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Get a flashvar value by key
+fn get_flashvar<'a>(vars: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    vars.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+}
+
+/// Extract video formats from KVS flashvars block content.
+///
+/// KVS uses numbered URL fields:
+/// - `video_url` / `video_url_text` — primary format
+/// - `video_alt_url` / `video_alt_url_text` — first alternate
+/// - `video_alt_url2` / `video_alt_url2_text` — second alternate (rare)
+pub fn extract_formats(flashvars_content: &str) -> Vec<Format> {
+    let vars = parse_flashvars(flashvars_content);
+    let mut formats = Vec::new();
+
+    // Primary format: video_url
+    if let Some(url) = get_flashvar(&vars, "video_url") {
+        if !url.is_empty() {
+            let quality = get_flashvar(&vars, "video_url_text").unwrap_or("default");
+            let format = build_kvs_format(quality, url);
+            debug!(format_id = format.format_id.as_str(), url; "[XTits] Primary format");
+            formats.push(format);
+        }
+    }
+
+    // Alternate format: video_alt_url
+    if let Some(url) = get_flashvar(&vars, "video_alt_url") {
+        if !url.is_empty() {
+            let quality = get_flashvar(&vars, "video_alt_url_text").unwrap_or("alt");
+            let format = build_kvs_format(quality, url);
+            debug!(format_id = format.format_id.as_str(), url; "[XTits] Alt format");
+            formats.push(format);
+        }
+    }
+
+    // Second alternate (rare): video_alt_url2
+    if let Some(url) = get_flashvar(&vars, "video_alt_url2") {
+        if !url.is_empty() {
+            let quality = get_flashvar(&vars, "video_alt_url2_text").unwrap_or("alt2");
+            let format = build_kvs_format(quality, url);
+            debug!(format_id = format.format_id.as_str(), url; "[XTits] Alt2 format");
+            formats.push(format);
+        }
+    }
+
+    formats
+}
+
+/// Extract thumbnail URL from flashvars
+pub fn extract_thumbnail(vars: &[(String, String)]) -> Option<String> {
+    get_flashvar(vars, "preview_url").map(|s| s.to_string())
+}
+
+/// Extract duration from flashvars (KVS stores as seconds string)
+pub fn extract_duration(vars: &[(String, String)]) -> Option<f64> {
+    get_flashvar(vars, "video_duration").and_then(|s| s.parse::<f64>().ok())
+}
+
+/// Parse flashvars content and return the key-value pairs (public for mod.rs)
+pub fn parse_flashvars_public(flashvars_content: &str) -> Vec<(String, String)> {
+    parse_flashvars(flashvars_content)
+}
+
+/// Build a Format from a KVS quality string and URL.
+fn build_kvs_format(quality_str: &str, url: &str) -> Format {
+    let height = BaseExtractor::parse_quality_height(quality_str);
+
+    let mut format = BaseExtractor::build_format(
+        quality_str.to_owned(),
+        url.to_owned(),
+        "mp4".to_owned(),
+        height,
+    );
+
+    format.container = Some("mp4".to_owned());
+    format.ext = "mp4".to_owned();
+
+    // KVS quality labels without height info get stored as format_note
+    if height.is_none() {
+        format.format_note = Some(quality_str.to_owned());
+    }
+
+    format
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_flashvars() {
+        let content = r#"
+            video_id: '183207',
+            video_url: 'https://example.com/video.mp4/',
+            video_url_text: '480p',
+            video_alt_url: 'https://example.com/video_720p.mp4/',
+            video_alt_url_text: '720p',
+            preview_url: 'https://example.com/preview.jpg',
+        "#;
+
+        let vars = parse_flashvars(content);
+        assert_eq!(get_flashvar(&vars, "video_id"), Some("183207"));
+        assert_eq!(get_flashvar(&vars, "video_url_text"), Some("480p"));
+        assert_eq!(get_flashvar(&vars, "video_alt_url_text"), Some("720p"));
+    }
+
+    #[test]
+    fn test_extract_formats() {
+        let content = r#"
+            video_url: 'https://example.com/video.mp4/',
+            video_url_text: '480p',
+            video_alt_url: 'https://example.com/video_720p.mp4/',
+            video_alt_url_text: '720p',
+        "#;
+
+        let formats = extract_formats(content);
+        assert_eq!(formats.len(), 2);
+        assert_eq!(formats[0].format_id, "480p");
+        assert_eq!(formats[0].height, Some(480));
+        assert_eq!(formats[1].format_id, "720p");
+        assert_eq!(formats[1].height, Some(720));
+    }
+
+    #[test]
+    fn test_extract_formats_single() {
+        let content = r#"
+            video_url: 'https://example.com/video.mp4/',
+            video_url_text: '480p',
+        "#;
+
+        let formats = extract_formats(content);
+        assert_eq!(formats.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_formats_empty_url_skipped() {
+        let content = r#"
+            video_url: 'https://example.com/video.mp4/',
+            video_url_text: '480p',
+            video_alt_url: '',
+            video_alt_url_text: '720p',
+        "#;
+
+        let formats = extract_formats(content);
+        assert_eq!(formats.len(), 1);
+    }
+
+    #[test]
+    fn test_build_kvs_format() {
+        let format = build_kvs_format("720p", "https://example.com/video.mp4");
+        assert_eq!(format.format_id, "720p");
+        assert_eq!(format.height, Some(720));
+        assert_eq!(format.width, Some(1280));
+        assert_eq!(format.ext, "mp4");
+        assert_eq!(format.container, Some("mp4".to_string()));
+    }
+
+    #[test]
+    fn test_build_kvs_format_unknown_quality() {
+        let format = build_kvs_format("default", "https://example.com/video.mp4");
+        assert_eq!(format.format_id, "default");
+        assert_eq!(format.height, None);
+        assert_eq!(format.format_note, Some("default".to_string()));
+    }
+
+    #[test]
+    fn test_parse_flashvars_single_line() {
+        // Real KVS pages often emit all flashvars on a single line
+        let content = "video_id: '183207',                                                                                     video_url: 'https://www.xtits.xxx/get_file/7/abc/183207.mp4/',                                                                                     video_url_text: '480p',                                                                                     video_alt_url: 'https://www.xtits.xxx/get_file/7/def/183207_720p.mp4/',                                                                                     video_alt_url_text: '720p',                                                                                     video_alt_url_hd: '1',                                                                                     preview_url: 'https://www.xtits.xxx/contents/videos_screenshots/183000/183207/preview.jpg'";
+
+        let vars = parse_flashvars(content);
+        assert_eq!(get_flashvar(&vars, "video_id"), Some("183207"));
+        assert_eq!(get_flashvar(&vars, "video_url_text"), Some("480p"));
+        assert_eq!(get_flashvar(&vars, "video_alt_url_text"), Some("720p"));
+        assert!(
+            get_flashvar(&vars, "video_url")
+                .unwrap()
+                .contains("183207.mp4")
+        );
+        assert!(
+            get_flashvar(&vars, "video_alt_url")
+                .unwrap()
+                .contains("720p.mp4")
+        );
+
+        let formats = extract_formats(content);
+        assert_eq!(formats.len(), 2);
+        assert_eq!(formats[0].height, Some(480));
+        assert_eq!(formats[1].height, Some(720));
+    }
+
+    #[test]
+    fn test_extract_thumbnail() {
+        let vars = parse_flashvars("preview_url: 'https://example.com/thumb.jpg',");
+        assert_eq!(
+            extract_thumbnail(&vars),
+            Some("https://example.com/thumb.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_duration() {
+        let vars = parse_flashvars("video_duration: '1698',");
+        assert_eq!(extract_duration(&vars), Some(1698.0));
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -1,0 +1,455 @@
+//! XTits extractor
+//!
+//! XTits is a KVS (Kernel Video Sharing) tube site serving direct MP4 downloads.
+//!
+//! Supports:
+//! - Video pages: `https://www.xtits.xxx/videos/183207/slug/`
+//! - Embed pages: `https://www.xtits.xxx/embed/183207`
+//!
+//! ## Module Structure
+//!
+//! - `patterns` - URL and flashvars regex patterns
+//! - `formats` - KVS flashvars format extraction
+
+mod formats;
+mod patterns;
+
+use async_trait::async_trait;
+use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result};
+use regex::Regex;
+use scraper::Html;
+
+use crate::base::common::BaseExtractor;
+
+/// Base URL for making relative hrefs absolute.
+const XTITS_BASE_URL: &str = "https://www.xtits.xxx";
+
+/// XTits extractor
+pub struct XTitsExtractor;
+
+impl XTitsExtractor {
+    /// Create a new XTits extractor
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for XTitsExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract categories from the video detail section
+fn extract_categories(html: &Html) -> Vec<String> {
+    extract_link_texts(html, ".info-block .list-items", "Categories:")
+}
+
+/// Extract tags from the video detail section
+fn extract_tags(html: &Html) -> Vec<String> {
+    extract_link_texts(html, ".info-block .list-items", "Tags:")
+}
+
+/// Extract model names from the video detail section
+fn extract_models(html: &Html) -> Vec<String> {
+    extract_link_texts(html, ".info-block .list-items", "Models:")
+}
+
+/// Extract link texts from a labeled list-items section.
+///
+/// KVS pages use `.list-items` divs with a `.title-row` label followed by `<a>` links.
+/// This finds the section whose label matches `label_text` and collects all link texts.
+fn extract_link_texts(html: &Html, container_sel: &str, label_text: &str) -> Vec<String> {
+    let container_selector = match scraper::Selector::parse(container_sel) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let title_selector = match scraper::Selector::parse(".title-row") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let link_selector = match scraper::Selector::parse("a.link") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    for container in html.select(&container_selector) {
+        // Check if this container's title-row matches the label
+        if let Some(title_el) = container.select(&title_selector).next() {
+            let title = title_el.text().collect::<String>();
+            if title.trim() == label_text {
+                return container
+                    .select(&link_selector)
+                    .map(|el| el.text().collect::<String>().trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+        }
+    }
+
+    Vec::new()
+}
+
+/// Extract rating percentage from the voters section
+fn extract_rating(html: &Html) -> Option<f64> {
+    BaseExtractor::extract_element_text_str(html, ".voters .bold")
+        .and_then(|text| text.trim().trim_end_matches('%').parse().ok())
+}
+
+/// Extract like/vote count from the voters section.
+///
+/// The page shows "(241 votes)" next to the rating percentage.
+fn extract_like_count(html: &Html) -> Option<u64> {
+    let selector = scraper::Selector::parse(".voters").ok()?;
+    let text: String = html.select(&selector).next()?.text().collect();
+    // Extract number from "(241 votes)" pattern
+    let start = text.find('(')? + 1;
+    let end = text.find("vote")?;
+    text[start..end]
+        .trim()
+        .replace([' ', ',', '\u{a0}'], "")
+        .parse()
+        .ok()
+}
+
+/// Extract first model's profile URL.
+///
+/// The "Models:" section contains `<a href="/models/jenni-lee/">Jenni Lee</a>`.
+fn extract_model_url(html: &Html) -> Option<String> {
+    extract_link_hrefs(html, ".info-block .list-items", "Models:")
+        .into_iter()
+        .next()
+}
+
+/// Extract link hrefs from a labeled list-items section.
+fn extract_link_hrefs(html: &Html, container_sel: &str, label_text: &str) -> Vec<String> {
+    let container_selector = match scraper::Selector::parse(container_sel) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let title_selector = match scraper::Selector::parse(".title-row") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let link_selector = match scraper::Selector::parse("a.link") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    for container in html.select(&container_selector) {
+        if let Some(title_el) = container.select(&title_selector).next() {
+            let title = title_el.text().collect::<String>();
+            if title.trim() == label_text {
+                return container
+                    .select(&link_selector)
+                    .filter_map(|el| {
+                        el.value()
+                            .attr("href")
+                            .map(|href| crate::utils::make_absolute_url(XTITS_BASE_URL, href))
+                    })
+                    .collect();
+            }
+        }
+    }
+
+    Vec::new()
+}
+
+/// Extract view count from the page
+fn extract_view_count(html: &Html) -> Option<u64> {
+    // Views are in a `.buttons-info .item` containing `.icon-eye`
+    let item_selector = scraper::Selector::parse(".buttons-info .item").ok()?;
+    let icon_selector = scraper::Selector::parse(".icon-eye").ok()?;
+
+    for item in html.select(&item_selector) {
+        if item.select(&icon_selector).next().is_some() {
+            let text: String = item.text().collect();
+            let cleaned = text.trim().replace([' ', ',', '\u{a0}'], "");
+            return cleaned.parse().ok();
+        }
+    }
+
+    None
+}
+
+/// Parse duration text like "28min 18sec" into seconds
+fn parse_duration_text(html: &Html) -> Option<f64> {
+    let item_selector = scraper::Selector::parse(".buttons-info .item").ok()?;
+    let icon_selector = scraper::Selector::parse(".icon-clock").ok()?;
+
+    for item in html.select(&item_selector) {
+        if item.select(&icon_selector).next().is_some() {
+            let text: String = item.text().collect();
+            return parse_min_sec_duration(text.trim());
+        }
+    }
+
+    None
+}
+
+/// Parse "28min 18sec" or "5min" or "30sec" into seconds
+fn parse_min_sec_duration(text: &str) -> Option<f64> {
+    let text = text.trim().to_lowercase();
+    let mut total_seconds = 0.0;
+
+    // Extract minutes
+    if let Some(min_idx) = text.find("min") {
+        let before = text[..min_idx].trim();
+        // Take only the last numeric token before "min"
+        if let Some(num_str) = before.split_whitespace().next_back() {
+            if let Ok(mins) = num_str.parse::<f64>() {
+                total_seconds += mins * 60.0;
+            }
+        }
+    }
+
+    // Extract seconds
+    if let Some(sec_idx) = text.find("sec") {
+        // Find the number just before "sec"
+        let before = text[..sec_idx].trim();
+        if let Some(num_str) = before.split_whitespace().next_back() {
+            if let Ok(secs) = num_str.parse::<f64>() {
+                total_seconds += secs;
+            }
+        }
+    }
+
+    if total_seconds > 0.0 {
+        Some(total_seconds)
+    } else {
+        None
+    }
+}
+
+#[async_trait]
+impl InfoExtractor for XTitsExtractor {
+    fn name(&self) -> &str {
+        "XTits"
+    }
+
+    fn valid_url(&self) -> &Regex {
+        &patterns::XTITS_URL_PATTERN
+    }
+
+    async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
+        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
+
+        let video_id = patterns::extract_video_id(url)
+            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
+
+        // Extract flashvars block
+        let flashvars_content = patterns::FLASHVARS_PATTERN
+            .captures(&webpage)
+            .and_then(|caps| caps.get(1))
+            .map(|m| m.as_str().to_string())
+            .ok_or_else(|| {
+                RdlpError::Extraction(format!(
+                    "Could not find KVS flashvars on page. Video may be unavailable. URL: {url}"
+                ))
+            })?;
+
+        // Extract formats from flashvars
+        let video_formats = formats::extract_formats(&flashvars_content);
+
+        if video_formats.is_empty() {
+            return Err(RdlpError::Extraction(format!(
+                "No video formats found in flashvars. URL: {url}"
+            )));
+        }
+
+        // Parse flashvars for metadata
+        let flashvars = formats::parse_flashvars_public(&flashvars_content);
+
+        // Detect file sizes for all formats
+        let (formats_with_size, _hls_flags) =
+            crate::hls::detect_format_sizes(video_formats, ctx, self.name()).await;
+
+        // Extract metadata from HTML (drop Html before any await)
+        let (
+            title,
+            description,
+            thumbnail,
+            categories,
+            tags,
+            models,
+            model_url,
+            rating,
+            like_count,
+            view_count,
+            duration,
+        ) = {
+            let html = Html::parse_document(&webpage);
+            let title = BaseExtractor::extract_element_text_str(&html, "h1.title")
+                .or_else(|| BaseExtractor::extract_title_multi_strategy(&html))
+                .unwrap_or_else(|| "Untitled".to_string());
+            let description = BaseExtractor::extract_description_multi_strategy(&html);
+
+            // Thumbnail: prefer flashvars, fall back to og:image
+            let thumbnail = formats::extract_thumbnail(&flashvars)
+                .or_else(|| BaseExtractor::extract_thumbnail_multi_strategy(&html));
+
+            let categories = extract_categories(&html);
+            let tags = extract_tags(&html);
+            let models = extract_models(&html);
+            let model_url = extract_model_url(&html);
+            let rating = extract_rating(&html);
+            let like_count = extract_like_count(&html);
+            let view_count = extract_view_count(&html);
+
+            // Duration: prefer flashvars, fall back to page text
+            let duration =
+                formats::extract_duration(&flashvars).or_else(|| parse_duration_text(&html));
+
+            (
+                title,
+                description,
+                thumbnail,
+                categories,
+                tags,
+                models,
+                model_url,
+                rating,
+                like_count,
+                view_count,
+                duration,
+            )
+        };
+
+        let mut info = InfoDict::new(video_id, title, self.name().to_string(), url.to_string());
+        info.description = description;
+        info.thumbnail = thumbnail;
+        info.categories = Some(categories);
+        info.tags = Some(tags);
+        info.average_rating = rating;
+        info.like_count = like_count;
+        info.view_count = view_count;
+        info.duration = duration;
+        info.age_limit = Some(18);
+        info.formats = formats_with_size;
+
+        // Store first model as uploader (KVS convention)
+        if !models.is_empty() {
+            info.uploader = Some(models.join(", "));
+            info.uploader_url = model_url;
+        }
+
+        Ok(info)
+    }
+
+    fn suitable(&self, url: &str) -> bool {
+        patterns::is_suitable(url)
+    }
+
+    fn priority(&self) -> i32 {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extractor_creation() {
+        let extractor = XTitsExtractor::new();
+        assert_eq!(extractor.name(), "XTits");
+    }
+
+    #[test]
+    fn test_suitable_urls() {
+        let extractor = XTitsExtractor::new();
+
+        assert!(extractor.suitable(
+            "https://www.xtits.xxx/videos/183207/spicy-lesbians-and-straight-girl-smutty-adult-movie/"
+        ));
+        assert!(extractor.suitable("https://xtits.xxx/videos/12345/test-title/"));
+        assert!(extractor.suitable("https://www.xtits.xxx/embed/183207"));
+
+        assert!(!extractor.suitable("https://youtube.com/watch?v=test"));
+        assert!(!extractor.suitable("https://www.pornhub.com/view_video.php?viewkey=ph123"));
+    }
+
+    #[test]
+    fn test_parse_min_sec_duration() {
+        assert_eq!(parse_min_sec_duration("28min 18sec"), Some(1698.0));
+        assert_eq!(parse_min_sec_duration("5min"), Some(300.0));
+        assert_eq!(parse_min_sec_duration("30sec"), Some(30.0));
+        assert_eq!(parse_min_sec_duration("1min 1sec"), Some(61.0));
+        assert_eq!(parse_min_sec_duration(""), None);
+    }
+
+    #[test]
+    fn test_extract_link_texts_from_html() {
+        let html_str = r#"
+        <div class="info-block">
+            <div class="row list-items">
+                <p class="title-row">Categories:</p>
+                <a class="link" href="/categories/big-tits/">Big Tits</a>
+                <a class="link" href="/categories/brunette/">Brunette</a>
+            </div>
+            <div class="row list-items">
+                <p class="title-row">Tags:</p>
+                <a class="link" href="/tags/hardcore/">hardcore</a>
+            </div>
+            <div class="row list-items">
+                <p class="title-row">Models:</p>
+                <a class="link" href="/models/jenni-lee/">Jenni Lee</a>
+            </div>
+        </div>
+        "#;
+
+        let html = Html::parse_document(html_str);
+        let cats = extract_categories(&html);
+        assert_eq!(cats, vec!["Big Tits", "Brunette"]);
+
+        let tags = extract_tags(&html);
+        assert_eq!(tags, vec!["hardcore"]);
+
+        let models = extract_models(&html);
+        assert_eq!(models, vec!["Jenni Lee"]);
+    }
+
+    #[test]
+    fn test_extract_rating() {
+        let html_str = r#"
+        <div class="rating-container">
+            <span class="voters">
+                <span class="bold">85%</span> (241 votes)
+            </span>
+        </div>
+        "#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(extract_rating(&html), Some(85.0));
+    }
+
+    #[test]
+    fn test_extract_like_count() {
+        let html_str = r#"
+        <div class="rating-container">
+            <span class="voters">
+                <span class="bold">85%</span> (241 votes)
+            </span>
+        </div>
+        "#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(extract_like_count(&html), Some(241));
+    }
+
+    #[test]
+    fn test_extract_model_url() {
+        let html_str = r#"
+        <div class="info-block">
+            <div class="row list-items">
+                <p class="title-row">Models:</p>
+                <a class="link" href="/models/jenni-lee/">Jenni Lee</a>
+            </div>
+        </div>
+        "#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(
+            extract_model_url(&html),
+            Some("https://www.xtits.xxx/models/jenni-lee/".to_string())
+        );
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/xtits/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/patterns.rs
@@ -1,0 +1,95 @@
+//! URL and extraction patterns for XTits
+//!
+//! Static regex patterns compiled once at first use via `once_cell::sync::Lazy`.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// URL pattern for XTits video pages
+///
+/// Supports:
+/// - Standard: `https://www.xtits.xxx/videos/183207/slug/`
+/// - Without trailing slash: `https://www.xtits.xxx/videos/183207/slug`
+/// - Without slug: `https://www.xtits.xxx/videos/183207/`
+pub static XTITS_URL_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"https?://(?:www\.)?xtits\.xxx/videos/(?P<id>\d+)/")
+        .expect("Valid XTits URL pattern")
+});
+
+/// URL pattern for XTits embed pages
+///
+/// Supports: `https://www.xtits.xxx/embed/183207`
+pub static XTITS_EMBED_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"https?://(?:www\.)?xtits\.xxx/embed/(?P<id>\d+)")
+        .expect("Valid XTits embed pattern")
+});
+
+/// Regex to extract the KVS flashvars JavaScript object
+///
+/// KVS players embed video configuration in a `var flashvars = {...};` block.
+/// This captures the JSON-like object content.
+pub static FLASHVARS_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?s)var\s+flashvars\s*=\s*\{(.+?)\};").expect("Valid flashvars pattern")
+});
+
+/// Check if URL is suitable for this extractor
+pub fn is_suitable(url: &str) -> bool {
+    XTITS_URL_PATTERN.is_match(url) || XTITS_EMBED_PATTERN.is_match(url)
+}
+
+/// Extract video ID from URL
+pub fn extract_video_id(url: &str) -> Option<String> {
+    XTITS_URL_PATTERN
+        .captures(url)
+        .or_else(|| XTITS_EMBED_PATTERN.captures(url))
+        .and_then(|caps| caps.name("id"))
+        .map(|m| m.as_str().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_pattern_standard() {
+        assert!(XTITS_URL_PATTERN.is_match(
+            "https://www.xtits.xxx/videos/183207/spicy-lesbians-and-straight-girl-smutty-adult-movie/"
+        ));
+        assert!(XTITS_URL_PATTERN.is_match("https://xtits.xxx/videos/183207/some-title/"));
+    }
+
+    #[test]
+    fn test_url_pattern_embed() {
+        assert!(XTITS_EMBED_PATTERN.is_match("https://www.xtits.xxx/embed/183207"));
+    }
+
+    #[test]
+    fn test_url_pattern_invalid() {
+        assert!(!is_suitable("https://youtube.com/watch?v=test"));
+        assert!(!is_suitable(
+            "https://www.pornhub.com/view_video.php?viewkey=ph123"
+        ));
+    }
+
+    #[test]
+    fn test_extract_video_id() {
+        assert_eq!(
+            extract_video_id(
+                "https://www.xtits.xxx/videos/183207/spicy-lesbians-and-straight-girl-smutty-adult-movie/"
+            ),
+            Some("183207".to_string())
+        );
+        assert_eq!(
+            extract_video_id("https://www.xtits.xxx/embed/183207"),
+            Some("183207".to_string())
+        );
+        assert_eq!(extract_video_id("https://youtube.com/watch?v=test"), None);
+    }
+
+    #[test]
+    fn test_flashvars_pattern() {
+        let webpage =
+            r#"var flashvars = { video_id: '123', video_url: 'https://example.com/v.mp4' };"#;
+        assert!(FLASHVARS_PATTERN.is_match(webpage));
+    }
+}

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -39,7 +39,7 @@ pub mod hls;
 pub mod utils;
 
 // Re-export extractors
-pub use extractors::{PornHubExtractor, RedTubeExtractor, TNAFlixExtractor};
+pub use extractors::{PornHubExtractor, RedTubeExtractor, TNAFlixExtractor, XTitsExtractor};
 
 // Re-export base utilities for convenient access
 pub use base::common::BaseExtractor;
@@ -80,6 +80,9 @@ impl ExtractorRegistry {
 
         // Register PornHub extractor (with playlist support)
         registry.register(Arc::new(PornHubExtractor::new()));
+
+        // Register XTits extractor
+        registry.register(Arc::new(XTitsExtractor::new()));
 
         registry
     }
@@ -159,6 +162,7 @@ mod tests {
         assert!(extractors.contains(&"MovieFap"));
         assert!(extractors.contains(&"RedTube"));
         assert!(extractors.contains(&"PornHub"));
+        assert!(extractors.contains(&"XTits"));
     }
 
     #[test]
@@ -176,6 +180,10 @@ mod tests {
         let redtube = registry.find_extractor("https://www.redtube.com/123456");
         assert!(redtube.is_some());
         assert_eq!(redtube.unwrap().name(), "RedTube");
+
+        let xtits = registry.find_extractor("https://www.xtits.xxx/videos/183207/spicy-lesbians/");
+        assert!(xtits.is_some());
+        assert_eq!(xtits.unwrap().name(), "XTits");
 
         let unknown = registry.find_extractor("https://youtube.com/watch?v=test");
         assert!(unknown.is_none());


### PR DESCRIPTION
This pull request adds support for the XTits video site to the extractor library. It introduces a new extractor for XTits, including URL and pattern matching, format extraction, and integration into the registry. The README is updated to reflect the new supported site, and comprehensive tests are included for the new functionality.

**XTits extractor integration:**

* Added new module `xtits` with format extraction logic, URL/pattern matching, and utility functions for XTits [[1]](diffhunk://#diff-e9f79b13d8f9bc8b79936dcda18c6e4d31906ce04ce936a7e5cbfb83e56bbd53R4-R9) [[2]](diffhunk://#diff-6d9b2b1543abab364779ef02796bddefbb3924808c07a6dd6c1603c2ee0b0d0aR1-R242) [[3]](diffhunk://#diff-7b989059209624195c1b8b40f7febb67d6ca0dc3a3e58c83fcf067e1f826e524R1-R95).
* Registered `XTitsExtractor` in the extractor registry, making it available for use and ensuring it is discoverable by URL [[1]](diffhunk://#diff-aaa9961259eba24f9299a0c2494da56d78618e7e1ea84e1cf6e9ca29ca6cce62L42-R42) [[2]](diffhunk://#diff-aaa9961259eba24f9299a0c2494da56d78618e7e1ea84e1cf6e9ca29ca6cce62R84-R86).

**Documentation updates:**

* Updated the `README.md` to list XTits as a supported site, including details on format and features.

**Testing and validation:**

* Added and updated tests to confirm XTits extractor registration, URL matching, and format extraction work as expected [[1]](diffhunk://#diff-aaa9961259eba24f9299a0c2494da56d78618e7e1ea84e1cf6e9ca29ca6cce62R165) [[2]](diffhunk://#diff-aaa9961259eba24f9299a0c2494da56d78618e7e1ea84e1cf6e9ca29ca6cce62R184-R187) [[3]](diffhunk://#diff-6d9b2b1543abab364779ef02796bddefbb3924808c07a6dd6c1603c2ee0b0d0aR1-R242) [[4]](diffhunk://#diff-7b989059209624195c1b8b40f7febb67d6ca0dc3a3e58c83fcf067e1f826e524R1-R95).

**Code consistency:**

* Minor cleanup and formatting improvements in related utility code for extractors.

**Other:**

* Removed the obsolete performance section from the `README.md` for clarity.Add new extractor for xtits.xxx, a KVS (Kernel Video Sharing) tube site. Parses flashvars JavaScript object for direct MP4 download URLs and extracts full metadata (title, categories, tags, models, rating, view count, duration, like count, uploader URL) from HTML. Also removes the Performance section from README.