### PR TITLE
refactor(ffmpeg): extract dispatch logic from encode.rs

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -1,0 +1,168 @@
+//! Dispatch logic for audio normalization encode paths.
+//!
+//! Decides whether to encode audio-only or merge with video, handles
+//! salvage retry, and builds mode-specific filter specs before delegating
+//! to [`super::encode::FFmpegRunner::encode_audio_only_sync`].
+
+use std::path::Path;
+
+use crate::error::{PostProcessError, Result};
+
+use super::super::{FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis};
+use super::helpers::{
+    TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD, audio_only_extension_for, build_alimiter_spec,
+    build_loudnorm_pass2_filter, cli_fallback_loudnorm, cli_fallback_peak, with_mux_retry,
+};
+
+impl FFmpegRunner {
+    /// Apply peak gain normalization: encode audio to temp, merge with video.
+    pub(super) fn apply_peak_gain_sync(
+        input: &Path,
+        output: &Path,
+        analysis: &PeakAnalysis,
+        opts: &NormalizeOptions,
+    ) -> Result<()> {
+        Self::dispatch_normalize_sync(
+            input,
+            output,
+            opts.salvage,
+            |inp, out, ext| Self::peak_encode_audio_only(inp, out, ext, analysis, opts),
+            |f_in, f_out| cli_fallback_peak(f_in, f_out, analysis, opts),
+        )
+    }
+
+    /// Encode peak-normalized audio to an output file (video streams discarded).
+    fn peak_encode_audio_only(
+        input: &Path,
+        output: &Path,
+        final_output_ext: &str,
+        analysis: &PeakAnalysis,
+        opts: &NormalizeOptions,
+    ) -> Result<()> {
+        let gain_db = opts.target_peak_db - analysis.peak_db;
+        let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
+        Self::encode_audio_only_sync(
+            input,
+            output,
+            final_output_ext,
+            "peak encode",
+            |fmt, rate, ch_layout| {
+                let oversample_prefix = if gain_db >= TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD {
+                    let rate_4x = rate * 4;
+                    format!("aresample={rate_4x},")
+                } else {
+                    String::new()
+                };
+                format!(
+                    "volume={gain_db:.6}dB,{oversample_prefix}aresample,\
+                     alimiter=limit={linear_limit:.6}:attack=5:release=50,\
+                     aformat=sample_fmts={fmt}:sample_rates={rate}:\
+                     channel_layouts={ch_layout}",
+                )
+            },
+        )
+    }
+
+    /// Loudnorm pass 2: apply normalization with measured values.
+    pub(super) fn loudnorm_pass2_sync(
+        input: &Path,
+        output: &Path,
+        opts: &NormalizeOptions,
+        measurements: &LoudnormMeasurements,
+    ) -> Result<()> {
+        Self::dispatch_normalize_sync(
+            input,
+            output,
+            opts.salvage,
+            |inp, out, ext| Self::loudnorm_encode_audio_only(inp, out, ext, opts, measurements),
+            |f_in, f_out| cli_fallback_loudnorm(f_in, f_out, opts, measurements),
+        )
+    }
+
+    /// Encode loudnorm-normalized audio to an output file (video streams discarded).
+    fn loudnorm_encode_audio_only(
+        input: &Path,
+        output: &Path,
+        final_output_ext: &str,
+        opts: &NormalizeOptions,
+        measurements: &LoudnormMeasurements,
+    ) -> Result<()> {
+        let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
+        let limiter = build_alimiter_spec(opts.target_tp);
+        Self::encode_audio_only_sync(
+            input,
+            output,
+            final_output_ext,
+            "loudnorm pass 2",
+            |fmt, rate, ch_layout| {
+                format!(
+                    "aformat=sample_fmts=dbl,{loudnorm_core},aresample,\
+                     {limiter},aformat=sample_fmts={fmt}:sample_rates={rate}:\
+                     channel_layouts={ch_layout}",
+                )
+            },
+        )
+    }
+
+    /// Common dispatch for normalize encode → merge with optional salvage retry.
+    ///
+    /// Both peak and loudnorm share this pattern: check has_video → audio-only
+    /// encode to temp → merge with original video → cleanup.  When `salvage` is
+    /// true, wraps the encode with `with_mux_retry` for two-tier recovery
+    /// (salvage remux → CLI fallback) on mux write failures.
+    fn dispatch_normalize_sync(
+        input: &Path,
+        output: &Path,
+        salvage: bool,
+        encode_fn: impl Fn(&Path, &Path, &str) -> Result<()>,
+        cli_fallback_fn: impl Fn(&Path, &Path) -> Result<()>,
+    ) -> Result<()> {
+        crate::ffmpeg::ensure_init()?;
+
+        let has_video = {
+            let ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
+                PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to open input {}: {e}", input.display()),
+                }
+            })?;
+            ictx.streams()
+                .best(ffmpeg_the_third::media::Type::Video)
+                .is_some()
+        };
+
+        let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
+
+        if has_video {
+            let audio_ext = audio_only_extension_for(ext);
+            let temp_audio = output.with_extension(format!("norm_audio.{audio_ext}"));
+
+            if salvage {
+                with_mux_retry(
+                    input,
+                    &temp_audio,
+                    |effective_input| encode_fn(effective_input, &temp_audio, ext),
+                    |fallback_in, fallback_out| cli_fallback_fn(fallback_in, fallback_out),
+                )?;
+            } else {
+                encode_fn(input, &temp_audio, ext)?;
+            }
+            let merge_result = Self::merge_sync(
+                input,
+                &temp_audio,
+                output,
+                &super::super::RemuxOptions::default(),
+            );
+            let _ = std::fs::remove_file(&temp_audio);
+            merge_result
+        } else if salvage {
+            with_mux_retry(
+                input,
+                output,
+                |effective_input| encode_fn(effective_input, output, ext),
+                |fallback_in, fallback_out| cli_fallback_fn(fallback_in, fallback_out),
+            )
+        } else {
+            encode_fn(input, output, ext)
+        }
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -1,7 +1,7 @@
 //! Audio encoding pipeline for normalization.
 //!
