### PR TITLE
Fix/enomem loudnorm pass2

### DIFF
--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -119,6 +119,18 @@ struct Args {
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
     remux: Option<String>,
 
+    /// Normalize audio levels (peak mode: volume + limiter)
+    #[arg(long)]
+    normalize_audio: bool,
+
+    /// Use EBU R128 loudnorm normalization (two-pass, implies --normalize-audio)
+    #[arg(long)]
+    loudnorm: bool,
+
+    /// Target peak level in dBFS for peak normalization (default: -1.0)
+    #[arg(long, allow_hyphen_values = true)]
+    audio_gain_target: Option<f64>,
+
     /// Keep original video file after post-processing
     #[arg(long)]
     keep_video: bool,
@@ -494,6 +506,17 @@ fn merge_config(
                     .map_err(|e| anyhow::anyhow!(e))?,
             );
         }
+    }
+
+    // Audio normalization: --loudnorm implies --normalize-audio
+    if args.normalize_audio || args.loudnorm {
+        config.normalize_audio = true;
+    }
+    if args.loudnorm {
+        config.loudnorm = true;
+    }
+    if let Some(target) = args.audio_gain_target {
+        config.audio_gain_target = Some(target);
     }
 
     if args.keep_video {

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -131,6 +131,30 @@ struct Args {
     #[arg(long, allow_hyphen_values = true)]
     audio_gain_target: Option<f64>,
 
+    /// Loudnorm preset: broadcast (-23 LUFS), streaming (-14 LUFS), loud (-11 LUFS)
+    #[arg(long)]
+    loudnorm_preset: Option<String>,
+
+    /// Target integrated loudness in LUFS for loudnorm (e.g., -14)
+    #[arg(long, allow_hyphen_values = true)]
+    loudnorm_i: Option<f64>,
+
+    /// Target true peak in dBTP for loudnorm (e.g., -1)
+    #[arg(long, allow_hyphen_values = true)]
+    loudnorm_tp: Option<f64>,
+
+    /// Target loudness range in LU for loudnorm (e.g., 11)
+    #[arg(long)]
+    loudnorm_lra: Option<f64>,
+
+    /// Force dynamic (per-frame compression) mode in loudnorm pass 2
+    #[arg(long)]
+    loudnorm_dynamic: bool,
+
+    /// Prepend a mild acompressor before loudnorm to tame extreme peaks
+    #[arg(long)]
+    loudnorm_precompress: bool,
+
     /// Keep original video file after post-processing
     #[arg(long)]
     keep_video: bool,
@@ -517,6 +541,24 @@ fn merge_config(
     }
     if let Some(target) = args.audio_gain_target {
         config.audio_gain_target = Some(target);
+    }
+    if let Some(ref preset) = args.loudnorm_preset {
+        config.loudnorm_preset = Some(preset.clone());
+    }
+    if let Some(i) = args.loudnorm_i {
+        config.loudnorm_target_i = Some(i);
+    }
+    if let Some(tp) = args.loudnorm_tp {
+        config.loudnorm_target_tp = Some(tp);
+    }
+    if let Some(lra) = args.loudnorm_lra {
+        config.loudnorm_target_lra = Some(lra);
+    }
+    if args.loudnorm_dynamic {
+        config.loudnorm_dynamic = true;
+    }
+    if args.loudnorm_precompress {
+        config.loudnorm_precompress = true;
     }
 
     if args.keep_video {

--- a/crates/rdlp-cli/src/orchestrator/paths.rs
+++ b/crates/rdlp-cli/src/orchestrator/paths.rs
@@ -25,9 +25,11 @@ impl Orchestrator {
             epoch: chrono::Utc::now().timestamp(),
             autonumber: 0,
         };
-        let rendered = template.render(info, format, &file_ext, &ctx).map_err(|e| {
-            super::OrchestratorError::Configuration(format!("Template rendering failed: {e}"))
-        })?;
+        let rendered = template
+            .render(info, format, &file_ext, &ctx)
+            .map_err(|e| {
+                super::OrchestratorError::Configuration(format!("Template rendering failed: {e}"))
+            })?;
 
         let path = self.sanitize_template_path(&rendered);
 

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -27,9 +27,12 @@ impl Orchestrator {
             normalize_audio: self.config.normalize_audio,
             loudnorm: self.config.loudnorm,
             audio_gain_target: self.config.audio_gain_target,
-            loudnorm_target_i: None,
-            loudnorm_target_tp: None,
-            loudnorm_target_lra: None,
+            loudnorm_preset: self.config.loudnorm_preset.clone(),
+            loudnorm_target_i: self.config.loudnorm_target_i,
+            loudnorm_target_tp: self.config.loudnorm_target_tp,
+            loudnorm_target_lra: self.config.loudnorm_target_lra,
+            loudnorm_dynamic: self.config.loudnorm_dynamic,
+            loudnorm_precompress: self.config.loudnorm_precompress,
         }
     }
 

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -24,6 +24,12 @@ impl Orchestrator {
             keep_video: self.config.keep_video,
             ffmpeg_location: self.config.ffmpeg_location.clone(),
             ffmpeg_args: self.config.ffmpeg_args.clone(),
+            normalize_audio: self.config.normalize_audio,
+            loudnorm: self.config.loudnorm,
+            audio_gain_target: self.config.audio_gain_target,
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
         }
     }
 
@@ -34,6 +40,7 @@ impl Orchestrator {
             || self.config.embed_thumbnail
             || self.config.recode_video.is_some()
             || self.config.remux_container.is_some()
+            || self.config.normalize_audio
     }
 
     /// Run post-processing pipeline on downloaded file(s)

--- a/crates/rdlp-cli/src/orchestrator/template.rs
+++ b/crates/rdlp-cli/src/orchestrator/template.rs
@@ -295,10 +295,7 @@ impl OutputTemplate {
                 } else {
                     Some(end_str.parse::<i64>().unwrap_or(0))
                 };
-                accessors.push(Accessor::Slice {
-                    start: None,
-                    end,
-                });
+                accessors.push(Accessor::Slice { start: None, end });
                 continue;
             }
 
@@ -312,7 +309,14 @@ impl OutputTemplate {
                 i += 1;
             }
 
-            while i < len && chars[i] != '.' && chars[i] != '+' && chars[i] != '-' && chars[i] != '>' && chars[i] != '*' && chars[i] != '/' {
+            while i < len
+                && chars[i] != '.'
+                && chars[i] != '+'
+                && chars[i] != '-'
+                && chars[i] != '>'
+                && chars[i] != '*'
+                && chars[i] != '/'
+            {
                 if chars[i] == ':' {
                     break;
                 }
@@ -386,10 +390,7 @@ impl OutputTemplate {
     }
 
     /// Parse the format specifier after `)` — e.g. `s`, `#05d`, `.2f`, `#j`
-    fn parse_format_specifier(
-        chars: &[char],
-        i: &mut usize,
-    ) -> Result<FormatSpec, TemplateError> {
+    fn parse_format_specifier(chars: &[char], i: &mut usize) -> Result<FormatSpec, TemplateError> {
         let spec_start = *i;
 
         // Defaults
@@ -412,7 +413,11 @@ impl OutputTemplate {
         }
 
         // Parse `0` flag (zero-pad)
-        if *i < chars.len() && chars[*i] == '0' && *i + 1 < chars.len() && chars[*i + 1].is_ascii_digit() {
+        if *i < chars.len()
+            && chars[*i] == '0'
+            && *i + 1 < chars.len()
+            && chars[*i + 1].is_ascii_digit()
+        {
             zero_pad = true;
             *i += 1;
         }
@@ -540,17 +545,11 @@ impl OutputTemplate {
 
         // Try explicit default
         if let Some(ref default) = spec.default {
-            return Ok(self.format_value(
-                &serde_json::Value::String(default.clone()),
-                &spec.format,
-            ));
+            return Ok(self.format_value(&serde_json::Value::String(default.clone()), &spec.format));
         }
 
         // yt-dlp behavior: missing fields produce "NA" (not an error)
-        Ok(self.format_value(
-            &serde_json::Value::String("NA".to_string()),
-            &spec.format,
-        ))
+        Ok(self.format_value(&serde_json::Value::String("NA".to_string()), &spec.format))
     }
 
     /// Look up a single field reference, applying accessors/arithmetic/date format.
@@ -658,35 +657,33 @@ fn apply_accessor(val: &serde_json::Value, accessor: &Accessor) -> Option<serde_
                 None
             }
         }
-        Accessor::Slice { start, end } => {
-            match val {
-                serde_json::Value::String(s) => {
-                    let chars: Vec<char> = s.chars().collect();
-                    let len = chars.len() as i64;
-                    let start_idx = resolve_slice_bound(start.unwrap_or(0), len);
-                    let end_idx = resolve_slice_bound(end.unwrap_or(len), len);
-                    if start_idx >= end_idx {
-                        Some(serde_json::Value::String(String::new()))
-                    } else {
-                        let sliced: String =
-                            chars[start_idx as usize..end_idx as usize].iter().collect();
-                        Some(serde_json::Value::String(sliced))
-                    }
+        Accessor::Slice { start, end } => match val {
+            serde_json::Value::String(s) => {
+                let chars: Vec<char> = s.chars().collect();
+                let len = chars.len() as i64;
+                let start_idx = resolve_slice_bound(start.unwrap_or(0), len);
+                let end_idx = resolve_slice_bound(end.unwrap_or(len), len);
+                if start_idx >= end_idx {
+                    Some(serde_json::Value::String(String::new()))
+                } else {
+                    let sliced: String =
+                        chars[start_idx as usize..end_idx as usize].iter().collect();
+                    Some(serde_json::Value::String(sliced))
                 }
-                serde_json::Value::Array(arr) => {
-                    let len = arr.len() as i64;
-                    let start_idx = resolve_slice_bound(start.unwrap_or(0), len);
-                    let end_idx = resolve_slice_bound(end.unwrap_or(len), len);
-                    if start_idx >= end_idx {
-                        Some(serde_json::Value::Array(Vec::new()))
-                    } else {
-                        let sliced = arr[start_idx as usize..end_idx as usize].to_vec();
-                        Some(serde_json::Value::Array(sliced))
-                    }
-                }
-                _ => None,
             }
-        }
+            serde_json::Value::Array(arr) => {
+                let len = arr.len() as i64;
+                let start_idx = resolve_slice_bound(start.unwrap_or(0), len);
+                let end_idx = resolve_slice_bound(end.unwrap_or(len), len);
+                if start_idx >= end_idx {
+                    Some(serde_json::Value::Array(Vec::new()))
+                } else {
+                    let sliced = arr[start_idx as usize..end_idx as usize].to_vec();
+                    Some(serde_json::Value::Array(sliced))
+                }
+            }
+            _ => None,
+        },
     }
 }
 
@@ -758,10 +755,9 @@ fn format_as_string(val: &serde_json::Value) -> String {
 /// Format as integer (type `d`)
 fn format_as_integer(val: &serde_json::Value, spec: &FormatSpec) -> String {
     let num = match val {
-        serde_json::Value::Number(n) => {
-            n.as_i64()
-                .unwrap_or_else(|| n.as_f64().unwrap_or(0.0) as i64)
-        }
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .unwrap_or_else(|| n.as_f64().unwrap_or(0.0) as i64),
         serde_json::Value::String(s) => s.parse::<f64>().unwrap_or(0.0) as i64,
         _ => 0,
     };
@@ -929,10 +925,9 @@ fn format_as_unicode(val: &serde_json::Value, _nfd: bool) -> String {
 /// Format with thousands separator (type `R`)
 fn format_as_thousands(val: &serde_json::Value) -> String {
     let num = match val {
-        serde_json::Value::Number(n) => {
-            n.as_i64()
-                .unwrap_or_else(|| n.as_f64().unwrap_or(0.0) as i64)
-        }
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .unwrap_or_else(|| n.as_f64().unwrap_or(0.0) as i64),
         serde_json::Value::String(s) => s.parse::<f64>().unwrap_or(0.0) as i64,
         _ => 0,
     };
@@ -957,10 +952,7 @@ fn format_as_thousands(val: &serde_json::Value) -> String {
 /// Apply width padding (for format types that don't handle it internally)
 fn apply_width(raw: &str, spec: &FormatSpec) -> String {
     // Integer and Float handle width internally
-    if matches!(
-        spec.type_char,
-        FormatType::Integer | FormatType::Float
-    ) {
+    if matches!(spec.type_char, FormatType::Integer | FormatType::Float) {
         return raw.to_string();
     }
 
@@ -1077,7 +1069,11 @@ mod tests {
         info.view_count = Some(12345);
         info.upload_date = Some("20231114".to_string());
         info.duration = Some(3661.5);
-        info.tags = Some(vec!["tag1".to_string(), "tag2".to_string(), "tag3".to_string()]);
+        info.tags = Some(vec![
+            "tag1".to_string(),
+            "tag2".to_string(),
+            "tag3".to_string(),
+        ]);
         info
     }
 
@@ -1225,10 +1221,7 @@ mod tests {
         match &t.segments[0] {
             Segment::Field(spec) => {
                 assert_eq!(spec.names[0].name, "upload_date");
-                assert_eq!(
-                    spec.names[0].date_format.as_deref(),
-                    Some("%Y-%m-%d")
-                );
+                assert_eq!(spec.names[0].date_format.as_deref(), Some("%Y-%m-%d"));
             }
             _ => panic!("Expected Field segment"),
         }
@@ -1680,9 +1673,7 @@ mod tests {
             i.title = "My: Video / Title".to_string();
             i
         };
-        let result = t
-            .render(&info, &test_format(), "mp4", &test_ctx())
-            .unwrap();
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
         assert_eq!(result, "My_ Video _ Title");
     }
 
@@ -1694,9 +1685,7 @@ mod tests {
             i.title = "日本語/Test".to_string();
             i
         };
-        let result = t
-            .render(&info, &test_format(), "mp4", &test_ctx())
-            .unwrap();
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
         assert_eq!(result, "____Test");
     }
 
@@ -1717,9 +1706,7 @@ mod tests {
             i.title = "It's a test".to_string();
             i
         };
-        let result = t
-            .render(&info, &test_format(), "mp4", &test_ctx())
-            .unwrap();
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
         // The `\` in `'\''` gets replaced with `_` by render()'s path sanitization
         assert_eq!(result, "'It'_''s a test'");
     }
@@ -1732,9 +1719,7 @@ mod tests {
             i.title = "<b>Bold & \"Fun\"</b>".to_string();
             i
         };
-        let result = t
-            .render(&info, &test_format(), "mp4", &test_ctx())
-            .unwrap();
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
         assert_eq!(result, "&lt;b&gt;Bold &amp; &quot;Fun&quot;&lt;_b&gt;");
     }
 
@@ -1746,9 +1731,7 @@ mod tests {
             i.view_count = Some(65); // ASCII 'A'
             i
         };
-        let result = t
-            .render(&info, &test_format(), "mp4", &test_ctx())
-            .unwrap();
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
         assert_eq!(result, "A");
     }
 
@@ -1786,9 +1769,7 @@ mod tests {
             epoch: 0,
             autonumber: 42,
         };
-        let result = t
-            .render(&test_info(), &test_format(), "mp4", &ctx)
-            .unwrap();
+        let result = t.render(&test_info(), &test_format(), "mp4", &ctx).unwrap();
         assert_eq!(result, "00042");
     }
 

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -120,6 +120,24 @@ pub struct PostProcessConfig {
 
     /// Additional FFmpeg arguments
     pub ffmpeg_args: Vec<String>,
+
+    /// Normalize audio levels (peak mode unless loudnorm is set)
+    pub normalize_audio: bool,
+
+    /// Use EBU R128 loudnorm normalization (implies normalize_audio)
+    pub loudnorm: bool,
+
+    /// Target peak level in dBFS for peak normalization (default -1.0)
+    pub audio_gain_target: Option<f64>,
+
+    /// Target integrated loudness in LUFS for loudnorm (default -16.0)
+    pub loudnorm_target_i: Option<f64>,
+
+    /// Target true peak in dBTP for loudnorm (default -1.5)
+    pub loudnorm_target_tp: Option<f64>,
+
+    /// Target loudness range in LU for loudnorm (default 11.0)
+    pub loudnorm_target_lra: Option<f64>,
 }
 
 impl Default for PostProcessConfig {
@@ -138,6 +156,12 @@ impl Default for PostProcessConfig {
             keep_video: false,
             ffmpeg_location: None,
             ffmpeg_args: Vec::new(),
+            normalize_audio: false,
+            loudnorm: false,
+            audio_gain_target: None,
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
         }
     }
 }

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -130,7 +130,10 @@ pub struct PostProcessConfig {
     /// Target peak level in dBFS for peak normalization (default -1.0)
     pub audio_gain_target: Option<f64>,
 
-    /// Target integrated loudness in LUFS for loudnorm (default -16.0)
+    /// Loudnorm preset name (broadcast, streaming, loud)
+    pub loudnorm_preset: Option<String>,
+
+    /// Target integrated loudness in LUFS for loudnorm (default -14.0)
     pub loudnorm_target_i: Option<f64>,
 
     /// Target true peak in dBTP for loudnorm (default -1.5)
@@ -138,6 +141,12 @@ pub struct PostProcessConfig {
 
     /// Target loudness range in LU for loudnorm (default 11.0)
     pub loudnorm_target_lra: Option<f64>,
+
+    /// Force dynamic (per-frame compression) mode in loudnorm pass 2
+    pub loudnorm_dynamic: bool,
+
+    /// Prepend a mild acompressor before loudnorm in pass 2
+    pub loudnorm_precompress: bool,
 }
 
 impl Default for PostProcessConfig {
@@ -159,9 +168,12 @@ impl Default for PostProcessConfig {
             normalize_audio: false,
             loudnorm: false,
             audio_gain_target: None,
+            loudnorm_preset: None,
             loudnorm_target_i: None,
             loudnorm_target_tp: None,
             loudnorm_target_lra: None,
+            loudnorm_dynamic: false,
+            loudnorm_precompress: false,
         }
     }
 }

--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -1,8 +1,27 @@
 //! Error types for post-processing operations.
 
 use rdlp_core::RdlpError;
+use std::fmt;
 use std::path::PathBuf;
 use thiserror::Error;
+
+/// Classification of input container corruption.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorruptionKind {
+    /// Matroska/WebM EBML structural errors:
+    /// - "invalid as first byte of an EBML number"
+    /// - "element exceeds containing master element"
+    /// - "Duplicate element"
+    MatroskaEbml,
+}
+
+impl fmt::Display for CorruptionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MatroskaEbml => write!(f, "matroska ebml"),
+        }
+    }
+}
 
 /// Errors that can occur during post-processing.
 #[derive(Debug, Error)]
@@ -72,6 +91,21 @@ pub enum PostProcessError {
     #[error("FFmpeg library error: {message}")]
     FFmpegLibraryError { message: String },
 
+    /// Mux/write operation failed with diagnostic packet context
+    #[error(
+        "Mux write failed ({operation}): {message} [stream={stream_index}, pts={pts:?}, dts={dts:?}, size={packet_size}, tb={time_base_num}/{time_base_den}]"
+    )]
+    MuxWriteError {
+        message: String,
+        operation: String,
+        stream_index: usize,
+        pts: Option<i64>,
+        dts: Option<i64>,
+        packet_size: i32,
+        time_base_num: i32,
+        time_base_den: i32,
+    },
+
     /// Post-processor not found in registry
     #[error("Post-processor not found: {name}")]
     ProcessorNotFound { name: String },
@@ -83,6 +117,30 @@ pub enum PostProcessError {
     /// Temporary file creation failed
     #[error("Failed to create temporary file: {message}")]
     TempFileError { message: String },
+
+    /// Audio normalization failed
+    #[error("Audio normalization failed: {message}")]
+    NormalizationFailed { message: String },
+
+    /// FFmpeg log capture failed
+    #[error("FFmpeg log capture failed: {message}")]
+    LogCaptureFailed { message: String },
+
+    /// Input container is structurally corrupt (detected via demuxer log analysis).
+    ///
+    /// Matroska/WebM EBML errors indicate malformed container structure that
+    /// produces invalid packets/timestamps, which cascade into muxer ENOMEM
+    /// failures during transcoding.
+    #[error("input corrupt ({kind}): {}", path.display())]
+    InputCorrupt {
+        kind: CorruptionKind,
+        path: PathBuf,
+        logs: Vec<String>,
+    },
+
+    /// Salvage remux failed — input too corrupt to recover.
+    #[error("Input corrupt and salvage failed: {message}")]
+    SalvageFailed { message: String },
 }
 
 impl PostProcessError {
@@ -99,6 +157,27 @@ impl PostProcessError {
         Self::IoError {
             message: message.into(),
             source,
+        }
+    }
+
+    /// True if this is a mux write error (ENOMEM / ENOSPC from the muxer).
+    #[must_use]
+    pub fn is_mux_write_error(&self) -> bool {
+        matches!(self, Self::MuxWriteError { .. })
+    }
+
+    /// True if this error may be recoverable by salvage-remuxing and retrying.
+    #[must_use]
+    pub fn is_salvage_retryable(&self) -> bool {
+        matches!(self, Self::MuxWriteError { .. } | Self::InputCorrupt { .. })
+    }
+
+    /// True if this error indicates memory exhaustion (ENOMEM/-12).
+    #[must_use]
+    pub fn is_enomem(&self) -> bool {
+        match self {
+            Self::MuxWriteError { message, .. } => message.contains("ret=-12"),
+            _ => false,
         }
     }
 }
@@ -121,14 +200,187 @@ impl From<PostProcessError> for RdlpError {
         match error {
             PostProcessError::FFmpegFailed { .. }
             | PostProcessError::FFmpegInitFailed { .. }
-            | PostProcessError::FFmpegLibraryError { .. } => RdlpError::FFmpeg(error.to_string()),
+            | PostProcessError::FFmpegLibraryError { .. }
+            | PostProcessError::MuxWriteError { .. } => RdlpError::FFmpeg(error.to_string()),
 
             PostProcessError::InputNotFound { .. }
             | PostProcessError::OutputExists { .. }
             | PostProcessError::IoError { .. }
             | PostProcessError::TempFileError { .. } => RdlpError::PostProcess(error.to_string()),
 
+            PostProcessError::InputCorrupt { .. } | PostProcessError::SalvageFailed { .. } => {
+                RdlpError::FFmpeg(error.to_string())
+            }
+
             _ => RdlpError::PostProcess(error.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mux_write_error_display() {
+        let err = PostProcessError::MuxWriteError {
+            message: "Not enough space".into(),
+            operation: "av_interleaved_write_frame".into(),
+            stream_index: 0,
+            pts: Some(12345),
+            dts: Some(12340),
+            packet_size: 1024,
+            time_base_num: 1,
+            time_base_den: 1000,
+        };
+        let display = err.to_string();
+        assert!(display.contains("av_interleaved_write_frame"));
+        assert!(display.contains("Not enough space"));
+        assert!(display.contains("stream=0"));
+        assert!(display.contains("pts=Some(12345)"));
+        assert!(display.contains("dts=Some(12340)"));
+        assert!(display.contains("size=1024"));
+        assert!(display.contains("tb=1/1000"));
+    }
+
+    #[test]
+    fn test_mux_write_error_display_none_timestamps() {
+        let err = PostProcessError::MuxWriteError {
+            message: "write failed".into(),
+            operation: "av_write_frame".into(),
+            stream_index: 1,
+            pts: None,
+            dts: None,
+            packet_size: 512,
+            time_base_num: 1,
+            time_base_den: 48000,
+        };
+        let display = err.to_string();
+        assert!(display.contains("av_write_frame"));
+        assert!(display.contains("pts=None"));
+        assert!(display.contains("dts=None"));
+        assert!(display.contains("tb=1/48000"));
+    }
+
+    #[test]
+    fn test_mux_write_error_direct_write_display() {
+        let err = PostProcessError::MuxWriteError {
+            message: "ret=-12 (Cannot allocate memory), dur=1024".into(),
+            operation: "av_write_frame".into(),
+            stream_index: 0,
+            pts: Some(48000),
+            dts: Some(48000),
+            packet_size: 2048,
+            time_base_num: 1,
+            time_base_den: 48000,
+        };
+        let display = err.to_string();
+        assert!(display.contains("av_write_frame"));
+        assert!(display.contains("Cannot allocate memory"));
+        assert!(display.contains("stream=0"));
+        assert!(display.contains("size=2048"));
+    }
+
+    #[test]
+    fn test_mux_write_error_converts_to_rdlp_ffmpeg() {
+        let err = PostProcessError::MuxWriteError {
+            message: "test".into(),
+            operation: "av_interleaved_write_frame".into(),
+            stream_index: 0,
+            pts: None,
+            dts: None,
+            packet_size: 0,
+            time_base_num: 1,
+            time_base_den: 1000,
+        };
+        let rdlp_err: RdlpError = err.into();
+        match rdlp_err {
+            RdlpError::FFmpeg(msg) => assert!(msg.contains("Mux write failed")),
+            other => panic!("expected RdlpError::FFmpeg, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_is_mux_write_error() {
+        let mux_err = PostProcessError::MuxWriteError {
+            message: "ENOMEM".into(),
+            operation: "av_write_frame".into(),
+            stream_index: 0,
+            pts: Some(100),
+            dts: Some(100),
+            packet_size: 1024,
+            time_base_num: 1,
+            time_base_den: 1000,
+        };
+        assert!(mux_err.is_mux_write_error());
+
+        let lib_err = PostProcessError::FFmpegLibraryError {
+            message: "something else".into(),
+        };
+        assert!(!lib_err.is_mux_write_error());
+    }
+
+    #[test]
+    fn test_is_enomem() {
+        let err = PostProcessError::MuxWriteError {
+            message: "ret=-12 (Cannot allocate memory), dur=23, pb->pos=1024".into(),
+            operation: "av_write_frame".into(),
+            stream_index: 0,
+            pts: Some(0),
+            dts: Some(0),
+            packet_size: 1024,
+            time_base_num: 1,
+            time_base_den: 1000,
+        };
+        assert!(err.is_enomem());
+        assert!(err.is_mux_write_error());
+        assert!(err.is_salvage_retryable());
+
+        let non_enomem = PostProcessError::MuxWriteError {
+            message: "ret=-28 (No space left on device)".into(),
+            operation: "av_write_frame".into(),
+            stream_index: 0,
+            pts: None,
+            dts: None,
+            packet_size: 512,
+            time_base_num: 1,
+            time_base_den: 48000,
+        };
+        assert!(!non_enomem.is_enomem());
+
+        let lib_err = PostProcessError::FFmpegLibraryError {
+            message: "ret=-12".into(),
+        };
+        assert!(!lib_err.is_enomem());
+    }
+
+    #[test]
+    fn test_is_salvage_retryable() {
+        let mux_err = PostProcessError::MuxWriteError {
+            message: "ENOMEM".into(),
+            operation: "av_write_frame".into(),
+            stream_index: 0,
+            pts: None,
+            dts: None,
+            packet_size: 0,
+            time_base_num: 1,
+            time_base_den: 1000,
+        };
+        assert!(mux_err.is_salvage_retryable());
+
+        let corrupt_err = PostProcessError::InputCorrupt {
+            kind: CorruptionKind::MatroskaEbml,
+            path: PathBuf::from("/tmp/test.mkv"),
+            logs: vec![],
+        };
+        assert!(corrupt_err.is_salvage_retryable());
+
+        let norm_err = PostProcessError::NormalizationFailed {
+            message: "decoder failed".into(),
+        };
+        assert!(!norm_err.is_salvage_retryable());
+
+        let no_audio = PostProcessError::NoAudioStream;
+        assert!(!no_audio.is_salvage_retryable());
     }
 }

--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -167,6 +167,9 @@ impl PostProcessError {
     }
 
     /// True if this error may be recoverable by salvage-remuxing and retrying.
+    ///
+    /// D1: Triggers on mux write errors (ENOMEM/ENOSPC/EIO/EINVAL),
+    /// stall watchdog aborts, and input container corruption.
     #[must_use]
     pub fn is_salvage_retryable(&self) -> bool {
         matches!(self, Self::MuxWriteError { .. } | Self::InputCorrupt { .. })
@@ -177,6 +180,24 @@ impl PostProcessError {
     pub fn is_enomem(&self) -> bool {
         match self {
             Self::MuxWriteError { message, .. } => message.contains("ret=-12"),
+            _ => false,
+        }
+    }
+
+    /// True if this error indicates an I/O error (EIO/-5).
+    #[must_use]
+    pub fn is_eio(&self) -> bool {
+        match self {
+            Self::MuxWriteError { message, .. } => message.contains("ret=-5"),
+            _ => false,
+        }
+    }
+
+    /// True if this error indicates a mux stall (watchdog abort).
+    #[must_use]
+    pub fn is_stall(&self) -> bool {
+        match self {
+            Self::MuxWriteError { operation, .. } => operation.contains("watchdog"),
             _ => false,
         }
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers.rs
@@ -120,6 +120,300 @@ impl FFmpegRunner {
         Ok(())
     }
 
+    /// Add an `abuffer` audio source filter to a graph using raw FFI.
+    ///
+    /// Uses `avfilter_graph_alloc_filter` + `av_opt_set*` + `avfilter_init_str`
+    /// instead of the args-string approach via `Graph::add()`. Required because
+    /// FFmpeg 8.0's abuffer option is `"channel_layout"` (not `"chlayout"`),
+    /// and the args-string parser rejects unknown option names.
+    pub(crate) fn add_abuffer_to_graph(
+        graph: &mut ffmpeg_the_third::filter::Graph,
+        name: &str,
+        time_base: ffmpeg_the_third::Rational,
+        sample_rate: u32,
+        sample_fmt_name: &str,
+        channel_layout_desc: &str,
+    ) -> Result<()> {
+        use std::ffi::CString;
+
+        use crate::error::PostProcessError;
+
+        let abuffer = ffmpeg_the_third::filter::find("abuffer")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffer filter not found"))?;
+
+        let name_c = CString::new(name)
+            .map_err(|_| PostProcessError::ffmpeg_failed("invalid filter name"))?;
+        let ch_layout_c = CString::new(channel_layout_desc)
+            .map_err(|_| PostProcessError::ffmpeg_failed("invalid channel layout"))?;
+        let sample_fmt_c = CString::new(sample_fmt_name)
+            .map_err(|_| PostProcessError::ffmpeg_failed("invalid sample format name"))?;
+
+        // Option key CStrings (static values, can't fail)
+        let key_channel_layout = CString::new("channel_layout").unwrap();
+        let key_sample_fmt = CString::new("sample_fmt").unwrap();
+        let key_time_base = CString::new("time_base").unwrap();
+        let key_sample_rate = CString::new("sample_rate").unwrap();
+
+        // SAFETY: All pointers are valid for the duration of this block.
+        // avfilter_graph_alloc_filter allocates within the graph's lifetime.
+        // av_opt_set* write to the allocated filter context.
+        // avfilter_init_str finalizes the filter initialization.
+        unsafe {
+            let ctx = ffmpeg_the_third::ffi::avfilter_graph_alloc_filter(
+                graph.as_mut_ptr(),
+                abuffer.as_ptr(),
+                name_c.as_ptr(),
+            );
+            if ctx.is_null() {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "failed to allocate abuffer filter context".into(),
+                });
+            }
+
+            let search = ffmpeg_the_third::ffi::AV_OPT_SEARCH_CHILDREN;
+
+            let ret = ffmpeg_the_third::ffi::av_opt_set(
+                ctx as *mut std::ffi::c_void,
+                key_channel_layout.as_ptr(),
+                ch_layout_c.as_ptr(),
+                search,
+            );
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "av_opt_set channel_layout={channel_layout_desc} failed: {ret}"
+                    ),
+                });
+            }
+
+            let ret = ffmpeg_the_third::ffi::av_opt_set(
+                ctx as *mut std::ffi::c_void,
+                key_sample_fmt.as_ptr(),
+                sample_fmt_c.as_ptr(),
+                search,
+            );
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!("av_opt_set sample_fmt={sample_fmt_name} failed: {ret}"),
+                });
+            }
+
+            let ret = ffmpeg_the_third::ffi::av_opt_set_q(
+                ctx as *mut std::ffi::c_void,
+                key_time_base.as_ptr(),
+                ffmpeg_the_third::ffi::AVRational {
+                    num: time_base.numerator(),
+                    den: time_base.denominator(),
+                },
+                search,
+            );
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "av_opt_set_q time_base={}/{} failed: {ret}",
+                        time_base.numerator(),
+                        time_base.denominator()
+                    ),
+                });
+            }
+
+            let ret = ffmpeg_the_third::ffi::av_opt_set_int(
+                ctx as *mut std::ffi::c_void,
+                key_sample_rate.as_ptr(),
+                i64::from(sample_rate),
+                search,
+            );
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!("av_opt_set_int sample_rate={sample_rate} failed: {ret}"),
+                });
+            }
+
+            let ret = ffmpeg_the_third::ffi::avfilter_init_str(ctx, std::ptr::null());
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!("avfilter_init_str for abuffer '{name}' failed: {ret}"),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Parse a filter spec between named source/sink and validate the graph.
+    ///
+    /// Bypasses the `ffmpeg-the-third` wrapper's `Parser::parse()` which may
+    /// swap the `inputs`/`outputs` parameters to `avfilter_graph_parse_ptr`.
+    /// Instead calls FFI directly matching FFmpeg's official `filter_audio.c`
+    /// example: `outputs` = source (abuffer), `inputs` = sink (abuffersink).
+    pub(crate) fn parse_and_validate_filter_graph(
+        graph: &mut ffmpeg_the_third::filter::Graph,
+        src_name: &str,
+        sink_name: &str,
+        filter_spec: &str,
+    ) -> Result<()> {
+        use std::ffi::CString;
+
+        use crate::error::PostProcessError;
+
+        let src_name_c = CString::new(src_name)
+            .map_err(|_| PostProcessError::ffmpeg_failed("invalid source filter name"))?;
+        let sink_name_c = CString::new(sink_name)
+            .map_err(|_| PostProcessError::ffmpeg_failed("invalid sink filter name"))?;
+        let spec_c = CString::new(filter_spec)
+            .map_err(|_| PostProcessError::ffmpeg_failed("invalid filter spec"))?;
+
+        // SAFETY: All pointers are valid for the duration of this block.
+        // avfilter_graph_get_filter retrieves contexts by name from the graph.
+        // avfilter_inout_alloc + av_strdup allocate memory freed by avfilter_inout_free.
+        // avfilter_graph_parse_ptr parses the spec and links intermediate filters.
+        // avfilter_graph_config validates format negotiation and link configuration.
+        unsafe {
+            let src_ctx = ffmpeg_the_third::ffi::avfilter_graph_get_filter(
+                graph.as_mut_ptr(),
+                src_name_c.as_ptr(),
+            );
+            if src_ctx.is_null() {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!("filter '{src_name}' not found in graph"),
+                });
+            }
+
+            let sink_ctx = ffmpeg_the_third::ffi::avfilter_graph_get_filter(
+                graph.as_mut_ptr(),
+                sink_name_c.as_ptr(),
+            );
+            if sink_ctx.is_null() {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!("filter '{sink_name}' not found in graph"),
+                });
+            }
+
+            // `outputs` = source (abuffer) with unconnected output pad.
+            // The parsed chain's implicit [in] label connects FROM this pad.
+            let outputs = ffmpeg_the_third::ffi::avfilter_inout_alloc();
+            if outputs.is_null() {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "failed to allocate AVFilterInOut for outputs".into(),
+                });
+            }
+            (*outputs).name = ffmpeg_the_third::ffi::av_strdup(src_name_c.as_ptr());
+            (*outputs).filter_ctx = src_ctx;
+            (*outputs).pad_idx = 0;
+            (*outputs).next = std::ptr::null_mut();
+
+            // `inputs` = sink (abuffersink) with unconnected input pad.
+            // The parsed chain's implicit [out] label connects TO this pad.
+            let inputs = ffmpeg_the_third::ffi::avfilter_inout_alloc();
+            if inputs.is_null() {
+                let mut out_ptr = outputs;
+                ffmpeg_the_third::ffi::avfilter_inout_free(&mut out_ptr);
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "failed to allocate AVFilterInOut for inputs".into(),
+                });
+            }
+            (*inputs).name = ffmpeg_the_third::ffi::av_strdup(sink_name_c.as_ptr());
+            (*inputs).filter_ctx = sink_ctx;
+            (*inputs).pad_idx = 0;
+            (*inputs).next = std::ptr::null_mut();
+
+            // Parse spec with FFmpeg-standard parameter order:
+            //   3rd = &inputs  (sink pads, abuffersink)
+            //   4th = &outputs (source pads, abuffer)
+            let mut inputs_ptr = inputs;
+            let mut outputs_ptr = outputs;
+            let ret = ffmpeg_the_third::ffi::avfilter_graph_parse_ptr(
+                graph.as_mut_ptr(),
+                spec_c.as_ptr(),
+                &mut inputs_ptr,
+                &mut outputs_ptr,
+                std::ptr::null_mut(),
+            );
+
+            // Free InOut structures (parse_ptr may set consumed pointers to NULL)
+            ffmpeg_the_third::ffi::avfilter_inout_free(&mut inputs_ptr);
+            ffmpeg_the_third::ffi::avfilter_inout_free(&mut outputs_ptr);
+
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "avfilter_graph_parse_ptr failed for spec '{filter_spec}': {ret}"
+                    ),
+                });
+            }
+
+            // Validate and configure the complete graph
+            let ret = ffmpeg_the_third::ffi::avfilter_graph_config(
+                graph.as_mut_ptr(),
+                std::ptr::null_mut(),
+            );
+            if ret < 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!("avfilter_graph_config failed: {ret}"),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Set `AVDISCARD_ALL` on all non-audio streams in an input context.
+    ///
+    /// Tells the demuxer to skip non-audio packets entirely, avoiding
+    /// memory allocation for large video packets during audio-only analysis.
+    pub(crate) fn discard_non_audio_streams(
+        ictx: &mut ffmpeg_the_third::format::context::Input,
+        audio_stream_index: usize,
+    ) {
+        // SAFETY: `ictx` owns a valid AVFormatContext. Setting `discard` on
+        // streams is a standard FFmpeg operation that tells the demuxer to
+        // skip packets for those streams.
+        unsafe {
+            let ctx_ptr = ictx.as_mut_ptr();
+            let nb_streams = (*ctx_ptr).nb_streams as usize;
+            for i in 0..nb_streams {
+                if i != audio_stream_index {
+                    let stream = *(*ctx_ptr).streams.add(i);
+                    (*stream).discard = ffmpeg_the_third::ffi::AVDiscard::AVDISCARD_ALL;
+                }
+            }
+        }
+    }
+
+    /// Set the frame size on an audio buffersink filter.
+    ///
+    /// Tells the buffersink to output exactly `frame_size` samples per frame.
+    /// The last frame at EOF is automatically zero-padded. This is the proper
+    /// way to feed fixed-frame-size encoders (AAC=1024, MP3=1152, Opus=960).
+    ///
+    /// No-op if `frame_size` is 0 (variable-frame-size codecs like FLAC/PCM).
+    pub(crate) fn set_buffersink_frame_size(
+        graph: &mut ffmpeg_the_third::filter::Graph,
+        sink_name: &str,
+        frame_size: u32,
+    ) {
+        if frame_size == 0 {
+            return;
+        }
+
+        let Ok(name_c) = std::ffi::CString::new(sink_name) else {
+            return;
+        };
+
+        // SAFETY: `graph` owns a valid filter graph. `avfilter_graph_get_filter`
+        // retrieves the named context. `av_buffersink_set_frame_size` sets the
+        // min/max sample counts on the sink's input link.
+        unsafe {
+            let ctx = ffmpeg_the_third::ffi::avfilter_graph_get_filter(
+                graph.as_mut_ptr(),
+                name_c.as_ptr(),
+            );
+            if !ctx.is_null() {
+                ffmpeg_the_third::ffi::av_buffersink_set_frame_size(ctx, frame_size);
+            }
+        }
+    }
+
     /// Configure a stream with `ATTACHED_PIC` disposition (for cover art).
     ///
     /// Sets the stream disposition and clears the codec tag. Used for MP4,
