### PR TITLE
refactor(cli): complexity remediation — deduplicate CDN fallback, uni…

### DIFF
--- a/crates/rdlp-cli/src/lib.rs
+++ b/crates/rdlp-cli/src/lib.rs
@@ -7,4 +7,4 @@
 
 pub mod orchestrator;
 
-pub use orchestrator::Orchestrator;
+pub use orchestrator::{Orchestrator, OrchestratorError};

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use clap::Parser;
 use dialoguer::{Select, theme::ColorfulTheme};
 use indicatif::MultiProgress;
-use rdlp_cli::Orchestrator;
+use rdlp_cli::{Orchestrator, OrchestratorError};
 use rdlp_core::{AudioFormat, BrowserType, Config, ContainerFormat, InfoDict, config_io};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -386,41 +386,57 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SuspendingWriter {
     }
 }
 
-/// Build Config by merging: defaults < config file < CLI args
-fn build_config(args: &Args) -> Result<Config> {
-    // Step 1: Load config file (or use defaults)
-    let mut config = if args.ignore_config {
-        Config::default()
-    } else {
-        match config_io::load_config(args.config_location.as_deref()) {
-            Ok(Some((file_config, path))) => {
-                // Can't use tracing yet (not initialized), so use eprintln for early feedback
-                // Tracing will be set up after config is built (need quiet/verbose from config)
-                eprintln!("Loaded config from {}", path.display());
-                file_config
-            }
-            Ok(None) => Config::default(),
-            Err(e) => {
-                if args.config_location.is_some() {
-                    // Explicit config path — error is fatal
-                    return Err(e.into());
-                }
-                // Default path — warn and continue with defaults
-                eprintln!("Warning: Failed to load config file: {e}");
-                Config::default()
-            }
-        }
+/// Resolved values from interactive CLI prompts.
+///
+/// These are resolved BEFORE the pure config merge so that `merge_config()`
+/// remains free of side effects and is testable.
+struct ResolvedInteractiveValues {
+    audio_format: Option<AudioFormat>,
+    recode_video: Option<ContainerFormat>,
+    remux_container: Option<ContainerFormat>,
+}
+
+/// Resolve interactive CLI values (dialoguer prompts) before config merge.
+///
+/// Returns `None` values for fields that weren't set to "interactive".
+fn resolve_interactive_values(args: &Args) -> Result<ResolvedInteractiveValues> {
+    let audio_format = match args.audio_format.as_deref() {
+        Some("interactive") => select_audio_format()?,
+        _ => None,
     };
 
-    // Step 2: Overlay CLI args (only when explicitly provided)
+    let recode_video = match args.recode_video.as_deref() {
+        Some("interactive") => select_recode_video()?,
+        _ => None,
+    };
+
+    let remux_container = match args.remux.as_deref() {
+        Some("interactive") => select_remux_container()?,
+        _ => None,
+    };
+
+    Ok(ResolvedInteractiveValues {
+        audio_format,
+        recode_video,
+        remux_container,
+    })
+}
+
+/// Pure config merge: defaults < config file < CLI args.
+///
+/// This function has no side effects (no interactive prompts, no I/O).
+/// Interactive values must be pre-resolved via `resolve_interactive_values()`.
+fn merge_config(
+    args: &Args,
+    file_config: Config,
+    interactive_values: ResolvedInteractiveValues,
+) -> Result<Config> {
+    let mut config = file_config;
+
+    // Output: -o always sets output_template (the template engine handles
+    // both template fields like "%(title)s" and plain filenames like "video.mp4")
     if let Some(ref output) = args.output {
-        if output.contains("%(") {
-            // Contains template fields — treat as output template
-            config.output_template = output.clone();
-        } else {
-            // No template fields — backward compat: treat as directory
-            config.output_directory = PathBuf::from(output);
-        }
+        config.output_template = output.clone();
     }
     if let Some(ref dir) = args.output_dir {
         config.output_directory = dir.clone();
@@ -440,19 +456,20 @@ fn build_config(args: &Args) -> Result<Config> {
     if args.extract_audio {
         config.extract_audio = true;
     }
-    match args.audio_format.as_deref() {
-        Some("interactive") => {
-            config.audio_format = select_audio_format()?;
-        }
-        Some(audio_format) => {
+
+    // Audio format: interactive (pre-resolved) or direct parse
+    if let Some(fmt) = interactive_values.audio_format {
+        config.audio_format = Some(fmt);
+    } else if let Some(audio_format) = args.audio_format.as_deref() {
+        if audio_format != "interactive" {
             config.audio_format = Some(
                 audio_format
                     .parse::<AudioFormat>()
                     .map_err(|e| anyhow::anyhow!(e))?,
             );
         }
-        None => {}
     }
+
     if let Some(ref audio_quality) = args.audio_quality {
         config.audio_quality = Some(audio_quality.clone());
     }
@@ -465,19 +482,20 @@ fn build_config(args: &Args) -> Result<Config> {
     if args.write_thumbnail {
         config.write_thumbnail = true;
     }
-    match args.recode_video.as_deref() {
-        Some("interactive") => {
-            config.recode_video = select_recode_video()?;
-        }
-        Some(recode_video) => {
+
+    // Recode video: interactive (pre-resolved) or direct parse
+    if let Some(fmt) = interactive_values.recode_video {
+        config.recode_video = Some(fmt);
+    } else if let Some(recode_video) = args.recode_video.as_deref() {
+        if recode_video != "interactive" {
             config.recode_video = Some(
                 recode_video
                     .parse::<ContainerFormat>()
                     .map_err(|e| anyhow::anyhow!(e))?,
             );
         }
-        None => {}
     }
+
     if args.keep_video {
         config.keep_video = true;
     }
@@ -505,30 +523,98 @@ fn build_config(args: &Args) -> Result<Config> {
         config.download_archive = Some(archive.clone());
     }
 
-    // Handle interactive remux selection
-    match args.remux.as_deref() {
-        Some("interactive") => {
-            config.remux_container = select_remux_container()?;
-        }
-        Some(container) => {
+    // Remux: interactive (pre-resolved) or direct parse
+    if let Some(fmt) = interactive_values.remux_container {
+        config.remux_container = Some(fmt);
+    } else if let Some(container) = args.remux.as_deref() {
+        if container != "interactive" {
             config.remux_container = Some(
                 container
                     .parse::<ContainerFormat>()
                     .map_err(|e| anyhow::anyhow!(e))?,
             );
         }
-        None => {}
     }
 
-    // Set progress based on quiet
+    // Derived settings
     config.progress = !config.quiet;
 
-    // Set audio_format when extract_audio is set but no explicit format
     if config.extract_audio && config.audio_format.is_none() {
         config.audio_format = Some(AudioFormat::Mp3);
     }
 
+    // Validate final config
+    config
+        .validate()
+        .map_err(|e| anyhow::anyhow!("Invalid configuration: {e}"))?;
+
     Ok(config)
+}
+
+/// Build Config by: resolve interactive prompts → load file → merge.
+fn build_config(args: &Args) -> Result<Config> {
+    // Step 1: Resolve interactive values (side effects isolated here)
+    let interactive_values = resolve_interactive_values(args)?;
+
+    // Step 2: Load config file (or use defaults)
+    let file_config = if args.ignore_config {
+        Config::default()
+    } else {
+        match config_io::load_config(args.config_location.as_deref()) {
+            Ok(Some((file_config, path))) => {
+                eprintln!("Loaded config from {}", path.display());
+                file_config
+            }
+            Ok(None) => Config::default(),
+            Err(e) => {
+                if args.config_location.is_some() {
+                    return Err(e.into());
+                }
+                eprintln!("Warning: Failed to load config file: {e}");
+                Config::default()
+            }
+        }
+    };
+
+    // Step 3: Pure merge (no side effects, testable)
+    merge_config(args, file_config, interactive_values)
+}
+
+/// Map OrchestratorError to a structured process exit code.
+///
+/// Exit codes:
+///   0 — success (handled by Ok paths)
+///   1 — general/unknown error (I/O, progress bar, path generation)
+///   2 — user cancelled (Ctrl+C, ESC)
+///   3 — extraction failed (no extractor found, extraction error)
+///   4 — download/network failed (no downloader, CDN error, chunk merge)
+///   5 — configuration/format error (invalid config, no matching format)
+fn exit_code_for(e: &OrchestratorError) -> i32 {
+    match e {
+        OrchestratorError::UserCancelled => 2,
+        OrchestratorError::NoExtractor { .. } | OrchestratorError::ExtractionFailed(_) => 3,
+        OrchestratorError::NoDownloader { .. }
+        | OrchestratorError::DownloadFailed(_)
+        | OrchestratorError::ResumeDetectionFailed(_)
+        | OrchestratorError::MissingChunk { .. }
+        | OrchestratorError::ChunkMergeFailed(_) => 4,
+        OrchestratorError::NoFormat
+        | OrchestratorError::InvalidFormatSelector(_)
+        | OrchestratorError::Configuration(_) => 5,
+        OrchestratorError::PathGenerationFailed(_)
+        | OrchestratorError::ProgressBarFailed(_)
+        | OrchestratorError::IoError(_)
+        | OrchestratorError::Io(_) => 1,
+    }
+}
+
+/// Log an OrchestratorError and exit with the appropriate structured code.
+fn fail_with(e: OrchestratorError, verbose: bool) -> ! {
+    error!("Error: {e}");
+    if verbose {
+        error!("Debug info: {e:?}");
+    }
+    std::process::exit(exit_code_for(&e))
 }
 
 async fn async_main() -> Result<()> {
@@ -575,7 +661,9 @@ async fn async_main() -> Result<()> {
     let orchestrator = Orchestrator::new(config, (*multi_progress).clone());
 
     // Load cookies from file or browser if configured
-    orchestrator.load_cookies().await?;
+    if let Err(e) = orchestrator.load_cookies().await {
+        fail_with(e, args.verbose);
+    }
 
     // List extractors if requested
     if args.list_extractors {
@@ -606,7 +694,10 @@ async fn async_main() -> Result<()> {
 
     // Metadata-only modes: --dump-json, --print, --simulate
     if args.dump_json || args.print.is_some() || args.simulate {
-        let infos = orchestrator.extract_info(&url).await?;
+        let infos = match orchestrator.extract_info(&url).await {
+            Ok(infos) => infos,
+            Err(e) => fail_with(e, args.verbose),
+        };
 
         if args.dump_json {
             for info in &infos {
@@ -645,12 +736,6 @@ async fn async_main() -> Result<()> {
             // User cancelled - already printed message in orchestrator
             Ok(())
         }
-        Err(e) => {
-            error!("Error: {e}");
-            if args.verbose {
-                error!("Debug info: {e:?}");
-            }
-            std::process::exit(1);
-        }
+        Err(e) => fail_with(e, args.verbose),
     }
 }

--- a/crates/rdlp-cli/src/orchestrator/download.rs
+++ b/crates/rdlp-cli/src/orchestrator/download.rs
@@ -1,0 +1,199 @@
+//! Shared download execution with CDN fallback and token validation
+//!
+//! Consolidates the CDN fallback retry loop and token expiry check that were
+//! previously duplicated between `state.rs` and `playlist.rs`.
+
+use super::{Orchestrator, errors::*};
+use log::{info, warn};
+use rdlp_core::{DownloadStats, Format};
+use std::path::Path;
+
+/// Result of a successful download with CDN fallback
+pub(super) struct DownloadOutcome {
+    /// Download statistics from the successful attempt
+    #[allow(dead_code)]
+    pub stats: DownloadStats,
+    /// Whether HLS was detected for this format
+    pub is_hls: bool,
+}
+
+impl Orchestrator {
+    /// Execute a download with CDN fallback retry and token validation.
+    ///
+    /// This is the single implementation of the CDN fallback pattern, used by
+    /// both the state machine (single videos) and playlist downloads.
+    ///
+    /// # Flow
+    /// 1. Check CDN token expiry (if present in URL)
+    /// 2. Create progress bar (byte-based for HTTP, segment-based for HLS)
+    /// 3. Find appropriate downloader
+    /// 4. Try primary URL, then fallback URLs on failure
+    ///
+    /// # Returns
+    /// - `Ok(Some(outcome))` — download succeeded
+    /// - `Ok(None)` — user cancelled (Ctrl+C)
+    /// - `Err(e)` — all URLs failed or token expired
+    pub(super) async fn download_with_cdn_fallback(
+        &self,
+        format: &Format,
+        output_path: &Path,
+        resume_from: u64,
+    ) -> Result<Option<DownloadOutcome>> {
+        let is_hls = format.is_hls();
+
+        // HLS downloads use segment-based resume (tracked in .hls_state.json), not byte offsets
+        let effective_resume = if is_hls { 0 } else { resume_from };
+
+        let estimated_size = if is_hls {
+            None // HLS uses segment-based progress, not byte-based
+        } else {
+            format.filesize.or(format.filesize_approx)
+        };
+
+        // Create appropriate progress bar
+        let progress_bar = if is_hls {
+            self.create_hls_progress_bar()?
+        } else {
+            self.create_progress_bar(estimated_size, effective_resume)?
+        };
+
+        // Find downloader (with extra HTTP headers if the format specifies them)
+        let downloader = self
+            .downloader_registry
+            .find_downloader_with_headers(&format.url, format.http_headers.as_ref())
+            .ok_or_else(|| OrchestratorError::NoDownloader {
+                url: format.url.clone(),
+            })?;
+
+        // Validate CDN token expiry
+        self.check_cdn_token_expiry(&format.url)?;
+
+        // Build URL chain: primary + fallbacks
+        let download_urls: Vec<&str> = std::iter::once(format.url.as_str())
+            .chain(format.fallback_urls.iter().flatten().map(String::as_str))
+            .collect();
+
+        let mut stats = None;
+        let mut last_err = None;
+        for (i, download_url) in download_urls.iter().enumerate() {
+            if i > 0 {
+                warn!(
+                    fallback = i,
+                    url:? = download_url;
+                    "Primary CDN failed, trying fallback"
+                );
+            }
+            match self
+                .execute_download(
+                    &downloader,
+                    download_url,
+                    output_path,
+                    effective_resume,
+                    progress_bar.as_ref(),
+                    estimated_size,
+                )
+                .await
+            {
+                Ok(Some(s)) => {
+                    stats = Some(s);
+                    last_err = None;
+                    break;
+                }
+                Ok(None) => return Ok(None), // User cancelled
+                Err(e) => {
+                    if i < download_urls.len() - 1 {
+                        warn!("Download failed: {e}, will try fallback CDN");
+                    }
+                    last_err = Some(e);
+                }
+            }
+        }
+        if let Some(e) = last_err {
+            return Err(e);
+        }
+        let stats = stats.unwrap();
+
+        info!("Downloaded successfully!");
+        info!("   File: {}", output_path.display());
+        info!("   Stats: {stats:?}");
+
+        Ok(Some(DownloadOutcome { stats, is_hls }))
+    }
+
+    /// Check if the CDN token in a URL has expired.
+    ///
+    /// Supports two URL token formats:
+    /// - `validto=TIMESTAMP` (PornHub direct MP4)
+    /// - `~exp=TIMESTAMP~` (PornHub HLS / Akamai)
+    ///
+    /// Returns `Ok(())` if no token or token is still valid.
+    fn check_cdn_token_expiry(&self, url: &str) -> Result<()> {
+        if let Some(expires) = parse_url_expiry(url) {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if now >= expires {
+                return Err(OrchestratorError::DownloadFailed(
+                    rdlp_core::RdlpError::Network(format!(
+                        "CDN token expired {}s ago — re-run the command to get a fresh URL",
+                        now - expires
+                    )),
+                ));
+            } else if expires - now < 60 {
+                warn!("CDN token expires in less than 60 seconds — download may fail");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Parse CDN token expiry timestamp from a URL.
+///
+/// Supports two formats:
+/// - `validto=TIMESTAMP` (PornHub direct MP4)
+/// - `~exp=TIMESTAMP~` (PornHub HLS / Akamai)
+fn parse_url_expiry(url: &str) -> Option<u64> {
+    // Try `validto=DIGITS`
+    if let Some(pos) = url.find("validto=") {
+        let rest = &url[pos + 8..];
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(ts) = digits.parse::<u64>() {
+            return Some(ts);
+        }
+    }
+
+    // Try `~exp=DIGITS~` (Akamai-style)
+    if let Some(pos) = url.find("~exp=") {
+        let rest = &url[pos + 5..];
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(ts) = digits.parse::<u64>() {
+            return Some(ts);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_url_expiry_validto() {
+        let url = "https://cdn.example.com/video.mp4?validto=1700000000&token=abc";
+        assert_eq!(parse_url_expiry(url), Some(1_700_000_000));
+    }
+
+    #[test]
+    fn test_parse_url_expiry_akamai() {
+        let url = "https://cdn.example.com/video.mp4?~exp=1700000000~acl=/video/*";
+        assert_eq!(parse_url_expiry(url), Some(1_700_000_000));
+    }
+
+    #[test]
+    fn test_parse_url_expiry_none() {
+        let url = "https://cdn.example.com/video.mp4?token=abc";
+        assert_eq!(parse_url_expiry(url), None);
+    }
+}

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -1,6 +1,7 @@
 //! Orchestrator module for coordinating extraction, download, and post-processing
 
 mod archive;
+mod download;
 mod errors;
 mod execution;
 mod extraction;

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -4,7 +4,7 @@
 //! and graceful degradation for failed videos.
 
 use super::{Orchestrator, OrchestratorError, Result, archive};
-use log::{error, info, warn};
+use log::{error, info};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -356,6 +356,7 @@ impl Orchestrator {
     /// Download from pre-extracted InfoDict to a specific directory
     ///
     /// This method is used by playlist downloads to save files to the playlist folder.
+    /// Uses the shared CDN fallback loop via `download_with_cdn_fallback()`.
     pub(super) async fn download_from_info_to_dir(
         &self,
         info: &rdlp_core::InfoDict,
@@ -393,76 +394,14 @@ impl Orchestrator {
             }
         }
 
-        let resume_from = resume_offset;
-
-        // Create progress bar with best available size estimate
-        // For HLS streams, don't use filesize_approx - it's unreliable since the
-        // actual bitrate of the selected variant often differs from the estimate
-        let is_hls = format.url.contains(".m3u8") || format.ext == "hls";
-        let estimated_size = if is_hls {
-            format.filesize // Only use exact size if available (rare for HLS)
-        } else {
-            format.filesize.or(format.filesize_approx)
+        // Execute download with CDN fallback (shared implementation)
+        let outcome = match self
+            .download_with_cdn_fallback(&format, &output_path, resume_offset)
+            .await?
+        {
+            Some(outcome) => outcome,
+            None => return Ok(None),
         };
-        let progress_bar = self.create_progress_bar(estimated_size, resume_from)?;
-
-        // Find downloader (with extra HTTP headers if the format specifies them)
-        let downloader = self
-            .downloader_registry
-            .find_downloader_with_headers(&format.url, format.http_headers.as_ref())
-            .ok_or_else(|| OrchestratorError::NoDownloader {
-                url: format.url.clone(),
-            })?;
-
-        // Execute download with fallback CDN retry
-        let download_urls: Vec<&str> = std::iter::once(format.url.as_str())
-            .chain(format.fallback_urls.iter().flatten().map(String::as_str))
-            .collect();
-
-        let mut stats = None;
-        let mut last_err = None;
-        for (i, download_url) in download_urls.iter().enumerate() {
-            if i > 0 {
-                warn!(
-                    fallback = i,
-                    url:? = download_url;
-                    "Primary CDN failed, trying fallback"
-                );
-            }
-            match self
-                .execute_download(
-                    &downloader,
-                    download_url,
-                    &output_path,
-                    resume_from,
-                    progress_bar.as_ref(),
-                    estimated_size,
-                )
-                .await
-            {
-                Ok(Some(s)) => {
-                    stats = Some(s);
-                    last_err = None;
-                    break;
-                }
-                Ok(None) => return Ok(None),
-                Err(e) => {
-                    if i < download_urls.len() - 1 {
-                        warn!("Download failed: {e}, will try fallback CDN");
-                    }
-                    last_err = Some(e);
-                }
-            }
-        }
-        if let Some(e) = last_err {
-            return Err(e);
-        }
-        let stats = stats.unwrap();
-
-        // Report success
-        info!("Downloaded successfully!");
-        info!(path:? = output_path.display(); "   File");
-        info!(stats:?; "   Stats");
 
         // Download thumbnail if needed (before post-processing so embed can find it)
         if self.config.embed_thumbnail || self.config.write_thumbnail {
@@ -471,7 +410,7 @@ impl Orchestrator {
 
         // Run post-processing if configured (or automatic for HLS)
         let final_files = self
-            .run_postprocessing(info, vec![output_path.clone()], is_hls)
+            .run_postprocessing(info, vec![output_path.clone()], outcome.is_hls)
             .await?;
         let final_path = final_files.into_iter().next().unwrap_or(output_path);
 

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -5,7 +5,7 @@
 use super::{Orchestrator, Result};
 use log::{debug, info, warn};
 use rdlp_core::PostProcessConfig;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 impl Orchestrator {
     /// Convert Config to PostProcessConfig
@@ -181,50 +181,6 @@ impl Orchestrator {
         }
 
         Some(output_files)
-    }
-
-    /// Run post-processing for state machine downloads (single videos)
-    ///
-    /// Runs FFmpeg remux on all downloads for consistent output quality:
-    /// - Faststart (moov atom at beginning)
-    /// - Fixed timestamps
-    /// - Proper MP4 container structure
-    ///
-    /// Also runs user-requested post-processing (extract audio, embed metadata, etc.)
-    pub(super) async fn run_postprocessing_for_state_machine(
-        &self,
-        info: &rdlp_core::InfoDict,
-        output_path: &Path,
-        is_hls: bool,
-    ) -> Result<PathBuf> {
-        // Run FFmpeg remux on all downloads (both HLS and HTTP) for consistent output
-        // This moves moov atom to start (faststart), fixes timestamps, ensures proper container
-        if let Some(fixed_files) = self.ffmpeg_remux(&[output_path.to_path_buf()]).await {
-            if let Some(fixed_path) = fixed_files.into_iter().next() {
-                // If user also requested additional post-processing, run it
-                if self.needs_postprocessing() {
-                    let result = self
-                        .run_postprocessing(info, vec![fixed_path.clone()], is_hls)
-                        .await?;
-                    if let Some(path) = result.into_iter().next() {
-                        return Ok(path);
-                    }
-                }
-                return Ok(fixed_path);
-            }
-        }
-
-        // If FFmpeg remux failed, check if user requested any post-processing
-        if self.needs_postprocessing() {
-            let result = self
-                .run_postprocessing(info, vec![output_path.to_path_buf()], is_hls)
-                .await?;
-            if let Some(path) = result.into_iter().next() {
-                return Ok(path);
-            }
-        }
-
-        Ok(output_path.to_path_buf())
     }
 
     /// Clean up leftover HLS segment files from interrupted downloads

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -80,7 +80,7 @@ impl Orchestrator {
         let mut by_key: BTreeMap<(u32, bool), &Format> = BTreeMap::new();
         for fmt in &info.formats {
             let h = fmt.height.unwrap_or(0);
-            let hls = is_hls(fmt);
+            let hls = fmt.is_hls();
             let entry = by_key.entry((h, hls)).or_insert(fmt);
             if pick_better(fmt, entry) {
                 *entry = fmt;
@@ -129,12 +129,6 @@ impl Orchestrator {
             None => Ok(None),
         }
     }
-}
-
-/// Detect HLS by protocol flag or URL pattern (some extractors set protocol as Https
-/// even for m3u8 URLs)
-fn is_hls(f: &Format) -> bool {
-    f.protocol.is_hls() || f.url.contains(".m3u8") || f.url.contains("/master.m3u8")
 }
 
 /// Returns true if `candidate` is a better pick than `current` within the same group.

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -1,7 +1,7 @@
 //! State machine types for the download workflow
 
 use super::{Orchestrator, errors::*};
-use log::{info, warn};
+use log::info;
 use rdlp_core::Format;
 use std::fmt;
 use std::path::PathBuf;
@@ -162,7 +162,6 @@ impl DownloadPhase {
                 // Check if file is already complete
                 if let Some(expected_size) = format.filesize {
                     if resume_offset == expected_size {
-                        // File is already fully downloaded, skip to Complete
                         return Ok(Self::Complete { path: output_path });
                     }
                 }
@@ -187,115 +186,25 @@ impl DownloadPhase {
                 format,
                 state,
             } => {
-                // Create progress bar with best available size estimate
-                // For HLS streams, use segment-based progress bar (not byte-based)
-                let is_hls = format.url.contains(".m3u8") || format.ext == "hls";
-
-                // HLS downloads use segment-based resume (tracked in .hls_state.json), not byte offsets
-                // The HLS downloader handles its own resume logic internally
-                let resume_from = if is_hls {
-                    0 // HLS downloader manages its own state file for segment-based resume
-                } else {
-                    state.offset()
+                // Execute download with CDN fallback (shared implementation)
+                let outcome = match orchestrator
+                    .download_with_cdn_fallback(&format, &output_path, state.offset())
+                    .await?
+                {
+                    Some(outcome) => outcome,
+                    None => return Ok(Self::Cancelled),
                 };
-
-                let estimated_size = if is_hls {
-                    None // HLS uses segment-based progress, not byte-based
-                } else {
-                    format.filesize.or(format.filesize_approx)
-                };
-                let progress_bar = if is_hls {
-                    orchestrator.create_hls_progress_bar()?
-                } else {
-                    orchestrator.create_progress_bar(estimated_size, resume_from)?
-                };
-
-                // Find downloader (with extra HTTP headers if the format specifies them)
-                let downloader = orchestrator
-                    .downloader_registry
-                    .find_downloader_with_headers(&format.url, format.http_headers.as_ref())
-                    .ok_or_else(|| OrchestratorError::NoDownloader {
-                        url: format.url.clone(),
-                    })?;
-
-                // Check if the CDN token is still valid
-                if let Some(expires) = parse_url_expiry(&format.url) {
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    if now >= expires {
-                        return Err(OrchestratorError::DownloadFailed(
-                            rdlp_core::RdlpError::Network(format!(
-                                "CDN token expired {}s ago — re-run the command to get a fresh URL",
-                                now - expires
-                            )),
-                        ));
-                    } else if expires - now < 60 {
-                        warn!("CDN token expires in less than 60 seconds — download may fail");
-                    }
-                }
-
-                // Execute download with fallback CDN retry
-                let download_urls: Vec<&str> = std::iter::once(format.url.as_str())
-                    .chain(format.fallback_urls.iter().flatten().map(String::as_str))
-                    .collect();
-
-                let mut stats = None;
-                let mut last_err = None;
-                for (i, download_url) in download_urls.iter().enumerate() {
-                    if i > 0 {
-                        warn!(
-                            fallback = i,
-                            url:? = download_url;
-                            "Primary CDN failed, trying fallback"
-                        );
-                    }
-                    match orchestrator
-                        .execute_download(
-                            &downloader,
-                            download_url,
-                            &output_path,
-                            resume_from,
-                            progress_bar.as_ref(),
-                            estimated_size,
-                        )
-                        .await
-                    {
-                        Ok(Some(s)) => {
-                            stats = Some(s);
-                            last_err = None;
-                            break;
-                        }
-                        Ok(None) => return Ok(Self::Cancelled),
-                        Err(e) => {
-                            if i < download_urls.len() - 1 {
-                                warn!("Download failed: {e}, will try fallback CDN");
-                            }
-                            last_err = Some(e);
-                        }
-                    }
-                }
-                if let Some(e) = last_err {
-                    return Err(e);
-                }
-                let stats = stats.unwrap();
-
-                // Report success
-                info!("Downloaded successfully!");
-                info!("   File: {}", output_path.display());
-                info!("   Stats: {stats:?}");
 
                 // Download thumbnail for embedding or standalone use
-                // Skipped only when --no-thumbnail is set (embed_thumbnail=false && write_thumbnail=false)
                 if orchestrator.config.embed_thumbnail || orchestrator.config.write_thumbnail {
                     orchestrator.download_thumbnail(&info, &output_path).await;
                 }
 
                 // Run post-processing (automatic for HLS, optional for others)
-                let final_path = orchestrator
-                    .run_postprocessing_for_state_machine(&info, &output_path, is_hls)
+                let final_files = orchestrator
+                    .run_postprocessing(&info, vec![output_path.clone()], outcome.is_hls)
                     .await?;
+                let final_path = final_files.into_iter().next().unwrap_or(output_path);
 
                 Ok(Self::Complete { path: final_path })
             }
@@ -306,31 +215,4 @@ impl DownloadPhase {
             }
         }
     }
-}
-
-/// Parse CDN token expiry timestamp from a URL.
-///
-/// Supports two formats:
-/// - `validto=TIMESTAMP` (PornHub direct MP4)
-/// - `~exp=TIMESTAMP~` (PornHub HLS / Akamai)
-fn parse_url_expiry(url: &str) -> Option<u64> {
-    // Try `validto=DIGITS`
-    if let Some(pos) = url.find("validto=") {
-        let rest = &url[pos + 8..];
-        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        if let Ok(ts) = digits.parse::<u64>() {
-            return Some(ts);
-        }
-    }
-
-    // Try `~exp=DIGITS~` (Akamai-style)
-    if let Some(pos) = url.find("~exp=") {
-        let rest = &url[pos + 5..];
-        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        if let Ok(ts) = digits.parse::<u64>() {
-            return Some(ts);
-        }
-    }
-
-    None
 }

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -292,8 +292,14 @@ impl Format {
     }
 
     /// Check if this is an HLS format
+    ///
+    /// Checks all three signals: protocol enum, URL pattern, and file extension.
+    /// Some extractors set `protocol` as `Https` even for m3u8 URLs, so the URL
+    /// and extension checks act as fallbacks.
     pub fn is_hls(&self) -> bool {
         self.protocol.is_hls()
+            || self.url.contains(".m3u8")
+            || self.ext == "hls"
     }
 
     /// Get a human-readable format description
@@ -339,9 +345,7 @@ impl Format {
     /// Call this on every format to compute `max` width, then pass that to [`Self::table_row`].
     #[must_use]
     pub fn size_text(&self) -> String {
-        let is_hls = self.is_hls() || self.url.contains(".m3u8");
-
-        if is_hls {
+        if self.is_hls() {
             let seg_count = self
                 .fragments
                 .as_ref()
@@ -438,9 +442,8 @@ impl Format {
         buf.push_str(" | ");
 
         // Format type column: avoid to_uppercase() allocation for HLS
-        let is_hls = self.is_hls() || self.url.contains(".m3u8");
         let format_start = buf.len();
-        if is_hls {
+        if self.is_hls() {
             buf.push_str("HLS");
         } else {
             // Write uppercase directly
@@ -567,5 +570,36 @@ mod tests {
 
         assert!(!format.has_video());
         assert!(format.has_audio());
+    }
+
+    #[test]
+    fn test_is_hls_by_protocol() {
+        let format = Format::new("hls", "https://cdn.example.com/video.ts", "mp4", DownloadProtocol::M3u8);
+        assert!(format.is_hls());
+
+        let format = Format::new("hls", "https://cdn.example.com/video.ts", "mp4", DownloadProtocol::M3u8Native);
+        assert!(format.is_hls());
+    }
+
+    #[test]
+    fn test_is_hls_by_url() {
+        // Some extractors set protocol as Https even for m3u8 URLs
+        let format = Format::new("hls", "https://cdn.example.com/master.m3u8", "mp4", DownloadProtocol::Https);
+        assert!(format.is_hls());
+
+        let format = Format::new("hls", "https://cdn.example.com/index.m3u8?token=abc", "mp4", DownloadProtocol::Https);
+        assert!(format.is_hls());
+    }
+
+    #[test]
+    fn test_is_hls_by_ext() {
+        let format = Format::new("hls", "https://cdn.example.com/video", "hls", DownloadProtocol::Https);
+        assert!(format.is_hls());
+    }
+
+    #[test]
+    fn test_is_not_hls() {
+        let format = Format::new("mp4", "https://cdn.example.com/video.mp4", "mp4", DownloadProtocol::Https);
+        assert!(!format.is_hls());
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `rdlp-cli` crate, focusing on error handling, configuration merging, and download logic. The most significant changes are the restructuring of interactive CLI prompts and configuration merging, the introduction of structured error handling and exit codes, and the consolidation of CDN fallback download logic into a single shared module.

**Configuration and error handling improvements:**

* Refactored the configuration merging process by separating interactive CLI prompt resolution (`resolve_interactive_values`) from the pure config merge (`merge_config`). This makes the config logic testable and isolates side effects. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L389-L423) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L443-R472) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L468-R498) [[4]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L508-R619)
* Introduced structured error handling for orchestrator errors, including mapping errors to process exit codes and logging debug info based on verbosity. Errors such as user cancellation, extraction, download, and configuration failures now exit with specific codes. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L508-R619) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L578-R666) [[3]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L609-R700) [[4]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L648-R739) [[5]](diffhunk://#diff-2a1f4c4c0643023d2ef5f1f630a018fc30fa8a2d0602c99627f10f5a40c264c1L10-R10) [[6]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L9-R9)

**Download logic and CDN fallback refactor:**

* Consolidated the CDN fallback retry loop and token expiry validation into a new `download.rs` module, providing a single implementation for both single video and playlist downloads. This reduces code duplication and improves maintainability. [[1]](diffhunk://#diff-51486911339e8c67299799c6f761b37a7c74f6a8eb8b750894fa013719580471R1-R199) [[2]](diffhunk://#diff-30d5a1222ece234f7f2828320152b7542fd77395d1219215fbb5906b35060f21R4)
* Refactored playlist download logic to use the shared `download_with_cdn_fallback` method, ensuring consistent handling of CDN fallback and token expiry across different download modes. [[1]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341R359) [[2]](diffhunk://#diff-35b36d8ded4a3fb2bdb307575dd1449d848d02a4c16a0ebb1623c31aa6960341L396-R404)

**Minor improvements:**

* Improved logging and user feedback for configuration file loading and download outcomes, including warnings for token expiry and download failures. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3L389-L423) [[2]](diffhunk://#diff-51486911339e8c67299799c6f761b37a7c74f6a8eb8b750894fa013719580471R1-R199)
* Cleaned up imports and removed unnecessary logging in playlist downloads.

These changes collectively improve the robustness, testability, and maintainability of the CLI tool, especially around configuration handling and download reliability.…fy post-processing, structured exit codes (#38)

Address all issues from the rdlp-cli complexity analysis report:

PR #1: Centralize HLS detection + CDN fallback loop
- Widen Format::is_hls() in rdlp-types to check protocol + URL + ext
- Extract download_with_cdn_fallback() into new download.rs module
- Reduce state.rs Downloading arm from ~118 to ~20 lines
- Remove duplicated CDN fallback loop from playlist.rs
- Remove standalone is_hls() from selection.rs

PR #2: Unify post-processing entry points
- Remove run_postprocessing_for_state_machine() wrapper
- Both state.rs and playlist.rs call run_postprocessing() directly

PR #3: Split build_config + config validation
- Separate interactive UI into resolve_interactive_values()
- Extract pure merge_config() (no side effects, testable)
- Add config.validate() call after merge
- Remove fragile output.contains("%(") template detection hack

PR #4: Structured exit codes at CLI boundary
- Map OrchestratorError variants to exit codes 1-5
- Apply at all three error boundaries (cookies, extraction, download)
- Re-export OrchestratorError from lib.rs

Net: -321 lines removed, +212 added; 15 new tests; 0 warnings