-//! Contains the unified audio-only encode function shared by peak
-//! normalization and loudnorm pass 2, plus mode-specific wrappers.
+//! Contains the unified decode → filter → encode → mux pipeline shared by
+//! peak normalization and loudnorm pass 2.
 
 use std::path::Path;
 
@@ -9,170 +9,16 @@ use log::{debug, info, warn};
 
 use crate::error::{PostProcessError, Result};
 
+use super::super::FFmpegRunner;
 use super::super::ffi_helpers::set_single_thread_codec;
 use super::super::log_capture::LogSuppressGuard;
 use super::super::transcode::MuxTimingState;
-use super::super::{FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis};
 use super::helpers::{
-    TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD, audio_only_extension_for, build_alimiter_spec,
-    build_audio_filter_with_spec, build_loudnorm_pass2_filter, cli_fallback_loudnorm,
-    cli_fallback_peak, default_bitrate_for_encoder, select_audio_encoder_for_container,
-    with_mux_retry,
+    build_audio_filter_with_spec, default_bitrate_for_encoder, select_audio_encoder_for_container,
 };
 use super::io_diag::validate_mux_header_state;
 
 impl FFmpegRunner {
-    /// Apply peak gain normalization: encode audio to temp, merge with video.
-    pub(super) fn apply_peak_gain_sync(
-        input: &Path,
-        output: &Path,
-        analysis: &PeakAnalysis,
-        opts: &NormalizeOptions,
-    ) -> Result<()> {
-        Self::dispatch_normalize_sync(
-            input,
-            output,
-            opts.salvage,
-            |inp, out, ext| Self::peak_encode_audio_only(inp, out, ext, analysis, opts),
-            |f_in, f_out| cli_fallback_peak(f_in, f_out, analysis, opts),
-        )
-    }
-
-    /// Encode peak-normalized audio to an output file (video streams discarded).
-    fn peak_encode_audio_only(
-        input: &Path,
-        output: &Path,
-        final_output_ext: &str,
-        analysis: &PeakAnalysis,
-        opts: &NormalizeOptions,
-    ) -> Result<()> {
-        let gain_db = opts.target_peak_db - analysis.peak_db;
-        let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
-        Self::encode_audio_only_sync(
-            input,
-            output,
-            final_output_ext,
-            "peak encode",
-            |fmt, rate, ch_layout| {
-                let oversample_prefix = if gain_db >= TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD {
-                    let rate_4x = rate * 4;
-                    format!("aresample={rate_4x},")
-                } else {
-                    String::new()
-                };
-                format!(
-                    "volume={gain_db:.6}dB,{oversample_prefix}aresample,\
-                     alimiter=limit={linear_limit:.6}:attack=5:release=50,\
-                     aformat=sample_fmts={fmt}:sample_rates={rate}:\
-                     channel_layouts={ch_layout}",
-                )
-            },
-        )
-    }
-
-    /// Loudnorm pass 2: apply normalization with measured values.
-    pub(super) fn loudnorm_pass2_sync(
-        input: &Path,
-        output: &Path,
-        opts: &NormalizeOptions,
-        measurements: &LoudnormMeasurements,
-    ) -> Result<()> {
-        Self::dispatch_normalize_sync(
-            input,
-            output,
-            opts.salvage,
-            |inp, out, ext| Self::loudnorm_encode_audio_only(inp, out, ext, opts, measurements),
-            |f_in, f_out| cli_fallback_loudnorm(f_in, f_out, opts, measurements),
-        )
-    }
-
-    /// Encode loudnorm-normalized audio to an output file (video streams discarded).
-    fn loudnorm_encode_audio_only(
-        input: &Path,
-        output: &Path,
-        final_output_ext: &str,
-        opts: &NormalizeOptions,
-        measurements: &LoudnormMeasurements,
-    ) -> Result<()> {
-        let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
-        let limiter = build_alimiter_spec(opts.target_tp);
-        Self::encode_audio_only_sync(
-            input,
-            output,
-            final_output_ext,
-            "loudnorm pass 2",
-            |fmt, rate, ch_layout| {
-                format!(
-                    "aformat=sample_fmts=dbl,{loudnorm_core},aresample,\
-                     {limiter},aformat=sample_fmts={fmt}:sample_rates={rate}:\
-                     channel_layouts={ch_layout}",
-                )
-            },
-        )
-    }
-
-    /// Common dispatch for normalize encode → merge with optional salvage retry.
-    ///
-    /// Both peak and loudnorm share this pattern: check has_video → audio-only
-    /// encode to temp → merge with original video → cleanup.  When `salvage` is
-    /// true, wraps the encode with `with_mux_retry` for two-tier recovery
-    /// (salvage remux → CLI fallback) on mux write failures.
-    fn dispatch_normalize_sync(
-        input: &Path,
-        output: &Path,
-        salvage: bool,
-        encode_fn: impl Fn(&Path, &Path, &str) -> Result<()>,
-        cli_fallback_fn: impl Fn(&Path, &Path) -> Result<()>,
-    ) -> Result<()> {
-        crate::ffmpeg::ensure_init()?;
-
-        let has_video = {
-            let ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to open input {}: {e}", input.display()),
-                }
-            })?;
-            ictx.streams()
-                .best(ffmpeg_the_third::media::Type::Video)
-                .is_some()
-        };
-
-        let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
-
-        if has_video {
-            let audio_ext = audio_only_extension_for(ext);
-            let temp_audio = output.with_extension(format!("norm_audio.{audio_ext}"));
-
-            if salvage {
-                with_mux_retry(
-                    input,
-                    &temp_audio,
-                    |effective_input| encode_fn(effective_input, &temp_audio, ext),
-                    |fallback_in, fallback_out| cli_fallback_fn(fallback_in, fallback_out),
-                )?;
-            } else {
-                encode_fn(input, &temp_audio, ext)?;
-            }
-            let merge_result = Self::merge_sync(
-                input,
-                &temp_audio,
-                output,
-                &super::super::RemuxOptions::default(),
-            );
-            let _ = std::fs::remove_file(&temp_audio);
-            merge_result
-        } else if salvage {
-            with_mux_retry(
-                input,
-                output,
-                |effective_input| encode_fn(effective_input, output, ext),
-                |fallback_in, fallback_out| cli_fallback_fn(fallback_in, fallback_out),
-            )
-        } else {
-            encode_fn(input, output, ext)
-        }
-    }
-
     /// Unified audio-only encode: decode → filter → encode → mux.
     ///
     /// Both peak normalization and loudnorm pass 2 share this pipeline.