@@ -133,5 +427,56 @@ impl FFmpegRunner {
             (*stream_ptr).disposition = ffmpeg_the_third::ffi::AV_DISPOSITION_ATTACHED_PIC;
             (*((*stream_ptr).codecpar)).codec_tag = 0;
         }
+    }
+}
+
+/// Release packet buffer references. Idempotent — safe on empty packets.
+///
+/// SAFETY: `Packet::as_ptr()` returns a valid, non-null AVPacket pointer
+/// owned by the Rust wrapper. `av_packet_unref` only zeroes internal fields.
+pub(crate) fn packet_unref(pkt: &mut ffmpeg_the_third::Packet) {
+    use ffmpeg_the_third::packet::Mut;
+    unsafe { ffmpeg_the_third::ffi::av_packet_unref(pkt.as_mut_ptr()) }
+}
+
+/// Release audio frame buffer references. Idempotent — safe on empty frames.
+///
+/// Calling this after `filter.source().add(&frame)` and after
+/// `encoder.send_frame(&frame)` releases our reference immediately,
+/// reducing peak memory when the filter/encoder also holds a ref.
+pub(crate) fn frame_unref_audio(frame: &mut ffmpeg_the_third::frame::Audio) {
+    unsafe { ffmpeg_the_third::ffi::av_frame_unref((*frame).as_mut_ptr()) }
+}
+
+/// Release video frame buffer references. Idempotent — safe on empty frames.
+pub(crate) fn frame_unref_video(frame: &mut ffmpeg_the_third::frame::Video) {
+    unsafe { ffmpeg_the_third::ffi::av_frame_unref((*frame).as_mut_ptr()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packet_unref_on_empty_packet() {
+        let mut pkt = ffmpeg_the_third::Packet::empty();
+        // Should not panic on an empty/zeroed packet
+        packet_unref(&mut pkt);
+        // Double-unref should also be safe (idempotent)
+        packet_unref(&mut pkt);
+    }
+
+    #[test]
+    fn frame_unref_audio_on_empty_frame() {
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        frame_unref_audio(&mut frame);
+        frame_unref_audio(&mut frame);
+    }
+
+    #[test]
+    fn frame_unref_video_on_empty_frame() {
+        let mut frame = ffmpeg_the_third::frame::Video::empty();
+        frame_unref_video(&mut frame);
+        frame_unref_video(&mut frame);
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers.rs
@@ -453,6 +453,43 @@ pub(crate) fn frame_unref_video(frame: &mut ffmpeg_the_third::frame::Video) {
     unsafe { ffmpeg_the_third::ffi::av_frame_unref((*frame).as_mut_ptr()) }
 }
 
+/// Force single-threaded operation on a codec context.
+///
+/// Must be called **before** `avcodec_open2` (i.e. before `.audio()?` or
+/// `.open_as()`). Setting `thread_count = 1` causes FFmpeg's
+/// `validate_thread_parameters()` to set `active_thread_type = 0`, which
+/// disables both frame threading and slice threading. This eliminates:
+/// - Frame threading's per-thread decode buffer pre-allocation (N × frame_size)
+/// - Slice threading's per-slice scratch buffers
+///
+/// For audio normalization paths this is the primary RSS reduction knob:
+/// the default auto-threading can allocate hundreds of MB in decode/encode
+/// buffers that are unnecessary for a single-stream sequential pipeline.
+///
+/// # Safety
+///
+/// `ctx_ptr` must point to a valid, **unopened** `AVCodecContext`.
+pub(crate) fn set_single_thread_codec(ctx_ptr: *mut ffmpeg_the_third::ffi::AVCodecContext) {
+    // SAFETY: caller guarantees ctx_ptr is valid and unopened.
+    // Setting thread_count before open is the documented way to control threading.
+    unsafe {
+        (*ctx_ptr).thread_count = 1;
+    }
+}
+
+/// Read `thread_count` and `active_thread_type` from an opened codec context.
+///
+/// Returns `(thread_count, active_thread_type)` for diagnostic logging.
+///
+/// # Safety
+///
+/// `ctx_ptr` must point to a valid, opened `AVCodecContext`.
+pub(crate) fn codec_threading_info(
+    ctx_ptr: *const ffmpeg_the_third::ffi::AVCodecContext,
+) -> (i32, i32) {
+    unsafe { ((*ctx_ptr).thread_count, (*ctx_ptr).active_thread_type) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -1,0 +1,226 @@
+//! Thread-safe FFmpeg log capture via `av_log_set_callback`.
+//!
+//! Provides an RAII guard that installs a custom FFmpeg log callback to capture
+//! log messages (e.g., loudnorm JSON output). On drop, restores the default
+//! callback and error-only log level.
+
+use std::ffi::{CStr, c_char, c_int, c_void};
+use std::sync::Mutex;
+
+use crate::error::PostProcessError;
+
+/// RAII guard that suppresses FFmpeg's internal C log messages.
+///
+/// Sets `av_log_set_level` to `AV_LOG_FATAL` on creation, restoring
+/// `AV_LOG_ERROR` on drop. Used during audio normalization decode loops
+/// to prevent the AAC decoder from spamming stderr with per-packet
+/// `get_buffer() failed` lines — we handle those errors at the Rust level.
+pub(crate) struct LogSuppressGuard {
+    _private: (),
+}
+
+impl LogSuppressGuard {
+    pub(crate) fn new() -> Self {
+        unsafe {
+            ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_FATAL);
+        }
+        Self { _private: () }
+    }
+
+    /// Suppress decoder WARNING spam while keeping muxer ERROR messages visible.
+    ///
+    /// Sets `av_log_set_level` to `AV_LOG_ERROR` instead of `AV_LOG_FATAL`.
+    /// Use this during encode loops where muxer errors must remain diagnosable
+    /// but decoder `get_buffer() failed` spam should be suppressed.
+    pub(crate) fn error_level() -> Self {
+        unsafe {
+            ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR);
+        }
+        Self { _private: () }
+    }
+}
+
+impl Drop for LogSuppressGuard {
+    fn drop(&mut self) {
+        unsafe {
+            ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR);
+        }
+    }
+}
+
+/// Global buffer for captured FFmpeg log messages.
+///
+/// Protected by a Mutex. Only populated when a `LogCaptureGuard` is active.
+static LOG_BUFFER: Mutex<Option<Vec<String>>> = Mutex::new(None);
+
+/// RAII guard for FFmpeg log capture.
+///
+/// While active, FFmpeg log messages at `AV_LOG_INFO` level and below (i.e.,
+/// more important) are captured into a global buffer. On drop, the default
+/// callback is restored and log level is set back to error-only.
+pub(crate) struct LogCaptureGuard {
+    _private: (), // prevent external construction
+}
+
+impl LogCaptureGuard {
+    /// Begin capturing FFmpeg log messages.
+    ///
+    /// Installs a custom `av_log_set_callback` that buffers messages. Only one
+    /// capture session should be active at a time (enforced by `spawn_blocking`
+    /// serialization).
+    pub(crate) fn begin() -> Result<Self, PostProcessError> {
+        // Initialize buffer
+        let mut buf = LOG_BUFFER
+            .lock()
+            .map_err(|e| PostProcessError::LogCaptureFailed {
+                message: format!("failed to lock log buffer: {e}"),
+            })?;
+        *buf = Some(Vec::new());
+        drop(buf);
+
+        // Set log level to INFO so loudnorm output is emitted
+        unsafe {
+            ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_INFO);
+            ffmpeg_the_third::ffi::av_log_set_callback(Some(capture_callback));
+        }
+
+        Ok(Self { _private: () })
+    }
+
+    /// Take all captured log lines, draining the buffer.
+    pub(crate) fn take_captured(&self) -> Result<Vec<String>, PostProcessError> {
+        let mut buf = LOG_BUFFER
+            .lock()
+            .map_err(|e| PostProcessError::LogCaptureFailed {
+                message: format!("failed to lock log buffer: {e}"),
+            })?;
+
+        match buf.as_mut() {
+            Some(v) => Ok(std::mem::take(v)),
+            None => Ok(Vec::new()),
+        }
+    }
+}
+
+impl Drop for LogCaptureGuard {
+    fn drop(&mut self) {
+        // Restore default callback and error-only level
+        unsafe {
+            ffmpeg_the_third::ffi::av_log_set_callback(Some(
+                ffmpeg_the_third::ffi::av_log_default_callback,
+            ));
+            ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR);
+        }
+
+        // Clear buffer
+        if let Ok(mut buf) = LOG_BUFFER.lock() {
+            *buf = None;
+        }
+    }
+}
+
+/// Custom FFmpeg log callback that captures messages into the global buffer.
+///
+/// # Safety
+///
+/// Called by FFmpeg's internal logging system. All pointer parameters are
+/// guaranteed valid by FFmpeg for the duration of the call. Uses
+/// `av_log_format_line2` to safely format the `va_list` arguments.
+unsafe extern "C" fn capture_callback(
+    avcl: *mut c_void,
+    level: c_int,
+    fmt: *const c_char,
+    vl: ffmpeg_the_third::ffi::va_list,
+) {
+    // Only capture AV_LOG_INFO (32) and more important (lower values)
+    if level > ffmpeg_the_third::ffi::AV_LOG_INFO {
+        return;
+    }
+
+    let mut buf = [0i8; 2048];
+    let mut prefix: c_int = 1;
+    // SAFETY: All pointers are valid for the duration of this callback invocation.
+    // av_log_format_line2 writes at most buf.len()-1 chars + null terminator.
+    let len = unsafe {
+        ffmpeg_the_third::ffi::av_log_format_line2(
+            avcl,
+            level,
+            fmt,
+            vl,
+            buf.as_mut_ptr() as *mut c_char,
+            buf.len() as c_int,
+            &mut prefix,
+        )
+    };
+
+    if len > 0 {
+        // SAFETY: av_log_format_line2 null-terminates the buffer
+        let msg = unsafe { CStr::from_ptr(buf.as_ptr() as *const c_char) }
+            .to_string_lossy()
+            .to_string();
+        if let Ok(mut guard) = LOG_BUFFER.lock() {
+            if let Some(ref mut v) = *guard {
+                v.push(msg);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_buffer_init_and_clear() {
+        // Ensure buffer starts as None
+        {
+            let buf = LOG_BUFFER.lock().unwrap();
+            assert!(buf.is_none() || buf.as_ref().unwrap().is_empty());
+        }
+
+        // Begin capture
+        let guard = LogCaptureGuard::begin().unwrap();
+
+        // Buffer should be Some(empty vec)
+        {
+            let buf = LOG_BUFFER.lock().unwrap();
+            assert!(buf.is_some());
+            assert!(buf.as_ref().unwrap().is_empty());
+        }
+
+        // Take should return empty
+        let captured = guard.take_captured().unwrap();
+        assert!(captured.is_empty());
+
+        // Drop guard
+        drop(guard);
+
+        // Buffer should be None again
+        {
+            let buf = LOG_BUFFER.lock().unwrap();
+            assert!(buf.is_none());
+        }
+    }
+
+    #[test]
+    fn test_log_suppress_guard_error_level() {
+        // error_level() sets AV_LOG_ERROR; drop restores AV_LOG_ERROR (no-op restore)
+        let guard = LogSuppressGuard::error_level();
+        let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
+        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_ERROR);
+        drop(guard);
+        let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
+        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_ERROR);
+    }
+
+    #[test]
+    fn test_log_suppress_guard_fatal_level() {
+        // new() sets AV_LOG_FATAL; drop restores AV_LOG_ERROR
+        let guard = LogSuppressGuard::new();
+        let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
+        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_FATAL);
+        drop(guard);
+        let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
+        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_ERROR);
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge.rs
@@ -1,4 +1,8 @@
 //! Video + audio stream merging (stream copy).
+//!
+//! Uses two-way timestamp-interleaved merging to avoid ENOMEM when
+//! `av_interleaved_write_frame` buffers one complete stream waiting
+//! for the other.
 
 use std::path::Path;
 
@@ -7,6 +11,116 @@ use log::debug;
 use crate::error::{PostProcessError, Result};
 
 use super::{FFmpegRunner, RemuxOptions, ensure_init};
+
+/// Common timebase for DTS comparison: 1 microsecond.
+const COMPARE_TB: ffmpeg_the_third::ffi::AVRational = ffmpeg_the_third::ffi::AVRational {
+    num: 1,
+    den: 1_000_000,
+};
+
+/// Read the next packet for `target_stream_idx` from a raw FFI input context.
+///
+/// Skips packets from non-target streams. Returns `true` if a packet was read
+/// into `pkt`, `false` on EOF/error.
+///
+/// # Safety
+///
+/// `ifmt_ctx` must point to a valid, open `AVFormatContext`.
+/// `pkt` must point to a valid (possibly unref'd) `AVPacket`.
+unsafe fn read_next_raw(
+    ifmt_ctx: *mut ffmpeg_the_third::ffi::AVFormatContext,
+    target_stream_idx: usize,
+    pkt: *mut ffmpeg_the_third::ffi::AVPacket,
+) -> bool {
+    unsafe {
+        loop {
+            let ret = ffmpeg_the_third::ffi::av_read_frame(ifmt_ctx, pkt);
+            if ret < 0 {
+                return false; // EOF or read error
+            }
+            if (*pkt).stream_index as usize == target_stream_idx {
+                return true;
+            }
+            ffmpeg_the_third::ffi::av_packet_unref(pkt);
+        }
+    }
+}
+
+/// Rescale PTS/DTS/duration from input timebase to output timebase, set the
+/// output stream index, and write via `av_interleaved_write_frame`.
+///
+/// Returns `Err` on write failure instead of silently breaking.
+///
+/// # Safety
+///
+/// `pkt` must point to a valid packet with data.
+/// `in_stream` must point to the source stream.
+/// `ofmt_ctx` must point to a valid, header-written output context.
+/// `out_stream_idx` must be a valid stream index in `ofmt_ctx`.
+unsafe fn rescale_and_write_raw(
+    pkt: *mut ffmpeg_the_third::ffi::AVPacket,
+    in_stream: *const ffmpeg_the_third::ffi::AVStream,
+    ofmt_ctx: *mut ffmpeg_the_third::ffi::AVFormatContext,
+    out_stream_idx: i32,
+) -> Result<()> {
+    unsafe {
+        (*pkt).stream_index = out_stream_idx;
+
+        let out_stream = *(*ofmt_ctx).streams.add(out_stream_idx as usize);
+        if (*pkt).pts != ffmpeg_the_third::ffi::AV_NOPTS_VALUE {
+            (*pkt).pts = ffmpeg_the_third::ffi::av_rescale_q_rnd(
+                (*pkt).pts,
+                (*in_stream).time_base,
+                (*out_stream).time_base,
+                ffmpeg_the_third::ffi::AVRounding::AV_ROUND_NEAR_INF,
+            );
+        }
+        if (*pkt).dts != ffmpeg_the_third::ffi::AV_NOPTS_VALUE {
+            (*pkt).dts = ffmpeg_the_third::ffi::av_rescale_q_rnd(
+                (*pkt).dts,
+                (*in_stream).time_base,
+                (*out_stream).time_base,
+                ffmpeg_the_third::ffi::AVRounding::AV_ROUND_NEAR_INF,
+            );
+        }
+        if (*pkt).duration > 0 {
+            (*pkt).duration = ffmpeg_the_third::ffi::av_rescale_q(
+                (*pkt).duration,
+                (*in_stream).time_base,
+                (*out_stream).time_base,
+            );
+        }
+        (*pkt).pos = -1;
+
+        let ret = ffmpeg_the_third::ffi::av_interleaved_write_frame(ofmt_ctx, pkt);
+        if ret < 0 {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: format!("av_interleaved_write_frame failed: error code {ret}"),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Rescale a DTS value to the comparison timebase for merge-sort ordering.
+///
+/// Returns `None` for `AV_NOPTS_VALUE`.
+///
+/// # Safety
+///
+/// `stream` must point to a valid `AVStream`.
+unsafe fn dts_in_us(dts: i64, stream: *const ffmpeg_the_third::ffi::AVStream) -> Option<i64> {
+    if dts == ffmpeg_the_third::ffi::AV_NOPTS_VALUE {
+        return None;
+    }
+    unsafe {
+        Some(ffmpeg_the_third::ffi::av_rescale_q(
+            dts,
+            (*stream).time_base,
+            COMPARE_TB,
+        ))
+    }
+}
 
 impl FFmpegRunner {
     /// Merge separate video and audio files into a single container (stream copy).
@@ -32,7 +146,7 @@ impl FFmpegRunner {
     }
 
     /// Merge separate video and audio files synchronously (stream copy).
-    fn merge_sync(
+    pub(crate) fn merge_sync(
         video_input: &Path,
         audio_input: &Path,
         output: &Path,
@@ -74,15 +188,6 @@ impl FFmpegRunner {
             .map(|s| s.index())
             .ok_or(PostProcessError::NoVideoStream)?;
 
-        let video_ist_time_base = ictx_video
-            .stream(video_ist_index)
-            .ok_or_else(|| {
-                PostProcessError::ffmpeg_failed(format!(
-                    "video input stream {video_ist_index} not found"
-                ))
-            })?
-            .time_base();
-
         let mut ost_video = octx
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
@@ -109,15 +214,6 @@ impl FFmpegRunner {
             .best(ffmpeg_the_third::media::Type::Audio)
             .map(|s| s.index())
             .ok_or(PostProcessError::NoAudioStream)?;
-
-        let audio_ist_time_base = ictx_audio
-            .stream(audio_ist_index)
-            .ok_or_else(|| {
-                PostProcessError::ffmpeg_failed(format!(
-                    "audio input stream {audio_ist_index} not found"
-                ))
-            })?
-            .time_base();
 
         let mut ost_audio = octx
             .add_stream(ffmpeg_the_third::encoder::find(
@@ -153,58 +249,99 @@ impl FFmpegRunner {
                 message: format!("failed to write output header: {e}"),
             })?;
 
-        // Copy video packets
-        for result in ictx_video.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read video packet: {e}"),
-                })?;
-            if stream.index() != video_ist_index {
-                continue;
-            }
-            let ost_time_base = octx
-                .stream(video_ost_index)
-                .ok_or_else(|| {
-                    PostProcessError::ffmpeg_failed(format!(
-                        "video output stream {video_ost_index} not found"
-                    ))
-                })?
-                .time_base();
-            packet.rescale_ts(video_ist_time_base, ost_time_base);
-            packet.set_position(-1);
-            packet.set_stream(video_ost_index);
-            packet.write_interleaved(&mut octx).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to write video packet: {e}"),
-                }
-            })?;
-        }
+        // Two-way timestamp-interleaved merge: read packets from both inputs
+        // and write them in DTS order to avoid ENOMEM from buffering an entire
+        // stream while waiting for the other.
+        //
+        // SAFETY: ictx_video/ictx_audio own valid AVFormatContext instances.
+        // octx owns a valid, header-written output context.
+        unsafe {
+            use ffmpeg_the_third::ffi;
 
-        // Copy audio packets
-        for result in ictx_audio.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read audio packet: {e}"),
-                })?;
-            if stream.index() != audio_ist_index {
-                continue;
-            }
-            let ost_time_base = octx
-                .stream(audio_ost_index)
-                .ok_or_else(|| {
-                    PostProcessError::ffmpeg_failed(format!(
-                        "audio output stream {audio_ost_index} not found"
-                    ))
-                })?
-                .time_base();
-            packet.rescale_ts(audio_ist_time_base, ost_time_base);
-            packet.set_position(-1);
-            packet.set_stream(audio_ost_index);
-            packet.write_interleaved(&mut octx).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to write audio packet: {e}"),
+            let video_ctx = ictx_video.as_mut_ptr();
+            let audio_ctx = ictx_audio.as_mut_ptr();
+            let out_ctx = octx.as_mut_ptr();
+
+            let in_video_stream = *(*video_ctx).streams.add(video_ist_index);
+            let in_audio_stream = *(*audio_ctx).streams.add(audio_ist_index);
+
+            let mut vpkt: ffi::AVPacket = std::mem::zeroed();
+            vpkt.pts = ffi::AV_NOPTS_VALUE;
+            vpkt.dts = ffi::AV_NOPTS_VALUE;
+            vpkt.pos = -1;
+
+            let mut apkt: ffi::AVPacket = std::mem::zeroed();
+            apkt.pts = ffi::AV_NOPTS_VALUE;
+            apkt.dts = ffi::AV_NOPTS_VALUE;
+            apkt.pos = -1;
+
+            let mut have_video = read_next_raw(video_ctx, video_ist_index, &mut vpkt);
+            let mut have_audio = read_next_raw(audio_ctx, audio_ist_index, &mut apkt);
+
+            loop {
+                match (have_video, have_audio) {
+                    (false, false) => break,
+                    (true, false) => {
+                        rescale_and_write_raw(
+                            &mut vpkt,
+                            in_video_stream,
+                            out_ctx,
+                            video_ost_index as i32,
+                        )?;
+                        ffi::av_packet_unref(&mut vpkt);
+                        have_video = read_next_raw(video_ctx, video_ist_index, &mut vpkt);
+                    }
+                    (false, true) => {
+                        rescale_and_write_raw(
+                            &mut apkt,
+                            in_audio_stream,
+                            out_ctx,
+                            audio_ost_index as i32,
+                        )?;
+                        ffi::av_packet_unref(&mut apkt);
+                        have_audio = read_next_raw(audio_ctx, audio_ist_index, &mut apkt);
+                    }
+                    (true, true) => {
+                        let v_us = dts_in_us(vpkt.dts, in_video_stream);
+                        let a_us = dts_in_us(apkt.dts, in_audio_stream);
+
+                        let write_video = match (v_us, a_us) {
+                            // Both NOPTS: write video first (arbitrary)
+                            (None, None) => true,
+                            // Video NOPTS: write it immediately
+                            (None, Some(_)) => true,
+                            // Audio NOPTS: write it immediately
+                            (Some(_), None) => false,
+                            // Both have DTS: write earlier one
+                            (Some(v), Some(a)) => v <= a,
+                        };
+
+                        if write_video {
+                            rescale_and_write_raw(
+                                &mut vpkt,
+                                in_video_stream,
+                                out_ctx,
+                                video_ost_index as i32,
+                            )?;
+                            ffi::av_packet_unref(&mut vpkt);
+                            have_video = read_next_raw(video_ctx, video_ist_index, &mut vpkt);
+                        } else {
+                            rescale_and_write_raw(
+                                &mut apkt,
+                                in_audio_stream,
+                                out_ctx,
+                                audio_ost_index as i32,
+                            )?;
+                            ffi::av_packet_unref(&mut apkt);
+                            have_audio = read_next_raw(audio_ctx, audio_ist_index, &mut apkt);
+                        }
+                    }
                 }
-            })?;
+            }
+
+            // Clean up any unreleased packets
+            ffi::av_packet_unref(&mut vpkt);
+            ffi::av_packet_unref(&mut apkt);
         }
 
         octx.write_trailer()
@@ -224,31 +361,27 @@ impl FFmpegRunner {
     /// - `sample_aspect_ratio` — pixel aspect ratio
     /// - `cluster_time_limit=500` — 500ms clusters for smooth seeking
     /// - `avoid_negative_ts` — timestamp normalization
-    /// - `max_interleave_delta=0` — immediate output
+    /// - `max_interleave_delta=0` — disables delta-based queue flushing (packets
+    ///   still flush via the two-way interleaved merge loop that feeds packets
+    ///   in DTS order, so the queue stays small)
     #[allow(clippy::too_many_lines)]
-    fn merge_mkv_raw_ffi(
-        video_input: &Path,
-        audio_input: &Path,
-        output: &Path,
-    ) -> Result<()> {
+    fn merge_mkv_raw_ffi(video_input: &Path, audio_input: &Path, output: &Path) -> Result<()> {
         use ffmpeg_the_third::ffi;
         use std::ffi::CString;
         use std::ptr;
 
         debug!("MKV merge via raw FFI with avg_frame_rate + cluster_time_limit=500");
 
-        let video_cstr =
-            CString::new(video_input.to_string_lossy().as_ref()).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("Invalid video input path: {e}"),
-                }
-            })?;
-        let audio_cstr =
-            CString::new(audio_input.to_string_lossy().as_ref()).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("Invalid audio input path: {e}"),
-                }
-            })?;
+        let video_cstr = CString::new(video_input.to_string_lossy().as_ref()).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("Invalid video input path: {e}"),
+            }
+        })?;
+        let audio_cstr = CString::new(audio_input.to_string_lossy().as_ref()).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("Invalid audio input path: {e}"),
+            }
+        })?;
         let output_cstr = CString::new(output.to_string_lossy().as_ref()).map_err(|e| {
             PostProcessError::FFmpegLibraryError {
                 message: format!("Invalid output path: {e}"),
@@ -274,9 +407,7 @@ impl FFmpegRunner {
             if ret < 0 {
                 ffi::avformat_close_input(&mut ifmt_video);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "Failed to find video stream info: error code {ret}"
-                    ),
+                    message: format!("Failed to find video stream info: error code {ret}"),
                 });
             }
 
@@ -300,9 +431,7 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_video);
                 ffi::avformat_close_input(&mut ifmt_audio);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "Failed to find audio stream info: error code {ret}"
-                    ),
+                    message: format!("Failed to find audio stream info: error code {ret}"),
                 });
             }
 
@@ -351,18 +480,14 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_video);
                 ffi::avformat_close_input(&mut ifmt_audio);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "Failed to create output context: error code {ret}"
-                    ),
+                    message: format!("Failed to create output context: error code {ret}"),
                 });
             }
 
             // 6. Add video output stream with full property copying
-            let in_video_stream =
-                *(*ifmt_video).streams.add(video_stream_idx);
+            let in_video_stream = *(*ifmt_video).streams.add(video_stream_idx);
 
-            let out_video_stream =
-                ffi::avformat_new_stream(ofmt_ctx, ptr::null());
+            let out_video_stream = ffi::avformat_new_stream(ofmt_ctx, ptr::null());
             if out_video_stream.is_null() {
                 ffi::avformat_close_input(&mut ifmt_video);
                 ffi::avformat_close_input(&mut ifmt_audio);
@@ -381,21 +506,16 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_audio);
                 ffi::avformat_free_context(ofmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "Failed to copy video codec params: error code {ret}"
-                    ),
+                    message: format!("Failed to copy video codec params: error code {ret}"),
                 });
             }
             (*(*out_video_stream).codecpar).codec_tag = 0;
 
             // CRITICAL: Copy stream timing properties for Matroska
             (*out_video_stream).time_base = (*in_video_stream).time_base;
-            (*out_video_stream).avg_frame_rate =
-                (*in_video_stream).avg_frame_rate;
-            (*out_video_stream).r_frame_rate =
-                (*in_video_stream).r_frame_rate;
-            (*out_video_stream).sample_aspect_ratio =
-                (*in_video_stream).sample_aspect_ratio;
+            (*out_video_stream).avg_frame_rate = (*in_video_stream).avg_frame_rate;
+            (*out_video_stream).r_frame_rate = (*in_video_stream).r_frame_rate;
+            (*out_video_stream).sample_aspect_ratio = (*in_video_stream).sample_aspect_ratio;
 
             let video_out_idx = (*out_video_stream).index;
 
@@ -410,11 +530,9 @@ impl FFmpegRunner {
             );
 
             // 7. Add audio output stream with full property copying
-            let in_audio_stream =
-                *(*ifmt_audio).streams.add(audio_stream_idx);
+            let in_audio_stream = *(*ifmt_audio).streams.add(audio_stream_idx);
 
-            let out_audio_stream =
-                ffi::avformat_new_stream(ofmt_ctx, ptr::null());
+            let out_audio_stream = ffi::avformat_new_stream(ofmt_ctx, ptr::null());
             if out_audio_stream.is_null() {
                 ffi::avformat_close_input(&mut ifmt_video);
                 ffi::avformat_close_input(&mut ifmt_audio);
@@ -433,21 +551,16 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_audio);
                 ffi::avformat_free_context(ofmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "Failed to copy audio codec params: error code {ret}"
-                    ),
+                    message: format!("Failed to copy audio codec params: error code {ret}"),
                 });
             }
             (*(*out_audio_stream).codecpar).codec_tag = 0;
 
             // Copy audio stream timing properties
             (*out_audio_stream).time_base = (*in_audio_stream).time_base;
-            (*out_audio_stream).avg_frame_rate =
-                (*in_audio_stream).avg_frame_rate;
-            (*out_audio_stream).r_frame_rate =
-                (*in_audio_stream).r_frame_rate;
-            (*out_audio_stream).sample_aspect_ratio =
-                (*in_audio_stream).sample_aspect_ratio;
+            (*out_audio_stream).avg_frame_rate = (*in_audio_stream).avg_frame_rate;
+            (*out_audio_stream).r_frame_rate = (*in_audio_stream).r_frame_rate;
+            (*out_audio_stream).sample_aspect_ratio = (*in_audio_stream).sample_aspect_ratio;
 
             let audio_out_idx = (*out_audio_stream).index;
 
@@ -460,8 +573,10 @@ impl FFmpegRunner {
             );
 
             // 8. Set format context options
-            (*ofmt_ctx).avoid_negative_ts =
-                ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
+            (*ofmt_ctx).avoid_negative_ts = ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
+            // Disable delta-based interleave flushing. Safe here because the
+            // two-way merge loop already feeds packets in DTS order, keeping
+            // the interleave queue small. 0 = no delta limit (not "flush immediately").
             (*ofmt_ctx).max_interleave_delta = 0;
             (*ofmt_ctx).flags |= ffi::AVFMT_FLAG_AUTO_BSF;
 
@@ -477,9 +592,7 @@ impl FFmpegRunner {
                     ffi::avformat_close_input(&mut ifmt_audio);
                     ffi::avformat_free_context(ofmt_ctx);
                     return Err(PostProcessError::FFmpegLibraryError {
-                        message: format!(
-                            "Failed to open output file: error code {ret}"
-                        ),
+                        message: format!("Failed to open output file: error code {ret}"),
                     });
                 }
             }
@@ -496,19 +609,12 @@ impl FFmpegRunner {
             // Check for unconsumed options
             let mut e: *mut ffi::AVDictionaryEntry = ptr::null_mut();
             loop {
-                e = ffi::av_dict_get(
-                    opts,
-                    c"".as_ptr(),
-                    e,
-                    ffi::AV_DICT_IGNORE_SUFFIX,
-                );
+                e = ffi::av_dict_get(opts, c"".as_ptr(), e, ffi::AV_DICT_IGNORE_SUFFIX);
                 if e.is_null() {
                     break;
                 }
-                let k =
-                    std::ffi::CStr::from_ptr((*e).key).to_string_lossy();
-                let v =
-                    std::ffi::CStr::from_ptr((*e).value).to_string_lossy();
+                let k = std::ffi::CStr::from_ptr((*e).key).to_string_lossy();
+                let v = std::ffi::CStr::from_ptr((*e).value).to_string_lossy();
                 log::warn!("Unconsumed FFI option: {k}={v}");
             }
             ffi::av_dict_free(&mut opts);
@@ -521,15 +627,12 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_audio);
                 ffi::avformat_free_context(ofmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "avformat_init_output failed: error code {ret}"
-                    ),
+                    message: format!("avformat_init_output failed: error code {ret}"),
                 });
             }
 
             // 12. Write header
-            let ret =
-                ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
+            let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {
                 if !(*ofmt_ctx).pb.is_null() {
                     ffi::avio_closep(&mut (*ofmt_ctx).pb);
@@ -538,134 +641,92 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_audio);
                 ffi::avformat_free_context(ofmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
-                    message: format!(
-                        "avformat_write_header failed: error code {ret}"
-                    ),
+                    message: format!("avformat_write_header failed: error code {ret}"),
                 });
             }
 
-            // 13. Copy video packets
-            let mut pkt = ffi::AVPacket {
-                buf: ptr::null_mut(),
-                pts: ffi::AV_NOPTS_VALUE,
-                dts: ffi::AV_NOPTS_VALUE,
-                data: ptr::null_mut(),
-                size: 0,
-                stream_index: 0,
-                flags: 0,
-                side_data: ptr::null_mut(),
-                side_data_elems: 0,
-                duration: 0,
-                pos: -1,
-                opaque: ptr::null_mut(),
-                opaque_ref: ptr::null_mut(),
-                time_base: ffi::AVRational { num: 0, den: 1 },
-            };
+            // 13. Two-way timestamp-interleaved merge
+            //
+            // Write packets from both inputs in DTS order to avoid ENOMEM
+            // from buffering an entire stream while waiting for the other.
+            // Errors are captured and propagated after cleanup.
+            let merge_result: Result<()> = (|| {
+                let mut vpkt: ffi::AVPacket = std::mem::zeroed();
+                vpkt.pts = ffi::AV_NOPTS_VALUE;
+                vpkt.dts = ffi::AV_NOPTS_VALUE;
+                vpkt.pos = -1;
 
-            loop {
-                let ret = ffi::av_read_frame(ifmt_video, &mut pkt);
-                if ret < 0 {
-                    break; // EOF or error
+                let mut apkt: ffi::AVPacket = std::mem::zeroed();
+                apkt.pts = ffi::AV_NOPTS_VALUE;
+                apkt.dts = ffi::AV_NOPTS_VALUE;
+                apkt.pos = -1;
+
+                let mut have_video = read_next_raw(ifmt_video, video_stream_idx, &mut vpkt);
+                let mut have_audio = read_next_raw(ifmt_audio, audio_stream_idx, &mut apkt);
+
+                loop {
+                    match (have_video, have_audio) {
+                        (false, false) => break,
+                        (true, false) => {
+                            rescale_and_write_raw(
+                                &mut vpkt,
+                                in_video_stream,
+                                ofmt_ctx,
+                                video_out_idx,
+                            )?;
+                            ffi::av_packet_unref(&mut vpkt);
+                            have_video = read_next_raw(ifmt_video, video_stream_idx, &mut vpkt);
+                        }
+                        (false, true) => {
+                            rescale_and_write_raw(
+                                &mut apkt,
+                                in_audio_stream,
+                                ofmt_ctx,
+                                audio_out_idx,
+                            )?;
+                            ffi::av_packet_unref(&mut apkt);
+                            have_audio = read_next_raw(ifmt_audio, audio_stream_idx, &mut apkt);
+                        }
+                        (true, true) => {
+                            let v_us = dts_in_us(vpkt.dts, in_video_stream);
+                            let a_us = dts_in_us(apkt.dts, in_audio_stream);
+
+                            let write_video = match (v_us, a_us) {
+                                (None, None) => true,
+                                (None, Some(_)) => true,
+                                (Some(_), None) => false,
+                                (Some(v), Some(a)) => v <= a,
+                            };
+
+                            if write_video {
+                                rescale_and_write_raw(
+                                    &mut vpkt,
+                                    in_video_stream,
+                                    ofmt_ctx,
+                                    video_out_idx,
+                                )?;
+                                ffi::av_packet_unref(&mut vpkt);
+                                have_video = read_next_raw(ifmt_video, video_stream_idx, &mut vpkt);
+                            } else {
+                                rescale_and_write_raw(
+                                    &mut apkt,
+                                    in_audio_stream,
+                                    ofmt_ctx,
+                                    audio_out_idx,
+                                )?;
+                                ffi::av_packet_unref(&mut apkt);
+                                have_audio = read_next_raw(ifmt_audio, audio_stream_idx, &mut apkt);
+                            }
+                        }
+                    }
                 }
 
-                if pkt.stream_index as usize != video_stream_idx {
-                    ffi::av_packet_unref(&mut pkt);
-                    continue;
-                }
+                ffi::av_packet_unref(&mut vpkt);
+                ffi::av_packet_unref(&mut apkt);
+                Ok(())
+            })();
 
-                pkt.stream_index = video_out_idx;
-
-                // Rescale timestamps (guard against AV_NOPTS_VALUE)
-                let out_stream =
-                    *(*ofmt_ctx).streams.add(video_out_idx as usize);
-                if pkt.pts != ffi::AV_NOPTS_VALUE {
-                    pkt.pts = ffi::av_rescale_q_rnd(
-                        pkt.pts,
-                        (*in_video_stream).time_base,
-                        (*out_stream).time_base,
-                        ffi::AVRounding::AV_ROUND_NEAR_INF,
-                    );
-                }
-                if pkt.dts != ffi::AV_NOPTS_VALUE {
-                    pkt.dts = ffi::av_rescale_q_rnd(
-                        pkt.dts,
-                        (*in_video_stream).time_base,
-                        (*out_stream).time_base,
-                        ffi::AVRounding::AV_ROUND_NEAR_INF,
-                    );
-                }
-                if pkt.duration > 0 {
-                    pkt.duration = ffi::av_rescale_q(
-                        pkt.duration,
-                        (*in_video_stream).time_base,
-                        (*out_stream).time_base,
-                    );
-                }
-                pkt.pos = -1;
-
-                let ret =
-                    ffi::av_interleaved_write_frame(ofmt_ctx, &mut pkt);
-                ffi::av_packet_unref(&mut pkt);
-
-                if ret < 0 {
-                    log::error!("Error writing video packet: {ret}");
-                    break;
-                }
-            }
-
-            // 14. Copy audio packets
-            loop {
-                let ret = ffi::av_read_frame(ifmt_audio, &mut pkt);
-                if ret < 0 {
-                    break; // EOF or error
-                }
-
-                if pkt.stream_index as usize != audio_stream_idx {
-                    ffi::av_packet_unref(&mut pkt);
-                    continue;
-                }
-
-                pkt.stream_index = audio_out_idx;
-
-                // Rescale timestamps (guard against AV_NOPTS_VALUE)
-                let out_stream =
-                    *(*ofmt_ctx).streams.add(audio_out_idx as usize);
-                if pkt.pts != ffi::AV_NOPTS_VALUE {
-                    pkt.pts = ffi::av_rescale_q_rnd(
-                        pkt.pts,
-                        (*in_audio_stream).time_base,
-                        (*out_stream).time_base,
-                        ffi::AVRounding::AV_ROUND_NEAR_INF,
-                    );
-                }
-                if pkt.dts != ffi::AV_NOPTS_VALUE {
-                    pkt.dts = ffi::av_rescale_q_rnd(
-                        pkt.dts,
-                        (*in_audio_stream).time_base,
-                        (*out_stream).time_base,
-                        ffi::AVRounding::AV_ROUND_NEAR_INF,
-                    );
-                }
-                if pkt.duration > 0 {
-                    pkt.duration = ffi::av_rescale_q(
-                        pkt.duration,
-                        (*in_audio_stream).time_base,
-                        (*out_stream).time_base,
-                    );
-                }
-                pkt.pos = -1;
-
-                let ret =
-                    ffi::av_interleaved_write_frame(ofmt_ctx, &mut pkt);
-                ffi::av_packet_unref(&mut pkt);
-
-                if ret < 0 {
-                    log::error!("Error writing audio packet: {ret}");
-                    break;
-                }
-            }
-
-            // 15. Write trailer and cleanup
+            // 14. Write trailer and cleanup (always runs, even on merge error)
             ffi::av_write_trailer(ofmt_ctx);
 
             if !(*ofmt_ctx).pb.is_null() {
@@ -674,6 +735,9 @@ impl FFmpegRunner {
             ffi::avformat_close_input(&mut ifmt_video);
             ffi::avformat_close_input(&mut ifmt_audio);
             ffi::avformat_free_context(ofmt_ctx);
+
+            // Propagate merge errors after cleanup
+            merge_result?;
         }
 
         Ok(())

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use log::debug;
+use log::{debug, info};
 
 use crate::error::{PostProcessError, Result};
 
@@ -233,6 +233,11 @@ impl FFmpegRunner {
                 .parameters(),
         );
         Self::clear_codec_tag(ost_audio.parameters().as_ptr());
+        // Set audio as default stream so players select it automatically
+        unsafe {
+            (*ost_audio.as_mut_ptr()).disposition =
+                ffmpeg_the_third::ffi::AV_DISPOSITION_DEFAULT;
+        }
         let audio_ost_index = ost_audio.index();
 
         // Build muxer options dictionary
@@ -248,6 +253,10 @@ impl FFmpegRunner {
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to write output header: {e}"),
             })?;
+
+        info!(
+            "Merge: video=stream#{video_ost_index}, audio=stream#{audio_ost_index} (DEFAULT)"
+        );
 
         // Two-way timestamp-interleaved merge: read packets from both inputs
         // and write them in DTS order to avoid ENOMEM from buffering an entire
@@ -562,6 +571,9 @@ impl FFmpegRunner {
             (*out_audio_stream).r_frame_rate = (*in_audio_stream).r_frame_rate;
             (*out_audio_stream).sample_aspect_ratio = (*in_audio_stream).sample_aspect_ratio;
 
+            // Set audio as default stream so players select it automatically
+            (*out_audio_stream).disposition = ffi::AV_DISPOSITION_DEFAULT;
+
             let audio_out_idx = (*out_audio_stream).index;
 
             debug!(
@@ -644,6 +656,10 @@ impl FFmpegRunner {
                     message: format!("avformat_write_header failed: error code {ret}"),
                 });
             }
+
+            info!(
+                "Merge: video=stream#{video_out_idx}, audio=stream#{audio_out_idx} (DEFAULT)"
+            );
 
             // 13. Two-way timestamp-interleaved merge
             //

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -28,10 +28,13 @@
 //! ```
 
 mod ffi_helpers;
+pub(crate) mod log_capture;
 mod merge;
 mod metadata;
+mod normalize;
 mod probe;
 mod remux;
+pub(crate) mod salvage;
 mod thumbnail;
 mod transcode;
 
@@ -289,11 +292,80 @@ pub struct ChapterEntry {
     pub title: String,
 }
 
+/// Audio normalization mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioNormMode {
+    /// Peak/gain normalization: analyze peak/RMS via astats, apply volume + alimiter.
+    Peak,
+    /// EBU R128 two-pass loudness normalization via loudnorm filter.
+    Loudnorm,
+}
+
+/// Options for audio normalization.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizeOptions {
+    /// Normalization mode (peak or loudnorm).
+    pub mode: AudioNormMode,
+    /// Target peak level in dBFS (Mode A, default -1.0).
+    pub target_peak_db: f64,
+    /// Target integrated loudness in LUFS (Mode B, default -16.0).
+    pub target_i: f64,
+    /// Target true peak in dBTP (Mode B, default -1.5).
+    pub target_tp: f64,
+    /// Target loudness range in LU (Mode B, default 11.0).
+    pub target_lra: f64,
+    /// Automatically salvage corrupt Matroska/WebM containers before processing.
+    ///
+    /// When enabled (default), corrupt inputs are detected via EBML log analysis
+    /// and automatically remuxed to a clean temporary file before normalization.
+    /// Disable for strict mode where corruption should be a hard error.
+    pub salvage: bool,
+}
+
+impl Default for NormalizeOptions {
+    fn default() -> Self {
+        Self {
+            mode: AudioNormMode::Peak,
+            target_peak_db: -1.0,
+            target_i: -16.0,
+            target_tp: -1.5,
+            target_lra: 11.0,
+            salvage: true,
+        }
+    }
+}
+
+/// Results from peak/RMS audio analysis.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeakAnalysis {
+    /// Peak level in dBFS.
+    pub peak_db: f64,
+    /// RMS level in dBFS.
+    pub rms_db: f64,
+    /// Computed gain adjustment in dB.
+    pub gain_db: f64,
+}
+
+/// Measurements from EBU R128 loudnorm first pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoudnormMeasurements {
+    /// Measured integrated loudness (LUFS).
+    pub input_i: f64,
+    /// Measured true peak (dBTP).
+    pub input_tp: f64,
+    /// Measured loudness range (LU).
+    pub input_lra: f64,
+    /// Measured loudness threshold (LUFS).
+    pub input_thresh: f64,
+    /// Target offset (LU).
+    pub target_offset: f64,
+}
+
 /// FFmpeg runner.
 ///
 /// Provides media operations via `ffmpeg-the-third` library bindings:
 /// probing, remuxing, merging, audio extraction, video conversion,
-/// metadata embedding, and thumbnail embedding.
+/// metadata embedding, thumbnail embedding, and audio normalization.
 #[derive(Debug, Clone)]
 pub struct FFmpegRunner;
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -301,6 +301,54 @@ pub enum AudioNormMode {
     Loudnorm,
 }
 
+/// Loudnorm target presets for common use cases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoudnormPreset {
+    /// Broadcast standard: I=-23 LUFS, TP=-2 dBTP, LRA=7 LU
+    Broadcast,
+    /// Streaming standard: I=-14 LUFS, TP=-1 dBTP, LRA=11 LU
+    Streaming,
+    /// Loud master: I=-11 LUFS, TP=-1 dBTP, LRA=11 LU
+    Loud,
+}
+
+impl LoudnormPreset {
+    /// Returns `(target_i, target_tp, target_lra)` for this preset.
+    #[must_use]
+    pub fn targets(self) -> (f64, f64, f64) {
+        match self {
+            Self::Broadcast => (-23.0, -2.0, 7.0),
+            Self::Streaming => (-14.0, -1.0, 11.0),
+            Self::Loud => (-11.0, -1.0, 11.0),
+        }
+    }
+}
+
+impl std::str::FromStr for LoudnormPreset {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "broadcast" => Ok(Self::Broadcast),
+            "streaming" => Ok(Self::Streaming),
+            "loud" => Ok(Self::Loud),
+            _ => Err(format!(
+                "unknown loudnorm preset '{s}': expected broadcast, streaming, or loud"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for LoudnormPreset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Broadcast => write!(f, "broadcast"),
+            Self::Streaming => write!(f, "streaming"),
+            Self::Loud => write!(f, "loud"),
+        }
+    }
+}
+
 /// Options for audio normalization.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NormalizeOptions {
@@ -320,17 +368,33 @@ pub struct NormalizeOptions {
     /// and automatically remuxed to a clean temporary file before normalization.
     /// Disable for strict mode where corruption should be a hard error.
     pub salvage: bool,
+    /// Force dynamic (per-frame compression) mode in loudnorm pass 2.
+    ///
+    /// By default, loudnorm uses `linear=true` (letting FFmpeg fall back to
+    /// dynamic internally if needed). This flag forces `linear=false` for users
+    /// who explicitly want dynamic compression. Corresponds to `--loudnorm-dynamic`.
+    pub force_dynamic: bool,
+    /// Prepend a mild acompressor before loudnorm in pass 2.
+    ///
+    /// Tames extreme peaks before loudnorm, allowing linear mode to apply more
+    /// gain without hitting the TP ceiling. Uses a conservative preset:
+    /// `threshold=-18dB, ratio=3:1, attack=20ms, release=200ms, makeup=2dB, knee=6dB`.
+    /// Corresponds to `--loudnorm-precompress`.
+    pub precompress: bool,
 }
 
 impl Default for NormalizeOptions {
     fn default() -> Self {
+        let (i, tp, lra) = LoudnormPreset::Streaming.targets();
         Self {
             mode: AudioNormMode::Peak,
             target_peak_db: -1.0,
-            target_i: -16.0,
-            target_tp: -1.5,
-            target_lra: 11.0,
+            target_i: i,
+            target_tp: tp,
+            target_lra: lra,
             salvage: true,
+            force_dynamic: false,
+            precompress: false,
         }
     }
 }
@@ -359,6 +423,35 @@ pub struct LoudnormMeasurements {
     pub input_thresh: f64,
     /// Target offset (LU).
     pub target_offset: f64,
+}
+
+impl LoudnormMeasurements {
+    /// Predict the gain (dB) that linear mode would apply.
+    ///
+    /// Linear mode applies a constant gain capped by the true-peak headroom:
+    /// `min(target_i - measured_i, target_tp - measured_tp)`.
+    #[must_use]
+    pub fn predict_linear_gain(&self, target_i: f64, target_tp: f64) -> f64 {
+        let desired = target_i - self.input_i;
+        let tp_headroom = target_tp - self.input_tp;
+        desired.min(tp_headroom)
+    }
+
+    /// Compute the shortfall (LU) when using linear mode.
+    ///
+    /// Returns `target_i - (measured_i + predicted_linear_gain)`.
+    /// A value <= 0 means linear mode fully reaches the target.
+    #[must_use]
+    pub fn linear_shortfall(&self, target_i: f64, target_tp: f64) -> f64 {
+        let gain = self.predict_linear_gain(target_i, target_tp);
+        target_i - (self.input_i + gain)
+    }
+
+    /// Returns `true` if linear mode can reach the target within 0.5 LU.
+    #[must_use]
+    pub fn linear_sufficient(&self, target_i: f64, target_tp: f64) -> bool {
+        self.linear_shortfall(target_i, target_tp) <= 0.5
+    }
 }
 
 /// FFmpeg runner.