@@ -183,7 +29,7 @@ impl FFmpegRunner {
     /// `label` appears in log and error messages (e.g. "peak encode",
     /// "loudnorm pass 2").
     #[allow(clippy::too_many_lines)]
-    fn encode_audio_only_sync(
+    pub(super) fn encode_audio_only_sync(
         input: &Path,
         output: &Path,
         final_output_ext: &str,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
@@ -8,6 +8,7 @@
 //!   them with `linear=true` for high-quality correction.
 
 mod analysis;
+mod dispatch;
 mod encode;
 mod helpers;
 mod io_diag;


### PR DESCRIPTION
## Summary

- Splits `normalize/encode.rs` (526 LOC, over the 500-line limit) into two focused modules
- New `normalize/dispatch.rs` (~167 LOC): routing, salvage retry, and mode-specific filter-spec builders (`apply_peak_gain_sync`, `peak_encode_audio_only`, `loudnorm_pass2_sync`, `loudnorm_encode_audio_only`, `dispatch_normalize_sync`)
- Trimmed `normalize/encode.rs` (~373 LOC): unified decode→filter→encode→mux pipeline (`encode_audio_only_sync`)

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -p rdlp-ffmpeg -- -D warnings` — zero warnings
- [x] `cargo test -p rdlp-ffmpeg` — all 74 tests pass
- [x] `cargo build --release -p rdlp-ffmpeg` — pass