@@ -429,6 +522,107 @@ mod tests {
         let flac = get_audio_codec("flac").unwrap();
         assert!(flac.encoder.is_none()); // Native codec
         assert!(flac.bitrate_range.is_none()); // Lossless
+    }
+
+    #[test]
+    fn test_loudnorm_preset_from_str() {
+        assert_eq!(
+            "broadcast".parse::<LoudnormPreset>().unwrap(),
+            LoudnormPreset::Broadcast
+        );
+        assert_eq!(
+            "Streaming".parse::<LoudnormPreset>().unwrap(),
+            LoudnormPreset::Streaming
+        );
+        assert_eq!(
+            "LOUD".parse::<LoudnormPreset>().unwrap(),
+            LoudnormPreset::Loud
+        );
+        assert!("unknown".parse::<LoudnormPreset>().is_err());
+    }
+
+    #[test]
+    fn test_loudnorm_preset_display() {
+        assert_eq!(LoudnormPreset::Broadcast.to_string(), "broadcast");
+        assert_eq!(LoudnormPreset::Streaming.to_string(), "streaming");
+        assert_eq!(LoudnormPreset::Loud.to_string(), "loud");
+    }
+
+    #[test]
+    fn test_loudnorm_preset_targets() {
+        let (i, tp, lra) = LoudnormPreset::Broadcast.targets();
+        assert!((i - (-23.0)).abs() < f64::EPSILON);
+        assert!((tp - (-2.0)).abs() < f64::EPSILON);
+        assert!((lra - 7.0).abs() < f64::EPSILON);
+
+        let (i, tp, lra) = LoudnormPreset::Streaming.targets();
+        assert!((i - (-14.0)).abs() < f64::EPSILON);
+        assert!((tp - (-1.0)).abs() < f64::EPSILON);
+        assert!((lra - 11.0).abs() < f64::EPSILON);
+
+        let (i, tp, lra) = LoudnormPreset::Loud.targets();
+        assert!((i - (-11.0)).abs() < f64::EPSILON);
+        assert!((tp - (-1.0)).abs() < f64::EPSILON);
+        assert!((lra - 11.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_normalize_options_default_uses_streaming() {
+        let opts = NormalizeOptions::default();
+        assert!((opts.target_i - (-14.0)).abs() < f64::EPSILON);
+        assert!((opts.target_tp - (-1.0)).abs() < f64::EPSILON);
+        assert!((opts.target_lra - 11.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_linear_shortfall_no_gap() {
+        // Source: I=-24, TP=-5 → target: I=-14, TP=-1
+        // desired=10, tp_headroom=4 → gain=4 → shortfall=-14-(-24+4)=6
+        // Wait, let me recalculate: shortfall = -14 - (-24 + 4) = -14 - (-20) = 6
+        // Actually: desired = -14 - (-24) = 10, tp_headroom = -1 - (-5) = 4
+        // gain = min(10, 4) = 4
+        // shortfall = -14 - (-24 + 4) = -14 + 20 = 6
+        let m = LoudnormMeasurements {
+            input_i: -20.0,
+            input_tp: -7.0,
+            input_lra: 8.0,
+            input_thresh: -30.0,
+            target_offset: 0.0,
+        };
+        // desired = -14 - (-20) = 6, tp_headroom = -1 - (-7) = 6
+        // gain = min(6, 6) = 6, shortfall = -14 - (-20 + 6) = -14 + 14 = 0
+        assert!((m.linear_shortfall(-14.0, -1.0)).abs() < f64::EPSILON);
+        assert!(m.linear_sufficient(-14.0, -1.0));
+    }
+
+    #[test]
+    fn test_linear_shortfall_small_gap() {
+        let m = LoudnormMeasurements {
+            input_i: -24.0,
+            input_tp: -3.0,
+            input_lra: 8.0,
+            input_thresh: -34.0,
+            target_offset: 0.0,
+        };
+        // desired = -14 - (-24) = 10, tp_headroom = -1 - (-3) = 2
+        // gain = min(10, 2) = 2, shortfall = -14 - (-24 + 2) = -14 + 22 = 8
+        assert!((m.linear_shortfall(-14.0, -1.0) - 8.0).abs() < f64::EPSILON);
+        assert!(!m.linear_sufficient(-14.0, -1.0));
+    }
+
+    #[test]
+    fn test_linear_shortfall_large_gap() {
+        let m = LoudnormMeasurements {
+            input_i: -30.0,
+            input_tp: -1.0,
+            input_lra: 12.0,
+            input_thresh: -40.0,
+            target_offset: 0.0,
+        };
+        // desired = -14 - (-30) = 16, tp_headroom = -1 - (-1) = 0
+        // gain = min(16, 0) = 0, shortfall = -14 - (-30 + 0) = -14 + 30 = 16
+        assert!((m.linear_shortfall(-14.0, -1.0) - 16.0).abs() < f64::EPSILON);
+        assert!(!m.linear_sufficient(-14.0, -1.0));
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize.rs
@@ -1,0 +1,1965 @@
+//! Audio normalization via FFmpeg library bindings.
+//!
+//! Two modes:
+//! - **Peak**: Analyze peak/RMS levels via `astats` filter frame metadata,
+//!   then apply `volume` + `alimiter` filters to normalize to a target peak.
+//! - **Loudnorm**: EBU R128 two-pass normalization via `loudnorm` filter.
+//!   Pass 1 captures measurements from FFmpeg log output, pass 2 applies
+//!   them with `linear=true` for high-quality correction.
+
+use std::ffi::CStr;
+use std::path::Path;
+
+use log::{debug, info, warn};
+
+use crate::error::{PostProcessError, Result};
+
+use super::log_capture::{LogCaptureGuard, LogSuppressGuard};
+use super::salvage::{prepare_input_with_salvage, salvage_remux_sync};
+use super::transcode::MuxTimingState;
+use super::{
+    AudioNormMode, FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis, ensure_init,
+};
+
+impl FFmpegRunner {
+    /// Normalize audio levels in a media file.
+    ///
+    /// Video streams are copied without re-encoding. Audio is decoded,
+    /// filtered (volume/limiter or loudnorm), and re-encoded with an
+    /// appropriate codec for the output container.
+    ///
+    /// When `opts.salvage` is true (default), corrupt Matroska/WebM containers
+    /// are automatically detected and remuxed to a clean temporary file before
+    /// normalization. This prevents EBML structural errors from cascading into
+    /// muxer ENOMEM failures during the encode pipeline.
+    pub async fn normalize_audio(
+        &self,
+        input: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+        opts: &NormalizeOptions,
+    ) -> Result<()> {
+        let input = input.as_ref().to_path_buf();
+        let output = output.as_ref().to_path_buf();
+        let opts = opts.clone();
+        Self::spawn_blocking("normalize_audio", move || {
+            // Check for container corruption and optionally salvage
+            let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, opts.salvage)?;
+
+            let result = match opts.mode {
+                AudioNormMode::Peak => Self::normalize_peak_sync(&effective_input, &output, &opts),
+                AudioNormMode::Loudnorm => {
+                    Self::normalize_loudnorm_sync(&effective_input, &output, &opts)
+                }
+            };
+
+            // Clean up salvage temp file regardless of success/failure
+            if let Some(ref temp) = salvage_temp {
+                let _ = std::fs::remove_file(temp);
+            }
+
+            result
+        })
+        .await
+    }
+
+    /// Peak normalization: analyze then apply gain + limiter.
+    fn normalize_peak_sync(input: &Path, output: &Path, opts: &NormalizeOptions) -> Result<()> {
+        let analysis = Self::analyze_peak_sync(input, opts.target_peak_db)?;
+
+        info!(
+            "Peak analysis: peak={:.1} dBFS, RMS={:.1} dBFS, gain={:.1} dB",
+            analysis.peak_db, analysis.rms_db, analysis.gain_db
+        );
+
+        // Skip if gain adjustment is negligible
+        if analysis.gain_db.abs() < 0.5 {
+            info!("Audio already near target peak, skipping normalization");
+            std::fs::copy(input, output).map_err(|e| PostProcessError::IoError {
+                message: format!("failed to copy file: {e}"),
+                source: e,
+            })?;
+            return Ok(());
+        }
+
+        Self::apply_peak_gain_sync(input, output, &analysis, opts)
+    }
+
+    /// Analyze peak and RMS levels using `astats` filter with frame metadata.
+    fn analyze_peak_sync(input: &Path, target_peak_db: f64) -> Result<PeakAnalysis> {
+        ensure_init()?;
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let ist = ictx.stream(ist_index).ok_or_else(|| {
+            PostProcessError::ffmpeg_failed(format!("audio input stream {ist_index} not found"))
+        })?;
+        let ist_time_base = ist.time_base();
+
+        let decoder_ctx =
+            ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())?;
+        let mut decoder = decoder_ctx.decoder().audio()?;
+
+        // Build astats filter graph
+        let mut graph = ffmpeg_the_third::filter::Graph::new();
+        let abuffersink = ffmpeg_the_third::filter::find("abuffersink")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffersink filter not found"))?;
+
+        FFmpegRunner::add_abuffer_to_graph(
+            &mut graph,
+            "in",
+            ist_time_base,
+            decoder.rate(),
+            decoder.format().name(),
+            &decoder.ch_layout().description(),
+        )?;
+        graph
+            .add(&abuffersink, "out", "")
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add abuffersink filter: {e}"),
+            })?;
+
+        let astats_spec = "astats=metadata=1:reset=0:measure_perchannel=none:measure_overall=Peak_level+RMS_level";
+        FFmpegRunner::parse_and_validate_filter_graph(&mut graph, "in", "out", astats_spec)?;
+
+        // Skip non-audio streams to avoid allocating memory for large video packets
+        Self::discard_non_audio_streams(&mut ictx, ist_index);
+
+        // Decode and filter all frames
+        let mut peak_db = f64::NEG_INFINITY;
+        let mut rms_db = f64::NEG_INFINITY;
+
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        let mut filtered = ffmpeg_the_third::frame::Audio::empty();
+        let mut packets_skipped = 0u64;
+
+        // Suppress FFmpeg's C-level decoder error spam during decode loop —
+        // we handle errors at the Rust level with rate-limited warnings.
+        let _log_suppress = LogSuppressGuard::new();
+
+        for result in ictx.packets() {
+            let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to read packet: {e}"),
+            })?;
+            if stream.index() != ist_index {
+                continue;
+            }
+            if let Err(e) = decoder.send_packet(&packet) {
+                if packets_skipped == 0 {
+                    warn!("Audio decoder error during analysis (skipping affected packets): {e}");
+                }
+                packets_skipped += 1;
+                // Clear internal decoder buffer
+                while decoder.receive_frame(&mut frame).is_ok() {}
+                continue;
+            }
+            while decoder.receive_frame(&mut frame).is_ok() {
+                graph
+                    .get("in")
+                    .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                    .source()
+                    .add(&frame)?;
+
+                loop {
+                    let mut out_node = graph.get("out").ok_or_else(|| {
+                        PostProcessError::ffmpeg_failed("filter node 'out' not found")
+                    })?;
+                    if out_node.sink().frame(&mut filtered).is_err() {
+                        break;
+                    }
+                    // Read metadata from filtered frame
+                    if let Some(p) = read_frame_metadata(
+                        unsafe { filtered.as_ptr() },
+                        "lavfi.astats.Overall.Peak_level",
+                    ) {
+                        peak_db = p;
+                    }
+                    if let Some(r) = read_frame_metadata(
+                        unsafe { filtered.as_ptr() },
+                        "lavfi.astats.Overall.RMS_level",
+                    ) {
+                        rms_db = r;
+                    }
+                }
+            }
+        }
+
+        if packets_skipped > 0 {
+            warn!(
+                "Skipped {packets_skipped} audio packet(s) during peak analysis due to decoder errors"
+            );
+        }
+
+        // Flush decoder — send_eof may fail if decoder is in a broken state
+        if let Err(e) = decoder.send_eof() {
+            warn!("Decoder send_eof failed during analysis (continuing with flush): {e}");
+        }
+        while decoder.receive_frame(&mut frame).is_ok() {
+            graph
+                .get("in")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                .source()
+                .add(&frame)?;
+
+            loop {
+                let mut out_node = graph.get("out").ok_or_else(|| {
+                    PostProcessError::ffmpeg_failed("filter node 'out' not found")
+                })?;
+                if out_node.sink().frame(&mut filtered).is_err() {
+                    break;
+                }
+                if let Some(p) = read_frame_metadata(
+                    unsafe { filtered.as_ptr() },
+                    "lavfi.astats.Overall.Peak_level",
+                ) {
+                    peak_db = p;
+                }
+                if let Some(r) = read_frame_metadata(
+                    unsafe { filtered.as_ptr() },
+                    "lavfi.astats.Overall.RMS_level",
+                ) {
+                    rms_db = r;
+                }
+            }
+        }
+
+        // Flush filter
+        graph
+            .get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+            .source()
+            .flush()?;
+        loop {
+            let mut out_node = graph
+                .get("out")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'out' not found"))?;
+            if out_node.sink().frame(&mut filtered).is_err() {
+                break;
+            }
+            if let Some(p) = read_frame_metadata(
+                unsafe { filtered.as_ptr() },
+                "lavfi.astats.Overall.Peak_level",
+            ) {
+                peak_db = p;
+            }
+            if let Some(r) = read_frame_metadata(
+                unsafe { filtered.as_ptr() },
+                "lavfi.astats.Overall.RMS_level",
+            ) {
+                rms_db = r;
+            }
+        }
+
+        if peak_db == f64::NEG_INFINITY {
+            return Err(PostProcessError::NormalizationFailed {
+                message: "could not determine peak level from astats metadata".into(),
+            });
+        }
+
+        let gain_db = target_peak_db - peak_db;
+
+        Ok(PeakAnalysis {
+            peak_db,
+            rms_db,
+            gain_db,
+        })
+    }
+
+    /// Apply peak gain normalization: encode audio to temp, merge with video.
+    ///
+    /// Same two-step approach as loudnorm pass 2: audio-only encode then merge.
+    /// When `opts.salvage` is true, wraps the encode with `with_mux_retry` for
+    /// two-tier recovery (salvage remux → CLI fallback) on mux write failures.
+    fn apply_peak_gain_sync(
+        input: &Path,
+        output: &Path,
+        analysis: &PeakAnalysis,
+        opts: &NormalizeOptions,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        let has_video = {
+            let ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to open input {}: {e}", input.display()),
+                }
+            })?;
+            ictx.streams()
+                .best(ffmpeg_the_third::media::Type::Video)
+                .is_some()
+        };
+
+        let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
+
+        if has_video {
+            let audio_ext = audio_only_extension_for(ext);
+            let temp_audio = output.with_extension(format!("norm_audio.{audio_ext}"));
+
+            if opts.salvage {
+                with_mux_retry(
+                    input,
+                    &temp_audio,
+                    |effective_input| {
+                        Self::peak_encode_audio_only(
+                            effective_input,
+                            &temp_audio,
+                            ext,
+                            analysis,
+                            opts,
+                        )
+                    },
+                    |fallback_in, fallback_out| {
+                        cli_fallback_peak(fallback_in, fallback_out, analysis, opts, ext)
+                    },
+                )?;
+            } else {
+                Self::peak_encode_audio_only(input, &temp_audio, ext, analysis, opts)?;
+            }
+            let merge_result =
+                Self::merge_sync(input, &temp_audio, output, &super::RemuxOptions::default());
+            let _ = std::fs::remove_file(&temp_audio);
+            merge_result
+        } else if opts.salvage {
+            with_mux_retry(
+                input,
+                output,
+                |effective_input| {
+                    Self::peak_encode_audio_only(effective_input, output, ext, analysis, opts)
+                },
+                |fallback_in, fallback_out| {
+                    cli_fallback_peak(fallback_in, fallback_out, analysis, opts, ext)
+                },
+            )
+        } else {
+            Self::peak_encode_audio_only(input, output, ext, analysis, opts)
+        }
+    }
+
+    /// Encode peak-normalized audio to an output file (video streams discarded).
+    #[allow(clippy::too_many_lines)]
+    fn peak_encode_audio_only(
+        input: &Path,
+        output: &Path,
+        final_output_ext: &str,
+        analysis: &PeakAnalysis,
+        opts: &NormalizeOptions,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        let gain_db = opts.target_peak_db - analysis.peak_db;
+        let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let audio_ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let audio_ist_time_base = ictx
+            .stream(audio_ist_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!(
+                    "audio input stream {audio_ist_index} not found"
+                ))
+            })?
+            .time_base();
+
+        let audio_ist = ictx.stream(audio_ist_index).ok_or_else(|| {
+            PostProcessError::ffmpeg_failed(format!(
+                "audio input stream {audio_ist_index} not found"
+            ))
+        })?;
+        let audio_dec_ctx =
+            ffmpeg_the_third::codec::context::Context::from_parameters(audio_ist.parameters())?;
+        let mut audio_decoder = audio_dec_ctx.decoder().audio()?;
+
+        let input_audio_bitrate = audio_ist.parameters().bit_rate() as usize;
+
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        // Use final_output_ext for encoder selection (not temp file ext) to ensure
+        // correct codec for stream copy during merge (e.g., AAC for MP4, Opus for MKV).
+        let enc_name = select_audio_encoder_for_container(final_output_ext);
+        let enc_codec = ffmpeg_the_third::encoder::find_by_name(enc_name).ok_or_else(|| {
+            PostProcessError::UnsupportedCodec {
+                codec: enc_name.to_string(),
+                operation: "audio normalization".into(),
+            }
+        })?;
+
+        let needs_global_header = octx
+            .format()
+            .flags()
+            .contains(ffmpeg_the_third::format::Flags::GLOBAL_HEADER);
+
+        // Audio-only output — no video stream
+        let audio_ost_index;
+        let audio_enc_context;
+        {
+            let ost =
+                octx.add_stream(enc_codec)
+                    .map_err(|e| PostProcessError::FFmpegLibraryError {
+                        message: format!("failed to add audio output stream: {e}"),
+                    })?;
+            audio_ost_index = ost.index();
+            audio_enc_context =
+                ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
+        }
+
+        let mut audio_encoder = audio_enc_context.encoder().audio()?;
+        let target_format = Self::pick_audio_sample_format(&enc_codec, audio_decoder.format());
+        audio_encoder.set_format(target_format);
+        audio_encoder.set_rate(audio_decoder.rate() as i32);
+        let enc_time_base = ffmpeg_the_third::Rational(1, audio_decoder.rate() as i32);
+        audio_encoder.set_time_base(enc_time_base);
+
+        let channels = audio_decoder.ch_layout().channels();
+        Self::set_default_channel_layout(unsafe { audio_encoder.as_mut_ptr() }, channels as i32);
+
+        let target_bitrate = if input_audio_bitrate > 0 {
+            input_audio_bitrate
+        } else {
+            default_bitrate_for_encoder(enc_name)
+        };
+        audio_encoder.set_bit_rate(target_bitrate);
+
+        if needs_global_header {
+            Self::set_global_header_flag(unsafe { audio_encoder.as_mut_ptr() });
+        }
+
+        let mut audio_encoder =
+            audio_encoder
+                .open_as(enc_codec)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to open audio encoder: {e}"),
+                })?;
+
+        // Read actual encoder time_base via FFI (may differ from configured after open)
+        // SAFETY: audio_encoder is a valid opened encoder context.
+        let enc_time_base = unsafe {
+            let tb = (*audio_encoder.as_ptr()).time_base;
+            ffmpeg_the_third::Rational(tb.num, tb.den)
+        };
+        debug!(
+            "Peak encoder time_base: configured=1/{}, actual={}/{}",
+            audio_decoder.rate(),
+            enc_time_base.numerator(),
+            enc_time_base.denominator(),
+        );
+
+        Self::copy_encoder_params_to_stream(&mut octx, audio_ost_index, unsafe {
+            audio_encoder.as_ptr()
+        });
+
+        // Set avoid_negative_ts for timestamp normalization (matches merge.rs/remux.rs)
+        unsafe {
+            (*octx.as_mut_ptr()).avoid_negative_ts =
+                ffmpeg_the_third::ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
+        }
+
+        // Flush packets to AVIO immediately — prevents Matroska cluster buffering stalls
+        unsafe {
+            (*octx.as_mut_ptr()).flags |= ffmpeg_the_third::ffi::AVFMT_FLAG_FLUSH_PACKETS;
+        }
+
+        // For audio-only output, set max_interleave_delta = 0 to disable the
+        // muxer's interleave queue entirely. Prevents residual buffer growth
+        // that can cause ENOMEM on certain MKV files.
+        unsafe {
+            (*octx.as_mut_ptr()).max_interleave_delta = 0;
+        }
+
+        let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
+        muxer_opts.set("cluster_time_limit", "500");
+        octx.write_header_with(muxer_opts)
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to write output header: {e}"),
+            })?;
+
+        // Log AVIO state for diagnostics after header write
+        // SAFETY: octx owns a valid, header-written output format context.
+        unsafe { dump_io_state(octx.as_mut_ptr(), output, "peak_encode_audio_only") };
+
+        // Fail-fast: reject CUSTOM_IO (expected file-based IO)
+        {
+            let flags = unsafe { (*octx.as_mut_ptr()).flags };
+            if flags & ffmpeg_the_third::ffi::AVFMT_FLAG_CUSTOM_IO != 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "[peak_encode_audio_only] AVFMT_FLAG_CUSTOM_IO is set — expected file-based IO".into(),
+                });
+            }
+        }
+
+        // Fail-fast: assert seekable IO context for Matroska (needs seeking for Cues/SeekHead)
+        unsafe {
+            assert_seekable_io(octx.as_mut_ptr(), "peak_encode_audio_only")?;
+        }
+
+        // Flush AVIO after header write to ensure bytes reach disk
+        unsafe {
+            let pb = (*octx.as_mut_ptr()).pb;
+            if !pb.is_null() {
+                ffmpeg_the_third::ffi::avio_flush(pb);
+            }
+        }
+        let file_size = std::fs::metadata(output).map(|m| m.len()).unwrap_or(0);
+        if file_size == 0 {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: "[peak_encode_audio_only] output file is 0 bytes after header write + avio_flush — IO sink is broken".into(),
+            });
+        }
+        info!("[peak_encode_audio_only] header written: {file_size} bytes on disk");
+
+        // Build audio filter: volume → alimiter → aresample → aformat → abuffersink
+        // The alimiter filter only supports dblp format. An explicit aresample
+        // bridges dblp→encoder format since FFmpeg 8.0's auto-conversion during
+        // graph_config may fail (same issue as loudnorm, see pass 1 comment).
+        let enc_ch_layout_desc = audio_encoder.ch_layout().description();
+        let filter_spec = format!(
+            "volume={gain_db:.6}dB,alimiter=limit={linear_limit:.6}:attack=5:release=50,aresample,aformat=sample_fmts={}:sample_rates={}:channel_layouts={}",
+            audio_encoder.format().name(),
+            audio_encoder.rate(),
+            enc_ch_layout_desc,
+        );
+
+        let mut filter_graph =
+            build_audio_filter_with_spec(&audio_decoder, audio_ist_time_base, &filter_spec)?;
+
+        // Tell buffersink to output exactly frame_size samples per frame.
+        // The last frame at EOF is zero-padded. Required for fixed-frame-size
+        // encoders (AAC=1024, MP3=1152, Opus=960).
+        Self::set_buffersink_frame_size(&mut filter_graph, "out", audio_encoder.frame_size());
+
+        // Discard non-audio streams to avoid ENOMEM on large video packets
+        Self::discard_non_audio_streams(&mut ictx, audio_ist_index);
+
+        // Read ost_time_base AFTER write_header (Matroska may change it)
+        let ost_time_base = octx
+            .stream(audio_ost_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("output stream not found"))?
+            .time_base();
+
+        let expected_duration = if audio_encoder.frame_size() > 0 {
+            unsafe {
+                ffmpeg_the_third::ffi::av_rescale_q(
+                    i64::from(audio_encoder.frame_size()),
+                    ffmpeg_the_third::ffi::AVRational {
+                        num: enc_time_base.numerator(),
+                        den: enc_time_base.denominator(),
+                    },
+                    ffmpeg_the_third::ffi::AVRational {
+                        num: ost_time_base.numerator(),
+                        den: ost_time_base.denominator(),
+                    },
+                )
+            }
+        } else {
+            0
+        };
+        info!(
+            "Expected audio packet duration: {} (frame_size={}, enc_tb={}/{}, ost_tb={}/{})",
+            expected_duration, audio_encoder.frame_size(),
+            enc_time_base.numerator(), enc_time_base.denominator(),
+            ost_time_base.numerator(), ost_time_base.denominator(),
+        );
+
+        // Suppress decoder WARNING spam while keeping muxer ERRORs visible.
+        // Uses error_level() instead of new() so Matroska muxer errors are diagnosable.
+        let _log_suppress = LogSuppressGuard::error_level();
+
+        let mut timing = MuxTimingState {
+            encoder_frame_size: audio_encoder.frame_size(),
+            expected_duration,
+            sample_rate: audio_decoder.rate(),
+            use_sample_clock: true,
+            ..Default::default()
+        };
+
+        // Transcode loop (audio only)
+        let mut packets_processed = 0u64;
+        let mut packets_skipped = 0u64;
+        for result in ictx.packets() {
+            let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to read packet: {e}"),
+            })?;
+            if stream.index() != audio_ist_index {
+                continue;
+            }
+            if let Err(e) = audio_decoder.send_packet(&packet) {
+                if packets_skipped == 0 {
+                    // ENOMEM = 12 on all POSIX platforms and Windows CRT
+                    if matches!(&e, ffmpeg_the_third::Error::Other { errno } if *errno == 12) {
+                        warn!(
+                            "Audio decoder allocation failure (ENOMEM) — \
+                             process may be running out of memory"
+                        );
+                    } else {
+                        warn!("Audio decoder error (skipping affected packets): {e}");
+                    }
+                }
+                packets_skipped += 1;
+                // Drain decoder to clear its internal buffer — send_packet buffers
+                // the packet before attempting decode, so receive_frame must be
+                // called to consume it even on failure.
+                if let Err(drain_err) = Self::receive_and_process_audio_direct(
+                    &mut audio_decoder,
+                    &mut filter_graph,
+                    &mut audio_encoder,
+                    &mut octx,
+                    audio_ost_index,
+                    enc_time_base,
+                    &mut timing,
+                    Some(output),
+                ) {
+                    // Propagate MuxWriteError directly for salvage retry eligibility
+                    if drain_err.is_mux_write_error() {
+                        return Err(drain_err);
+                    }
+                    return Err(PostProcessError::FFmpegLibraryError {
+                        message: format!(
+                            "(peak encode) mux/encode pipeline failed while draining after decoder error: {drain_err}"
+                        ),
+                    });
+                }
+                continue;
+            }
+            packets_processed += 1;
+            Self::receive_and_process_audio_direct(
+                &mut audio_decoder,
+                &mut filter_graph,
+                &mut audio_encoder,
+                &mut octx,
+                audio_ost_index,
+                enc_time_base,
+                &mut timing,
+                Some(output),
+            )?;
+        }
+
+        if packets_skipped > 0 {
+            warn!(
+                "Skipped {packets_skipped} of {} audio packet(s) due to decoder errors",
+                packets_processed + packets_skipped,
+            );
+        }
+
+        // If every packet failed, the decoder is in a broken state and the
+        // output would be empty/corrupt. Bail out so the caller can fall back
+        // to copying the file unchanged.
+        if packets_processed == 0 && packets_skipped > 0 {
+            return Err(PostProcessError::NormalizationFailed {
+                message: format!(
+                    "audio decoder failed on all {packets_skipped} packets — cannot normalize"
+                ),
+            });
+        }
+
+        // Flush — send_eof may fail if decoder encountered persistent errors
+        if let Err(e) = audio_decoder.send_eof() {
+            warn!("Decoder send_eof failed (continuing with flush): {e}");
+        }
+        Self::receive_and_process_audio_direct(
+            &mut audio_decoder,
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            audio_ost_index,
+            enc_time_base,
+            &mut timing,
+            Some(output),
+        )?;
+
+        filter_graph
+            .get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+            .source()
+            .flush()?;
+        Self::drain_filter_to_encoder_direct(
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            audio_ost_index,
+            enc_time_base,
+            &mut timing,
+            Some(output),
+        )?;
+
+        audio_encoder.send_eof()?;
+        Self::drain_encoder_packets_direct(
+            &mut audio_encoder,
+            &mut octx,
+            audio_ost_index,
+            enc_time_base,
+            &mut timing,
+            Some(output),
+        )?;
+
+        // Drop suppress guard before write_trailer so any trailer errors are visible
+        drop(_log_suppress);
+
+        octx.write_trailer()
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to write output trailer: {e}"),
+            })?;
+
+        Ok(())
+    }
+
+    /// EBU R128 loudnorm two-pass normalization.
+    fn normalize_loudnorm_sync(input: &Path, output: &Path, opts: &NormalizeOptions) -> Result<()> {
+        info!("Loudnorm pass 1: analyzing EBU R128 levels...");
+        let measurements = Self::loudnorm_pass1_sync(input, opts)?;
+
+        info!(
+            "Loudnorm measurements: I={:.1} LUFS, TP={:.1} dBTP, LRA={:.1} LU",
+            measurements.input_i, measurements.input_tp, measurements.input_lra
+        );
+
+        info!("Loudnorm pass 2: applying normalization...");
+        Self::loudnorm_pass2_sync(input, output, opts, &measurements)
+    }
+
+    /// Loudnorm pass 1: run loudnorm filter in analysis mode, capture JSON from logs.
+    fn loudnorm_pass1_sync(input: &Path, opts: &NormalizeOptions) -> Result<LoudnormMeasurements> {
+        ensure_init()?;
+
+        let guard = LogCaptureGuard::begin()?;
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let ist = ictx.stream(ist_index).ok_or_else(|| {
+            PostProcessError::ffmpeg_failed(format!("audio input stream {ist_index} not found"))
+        })?;
+        let ist_time_base = ist.time_base();
+
+        let decoder_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(
+            ist.parameters(),
+        )
+        .map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to create decoder context: {e}"),
+        })?;
+        let mut decoder =
+            decoder_ctx
+                .decoder()
+                .audio()
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to open audio decoder: {e}"),
+                })?;
+
+        debug!(
+            "loudnorm pass 1 decoder: rate={}, fmt={}, ch_layout={}, time_base={}/{}",
+            decoder.rate(),
+            decoder.format().name(),
+            decoder.ch_layout().description(),
+            ist_time_base.numerator(),
+            ist_time_base.denominator(),
+        );
+
+        // Build loudnorm analysis filter
+        // loudnorm only supports AV_SAMPLE_FMT_DBL; explicitly convert from
+        // decoder format (typically fltp) since FFmpeg 8.0's auto-conversion
+        // during graph_config may fail with EINVAL.
+        let loudnorm_spec = format!(
+            "aformat=sample_fmts=dbl,loudnorm=I={:.1}:TP={:.1}:LRA={:.1}:print_format=json",
+            opts.target_i, opts.target_tp, opts.target_lra,
+        );
+
+        let mut graph = ffmpeg_the_third::filter::Graph::new();
+        let abuffersink = ffmpeg_the_third::filter::find("abuffersink")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffersink filter not found"))?;
+
+        FFmpegRunner::add_abuffer_to_graph(
+            &mut graph,
+            "in",
+            ist_time_base,
+            decoder.rate(),
+            decoder.format().name(),
+            &decoder.ch_layout().description(),
+        )?;
+        graph
+            .add(&abuffersink, "out", "")
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to add abuffersink filter: {e}"),
+            })?;
+
+        FFmpegRunner::parse_and_validate_filter_graph(&mut graph, "in", "out", &loudnorm_spec)?;
+
+        // Skip non-audio streams to avoid allocating memory for large video packets
+        Self::discard_non_audio_streams(&mut ictx, ist_index);
+
+        // Process all audio frames (discard output, we just need the log JSON)
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        let mut filtered = ffmpeg_the_third::frame::Audio::empty();
+        let mut packets_skipped = 0u64;
+
+        for result in ictx.packets() {
+            let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to read packet: {e}"),
+            })?;
+            if stream.index() != ist_index {
+                continue;
+            }
+            if let Err(e) = decoder.send_packet(&packet) {
+                if packets_skipped == 0 {
+                    warn!(
+                        "Audio decoder error during loudnorm analysis (skipping affected packets): {e}"
+                    );
+                }
+                packets_skipped += 1;
+                // Clear internal decoder buffer
+                while decoder.receive_frame(&mut frame).is_ok() {}
+                continue;
+            }
+            while decoder.receive_frame(&mut frame).is_ok() {
+                graph
+                    .get("in")
+                    .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                    .source()
+                    .add(&frame)
+                    .map_err(|e| PostProcessError::FFmpegLibraryError {
+                        message: format!("filter source add frame failed: {e}"),
+                    })?;
+
+                // Drain filter output (discard frames)
+                loop {
+                    let mut out_node = graph.get("out").ok_or_else(|| {
+                        PostProcessError::ffmpeg_failed("filter node 'out' not found")
+                    })?;
+                    if out_node.sink().frame(&mut filtered).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if packets_skipped > 0 {
+            warn!(
+                "Skipped {packets_skipped} audio packet(s) during loudnorm analysis due to decoder errors"
+            );
+        }
+
+        // Flush decoder — send_eof may fail if decoder is in a broken state
+        if let Err(e) = decoder.send_eof() {
+            warn!("Decoder send_eof failed during loudnorm analysis (continuing with flush): {e}");
+        }
+        while decoder.receive_frame(&mut frame).is_ok() {
+            graph
+                .get("in")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                .source()
+                .add(&frame)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("filter source add frame (flush) failed: {e}"),
+                })?;
+
+            loop {
+                let mut out_node = graph.get("out").ok_or_else(|| {
+                    PostProcessError::ffmpeg_failed("filter node 'out' not found")
+                })?;
+                if out_node.sink().frame(&mut filtered).is_err() {
+                    break;
+                }
+            }
+        }
+
+        // Flush filter
+        graph
+            .get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+            .source()
+            .flush()
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("filter source flush failed: {e}"),
+            })?;
+        loop {
+            let mut out_node = graph
+                .get("out")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'out' not found"))?;
+            if out_node.sink().frame(&mut filtered).is_err() {
+                break;
+            }
+        }
+
+        // Drop the filter graph to trigger loudnorm's uninit(), which emits
+        // the JSON measurements via av_log at AV_LOG_INFO level.
+        drop(graph);
+
+        // Now capture the log output (JSON was emitted during graph drop)
+        let lines = guard.take_captured()?;
+        drop(guard);
+
+        debug!("Captured {} log lines from loudnorm pass 1", lines.len());
+
+        parse_loudnorm_json(&lines)
+    }
+
+    /// Loudnorm pass 2: apply normalization with measured values.
+    ///
+    /// For files with video, uses a two-step approach to avoid ENOMEM from
+    /// large video packets: (1) encode normalized audio to a temp file with
+    /// video discarded, (2) merge original video + normalized audio via
+    /// stream copy.
+    ///
+    /// When `opts.salvage` is true, wraps the encode with `with_mux_retry` for
+    /// two-tier recovery (salvage remux → CLI fallback) on mux write failures.
+    fn loudnorm_pass2_sync(
+        input: &Path,
+        output: &Path,
+        opts: &NormalizeOptions,
+        measurements: &LoudnormMeasurements,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        // Check if input has video
+        let has_video = {
+            let ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to open input {}: {e}", input.display()),
+                }
+            })?;
+            ictx.streams()
+                .best(ffmpeg_the_third::media::Type::Video)
+                .is_some()
+        };
+
+        let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
+
+        if has_video {
+            // Two-step: audio-only encode → merge with original video
+            let audio_ext = audio_only_extension_for(ext);
+            let temp_audio = output.with_extension(format!("norm_audio.{audio_ext}"));
+
+            if opts.salvage {
+                with_mux_retry(
+                    input,
+                    &temp_audio,
+                    |effective_input| {
+                        Self::loudnorm_encode_audio_only(
+                            effective_input,
+                            &temp_audio,
+                            ext,
+                            opts,
+                            measurements,
+                        )
+                    },
+                    |fallback_in, fallback_out| {
+                        cli_fallback_loudnorm(fallback_in, fallback_out, opts, measurements, ext)
+                    },
+                )?;
+            } else {
+                Self::loudnorm_encode_audio_only(input, &temp_audio, ext, opts, measurements)?;
+            }
+            let merge_result =
+                Self::merge_sync(input, &temp_audio, output, &super::RemuxOptions::default());
+            let _ = std::fs::remove_file(&temp_audio);
+            merge_result
+        } else if opts.salvage {
+            with_mux_retry(
+                input,
+                output,
+                |effective_input| {
+                    Self::loudnorm_encode_audio_only(
+                        effective_input,
+                        output,
+                        ext,
+                        opts,
+                        measurements,
+                    )
+                },
+                |fallback_in, fallback_out| {
+                    cli_fallback_loudnorm(fallback_in, fallback_out, opts, measurements, ext)
+                },
+            )
+        } else {
+            // Audio-only file: encode directly to output
+            Self::loudnorm_encode_audio_only(input, output, ext, opts, measurements)
+        }
+    }
+
+    /// Encode normalized audio to an output file (video streams discarded).
+    #[allow(clippy::too_many_lines)]
+    fn loudnorm_encode_audio_only(
+        input: &Path,
+        output: &Path,
+        final_output_ext: &str,
+        opts: &NormalizeOptions,
+        measurements: &LoudnormMeasurements,
+    ) -> Result<()> {
+        ensure_init()?;
+
+        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to open input {}: {e}", input.display()),
+            }
+        })?;
+
+        let audio_ist_index = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Audio)
+            .map(|s| s.index())
+            .ok_or(PostProcessError::NoAudioStream)?;
+
+        let audio_ist_time_base = ictx
+            .stream(audio_ist_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!(
+                    "audio input stream {audio_ist_index} not found"
+                ))
+            })?
+            .time_base();
+
+        let audio_ist = ictx.stream(audio_ist_index).ok_or_else(|| {
+            PostProcessError::ffmpeg_failed(format!(
+                "audio input stream {audio_ist_index} not found"
+            ))
+        })?;
+        let audio_dec_ctx =
+            ffmpeg_the_third::codec::context::Context::from_parameters(audio_ist.parameters())?;
+        let mut audio_decoder = audio_dec_ctx.decoder().audio()?;
+
+        let input_audio_bitrate = audio_ist.parameters().bit_rate() as usize;
+
+        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
+            PostProcessError::FFmpegLibraryError {
+                message: format!("failed to create output {}: {e}", output.display()),
+            }
+        })?;
+
+        // Use final_output_ext for encoder selection (not temp file ext) to ensure
+        // correct codec for stream copy during merge (e.g., AAC for MP4, Opus for MKV).
+        let enc_name = select_audio_encoder_for_container(final_output_ext);
+        let enc_codec = ffmpeg_the_third::encoder::find_by_name(enc_name).ok_or_else(|| {
+            PostProcessError::UnsupportedCodec {
+                codec: enc_name.to_string(),
+                operation: "audio normalization (loudnorm)".into(),
+            }
+        })?;
+
+        let needs_global_header = octx
+            .format()
+            .flags()
+            .contains(ffmpeg_the_third::format::Flags::GLOBAL_HEADER);
+
+        // Audio-only output — no video stream
+        let audio_ost_index;
+        let audio_enc_context;
+        {
+            let ost =
+                octx.add_stream(enc_codec)
+                    .map_err(|e| PostProcessError::FFmpegLibraryError {
+                        message: format!("failed to add audio output stream: {e}"),
+                    })?;
+            audio_ost_index = ost.index();
+            audio_enc_context =
+                ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
+        }
+
+        let mut audio_encoder = audio_enc_context.encoder().audio()?;
+        let target_format = Self::pick_audio_sample_format(&enc_codec, audio_decoder.format());
+        audio_encoder.set_format(target_format);
+        audio_encoder.set_rate(audio_decoder.rate() as i32);
+        let enc_time_base = ffmpeg_the_third::Rational(1, audio_decoder.rate() as i32);
+        audio_encoder.set_time_base(enc_time_base);
+
+        let channels = audio_decoder.ch_layout().channels();
+        Self::set_default_channel_layout(unsafe { audio_encoder.as_mut_ptr() }, channels as i32);
+
+        let target_bitrate = if input_audio_bitrate > 0 {
+            input_audio_bitrate
+        } else {
+            default_bitrate_for_encoder(enc_name)
+        };
+        audio_encoder.set_bit_rate(target_bitrate);
+
+        if needs_global_header {
+            Self::set_global_header_flag(unsafe { audio_encoder.as_mut_ptr() });
+        }
+
+        let mut audio_encoder =
+            audio_encoder
+                .open_as(enc_codec)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to open audio encoder: {e}"),
+                })?;
+
+        // Read actual encoder time_base via FFI (may differ from configured after open)
+        // SAFETY: audio_encoder is a valid opened encoder context.
+        let enc_time_base = unsafe {
+            let tb = (*audio_encoder.as_ptr()).time_base;
+            ffmpeg_the_third::Rational(tb.num, tb.den)
+        };
+        debug!(
+            "Loudnorm encoder time_base: configured=1/{}, actual={}/{}",
+            audio_decoder.rate(),
+            enc_time_base.numerator(),
+            enc_time_base.denominator(),
+        );
+
+        Self::copy_encoder_params_to_stream(&mut octx, audio_ost_index, unsafe {
+            audio_encoder.as_ptr()
+        });
+
+        // Set avoid_negative_ts for timestamp normalization (matches merge.rs/remux.rs)
+        unsafe {
+            (*octx.as_mut_ptr()).avoid_negative_ts =
+                ffmpeg_the_third::ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
+        }
+
+        // Flush packets to AVIO immediately — prevents Matroska cluster buffering stalls
+        unsafe {
+            (*octx.as_mut_ptr()).flags |= ffmpeg_the_third::ffi::AVFMT_FLAG_FLUSH_PACKETS;
+        }
+
+        // For audio-only output using av_write_frame (non-interleaved), set
+        // max_interleave_delta = 0 to disable the muxer's interleave queue entirely.
+        // Harmless when using direct writes; prevents any residual queue growth.
+        unsafe {
+            (*octx.as_mut_ptr()).max_interleave_delta = 0;
+        }
+
+        let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
+        muxer_opts.set("cluster_time_limit", "500");
+        octx.write_header_with(muxer_opts)
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to write output header: {e}"),
+            })?;
+
+        // Log AVIO state for diagnostics after header write
+        // SAFETY: octx owns a valid, header-written output format context.
+        unsafe { dump_io_state(octx.as_mut_ptr(), output, "loudnorm_encode_audio_only") };
+
+        // Fail-fast: reject CUSTOM_IO (expected file-based IO)
+        {
+            let flags = unsafe { (*octx.as_mut_ptr()).flags };
+            if flags & ffmpeg_the_third::ffi::AVFMT_FLAG_CUSTOM_IO != 0 {
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "[loudnorm_encode_audio_only] AVFMT_FLAG_CUSTOM_IO is set — expected file-based IO".into(),
+                });
+            }
+        }
+
+        // Fail-fast: assert seekable IO context for Matroska (needs seeking for Cues/SeekHead)
+        unsafe {
+            assert_seekable_io(octx.as_mut_ptr(), "loudnorm_encode_audio_only")?;
+        }
+
+        // Flush AVIO after header write to ensure bytes reach disk
+        unsafe {
+            let pb = (*octx.as_mut_ptr()).pb;
+            if !pb.is_null() {
+                ffmpeg_the_third::ffi::avio_flush(pb);
+            }
+        }
+        let file_size = std::fs::metadata(output).map(|m| m.len()).unwrap_or(0);
+        if file_size == 0 {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: "[loudnorm_encode_audio_only] output file is 0 bytes after header write + avio_flush — IO sink is broken".into(),
+            });
+        }
+        info!("[loudnorm_encode_audio_only] header written: {file_size} bytes on disk");
+
+        // Build loudnorm pass 2 filter with measured values.
+        // An explicit aresample bridges dbl→encoder format since FFmpeg 8.0's
+        // auto-conversion during graph_config may fail with EINVAL (same issue
+        // that required the leading aformat=dbl in pass 1).
+        let m = measurements;
+        let enc_ch_layout_desc = audio_encoder.ch_layout().description();
+        let filter_spec = format!(
+            "aformat=sample_fmts=dbl,loudnorm=I={:.1}:TP={:.1}:LRA={:.1}:measured_I={:.2}:measured_TP={:.2}:measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear=true:print_format=summary,aresample,aformat=sample_fmts={}:sample_rates={}:channel_layouts={}",
+            opts.target_i,
+            opts.target_tp,
+            opts.target_lra,
+            m.input_i,
+            m.input_tp,
+            m.input_lra,
+            m.input_thresh,
+            m.target_offset,
+            audio_encoder.format().name(),
+            audio_encoder.rate(),
+            enc_ch_layout_desc,
+        );
+
+        let mut filter_graph =
+            build_audio_filter_with_spec(&audio_decoder, audio_ist_time_base, &filter_spec)?;
+
+        // Tell buffersink to output exactly frame_size samples per frame.
+        // The last frame at EOF is zero-padded. Required for fixed-frame-size
+        // encoders (AAC=1024, MP3=1152, Opus=960).
+        Self::set_buffersink_frame_size(&mut filter_graph, "out", audio_encoder.frame_size());
+
+        // Discard non-audio streams to avoid ENOMEM on large video packets
+        Self::discard_non_audio_streams(&mut ictx, audio_ist_index);
+
+        // Read ost_time_base AFTER write_header (Matroska may change it)
+        let ost_time_base = octx
+            .stream(audio_ost_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("output stream not found"))?
+            .time_base();
+
+        let expected_duration = if audio_encoder.frame_size() > 0 {
+            unsafe {
+                ffmpeg_the_third::ffi::av_rescale_q(
+                    i64::from(audio_encoder.frame_size()),
+                    ffmpeg_the_third::ffi::AVRational {
+                        num: enc_time_base.numerator(),
+                        den: enc_time_base.denominator(),
+                    },
+                    ffmpeg_the_third::ffi::AVRational {
+                        num: ost_time_base.numerator(),
+                        den: ost_time_base.denominator(),
+                    },
+                )
+            }
+        } else {
+            0
+        };
+        info!(
+            "Expected audio packet duration: {} (frame_size={}, enc_tb={}/{}, ost_tb={}/{})",
+            expected_duration, audio_encoder.frame_size(),
+            enc_time_base.numerator(), enc_time_base.denominator(),
+            ost_time_base.numerator(), ost_time_base.denominator(),
+        );
+
+        // Suppress decoder WARNING spam while keeping muxer ERRORs visible.
+        // Uses error_level() instead of new() so Matroska muxer errors are diagnosable.
+        let _log_suppress = LogSuppressGuard::error_level();
+
+        let mut timing = MuxTimingState {
+            encoder_frame_size: audio_encoder.frame_size(),
+            expected_duration,
+            sample_rate: audio_decoder.rate(),
+            use_sample_clock: true,
+            ..Default::default()
+        };
+
+        // Transcode loop (audio only)
+        let mut packets_processed = 0u64;
+        let mut packets_skipped = 0u64;
+        for result in ictx.packets() {
+            let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to read packet: {e}"),
+            })?;
+            if stream.index() != audio_ist_index {
+                continue;
+            }
+            if let Err(e) = audio_decoder.send_packet(&packet) {
+                if packets_skipped == 0 {
+                    // ENOMEM = 12 on all POSIX platforms and Windows CRT
+                    if matches!(&e, ffmpeg_the_third::Error::Other { errno } if *errno == 12) {
+                        warn!(
+                            "Audio decoder allocation failure (ENOMEM) — \
+                             process may be running out of memory"
+                        );
+                    } else {
+                        warn!("Audio decoder error (skipping affected packets): {e}");
+                    }
+                }
+                packets_skipped += 1;
+                // Drain decoder to clear its internal buffer — send_packet buffers
+                // the packet before attempting decode, so receive_frame must be
+                // called to consume it even on failure.
+                if let Err(drain_err) = Self::receive_and_process_audio_direct(
+                    &mut audio_decoder,
+                    &mut filter_graph,
+                    &mut audio_encoder,
+                    &mut octx,
+                    audio_ost_index,
+                    enc_time_base,
+                    &mut timing,
+                    Some(output),
+                ) {
+                    // Propagate MuxWriteError directly for salvage retry eligibility
+                    if drain_err.is_mux_write_error() {
+                        return Err(drain_err);
+                    }
+                    return Err(PostProcessError::FFmpegLibraryError {
+                        message: format!(
+                            "(loudnorm pass 2) mux/encode pipeline failed while draining after decoder error: {drain_err}"
+                        ),
+                    });
+                }
+                continue;
+            }
+            packets_processed += 1;
+            Self::receive_and_process_audio_direct(
+                &mut audio_decoder,
+                &mut filter_graph,
+                &mut audio_encoder,
+                &mut octx,
+                audio_ost_index,
+                enc_time_base,
+                &mut timing,
+                Some(output),
+            )?;
+        }
+
+        if packets_skipped > 0 {
+            warn!(
+                "Skipped {packets_skipped} of {} audio packet(s) due to decoder errors",
+                packets_processed + packets_skipped,
+            );
+        }
+
+        // If every packet failed, the decoder is in a broken state and the
+        // output would be empty/corrupt. Bail out so the caller can fall back
+        // to copying the file unchanged.
+        if packets_processed == 0 && packets_skipped > 0 {
+            return Err(PostProcessError::NormalizationFailed {
+                message: format!(
+                    "audio decoder failed on all {packets_skipped} packets — cannot normalize"
+                ),
+            });
+        }
+
+        // Flush — send_eof may fail if decoder encountered persistent errors
+        if let Err(e) = audio_decoder.send_eof() {
+            warn!("Decoder send_eof failed (continuing with flush): {e}");
+        }
+        Self::receive_and_process_audio_direct(
+            &mut audio_decoder,
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            audio_ost_index,
+            enc_time_base,
+            &mut timing,
+            Some(output),
+        )?;
+
+        filter_graph
+            .get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+            .source()
+            .flush()?;
+        Self::drain_filter_to_encoder_direct(
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            audio_ost_index,
+            enc_time_base,
+            &mut timing,
+            Some(output),
+        )?;
+
+        audio_encoder.send_eof()?;
+        Self::drain_encoder_packets_direct(
+            &mut audio_encoder,
+            &mut octx,
+            audio_ost_index,
+            enc_time_base,
+            &mut timing,
+            Some(output),
+        )?;
+
+        // Drop suppress guard before write_trailer so any trailer errors are visible
+        drop(_log_suppress);
+
+        octx.write_trailer()
+            .map_err(|e| PostProcessError::FFmpegLibraryError {
+                message: format!("failed to write output trailer: {e}"),
+            })?;
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/// Comprehensive IO state dump for diagnostics.
+///
+/// Logs muxer name, format context URL and flags, AVIO buffer state,
+/// and the actual file size on disk. Used after `write_header`, before
+/// first packet write, and on watchdog stall to capture the full IO
+/// picture for debugging.
+///
+/// # Safety
+///
+/// `octx_ptr` must point to a valid, header-written `AVFormatContext`.
+pub(crate) unsafe fn dump_io_state(
+    octx_ptr: *mut ffmpeg_the_third::ffi::AVFormatContext,
+    rust_output_path: &Path,
+    label: &str,
+) {
+    unsafe {
+        let oformat = (*octx_ptr).oformat;
+        let muxer_name = if !oformat.is_null() && !(*oformat).name.is_null() {
+            CStr::from_ptr((*oformat).name)
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            "unknown".to_string()
+        };
+
+        let url = if !(*octx_ptr).url.is_null() {
+            CStr::from_ptr((*octx_ptr).url)
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            "NULL".to_string()
+        };
+
+        let flags = (*octx_ptr).flags;
+        let custom_io = (flags & ffmpeg_the_third::ffi::AVFMT_FLAG_CUSTOM_IO) != 0;
+
+        let pb = (*octx_ptr).pb;
+        if pb.is_null() {
+            info!(
+                "[{label}] IO dump: muxer={muxer_name}, url={url}, flags=0x{flags:x}, \
+                 custom_io={custom_io}, pb=NULL"
+            );
+            return;
+        }
+
+        let seekable = (*pb).seekable;
+        let buffer_size = (*pb).buffer_size;
+        let pos = (*pb).pos;
+        let error = (*pb).error;
+        let direct = (*pb).direct;
+        let write_flag = (*pb).write_flag;
+        let has_write_cb = (*pb).write_packet.is_some();
+
+        let file_size = std::fs::metadata(rust_output_path)
+            .map(|m| m.len() as i64)
+            .unwrap_or(-1);
+
+        info!(
+            "[{label}] IO dump: muxer={muxer_name}, url={url}, flags=0x{flags:x}, \
+             custom_io={custom_io}, pb={{seekable={seekable}, buffer_size={buffer_size}, \
+             pos={pos}, error={error}, direct={direct}, write_flag={write_flag}, \
+             write_cb={}}}, rust_path={}, file_size={file_size}",
+            if has_write_cb { "present" } else { "NULL" },
+            rust_output_path.display(),
+        );
+    }
+}
+
+/// Assert that the output format context has a seekable IO context.
+///
+/// Matroska requires seeking for Cues/SeekHead; a non-seekable output
+/// silently stalls the muxer. This check fails fast after `write_header`
+/// so the error is caught before the encode loop.
+///
+/// # Safety
+///
+/// `octx_ptr` must point to a valid, header-written `AVFormatContext`.
+unsafe fn assert_seekable_io(
+    octx_ptr: *mut ffmpeg_the_third::ffi::AVFormatContext,
+    label: &str,
+) -> crate::error::Result<()> {
+    unsafe {
+        let pb = (*octx_ptr).pb;
+        if pb.is_null() {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: format!("[{label}] output IO context (pb) is NULL — no output possible"),
+            });
+        }
+        if (*pb).seekable == 0 {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: format!(
+                    "[{label}] output IO context is not seekable (pb->seekable=0) — \
+                     Matroska muxer requires seeking for Cues/SeekHead"
+                ),
+            });
+        }
+        let oformat = (*octx_ptr).oformat;
+        if !oformat.is_null() && ((*oformat).flags & ffmpeg_the_third::ffi::AVFMT_NOFILE) != 0 {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: format!(
+                    "[{label}] output format has AVFMT_NOFILE flag — expected file-based IO"
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Read a metadata value from an FFmpeg frame as f64.
+///
+/// # Safety
+///
+/// `frame_ptr` must point to a valid `AVFrame`.
+fn read_frame_metadata(frame_ptr: *const ffmpeg_the_third::ffi::AVFrame, key: &str) -> Option<f64> {
+    let key_cstr = std::ffi::CString::new(key).ok()?;
+    unsafe {
+        let metadata = (*frame_ptr).metadata;
+        if metadata.is_null() {
+            return None;
+        }
+        let entry =
+            ffmpeg_the_third::ffi::av_dict_get(metadata, key_cstr.as_ptr(), std::ptr::null(), 0);
+        if entry.is_null() {
+            return None;
+        }
+        let value = CStr::from_ptr((*entry).value).to_string_lossy();
+        // Handle "-inf" as negative infinity
+        if value.trim() == "-inf" {
+            return Some(f64::NEG_INFINITY);
+        }
+        value.trim().parse::<f64>().ok()
+    }
+}
+
+/// Select the appropriate audio encoder for a container extension.
+fn select_audio_encoder_for_container(ext: &str) -> &'static str {
+    match ext.to_lowercase().as_str() {
+        "mp4" | "m4a" | "mov" | "f4v" | "3gp" => "aac",
+        "webm" | "ogg" | "opus" => "libopus",
+        "mkv" | "mka" => "libopus",
+        "ts" | "mpg" => "aac",
+        "avi" => "libmp3lame",
+        "flv" => "aac",
+        "mp3" => "libmp3lame",
+        "flac" => "flac",
+        "wav" => "pcm_s16le",
+        _ => "aac",
+    }
+}
+
+/// Get a sensible default bitrate (in bps) for an encoder.
+fn default_bitrate_for_encoder(encoder: &str) -> usize {
+    match encoder {
+        "aac" => 128_000,
+        "libmp3lame" => 192_000,
+        "libopus" => 128_000,
+        "flac" | "pcm_s16le" => 0, // Lossless / PCM, no bitrate needed
+        _ => 128_000,
+    }
+}
+
+/// Map a container extension to an audio-only container extension for temp files.
+///
+/// Uses MKA for all MOV-based formats to avoid the MOV muxer's ENOMEM issue.
+/// The MOV muxer accumulates per-packet metadata in memory until trailer write,
+/// causing allocation failures on long audio tracks. Matroska writes metadata
+/// incrementally without unbounded buffering.
+fn audio_only_extension_for(ext: &str) -> &'static str {
+    match ext.to_lowercase().as_str() {
+        "mp4" | "m4a" | "mov" | "f4v" | "3gp" | "ts" | "mpg" | "flv" => "mka",
+        "mkv" | "mka" | "webm" => "mka",
+        "avi" | "mp3" => "mp3",
+        "ogg" | "opus" => "opus",
+        "flac" => "flac",
+        "wav" => "wav",
+        _ => "mka",
+    }
+}
+
+/// Two-tier recovery for mux failures during audio normalization.
+///
+/// Tier 1: Salvage-remux input → retry library encode.
+/// Tier 2: External ffmpeg CLI with `-fflags +discardcorrupt+genpts`.
+///
+/// Loudnorm pass 1 measurements remain valid after salvage/CLI because:
+/// - Salvage uses stream copy (audio bit-identical)
+/// - CLI pass 2 uses the same measured values from pass 1
+fn with_mux_retry<F, G>(input: &Path, output: &Path, encode_fn: F, cli_fallback_fn: G) -> Result<()>
+where
+    F: Fn(&Path) -> Result<()>,
+    G: FnOnce(&Path, &Path) -> Result<()>,
+{
+    // First attempt: library encode
+    match encode_fn(input) {
+        Ok(()) => return Ok(()),
+        Err(e) if !e.is_salvage_retryable() => {
+            // If decoder failed on ALL packets, CLI won't fare better — abort early
+            if matches!(&e, PostProcessError::NormalizationFailed { message } if message.contains("all") && message.contains("packets")) {
+                warn!("Decoder failed on all packets — skipping salvage/CLI fallback");
+            }
+            return Err(e);
+        }
+        Err(e) => {
+            warn!("Encode failed with mux error, attempting salvage retry: {e}");
+        }
+    }
+
+    // Clean up potentially corrupt partial output before retry
+    let _ = std::fs::remove_file(output);
+    if output.exists() {
+        warn!(
+            "Cannot remove partial output {}; skipping salvage, falling to CLI",
+            output.display()
+        );
+        return cli_fallback_fn(input, output);
+    }
+
+    // Tier 1: salvage remux → retry library encode
+    match salvage_remux_sync(input) {
+        Ok(salvaged) => {
+            let result = encode_fn(&salvaged);
+            let _ = std::fs::remove_file(&salvaged);
+            if result.is_ok() {
+                return result;
+            }
+            warn!(
+                "Salvage retry also failed, falling back to CLI: {}",
+                result.as_ref().unwrap_err()
+            );
+            let _ = std::fs::remove_file(output);
+            if output.exists() {
+                warn!(
+                    "Cannot remove failed retry output {}; falling to CLI",
+                    output.display()
+                );
+            }
+        }
+        Err(e) => {
+            warn!("Salvage remux failed, falling back to CLI: {e}");
+        }
+    }
+
+    // Tier 2: external ffmpeg CLI
+    info!("Attempting CLI fallback normalization...");
+    cli_fallback_fn(input, output)
+}
+
+/// Run peak normalization via external ffmpeg CLI.
+///
+/// Uses `-fflags +discardcorrupt+genpts` to handle corrupt input that
+/// the library cannot process.
+fn cli_fallback_peak(
+    input: &Path,
+    output: &Path,
+    analysis: &PeakAnalysis,
+    opts: &NormalizeOptions,
+    _final_ext: &str,
+) -> Result<()> {
+    // Use the actual output extension for codec selection — the output is
+    // a temp .mka file, not the final container. Using final_ext (e.g. "mkv")
+    // could select a codec incompatible with the temp container.
+    let output_ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mka");
+    let enc_name = select_audio_encoder_for_container(output_ext);
+    let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
+    let filter = format!(
+        "volume={:.6}dB,alimiter=limit={:.6}:attack=5:release=50",
+        analysis.gain_db, linear_limit
+    );
+
+    let mut cmd = std::process::Command::new("ffmpeg");
+    cmd.args(["-y", "-fflags", "+discardcorrupt+genpts"])
+        .arg("-i")
+        .arg(input)
+        .args(["-vn", "-af", &filter])
+        .args(["-c:a", enc_name]);
+    if enc_name == "libopus" {
+        cmd.args(["-ar", "48000"]);
+    }
+    let cmd_output = cmd
+        .arg(output)
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|e| PostProcessError::FFmpegFailed {
+            message: format!("failed to spawn ffmpeg CLI: {e}"),
+            source: Some(e),
+        })?;
+
+    if !cmd_output.status.success() {
+        let stderr = String::from_utf8_lossy(&cmd_output.stderr);
+        let excerpt: String = stderr.lines().rev().take(5).collect::<Vec<_>>().into_iter().rev().collect::<Vec<_>>().join("\n");
+        return Err(PostProcessError::NormalizationFailed {
+            message: format!(
+                "CLI fallback peak normalization failed (exit {}): {}",
+                cmd_output.status.code().unwrap_or(-1),
+                excerpt,
+            ),
+        });
+    }
+    info!("CLI fallback peak normalization succeeded");
+    Ok(())
+}
+
+/// Run loudnorm two-pass normalization via external ffmpeg CLI.
+///
+/// Uses `-fflags +discardcorrupt+genpts` to handle corrupt input that
+/// the library cannot process. Pass 1 measurements are reused from the
+/// prior library analysis.
+fn cli_fallback_loudnorm(
+    input: &Path,
+    output: &Path,
+    opts: &NormalizeOptions,
+    measurements: &LoudnormMeasurements,
+    _final_ext: &str,
+) -> Result<()> {
+    // Use the actual output extension for codec selection — the output is
+    // a temp .mka file, not the final container. Using final_ext (e.g. "mkv")
+    // could select a codec incompatible with the temp container.
+    let output_ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mka");
+    let enc_name = select_audio_encoder_for_container(output_ext);
+    let m = measurements;
+    let filter = format!(
+        "loudnorm=I={:.1}:TP={:.1}:LRA={:.1}:measured_I={:.2}:measured_TP={:.2}:\
+         measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear=true",
+        opts.target_i,
+        opts.target_tp,
+        opts.target_lra,
+        m.input_i,
+        m.input_tp,
+        m.input_lra,
+        m.input_thresh,
+        m.target_offset,
+    );
+
+    let mut cmd = std::process::Command::new("ffmpeg");
+    cmd.args(["-y", "-fflags", "+discardcorrupt+genpts"])
+        .arg("-i")
+        .arg(input)
+        .args(["-vn", "-af", &filter])
+        .args(["-c:a", enc_name]);
+    if enc_name == "libopus" {
+        cmd.args(["-ar", "48000"]);
+    }
+    let cmd_output = cmd
+        .arg(output)
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|e| PostProcessError::FFmpegFailed {
+            message: format!("failed to spawn ffmpeg CLI: {e}"),
+            source: Some(e),
+        })?;
+
+    if !cmd_output.status.success() {
+        let stderr = String::from_utf8_lossy(&cmd_output.stderr);
+        let excerpt: String = stderr.lines().rev().take(5).collect::<Vec<_>>().into_iter().rev().collect::<Vec<_>>().join("\n");
+        return Err(PostProcessError::NormalizationFailed {
+            message: format!(
+                "CLI fallback loudnorm normalization failed (exit {}): {}",
+                cmd_output.status.code().unwrap_or(-1),
+                excerpt,
+            ),
+        });
+    }
+    info!("CLI fallback loudnorm normalization succeeded");
+    Ok(())
+}
+
+/// Build an audio filter graph with a custom filter spec string.
+///
+/// Creates: `abuffer → {filter_spec} → abuffersink`
+fn build_audio_filter_with_spec(
+    decoder: &ffmpeg_the_third::decoder::Audio,
+    ist_time_base: ffmpeg_the_third::Rational,
+    filter_spec: &str,
+) -> Result<ffmpeg_the_third::filter::Graph> {
+    let mut graph = ffmpeg_the_third::filter::Graph::new();
+
+    let abuffersink = ffmpeg_the_third::filter::find("abuffersink")
+        .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffersink filter not found"))?;
+
+    FFmpegRunner::add_abuffer_to_graph(
+        &mut graph,
+        "in",
+        ist_time_base,
+        decoder.rate(),
+        decoder.format().name(),
+        &decoder.ch_layout().description(),
+    )?;
+    graph
+        .add(&abuffersink, "out", "")
+        .map_err(|e| PostProcessError::FFmpegLibraryError {
+            message: format!("failed to add abuffersink filter: {e}"),
+        })?;
+
+    FFmpegRunner::parse_and_validate_filter_graph(&mut graph, "in", "out", filter_spec)?;
+
+    Ok(graph)
+}
+
+/// Parse loudnorm JSON output from captured FFmpeg log lines.
+///
+/// Looks for lines containing `"input_i"`, `"input_tp"`, etc. and extracts
+/// the values from the JSON block emitted by `loudnorm print_format=json`.
+fn parse_loudnorm_json(lines: &[String]) -> Result<LoudnormMeasurements> {
+    // Join all lines and find the JSON block
+    let full_text = lines.join("");
+
+    // Extract values by looking for JSON keys
+    let input_i = extract_json_value(&full_text, "input_i").ok_or_else(|| {
+        PostProcessError::NormalizationFailed {
+            message: "missing 'input_i' in loudnorm output".into(),
+        }
+    })?;
+    let input_tp = extract_json_value(&full_text, "input_tp").ok_or_else(|| {
+        PostProcessError::NormalizationFailed {
+            message: "missing 'input_tp' in loudnorm output".into(),
+        }
+    })?;
+    let input_lra = extract_json_value(&full_text, "input_lra").ok_or_else(|| {
+        PostProcessError::NormalizationFailed {
+            message: "missing 'input_lra' in loudnorm output".into(),
+        }
+    })?;
+    let input_thresh = extract_json_value(&full_text, "input_thresh").ok_or_else(|| {
+        PostProcessError::NormalizationFailed {
+            message: "missing 'input_thresh' in loudnorm output".into(),
+        }
+    })?;
+    let target_offset = extract_json_value(&full_text, "target_offset").ok_or_else(|| {
+        PostProcessError::NormalizationFailed {
+            message: "missing 'target_offset' in loudnorm output".into(),
+        }
+    })?;
+
+    Ok(LoudnormMeasurements {
+        input_i,
+        input_tp,
+        input_lra,
+        input_thresh,
+        target_offset,
+    })
+}
+
+/// Extract a numeric value from loudnorm JSON output for a given key.
+///
+/// Handles the format: `"key" : "value"` where value may be a number string.
+fn extract_json_value(text: &str, key: &str) -> Option<f64> {
+    let search = format!("\"{key}\"");
+    let pos = text.find(&search)?;
+    let after_key = &text[pos + search.len()..];
+
+    // Skip whitespace and colon
+    let after_colon = after_key.find(':')? + 1;
+    let value_start = &after_key[after_colon..];
+
+    // Find the quoted value
+    let quote_start = value_start.find('"')? + 1;
+    let value_after_quote = &value_start[quote_start..];
+    let quote_end = value_after_quote.find('"')?;
+    let value_str = &value_after_quote[..quote_end];
+
+    value_str.trim().parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_audio_encoder_for_container() {
+        assert_eq!(select_audio_encoder_for_container("mp4"), "aac");
+        assert_eq!(select_audio_encoder_for_container("m4a"), "aac");
+        assert_eq!(select_audio_encoder_for_container("mov"), "aac");
+        assert_eq!(select_audio_encoder_for_container("webm"), "libopus");
+        assert_eq!(select_audio_encoder_for_container("mkv"), "libopus");
+        assert_eq!(select_audio_encoder_for_container("avi"), "libmp3lame");
+        assert_eq!(select_audio_encoder_for_container("mp3"), "libmp3lame");
+        assert_eq!(select_audio_encoder_for_container("flac"), "flac");
+        assert_eq!(select_audio_encoder_for_container("wav"), "pcm_s16le");
+        assert_eq!(select_audio_encoder_for_container("ts"), "aac");
+        assert_eq!(select_audio_encoder_for_container("ogg"), "libopus");
+        assert_eq!(select_audio_encoder_for_container("flv"), "aac");
+        assert_eq!(select_audio_encoder_for_container("xyz"), "aac");
+    }
+
+    #[test]
+    fn test_default_bitrate_for_encoder() {
+        assert_eq!(default_bitrate_for_encoder("aac"), 128_000);
+        assert_eq!(default_bitrate_for_encoder("libmp3lame"), 192_000);
+        assert_eq!(default_bitrate_for_encoder("libopus"), 128_000);
+        assert_eq!(default_bitrate_for_encoder("flac"), 0);
+        assert_eq!(default_bitrate_for_encoder("pcm_s16le"), 0);
+    }
+
+    #[test]
+    fn test_parse_loudnorm_json() {
+        let lines = vec![
+            "[Parsed_loudnorm_0 @ 0x...] ".to_string(),
+            "{\n".to_string(),
+            "    \"input_i\" : \"-24.50\",\n".to_string(),
+            "    \"input_tp\" : \"-3.20\",\n".to_string(),
+            "    \"input_lra\" : \"8.30\",\n".to_string(),
+            "    \"input_thresh\" : \"-35.10\",\n".to_string(),
+            "    \"output_i\" : \"-16.00\",\n".to_string(),
+            "    \"output_tp\" : \"-1.50\",\n".to_string(),
+            "    \"output_lra\" : \"7.20\",\n".to_string(),
+            "    \"output_thresh\" : \"-26.60\",\n".to_string(),
+            "    \"normalization_type\" : \"dynamic\",\n".to_string(),
+            "    \"target_offset\" : \"0.50\"\n".to_string(),
+            "}\n".to_string(),
+        ];
+
+        let m = parse_loudnorm_json(&lines).unwrap();
+        assert!((m.input_i - (-24.5)).abs() < 0.01);
+        assert!((m.input_tp - (-3.2)).abs() < 0.01);
+        assert!((m.input_lra - 8.3).abs() < 0.01);
+        assert!((m.input_thresh - (-35.1)).abs() < 0.01);
+        assert!((m.target_offset - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_loudnorm_json_missing_field() {
+        let lines = vec!["{ \"input_i\" : \"-24.50\", \"input_tp\" : \"-3.20\" }".to_string()];
+
+        let result = parse_loudnorm_json(&lines);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_json_value() {
+        let text = r#""input_i" : "-24.50""#;
+        assert!((extract_json_value(text, "input_i").unwrap() - (-24.5)).abs() < 0.01);
+
+        let text = r#""target_offset" : "0.50""#;
+        assert!((extract_json_value(text, "target_offset").unwrap() - 0.5).abs() < 0.01);
+
+        assert!(extract_json_value(text, "nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_audio_only_extension_for() {
+        // MOV-based formats now use MKA to avoid ENOMEM
+        assert_eq!(audio_only_extension_for("mp4"), "mka");
+        assert_eq!(audio_only_extension_for("m4a"), "mka");
+        assert_eq!(audio_only_extension_for("mov"), "mka");
+        assert_eq!(audio_only_extension_for("f4v"), "mka");
+        assert_eq!(audio_only_extension_for("3gp"), "mka");
+        assert_eq!(audio_only_extension_for("ts"), "mka");
+        assert_eq!(audio_only_extension_for("mpg"), "mka");
+        assert_eq!(audio_only_extension_for("flv"), "mka");
+
+        // Matroska-based formats
+        assert_eq!(audio_only_extension_for("mkv"), "mka");
+        assert_eq!(audio_only_extension_for("mka"), "mka");
+        assert_eq!(audio_only_extension_for("webm"), "mka");
+
+        // Other formats
+        assert_eq!(audio_only_extension_for("avi"), "mp3");
+        assert_eq!(audio_only_extension_for("mp3"), "mp3");
+        assert_eq!(audio_only_extension_for("ogg"), "opus");
+        assert_eq!(audio_only_extension_for("opus"), "opus");
+        assert_eq!(audio_only_extension_for("flac"), "flac");
+        assert_eq!(audio_only_extension_for("wav"), "wav");
+
+        // Default
+        assert_eq!(audio_only_extension_for("xyz"), "mka");
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize.rs
@@ -14,12 +14,99 @@ use log::{debug, info, warn};
 
 use crate::error::{PostProcessError, Result};
 
+use super::ffi_helpers::{codec_threading_info, frame_unref_audio, set_single_thread_codec};
 use super::log_capture::{LogCaptureGuard, LogSuppressGuard};
 use super::salvage::{prepare_input_with_salvage, salvage_remux_sync};
 use super::transcode::MuxTimingState;
 use super::{
     AudioNormMode, FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis, ensure_init,
 };
+
+/// Extra headroom (dB) subtracted from the alimiter ceiling to account for
+/// inter-sample true peak overshoot and lossy encoder artifacts.
+///
+/// `alimiter` is a sample-level limiter — it clamps digital sample values but
+/// EBU R128 true peak measurement uses 4× oversampling to detect inter-sample
+/// peaks.  Resampling (e.g. 44.1→48 kHz) and lossy encoding (AAC, Opus) can
+/// also introduce ~0.5-2 dB of peak overshoot.  1.5 dB headroom is standard
+/// broadcast practice (ITU-R BS.1770-5 recommendation).
+const ALIMITER_TP_HEADROOM_DB: f64 = 1.5;
+
+/// Build the alimiter filter spec with true-peak headroom.
+///
+/// Ceiling is `10^((target_tp - headroom) / 20)` in linear scale.
+fn build_alimiter_spec(target_tp: f64) -> String {
+    let ceiling = 10f64.powf((target_tp - ALIMITER_TP_HEADROOM_DB) / 20.0);
+    format!("alimiter=limit={ceiling:.6}:attack=5:release=50")
+}
+
+/// Build the loudnorm pass 2 core filter string (without alimiter).
+///
+/// Returns the loudnorm filter (optionally preceded by acompressor when
+/// `opts.precompress` is true).  The caller is responsible for appending
+/// the alimiter via [`build_alimiter_spec`] at the correct position in
+/// the filter chain:
+///
+/// - **Library path**: after `aresample` so resampling overshoot is caught.
+/// - **CLI path**: after loudnorm (FFmpeg CLI inserts its own converters).
+///
+/// Default strategy: always `linear=true`.  FFmpeg's loudnorm with
+/// `linear=true` falls back to dynamic internally when conditions aren't
+/// met, so forcing `linear=false` is unnecessary and often produces worse
+/// perceived loudness due to over-compression.
+///
+/// When `opts.force_dynamic` is true, uses `linear=false` instead.
+fn build_loudnorm_pass2_filter(
+    opts: &NormalizeOptions,
+    measurements: &LoudnormMeasurements,
+) -> String {
+    let shortfall = measurements.linear_shortfall(opts.target_i, opts.target_tp);
+    let predicted_gain = measurements.predict_linear_gain(opts.target_i, opts.target_tp);
+
+    info!(
+        "Loudnorm analysis: desired_gain={:.1} dB, predicted_linear_gain={:.1} dB, \
+         shortfall={:.1} LU",
+        opts.target_i - measurements.input_i,
+        predicted_gain,
+        shortfall,
+    );
+
+    let linear_mode = if opts.force_dynamic {
+        info!("Strategy: dynamic (forced via --loudnorm-dynamic)");
+        "false"
+    } else {
+        info!(
+            "Strategy: linear (shortfall={shortfall:.1} LU, \
+             loudnorm handles internal fallback to dynamic if needed)"
+        );
+        "true"
+    };
+
+    let m = measurements;
+    let loudnorm = format!(
+        "loudnorm=I={:.1}:TP={:.1}:LRA={:.1}:measured_I={:.2}:measured_TP={:.2}:\
+         measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear={linear_mode}:\
+         print_format=summary",
+        opts.target_i,
+        opts.target_tp,
+        opts.target_lra,
+        m.input_i,
+        m.input_tp,
+        m.input_lra,
+        m.input_thresh,
+        m.target_offset,
+    );
+
+    if opts.precompress {
+        info!("Precompress enabled: prepending acompressor (threshold=-18dB, ratio=3:1)");
+        format!(
+            "acompressor=threshold=0.125893:ratio=3:attack=20:release=200:makeup=2:knee=6,\
+             {loudnorm}"
+        )
+    } else {
+        loudnorm
+    }
+}
 
 impl FFmpegRunner {
     /// Normalize audio levels in a media file.
@@ -105,8 +192,9 @@ impl FFmpegRunner {
         })?;
         let ist_time_base = ist.time_base();
 
-        let decoder_ctx =
+        let mut decoder_ctx =
             ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())?;
+        set_single_thread_codec(unsafe { decoder_ctx.as_mut_ptr() });
         let mut decoder = decoder_ctx.decoder().audio()?;
 
         // Build astats filter graph
@@ -384,8 +472,9 @@ impl FFmpegRunner {
                 "audio input stream {audio_ist_index} not found"
             ))
         })?;
-        let audio_dec_ctx =
+        let mut audio_dec_ctx =
             ffmpeg_the_third::codec::context::Context::from_parameters(audio_ist.parameters())?;
+        set_single_thread_codec(unsafe { audio_dec_ctx.as_mut_ptr() });
         let mut audio_decoder = audio_dec_ctx.decoder().audio()?;
 
         let input_audio_bitrate = audio_ist.parameters().bit_rate() as usize;
@@ -445,6 +534,7 @@ impl FFmpegRunner {
         if needs_global_header {
             Self::set_global_header_flag(unsafe { audio_encoder.as_mut_ptr() });
         }
+        set_single_thread_codec(unsafe { audio_encoder.as_mut_ptr() });
 
         let mut audio_encoder =
             audio_encoder
@@ -476,7 +566,7 @@ impl FFmpegRunner {
                 ffmpeg_the_third::ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
         }
 
-        // Flush packets to AVIO immediately — prevents Matroska cluster buffering stalls
+        // A2: Flush packets to AVIO immediately — prevents Matroska cluster buffering stalls.
         unsafe {
             (*octx.as_mut_ptr()).flags |= ffmpeg_the_third::ffi::AVFMT_FLAG_FLUSH_PACKETS;
         }
@@ -494,6 +584,24 @@ impl FFmpegRunner {
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to write output header: {e}"),
             })?;
+
+        // E1: Log threading knobs and mux flags
+        {
+            let (dec_tc, dec_att) =
+                codec_threading_info(unsafe { audio_decoder.as_ptr() });
+            let (enc_tc, enc_att) =
+                codec_threading_info(unsafe { audio_encoder.as_ptr() });
+            let mux_flags = unsafe { (*octx.as_mut_ptr()).flags };
+            let pb_buf_size = unsafe {
+                let pb = (*octx.as_mut_ptr()).pb;
+                if !pb.is_null() { (*pb).buffer_size } else { 0 }
+            };
+            info!(
+                "[peak encode] decoder: thread_count={dec_tc}, active_thread_type={dec_att}; \
+                 encoder: thread_count={enc_tc}, active_thread_type={enc_att}; \
+                 mux_flags=0x{mux_flags:x}; pb_buffer_size={pb_buf_size}",
+            );
+        }
 
         // Log AVIO state for diagnostics after header write
         // SAFETY: octx owns a valid, header-written output format context.
@@ -734,8 +842,58 @@ impl FFmpegRunner {
             measurements.input_i, measurements.input_tp, measurements.input_lra
         );
 
+        if measurements.input_i < -35.0 {
+            warn!(
+                "Very quiet source ({:.1} LUFS) — normalization will amplify noise",
+                measurements.input_i,
+            );
+        }
+
         info!("Loudnorm pass 2: applying normalization...");
-        Self::loudnorm_pass2_sync(input, output, opts, &measurements)
+        Self::loudnorm_pass2_sync(input, output, opts, &measurements)?;
+
+        // Verify output loudness against targets
+        Self::verify_loudness_sync(output, opts)?;
+
+        Ok(())
+    }
+
+    /// Post-normalization loudness verification.
+    ///
+    /// Runs loudnorm pass 1 on the **output** file and compares measured
+    /// levels against targets. Warns on significant deviations but does
+    /// not fail — the output is already written.
+    fn verify_loudness_sync(output: &Path, opts: &NormalizeOptions) -> Result<()> {
+        info!("Loudness verification: analyzing output...");
+        match Self::loudnorm_pass1_sync(output, opts) {
+            Ok(measured) => {
+                info!(
+                    "Loudness verification: I={:.1} LUFS, TP={:.1} dBTP, LRA={:.1} LU",
+                    measured.input_i, measured.input_tp, measured.input_lra
+                );
+
+                let i_delta = (measured.input_i - opts.target_i).abs();
+                if i_delta > 2.0 {
+                    warn!(
+                        "Loudness verification: integrated loudness off by {i_delta:.1} LU \
+                         (measured={:.1}, target={:.1})",
+                        measured.input_i, opts.target_i
+                    );
+                }
+                if measured.input_tp > opts.target_tp + 0.5 {
+                    warn!(
+                        "Loudness verification: true peak exceeds target \
+                         (measured={:.1} dBTP, target={:.1} dBTP)",
+                        measured.input_tp, opts.target_tp
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                warn!("Loudness verification failed (non-fatal): {e}");
+                Ok(())
+            }
+        }
     }
 
     /// Loudnorm pass 1: run loudnorm filter in analysis mode, capture JSON from logs.
@@ -761,12 +919,14 @@ impl FFmpegRunner {
         })?;
         let ist_time_base = ist.time_base();
 
-        let decoder_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(
+        let mut decoder_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(
             ist.parameters(),
         )
         .map_err(|e| PostProcessError::FFmpegLibraryError {
             message: format!("failed to create decoder context: {e}"),
         })?;
+        // B1: Single-threaded decode for pass 1 — reduces RSS during analysis.
+        set_single_thread_codec(unsafe { decoder_ctx.as_mut_ptr() });
         let mut decoder =
             decoder_ctx
                 .decoder()
@@ -848,6 +1008,8 @@ impl FFmpegRunner {
                     .map_err(|e| PostProcessError::FFmpegLibraryError {
                         message: format!("filter source add frame failed: {e}"),
                     })?;
+                // B3: Release decode buffer ref immediately — filter holds its own.
+                frame_unref_audio(&mut frame);
 
                 // Drain filter output (discard frames)
                 loop {
@@ -857,6 +1019,7 @@ impl FFmpegRunner {
                     if out_node.sink().frame(&mut filtered).is_err() {
                         break;
                     }
+                    frame_unref_audio(&mut filtered);
                 }
             }
         }
@@ -880,6 +1043,7 @@ impl FFmpegRunner {
                 .map_err(|e| PostProcessError::FFmpegLibraryError {
                     message: format!("filter source add frame (flush) failed: {e}"),
                 })?;
+            frame_unref_audio(&mut frame);
 
             loop {
                 let mut out_node = graph.get("out").ok_or_else(|| {
@@ -888,6 +1052,7 @@ impl FFmpegRunner {
                 if out_node.sink().frame(&mut filtered).is_err() {
                     break;
                 }
+                frame_unref_audio(&mut filtered);
             }
         }
 
@@ -907,6 +1072,7 @@ impl FFmpegRunner {
             if out_node.sink().frame(&mut filtered).is_err() {
                 break;
             }
+            frame_unref_audio(&mut filtered);
         }
 
         // Drop the filter graph to trigger loudnorm's uninit(), which emits
@@ -1042,8 +1208,11 @@ impl FFmpegRunner {
                 "audio input stream {audio_ist_index} not found"
             ))
         })?;
-        let audio_dec_ctx =
+        let mut audio_dec_ctx =
             ffmpeg_the_third::codec::context::Context::from_parameters(audio_ist.parameters())?;
+        // B1: Force single-threaded decode — eliminates frame-threading buffer
+        // pre-allocation that inflates RSS by hundreds of MB on long audio.
+        set_single_thread_codec(unsafe { audio_dec_ctx.as_mut_ptr() });
         let mut audio_decoder = audio_dec_ctx.decoder().audio()?;
 
         let input_audio_bitrate = audio_ist.parameters().bit_rate() as usize;
@@ -1104,6 +1273,9 @@ impl FFmpegRunner {
             Self::set_global_header_flag(unsafe { audio_encoder.as_mut_ptr() });
         }
 
+        // B2: Force single-threaded encode — reduces encoder buffer pool memory.
+        set_single_thread_codec(unsafe { audio_encoder.as_mut_ptr() });
+
         let mut audio_encoder =
             audio_encoder
                 .open_as(enc_codec)
@@ -1134,12 +1306,12 @@ impl FFmpegRunner {
                 ffmpeg_the_third::ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
         }
 
-        // Flush packets to AVIO immediately — prevents Matroska cluster buffering stalls
+        // A2: Flush packets to AVIO immediately — prevents Matroska cluster buffering stalls.
         unsafe {
             (*octx.as_mut_ptr()).flags |= ffmpeg_the_third::ffi::AVFMT_FLAG_FLUSH_PACKETS;
         }
 
-        // For audio-only output using av_write_frame (non-interleaved), set
+        // A1: For audio-only output using av_write_frame (non-interleaved), set
         // max_interleave_delta = 0 to disable the muxer's interleave queue entirely.
         // Harmless when using direct writes; prevents any residual queue growth.
         unsafe {
@@ -1152,6 +1324,26 @@ impl FFmpegRunner {
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to write output header: {e}"),
             })?;
+
+        // E1: Log threading knobs, mux flags, and AVIO state for diagnostics
+        {
+            let (dec_tc, dec_att) =
+                codec_threading_info(unsafe { audio_decoder.as_ptr() });
+            let (enc_tc, enc_att) =
+                codec_threading_info(unsafe { audio_encoder.as_ptr() });
+            let mux_flags = unsafe { (*octx.as_mut_ptr()).flags };
+            let pb_buf_size = unsafe {
+                let pb = (*octx.as_mut_ptr()).pb;
+                if !pb.is_null() { (*pb).buffer_size } else { 0 }
+            };
+            info!(
+                "[loudnorm pass 2] decoder: thread_count={dec_tc}, active_thread_type={dec_att}; \
+                 encoder: thread_count={enc_tc}, active_thread_type={enc_att}; \
+                 mux_flags=0x{mux_flags:x} (flush_packets={}); \
+                 pb_buffer_size={pb_buf_size}",
+                (mux_flags & ffmpeg_the_third::ffi::AVFMT_FLAG_FLUSH_PACKETS) != 0,
+            );
+        }
 
         // Log AVIO state for diagnostics after header write
         // SAFETY: octx owns a valid, header-written output format context.
@@ -1187,24 +1379,44 @@ impl FFmpegRunner {
         }
         info!("[loudnorm_encode_audio_only] header written: {file_size} bytes on disk");
 
-        // Build loudnorm pass 2 filter with measured values.
+        // Build loudnorm pass 2 filter chain.
+        //
+        // Chain order matters for true-peak compliance:
+        //   aformat=dbl → [precomp] → loudnorm → aresample → alimiter → aformat
+        //
+        // The alimiter MUST come AFTER aresample because resampling (e.g.
+        // 44100→48000 Hz sinc interpolation) can introduce ~1-2 dB of peak
+        // overshoot.  Placing the limiter last in the chain guarantees the
+        // encoder receives peak-compliant samples.
+        //
         // An explicit aresample bridges dbl→encoder format since FFmpeg 8.0's
         // auto-conversion during graph_config may fail with EINVAL (same issue
         // that required the leading aformat=dbl in pass 1).
-        let m = measurements;
+        // Note: aresample is kept plain (no async/first_pts options) — adding
+        // async=0:first_pts=0 caused silent padding that lowered output volume.
+        let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
+        let limiter = build_alimiter_spec(opts.target_tp);
         let enc_ch_layout_desc = audio_encoder.ch_layout().description();
         let filter_spec = format!(
-            "aformat=sample_fmts=dbl,loudnorm=I={:.1}:TP={:.1}:LRA={:.1}:measured_I={:.2}:measured_TP={:.2}:measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear=true:print_format=summary,aresample,aformat=sample_fmts={}:sample_rates={}:channel_layouts={}",
-            opts.target_i,
-            opts.target_tp,
-            opts.target_lra,
-            m.input_i,
-            m.input_tp,
-            m.input_lra,
-            m.input_thresh,
-            m.target_offset,
+            "aformat=sample_fmts=dbl,{loudnorm_core},aresample,{limiter},\
+             aformat=sample_fmts={}:sample_rates={}:channel_layouts={}",
             audio_encoder.format().name(),
             audio_encoder.rate(),
+            enc_ch_layout_desc,
+        );
+        info!("Loudnorm pass 2 filter_spec={filter_spec}");
+
+        // Log decoder/encoder audio parameters for diagnostics
+        info!(
+            "Loudnorm pass 2 decoder: sample_rate={}, format={}, ch_layout={}",
+            audio_decoder.rate(),
+            audio_decoder.format().name(),
+            audio_decoder.ch_layout().description(),
+        );
+        info!(
+            "Loudnorm pass 2 encoder: sample_rate={}, format={}, ch_layout={}",
+            audio_encoder.rate(),
+            audio_encoder.format().name(),
             enc_ch_layout_desc,
         );
 
@@ -1577,8 +1789,12 @@ fn audio_only_extension_for(ext: &str) -> &'static str {
 
 /// Two-tier recovery for mux failures during audio normalization.
 ///
-/// Tier 1: Salvage-remux input → retry library encode.
-/// Tier 2: External ffmpeg CLI with `-fflags +discardcorrupt+genpts`.
+/// D2: One-shot salvage retry with deterministic cleanup.
+/// - Tier 1: Salvage-remux input → retry library encode (one attempt only).
+/// - Tier 2: External ffmpeg CLI with `-fflags +discardcorrupt+genpts`.
+/// - Never overwrites the original input.
+/// - Salvage temp is deleted on success unless `RDLP_KEEP_SALVAGE=1`.
+/// - Salvage temp is kept on failure for post-mortem analysis.
 ///
 /// Loudnorm pass 1 measurements remain valid after salvage/CLI because:
 /// - Salvage uses stream copy (audio bit-identical)
@@ -1588,6 +1804,10 @@ where
     F: Fn(&Path) -> Result<()>,
     G: FnOnce(&Path, &Path) -> Result<()>,
 {
+    let keep_salvage = std::env::var("RDLP_KEEP_SALVAGE")
+        .map(|v| v == "1")
+        .unwrap_or(false);
+
     // First attempt: library encode
     match encode_fn(input) {
         Ok(()) => return Ok(()),
@@ -1599,7 +1819,7 @@ where
             return Err(e);
         }
         Err(e) => {
-            warn!("Encode failed with mux error, attempting salvage retry: {e}");
+            warn!("Encode failed with mux error, attempting one-shot salvage retry: {e}");
         }
     }
 
@@ -1613,18 +1833,33 @@ where
         return cli_fallback_fn(input, output);
     }
 
-    // Tier 1: salvage remux → retry library encode
+    // Tier 1: salvage remux → retry library encode (ONE attempt only)
     match salvage_remux_sync(input) {
         Ok(salvaged) => {
             let result = encode_fn(&salvaged);
-            let _ = std::fs::remove_file(&salvaged);
             if result.is_ok() {
+                // D2: Delete salvage temp on success unless RDLP_KEEP_SALVAGE=1
+                if keep_salvage {
+                    info!(
+                        "RDLP_KEEP_SALVAGE=1: keeping salvage temp {}",
+                        salvaged.display()
+                    );
+                } else {
+                    let _ = std::fs::remove_file(&salvaged);
+                }
                 return result;
             }
             warn!(
                 "Salvage retry also failed, falling back to CLI: {}",
                 result.as_ref().unwrap_err()
             );
+            // D2: Keep salvage temp on failure for post-mortem analysis
+            if !keep_salvage {
+                info!(
+                    "Keeping salvage temp for post-mortem: {}",
+                    salvaged.display()
+                );
+            }
             let _ = std::fs::remove_file(output);
             if output.exists() {
                 warn!(
@@ -1715,19 +1950,11 @@ fn cli_fallback_loudnorm(
     // could select a codec incompatible with the temp container.
     let output_ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mka");
     let enc_name = select_audio_encoder_for_container(output_ext);
-    let m = measurements;
-    let filter = format!(
-        "loudnorm=I={:.1}:TP={:.1}:LRA={:.1}:measured_I={:.2}:measured_TP={:.2}:\
-         measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear=true",
-        opts.target_i,
-        opts.target_tp,
-        opts.target_lra,
-        m.input_i,
-        m.input_tp,
-        m.input_lra,
-        m.input_thresh,
-        m.target_offset,
-    );
+    // Build filter string — ffmpeg CLI handles format negotiation
+    let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
+    let limiter = build_alimiter_spec(opts.target_tp);
+    let filter = format!("{loudnorm_core},{limiter}");
+    info!("CLI fallback loudnorm filter: {filter}");
 
     let mut cmd = std::process::Command::new("ffmpeg");
     cmd.args(["-y", "-fflags", "+discardcorrupt+genpts"])
@@ -1932,6 +2159,154 @@ mod tests {
         assert!((extract_json_value(text, "target_offset").unwrap() - 0.5).abs() < 0.01);
 
         assert!(extract_json_value(text, "nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_build_alimiter_spec_headroom() {
+        // target_tp=-1.0 → ceiling = 10^((-1.0 - 1.5) / 20) = 10^(-0.125)
+        let spec = build_alimiter_spec(-1.0);
+        assert!(spec.starts_with("alimiter=limit="));
+        assert!(spec.contains("attack=5"));
+        assert!(spec.contains("release=50"));
+
+        // Verify headroom: ceiling should be lower than 10^(-1/20) ≈ 0.891
+        // With 1.5 dB headroom: 10^(-2.5/20) ≈ 0.750
+        let limit_str = spec
+            .strip_prefix("alimiter=limit=")
+            .unwrap()
+            .split(':')
+            .next()
+            .unwrap();
+        let limit: f64 = limit_str.parse().unwrap();
+        let expected = 10f64.powf((-1.0 - ALIMITER_TP_HEADROOM_DB) / 20.0);
+        assert!(
+            (limit - expected).abs() < 0.001,
+            "limit={limit}, expected={expected}"
+        );
+    }
+
+    #[test]
+    fn test_build_loudnorm_pass2_filter_linear_no_shortfall() {
+        // Source I=-20, TP=-7 → target I=-14, TP=-1
+        // shortfall=0 → always linear=true (alimiter added by caller)
+        let opts = NormalizeOptions {
+            mode: AudioNormMode::Loudnorm,
+            target_i: -14.0,
+            target_tp: -1.0,
+            target_lra: 11.0,
+            ..Default::default()
+        };
+        let m = LoudnormMeasurements {
+            input_i: -20.0,
+            input_tp: -7.0,
+            input_lra: 8.0,
+            input_thresh: -30.0,
+            target_offset: 0.0,
+        };
+        let filter = build_loudnorm_pass2_filter(&opts, &m);
+        assert!(filter.contains("linear=true"));
+        // alimiter is no longer part of this function (caller appends it)
+        assert!(!filter.contains("alimiter="));
+        assert!(!filter.contains("volume="));
+        assert!(!filter.contains("acompressor="));
+    }
+
+    #[test]
+    fn test_build_loudnorm_pass2_filter_moderate_shortfall() {
+        // Source I=-17, TP=-1.5 → target I=-14, TP=-1 → shortfall=2.5
+        // V2: still uses linear=true (no volume boost tier)
+        let opts = NormalizeOptions {
+            mode: AudioNormMode::Loudnorm,
+            target_i: -14.0,
+            target_tp: -1.0,
+            target_lra: 11.0,
+            ..Default::default()
+        };
+        let m = LoudnormMeasurements {
+            input_i: -17.0,
+            input_tp: -1.5,
+            input_lra: 8.0,
+            input_thresh: -27.0,
+            target_offset: 0.0,
+        };
+        let filter = build_loudnorm_pass2_filter(&opts, &m);
+        assert!(filter.contains("linear=true"));
+        assert!(!filter.contains("alimiter="));
+        assert!(!filter.contains("volume="));
+    }
+
+    #[test]
+    fn test_build_loudnorm_pass2_filter_large_shortfall() {
+        // Source I=-30, TP=-1 → target I=-14, TP=-1 → shortfall=16
+        // V2: still uses linear=true (loudnorm falls back to dynamic internally)
+        let opts = NormalizeOptions {
+            mode: AudioNormMode::Loudnorm,
+            target_i: -14.0,
+            target_tp: -1.0,
+            target_lra: 11.0,
+            ..Default::default()
+        };
+        let m = LoudnormMeasurements {
+            input_i: -30.0,
+            input_tp: -1.0,
+            input_lra: 12.0,
+            input_thresh: -40.0,
+            target_offset: 0.0,
+        };
+        let filter = build_loudnorm_pass2_filter(&opts, &m);
+        assert!(filter.contains("linear=true"));
+        assert!(!filter.contains("alimiter="));
+        assert!(!filter.contains("linear=false"));
+    }
+
+    #[test]
+    fn test_build_loudnorm_pass2_filter_force_dynamic() {
+        let opts = NormalizeOptions {
+            mode: AudioNormMode::Loudnorm,
+            target_i: -14.0,
+            target_tp: -1.0,
+            target_lra: 11.0,
+            force_dynamic: true,
+            ..Default::default()
+        };
+        let m = LoudnormMeasurements {
+            input_i: -20.0,
+            input_tp: -7.0,
+            input_lra: 8.0,
+            input_thresh: -30.0,
+            target_offset: 0.0,
+        };
+        let filter = build_loudnorm_pass2_filter(&opts, &m);
+        assert!(filter.contains("linear=false"));
+        assert!(!filter.contains("alimiter="));
+        assert!(!filter.contains("linear=true"));
+    }
+
+    #[test]
+    fn test_build_loudnorm_pass2_filter_precompress() {
+        let opts = NormalizeOptions {
+            mode: AudioNormMode::Loudnorm,
+            target_i: -14.0,
+            target_tp: -1.0,
+            target_lra: 11.0,
+            precompress: true,
+            ..Default::default()
+        };
+        let m = LoudnormMeasurements {
+            input_i: -20.0,
+            input_tp: -7.0,
+            input_lra: 8.0,
+            input_thresh: -30.0,
+            target_offset: 0.0,
+        };
+        let filter = build_loudnorm_pass2_filter(&opts, &m);
+        assert!(filter.contains("acompressor="));
+        assert!(filter.contains("linear=true"));
+        assert!(!filter.contains("alimiter="));
+        // acompressor should come BEFORE loudnorm
+        let comp_pos = filter.find("acompressor=").unwrap();
+        let loud_pos = filter.find("loudnorm=").unwrap();
+        assert!(comp_pos < loud_pos, "acompressor must precede loudnorm");
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -190,7 +190,8 @@ impl FFmpegRunner {
     /// - `sample_aspect_ratio` — pixel aspect ratio
     /// - `cluster_time_limit=500` — 500ms clusters for smooth seeking
     /// - `avoid_negative_ts` — timestamp normalization
-    /// - `max_interleave_delta=0` — immediate output
+    /// - `max_interleave_delta=0` — disables delta-based queue flushing (safe
+    ///   for remux since packets arrive in muxer order from a single input)
     #[allow(clippy::too_many_lines, clippy::needless_range_loop)]
     fn remux_mkv_raw_ffi(input: &Path, output: &Path) -> Result<()> {
         use ffmpeg_the_third::ffi;
@@ -323,7 +324,9 @@ impl FFmpegRunner {
             // Enable avoid_negative_ts to normalize timestamps
             (*ofmt_ctx).avoid_negative_ts = ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
 
-            // Set max_interleave_delta to 0 for immediate output (no buffering)
+            // Disable delta-based interleave flushing. Safe for remux since
+            // packets arrive in muxer order from a single input, keeping the
+            // interleave queue small. 0 = no delta limit (not "flush immediately").
             (*ofmt_ctx).max_interleave_delta = 0;
 
             // Enable auto bitstream filters

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -1,0 +1,390 @@
+//! Matroska/WebM container corruption detection and salvage remux.
+//!
+//! Detects structurally corrupt Matroska/WebM containers by capturing FFmpeg
+//! demuxer log output during packet iteration and checking for known EBML
+//! error markers. When corruption is detected, a salvage remux (stream copy)
+//! produces a structurally valid container that can be processed normally.
+//!
+//! ## Why EBML corruption causes downstream ENOSPC
+//!
+//! Malformed EBML elements (invalid IDs, truncated sizes, elements exceeding
+//! their parent) cause the Matroska demuxer to produce packets with broken
+//! timestamps (out-of-order DTS, negative durations, implausible PTS values).
+//! When these packets enter the muxer's interleave queue, the queue grows
+//! unboundedly waiting for "future" packets that will never arrive at the
+//! expected timestamps. Once the muxer's internal buffer exceeds its limit,
+//! `av_interleaved_write_frame` returns AVERROR(ENOSPC) — "Not enough space"
+//! — which is a muxer queue overflow, not a disk space error.
+//!
+//! ## Why salvage remux fixes it deterministically
+//!
+//! FFmpeg's Matroska demuxer is resilient to many structural errors — it logs
+//! warnings but continues reading. A stream-copy remux reads all recoverable
+//! packets from the corrupt input and writes them into a fresh container with
+//! valid EBML structure, monotonic timestamps, and correct cluster boundaries.
+//! The salvaged output is structurally sound, so subsequent transcoding or
+//! normalization operates on clean data without triggering the ENOSPC cascade.
+
+use std::path::{Path, PathBuf};
+
+use log::{debug, info, warn};
+
+use crate::error::{CorruptionKind, PostProcessError, Result};
+
+use super::ffi_helpers::packet_unref;
+use super::log_capture::{LogCaptureGuard, LogSuppressGuard};
+use super::{FFmpegRunner, ensure_init};
+
+/// EBML corruption marker substrings that indicate malformed Matroska/WebM containers.
+///
+/// These are emitted by FFmpeg's Matroska demuxer at WARNING/ERROR level when
+/// it encounters structural problems in the EBML byte stream.
+const EBML_CORRUPTION_MARKERS: &[&str] = &[
+    "invalid as first byte of an EBML number",
+    "exceeds containing master element",
+    "Duplicate element",
+];
+
+/// Check a media input for Matroska/WebM container-level corruption.
+///
+/// Opens the input with log capture active, reads all packets (no decoding),
+/// and checks for EBML structural error markers in the demuxer log output.
+///
+/// Returns `Ok(())` if the container is clean or not Matroska/WebM.
+/// Returns `Err(InputCorrupt { kind: MatroskaEbml, .. })` if corruption is detected.
+pub(crate) fn check_matroska_integrity(input: &Path) -> Result<()> {
+    ensure_init()?;
+
+    let guard = LogCaptureGuard::begin()?;
+
+    // Open input — this reads the Matroska header and may already trigger EBML warnings
+    let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+        PostProcessError::FFmpegLibraryError {
+            message: format!(
+                "failed to open input for integrity check {}: {e}",
+                input.display()
+            ),
+        }
+    })?;
+
+    // Only check Matroska/WebM containers — other formats are not affected
+    let format_name = ictx.format().name().to_string();
+    if !format_name.contains("matroska") && !format_name.contains("webm") {
+        drop(guard);
+        return Ok(());
+    }
+
+    debug!(
+        "Checking matroska container integrity: {} (format: {})",
+        input.display(),
+        format_name,
+    );
+
+    // Read all packets to trigger demuxer EBML validation.
+    // This is a packet-level scan (no decoding), so it's fast — bounded
+    // only by disk I/O speed.
+    for result in ictx.packets() {
+        if result.is_err() {
+            break; // Demuxer hard error — check logs below
+        }
+    }
+
+    // Check captured logs for EBML corruption markers
+    let lines = guard.take_captured()?;
+    drop(guard);
+
+    let corrupt_logs: Vec<String> = lines
+        .into_iter()
+        .filter(|line| {
+            EBML_CORRUPTION_MARKERS
+                .iter()
+                .any(|marker| line.contains(marker))
+        })
+        .collect();
+
+    if corrupt_logs.is_empty() {
+        Ok(())
+    } else {
+        Err(PostProcessError::InputCorrupt {
+            kind: CorruptionKind::MatroskaEbml,
+            path: input.to_path_buf(),
+            logs: corrupt_logs,
+        })
+    }
+}
+
+/// Salvage a corrupt Matroska/WebM container by remuxing with stream copy.
+///
+/// Reads all recoverable packets from the corrupt input and writes them into
+/// a fresh container with valid EBML structure. Uses `LogSuppressGuard` to
+/// suppress the expected EBML warning spam during the remux.
+///
+/// Returns the path to the salvaged temporary file. The caller is responsible
+/// for cleaning up this file when done.
+pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
+    ensure_init()?;
+
+    // Always use MKV for salvage output. Matroska writes metadata
+    // incrementally (no trailer indexing), avoiding ENOMEM that occurs
+    // with MP4/MOV trailer writes under memory pressure.
+    let ext = "mkv";
+    let stem = input
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("salvage");
+    let salvage_path = {
+        let base = input.with_file_name(format!("{stem}.salvage.{ext}"));
+        if !base.exists() {
+            base
+        } else {
+            // Find unique path to avoid reusing partially written files
+            let mut attempt = 1u32;
+            loop {
+                let candidate = input.with_file_name(format!("{stem}.salvage{attempt}.{ext}"));
+                if !candidate.exists() || attempt > 99 {
+                    break candidate;
+                }
+                attempt += 1;
+            }
+        }
+    };
+
+    info!(
+        "Salvage remuxing corrupt input: {} -> {}",
+        input.display(),
+        salvage_path.display(),
+    );
+
+    // Suppress FFmpeg log output during salvage — the corrupt input will
+    // generate many EBML warnings that we've already captured and reported.
+    let _log_suppress = LogSuppressGuard::new();
+
+    // Open corrupt input — FFmpeg will log warnings but continue reading
+    let mut ictx =
+        ffmpeg_the_third::format::input(input).map_err(|e| PostProcessError::SalvageFailed {
+            message: format!("failed to open corrupt input {}: {e}", input.display()),
+        })?;
+
+    let mut octx = ffmpeg_the_third::format::output(&salvage_path).map_err(|e| {
+        PostProcessError::SalvageFailed {
+            message: format!(
+                "failed to create salvage output {}: {e}",
+                salvage_path.display()
+            ),
+        }
+    })?;
+
+    // Map all input streams to output (stream copy, no re-encoding)
+    let stream_count = ictx.streams().count();
+    for ist in ictx.streams() {
+        let mut ost = octx
+            .add_stream(ffmpeg_the_third::encoder::find(
+                ffmpeg_the_third::codec::Id::None,
+            ))
+            .map_err(|e| PostProcessError::SalvageFailed {
+                message: format!("failed to add output stream: {e}"),
+            })?;
+        ost.set_parameters(ist.parameters());
+        FFmpegRunner::clear_codec_tag(ost.parameters().as_ptr());
+    }
+
+    // Use FFmpeg's default 10s max_interleave_delta for salvage. This prevents
+    // unbounded queue growth from corrupt timestamps in the input while still
+    // allowing reasonable interleave buffering. 0 would mean "no delta limit"
+    // (not "flush immediately"), risking ENOMEM on severely corrupt inputs.
+    // SAFETY: octx owns a valid, pre-header output format context.
+    unsafe {
+        (*octx.as_mut_ptr()).max_interleave_delta = 10_000_000;
+    }
+    let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
+    muxer_opts.set("cluster_time_limit", "500");
+
+    octx.write_header_with(muxer_opts)
+        .map_err(|e| PostProcessError::SalvageFailed {
+            message: format!("failed to write salvage output header: {e}"),
+        })?;
+
+    // Copy all recoverable packets, skipping ones that fail to read or write
+    let mut copied = 0u64;
+    let mut skipped = 0u64;
+
+    for result in ictx.packets() {
+        match result {
+            Ok((stream, mut packet)) => {
+                let in_idx = stream.index();
+                if in_idx >= stream_count {
+                    skipped += 1;
+                    continue;
+                }
+
+                let in_tb = stream.time_base();
+                let out_tb = match octx.stream(in_idx) {
+                    Some(s) => s.time_base(),
+                    None => {
+                        skipped += 1;
+                        continue;
+                    }
+                };
+
+                packet.rescale_ts(in_tb, out_tb);
+                packet.set_stream(in_idx);
+                packet.set_position(-1);
+
+                if packet.write_interleaved(&mut octx).is_ok() {
+                    copied += 1;
+                } else {
+                    skipped += 1;
+                }
+                packet_unref(&mut packet);
+            }
+            Err(_) => {
+                skipped += 1;
+            }
+        }
+    }
+
+    // Drop suppress guard before write_trailer so any trailer errors are visible
+    drop(_log_suppress);
+
+    octx.write_trailer()
+        .map_err(|e| PostProcessError::SalvageFailed {
+            message: format!("failed to write salvage output trailer: {e}"),
+        })?;
+
+    info!("Salvage remux complete: {copied} packets copied, {skipped} skipped");
+
+    if copied == 0 {
+        let _ = std::fs::remove_file(&salvage_path);
+        return Err(PostProcessError::SalvageFailed {
+            message: "no packets could be recovered from corrupt input".into(),
+        });
+    }
+
+    Ok(salvage_path)
+}
+
+/// Check container integrity and optionally salvage corrupt Matroska/WebM inputs.
+///
+/// Returns `(effective_input, salvage_temp)` where:
+/// - `effective_input` is the path to use for processing (original if clean, salvaged if corrupt)
+/// - `salvage_temp` is `Some(path)` if a temp file was created that the caller must clean up
+///
+/// If `salvage_enabled` is false and corruption is detected, returns the
+/// `InputCorrupt` error directly.
+pub(crate) fn prepare_input_with_salvage(
+    input: &Path,
+    salvage_enabled: bool,
+) -> Result<(PathBuf, Option<PathBuf>)> {
+    match check_matroska_integrity(input) {
+        Ok(()) => Ok((input.to_path_buf(), None)),
+        Err(e @ PostProcessError::InputCorrupt { .. }) => {
+            if let PostProcessError::InputCorrupt {
+                ref kind, ref logs, ..
+            } = e
+            {
+                warn!(
+                    "input corrupt ({kind}): {} ({} demuxer error(s))",
+                    input.display(),
+                    logs.len(),
+                );
+                for line in logs {
+                    debug!("  ebml: {}", line.trim());
+                }
+            }
+
+            if !salvage_enabled {
+                return Err(e);
+            }
+
+            info!("Attempting salvage remux for corrupt input...");
+            let salvaged = salvage_remux_sync(input)?;
+            Ok((salvaged.clone(), Some(salvaged)))
+        }
+        Err(other) => Err(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ebml_markers_detect_invalid_first_byte() {
+        let line = "[matroska,webm @ 0x1234] invalid as first byte of an EBML number";
+        assert!(
+            EBML_CORRUPTION_MARKERS
+                .iter()
+                .any(|marker| line.contains(marker))
+        );
+    }
+
+    #[test]
+    fn test_ebml_markers_detect_exceeds_master() {
+        let line = "[matroska,webm @ 0x5678] element exceeds containing master element size";
+        assert!(
+            EBML_CORRUPTION_MARKERS
+                .iter()
+                .any(|marker| line.contains(marker))
+        );
+    }
+
+    #[test]
+    fn test_ebml_markers_detect_duplicate() {
+        let line = "[matroska,webm @ 0x9abc] Duplicate element";
+        assert!(
+            EBML_CORRUPTION_MARKERS
+                .iter()
+                .any(|marker| line.contains(marker))
+        );
+    }
+
+    #[test]
+    fn test_ebml_markers_reject_normal_logs() {
+        let lines = [
+            "[info] loudnorm pass 1 complete",
+            "[aac @ 0x1234] channel layout not set",
+            "[mp4 @ 0x5678] muxing complete",
+        ];
+        for line in &lines {
+            assert!(
+                !EBML_CORRUPTION_MARKERS
+                    .iter()
+                    .any(|marker| line.contains(marker))
+            );
+        }
+    }
+
+    #[test]
+    fn test_corruption_kind_display() {
+        assert_eq!(CorruptionKind::MatroskaEbml.to_string(), "matroska ebml");
+    }
+
+    #[test]
+    fn test_input_corrupt_error_display() {
+        let err = PostProcessError::InputCorrupt {
+            kind: CorruptionKind::MatroskaEbml,
+            path: PathBuf::from("/tmp/test.mkv"),
+            logs: vec!["Duplicate element".into()],
+        };
+        let display = err.to_string();
+        assert!(display.contains("matroska ebml"));
+        assert!(display.contains("test.mkv"));
+    }
+
+    #[test]
+    fn test_salvage_failed_error_display() {
+        let err = PostProcessError::SalvageFailed {
+            message: "no packets recovered".into(),
+        };
+        assert!(err.to_string().contains("salvage failed"));
+    }
+
+    #[test]
+    fn test_check_nonexistent_file_returns_error() {
+        if ensure_init().is_err() {
+            return; // FFmpeg not available
+        }
+        let result = check_matroska_integrity(Path::new("/nonexistent/file.mkv"));
+        assert!(result.is_err());
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail.rs
@@ -449,6 +449,9 @@ impl FFmpegRunner {
 
             // 6. Set format options
             (*ofmt_ctx).avoid_negative_ts = ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
+            // Disable delta-based interleave flushing. 0 = no delta limit
+            // (not "flush immediately"). Safe here because thumbnail embed
+            // copies packets in input order from a single source.
             (*ofmt_ctx).max_interleave_delta = 0;
             (*ofmt_ctx).flags |= ffi::AVFMT_FLAG_AUTO_BSF;
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode.rs
@@ -5,10 +5,14 @@
 
 use std::path::Path;
 
-use log::debug;
+use log::{debug, info, warn};
+
+use ffmpeg_the_third::packet::Ref as PacketRef;
 
 use crate::error::{PostProcessError, Result};
 
+use super::ffi_helpers::{frame_unref_audio, frame_unref_video, packet_unref};
+use super::salvage::prepare_input_with_salvage;
 use super::{AudioExtractOptions, FFmpegRunner, RemuxOptions, VideoConvertOptions, ensure_init};
 
 impl FFmpegRunner {
@@ -16,6 +20,9 @@ impl FFmpegRunner {
     ///
     /// Uses `opts.copy` to determine whether to copy or transcode.
     /// For transcoding, supports bitrate (CBR) and quality scale (VBR) modes.
+    ///
+    /// Automatically detects and salvages corrupt Matroska/WebM containers
+    /// before extraction to prevent EBML-induced muxer failures.
     pub async fn extract_audio(
         &self,
         input: impl AsRef<Path>,
@@ -26,7 +33,15 @@ impl FFmpegRunner {
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
         Self::spawn_blocking("extract_audio", move || {
-            Self::extract_audio_sync(&input, &output, &opts)
+            let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, true)?;
+
+            let result = Self::extract_audio_sync(&effective_input, &output, &opts);
+
+            if let Some(ref temp) = salvage_temp {
+                let _ = std::fs::remove_file(temp);
+            }
+
+            result
         })
         .await
     }
@@ -217,7 +232,8 @@ impl FFmpegRunner {
         let target_format = Self::pick_audio_sample_format(&enc_codec, decoder.format());
         audio_encoder.set_format(target_format);
         audio_encoder.set_rate(decoder.rate() as i32);
-        audio_encoder.set_time_base(ffmpeg_the_third::Rational(1, decoder.rate() as i32));
+        let enc_time_base = ffmpeg_the_third::Rational(1, decoder.rate() as i32);
+        audio_encoder.set_time_base(enc_time_base);
 
         // Set channel layout from decoder (default layout matching channel count)
         let channels = decoder.ch_layout().channels();
@@ -249,6 +265,19 @@ impl FFmpegRunner {
                     message: format!("failed to open audio encoder: {e}"),
                 })?;
 
+        // Read actual encoder time_base via FFI (may differ from configured after open)
+        // SAFETY: audio_encoder is a valid opened encoder context.
+        let enc_time_base = unsafe {
+            let tb = (*audio_encoder.as_ptr()).time_base;
+            ffmpeg_the_third::Rational(tb.num, tb.den)
+        };
+        debug!(
+            "Encoder time_base: configured=1/{}, actual={}/{}",
+            decoder.rate(),
+            enc_time_base.numerator(),
+            enc_time_base.denominator(),
+        );
+
         // Copy encoder parameters back to output stream
         // SAFETY: audio_encoder is a valid opened encoder context.
         Self::copy_encoder_params_to_stream(&mut octx, ost_index, unsafe {
@@ -260,8 +289,44 @@ impl FFmpegRunner {
                 message: format!("failed to write output header: {e}"),
             })?;
 
+        // Read ost_time_base AFTER write_header (Matroska may change it)
+        let ost_time_base = octx
+            .stream(ost_index)
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("output stream not found"))?
+            .time_base();
+
+        let expected_duration = if audio_encoder.frame_size() > 0 {
+            unsafe {
+                ffmpeg_the_third::ffi::av_rescale_q(
+                    i64::from(audio_encoder.frame_size()),
+                    ffmpeg_the_third::ffi::AVRational {
+                        num: enc_time_base.numerator(),
+                        den: enc_time_base.denominator(),
+                    },
+                    ffmpeg_the_third::ffi::AVRational {
+                        num: ost_time_base.numerator(),
+                        den: ost_time_base.denominator(),
+                    },
+                )
+            }
+        } else {
+            0
+        };
+        info!(
+            "Expected audio packet duration: {} (frame_size={}, enc_tb={}/{}, ost_tb={}/{})",
+            expected_duration, audio_encoder.frame_size(),
+            enc_time_base.numerator(), enc_time_base.denominator(),
+            ost_time_base.numerator(), ost_time_base.denominator(),
+        );
+
         // Build filter graph for sample format/rate conversion
         let mut filter_graph = Self::build_audio_filter(&decoder, &audio_encoder, ist_time_base)?;
+
+        let mut timing = MuxTimingState {
+            encoder_frame_size: audio_encoder.frame_size(),
+            expected_duration,
+            ..Default::default()
+        };
 
         // Transcode loop: read → decode → filter → encode → write
         for result in ictx.packets() {
@@ -278,6 +343,8 @@ impl FFmpegRunner {
                 &mut audio_encoder,
                 &mut octx,
                 ost_index,
+                enc_time_base,
+                &mut timing,
             )?;
         }
 
@@ -289,6 +356,8 @@ impl FFmpegRunner {
             &mut audio_encoder,
             &mut octx,
             ost_index,
+            enc_time_base,
+            &mut timing,
         )?;
 
         // Flush filter graph (signal EOF to source)
@@ -297,11 +366,27 @@ impl FFmpegRunner {
             .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
             .source()
             .flush()?;
-        Self::drain_filter_to_encoder(&mut filter_graph, &mut audio_encoder, &mut octx, ost_index)?;
+        Self::drain_filter_to_encoder(
+            &mut filter_graph,
+            &mut audio_encoder,
+            &mut octx,
+            ost_index,
+            enc_time_base,
+            &mut timing,
+        )?;
 
         // Flush encoder
         audio_encoder.send_eof()?;
-        Self::drain_encoder_packets(&mut audio_encoder, &mut octx, ost_index)?;
+        Self::drain_encoder_packets(
+            &mut audio_encoder,
+            &mut octx,
+            ost_index,
+            enc_time_base,
+            &mut timing,
+        )?;
+
+        // Flush interleave queue before trailer
+        flush_interleave_queue(&mut octx);
 
         octx.write_trailer()
             .map_err(|e| PostProcessError::FFmpegLibraryError {
@@ -312,7 +397,7 @@ impl FFmpegRunner {
     }
 
     /// Pick a sample format supported by the encoder, preferring the decoder's format.
-    fn pick_audio_sample_format(
+    pub(crate) fn pick_audio_sample_format(
         codec: &ffmpeg_the_third::Codec,
         preferred: ffmpeg_the_third::format::Sample,
     ) -> ffmpeg_the_third::format::Sample {
@@ -357,27 +442,17 @@ impl FFmpegRunner {
     ) -> Result<ffmpeg_the_third::filter::Graph> {
         let mut graph = ffmpeg_the_third::filter::Graph::new();
 
-        let abuffer = ffmpeg_the_third::filter::find("abuffer")
-            .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffer filter not found"))?;
         let abuffersink = ffmpeg_the_third::filter::find("abuffersink")
             .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffersink filter not found"))?;
 
-        // Build abuffer args with decoder's output parameters
-        let channels = decoder.ch_layout().channels();
-        let args = format!(
-            "time_base={}/{}:sample_rate={}:sample_fmt={}:chlayout={}c",
-            ist_time_base.numerator(),
-            ist_time_base.denominator(),
+        Self::add_abuffer_to_graph(
+            &mut graph,
+            "in",
+            ist_time_base,
             decoder.rate(),
             decoder.format().name(),
-            channels,
-        );
-
-        graph
-            .add(&abuffer, "in", &args)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to add abuffer filter: {e}"),
-            })?;
+            &decoder.ch_layout().description(),
+        )?;
         graph
             .add(&abuffersink, "out", "")
             .map_err(|e| PostProcessError::FFmpegLibraryError {
@@ -385,30 +460,30 @@ impl FFmpegRunner {
             })?;
 
         // Build aformat spec to convert to encoder's expected format
-        let enc_channels = encoder.ch_layout().channels();
+        let enc_ch_layout_desc = encoder.ch_layout().description();
         let aformat_spec = format!(
-            "aformat=sample_fmts={}:sample_rates={}:channel_layouts={}c",
+            "aformat=sample_fmts={}:sample_rates={}:channel_layouts={}",
             encoder.format().name(),
             encoder.rate(),
-            enc_channels,
+            enc_ch_layout_desc,
         );
 
-        graph
-            .output("out", 0)?
-            .input("in", 0)?
-            .parse(&aformat_spec)?;
-        graph.validate()?;
+        Self::parse_and_validate_filter_graph(&mut graph, "in", "out", &aformat_spec)?;
 
         Ok(graph)
     }
 
     /// Receive decoded frames from decoder, push through filter, encode, and write.
-    fn receive_and_process_audio(
+    ///
+    /// Uses interleaved writes — appropriate for multi-stream output.
+    pub(crate) fn receive_and_process_audio(
         decoder: &mut ffmpeg_the_third::decoder::Audio,
         filter: &mut ffmpeg_the_third::filter::Graph,
         encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
         octx: &mut ffmpeg_the_third::format::context::Output,
         ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
     ) -> Result<()> {
         let mut frame = ffmpeg_the_third::frame::Audio::empty();
         while decoder.receive_frame(&mut frame).is_ok() {
@@ -416,18 +491,26 @@ impl FFmpegRunner {
                 .get("in")
                 .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
                 .source()
-                .add(&frame)?;
-            Self::drain_filter_to_encoder(filter, encoder, octx, ost_index)?;
+                .add(&frame)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("av_buffersrc_add_frame failed: {e}"),
+                })?;
+            frame_unref_audio(&mut frame);
+            Self::drain_filter_to_encoder(filter, encoder, octx, ost_index, enc_time_base, timing)?;
         }
         Ok(())
     }
 
     /// Pull filtered frames from filter graph, encode, and write.
-    fn drain_filter_to_encoder(
+    ///
+    /// Uses interleaved writes — appropriate for multi-stream output.
+    pub(crate) fn drain_filter_to_encoder(
         filter: &mut ffmpeg_the_third::filter::Graph,
         encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
         octx: &mut ffmpeg_the_third::format::context::Output,
         ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
     ) -> Result<()> {
         let mut filtered = ffmpeg_the_third::frame::Audio::empty();
         loop {
@@ -437,22 +520,732 @@ impl FFmpegRunner {
             if out_node.sink().frame(&mut filtered).is_err() {
                 break;
             }
-            encoder.send_frame(&filtered)?;
-            Self::drain_encoder_packets(encoder, octx, ost_index)?;
+            encoder
+                .send_frame(&filtered)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("avcodec_send_frame failed: {e}"),
+                })?;
+            frame_unref_audio(&mut filtered);
+            Self::drain_encoder_packets(encoder, octx, ost_index, enc_time_base, timing)?;
         }
         Ok(())
     }
 
-    /// Receive encoded packets from encoder and write to output.
-    fn drain_encoder_packets(
+    /// Receive encoded packets from encoder and write to output (interleaved).
+    ///
+    /// Rescales packet timestamps from encoder timebase to output stream
+    /// timebase, enforces monotonic DTS, fixes zero-duration packets, then
+    /// writes via direct FFI `av_interleaved_write_frame` to capture the raw
+    /// return code and I/O diagnostics on failure. Appropriate for
+    /// multi-stream output.
+    pub(crate) fn drain_encoder_packets(
         encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
         octx: &mut ffmpeg_the_third::format::context::Output,
         ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
     ) -> Result<()> {
+        let ost_time_base = octx
+            .stream(ost_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!("output stream {ost_index} not found"))
+            })?
+            .time_base();
         let mut packet = ffmpeg_the_third::Packet::empty();
         while encoder.receive_packet(&mut packet).is_ok() {
             packet.set_stream(ost_index);
-            packet.write_interleaved(octx)?;
+            packet.rescale_ts(enc_time_base, ost_time_base);
+            packet.set_position(-1);
+
+            if timing.pkt_count == 0 {
+                debug!(
+                    "First encoded packet: pts={:?}, dts={:?}, size={}, dur={}, enc_tb={}/{}, ost_tb={}/{}, exp_dur={}",
+                    packet.pts(),
+                    packet.dts(),
+                    packet.size(),
+                    packet.duration(),
+                    enc_time_base.numerator(),
+                    enc_time_base.denominator(),
+                    ost_time_base.numerator(),
+                    ost_time_base.denominator(),
+                    timing.expected_duration,
+                );
+            }
+
+            // Unified timestamp + duration fix
+            let (new_dts, new_pts, new_dur, updated) = fix_audio_timestamps(
+                packet.dts(),
+                packet.pts(),
+                packet.duration(),
+                timing,
+            );
+            if new_dts != packet.dts() || new_dur != packet.duration() {
+                debug!(
+                    "Timestamp fix: pkt#{} dts={:?}->{new_dts:?}, pts={:?}->{new_pts:?}, dur={}->{new_dur}",
+                    timing.pkt_count, packet.dts(), packet.pts(), packet.duration(),
+                );
+            }
+            packet.set_dts(new_dts);
+            packet.set_pts(new_pts);
+            packet.set_duration(new_dur);
+            timing.last_dts = updated;
+            timing.last_duration = new_dur;
+
+            // Capture packet metadata before write (av_interleaved_write_frame unrefs)
+            let pts = packet.pts();
+            let dts = packet.dts();
+            let size = packet.size() as i32;
+            let dur = packet.duration();
+
+            // Direct FFI call to capture raw return code
+            // SAFETY: octx and packet are valid; av_interleaved_write_frame takes
+            // ownership of the packet buffer and unrefs it on success.
+            let ret = unsafe {
+                ffmpeg_the_third::ffi::av_interleaved_write_frame(
+                    octx.as_mut_ptr(),
+                    packet.as_ptr() as *mut _,
+                )
+            };
+            // Unref immediately: frees encoded data before next receive_packet.
+            // av_interleaved_write_frame unrefs on success in FFmpeg 8.0, but NOT
+            // on failure. Explicit unref is idempotent and matches
+            // merge.rs / remux.rs / thumbnail.rs patterns.
+            packet_unref(&mut packet);
+            if ret < 0 {
+                if ret == -12 {
+                    warn!(
+                        "FFmpeg allocation failure (ENOMEM) during mux write — \
+                         likely packet/frame leak or extreme memory pressure (rss={}KB)",
+                        get_process_rss_kb(),
+                    );
+                }
+                let strerr = av_strerror_string(ret);
+                // SAFETY: octx owns a valid format context
+                let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                return Err(PostProcessError::MuxWriteError {
+                    message: format!("ret={ret} ({strerr}), dur={dur}, {io_diag}"),
+                    operation: "av_interleaved_write_frame".into(),
+                    stream_index: ost_index,
+                    pts,
+                    dts,
+                    packet_size: size,
+                    time_base_num: ost_time_base.numerator(),
+                    time_base_den: ost_time_base.denominator(),
+                });
+            }
+            timing.pkt_count += 1;
+
+            // Mux progress watchdog (interleaved path): flush AVIO then check
+            // pos and file size, same dual-signal approach as the direct path.
+            if timing.pkt_count % 256 == 0 {
+                unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() {
+                        ffmpeg_the_third::ffi::avio_flush(pb);
+                    }
+                }
+
+                let current_pos = unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() { (*pb).pos } else { 0 }
+                };
+                if current_pos > timing.last_pos_check {
+                    timing.last_pos_check = current_pos;
+                    timing.stall_count = 0;
+                } else {
+                    timing.stall_count += 1;
+                    if timing.stall_count >= 3 {
+                        let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                        return Err(PostProcessError::MuxWriteError {
+                            message: format!(
+                                "mux stall detected: pb->pos={current_pos} unchanged for {} packets, {io_diag}",
+                                timing.stall_count * 256
+                            ),
+                            operation: "av_interleaved_write_frame (watchdog)".into(),
+                            stream_index: ost_index,
+                            pts,
+                            dts,
+                            packet_size: size,
+                            time_base_num: ost_time_base.numerator(),
+                            time_base_den: ost_time_base.denominator(),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Receive decoded frames from decoder, push through filter, encode, and write.
+    ///
+    /// Uses direct (non-interleaved) writes — appropriate for single-stream
+    /// audio-only output where the muxer's interleaving buffer is unnecessary.
+    /// Primary path for audio-only normalization to avoid interleave queue ENOMEM.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn receive_and_process_audio_direct(
+        decoder: &mut ffmpeg_the_third::decoder::Audio,
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
+        output_path: Option<&Path>,
+    ) -> Result<()> {
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        while decoder.receive_frame(&mut frame).is_ok() {
+            filter
+                .get("in")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                .source()
+                .add(&frame)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("av_buffersrc_add_frame failed: {e}"),
+                })?;
+            frame_unref_audio(&mut frame);
+            Self::drain_filter_to_encoder_direct(
+                filter,
+                encoder,
+                octx,
+                ost_index,
+                enc_time_base,
+                timing,
+                output_path,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Pull filtered frames from filter graph, encode, and write.
+    ///
+    /// Uses direct (non-interleaved) writes — appropriate for single-stream
+    /// audio-only output. Primary path for normalization to avoid ENOMEM.
+    pub(crate) fn drain_filter_to_encoder_direct(
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
+        output_path: Option<&Path>,
+    ) -> Result<()> {
+        let mut filtered = ffmpeg_the_third::frame::Audio::empty();
+        loop {
+            let mut out_node = filter
+                .get("out")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'out' not found"))?;
+            if out_node.sink().frame(&mut filtered).is_err() {
+                break;
+            }
+            encoder
+                .send_frame(&filtered)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("avcodec_send_frame failed: {e}"),
+                })?;
+            frame_unref_audio(&mut filtered);
+            Self::drain_encoder_packets_direct(encoder, octx, ost_index, enc_time_base, timing, output_path)?;
+        }
+        Ok(())
+    }
+
+    /// Receive encoded packets from encoder and write to output (direct).
+    ///
+    /// Rescales packet timestamps from encoder timebase to output stream
+    /// timebase, enforces monotonic DTS, fixes zero-duration packets, then
+    /// writes via direct FFI `av_write_frame` (non-interleaved) to bypass
+    /// the muxer's interleave queue. This is appropriate for single-stream
+    /// audio-only output where interleaving is unnecessary — the queue would
+    /// only buffer packets without flushing, risking ENOMEM on long files.
+    /// The rescaling is critical for Matroska muxer which changes the stream
+    /// timebase after `write_header()` (e.g. from `1/48000` to `1/1000`).
+    ///
+    /// `output_path` enables the watchdog to check actual file size on disk
+    /// as a secondary progress signal alongside `pb->pos`.
+    ///
+    /// Primary path for audio-only normalization to avoid interleave queue ENOMEM.
+    pub(crate) fn drain_encoder_packets_direct(
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
+        output_path: Option<&Path>,
+    ) -> Result<()> {
+        let ost_time_base = octx
+            .stream(ost_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!("output stream {ost_index} not found"))
+            })?
+            .time_base();
+        let mut packet = ffmpeg_the_third::Packet::empty();
+        while encoder.receive_packet(&mut packet).is_ok() {
+            packet.set_stream(ost_index);
+            packet.set_position(-1);
+
+            if timing.use_sample_clock {
+                // Sample-clock: synthesize timestamps from cumulative sample count
+                let dur_samples = i64::from(timing.encoder_frame_size).max(1);
+                let sr_tb = ffmpeg_the_third::ffi::AVRational {
+                    num: 1,
+                    den: timing.sample_rate as i32,
+                };
+                let ost_tb = ffmpeg_the_third::ffi::AVRational {
+                    num: ost_time_base.numerator(),
+                    den: ost_time_base.denominator(),
+                };
+                let dts = unsafe { ffmpeg_the_third::ffi::av_rescale_q(timing.samples_written, sr_tb, ost_tb) };
+                let dur_tb = unsafe { ffmpeg_the_third::ffi::av_rescale_q(dur_samples, sr_tb, ost_tb) }.max(1);
+
+                packet.set_dts(Some(dts));
+                packet.set_pts(Some(dts));
+                packet.set_duration(dur_tb);
+                timing.samples_written += dur_samples;
+
+                // Safety net: run through fix_audio_timestamps (should be no-op)
+                let (new_dts, new_pts, new_dur, updated) =
+                    fix_audio_timestamps(packet.dts(), packet.pts(), packet.duration(), timing);
+                packet.set_dts(new_dts);
+                packet.set_pts(new_pts);
+                packet.set_duration(new_dur);
+                timing.last_dts = updated;
+                timing.last_duration = new_dur;
+            } else {
+                // Legacy path: use encoder timestamps + rescale
+                packet.rescale_ts(enc_time_base, ost_time_base);
+
+                if timing.pkt_count == 0 {
+                    debug!(
+                        "First encoded packet (direct): pts={:?}, dts={:?}, size={}, dur={}, enc_tb={}/{}, ost_tb={}/{}, exp_dur={}",
+                        packet.pts(),
+                        packet.dts(),
+                        packet.size(),
+                        packet.duration(),
+                        enc_time_base.numerator(),
+                        enc_time_base.denominator(),
+                        ost_time_base.numerator(),
+                        ost_time_base.denominator(),
+                        timing.expected_duration,
+                    );
+                }
+
+                let (new_dts, new_pts, new_dur, updated) = fix_audio_timestamps(
+                    packet.dts(),
+                    packet.pts(),
+                    packet.duration(),
+                    timing,
+                );
+                if new_dts != packet.dts() || new_dur != packet.duration() {
+                    debug!(
+                        "Timestamp fix: pkt#{} dts={:?}->{new_dts:?}, pts={:?}->{new_pts:?}, dur={}->{new_dur}",
+                        timing.pkt_count, packet.dts(), packet.pts(), packet.duration(),
+                    );
+                }
+                packet.set_dts(new_dts);
+                packet.set_pts(new_pts);
+                packet.set_duration(new_dur);
+                timing.last_dts = updated;
+                timing.last_duration = new_dur;
+            }
+
+            // Diagnostic logging for first 5 packets (sample-clock path)
+            if timing.pkt_count < 5 {
+                let pb_pos = unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() { (*pb).pos } else { 0 }
+                };
+                let file_sz = output_path
+                    .and_then(|p| std::fs::metadata(p).ok())
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                info!(
+                    "[audio_only_mux] pkt#{}: dts={:?}, pts={:?}, dur={}, \
+                     samples_written={}, sr={}, ost_tb={}/{}, pb_pos={}, file={}B",
+                    timing.pkt_count,
+                    packet.dts(),
+                    packet.pts(),
+                    packet.duration(),
+                    timing.samples_written,
+                    timing.sample_rate,
+                    ost_time_base.numerator(),
+                    ost_time_base.denominator(),
+                    pb_pos,
+                    file_sz,
+                );
+            }
+
+            // Capture packet metadata before write (av_write_frame may unref)
+            let pts = packet.pts();
+            let dts = packet.dts();
+            let size = packet.size() as i32;
+            let dur = packet.duration();
+
+            // Direct FFI call using av_write_frame (non-interleaved) to bypass
+            // the muxer's interleave queue. For single-stream audio output,
+            // interleaving is unnecessary and the queue can grow unbounded.
+            // SAFETY: octx and packet are valid; av_write_frame writes the
+            // packet directly without buffering in an interleave queue.
+            let ret = unsafe {
+                ffmpeg_the_third::ffi::av_write_frame(octx.as_mut_ptr(), packet.as_ptr() as *mut _)
+            };
+            // Unref immediately: frees encoded data before next receive_packet.
+            // av_write_frame unrefs on success in FFmpeg 8.0, but NOT on failure.
+            // Explicit unref is idempotent and matches merge.rs / remux.rs /
+            // thumbnail.rs patterns.
+            packet_unref(&mut packet);
+            if ret < 0 {
+                if ret == -12 {
+                    warn!(
+                        "FFmpeg allocation failure (ENOMEM) during mux write — \
+                         likely packet/frame leak or extreme memory pressure (rss={}KB)",
+                        get_process_rss_kb(),
+                    );
+                }
+                let strerr = av_strerror_string(ret);
+                // SAFETY: octx owns a valid format context
+                let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                return Err(PostProcessError::MuxWriteError {
+                    message: format!("ret={ret} ({strerr}), dur={dur}, {io_diag}"),
+                    operation: "av_write_frame".into(),
+                    stream_index: ost_index,
+                    pts,
+                    dts,
+                    packet_size: size,
+                    time_base_num: ost_time_base.numerator(),
+                    time_base_den: ost_time_base.denominator(),
+                });
+            }
+            timing.pkt_count += 1;
+
+            // Mux-pressure instrumentation: log progress every 10,000 packets
+            if timing.pkt_count % 10_000 == 0 {
+                let pb_pos = unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() { (*pb).pos } else { 0 }
+                };
+                let file_sz = output_path
+                    .and_then(|p| std::fs::metadata(p).ok())
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                let rss_kb = get_process_rss_kb();
+                info!(
+                    "[mux progress] pkt={}, dts={:?}, dur={}, samples={}, pos={}, file={}KB, rss={}KB",
+                    timing.pkt_count, dts, dur,
+                    timing.samples_written, pb_pos, file_sz / 1024, rss_kb,
+                );
+            }
+
+            // Mux progress watchdog: every 256 packets, flush AVIO so pb->pos
+            // reflects actual writes, then check both pos and file size.
+            // If neither advances for 3 consecutive checks (768 packets), the
+            // muxer is stuck. Abort with a retryable error so salvage/CLI
+            // fallback can recover.
+            if timing.pkt_count % 256 == 0 {
+                // Flush AVIO buffer so pb->pos reflects actual write progress
+                unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() {
+                        ffmpeg_the_third::ffi::avio_flush(pb);
+                    }
+                }
+
+                let current_pos = unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() { (*pb).pos } else { 0 }
+                };
+
+                let file_size = output_path
+                    .and_then(|p| std::fs::metadata(p).ok())
+                    .map(|m| m.len() as i64)
+                    .unwrap_or(-1);
+
+                let progressing = current_pos > timing.last_pos_check
+                    || (file_size > 0 && file_size > timing.last_file_size);
+
+                if progressing {
+                    timing.last_pos_check = current_pos;
+                    if file_size > 0 {
+                        timing.last_file_size = file_size;
+                    }
+                    timing.stall_count = 0;
+                } else {
+                    timing.stall_count += 1;
+                    if timing.stall_count >= 3 {
+                        // Full IO dump before returning error
+                        if let Some(path) = output_path {
+                            unsafe {
+                                super::normalize::dump_io_state(
+                                    octx.as_mut_ptr(),
+                                    path,
+                                    "watchdog_stall",
+                                );
+                            }
+                        }
+                        let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                        return Err(PostProcessError::MuxWriteError {
+                            message: format!(
+                                "mux stall detected: pb->pos={current_pos}, file_size={file_size} unchanged for {} packets, {io_diag}",
+                                timing.stall_count * 256
+                            ),
+                            operation: "av_write_frame (watchdog)".into(),
+                            stream_index: ost_index,
+                            pts,
+                            dts,
+                            packet_size: size,
+                            time_base_num: ost_time_base.numerator(),
+                            time_base_den: ost_time_base.denominator(),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Receive decoded frames from decoder, push through filter, encode, and write.
+    ///
+    /// Uses interleaved writes with `AVFMT_FLAG_FLUSH_PACKETS`.
+    /// Kept as fallback; direct-write path is now primary for normalization.
+    #[allow(dead_code, clippy::too_many_arguments)]
+    pub(crate) fn receive_and_process_audio_interleaved(
+        decoder: &mut ffmpeg_the_third::decoder::Audio,
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
+        output_path: Option<&Path>,
+    ) -> Result<()> {
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        while decoder.receive_frame(&mut frame).is_ok() {
+            filter
+                .get("in")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
+                .source()
+                .add(&frame)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("av_buffersrc_add_frame failed: {e}"),
+                })?;
+            frame_unref_audio(&mut frame);
+            Self::drain_filter_to_encoder_interleaved(
+                filter,
+                encoder,
+                octx,
+                ost_index,
+                enc_time_base,
+                timing,
+                output_path,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Pull filtered frames from filter graph, encode, and write (interleaved).
+    /// Kept as fallback; direct-write path is now primary for normalization.
+    #[allow(dead_code)]
+    pub(crate) fn drain_filter_to_encoder_interleaved(
+        filter: &mut ffmpeg_the_third::filter::Graph,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
+        output_path: Option<&Path>,
+    ) -> Result<()> {
+        let mut filtered = ffmpeg_the_third::frame::Audio::empty();
+        loop {
+            let mut out_node = filter
+                .get("out")
+                .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'out' not found"))?;
+            if out_node.sink().frame(&mut filtered).is_err() {
+                break;
+            }
+            encoder
+                .send_frame(&filtered)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("avcodec_send_frame failed: {e}"),
+                })?;
+            frame_unref_audio(&mut filtered);
+            Self::drain_encoder_packets_interleaved(encoder, octx, ost_index, enc_time_base, timing, output_path)?;
+        }
+        Ok(())
+    }
+
+    /// Receive encoded packets from encoder and write to output (interleaved).
+    ///
+    /// Mirrors `drain_encoder_packets_direct` but uses `av_interleaved_write_frame`.
+    /// Kept as fallback; direct-write path with sample-clock is now primary
+    /// for normalization to avoid interleave queue ENOMEM.
+    #[allow(dead_code)]
+    pub(crate) fn drain_encoder_packets_interleaved(
+        encoder: &mut ffmpeg_the_third::encoder::audio::Audio,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        ost_index: usize,
+        enc_time_base: ffmpeg_the_third::Rational,
+        timing: &mut MuxTimingState,
+        output_path: Option<&Path>,
+    ) -> Result<()> {
+        let ost_time_base = octx
+            .stream(ost_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!("output stream {ost_index} not found"))
+            })?
+            .time_base();
+        let mut packet = ffmpeg_the_third::Packet::empty();
+        while encoder.receive_packet(&mut packet).is_ok() {
+            packet.set_stream(ost_index);
+            packet.rescale_ts(enc_time_base, ost_time_base);
+            packet.set_position(-1);
+
+            if timing.pkt_count == 0 {
+                debug!(
+                    "First encoded packet (interleaved): pts={:?}, dts={:?}, size={}, dur={}, enc_tb={}/{}, ost_tb={}/{}, exp_dur={}",
+                    packet.pts(),
+                    packet.dts(),
+                    packet.size(),
+                    packet.duration(),
+                    enc_time_base.numerator(),
+                    enc_time_base.denominator(),
+                    ost_time_base.numerator(),
+                    ost_time_base.denominator(),
+                    timing.expected_duration,
+                );
+            }
+
+            // Unified timestamp + duration fix
+            let (new_dts, new_pts, new_dur, updated) = fix_audio_timestamps(
+                packet.dts(),
+                packet.pts(),
+                packet.duration(),
+                timing,
+            );
+            if new_dts != packet.dts() || new_dur != packet.duration() {
+                debug!(
+                    "Timestamp fix: pkt#{} dts={:?}->{new_dts:?}, pts={:?}->{new_pts:?}, dur={}->{new_dur}",
+                    timing.pkt_count, packet.dts(), packet.pts(), packet.duration(),
+                );
+            }
+            packet.set_dts(new_dts);
+            packet.set_pts(new_pts);
+            packet.set_duration(new_dur);
+            timing.last_dts = updated;
+            timing.last_duration = new_dur;
+
+            // Capture packet metadata before write
+            let pts = packet.pts();
+            let dts = packet.dts();
+            let size = packet.size() as i32;
+            let dur = packet.duration();
+
+            let ret = unsafe {
+                ffmpeg_the_third::ffi::av_interleaved_write_frame(
+                    octx.as_mut_ptr(),
+                    packet.as_ptr() as *mut _,
+                )
+            };
+            // Unref immediately: frees encoded data before next receive_packet.
+            // av_interleaved_write_frame unrefs on success in FFmpeg 8.0, but NOT
+            // on failure. Explicit unref is idempotent and matches
+            // merge.rs / remux.rs / thumbnail.rs patterns.
+            packet_unref(&mut packet);
+            if ret < 0 {
+                if ret == -12 {
+                    warn!(
+                        "FFmpeg allocation failure (ENOMEM) during mux write — \
+                         likely packet/frame leak or extreme memory pressure (rss={}KB)",
+                        get_process_rss_kb(),
+                    );
+                }
+                let strerr = av_strerror_string(ret);
+                let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                return Err(PostProcessError::MuxWriteError {
+                    message: format!("ret={ret} ({strerr}), dur={dur}, {io_diag}"),
+                    operation: "av_interleaved_write_frame (normalize)".into(),
+                    stream_index: ost_index,
+                    pts,
+                    dts,
+                    packet_size: size,
+                    time_base_num: ost_time_base.numerator(),
+                    time_base_den: ost_time_base.denominator(),
+                });
+            }
+            timing.pkt_count += 1;
+
+            // Mux-pressure instrumentation: log progress every 10,000 packets
+            if timing.pkt_count % 10_000 == 0 {
+                let current_pos_for_log = unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() { (*pb).pos } else { 0 }
+                };
+                let file_size = output_path
+                    .and_then(|p| std::fs::metadata(p).ok())
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                let rss_kb = get_process_rss_kb();
+                info!(
+                    "[mux progress] pkt={}, dts={:?}, dur={}, pos={}, file={}KB, rss={}KB, exp_dur={}",
+                    timing.pkt_count, dts, dur, current_pos_for_log, file_size / 1024,
+                    rss_kb, timing.expected_duration,
+                );
+            }
+
+            // Mux progress watchdog: flush AVIO then check pos + file size
+            if timing.pkt_count % 256 == 0 {
+                unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() {
+                        ffmpeg_the_third::ffi::avio_flush(pb);
+                    }
+                }
+
+                let current_pos = unsafe {
+                    let pb = (*octx.as_mut_ptr()).pb;
+                    if !pb.is_null() { (*pb).pos } else { 0 }
+                };
+
+                let file_size = output_path
+                    .and_then(|p| std::fs::metadata(p).ok())
+                    .map(|m| m.len() as i64)
+                    .unwrap_or(-1);
+
+                let progressing = current_pos > timing.last_pos_check
+                    || (file_size > 0 && file_size > timing.last_file_size);
+
+                if progressing {
+                    timing.last_pos_check = current_pos;
+                    if file_size > 0 {
+                        timing.last_file_size = file_size;
+                    }
+                    timing.stall_count = 0;
+                } else {
+                    timing.stall_count += 1;
+                    if timing.stall_count >= 3 {
+                        if let Some(path) = output_path {
+                            unsafe {
+                                super::normalize::dump_io_state(
+                                    octx.as_mut_ptr(),
+                                    path,
+                                    "watchdog_stall_interleaved",
+                                );
+                            }
+                        }
+                        let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                        return Err(PostProcessError::MuxWriteError {
+                            message: format!(
+                                "mux stall detected: pb->pos={current_pos}, file_size={file_size} unchanged for {} packets, {io_diag}",
+                                timing.stall_count * 256
+                            ),
+                            operation: "av_interleaved_write_frame (watchdog)".into(),
+                            stream_index: ost_index,
+                            pts,
+                            dts,
+                            packet_size: size,
+                            time_base_num: ost_time_base.numerator(),
+                            time_base_den: ost_time_base.denominator(),
+                        });
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -462,6 +1255,9 @@ impl FFmpegRunner {
     /// Uses `opts.remux_only` to determine whether to stream-copy or transcode.
     /// For transcoding, encodes video with the specified codec while optionally
     /// copying the audio stream unchanged.
+    ///
+    /// Automatically detects and salvages corrupt Matroska/WebM containers
+    /// before conversion to prevent EBML-induced muxer failures.
     pub async fn convert_video(
         &self,
         input: impl AsRef<Path>,
@@ -472,7 +1268,15 @@ impl FFmpegRunner {
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
         Self::spawn_blocking("convert_video", move || {
-            Self::convert_video_sync(&input, &output, &opts)
+            let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, true)?;
+
+            let result = Self::convert_video_sync(&effective_input, &output, &opts);
+
+            if let Some(ref temp) = salvage_temp {
+                let _ = std::fs::remove_file(temp);
+            }
+
+            result
         })
         .await
     }
@@ -772,6 +1576,9 @@ impl FFmpegRunner {
         video_encoder.send_eof()?;
         Self::drain_video_encoder_packets(&mut video_encoder, &mut octx, video_ost_index)?;
 
+        // Flush interleave queue before trailer
+        flush_interleave_queue(&mut octx);
+
         octx.write_trailer()
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to write output trailer: {e}"),
@@ -873,11 +1680,7 @@ impl FFmpegRunner {
 
         let format_spec = format!("format=pix_fmts={enc_pix_fmt_name}");
 
-        graph
-            .output("out", 0)?
-            .input("in", 0)?
-            .parse(&format_spec)?;
-        graph.validate()?;
+        Self::parse_and_validate_filter_graph(&mut graph, "in", "out", &format_spec)?;
 
         Ok(graph)
     }
@@ -897,6 +1700,7 @@ impl FFmpegRunner {
                 .ok_or_else(|| PostProcessError::ffmpeg_failed("video filter node 'in' not found"))?
                 .source()
                 .add(&frame)?;
+            frame_unref_video(&mut frame);
             Self::drain_video_filter_to_encoder(filter, encoder, octx, ost_index)?;
         }
         Ok(())
@@ -918,6 +1722,7 @@ impl FFmpegRunner {
                 break;
             }
             encoder.send_frame(&filtered)?;
+            frame_unref_video(&mut filtered);
             Self::drain_video_encoder_packets(encoder, octx, ost_index)?;
         }
         Ok(())
@@ -929,11 +1734,645 @@ impl FFmpegRunner {
         octx: &mut ffmpeg_the_third::format::context::Output,
         ost_index: usize,
     ) -> Result<()> {
+        let ost_time_base = octx
+            .stream(ost_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!("output stream {ost_index} not found"))
+            })?
+            .time_base();
         let mut packet = ffmpeg_the_third::Packet::empty();
         while encoder.receive_packet(&mut packet).is_ok() {
             packet.set_stream(ost_index);
-            packet.write_interleaved(octx)?;
+
+            // Capture packet metadata before write
+            let pts = packet.pts();
+            let dts = packet.dts();
+            let size = packet.size() as i32;
+
+            // Direct FFI call to capture raw return code
+            // SAFETY: octx and packet are valid; av_interleaved_write_frame takes
+            // ownership of the packet buffer and unrefs it on success.
+            let ret = unsafe {
+                ffmpeg_the_third::ffi::av_interleaved_write_frame(
+                    octx.as_mut_ptr(),
+                    packet.as_ptr() as *mut _,
+                )
+            };
+            // Unref immediately: frees encoded data before next receive_packet.
+            // av_interleaved_write_frame unrefs on success in FFmpeg 8.0, but NOT
+            // on failure. Explicit unref is idempotent and matches
+            // merge.rs / remux.rs / thumbnail.rs patterns.
+            packet_unref(&mut packet);
+            if ret < 0 {
+                if ret == -12 {
+                    warn!(
+                        "FFmpeg allocation failure (ENOMEM) during video mux write — \
+                         likely packet/frame leak or extreme memory pressure (rss={}KB)",
+                        get_process_rss_kb(),
+                    );
+                }
+                let strerr = av_strerror_string(ret);
+                let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
+                return Err(PostProcessError::MuxWriteError {
+                    message: format!("ret={ret} ({strerr}), {io_diag}"),
+                    operation: "av_interleaved_write_frame (video)".into(),
+                    stream_index: ost_index,
+                    pts,
+                    dts,
+                    packet_size: size,
+                    time_base_num: ost_time_base.numerator(),
+                    time_base_den: ost_time_base.denominator(),
+                });
+            }
         }
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/// Persistent muxing state for monotonic DTS enforcement across drain calls.
+///
+/// Created once per encode session and threaded through all pipeline functions
+/// so that DTS monotonicity is enforced across call boundaries, not just within
+/// a single drain call.
+#[derive(Default, Debug)]
+pub(crate) struct MuxTimingState {
+    /// Last DTS written to the muxer (in output stream timebase).
+    pub last_dts: Option<i64>,
+    /// Duration of the last packet written (output stream timebase).
+    /// Used for duration-aware DTS correction to maintain proper packet spacing.
+    pub last_duration: i64,
+    /// Precomputed expected packet duration in output stream timebase.
+    /// Derived from `encoder_frame_size` rescaled from encoder timebase to
+    /// output stream timebase. Used as the primary step size when correcting
+    /// DTS regressions, ensuring the Matroska muxer's cluster boundaries
+    /// trigger correctly (preventing unbounded cache growth / ENOMEM).
+    pub expected_duration: i64,
+    /// Total packets written in this encode session.
+    pub pkt_count: u64,
+    /// Encoder frame size in samples. Used for sample-clock DTS synthesis
+    /// (`dur_samples = encoder_frame_size`) and retained for diagnostics.
+    pub encoder_frame_size: u32,
+    /// `pb->pos` at last watchdog check (mux progress tracking).
+    pub last_pos_check: i64,
+    /// Consecutive watchdog checks without `pb->pos` advancement.
+    /// When this reaches the stall threshold, the encode is aborted
+    /// with a retryable `MuxWriteError`.
+    pub stall_count: u32,
+    /// File size on disk at last watchdog check (secondary progress signal).
+    pub last_file_size: i64,
+    /// Cumulative samples written. Primary clock for audio-only outputs.
+    /// DTS = rescale_q(samples_written, 1/sample_rate, ost_tb).
+    pub samples_written: i64,
+    /// Audio sample rate (Hz). Set once during init.
+    pub sample_rate: u32,
+    /// When true, synthesize DTS/PTS from `samples_written`
+    /// instead of using encoder-produced timestamps.
+    pub use_sample_clock: bool,
+}
+
+/// Fix audio packet timestamps for muxer compatibility.
+///
+/// Ensures:
+/// 1. Duration is set (uses `expected_duration` if packet duration is 0/negative)
+/// 2. DTS is strictly increasing with proper packet spacing
+/// 3. PTS >= DTS (muxer invariant)
+///
+/// When correcting DTS regressions, steps by `expected_duration` (not 1) to
+/// maintain correct packet spacing. This prevents the Matroska muxer from
+/// accumulating an unbounded cluster cache due to artificially dense timestamps.
+///
+/// Returns `(corrected_dts, corrected_pts, duration, updated_last_dts)`.
+fn fix_audio_timestamps(
+    dts: Option<i64>,
+    pts: Option<i64>,
+    duration: i64,
+    timing: &MuxTimingState,
+) -> (Option<i64>, Option<i64>, i64, Option<i64>) {
+    // 1. Fix duration first
+    let dur = if duration > 0 {
+        duration
+    } else if timing.expected_duration > 0 {
+        timing.expected_duration
+    } else {
+        timing.last_duration.max(1)
+    };
+
+    // 2. Fix DTS
+    let Some(d) = dts else {
+        return (dts, pts, dur, timing.last_dts);
+    };
+
+    if let Some(prev) = timing.last_dts {
+        if d <= prev {
+            let step = if timing.expected_duration > 0 {
+                timing.expected_duration
+            } else {
+                dur.max(1)
+            };
+            let corrected = prev + step;
+            let p = pts.map(|p| p.max(corrected)).or(Some(corrected));
+            return (Some(corrected), p, dur, Some(corrected));
+        }
+    }
+
+    // 3. Ensure pts >= dts even without correction (pts must be Some when dts is Some)
+    let p = pts.map(|p| p.max(d)).or(Some(d));
+    (Some(d), p, dur, Some(d))
+}
+
+/// Convert an FFmpeg error code to a human-readable string via `av_strerror`.
+fn av_strerror_string(errnum: i32) -> String {
+    let mut buf = [0u8; 256];
+    // SAFETY: buf is a stack-allocated array with known size; av_strerror
+    // writes at most errbuf_size bytes including the NUL terminator.
+    unsafe {
+        ffmpeg_the_third::ffi::av_strerror(errnum, buf.as_mut_ptr() as *mut _, buf.len());
+    }
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..end]).into_owned()
+}
+
+/// Flush the muxer's interleave queue before writing the trailer.
+///
+/// Sends a NULL packet to `av_interleaved_write_frame` which signals
+/// the muxer to flush any buffered packets in the interleave queue.
+/// Only needed for the interleaved write path; the direct `av_write_frame`
+/// path bypasses the queue entirely.
+pub(crate) fn flush_interleave_queue(octx: &mut ffmpeg_the_third::format::context::Output) {
+    // SAFETY: octx is a valid output format context; passing a null packet
+    // signals the muxer to flush its internal interleave queue.
+    let ret = unsafe {
+        ffmpeg_the_third::ffi::av_interleaved_write_frame(octx.as_mut_ptr(), std::ptr::null_mut())
+    };
+    if ret < 0 {
+        let strerr = av_strerror_string(ret);
+        warn!("Interleave queue flush returned {ret} ({strerr})");
+    }
+}
+
+/// Diagnose the I/O context of an output format context at a write failure.
+///
+/// # Safety
+///
+/// `octx_ptr` must point to a valid `AVFormatContext`.
+unsafe fn diagnose_mux_io(octx_ptr: *mut ffmpeg_the_third::ffi::AVFormatContext) -> String {
+    // SAFETY: caller guarantees octx_ptr is valid; all field reads are from
+    // FFmpeg-allocated structs whose layout is defined by the C ABI.
+    unsafe {
+        let pb = (*octx_ptr).pb;
+        if pb.is_null() {
+            return "pb=NULL".to_string();
+        }
+        let error = (*pb).error;
+        let write_flag = (*pb).write_flag;
+        let has_write_cb = (*pb).write_packet.is_some();
+        let pos = (*pb).pos;
+        let eof = (*pb).eof_reached;
+        format!(
+            "pb={{write_flag={write_flag}, error={error}, pos={pos}, eof_reached={eof}, write_cb={}}}",
+            if has_write_cb { "present" } else { "NULL" }
+        )
+    }
+}
+
+/// Get current process RSS in KB. Returns 0 if unavailable.
+fn get_process_rss_kb() -> u64 {
+    #[cfg(target_os = "windows")]
+    {
+        use std::mem;
+
+        #[repr(C)]
+        struct ProcessMemoryCounters {
+            cb: u32,
+            page_fault_count: u32,
+            peak_working_set_size: usize,
+            working_set_size: usize,
+            quota_peak_paged_pool_usage: usize,
+            quota_paged_pool_usage: usize,
+            quota_peak_non_paged_pool_usage: usize,
+            quota_non_paged_pool_usage: usize,
+            pagefile_usage: usize,
+            peak_pagefile_usage: usize,
+        }
+
+        unsafe extern "system" {
+            fn K32GetProcessMemoryInfo(
+                process: *mut std::ffi::c_void,
+                ppsmemcounters: *mut ProcessMemoryCounters,
+                cb: u32,
+            ) -> i32;
+            fn GetCurrentProcess() -> *mut std::ffi::c_void;
+        }
+
+        unsafe {
+            let mut pmc: ProcessMemoryCounters = mem::zeroed();
+            pmc.cb = mem::size_of::<ProcessMemoryCounters>() as u32;
+            if K32GetProcessMemoryInfo(GetCurrentProcess(), &mut pmc, pmc.cb) != 0 {
+                return (pmc.working_set_size / 1024) as u64;
+            }
+        }
+        0
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/self/status")
+            .ok()
+            .and_then(|s| {
+                s.lines()
+                    .find(|l| l.starts_with("VmRSS:"))
+                    .and_then(|l| l.split_whitespace().nth(1))
+                    .and_then(|v| v.parse().ok())
+            })
+            .unwrap_or(0)
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fix_audio_timestamps_normal() {
+        // Increasing sequence passes through unchanged
+        let timing = MuxTimingState::default();
+        let (d, p, dur, last) = fix_audio_timestamps(Some(10), Some(10), 21, &timing);
+        assert_eq!(d, Some(10));
+        assert_eq!(p, Some(10));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(10));
+
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            last_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(20), Some(20), 21, &timing);
+        assert_eq!(d, Some(20));
+        assert_eq!(p, Some(20));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(20));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_duplicate() {
+        // Same DTS clamped to prev + expected_duration (or dur.max(1) if no expected)
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(10), Some(10), 21, &timing);
+        assert_eq!(d, Some(31)); // 10 + dur=21
+        assert_eq!(p, Some(31));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(31));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_regression() {
+        // Backwards DTS clamped to prev + expected_duration
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(5), Some(5), 21, &timing);
+        assert_eq!(d, Some(31)); // 10 + 21
+        assert_eq!(p, Some(31));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(31));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_pts_correction() {
+        // PTS < corrected DTS gets bumped
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(10), Some(8), 21, &timing);
+        assert_eq!(d, Some(31));
+        assert_eq!(p, Some(31)); // PTS bumped from 8 to 31
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(31));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_none() {
+        // None DTS passes through, last_dts unchanged
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(None, Some(42), 21, &timing);
+        assert_eq!(d, None);
+        assert_eq!(p, Some(42));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(10));
+
+        let timing = MuxTimingState::default();
+        let (d, p, dur, last) = fix_audio_timestamps(None, None, 21, &timing);
+        assert_eq!(d, None);
+        assert_eq!(p, None);
+        assert_eq!(dur, 21);
+        assert_eq!(last, None);
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_pts_ge_dts_no_correction() {
+        // Even without DTS correction, ensure pts >= dts
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(20), Some(15), 21, &timing);
+        assert_eq!(d, Some(20));
+        assert_eq!(p, Some(20)); // PTS bumped from 15 to 20
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(20));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_cross_call_persistence() {
+        // Simulates the cross-call scenario: call 1 ends with last_dts=100,
+        // call 2 starts with dts=100 → must correct.
+        let timing = MuxTimingState {
+            last_dts: Some(100),
+            expected_duration: 21,
+            pkt_count: 50,
+            ..Default::default()
+        };
+        let (d, p, dur, updated) = fix_audio_timestamps(Some(100), Some(100), 21, &timing);
+        assert_eq!(d, Some(121)); // 100 + 21
+        assert_eq!(p, Some(121));
+        assert_eq!(dur, 21);
+        assert_eq!(updated, Some(121));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_pts_none_gets_set() {
+        // dts=Some(50), pts=None → pts=Some(50)
+        let timing = MuxTimingState::default();
+        let (d, p, dur, last) = fix_audio_timestamps(Some(50), None, 21, &timing);
+        assert_eq!(d, Some(50));
+        assert_eq!(p, Some(50));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(50));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_pts_none_with_correction() {
+        // dts=Some(5), pts=None, last_dts=Some(10) → corrected
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(5), None, 21, &timing);
+        assert_eq!(d, Some(31)); // 10 + 21
+        assert_eq!(p, Some(31));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(31));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_expected_duration_step() {
+        // AAC at 48kHz in 1/1000 tb: expected_duration=21
+        let timing = MuxTimingState {
+            last_dts: Some(105),
+            last_duration: 21,
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(100), Some(100), 21, &timing);
+        assert_eq!(d, Some(126)); // 105 + 21
+        assert_eq!(p, Some(126));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(126));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_zero_duration_fixed() {
+        // Zero duration gets fixed from expected_duration
+        let timing = MuxTimingState {
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(0), Some(0), 0, &timing);
+        assert_eq!(d, Some(0));
+        assert_eq!(p, Some(0));
+        assert_eq!(dur, 21); // Fixed from 0 to expected
+        assert_eq!(last, Some(0));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_normal_progression() {
+        // Normal progression with expected_duration: no correction needed
+        let timing = MuxTimingState {
+            last_dts: Some(21),
+            last_duration: 21,
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(42), Some(42), 21, &timing);
+        assert_eq!(d, Some(42)); // No correction needed
+        assert_eq!(p, Some(42));
+        assert_eq!(dur, 21);
+        assert_eq!(last, Some(42));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_zero_duration_no_expected() {
+        // Zero duration, no expected_duration → fallback to last_duration or 1
+        let timing = MuxTimingState {
+            last_dts: Some(10),
+            last_duration: 0,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(10), Some(10), 0, &timing);
+        // duration fixed to max(last_duration=0, 1) = 1
+        assert_eq!(dur, 1);
+        // DTS corrected: 10 + dur.max(1)=1 = 11 (no expected_duration)
+        assert_eq!(d, Some(11));
+        assert_eq!(p, Some(11));
+        assert_eq!(last, Some(11));
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_negative_duration_fallback() {
+        // Negative duration → fixed via expected_duration
+        let timing = MuxTimingState {
+            expected_duration: 21,
+            ..Default::default()
+        };
+        let (d, p, dur, last) = fix_audio_timestamps(Some(10), Some(10), -5, &timing);
+        assert_eq!(dur, 21); // Fixed from -5 to expected=21
+        assert_eq!(d, Some(10));
+        assert_eq!(p, Some(10));
+        assert_eq!(last, Some(10));
+    }
+
+    #[test]
+    fn test_mux_timing_state_default() {
+        let timing = MuxTimingState::default();
+        assert_eq!(timing.last_dts, None);
+        assert_eq!(timing.last_duration, 0);
+        assert_eq!(timing.expected_duration, 0);
+        assert_eq!(timing.pkt_count, 0);
+        assert_eq!(timing.encoder_frame_size, 0);
+        assert_eq!(timing.last_pos_check, 0);
+        assert_eq!(timing.stall_count, 0);
+        assert_eq!(timing.last_file_size, 0);
+        assert_eq!(timing.samples_written, 0);
+        assert_eq!(timing.sample_rate, 0);
+        assert!(!timing.use_sample_clock);
+    }
+
+    #[test]
+    fn test_mux_timing_state_stall_tracking() {
+        let mut timing = MuxTimingState::default();
+
+        // Simulate pos advancing — stall_count resets
+        timing.last_pos_check = 1000;
+        timing.stall_count = 2;
+        // pos advanced
+        let new_pos: i64 = 2000;
+        if new_pos > timing.last_pos_check {
+            timing.last_pos_check = new_pos;
+            timing.stall_count = 0;
+        }
+        assert_eq!(timing.last_pos_check, 2000);
+        assert_eq!(timing.stall_count, 0);
+
+        // Simulate pos NOT advancing — stall_count increments
+        let same_pos: i64 = 2000;
+        if same_pos > timing.last_pos_check {
+            timing.last_pos_check = same_pos;
+            timing.stall_count = 0;
+        } else {
+            timing.stall_count += 1;
+        }
+        assert_eq!(timing.stall_count, 1);
+
+        // Two more stalls reach threshold
+        timing.stall_count += 1;
+        timing.stall_count += 1;
+        assert_eq!(timing.stall_count, 3);
+        assert!(timing.stall_count >= 3, "stall threshold reached");
+    }
+
+    #[test]
+    fn test_fix_audio_timestamps_with_sample_clock_noop() {
+        // When timestamps are already monotonic from sample-clock,
+        // fix_audio_timestamps should pass them through unchanged.
+        let mut timing = MuxTimingState {
+            expected_duration: 21,
+            use_sample_clock: true,
+            sample_rate: 48000,
+            encoder_frame_size: 1024,
+            ..Default::default()
+        };
+
+        // Simulate 3 packets with perfectly monotonic timestamps
+        for i in 0..3 {
+            let dts = i * 21;
+            let (d, p, dur, last) = fix_audio_timestamps(Some(dts), Some(dts), 21, &timing);
+            assert_eq!(d, Some(dts), "pkt {i}: dts passthrough");
+            assert_eq!(p, Some(dts), "pkt {i}: pts passthrough");
+            assert_eq!(dur, 21, "pkt {i}: dur passthrough");
+            assert_eq!(last, Some(dts), "pkt {i}: last_dts updated");
+            timing.last_dts = last;
+            timing.last_duration = dur;
+        }
+    }
+
+    /// Helper: compute expected DTS/duration for sample-clock synthesis
+    /// using `av_rescale_q(samples, 1/sample_rate, ost_tb)`.
+    fn sample_clock_rescale(samples: i64, sample_rate: i32, ost_tb_num: i32, ost_tb_den: i32) -> i64 {
+        // av_rescale_q(a, bq, cq) = a * bq.num * cq.den / (bq.den * cq.num)
+        // bq = {1, sample_rate}, cq = {ost_tb_num, ost_tb_den}
+        // = samples * 1 * ost_tb_den / (sample_rate * ost_tb_num)
+        let num = samples as i128 * ost_tb_den as i128;
+        let den = sample_rate as i128 * ost_tb_num as i128;
+        // Round to nearest (matching av_rescale_q behavior)
+        ((num + den / 2) / den) as i64
+    }
+
+    #[test]
+    fn test_sample_clock_aac_48000() {
+        // AAC: 1024 samples at 48000 Hz, ost_tb=1/1000
+        let sr = 48000;
+        let frame = 1024i64;
+
+        let dur = sample_clock_rescale(frame, sr, 1, 1000);
+        assert_eq!(dur, 21, "AAC 48kHz dur in 1/1000 tb");
+
+        let dts0 = sample_clock_rescale(0, sr, 1, 1000);
+        assert_eq!(dts0, 0);
+        let dts1 = sample_clock_rescale(frame, sr, 1, 1000);
+        assert_eq!(dts1, 21);
+        let dts2 = sample_clock_rescale(frame * 2, sr, 1, 1000);
+        assert_eq!(dts2, 43); // 2048/48000*1000 = 42.666... → 43
+        let dts3 = sample_clock_rescale(frame * 3, sr, 1, 1000);
+        assert_eq!(dts3, 64); // 3072/48000*1000 = 64.0
+
+        // Monotonic
+        assert!(dts1 > dts0);
+        assert!(dts2 > dts1);
+        assert!(dts3 > dts2);
+    }
+
+    #[test]
+    fn test_sample_clock_opus_48000() {
+        // Opus: 960 samples at 48000 Hz, ost_tb=1/1000
+        let sr = 48000;
+        let frame = 960i64;
+
+        let dur = sample_clock_rescale(frame, sr, 1, 1000);
+        assert_eq!(dur, 20, "Opus 48kHz dur in 1/1000 tb");
+
+        let dts0 = sample_clock_rescale(0, sr, 1, 1000);
+        assert_eq!(dts0, 0);
+        let dts1 = sample_clock_rescale(frame, sr, 1, 1000);
+        assert_eq!(dts1, 20);
+        let dts2 = sample_clock_rescale(frame * 2, sr, 1, 1000);
+        assert_eq!(dts2, 40);
+        let dts3 = sample_clock_rescale(frame * 3, sr, 1, 1000);
+        assert_eq!(dts3, 60);
+
+        assert!(dts1 > dts0);
+        assert!(dts2 > dts1);
+        assert!(dts3 > dts2);
+    }
+
+    #[test]
+    fn test_sample_clock_aac_44100() {
+        // AAC: 1024 samples at 44100 Hz, ost_tb=1/1000
+        let sr = 44100;
+        let frame = 1024i64;
+
+        let dur = sample_clock_rescale(frame, sr, 1, 1000);
+        assert_eq!(dur, 23, "AAC 44100Hz dur in 1/1000 tb"); // 1024/44100*1000 = 23.21... → 23
+
+        let dts0 = sample_clock_rescale(0, sr, 1, 1000);
+        assert_eq!(dts0, 0);
+        let dts1 = sample_clock_rescale(frame, sr, 1, 1000);
+        assert_eq!(dts1, 23);
+        let dts2 = sample_clock_rescale(frame * 2, sr, 1, 1000);
+        assert_eq!(dts2, 46);
+        let dts3 = sample_clock_rescale(frame * 3, sr, 1, 1000);
+        assert_eq!(dts3, 70); // 3072/44100*1000 = 69.65... → 70
+
+        assert!(dts1 > dts0);
+        assert!(dts2 > dts1);
+        assert!(dts3 > dts2);
     }
 }

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -41,6 +41,6 @@ pub mod ffmpeg;
 pub use error::{CorruptionKind, PostProcessError, Result};
 pub use ffmpeg::{
     AudioExtractOptions, AudioNormMode, ChapterEntry, FFmpegRunner, LoudnormMeasurements,
-    MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo, VideoConvertOptions,
-    set_verbose,
+    LoudnormPreset, MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo,
+    VideoConvertOptions, set_verbose,
 };

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -38,8 +38,9 @@ pub mod error;
 pub mod ffmpeg;
 
 // Re-export main types at crate root
-pub use error::{PostProcessError, Result};
+pub use error::{CorruptionKind, PostProcessError, Result};
 pub use ffmpeg::{
-    AudioExtractOptions, ChapterEntry, FFmpegRunner, MediaInfo, RemuxOptions, StreamInfo,
-    VideoConvertOptions, set_verbose,
+    AudioExtractOptions, AudioNormMode, ChapterEntry, FFmpegRunner, LoudnormMeasurements,
+    MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo, VideoConvertOptions,
+    set_verbose,
 };

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -120,16 +120,16 @@ pub mod registry;
 pub use rdlp_ffmpeg::error;
 pub use rdlp_ffmpeg::ffmpeg;
 pub use rdlp_ffmpeg::{
-    AudioExtractOptions, ChapterEntry, FFmpegRunner, MediaInfo, PostProcessError, RemuxOptions,
-    Result, StreamInfo, VideoConvertOptions,
+    AudioExtractOptions, ChapterEntry, CorruptionKind, FFmpegRunner, MediaInfo, PostProcessError,
+    RemuxOptions, Result, StreamInfo, VideoConvertOptions,
 };
 
 pub use registry::{PostProcessorRegistry, PostProcessorRegistryTrait};
 
 // Re-export processor types
 pub use processors::{
-    EmbedThumbnail, FFmpegExtractAudio, FFmpegMerger, FFmpegMetadata, FFmpegRemuxer,
-    FFmpegVideoConvertor,
+    EmbedThumbnail, FFmpegExtractAudio, FFmpegMerger, FFmpegMetadata, FFmpegNormalizeAudio,
+    FFmpegRemuxer, FFmpegVideoConvertor,
 };
 
 // Re-export core types for convenience

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use log::info;
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
-use rdlp_ffmpeg::{AudioNormMode, NormalizeOptions, PostProcessError};
+use rdlp_ffmpeg::{AudioNormMode, LoudnormPreset, NormalizeOptions, PostProcessError};
 
 ffmpeg_processor!(
     FFmpegNormalizeAudio,
@@ -28,6 +28,8 @@ ffmpeg_processor!(
 
 impl FFmpegNormalizeAudio {
     /// Build normalization options from PostProcessConfig.
+    ///
+    /// Resolution order: preset first (defaults to streaming), then individual overrides.
     fn build_options(config: &PostProcessConfig) -> NormalizeOptions {
         let mode = if config.loudnorm {
             AudioNormMode::Loudnorm
@@ -35,13 +37,24 @@ impl FFmpegNormalizeAudio {
             AudioNormMode::Peak
         };
 
+        // Resolve preset → base targets, then allow individual overrides
+        let (default_i, default_tp, default_lra) = match config.loudnorm_preset {
+            Some(ref s) => s
+                .parse::<LoudnormPreset>()
+                .unwrap_or(LoudnormPreset::Streaming)
+                .targets(),
+            None => LoudnormPreset::Streaming.targets(),
+        };
+
         NormalizeOptions {
             mode,
             target_peak_db: config.audio_gain_target.unwrap_or(-1.0),
-            target_i: config.loudnorm_target_i.unwrap_or(-16.0),
-            target_tp: config.loudnorm_target_tp.unwrap_or(-1.5),
-            target_lra: config.loudnorm_target_lra.unwrap_or(11.0),
+            target_i: config.loudnorm_target_i.unwrap_or(default_i),
+            target_tp: config.loudnorm_target_tp.unwrap_or(default_tp),
+            target_lra: config.loudnorm_target_lra.unwrap_or(default_lra),
             salvage: true,
+            force_dynamic: config.loudnorm_dynamic,
+            precompress: config.loudnorm_precompress,
         }
     }
 }
@@ -145,8 +158,9 @@ mod tests {
         };
         let opts = FFmpegNormalizeAudio::build_options(&config);
         assert_eq!(opts.mode, AudioNormMode::Loudnorm);
-        assert!((opts.target_i - (-16.0)).abs() < f64::EPSILON);
-        assert!((opts.target_tp - (-1.5)).abs() < f64::EPSILON);
+        // Default preset is streaming: I=-14, TP=-1, LRA=11
+        assert!((opts.target_i - (-14.0)).abs() < f64::EPSILON);
+        assert!((opts.target_tp - (-1.0)).abs() < f64::EPSILON);
         assert!((opts.target_lra - 11.0).abs() < f64::EPSILON);
     }
 
@@ -159,6 +173,38 @@ mod tests {
         };
         let opts = FFmpegNormalizeAudio::build_options(&config);
         assert!((opts.target_peak_db - (-3.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_build_options_loudnorm_broadcast_preset() {
+        let config = PostProcessConfig {
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_preset: Some("broadcast".to_string()),
+            ..PostProcessConfig::default()
+        };
+        let opts = FFmpegNormalizeAudio::build_options(&config);
+        assert_eq!(opts.mode, AudioNormMode::Loudnorm);
+        assert!((opts.target_i - (-23.0)).abs() < f64::EPSILON);
+        assert!((opts.target_tp - (-2.0)).abs() < f64::EPSILON);
+        assert!((opts.target_lra - 7.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_build_options_individual_overrides() {
+        let config = PostProcessConfig {
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_preset: Some("broadcast".to_string()),
+            loudnorm_target_i: Some(-16.0),
+            loudnorm_target_tp: Some(-1.5),
+            // lra not overridden → should use broadcast default (7.0)
+            ..PostProcessConfig::default()
+        };
+        let opts = FFmpegNormalizeAudio::build_options(&config);
+        assert!((opts.target_i - (-16.0)).abs() < f64::EPSILON);
+        assert!((opts.target_tp - (-1.5)).abs() < f64::EPSILON);
+        assert!((opts.target_lra - 7.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
@@ -1,0 +1,171 @@
+//! FFmpeg audio normalization post-processor.
+//!
+//! Normalizes audio levels in media files using either peak/gain mode
+//! (volume + alimiter filters) or EBU R128 loudnorm two-pass mode.
+//! Video streams are copied without re-encoding.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use log::info;
+use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+
+use rdlp_ffmpeg::{AudioNormMode, NormalizeOptions, PostProcessError};
+
+ffmpeg_processor!(
+    FFmpegNormalizeAudio,
+    "FFmpegNormalizeAudio",
+    48,
+    "Post-processor that normalizes audio levels in media files.\n\n\
+     Supports two modes:\n\
+     - **Peak**: Analyzes peak/RMS via astats, applies volume + alimiter\n\
+     - **Loudnorm**: EBU R128 two-pass normalization\n\n\
+     # Priority\n\
+     This processor has priority 48 (runs after audio extraction, before remuxing).\n\n\
+     # When it runs\n\
+     When `normalize_audio` is true in config."
+);
+
+impl FFmpegNormalizeAudio {
+    /// Build normalization options from PostProcessConfig.
+    fn build_options(config: &PostProcessConfig) -> NormalizeOptions {
+        let mode = if config.loudnorm {
+            AudioNormMode::Loudnorm
+        } else {
+            AudioNormMode::Peak
+        };
+
+        NormalizeOptions {
+            mode,
+            target_peak_db: config.audio_gain_target.unwrap_or(-1.0),
+            target_i: config.loudnorm_target_i.unwrap_or(-16.0),
+            target_tp: config.loudnorm_target_tp.unwrap_or(-1.5),
+            target_lra: config.loudnorm_target_lra.unwrap_or(11.0),
+            salvage: true,
+        }
+    }
+}
+
+#[async_trait]
+impl PostProcessor for FFmpegNormalizeAudio {
+    fn name(&self) -> &str {
+        self.processor_name()
+    }
+
+    fn priority(&self) -> i32 {
+        self.processor_priority()
+    }
+
+    fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {
+        config.normalize_audio
+    }
+
+    async fn process(
+        &self,
+        info: &InfoDict,
+        files: Vec<PathBuf>,
+        config: &PostProcessConfig,
+    ) -> Result<PostProcessResult> {
+        if files.is_empty() {
+            return Ok(PostProcessResult::new(info.clone(), files));
+        }
+
+        let input_file = &files[0];
+
+        // Verify audio exists
+        let media_info = self.ffmpeg.probe(input_file).await?;
+        if !media_info.has_audio {
+            return Err(PostProcessError::NoAudioStream.into());
+        }
+
+        let opts = Self::build_options(config);
+        let mode_name = match opts.mode {
+            AudioNormMode::Peak => "peak",
+            AudioNormMode::Loudnorm => "loudnorm (EBU R128)",
+        };
+
+        info!(
+            "Normalizing audio ({mode_name}) for {}",
+            input_file.display()
+        );
+
+        // Build temp output path
+        let ext = input_file
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("mp4");
+        let stem = input_file
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("output");
+        let output_path = input_file.with_file_name(format!("{stem}.norm.{ext}"));
+
+        self.ffmpeg
+            .normalize_audio(input_file, &output_path, &opts)
+            .await?;
+
+        info!("Audio normalization complete: {}", output_path.display());
+
+        let temp_files = if config.keep_video {
+            Vec::new()
+        } else {
+            files.clone()
+        };
+
+        Ok(PostProcessResult {
+            info: info.clone(),
+            files: vec![output_path],
+            temp_files,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_build_options_peak_defaults() {
+        let config = PostProcessConfig {
+            normalize_audio: true,
+            ..PostProcessConfig::default()
+        };
+        let opts = FFmpegNormalizeAudio::build_options(&config);
+        assert_eq!(opts.mode, AudioNormMode::Peak);
+        assert!((opts.target_peak_db - (-1.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_build_options_loudnorm() {
+        let config = PostProcessConfig {
+            normalize_audio: true,
+            loudnorm: true,
+            ..PostProcessConfig::default()
+        };
+        let opts = FFmpegNormalizeAudio::build_options(&config);
+        assert_eq!(opts.mode, AudioNormMode::Loudnorm);
+        assert!((opts.target_i - (-16.0)).abs() < f64::EPSILON);
+        assert!((opts.target_tp - (-1.5)).abs() < f64::EPSILON);
+        assert!((opts.target_lra - 11.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_build_options_custom_target() {
+        let config = PostProcessConfig {
+            normalize_audio: true,
+            audio_gain_target: Some(-3.0),
+            ..PostProcessConfig::default()
+        };
+        let opts = FFmpegNormalizeAudio::build_options(&config);
+        assert!((opts.target_peak_db - (-3.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_priority() {
+        if let Ok(ffmpeg) = rdlp_ffmpeg::FFmpegRunner::new() {
+            let processor = FFmpegNormalizeAudio::new(Arc::new(ffmpeg));
+            assert_eq!(processor.priority(), 48);
+        }
+    }
+}

--- a/crates/rdlp-postprocess/src/processors/mod.rs
+++ b/crates/rdlp-postprocess/src/processors/mod.rs
@@ -66,6 +66,7 @@ mod embed_thumbnail;
 mod ffmpeg_extract_audio;
 mod ffmpeg_merger;
 mod ffmpeg_metadata;
+mod ffmpeg_normalize_audio;
 mod ffmpeg_remuxer;
 mod ffmpeg_video_convertor;
 
@@ -73,5 +74,6 @@ pub use embed_thumbnail::EmbedThumbnail;
 pub use ffmpeg_extract_audio::FFmpegExtractAudio;
 pub use ffmpeg_merger::FFmpegMerger;
 pub use ffmpeg_metadata::FFmpegMetadata;
+pub use ffmpeg_normalize_audio::FFmpegNormalizeAudio;
 pub use ffmpeg_remuxer::FFmpegRemuxer;
 pub use ffmpeg_video_convertor::FFmpegVideoConvertor;

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -118,6 +118,9 @@ impl PostProcessorRegistry {
         // Priority 50: Extract audio
         self.register(Arc::new(FFmpegExtractAudio::new(self.ffmpeg.clone())));
 
+        // Priority 48: Audio normalization (peak or loudnorm)
+        self.register(Arc::new(FFmpegNormalizeAudio::new(self.ffmpeg.clone())));
+
         // Priority 45: Container remuxing (TS → MP4/MKV for better seeking)
         self.register(Arc::new(FFmpegRemuxer::new(self.ffmpeg.clone())));
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -152,6 +152,15 @@ pub struct Config {
     /// Keep original files after post-processing
     pub keep_video: bool,
 
+    /// Normalize audio levels (peak mode unless loudnorm is set)
+    pub normalize_audio: bool,
+
+    /// Use EBU R128 loudnorm normalization (implies normalize_audio)
+    pub loudnorm: bool,
+
+    /// Target peak level in dBFS for peak normalization (default -1.0)
+    pub audio_gain_target: Option<f64>,
+
     /// FFmpeg location (if not in PATH)
     pub ffmpeg_location: Option<PathBuf>,
 
@@ -284,6 +293,9 @@ impl Default for Config {
             embed_metadata: false,
             embed_subtitles: false,
             keep_video: false,
+            normalize_audio: false,
+            loudnorm: false,
+            audio_gain_target: None,
             ffmpeg_location: None,
             ffmpeg_args: Vec::new(),
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -161,6 +161,24 @@ pub struct Config {
     /// Target peak level in dBFS for peak normalization (default -1.0)
     pub audio_gain_target: Option<f64>,
 
+    /// Loudnorm preset name (broadcast, streaming, loud)
+    pub loudnorm_preset: Option<String>,
+
+    /// Target integrated loudness in LUFS for loudnorm
+    pub loudnorm_target_i: Option<f64>,
+
+    /// Target true peak in dBTP for loudnorm
+    pub loudnorm_target_tp: Option<f64>,
+
+    /// Target loudness range in LU for loudnorm
+    pub loudnorm_target_lra: Option<f64>,
+
+    /// Force dynamic (per-frame compression) mode in loudnorm pass 2
+    pub loudnorm_dynamic: bool,
+
+    /// Prepend a mild acompressor before loudnorm in pass 2
+    pub loudnorm_precompress: bool,
+
     /// FFmpeg location (if not in PATH)
     pub ffmpeg_location: Option<PathBuf>,
 
@@ -296,6 +314,12 @@ impl Default for Config {
             normalize_audio: false,
             loudnorm: false,
             audio_gain_target: None,
+            loudnorm_preset: None,
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
+            loudnorm_dynamic: false,
+            loudnorm_precompress: false,
             ffmpeg_location: None,
             ffmpeg_args: Vec::new(),
 

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -297,9 +297,7 @@ impl Format {
     /// Some extractors set `protocol` as `Https` even for m3u8 URLs, so the URL
     /// and extension checks act as fallbacks.
     pub fn is_hls(&self) -> bool {
-        self.protocol.is_hls()
-            || self.url.contains(".m3u8")
-            || self.ext == "hls"
+        self.protocol.is_hls() || self.url.contains(".m3u8") || self.ext == "hls"
     }
 
     /// Get a human-readable format description
@@ -574,32 +572,62 @@ mod tests {
 
     #[test]
     fn test_is_hls_by_protocol() {
-        let format = Format::new("hls", "https://cdn.example.com/video.ts", "mp4", DownloadProtocol::M3u8);
+        let format = Format::new(
+            "hls",
+            "https://cdn.example.com/video.ts",
+            "mp4",
+            DownloadProtocol::M3u8,
+        );
         assert!(format.is_hls());
 
-        let format = Format::new("hls", "https://cdn.example.com/video.ts", "mp4", DownloadProtocol::M3u8Native);
+        let format = Format::new(
+            "hls",
+            "https://cdn.example.com/video.ts",
+            "mp4",
+            DownloadProtocol::M3u8Native,
+        );
         assert!(format.is_hls());
     }
 
     #[test]
     fn test_is_hls_by_url() {
         // Some extractors set protocol as Https even for m3u8 URLs
-        let format = Format::new("hls", "https://cdn.example.com/master.m3u8", "mp4", DownloadProtocol::Https);
+        let format = Format::new(
+            "hls",
+            "https://cdn.example.com/master.m3u8",
+            "mp4",
+            DownloadProtocol::Https,
+        );
         assert!(format.is_hls());
 
-        let format = Format::new("hls", "https://cdn.example.com/index.m3u8?token=abc", "mp4", DownloadProtocol::Https);
+        let format = Format::new(
+            "hls",
+            "https://cdn.example.com/index.m3u8?token=abc",
+            "mp4",
+            DownloadProtocol::Https,
+        );
         assert!(format.is_hls());
     }
 
     #[test]
     fn test_is_hls_by_ext() {
-        let format = Format::new("hls", "https://cdn.example.com/video", "hls", DownloadProtocol::Https);
+        let format = Format::new(
+            "hls",
+            "https://cdn.example.com/video",
+            "hls",
+            DownloadProtocol::Https,
+        );
         assert!(format.is_hls());
     }
 
     #[test]
     fn test_is_not_hls() {
-        let format = Format::new("mp4", "https://cdn.example.com/video.mp4", "mp4", DownloadProtocol::Https);
+        let format = Format::new(
+            "mp4",
+            "https://cdn.example.com/video.mp4",
+            "mp4",
+            DownloadProtocol::Https,
+        );
         assert!(!format.is_hls());
     }
 }


### PR DESCRIPTION
This pull request introduces a new set of audio normalization features to the CLI and core post-processing configuration, as well as some minor code style improvements and error handling enhancements. The most significant changes add options for peak and EBU R128 loudness normalization, with several configurable parameters. Additionally, new error types and diagnostics are introduced for post-processing failures, and there are minor refactorings and formatting improvements in the template handling code.

**Audio Normalization Features:**

* Added CLI arguments and configuration fields for audio normalization, including `--normalize-audio`, `--loudnorm`, target gain/loudness options, and related toggles (peak level, preset, integrated loudness, true peak, loudness range, dynamic mode, and precompression). This enables both simple peak normalization and advanced two-pass EBU R128 normalization workflows. [[1]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R122-R157) [[2]](diffhunk://#diff-a7649adb19cb943b312e81bf5893a45226c48b667b49038e6b51f7f77ecee4e3R535-R563) [[3]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afR27-R35) [[4]](diffhunk://#diff-ec18d19a977157b7a250d6ae24e78f8783ced973ad60563b83eda93ba27bb8afR46) [[5]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R123-R149) [[6]](diffhunk://#diff-f68a2ee3b2fc088818f499e8e959f98ec84ce90ad23eb33f35f1beeab50e7164R168-R176)

**Error Handling Improvements:**

* Added a new `CorruptionKind` enum to classify input container corruption, and a new `MuxWriteError` variant to `PostProcessError` with detailed diagnostic context for muxing failures in FFmpeg-based post-processing. [[1]](diffhunk://#diff-cefed1119f7f22290879612cf4e1c449c86ef2ec8fb777bd0e5a09baff946c3eR4-R25) [[2]](diffhunk://#diff-cefed1119f7f22290879612cf4e1c449c86ef2ec8fb777bd0e5a09baff946c3eR94-R108)

**Code Style and Refactoring (Template Handling):**

* Refactored and reformatted code in `template.rs` for improved readability, including more idiomatic Rust formatting, simplified expressions, and consistent test code formatting. No logic changes were made in these sections. [[1]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L298-R298) [[2]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L315-R319) [[3]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L389-R393) [[4]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L415-R420) [[5]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L543-R552) [[6]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L661-R660) [[7]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L688-R686) [[8]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L761-R760) [[9]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L932-R930) [[10]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L960-R955) [[11]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1080-R1076) [[12]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1228-R1224) [[13]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1683-R1676) [[14]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1697-R1688) [[15]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1720-R1709) [[16]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1735-R1722) [[17]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1749-R1734) [[18]](diffhunk://#diff-7dc8c2367a95c94b8d33804c6e228cc8a849c53be360d21eb5b34ee67fc6fa72L1789-R1772)

**Other Minor Fixes:**

* Improved error reporting for template rendering failures in orchestrator path handling.