### PR TITLE
fix(playlist): per-episode subtitle resolution + workspace simplification

### DIFF
--- a/crates/rdlp-cli/src/orchestrator/archive.rs
+++ b/crates/rdlp-cli/src/orchestrator/archive.rs
@@ -14,9 +14,8 @@ use std::path::Path;
 /// Returns an empty set if the file does not exist. Blank lines and lines
 /// starting with `#` are ignored.
 pub fn load_archive(path: &Path) -> HashSet<String> {
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return HashSet::new(),
+    let Ok(file) = std::fs::File::open(path) else {
+        return HashSet::new();
     };
 
     BufReader::new(file)
@@ -53,7 +52,6 @@ pub fn record_in_archive(path: &Path, extractor: &str, id: &str) -> std::io::Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write as _;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/crates/rdlp-cli/src/orchestrator/download.rs
+++ b/crates/rdlp-cli/src/orchestrator/download.rs
@@ -154,25 +154,14 @@ impl Orchestrator {
 /// - `validto=TIMESTAMP` (PornHub direct MP4)
 /// - `~exp=TIMESTAMP~` (PornHub HLS / Akamai)
 fn parse_url_expiry(url: &str) -> Option<u64> {
-    // Try `validto=DIGITS`
-    if let Some(pos) = url.find("validto=") {
-        let rest = &url[pos + 8..];
+    /// Extract a `u64` timestamp immediately following `prefix` in `url`.
+    fn extract_ts_after(url: &str, prefix: &str) -> Option<u64> {
+        let rest = &url[url.find(prefix)? + prefix.len()..];
         let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        if let Ok(ts) = digits.parse::<u64>() {
-            return Some(ts);
-        }
+        digits.parse::<u64>().ok()
     }
 
-    // Try `~exp=DIGITS~` (Akamai-style)
-    if let Some(pos) = url.find("~exp=") {
-        let rest = &url[pos + 5..];
-        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        if let Ok(ts) = digits.parse::<u64>() {
-            return Some(ts);
-        }
-    }
-
-    None
+    extract_ts_after(url, "validto=").or_else(|| extract_ts_after(url, "~exp="))
 }
 
 #[cfg(test)]

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -85,11 +85,8 @@ impl Orchestrator {
     fn create_postprocessor_registry(
         config: &Config,
     ) -> Option<Arc<dyn PostProcessorRegistryTrait>> {
-        let registry_result = if let Some(ref ffmpeg_path) = config.ffmpeg_location {
-            PostProcessorRegistry::with_ffmpeg_location(Some(ffmpeg_path.as_path()))
-        } else {
-            PostProcessorRegistry::new()
-        };
+        let registry_result =
+            PostProcessorRegistry::with_ffmpeg_location(config.ffmpeg_location.as_deref());
 
         match registry_result {
             Ok(registry) => {

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -132,32 +132,30 @@ impl Orchestrator {
         }
 
         // Interactive subtitle selection (once for the whole playlist, before confirm)
+        // We select language names using the first episode that has subtitles, then
+        // resolve actual subtitle URLs per-episode during download.
         let list_subs = self.config.list_subs;
-        let has_subs = infos[0]
-            .subtitles
-            .as_ref()
-            .is_some_and(|s| !s.is_empty());
-        let has_auto = infos[0]
-            .automatic_captions
-            .as_ref()
-            .is_some_and(|a| !a.is_empty());
+        let sub_representative = infos.iter().find(|i| {
+            i.subtitles.as_ref().is_some_and(|s| !s.is_empty())
+                || i.automatic_captions.as_ref().is_some_and(|a| !a.is_empty())
+        });
         debug!(
-            has_subs, has_auto, interactive, list_subs;
+            has_subs = sub_representative.is_some(), interactive, list_subs;
             "Playlist subtitle selection check"
         );
 
-        let subtitle_selection = if interactive || list_subs {
-            // Use the first episode's subtitle data as representative
-            match self
-                .select_subtitles_if_needed(&infos[0], interactive, list_subs)
-                .await?
-            {
-                Some(sel) => sel,
-                None => return Ok(None),
-            }
-        } else {
-            Vec::new()
-        };
+        let selected_sub_langs: Vec<String> =
+            if let Some(rep) = sub_representative.filter(|_| interactive || list_subs) {
+                match self
+                    .select_subtitles_if_needed(rep, interactive, list_subs)
+                    .await?
+                {
+                    Some(sel) => sel.into_iter().map(|(lang, _)| lang).collect(),
+                    None => return Ok(None),
+                }
+            } else {
+                Vec::new()
+            };
 
         // Confirm before downloading (unless non-interactive)
         if interactive && remaining > 0 {
@@ -235,7 +233,7 @@ impl Orchestrator {
             // Race download against Ctrl+C signal
             tokio::select! {
                 // Download single video to playlist folder (non-interactive)
-                result = self.download_from_info_to_dir(info, false, &playlist_dir, &subtitle_selection) => {
+                result = self.download_from_info_to_dir(info, false, &playlist_dir, &selected_sub_langs) => {
                     match result {
                         Ok(Some(path)) => {
                             info!(position, total, path:? = path.display(); "Saved");
@@ -279,9 +277,8 @@ impl Orchestrator {
             info!("  (previously: {already_downloaded}, this session: {newly_downloaded})");
         }
 
-        if !subtitle_selection.is_empty() {
-            let langs: Vec<&str> = subtitle_selection.iter().map(|(l, _)| l.as_str()).collect();
-            info!("Subtitles: {}", langs.join(", "));
+        if !selected_sub_langs.is_empty() {
+            info!("Subtitles: {}", selected_sub_langs.join(", "));
         }
 
         if !failed.is_empty() {
@@ -427,18 +424,17 @@ impl Orchestrator {
     /// * `info` - Pre-extracted video metadata
     /// * `interactive` - Whether interactive mode is active
     /// * `output_dir` - Directory to save the file in
-    /// * `subtitle_selection` - Pre-selected subtitles from interactive menu (empty = config-based)
+    /// * `subtitle_langs` - Pre-selected subtitle language names (empty = config-based)
     pub(super) async fn download_from_info_to_dir(
         &self,
         info: &rdlp_core::InfoDict,
         interactive: bool,
         output_dir: &std::path::Path,
-        subtitle_selection: &[(String, rdlp_core::Subtitle)],
+        subtitle_langs: &[String],
     ) -> Result<Option<PathBuf>> {
         // Select format
-        let format = match self.select_format(info, interactive).await? {
-            Some(format) => format,
-            None => return Ok(None),
+        let Some(format) = self.select_format(info, interactive).await? else {
+            return Ok(None);
         };
 
         // Generate output path in the specified directory
@@ -467,12 +463,11 @@ impl Orchestrator {
         }
 
         // Execute download with CDN fallback (shared implementation)
-        let outcome = match self
+        let Some(outcome) = self
             .download_with_cdn_fallback(&format, &output_path, resume_offset)
             .await?
-        {
-            Some(outcome) => outcome,
-            None => return Ok(None),
+        else {
+            return Ok(None);
         };
 
         // Download thumbnail if needed (before post-processing so embed can find it)
@@ -480,8 +475,13 @@ impl Orchestrator {
             self.download_thumbnail(info, &output_path).await;
         }
 
-        // Download subtitles (interactive selection or config-based)
-        self.download_subtitles(info, &output_path, subtitle_selection)
+        // Download subtitles: resolve per-episode URLs from language names
+        let episode_subs = if !subtitle_langs.is_empty() {
+            self.resolve_subtitles_for_episode(info, subtitle_langs)
+        } else {
+            Vec::new()
+        };
+        self.download_subtitles(info, &output_path, &episode_subs)
             .await?;
 
         // Run post-processing if configured (or automatic for HLS)
@@ -499,17 +499,14 @@ impl Orchestrator {
 /// Scans format `language` fields and returns sorted unique values.
 /// Used to offer SUB/DUB selection before batch download.
 fn detect_audio_types(infos: &[rdlp_core::InfoDict]) -> Vec<String> {
-    let mut types = HashSet::new();
-    for info in infos {
-        for format in &info.formats {
-            if let Some(lang) = &format.language {
-                if !lang.is_empty() {
-                    types.insert(lang.clone());
-                }
-            }
-        }
-    }
-    let mut result: Vec<String> = types.into_iter().collect();
+    let types: HashSet<&str> = infos
+        .iter()
+        .flat_map(|info| &info.formats)
+        .filter_map(|f| f.language.as_deref())
+        .filter(|lang| !lang.is_empty())
+        .collect();
+
+    let mut result: Vec<String> = types.into_iter().map(String::from).collect();
     result.sort();
     result
 }

--- a/crates/rdlp-cli/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-cli/src/orchestrator/postprocess.rs
@@ -215,18 +215,22 @@ impl Orchestrator {
         let mut deleted = 0;
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
-            if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
-                // Match pattern: base_name.part{number}
-                if filename.starts_with(base_name) && filename.contains(".part") {
-                    // Verify it's a segment file (has numeric suffix after .part)
-                    if let Some(part_idx) = filename.rfind(".part") {
-                        let suffix = &filename[part_idx + 5..];
-                        if suffix.chars().all(|c| c.is_ascii_digit())
-                            && tokio::fs::remove_file(&path).await.is_ok()
-                        {
-                            deleted += 1;
-                        }
-                    }
+            let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
+                continue;
+            };
+
+            // Match pattern: base_name.part{number}
+            if !filename.starts_with(base_name) || !filename.contains(".part") {
+                continue;
+            }
+
+            // Verify it's a segment file (has numeric suffix after .part)
+            if let Some(part_idx) = filename.rfind(".part") {
+                let suffix = &filename[part_idx + 5..];
+                if suffix.chars().all(|c| c.is_ascii_digit())
+                    && tokio::fs::remove_file(&path).await.is_ok()
+                {
+                    deleted += 1;
                 }
             }
         }

--- a/crates/rdlp-cli/src/orchestrator/selection.rs
+++ b/crates/rdlp-cli/src/orchestrator/selection.rs
@@ -123,10 +123,7 @@ impl Orchestrator {
         .map_err(|e| OrchestratorError::Io(std::io::Error::other(e)))?
         .map_err(|e| OrchestratorError::Io(e.into()))?;
 
-        match selection {
-            Some(index) => Ok(Some(grouped[index].clone())),
-            None => Ok(None),
-        }
+        Ok(selection.map(|index| grouped[index].clone()))
     }
 }
 
@@ -135,8 +132,7 @@ impl Orchestrator {
 /// Prefer formats with audio over video-only, then higher quality, then larger filesize.
 fn pick_better(candidate: &Format, current: &Format) -> bool {
     // Prefer formats that have audio over video-only
-    let has_audio = |f: &Format| f.acodec.is_some();
-    match (has_audio(candidate), has_audio(current)) {
+    match (candidate.acodec.is_some(), current.acodec.is_some()) {
         (true, false) => return true,
         (false, true) => return false,
         _ => {}
@@ -148,8 +144,8 @@ fn pick_better(candidate: &Format, current: &Format) -> bool {
     }
 
     // Larger filesize wins (more likely to be higher quality)
-    match (candidate.filesize, current.filesize) {
-        (Some(a), Some(b)) if a != b => a > b,
-        _ => false,
-    }
+    matches!(
+        (candidate.filesize, current.filesize),
+        (Some(a), Some(b)) if a > b
+    )
 }

--- a/crates/rdlp-cli/src/orchestrator/state.rs
+++ b/crates/rdlp-cli/src/orchestrator/state.rs
@@ -155,9 +155,8 @@ impl DownloadPhase {
             }
 
             Self::SelectingFormat { info } => {
-                let format = match orchestrator.select_format(&info, interactive).await? {
-                    Some(format) => format,
-                    None => return Ok(Self::Cancelled),
+                let Some(format) = orchestrator.select_format(&info, interactive).await? else {
+                    return Ok(Self::Cancelled);
                 };
 
                 Ok(Self::SelectingSubtitles {
@@ -168,12 +167,11 @@ impl DownloadPhase {
 
             Self::SelectingSubtitles { info, format } => {
                 let list_subs = orchestrator.config.list_subs;
-                let subtitle_selection = match orchestrator
+                let Some(subtitle_selection) = orchestrator
                     .select_subtitles_if_needed(&info, interactive, list_subs)
                     .await?
-                {
-                    Some(sel) => sel,
-                    None => return Ok(Self::Cancelled),
+                else {
+                    return Ok(Self::Cancelled);
                 };
 
                 Ok(Self::Preparing {
@@ -225,12 +223,11 @@ impl DownloadPhase {
                 subtitle_selection,
             } => {
                 // Execute download with CDN fallback (shared implementation)
-                let outcome = match orchestrator
+                let Some(outcome) = orchestrator
                     .download_with_cdn_fallback(&format, &output_path, state.offset())
                     .await?
-                {
-                    Some(outcome) => outcome,
-                    None => return Ok(Self::Cancelled),
+                else {
+                    return Ok(Self::Cancelled);
                 };
 
                 // Download thumbnail for embedding or standalone use

--- a/crates/rdlp-cli/src/orchestrator/subtitle.rs
+++ b/crates/rdlp-cli/src/orchestrator/subtitle.rs
@@ -184,9 +184,8 @@ impl Orchestrator {
         .map_err(|e| super::OrchestratorError::Io(std::io::Error::other(e)))?
         .map_err(|e| super::OrchestratorError::Io(e.into()))?;
 
-        let selected_indices = match selection {
-            Some(indices) => indices,
-            None => return Ok(None), // ESC pressed
+        let Some(selected_indices) = selection else {
+            return Ok(None); // ESC pressed
         };
 
         if selected_indices.is_empty() {
@@ -279,6 +278,37 @@ impl Orchestrator {
 
         // Fallback to first entry
         Some(entries[0].clone())
+    }
+
+    /// Resolve subtitle entries for a specific episode from language names.
+    ///
+    /// Used by playlist downloads: the user selects languages once (from the
+    /// first episode's menu), then each episode resolves its own subtitle
+    /// URLs for those languages.
+    ///
+    /// # Arguments
+    /// * `info` - Episode metadata with subtitle URLs
+    /// * `langs` - Language names selected by the user
+    ///
+    /// # Returns
+    /// Vec of (lang, Subtitle) pairs with URLs specific to this episode
+    pub(super) fn resolve_subtitles_for_episode(
+        &self,
+        info: &InfoDict,
+        langs: &[String],
+    ) -> Vec<(String, rdlp_core::Subtitle)> {
+        let mut result = Vec::new();
+        for lang in langs {
+            // Try manual subtitles first, then auto-captions
+            if let Some(sub) = self.pick_best_subtitle_for_lang(info, lang, false) {
+                result.push((lang.clone(), sub));
+            } else if let Some(sub) = self.pick_best_subtitle_for_lang(info, lang, true) {
+                result.push((lang.clone(), sub));
+            } else {
+                debug!(lang:%; "No subtitle found for language in this episode");
+            }
+        }
+        result
     }
 
     /// Download subtitles for a video.
@@ -421,9 +451,8 @@ impl Orchestrator {
         &self,
         info: &InfoDict,
     ) -> Result<Option<Vec<PathBuf>>> {
-        let selected = match self.select_subtitles_interactive(info).await? {
-            Some(sel) => sel,
-            None => return Ok(None),
+        let Some(selected) = self.select_subtitles_interactive(info).await? else {
+            return Ok(None);
         };
 
         if selected.is_empty() {

--- a/crates/rdlp-cli/src/orchestrator/template.rs
+++ b/crates/rdlp-cli/src/orchestrator/template.rs
@@ -966,8 +966,7 @@ fn apply_width(raw: &str, spec: &FormatSpec) -> String {
     } else if let Some(prec) = spec.precision {
         // For strings, precision truncates
         if spec.type_char == FormatType::String {
-            let truncated: String = raw.chars().take(prec).collect();
-            truncated
+            raw.chars().take(prec).collect()
         } else {
             raw.to_string()
         }

--- a/crates/rdlp-cli/src/orchestrator/tests.rs
+++ b/crates/rdlp-cli/src/orchestrator/tests.rs
@@ -13,10 +13,10 @@ pub(crate) fn create_test_orchestrator() -> Orchestrator {
 /// Helper function to wrap formats in an InfoDict for testing
 fn create_test_info_dict(formats: Vec<Format>) -> InfoDict {
     let mut info = InfoDict::new(
-        "test_id".to_string(),
-        "Test Video".to_string(),
-        "TestExtractor".to_string(),
-        "https://example.com/video".to_string(),
+        "test_id",
+        "Test Video",
+        "TestExtractor",
+        "https://example.com/video",
     );
     info.formats = formats;
     info
@@ -25,9 +25,9 @@ fn create_test_info_dict(formats: Vec<Format>) -> InfoDict {
 /// Helper function to create a test format
 fn create_test_format(format_id: &str, quality: &str, filesize: Option<u64>) -> Format {
     let mut format = Format::new(
-        format_id.to_string(),
-        "https://example.com/video.mp4".to_string(),
-        "mp4".to_string(),
+        format_id,
+        "https://example.com/video.mp4",
+        "mp4",
         rdlp_core::DownloadProtocol::Https,
     );
     format.format_note = Some(quality.to_string());
@@ -153,12 +153,8 @@ fn test_sanitize_filename_length_truncation() {
 #[test]
 fn test_generate_output_path() {
     let orchestrator = create_test_orchestrator();
-    let mut info = rdlp_core::InfoDict::new(
-        "test123".to_string(),
-        "Test Video".to_string(),
-        "test".to_string(),
-        "https://example.com/test".to_string(),
-    );
+    let mut info =
+        rdlp_core::InfoDict::new("test123", "Test Video", "test", "https://example.com/test");
     info.formats = vec![];
     let format = create_test_format("720p", "720p", Some(1000000));
 
@@ -173,10 +169,10 @@ fn test_generate_output_path() {
 fn test_generate_output_path_sanitizes_invalid_chars() {
     let orchestrator = create_test_orchestrator();
     let mut info = rdlp_core::InfoDict::new(
-        "test123".to_string(),
-        "Invalid/Characters\\In:Title*?.mp4".to_string(),
-        "test".to_string(),
-        "https://example.com/test".to_string(),
+        "test123",
+        "Invalid/Characters\\In:Title*?.mp4",
+        "test",
+        "https://example.com/test",
     );
     info.formats = vec![];
     let format = create_test_format("720p", "720p", Some(1000000));
@@ -192,10 +188,10 @@ fn test_generate_output_path_sanitizes_invalid_chars() {
 fn test_generate_output_path_hls_extension() {
     let orchestrator = create_test_orchestrator();
     let mut info = rdlp_core::InfoDict::new(
-        "test123".to_string(),
-        "HLS Test Video".to_string(),
-        "test".to_string(),
-        "https://example.com/test".to_string(),
+        "test123",
+        "HLS Test Video",
+        "test",
+        "https://example.com/test",
     );
     info.formats = vec![];
 

--- a/crates/rdlp-cli/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-cli/src/orchestrator/thumbnail.rs
@@ -44,13 +44,12 @@ impl Orchestrator {
                 let filename = filename.split('?').next().unwrap_or(filename);
                 filename.rsplit('.').next()
             })
-            .and_then(|ext| {
-                let ext = ext.to_lowercase();
-                match ext.as_str() {
-                    "jpg" | "jpeg" | "png" | "webp" => Some(ext),
-                    _ => None,
-                }
+            .filter(|ext| {
+                ["jpg", "jpeg", "png", "webp"]
+                    .iter()
+                    .any(|known| ext.eq_ignore_ascii_case(known))
             })
+            .map(str::to_lowercase)
             .unwrap_or_else(|| "jpg".to_string());
 
         // Build output path: {media_stem}.{ext}

--- a/crates/rdlp-cookies/src/chrome.rs
+++ b/crates/rdlp-cookies/src/chrome.rs
@@ -23,7 +23,7 @@ const V10_PREFIX: &[u8] = b"v10";
 /// Extract cookies from Chrome and insert them into the jar.
 ///
 /// Returns the number of cookies loaded.
-pub fn extract_cookies(jar: &impl CookieStore) -> Result<usize, std::io::Error> {
+pub(crate) fn extract_cookies(jar: &impl CookieStore) -> Result<usize, std::io::Error> {
     let cookie_db = find_cookie_db()?;
     let local_state = find_local_state()?;
 

--- a/crates/rdlp-cookies/src/firefox.rs
+++ b/crates/rdlp-cookies/src/firefox.rs
@@ -13,7 +13,7 @@ use crate::util;
 /// Extract cookies from Firefox and insert them into the jar.
 ///
 /// Returns the number of cookies loaded.
-pub fn extract_cookies(jar: &impl CookieStore) -> Result<usize, std::io::Error> {
+pub(crate) fn extract_cookies(jar: &impl CookieStore) -> Result<usize, std::io::Error> {
     let cookie_db = find_cookie_db()?;
     debug!("Firefox cookie DB: {}", cookie_db.display());
 
@@ -92,8 +92,8 @@ fn find_default_profile() -> Result<PathBuf, std::io::Error> {
 fn parse_profiles_ini(ini_path: &Path, profiles_dir: &Path) -> Option<PathBuf> {
     let content = std::fs::read_to_string(ini_path).ok()?;
 
-    let try_commit = |path: &Option<String>, is_relative: bool| -> Option<PathBuf> {
-        let path = path.as_ref()?;
+    let try_commit = |path: Option<&str>, is_relative: bool| -> Option<PathBuf> {
+        let path = path?;
         let profile_path = if is_relative {
             profiles_dir.join(path)
         } else {
@@ -114,7 +114,7 @@ fn parse_profiles_ini(ini_path: &Path, profiles_dir: &Path) -> Option<PathBuf> {
 
         if line.starts_with('[') {
             if current_is_default {
-                if let Some(profile) = try_commit(&current_path, current_is_relative) {
+                if let Some(profile) = try_commit(current_path.as_deref(), current_is_relative) {
                     return Some(profile);
                 }
             }
@@ -137,7 +137,7 @@ fn parse_profiles_ini(ini_path: &Path, profiles_dir: &Path) -> Option<PathBuf> {
 
     // Check last section
     if current_is_default {
-        return try_commit(&current_path, current_is_relative);
+        return try_commit(current_path.as_deref(), current_is_relative);
     }
 
     None

--- a/crates/rdlp-cookies/src/netscape.rs
+++ b/crates/rdlp-cookies/src/netscape.rs
@@ -27,7 +27,10 @@ struct NetscapeCookie {
 /// Parse a Netscape-format cookie file and insert cookies into the jar.
 ///
 /// Returns the number of cookies successfully loaded.
-pub fn load_cookie_file(path: &Path, jar: &impl CookieStore) -> Result<usize, std::io::Error> {
+pub(crate) fn load_cookie_file(
+    path: &Path,
+    jar: &impl CookieStore,
+) -> Result<usize, std::io::Error> {
     let content = std::fs::read_to_string(path)?;
     Ok(load_cookie_string(&content, jar))
 }
@@ -35,7 +38,7 @@ pub fn load_cookie_file(path: &Path, jar: &impl CookieStore) -> Result<usize, st
 /// Parse cookie string content and insert into jar.
 ///
 /// Returns the number of cookies loaded.
-pub fn load_cookie_string(content: &str, jar: &impl CookieStore) -> usize {
+fn load_cookie_string(content: &str, jar: &impl CookieStore) -> usize {
     let mut count = 0;
 
     for line in content.lines() {

--- a/crates/rdlp-cookies/src/util.rs
+++ b/crates/rdlp-cookies/src/util.rs
@@ -10,7 +10,7 @@ use url::Url;
 /// Build a URL and `Set-Cookie` header from cookie fields, then insert into the jar.
 ///
 /// Returns `true` if the cookie was successfully inserted.
-pub fn insert_cookie_into_jar(
+pub(crate) fn insert_cookie_into_jar(
     jar: &impl CookieStore,
     domain: &str,
     name: &str,
@@ -52,7 +52,11 @@ pub fn insert_cookie_into_jar(
 ///
 /// Browsers lock their SQLite databases while running. Copying to a temp file
 /// avoids `SQLITE_BUSY` / `SQLITE_LOCKED` errors.
-pub fn with_temp_db_copy<F, T>(db_path: &Path, temp_name: &str, f: F) -> Result<T, std::io::Error>
+pub(crate) fn with_temp_db_copy<F, T>(
+    db_path: &Path,
+    temp_name: &str,
+    f: F,
+) -> Result<T, std::io::Error>
 where
     F: FnOnce(&Path) -> Result<T, std::io::Error>,
 {
@@ -68,7 +72,7 @@ where
 
 /// Read the `HOME` environment variable, returning an `io::Error` if unset.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-pub fn home_dir() -> Result<std::path::PathBuf, std::io::Error> {
+pub(crate) fn home_dir() -> Result<std::path::PathBuf, std::io::Error> {
     std::env::var("HOME")
         .map(std::path::PathBuf::from)
         .map_err(|_| std::io::Error::new(std::io::ErrorKind::NotFound, "HOME not set"))

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -12,12 +12,12 @@
 //! ```rust,no_run
 //! use rdlp_core::{InfoDict, Format, Config};
 //!
-//! // Create a new InfoDict
+//! // Create a new InfoDict (constructor accepts impl Into<String>)
 //! let info = InfoDict::new(
-//!     "video123".to_string(),
-//!     "My Video".to_string(),
-//!     "YouTube".to_string(),
-//!     "https://youtube.com/watch?v=video123".to_string(),
+//!     "video123",
+//!     "My Video",
+//!     "YouTube",
+//!     "https://youtube.com/watch?v=video123",
 //! );
 //!
 //! // Create a default configuration

--- a/crates/rdlp-core/src/retry.rs
+++ b/crates/rdlp-core/src/retry.rs
@@ -126,11 +126,8 @@ pub fn is_retryable_error(error: &RdlpError) -> bool {
     match error {
         // Structured HTTP errors: retry 5xx and 429, not other 4xx
         RdlpError::Http { status, .. } => *status == 429 || *status >= 500,
-        // Legacy network errors are generally retryable
-        RdlpError::Network(_) => true,
-        // I/O errors might be retryable (disk full, temp failure)
-        RdlpError::Io(_) => true,
-        // Other errors are not retryable
+        // Network and I/O errors are generally retryable (transient)
+        RdlpError::Network(_) | RdlpError::Io(_) => true,
         _ => false,
     }
 }

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -386,8 +386,7 @@ fn format_bytes(bytes: u64) -> String {
     }
 
     let bytes_f = bytes as f64;
-    let exponent = (bytes_f.log2() / 10.0).floor() as usize;
-    let exponent = exponent.min(UNITS.len() - 1);
+    let exponent = ((bytes_f.log2() / 10.0).floor() as usize).min(UNITS.len() - 1);
 
     let value = bytes_f / 1024_f64.powi(exponent as i32);
     let unit = UNITS[exponent];

--- a/crates/rdlp-downloader/src/chunking.rs
+++ b/crates/rdlp-downloader/src/chunking.rs
@@ -120,13 +120,6 @@ pub fn calculate_chunks(file_size: u64, strategy: ChunkSizeStrategy) -> (usize, 
     (chunk_size, total_chunks)
 }
 
-/// Check if a number is a power of two
-#[inline]
-#[allow(dead_code)] // Used in tests and property tests
-pub(crate) const fn is_power_of_two(n: usize) -> bool {
-    n != 0 && (n & (n - 1)) == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,7 +174,7 @@ mod tests {
         for file_size in test_sizes {
             let chunk_size = chunk_size_for_file(file_size);
             assert!(
-                is_power_of_two(chunk_size),
+                chunk_size.is_power_of_two(),
                 "Chunk size {chunk_size} for file {file_size} is not power of two"
             );
         }
@@ -257,16 +250,16 @@ mod tests {
 
     #[test]
     fn test_is_power_of_two() {
-        assert!(is_power_of_two(1));
-        assert!(is_power_of_two(2));
-        assert!(is_power_of_two(64));
-        assert!(is_power_of_two(1024));
-        assert!(is_power_of_two(1024 * 1024));
+        assert!(1usize.is_power_of_two());
+        assert!(2usize.is_power_of_two());
+        assert!(64usize.is_power_of_two());
+        assert!(1024usize.is_power_of_two());
+        assert!((1024 * 1024usize).is_power_of_two());
 
-        assert!(!is_power_of_two(0));
-        assert!(!is_power_of_two(3));
-        assert!(!is_power_of_two(100));
-        assert!(!is_power_of_two(1000));
+        assert!(!0usize.is_power_of_two());
+        assert!(!3usize.is_power_of_two());
+        assert!(!100usize.is_power_of_two());
+        assert!(!1000usize.is_power_of_two());
     }
 }
 
@@ -281,7 +274,7 @@ mod property_tests {
             file_size in 1u64..100_000_000_000u64 // 1 byte to 100 GB
         ) {
             let chunk_size = chunk_size_for_file(file_size);
-            prop_assert!(is_power_of_two(chunk_size));
+            prop_assert!(chunk_size.is_power_of_two());
         }
 
         #[test]

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -51,7 +51,7 @@ pub(crate) async fn download_segments_with_resume(
     buffer_size: usize,
     concurrent_segments: usize,
     max_segment_failures: usize,
-    segments: Vec<SegmentInfo>,
+    segments: &[SegmentInfo],
     temp_dir: &Path,
     base_filename: &str,
     progress_counter: Arc<AtomicU64>,
@@ -66,21 +66,22 @@ pub(crate) async fn download_segments_with_resume(
     let original_completed: HashSet<usize> = state.lock().await.completed_segments.clone();
 
     // Verify completed segments actually exist on disk (handles corrupted/deleted files)
-    let mut completed: HashSet<usize> = HashSet::new();
-    let mut missing_segments = Vec::new();
-    for idx in &original_completed {
+    let is_valid_on_disk = |idx: &usize| -> bool {
         let segment_path = temp_dir.join(format!("{base_filename}.part{idx}"));
-        if segment_path.exists() {
-            // Also verify file is non-empty
-            if let Ok(meta) = std::fs::metadata(&segment_path) {
-                if meta.len() > 0 {
-                    completed.insert(*idx);
-                    continue;
-                }
-            }
-        }
-        missing_segments.push(*idx);
-    }
+        std::fs::metadata(&segment_path)
+            .map(|meta| meta.len() > 0)
+            .unwrap_or(false)
+    };
+    let completed: HashSet<usize> = original_completed
+        .iter()
+        .copied()
+        .filter(is_valid_on_disk)
+        .collect();
+    let mut missing_segments: Vec<usize> = original_completed
+        .iter()
+        .copied()
+        .filter(|idx| !completed.contains(idx))
+        .collect();
 
     if !missing_segments.is_empty() {
         missing_segments.sort_unstable();

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -266,7 +266,7 @@ impl Downloader for HlsDownloader {
                 self.buffer_size,
                 self.concurrent_segments,
                 self.max_segment_failures,
-                segments.clone(),
+                &segments,
                 temp_dir,
                 base_filename,
                 downloaded.clone(),
@@ -294,27 +294,19 @@ impl Downloader for HlsDownloader {
 
             // Step 5: Download unique init segments (fMP4 EXT-X-MAP)
             // Collect unique init segments and download each once.
-            let mut init_file_map: HashMap<InitSegmentInfo, std::path::PathBuf> = HashMap::new();
-            {
-                let unique_inits: Vec<InitSegmentInfo> = segments
-                    .iter()
-                    .filter_map(|s| s.init_segment.clone())
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect();
+            let unique_inits: HashSet<InitSegmentInfo> = segments
+                .iter()
+                .filter_map(|s| s.init_segment.clone())
+                .collect();
 
-                for (i, init) in unique_inits.into_iter().enumerate() {
-                    let init_path = temp_dir.join(format!("{base_filename}.init{i}"));
-                    info!(index = i; "Downloading fMP4 init segment (EXT-X-MAP): {}", init.url);
-                    download_init_segment(
-                        &self.http_downloader,
-                        &self.retry_config,
-                        &init,
-                        &init_path,
-                    )
+            let mut init_file_map: HashMap<InitSegmentInfo, std::path::PathBuf> =
+                HashMap::with_capacity(unique_inits.len());
+            for (i, init) in unique_inits.into_iter().enumerate() {
+                let init_path = temp_dir.join(format!("{base_filename}.init{i}"));
+                info!(index = i; "Downloading fMP4 init segment (EXT-X-MAP): {}", init.url);
+                download_init_segment(&self.http_downloader, &self.retry_config, &init, &init_path)
                     .await?;
-                    init_file_map.insert(init, init_path);
-                }
+                init_file_map.insert(init, init_path);
             }
 
             // Build per-segment init path mapping for merge

--- a/crates/rdlp-downloader/src/hls_state.rs
+++ b/crates/rdlp-downloader/src/hls_state.rs
@@ -108,24 +108,24 @@ impl HlsDownloadState {
         }
 
         // Read and parse state file
-        let state: Self = match File::open(&state_path).await {
-            Ok(mut file) => {
-                let mut contents = String::new();
-                if let Err(e) = file.read_to_string(&mut contents).await {
-                    warn!("Failed to read HLS state file: {e}");
-                    return None;
-                }
-
-                match serde_json::from_str(&contents) {
-                    Ok(state) => state,
-                    Err(e) => {
-                        warn!("Failed to parse HLS state file: {e}");
-                        return None;
-                    }
-                }
-            }
+        let mut file = match File::open(&state_path).await {
+            Ok(file) => file,
             Err(e) => {
                 warn!("Failed to open HLS state file: {e}");
+                return None;
+            }
+        };
+
+        let mut contents = String::new();
+        if let Err(e) = file.read_to_string(&mut contents).await {
+            warn!("Failed to read HLS state file: {e}");
+            return None;
+        }
+
+        let state: Self = match serde_json::from_str(&contents) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!("Failed to parse HLS state file: {e}");
                 return None;
             }
         };

--- a/crates/rdlp-downloader/src/http/config.rs
+++ b/crates/rdlp-downloader/src/http/config.rs
@@ -12,25 +12,25 @@ use std::time::Duration;
 // =============================================================================
 
 /// Minimum file size to enable parallel downloads (10 MB)
-pub const PARALLEL_THRESHOLD: u64 = 10 * 1024 * 1024;
+pub(super) const PARALLEL_THRESHOLD: u64 = 10 * 1024 * 1024;
 
 /// Progress callback update interval
-pub const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
+pub(super) const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Default buffer size for I/O operations (2 MB)
-pub const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
 /// Maximum concurrent connections cap
-pub const MAX_CONCURRENT_CONNECTIONS: usize = 8;
+const MAX_CONCURRENT_CONNECTIONS: usize = 8;
 
 /// Default per-read idle timeout (60 seconds)
-pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Default total download timeout (1 hour)
-pub const DEFAULT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(3600);
+const DEFAULT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(3600);
 
 /// Default merge operation timeout (30 minutes)
-pub const DEFAULT_MERGE_TIMEOUT: Duration = Duration::from_secs(1800);
+const DEFAULT_MERGE_TIMEOUT: Duration = Duration::from_secs(1800);
 
 /// Downloader configuration (shared across clones via Arc)
 ///

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -195,8 +195,7 @@ impl HttpDownloader {
             .headers()
             .get("accept-ranges")
             .and_then(|v| v.to_str().ok())
-            .map(|v| v != "none")
-            .unwrap_or(false))
+            .is_some_and(|v| v != "none"))
     }
 
     /// Download a specific byte range with shared progress tracking
@@ -551,8 +550,7 @@ impl Downloader for HttpDownloader {
                     .headers()
                     .get("accept-ranges")
                     .and_then(|v| v.to_str().ok())
-                    .map(|v| v != "none")
-                    .unwrap_or(true);
+                    != Some("none");
 
                 debug!(
                     "Resume analysis: {:.1}% ({} MB / {} MB), remaining={} MB, concurrent={}, ranges={}",
@@ -589,9 +587,6 @@ impl Downloader for HttpDownloader {
                     supports_ranges
                 );
             }
-
-            let total_size =
-                total_size.or_else(|| response.content_length().map(|size| size + resume_from));
 
             let file = tokio::fs::OpenOptions::new()
                 .append(true)

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -43,10 +43,10 @@ impl MergeMode {
 }
 
 /// Global atomic counter for generating unique download IDs
-pub(super) static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Cleanup chunk files on error
-pub(super) async fn cleanup_chunk_files(
+async fn cleanup_chunk_files(
     temp_dir: &Path,
     filename: &str,
     download_id: u64,

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -134,51 +134,45 @@ pub fn spawn_progress_reporter(
 ) -> ProgressGuard {
     let task = callback.map(|cb| {
         tokio::spawn(async move {
-            let mut last_update = Instant::now();
-
             loop {
                 tokio::time::sleep(config.update_interval).await;
-                let now = Instant::now();
 
-                if now.duration_since(last_update) >= config.update_interval {
-                    let bytes = metrics.downloaded.load(Ordering::Relaxed);
-                    let elapsed = now.duration_since(config.start_time).as_secs_f64();
-                    let speed = if elapsed > 0.0 {
-                        (bytes - config.resume_from) as f64 / elapsed
-                    } else {
-                        0.0
-                    };
+                let bytes = metrics.downloaded.load(Ordering::Relaxed);
+                let elapsed = Instant::now()
+                    .duration_since(config.start_time)
+                    .as_secs_f64();
+                let speed = if elapsed > 0.0 {
+                    (bytes - config.resume_from) as f64 / elapsed
+                } else {
+                    0.0
+                };
 
-                    let progress_info = if let (Some(segments_counter), Some(duration_counter)) =
-                        (&metrics.segments_completed, &metrics.duration_completed)
-                    {
-                        // HLS: duration-based progress
-                        let segments = segments_counter.load(Ordering::Relaxed);
-                        let dur_centis = duration_counter.load(Ordering::Relaxed);
-                        let dur_downloaded = dur_centis as f64 / 100.0;
+                let progress_info = if let (Some(segments_counter), Some(duration_counter)) =
+                    (&metrics.segments_completed, &metrics.duration_completed)
+                {
+                    // HLS: duration-based progress
+                    let segments = segments_counter.load(Ordering::Relaxed);
+                    let dur_centis = duration_counter.load(Ordering::Relaxed);
+                    let dur_downloaded = dur_centis as f64 / 100.0;
 
-                        DownloadProgress::new_with_duration(
-                            bytes,
-                            speed,
-                            segments,
-                            config.total_segments.unwrap_or(0),
-                            dur_downloaded,
-                            config.total_duration.unwrap_or(0.0),
-                        )
-                    } else {
-                        // HTTP: byte-based progress
-                        DownloadProgress::new(bytes, config.total_size, speed)
-                    };
+                    DownloadProgress::new_with_duration(
+                        bytes,
+                        speed,
+                        segments,
+                        config.total_segments.unwrap_or(0),
+                        dur_downloaded,
+                        config.total_duration.unwrap_or(0.0),
+                    )
+                } else {
+                    // HTTP: byte-based progress
+                    DownloadProgress::new(bytes, config.total_size, speed)
+                };
 
-                    cb.on_progress(&progress_info);
-                    last_update = now;
+                cb.on_progress(&progress_info);
 
-                    // Exit when download is complete (HTTP only - has known total)
-                    if let Some(total) = config.total_size {
-                        if bytes >= total {
-                            break;
-                        }
-                    }
+                // Exit when download is complete (HTTP only - has known total)
+                if config.total_size.is_some_and(|total| bytes >= total) {
+                    break;
                 }
             }
         })

--- a/crates/rdlp-extractor/src/extractors/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/mod.rs
@@ -1,3 +1,9 @@
+//! Site-specific extractor implementations
+//!
+//! Each submodule implements a single extractor (or extractor family) for a
+//! particular website. Re-exports provide convenient access to the top-level
+//! extractor types.
+
 pub mod nine_anime;
 pub mod pornhub;
 pub mod redtube;

--- a/crates/rdlp-extractor/src/extractors/nine_anime/api.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/api.rs
@@ -114,17 +114,14 @@ fn extract_inner_text(html: &str) -> Option<String> {
     static INNER_TEXT: Lazy<Regex> =
         Lazy::new(|| Regex::new(r#">([^<]+)<"#).expect("Valid inner text pattern"));
 
-    INNER_TEXT
-        .captures_iter(html)
-        .filter_map(|c| {
-            let text = c[1].trim();
-            if text.is_empty() {
-                None
-            } else {
-                Some(text.to_string())
-            }
-        })
-        .next()
+    INNER_TEXT.captures_iter(html).find_map(|c| {
+        let text = c[1].trim();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text.to_string())
+        }
+    })
 }
 
 /// Parse all server items from the AJAX HTML response.
@@ -139,10 +136,10 @@ fn parse_server_items(html: &str) -> Vec<ServerEntry> {
     for block_match in SERVER_ITEM_BLOCK.find_iter(html) {
         let block = block_match.as_str();
 
-        let data_id = match DATA_ID_ATTR.captures(block) {
-            Some(c) => c[1].to_string(),
-            None => continue,
+        let Some(data_id_caps) = DATA_ID_ATTR.captures(block) else {
+            continue;
         };
+        let data_id = data_id_caps[1].to_string();
 
         let server_id: u32 = SERVER_ID_ATTR
             .captures(block)
@@ -154,9 +151,8 @@ fn parse_server_items(html: &str) -> Vec<ServerEntry> {
             _ => AudioType::Sub,
         };
 
-        let server_name = match extract_inner_text(block) {
-            Some(name) => name,
-            None => continue,
+        let Some(server_name) = extract_inner_text(block) else {
+            continue;
         };
 
         // Avoid duplicates
@@ -179,10 +175,14 @@ const PREFERRED_SERVERS: &[&str] = &["Vidcloud", "Vidstreaming", "DouVideo"];
 /// Sort servers by preference (Vidcloud first, then Vidstreaming, then others).
 pub fn sort_by_preference(servers: &mut [ServerEntry]) {
     servers.sort_by_key(|s| {
-        let name_lower = s.server_name.to_lowercase();
         PREFERRED_SERVERS
             .iter()
-            .position(|p| name_lower.contains(&p.to_lowercase()))
+            .position(|p| {
+                s.server_name
+                    .as_bytes()
+                    .windows(p.len())
+                    .any(|w| w.eq_ignore_ascii_case(p.as_bytes()))
+            })
             .unwrap_or(PREFERRED_SERVERS.len())
     });
 }
@@ -292,8 +292,8 @@ fn parse_episode_info(html: &str, episode_data_id: &str) -> Option<EpisodeInfo> 
         let block = block_match.as_str();
 
         // Check if this block's data-id matches
-        let data_id = EP_ITEM_DATA_ID.captures(block).map(|c| c[1].to_string())?;
-        if data_id != episode_data_id {
+        let id_caps = EP_ITEM_DATA_ID.captures(block)?;
+        if &id_caps[1] != episode_data_id {
             continue;
         }
 
@@ -332,14 +332,11 @@ pub fn parse_all_episodes(html: &str) -> Vec<EpisodeListEntry> {
     for block_match in EP_ITEM_BLOCK.find_iter(html) {
         let block = block_match.as_str();
 
-        let data_id = match EP_ITEM_DATA_ID.captures(block) {
-            Some(c) => c[1].to_string(),
-            None => continue,
+        let Some(id_caps) = EP_ITEM_DATA_ID.captures(block) else {
+            continue;
         };
-
-        let number = match EP_DATA_NUMBER.captures(block) {
-            Some(c) => c[1].to_string(),
-            None => continue,
+        let Some(num_caps) = EP_DATA_NUMBER.captures(block) else {
+            continue;
         };
 
         let title = EP_TITLE_ATTR
@@ -348,8 +345,11 @@ pub fn parse_all_episodes(html: &str) -> Vec<EpisodeListEntry> {
             .filter(|t| !t.is_empty());
 
         entries.push(EpisodeListEntry {
-            data_id,
-            info: EpisodeInfo { number, title },
+            data_id: id_caps[1].to_string(),
+            info: EpisodeInfo {
+                number: num_caps[1].to_string(),
+                title,
+            },
         });
     }
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
@@ -74,10 +74,11 @@ pub fn decrypt_src(src: &str, client_key: &str, megacloud_key: &str) -> Result<S
 fn reverse_layer(dec_src: &mut Vec<char>, layer_key: &str, chars: &[char]) {
     // Step 1: Reverse substitution mapping
     let sub_values = seed_shuffle(chars, layer_key);
-    let mut char_map = std::collections::HashMap::new();
-    for (i, &ch) in sub_values.iter().enumerate() {
-        char_map.insert(ch, chars[i]);
-    }
+    let char_map: std::collections::HashMap<char, char> = sub_values
+        .iter()
+        .zip(chars.iter())
+        .map(|(&shuffled, &original)| (shuffled, original))
+        .collect();
     for ch in dec_src.iter_mut() {
         if let Some(&mapped) = char_map.get(ch) {
             *ch = mapped;
@@ -155,9 +156,7 @@ fn columnar_cipher(src: &[char], key: &str) -> Vec<char> {
     // Read grid row-by-row
     let mut result = Vec::with_capacity(src.len());
     for row in &grid {
-        for &ch in row {
-            result.push(ch);
-        }
+        result.extend(row);
     }
     result
 }
@@ -204,13 +203,13 @@ fn keygen(megacloud_key: &str, client_key: &str) -> String {
     // Interleave with reversed client key char codes
     let leaf: Vec<u32> = client_key.chars().rev().map(|c| c as u32).collect();
     let max_len = shifted.len().max(leaf.len());
-    let mut return_codes: Vec<u32> = Vec::with_capacity(max_len * 2);
+    let mut return_codes = Vec::with_capacity(max_len * 2);
     for i in 0..max_len {
-        if i < shifted.len() {
-            return_codes.push(shifted[i]);
+        if let Some(&code) = shifted.get(i) {
+            return_codes.push(code);
         }
-        if i < leaf.len() {
-            return_codes.push(leaf[i]);
+        if let Some(&code) = leaf.get(i) {
+            return_codes.push(code);
         }
     }
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
@@ -231,25 +231,15 @@ async fn extract_client_key(source_id: &str, ctx: &ExtractionContext) -> Result<
 /// Parse the client key from embed page HTML using pattern matching.
 fn parse_client_key(html: &str) -> Result<String> {
     // Find the first matching obfuscation pattern
-    let mut matched_pattern_idx = None;
-    let mut matched_text = None;
-
-    for (idx, pattern) in CLIENT_KEY_PATTERNS.iter().enumerate() {
-        if let Some(m) = pattern.find(html) {
-            matched_pattern_idx = Some(idx);
-            matched_text = Some(m.as_str().to_string());
-            break;
-        }
-    }
-
-    let (pattern_idx, text) = match (matched_pattern_idx, matched_text) {
-        (Some(idx), Some(text)) => (idx, text),
-        _ => {
-            return Err(RdlpError::Extraction(
+    let (pattern_idx, text) = CLIENT_KEY_PATTERNS
+        .iter()
+        .enumerate()
+        .find_map(|(idx, pattern)| pattern.find(html).map(|m| (idx, m.as_str().to_string())))
+        .ok_or_else(|| {
+            RdlpError::Extraction(
                 "Could not find client key in embed page (no pattern matched)".to_string(),
-            ));
-        }
-    };
+            )
+        })?;
 
     match pattern_idx {
         // Pattern 1: Comment — key follows colon, no quotes

--- a/crates/rdlp-extractor/src/extractors/nine_anime/metadata.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/metadata.rs
@@ -34,7 +34,7 @@ pub fn extract_metadata(html: &Html, webpage: &str) -> AnimeMetadata {
 }
 
 /// Extract the anime title, trying multiple strategies.
-fn extract_title(html: &Html, webpage: &str) -> String {
+fn extract_title(html: &Html, _webpage: &str) -> String {
     // Strategy 1: h2 element — 9anime puts the clean title here
     for selector_str in &["h2.film-name", "h2"] {
         if let Ok(sel) = Selector::parse(selector_str) {
@@ -67,7 +67,6 @@ fn extract_title(html: &Html, webpage: &str) -> String {
         }
     }
 
-    let _ = webpage;
     "Unknown Anime".to_string()
 }
 
@@ -90,16 +89,13 @@ fn clean_9anime_title(title: &str) -> String {
 
 /// Extract thumbnail URL from the page.
 fn extract_thumbnail(html: &Html) -> Option<String> {
-    // Try OG image
-    if let Some(url) = BaseExtractor::extract_thumbnail_multi_strategy(html) {
-        return Some(url);
-    }
-
-    // Fallback: look for poster image
-    let img_selector = Selector::parse("img.film-poster-img").ok()?;
-    html.select(&img_selector)
-        .next()
-        .and_then(|e| e.value().attr("src").map(String::from))
+    // Try OG image first, then fall back to poster image
+    BaseExtractor::extract_thumbnail_multi_strategy(html).or_else(|| {
+        let img_selector = Selector::parse("img.film-poster-img").ok()?;
+        html.select(&img_selector)
+            .next()
+            .and_then(|e| e.value().attr("src").map(String::from))
+    })
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -34,7 +34,7 @@ pub mod patterns;
 pub mod playlist;
 
 use async_trait::async_trait;
-use log::{debug, info, warn};
+use log::{debug, info};
 use rdlp_core::{
     DownloadProtocol, ExtractionContext, Format, InfoDict, InfoExtractor, RdlpError, Result,
 };
@@ -116,7 +116,7 @@ pub(crate) async fn resolve_episode_formats(
         let source = match api::fetch_source(&server.data_id, ctx).await {
             Ok(s) => s,
             Err(e) => {
-                warn!(
+                debug!(
                     server:% = server.server_name;
                     "Failed to fetch source: {e}"
                 );
@@ -154,10 +154,8 @@ pub(crate) async fn resolve_episode_formats(
                         DownloadProtocol::Https
                     };
 
-                    let ext = "mp4";
                     let audio_label = server.audio_type.to_string();
-
-                    let mut format = Format::new(&format_id, &src.url, ext, protocol);
+                    let mut format = Format::new(&format_id, &src.url, "mp4", protocol);
                     format.format_note =
                         Some(format!("{} ({})", server.audio_type, server.server_name));
                     format.language = Some(audio_label);
@@ -186,7 +184,7 @@ pub(crate) async fn resolve_episode_formats(
                 }
             }
             Err(e) => {
-                warn!(
+                debug!(
                     server:% = server.server_name;
                     "Megacloud extraction failed: {e}"
                 );

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -13,6 +13,15 @@ use super::patterns::{
 use crate::base::common::BaseExtractor;
 use std::collections::HashSet;
 
+/// Extend `dest` with `formats`, skipping URLs already in `seen`.
+fn extend_deduped(dest: &mut Vec<Format>, seen: &mut HashSet<String>, formats: Vec<Format>) {
+    for format in formats {
+        if seen.insert(format.url.clone()) {
+            dest.push(format);
+        }
+    }
+}
+
 /// Extract all formats using multiple strategies
 ///
 /// Tries strategies in order:
@@ -25,32 +34,25 @@ pub async fn extract_all_formats(webpage: &str, ctx: &ExtractionContext) -> Resu
 
     // Strategy 1: flashvars (primary)
     if let Ok(formats) = extract_from_flashvars(webpage, ctx).await {
-        for format in formats {
-            if seen_urls.insert(format.url.clone()) {
-                all_formats.push(format);
-            }
-        }
+        extend_deduped(&mut all_formats, &mut seen_urls, formats);
         if !all_formats.is_empty() {
-            debug!(
-                "[PornHub] Extracted {} formats from flashvars",
-                all_formats.len()
-            );
+            debug!(count = all_formats.len(); "[PornHub] Extracted formats from flashvars");
         }
     }
 
     // Strategy 2: JavaScript variables
-    for format in extract_from_js_vars(webpage) {
-        if seen_urls.insert(format.url.clone()) {
-            all_formats.push(format);
-        }
-    }
+    extend_deduped(
+        &mut all_formats,
+        &mut seen_urls,
+        extract_from_js_vars(webpage),
+    );
 
     // Strategy 3: Download buttons
-    for format in extract_from_download_buttons(webpage) {
-        if seen_urls.insert(format.url.clone()) {
-            all_formats.push(format);
-        }
-    }
+    extend_deduped(
+        &mut all_formats,
+        &mut seen_urls,
+        extract_from_download_buttons(webpage),
+    );
 
     if all_formats.is_empty() {
         return Err(RdlpError::Extraction(
@@ -232,29 +234,26 @@ fn extract_from_js_vars(webpage: &str) -> Vec<Format> {
 
 /// Extract formats from download buttons
 fn extract_from_download_buttons(webpage: &str) -> Vec<Format> {
-    let mut formats = Vec::new();
-
-    for caps in DOWNLOAD_BTN_PATTERN.captures_iter(webpage) {
-        if let Some(url_match) = caps.get(1) {
-            let url = url_match.as_str();
+    DOWNLOAD_BTN_PATTERN
+        .captures_iter(webpage)
+        .filter_map(|caps| {
+            let url = caps.get(1)?.as_str();
             let quality = parse_quality_from_url(url);
-
             let format_id = quality
                 .map(|q| format!("{q}p"))
                 .unwrap_or_else(|| "download".to_string());
-
             let height = quality.map(|q| q as u32);
 
             debug!(format_id:?; "[PornHub] Found format from download button");
 
-            let format =
-                BaseExtractor::build_format(format_id, url.to_string(), "mp4".to_string(), height);
-
-            formats.push(format);
-        }
-    }
-
-    formats
+            Some(BaseExtractor::build_format(
+                format_id,
+                url.to_string(),
+                "mp4".to_string(),
+                height,
+            ))
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -132,7 +132,7 @@ impl InfoExtractor for PornHubExtractor {
         let (formats_with_size, hls_flags) = detect_format_sizes(formats, ctx, self.name()).await;
 
         // Build InfoDict with all metadata
-        let mut info = InfoDict::new(video_id, title, self.name().to_string(), url.to_string());
+        let mut info = InfoDict::new(video_id, title, self.name(), url);
         info.description = description;
         info.thumbnail = thumbnail;
         info.uploader = uploader;

--- a/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
@@ -295,7 +295,7 @@ fn calculate_page_count(video_count: usize) -> usize {
     if video_count <= 36 {
         1
     } else {
-        ((video_count - 36) as f64 / 40.0).ceil() as usize + 1
+        (video_count - 36).div_ceil(40) + 1
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
@@ -77,17 +77,9 @@ pub async fn set_age_cookies(host: &str, ctx: &ExtractionContext) -> Result<()> 
 ///
 /// Returns error message if video is unavailable, None otherwise
 pub fn detect_video_unavailable(webpage: &str) -> Option<String> {
-    // Check for removed/flagged videos
-    if let Some(caps) = REMOVED_VIDEO_PATTERN.captures(webpage) {
-        if let Some(error) = caps.name("error") {
-            let cleaned = BaseExtractor::clean_html_tags(error.as_str(), Some(200));
-            return Some(format!("Video unavailable: {cleaned}"));
-        }
-    }
-
-    // Check for noVideo section
-    if let Some(caps) = NO_VIDEO_PATTERN.captures(webpage) {
-        if let Some(error) = caps.name("error") {
+    // Check for removed/flagged videos or noVideo section
+    for pattern in [&*REMOVED_VIDEO_PATTERN, &*NO_VIDEO_PATTERN] {
+        if let Some(error) = pattern.captures(webpage).and_then(|c| c.name("error")) {
             let cleaned = BaseExtractor::clean_html_tags(error.as_str(), Some(200));
             return Some(format!("Video unavailable: {cleaned}"));
         }
@@ -127,16 +119,12 @@ pub fn extract_title(html: &Html, webpage: &str) -> String {
     }
 
     // Strategy 3: PornHub-specific shareTitle JavaScript variable
-    if let Some(caps) = SHARE_TITLE_PATTERN.captures(webpage) {
-        if let Some(m) = caps.get(1) {
-            let title = m.as_str().trim();
-            if !title.is_empty() {
-                return title.to_string();
-            }
-        }
-    }
-
-    "Untitled".to_string()
+    SHARE_TITLE_PATTERN
+        .captures(webpage)
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str().trim())
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| "Untitled".to_string(), |s| s.to_string())
 }
 
 /// Extract video description from HTML.
@@ -216,31 +204,25 @@ pub fn extract_channel_url(html: &Html) -> Option<String> {
 
 /// Extract view count from HTML
 pub fn extract_view_count(html: &Html) -> Option<u64> {
-    BaseExtractor::extract_element_text_str(html, ".count")
-        .and_then(|t| parse_view_count(&t))
-        .or_else(|| {
-            BaseExtractor::extract_element_text_str(html, ".views")
-                .and_then(|t| parse_view_count(&t))
-        })
+    [".count", ".views"].iter().find_map(|sel| {
+        BaseExtractor::extract_element_text_str(html, sel).and_then(|t| parse_view_count(&t))
+    })
 }
 
 /// Parse view count string (handles "1.5M", "500K", etc.)
 fn parse_view_count(text: &str) -> Option<u64> {
     let text = text.trim().to_uppercase();
-    let text = text.replace(',', "").replace(" ", "");
+    let text = text.replace([',', ' '], "");
 
-    if text.ends_with('K') {
-        let num: f64 = text.trim_end_matches('K').parse().ok()?;
-        Some((num * 1000.0) as u64)
-    } else if text.ends_with('M') {
-        let num: f64 = text.trim_end_matches('M').parse().ok()?;
-        Some((num * 1_000_000.0) as u64)
-    } else if text.ends_with('B') {
-        let num: f64 = text.trim_end_matches('B').parse().ok()?;
-        Some((num * 1_000_000_000.0) as u64)
-    } else {
-        text.parse().ok()
-    }
+    let (suffix_multiplier, num_str) = match text.as_bytes().last()? {
+        b'K' => (1_000.0, &text[..text.len() - 1]),
+        b'M' => (1_000_000.0, &text[..text.len() - 1]),
+        b'B' => (1_000_000_000.0, &text[..text.len() - 1]),
+        _ => return text.parse().ok(),
+    };
+
+    let num: f64 = num_str.parse().ok()?;
+    Some((num * suffix_multiplier) as u64)
 }
 
 /// Extract rating percentage from HTML

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -3,10 +3,10 @@
 //! Extracts video formats from JavaScript sources and mediaDefinition arrays.
 
 use log::{debug, warn};
+use once_cell::sync::Lazy;
 use rdlp_core::{ExtractionContext, Format};
 use regex::Regex;
 use serde_json::Value;
-use std::sync::LazyLock;
 
 use crate::base::common::BaseExtractor;
 use crate::utils::{extract_extension_from_url, make_absolute_url};
@@ -29,8 +29,8 @@ pub fn parse_quality(item: &Value) -> String {
 fn extract_bitrate_from_url(url: &str) -> Option<f64> {
     // Pattern: digits followed by K (case insensitive) before file extension
     // Example: 4000K, 2000K, 1500K
-    static BITRATE_PATTERN: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(\d+)[Kk]_\d+\.[a-zA-Z0-9]+$").unwrap());
+    static BITRATE_PATTERN: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(\d+)[Kk]_\d+\.[a-zA-Z0-9]+$").expect("Valid bitrate pattern"));
 
     BITRATE_PATTERN
         .captures(url)
@@ -173,7 +173,7 @@ pub async fn extract_from_media_definition(webpage: &str, ctx: &ExtractionContex
                             let has_quality = item.get("quality").is_some();
 
                             // If format is mp4/hls without quality, fetch JSON to get actual formats
-                            if (format_type == "mp4" || format_type == "hls") && !has_quality {
+                            if matches!(format_type, "mp4" | "hls") && !has_quality {
                                 if let Some(fetched) =
                                     fetch_formats_from_endpoint(video_url, ctx).await
                                 {

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -116,12 +116,7 @@ impl InfoExtractor for RedTubeExtractor {
         let (formats, hls_flags) = detect_format_sizes(formats, ctx, self.name()).await;
 
         // Build InfoDict with all extracted metadata
-        let mut info = InfoDict::new(
-            video_id,
-            metadata.title,
-            self.name().to_string(),
-            url.to_string(),
-        );
+        let mut info = InfoDict::new(video_id, metadata.title, self.name(), url);
         info.description = metadata.description;
         info.uploader = metadata.uploader;
         info.uploader_id = metadata.uploader_id;

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -26,7 +26,7 @@ use patterns::{EMPFLIX_URL_PATTERN, MOVIEFAP_URL_PATTERN, TNAFLIX_URL_PATTERN};
 ///
 /// Uses [`TnaFlixNetworkBase`] for shared extraction logic.
 pub struct TNAFlixExtractor {
-    name: String,
+    name: &'static str,
     url_pattern: &'static Regex,
     base: TnaFlixNetworkBase,
 }
@@ -36,7 +36,7 @@ impl TNAFlixExtractor {
     #[must_use]
     pub fn tnaflix() -> Self {
         Self {
-            name: "TNAFlix".to_string(),
+            name: "TNAFlix",
             url_pattern: &TNAFLIX_URL_PATTERN,
             base: TnaFlixNetworkBase::new(),
         }
@@ -46,7 +46,7 @@ impl TNAFlixExtractor {
     #[must_use]
     pub fn empflix() -> Self {
         Self {
-            name: "EMPFlix".to_string(),
+            name: "EMPFlix",
             url_pattern: &EMPFLIX_URL_PATTERN,
             base: TnaFlixNetworkBase::new(),
         }
@@ -56,7 +56,7 @@ impl TNAFlixExtractor {
     #[must_use]
     pub fn moviefap() -> Self {
         Self {
-            name: "MovieFap".to_string(),
+            name: "MovieFap",
             url_pattern: &MOVIEFAP_URL_PATTERN,
             base: TnaFlixNetworkBase::new(),
         }
@@ -72,7 +72,7 @@ impl TNAFlixExtractor {
 #[async_trait]
 impl InfoExtractor for TNAFlixExtractor {
     fn name(&self) -> &str {
-        &self.name
+        self.name
     }
 
     fn valid_url(&self) -> &Regex {
@@ -159,7 +159,7 @@ impl InfoExtractor for TNAFlixExtractor {
         }
 
         // Build InfoDict with all extracted metadata
-        let mut info = InfoDict::new(video_id, metadata.title, self.name.clone(), url.to_string());
+        let mut info = InfoDict::new(video_id, metadata.title, self.name, url);
         info.description = metadata.description;
         info.uploader = metadata.uploader;
         info.uploader_id = metadata.uploader_id;

--- a/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
@@ -23,24 +23,18 @@ fn get_height(s: &str) -> Option<u32> {
 }
 
 /// Detect vcodec from URL by checking for `.av1.` or `.h264.` in the path.
-fn detect_vcodec(url: &str) -> Option<String> {
-    if url.contains(".av1.") {
-        Some("av1".to_string())
-    } else if url.contains(".h264.") {
-        Some("h264".to_string())
-    } else {
-        None
-    }
+fn detect_vcodec(url: &str) -> Option<&'static str> {
+    [(".av1.", "av1"), (".h264.", "h264")]
+        .iter()
+        .find(|(pattern, _)| url.contains(pattern))
+        .map(|(_, codec)| *codec)
 }
 
 /// Apply codec fixup to all formats (detect vcodec from URL patterns).
 pub fn fixup_formats(formats: &mut [Format]) {
-    for f in formats {
-        if f.vcodec.is_some() {
-            continue;
-        }
+    for f in formats.iter_mut().filter(|f| f.vcodec.is_none()) {
         if let Some(vcodec) = detect_vcodec(&f.url) {
-            f.vcodec = Some(vcodec);
+            f.vcodec = Some(vcodec.to_string());
         }
     }
 }
@@ -208,30 +202,22 @@ pub fn extract_from_initials(initials: &Value, page_url: &str) -> Vec<Format> {
                             continue;
                         }
 
-                        let quality = std_obj
+                        // Extract quality as a displayable string from "quality" (string or int)
+                        // or "label" as fallback.
+                        let quality_str = std_obj
                             .get("quality")
-                            .and_then(|v| v.as_str().or_else(|| v.as_i64().map(|_| "")))
-                            .or_else(|| std_obj.get("label").and_then(|v| v.as_str()))
-                            .unwrap_or("");
-
-                        let quality_str = if !quality.is_empty() {
-                            std_obj
-                                .get("quality")
-                                .and_then(|v| {
-                                    v.as_str()
-                                        .map(|s| s.to_string())
-                                        .or_else(|| v.as_i64().map(|i| i.to_string()))
-                                })
-                                .or_else(|| {
-                                    std_obj
-                                        .get("label")
-                                        .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string())
-                                })
-                                .unwrap_or_default()
-                        } else {
-                            String::new()
-                        };
+                            .and_then(|v| {
+                                v.as_str()
+                                    .map(|s| s.to_string())
+                                    .or_else(|| v.as_i64().map(|i| i.to_string()))
+                            })
+                            .or_else(|| {
+                                std_obj
+                                    .get("label")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                            })
+                            .unwrap_or_default();
 
                         let format_id = if quality_str.is_empty() {
                             identifier.clone()
@@ -292,26 +278,26 @@ pub fn extract_from_legacy(webpage: &str) -> Vec<Format> {
     let mut seen_urls: HashSet<String> = HashSet::new();
 
     // Strategy 1: sources: {...} JS object
-    if let Some(caps) = patterns::LEGACY_SOURCES_PATTERN.captures(webpage) {
-        if let Some(json_str) = caps.get(1) {
-            if let Ok(sources) = serde_json::from_str::<Value>(json_str.as_str()) {
-                if let Some(obj) = sources.as_object() {
-                    for (format_id, url_val) in obj {
-                        if let Some(url) = url_val.as_str() {
-                            if url.is_empty() || !seen_urls.insert(url.to_string()) {
-                                continue;
-                            }
-                            let height = get_height(format_id);
-                            let format = BaseExtractor::build_format(
-                                format_id.clone(),
-                                url.to_string(),
-                                "mp4".to_string(),
-                                height,
-                            );
-                            formats.push(format);
-                        }
-                    }
+    if let Some(sources) = patterns::LEGACY_SOURCES_PATTERN
+        .captures(webpage)
+        .and_then(|caps| caps.get(1))
+        .and_then(|json_str| serde_json::from_str::<Value>(json_str.as_str()).ok())
+    {
+        if let Some(obj) = sources.as_object() {
+            for (format_id, url_val) in obj {
+                let Some(url) = url_val.as_str().filter(|u| !u.is_empty()) else {
+                    continue;
+                };
+                if !seen_urls.insert(url.to_string()) {
+                    continue;
                 }
+                let height = get_height(format_id);
+                formats.push(BaseExtractor::build_format(
+                    format_id.clone(),
+                    url.to_string(),
+                    "mp4".to_string(),
+                    height,
+                ));
             }
         }
     }
@@ -324,14 +310,19 @@ pub fn extract_from_legacy(webpage: &str) -> Vec<Format> {
     ];
 
     for pattern in &url_patterns {
-        if let Some(caps) = pattern.captures(webpage) {
-            if let Some(url_match) = caps.name("url") {
-                let url = url_match.as_str();
-                if !url.is_empty() && seen_urls.insert(url.to_string()) {
-                    let format =
-                        Format::new("video", url, "mp4", rdlp_core::DownloadProtocol::Https);
-                    formats.push(format);
-                }
+        if let Some(url) = pattern
+            .captures(webpage)
+            .and_then(|caps| caps.name("url"))
+            .map(|m| m.as_str())
+            .filter(|u| !u.is_empty())
+        {
+            if seen_urls.insert(url.to_string()) {
+                formats.push(Format::new(
+                    "video",
+                    url,
+                    "mp4",
+                    rdlp_core::DownloadProtocol::Https,
+                ));
             }
         }
     }
@@ -361,11 +352,11 @@ mod tests {
     fn test_detect_vcodec() {
         assert_eq!(
             detect_vcodec("https://example.com/video.h264.mp4"),
-            Some("h264".to_string())
+            Some("h264")
         );
         assert_eq!(
             detect_vcodec("https://example.com/video.av1.mp4"),
-            Some("av1".to_string())
+            Some("av1")
         );
         assert_eq!(detect_vcodec("https://example.com/video.mp4"), None);
     }

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -160,29 +160,29 @@ impl XHamsterExtractor {
         let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 
         // Try to find the real video URL in the embed page
-        if let Some(caps) = patterns::EMBED_VIDEO_URL_PATTERN.captures(&webpage) {
-            if let Some(video_url) = caps.get(1) {
-                debug!(video_url:? = video_url.as_str(); "[XHamster] Found video URL in embed page");
-                return self.extract_video(video_url.as_str(), ctx).await;
-            }
+        if let Some(video_url) = patterns::EMBED_VIDEO_URL_PATTERN
+            .captures(&webpage)
+            .and_then(|caps| caps.get(1))
+        {
+            debug!(video_url:? = video_url.as_str(); "[XHamster] Found video URL in embed page");
+            return self.extract_video(video_url.as_str(), ctx).await;
         }
 
         // Try extracting from embed vars JSON
-        if let Some(caps) = patterns::EMBED_VARS_PATTERN.captures(&webpage) {
-            if let Some(json_str) = caps.get(1) {
-                if let Ok(vars) = serde_json::from_str::<serde_json::Value>(json_str.as_str()) {
-                    if let Some(video_url) = vars
-                        .get("downloadLink")
-                        .or_else(|| vars.get("mp4File"))
-                        .and_then(|v| v.as_str())
-                    {
-                        if !video_url.is_empty() {
-                            debug!(video_url:?; "[XHamster] Found video URL in embed vars");
-                            return self.extract_video(video_url, ctx).await;
-                        }
-                    }
-                }
-            }
+        if let Some(video_url) = patterns::EMBED_VARS_PATTERN
+            .captures(&webpage)
+            .and_then(|caps| caps.get(1))
+            .and_then(|json_str| serde_json::from_str::<serde_json::Value>(json_str.as_str()).ok())
+            .and_then(|vars| {
+                vars.get("downloadLink")
+                    .or_else(|| vars.get("mp4File"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+            })
+        {
+            debug!(video_url:?; "[XHamster] Found video URL in embed vars");
+            return self.extract_video(&video_url, ctx).await;
         }
 
         Err(RdlpError::Extraction(format!(
@@ -379,19 +379,18 @@ impl InfoExtractor for XHamsterExtractor {
 /// Try to extract and parse `window.initials` JSON from the page source.
 fn extract_initials_json(webpage: &str) -> Option<serde_json::Value> {
     // Try strict pattern first, then fallback
-    let json_str = patterns::INITIALS_PATTERN
-        .captures(webpage)
-        .or_else(|| patterns::INITIALS_FALLBACK_PATTERN.captures(webpage))
-        .and_then(|caps| caps.get(1))
-        .map(|m| m.as_str())?;
+    let json_str = [
+        &*patterns::INITIALS_PATTERN,
+        &*patterns::INITIALS_FALLBACK_PATTERN,
+    ]
+    .iter()
+    .find_map(|pat| pat.captures(webpage))
+    .and_then(|caps| caps.get(1))
+    .map(|m| m.as_str())?;
 
-    match serde_json::from_str(json_str) {
-        Ok(val) => Some(val),
-        Err(e) => {
-            debug!("[XHamster] Failed to parse window.initials JSON: {e}");
-            None
-        }
-    }
+    serde_json::from_str(json_str)
+        .inspect_err(|e| debug!("[XHamster] Failed to parse window.initials JSON: {e}"))
+        .ok()
 }
 
 /// Extract video URLs from a user/creator page HTML.

--- a/crates/rdlp-extractor/src/extractors/xhamster/utils.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/utils.rs
@@ -89,11 +89,7 @@ pub fn detect_video_unavailable(webpage: &str) -> Option<String> {
 /// Returns 18 if the RTA tag is present, `None` otherwise.
 /// The caller should default to 18 for xHamster regardless.
 pub fn extract_age_limit(webpage: &str) -> Option<u8> {
-    if RTA_PATTERN.is_match(webpage) {
-        Some(18)
-    } else {
-        None
-    }
+    RTA_PATTERN.is_match(webpage).then_some(18)
 }
 
 /// Extract metadata from `videoModel` JSON and build an `InfoDict`.
@@ -113,7 +109,7 @@ pub fn extract_metadata_from_json(
         .unwrap_or("Untitled")
         .to_string();
 
-    let mut info = InfoDict::new(video_id, title, extractor_name.to_string(), url.to_string());
+    let mut info = InfoDict::new(video_id, title, extractor_name, url);
 
     info.description = video_model
         .get("description")
@@ -154,15 +150,14 @@ pub fn extract_metadata_from_json(
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let uploader_url = author
+        info.uploader_url = author
             .get("pageURL")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        if let Some(ref u_url) = uploader_url {
+        if let Some(ref u_url) = info.uploader_url {
             info.uploader_id = u_url.split('/').next_back().map(|s| s.to_string());
         }
-        info.uploader_url = uploader_url;
     }
 
     // Categories
@@ -214,7 +209,7 @@ pub fn extract_metadata_from_html(
         })
         .unwrap_or_else(|| "Untitled".to_string());
 
-    let mut info = InfoDict::new(video_id, title, extractor_name.to_string(), url.to_string());
+    let mut info = InfoDict::new(video_id, title, extractor_name, url);
 
     // Description
     info.description = LEGACY_DESCRIPTION_PATTERN
@@ -247,17 +242,13 @@ pub fn extract_metadata_from_html(
     });
 
     // Duration (parse "PT1M30S" or "1:30" formats)
-    for pattern in &LEGACY_DURATION_PATTERNS {
-        if let Some(caps) = Regex::new(pattern).ok().and_then(|re| re.captures(webpage)) {
-            if let Some(m) = caps.get(1) {
-                let dur_str = m.as_str().trim();
-                info.duration = BaseExtractor::parse_duration(dur_str);
-                if info.duration.is_some() {
-                    break;
-                }
-            }
-        }
-    }
+    info.duration = LEGACY_DURATION_PATTERNS.iter().find_map(|pattern| {
+        Regex::new(pattern)
+            .ok()
+            .and_then(|re| re.captures(webpage))
+            .and_then(|caps| caps.get(1))
+            .and_then(|m| BaseExtractor::parse_duration(m.as_str().trim()))
+    });
 
     // View count
     info.view_count = LEGACY_VIEW_COUNT_PATTERN

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -56,11 +56,20 @@ fn extract_models(html: &Html) -> Vec<String> {
     extract_link_texts(html, ".info-block .list-items", "Models:")
 }
 
-/// Extract link texts from a labeled list-items section.
+/// Extract values from `<a>` links inside a labeled `.list-items` section.
 ///
 /// KVS pages use `.list-items` divs with a `.title-row` label followed by `<a>` links.
-/// This finds the section whose label matches `label_text` and collects all link texts.
-fn extract_link_texts(html: &Html, container_sel: &str, label_text: &str) -> Vec<String> {
+/// This finds the section whose label matches `label_text` and applies `extract_fn`
+/// to each link element.
+fn extract_from_labeled_links<F>(
+    html: &Html,
+    container_sel: &str,
+    label_text: &str,
+    extract_fn: F,
+) -> Vec<String>
+where
+    F: Fn(&scraper::ElementRef) -> Option<String>,
+{
     let container_selector = match scraper::Selector::parse(container_sel) {
         Ok(s) => s,
         Err(_) => return Vec::new(),
@@ -75,20 +84,26 @@ fn extract_link_texts(html: &Html, container_sel: &str, label_text: &str) -> Vec
     };
 
     for container in html.select(&container_selector) {
-        // Check if this container's title-row matches the label
         if let Some(title_el) = container.select(&title_selector).next() {
             let title = title_el.text().collect::<String>();
             if title.trim() == label_text {
                 return container
                     .select(&link_selector)
-                    .map(|el| el.text().collect::<String>().trim().to_string())
-                    .filter(|s| !s.is_empty())
+                    .filter_map(|el| extract_fn(&el))
                     .collect();
             }
         }
     }
 
     Vec::new()
+}
+
+/// Extract link texts from a labeled list-items section.
+fn extract_link_texts(html: &Html, container_sel: &str, label_text: &str) -> Vec<String> {
+    extract_from_labeled_links(html, container_sel, label_text, |el| {
+        let text = el.text().collect::<String>().trim().to_string();
+        if text.is_empty() { None } else { Some(text) }
+    })
 }
 
 /// Extract rating percentage from the voters section
@@ -117,75 +132,42 @@ fn extract_like_count(html: &Html) -> Option<u64> {
 ///
 /// The "Models:" section contains `<a href="/models/jenni-lee/">Jenni Lee</a>`.
 fn extract_model_url(html: &Html) -> Option<String> {
-    extract_link_hrefs(html, ".info-block .list-items", "Models:")
-        .into_iter()
-        .next()
+    extract_from_labeled_links(html, ".info-block .list-items", "Models:", |el| {
+        el.value()
+            .attr("href")
+            .map(|href| crate::utils::make_absolute_url(XTITS_BASE_URL, href))
+    })
+    .into_iter()
+    .next()
 }
 
-/// Extract link hrefs from a labeled list-items section.
-fn extract_link_hrefs(html: &Html, container_sel: &str, label_text: &str) -> Vec<String> {
-    let container_selector = match scraper::Selector::parse(container_sel) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
-    let title_selector = match scraper::Selector::parse(".title-row") {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
-    let link_selector = match scraper::Selector::parse("a.link") {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
+/// Extract text from a `.buttons-info .item` element identified by its icon class.
+///
+/// KVS info bars use `.item` divs with an icon element (e.g. `.icon-eye`, `.icon-clock`)
+/// followed by a text value. This returns the combined text of the matching item.
+fn extract_info_bar_text(html: &Html, icon_class: &str) -> Option<String> {
+    let item_selector = scraper::Selector::parse(".buttons-info .item").ok()?;
+    let icon_selector = scraper::Selector::parse(icon_class).ok()?;
 
-    for container in html.select(&container_selector) {
-        if let Some(title_el) = container.select(&title_selector).next() {
-            let title = title_el.text().collect::<String>();
-            if title.trim() == label_text {
-                return container
-                    .select(&link_selector)
-                    .filter_map(|el| {
-                        el.value()
-                            .attr("href")
-                            .map(|href| crate::utils::make_absolute_url(XTITS_BASE_URL, href))
-                    })
-                    .collect();
-            }
+    for item in html.select(&item_selector) {
+        if item.select(&icon_selector).next().is_some() {
+            return Some(item.text().collect());
         }
     }
 
-    Vec::new()
+    None
 }
 
 /// Extract view count from the page
 fn extract_view_count(html: &Html) -> Option<u64> {
-    // Views are in a `.buttons-info .item` containing `.icon-eye`
-    let item_selector = scraper::Selector::parse(".buttons-info .item").ok()?;
-    let icon_selector = scraper::Selector::parse(".icon-eye").ok()?;
-
-    for item in html.select(&item_selector) {
-        if item.select(&icon_selector).next().is_some() {
-            let text: String = item.text().collect();
-            let cleaned = text.trim().replace([' ', ',', '\u{a0}'], "");
-            return cleaned.parse().ok();
-        }
-    }
-
-    None
+    extract_info_bar_text(html, ".icon-eye")
+        .and_then(|text| text.trim().replace([' ', ',', '\u{a0}'], "").parse().ok())
 }
 
 /// Parse duration text like "28min 18sec" into seconds
 fn parse_duration_text(html: &Html) -> Option<f64> {
-    let item_selector = scraper::Selector::parse(".buttons-info .item").ok()?;
-    let icon_selector = scraper::Selector::parse(".icon-clock").ok()?;
-
-    for item in html.select(&item_selector) {
-        if item.select(&icon_selector).next().is_some() {
-            let text: String = item.text().collect();
-            return BaseExtractor::parse_text_duration(text.trim());
-        }
-    }
-
-    None
+    extract_info_bar_text(html, ".icon-clock")
+        .and_then(|text| BaseExtractor::parse_text_duration(text.trim()))
 }
 
 #[async_trait]
@@ -282,7 +264,7 @@ impl InfoExtractor for XTitsExtractor {
             )
         };
 
-        let mut info = InfoDict::new(video_id, title, self.name().to_string(), url.to_string());
+        let mut info = InfoDict::new(video_id, title, self.name(), url);
         info.description = description;
         info.thumbnail = thumbnail;
         info.categories = Some(categories);

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -133,10 +133,9 @@ struct MediaPlaylistInfo {
 
 /// Detect container format from segment URL extension
 fn detect_segment_container(segment_uri: &str) -> Option<String> {
-    let path = segment_uri.split('?').next().unwrap_or(segment_uri);
-    path.rfind('.')
-        .map(|pos| path[pos + 1..].to_lowercase())
-        .filter(|ext| !ext.is_empty())
+    let path = segment_uri.split('?').next()?;
+    let ext = path[path.rfind('.')? + 1..].to_lowercase();
+    if ext.is_empty() { None } else { Some(ext) }
 }
 
 /// HLS playlist size detector
@@ -847,14 +846,14 @@ impl HlsSizeDetector {
         }
 
         // Try Content-Range header: "bytes 0-0/123456"
-        if let Some(content_range) = range_response.headers().get("content-range") {
-            if let Ok(range_str) = content_range.to_str() {
-                if let Some(total) = range_str.split('/').nth(1) {
-                    if let Ok(size) = total.parse::<u64>() {
-                        return Ok(size);
-                    }
-                }
-            }
+        if let Some(size) = range_response
+            .headers()
+            .get("content-range")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.split('/').nth(1))
+            .and_then(|total| total.parse::<u64>().ok())
+        {
+            return Ok(size);
         }
 
         // Last fallback: Content-Length from Range response
@@ -1013,32 +1012,7 @@ async fn enrich_single_hls_format(
         }
     };
 
-    // Enrich format with metadata
-    if let Some((w, h)) = hls_info.resolution {
-        format.width = Some(w as u32);
-        format.height = Some(h as u32);
-        format.format_note = Some(format!("{h}p"));
-    }
-    if let Some(vc) = &hls_info.video_codec {
-        format.vcodec = Some(vc.clone());
-    }
-    if let Some(ac) = &hls_info.audio_codec {
-        format.acodec = Some(ac.clone());
-    }
-    format.fps = hls_info.frame_rate;
-    if let Some(bw) = hls_info.bandwidth {
-        format.tbr = Some(bw as f64 / 1000.0);
-    }
-    format.duration = hls_info.total_duration;
-    format.filesize_approx = Some(hls_info.segment_count as u64);
-    format.container = hls_info.segment_container;
-    if hls_info.has_encryption {
-        format.has_drm = Some(true);
-    }
-    if let Some(h) = format.height {
-        format.quality = Some((h / 100) as i32);
-    }
-
+    // Log before moving fields out of hls_info
     if verbose {
         debug!(
             extractor:? = extractor_name,
@@ -1049,7 +1023,36 @@ async fn enrich_single_hls_format(
         );
     }
 
-    (Some(hls_info.is_live), Some(hls_info.has_encryption))
+    let is_live = hls_info.is_live;
+    let has_encryption = hls_info.has_encryption;
+
+    // Enrich format with metadata — move owned fields to avoid cloning.
+    if let Some((w, h)) = hls_info.resolution {
+        format.width = Some(w as u32);
+        format.height = Some(h as u32);
+        format.format_note = Some(format!("{h}p"));
+    }
+    if hls_info.video_codec.is_some() {
+        format.vcodec = hls_info.video_codec;
+    }
+    if hls_info.audio_codec.is_some() {
+        format.acodec = hls_info.audio_codec;
+    }
+    format.fps = hls_info.frame_rate;
+    if let Some(bw) = hls_info.bandwidth {
+        format.tbr = Some(bw as f64 / 1000.0);
+    }
+    format.duration = hls_info.total_duration;
+    format.filesize_approx = Some(hls_info.segment_count as u64);
+    format.container = hls_info.segment_container;
+    if has_encryption {
+        format.has_drm = Some(true);
+    }
+    if let Some(h) = format.height {
+        format.quality = Some((h / 100) as i32);
+    }
+
+    (Some(is_live), Some(has_encryption))
 }
 
 /// Detect file sizes and segment counts for all formats in parallel
@@ -1244,15 +1247,12 @@ pub async fn detect_format_sizes(
                             existing.filesize_approx = format.filesize_approx;
                             existing.duration = format.duration;
                             existing.filesize = format.filesize;
-                            existing
-                                .fallback_urls
-                                .get_or_insert_with(Vec::new)
-                                .push(old_url);
+                            existing.fallback_urls.get_or_insert_default().push(old_url);
                         } else {
                             // Existing has equal or more segments - keep it, add new as fallback
                             existing
                                 .fallback_urls
-                                .get_or_insert_with(Vec::new)
+                                .get_or_insert_default()
                                 .push(format.url.clone());
                         }
                     }

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -70,7 +70,7 @@ impl ExtractorRegistry {
     #[must_use]
     pub fn new() -> Self {
         let mut registry = Self {
-            extractors: Vec::new(),
+            extractors: Vec::with_capacity(8),
         };
 
         // Register TNAFlix network extractors

--- a/crates/rdlp-extractor/src/utils.rs
+++ b/crates/rdlp-extractor/src/utils.rs
@@ -219,24 +219,15 @@ pub fn decode_html_entities(text: &str) -> String {
 /// ```
 #[must_use]
 pub fn extract_extension_from_url(url: &str) -> Option<String> {
-    // Parse URL to get path
+    // url::Url::path() strips query strings, so no need to handle '?' in the extension
     let parsed = url::Url::parse(url).ok()?;
-    let path = parsed.path();
+    let last_segment = parsed.path().split('/').next_back()?;
+    let ext = &last_segment[last_segment.rfind('.')? + 1..];
 
-    // Get last segment
-    let last_segment = path.split('/').next_back()?;
-
-    // Find extension (after last dot)
-    let dot_pos = last_segment.rfind('.')?;
-    let ext = &last_segment[dot_pos + 1..];
-
-    // Filter out query strings that might be attached
-    let ext_clean = ext.split('?').next().unwrap_or(ext);
-
-    if ext_clean.is_empty() || ext_clean.len() > 10 {
+    if ext.is_empty() || ext.len() > 10 {
         None
     } else {
-        Some(ext_clean.to_lowercase())
+        Some(ext.to_lowercase())
     }
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -95,10 +95,7 @@ impl LogCaptureGuard {
                 message: format!("failed to lock log buffer: {e}"),
             })?;
 
-        match buf.as_mut() {
-            Some(v) => Ok(std::mem::take(v)),
-            None => Ok(Vec::new()),
-        }
+        Ok(buf.as_mut().map(std::mem::take).unwrap_or_default())
     }
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -65,9 +65,10 @@ impl FFmpegRunner {
 
         for (ist_index, ist) in ictx.streams().enumerate() {
             let medium = ist.parameters().medium();
-            if medium != ffmpeg_the_third::media::Type::Video
-                && medium != ffmpeg_the_third::media::Type::Audio
-            {
+            if !matches!(
+                medium,
+                ffmpeg_the_third::media::Type::Video | ffmpeg_the_third::media::Type::Audio
+            ) {
                 continue;
             }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/probe.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/probe.rs
@@ -137,7 +137,7 @@ impl FFmpegRunner {
             let mut stream_info = StreamInfo {
                 index: stream.index(),
                 codec_type: codec_type_str.to_string(),
-                codec_name: Some(codec_name.clone()),
+                codec_name: Some(codec_name),
                 metadata: HashMap::new(),
             };
 
@@ -152,7 +152,7 @@ impl FFmpegRunner {
                 ffmpeg_the_third::media::Type::Video => {
                     info.has_video = true;
                     if info.video_codec.is_none() {
-                        info.video_codec = Some(codec_name);
+                        info.video_codec = stream_info.codec_name.clone();
                     }
 
                     if let Ok(codec_ctx) =
@@ -183,7 +183,7 @@ impl FFmpegRunner {
                 ffmpeg_the_third::media::Type::Audio => {
                     info.has_audio = true;
                     if info.audio_codec.is_none() {
-                        info.audio_codec = Some(codec_name);
+                        info.audio_codec = stream_info.codec_name.clone();
                     }
 
                     if let Ok(codec_ctx) =

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -63,32 +63,32 @@ impl FFmpegRunner {
         let mut ost_index: i32 = 0;
 
         // Find minimum start_time across all video/audio streams for normalization
-        let mut min_start_time_seconds: f64 = f64::MAX;
-        for ist in ictx.streams() {
-            let medium = ist.parameters().medium();
-            if medium == ffmpeg_the_third::media::Type::Video
-                || medium == ffmpeg_the_third::media::Type::Audio
-            {
+        let min_start_time_seconds: f64 = ictx
+            .streams()
+            .filter(|ist| {
+                matches!(
+                    ist.parameters().medium(),
+                    ffmpeg_the_third::media::Type::Video | ffmpeg_the_third::media::Type::Audio
+                )
+            })
+            .filter_map(|ist| {
                 let start = ist.start_time();
                 if start > 0 {
                     let tb = ist.time_base();
-                    let start_secs = start as f64 * tb.0 as f64 / tb.1 as f64;
-                    if start_secs < min_start_time_seconds {
-                        min_start_time_seconds = start_secs;
-                    }
+                    Some(start as f64 * tb.0 as f64 / tb.1 as f64)
+                } else {
+                    None
                 }
-            }
-        }
-        // If no positive start_time found, no normalization needed
-        if min_start_time_seconds == f64::MAX {
-            min_start_time_seconds = 0.0;
-        }
+            })
+            .reduce(f64::min)
+            .unwrap_or(0.0);
 
         for (ist_index, ist) in ictx.streams().enumerate() {
             let medium = ist.parameters().medium();
-            if medium != ffmpeg_the_third::media::Type::Video
-                && medium != ffmpeg_the_third::media::Type::Audio
-            {
+            if !matches!(
+                medium,
+                ffmpeg_the_third::media::Type::Video | ffmpeg_the_third::media::Type::Audio
+            ) {
                 continue;
             }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail.rs
@@ -95,9 +95,10 @@ impl FFmpegRunner {
                 continue;
             }
 
-            if medium != ffmpeg_the_third::media::Type::Video
-                && medium != ffmpeg_the_third::media::Type::Audio
-            {
+            if !matches!(
+                medium,
+                ffmpeg_the_third::media::Type::Video | ffmpeg_the_third::media::Type::Audio
+            ) {
                 continue;
             }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode.rs
@@ -421,9 +421,7 @@ impl FFmpegRunner {
                     break;
                 }
                 let sample = ffmpeg_the_third::format::Sample::from(fmt);
-                if first.is_none() {
-                    first = Some(sample);
-                }
+                first.get_or_insert(sample);
                 if sample == preferred {
                     return preferred;
                 }
@@ -1635,9 +1633,7 @@ impl FFmpegRunner {
                     break;
                 }
                 let pixel = ffmpeg_the_third::format::Pixel::from(fmt);
-                if first.is_none() {
-                    first = Some(pixel);
-                }
+                first.get_or_insert(pixel);
                 if pixel == preferred {
                     return preferred;
                 }

--- a/crates/rdlp-http/src/client.rs
+++ b/crates/rdlp-http/src/client.rs
@@ -79,7 +79,7 @@ impl HttpClientFactory {
             builder = builder.cookie_provider(jar);
         }
 
-        if let Some(ref proxy_url) = self.config.proxy {
+        if let Some(proxy_url) = &self.config.proxy {
             match reqwest::Proxy::all(proxy_url) {
                 Ok(proxy) => builder = builder.proxy(proxy),
                 Err(e) => tracing::warn!("Invalid proxy URL '{}': {}", proxy_url, e),

--- a/crates/rdlp-http/src/config.rs
+++ b/crates/rdlp-http/src/config.rs
@@ -60,20 +60,21 @@ impl HttpClientConfig {
     pub fn from_rdlp_config(config: &rdlp_types::Config) -> Self {
         let mut http_config = Self::default();
 
-        if let Some(ref user_agent) = config.user_agent {
-            http_config.user_agent = user_agent.clone();
+        if let Some(user_agent) = &config.user_agent {
+            http_config.user_agent.clone_from(user_agent);
         }
 
         if let Some(timeout) = config.socket_timeout {
             http_config.connect_timeout_secs = timeout;
         }
 
-        http_config.proxy = config.proxy.clone();
+        http_config.proxy.clone_from(&config.proxy);
 
         http_config
     }
 
     /// Set the user agent string
+    #[must_use]
     pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
         self.user_agent = user_agent.into();
         self
@@ -122,6 +123,7 @@ impl HttpClientConfig {
     }
 
     /// Set a proxy URL
+    #[must_use]
     pub fn with_proxy(mut self, proxy: impl Into<String>) -> Self {
         self.proxy = Some(proxy.into());
         self

--- a/crates/rdlp-jsinterp/src/convert.rs
+++ b/crates/rdlp-jsinterp/src/convert.rs
@@ -26,8 +26,8 @@ pub fn js_to_json(value: &JsValue, ctx: &mut Context) -> JsResult<JsonValue> {
             .unwrap_or(JsonValue::Null));
     }
 
-    if let Ok(s) = value.to_string(ctx) {
-        if value.is_string() {
+    if value.is_string() {
+        if let Ok(s) = value.to_string(ctx) {
             return Ok(JsonValue::String(s.to_std_string_escaped()));
         }
     }

--- a/crates/rdlp-postprocess/src/processors/embed_subtitles.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_subtitles.rs
@@ -46,12 +46,21 @@ impl EmbedSubtitles {
     /// # Returns
     /// The appropriate subtitle codec name, or `"srt"` as fallback.
     fn subtitle_codec_for_container(container_ext: &str) -> &'static str {
-        let lower = container_ext.to_lowercase();
-        match lower.as_str() {
-            "mp4" | "m4a" | "m4v" | "mov" => "mov_text",
-            "mkv" | "mka" => "srt",
-            "webm" => "webvtt",
-            _ => "srt",
+        // Use case-insensitive matching to avoid allocating a lowercase copy
+        if ["mp4", "m4a", "m4v", "mov"]
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(container_ext))
+        {
+            "mov_text"
+        } else if ["mkv", "mka"]
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(container_ext))
+        {
+            "srt"
+        } else if container_ext.eq_ignore_ascii_case("webm") {
+            "webvtt"
+        } else {
+            "srt"
         }
     }
 
@@ -65,13 +74,11 @@ impl EmbedSubtitles {
     /// # Returns
     /// A vector of `(language_code, subtitle_path)` pairs.
     fn find_subtitle_files(media_file: &Path) -> Vec<(String, PathBuf)> {
-        let stem = match media_file.file_stem().and_then(|s| s.to_str()) {
-            Some(s) => s,
-            None => return Vec::new(),
+        let Some(stem) = media_file.file_stem().and_then(|s| s.to_str()) else {
+            return Vec::new();
         };
-        let parent = match media_file.parent() {
-            Some(p) => p,
-            None => return Vec::new(),
+        let Some(parent) = media_file.parent() else {
+            return Vec::new();
         };
 
         let candidates = Self::stem_candidates(stem);
@@ -89,29 +96,29 @@ impl EmbedSubtitles {
                     continue;
                 }
 
-                let filename = match path.file_name().and_then(|f| f.to_str()) {
-                    Some(f) => f.to_string(),
-                    None => continue,
+                let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
+                    continue;
                 };
 
                 // Check pattern: {candidate}.{lang}.{ext}
                 for sub_ext in SUBTITLE_EXTENSIONS {
-                    let suffix = format!(".{sub_ext}");
-                    if !filename.ends_with(&suffix) {
+                    // Strip the subtitle extension
+                    let Some(without_ext) = filename
+                        .strip_suffix(sub_ext)
+                        .and_then(|s| s.strip_suffix('.'))
+                    else {
                         continue;
-                    }
+                    };
 
-                    // Strip the subtitle extension to get {candidate}.{lang}
-                    let without_ext = &filename[..filename.len() - suffix.len()];
-
-                    // Must start with the candidate stem followed by a dot
-                    let prefix = format!("{candidate}.");
-                    if !without_ext.starts_with(&prefix) {
+                    // Strip the candidate stem prefix + dot
+                    let Some(lang) = without_ext
+                        .strip_prefix(candidate)
+                        .and_then(|s| s.strip_prefix('.'))
+                    else {
                         continue;
-                    }
+                    };
 
                     // The remainder is the language code
-                    let lang = &without_ext[prefix.len()..];
                     if !lang.is_empty() {
                         result.push((lang.to_string(), path.clone()));
                         break; // Found match for this entry, move on

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -113,15 +113,11 @@ impl EmbedThumbnail {
         let result = tokio::task::spawn_blocking(move || {
             let cover_bytes = std::fs::read(&thumb)?;
 
-            let img = match thumb
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("")
-                .to_lowercase()
-                .as_str()
-            {
-                "png" => mp4ameta::Img::png(cover_bytes),
-                _ => mp4ameta::Img::jpeg(cover_bytes),
+            let ext = thumb.extension().and_then(|e| e.to_str()).unwrap_or("");
+            let img = if ext.eq_ignore_ascii_case("png") {
+                mp4ameta::Img::png(cover_bytes)
+            } else {
+                mp4ameta::Img::jpeg(cover_bytes)
             };
 
             let mut tag =

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -31,7 +31,7 @@ ffmpeg_processor!(
 impl FFmpegMetadata {
     /// Build a metadata `HashMap` from `InfoDict`.
     fn build_metadata(info: &InfoDict) -> HashMap<String, String> {
-        let mut meta = HashMap::new();
+        let mut meta = HashMap::with_capacity(10);
 
         // Title
         meta.insert("title".to_string(), info.title.clone());

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -65,11 +65,10 @@ impl PostProcessor for FFmpegRemuxer {
         let input_ext = input_file
             .extension()
             .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase();
+            .unwrap_or("");
 
         // Skip if already in target container
-        if input_ext == target_container.as_ext() {
+        if input_ext.eq_ignore_ascii_case(target_container.as_ext()) {
             debug!(
                 container = target_container.as_ext();
                 "File already in target container, skipping remux"
@@ -79,7 +78,7 @@ impl PostProcessor for FFmpegRemuxer {
 
         info!(
             file:? = input_file.display(),
-            from = input_ext.as_str(),
+            from = input_ext,
             to = target_container.as_ext();
             "Remuxing to improve seeking"
         );

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -63,38 +63,47 @@ impl FFmpegVideoConvertor {
 
     /// Determine if we can remux (copy) or need to transcode.
     fn can_remux(input_ext: &str, output_ext: &str, video_codec: Option<&str>) -> bool {
+        /// Check if `codec` case-insensitively matches any of the given names.
+        fn codec_is(codec: &str, names: &[&str]) -> bool {
+            names.iter().any(|n| n.eq_ignore_ascii_case(codec))
+        }
+
+        /// Check if `ext` case-insensitively matches any of the given extensions.
+        fn ext_is(ext: &str, exts: &[&str]) -> bool {
+            exts.iter().any(|e| e.eq_ignore_ascii_case(ext))
+        }
+
         // Check if the codec is compatible with the target container
-        match (output_ext.to_lowercase().as_str(), video_codec) {
-            // MP4/F4v supports H.264, H.265, MPEG-4, AV1
-            ("mp4" | "f4v", Some(c)) => matches!(
-                c.to_lowercase().as_str(),
-                "h264" | "avc" | "h265" | "hevc" | "mpeg4" | "av1"
-            ),
+        if ext_is(output_ext, &["mp4", "f4v"]) {
+            // MP4/F4V supports H.264, H.265, MPEG-4, AV1
+            video_codec
+                .is_some_and(|c| codec_is(c, &["h264", "avc", "h265", "hevc", "mpeg4", "av1"]))
+        } else if ext_is(output_ext, &["mkv", "mka", "nut", "mxf"]) {
             // MKV, MKA, NUT, MXF accept almost everything
-            ("mkv" | "mka" | "nut" | "mxf", _) => true,
+            true
+        } else if output_ext.eq_ignore_ascii_case("webm") {
             // WebM supports VP8, VP9, AV1
-            ("webm", Some(c)) => matches!(c.to_lowercase().as_str(), "vp8" | "vp9" | "av1"),
+            video_codec.is_some_and(|c| codec_is(c, &["vp8", "vp9", "av1"]))
+        } else if output_ext.eq_ignore_ascii_case("ivf") {
             // IVF supports VP8, VP9, AV1
-            ("ivf", Some(c)) => matches!(c.to_lowercase().as_str(), "vp8" | "vp9" | "av1"),
+            video_codec.is_some_and(|c| codec_is(c, &["vp8", "vp9", "av1"]))
+        } else if output_ext.eq_ignore_ascii_case("3gp") {
             // 3GP supports H.264, H.263, MPEG-4
-            ("3gp", Some(c)) => {
-                matches!(c.to_lowercase().as_str(), "h264" | "avc" | "h263" | "mpeg4")
-            }
+            video_codec.is_some_and(|c| codec_is(c, &["h264", "avc", "h263", "mpeg4"]))
+        } else if output_ext.eq_ignore_ascii_case("asf") {
             // ASF/WMV supports WMV, H.264, MPEG-4
-            ("asf", Some(c)) => matches!(
-                c.to_lowercase().as_str(),
-                "wmv1" | "wmv2" | "h264" | "avc" | "mpeg4"
-            ),
+            video_codec.is_some_and(|c| codec_is(c, &["wmv1", "wmv2", "h264", "avc", "mpeg4"]))
+        } else if ext_is(output_ext, &["mpg", "vob"]) {
             // MPEG/VOB supports MPEG-1, MPEG-2, MPEG-4
-            ("mpg" | "vob", Some(c)) => matches!(
-                c.to_lowercase().as_str(),
-                "mpeg1" | "mpeg1video" | "mpeg2" | "mpeg2video" | "mpeg4"
-            ),
+            video_codec.is_some_and(|c| {
+                codec_is(c, &["mpeg1", "mpeg1video", "mpeg2", "mpeg2video", "mpeg4"])
+            })
+        } else if output_ext.eq_ignore_ascii_case("avi") {
             // AVI supports most codecs
-            ("avi", _) => true,
+            true
+        } else {
             // Same container - can copy
-            _ if input_ext.eq_ignore_ascii_case(output_ext) => true,
-            _ => false,
+            input_ext.eq_ignore_ascii_case(output_ext)
         }
     }
 

--- a/crates/rdlp-security/src/lib.rs
+++ b/crates/rdlp-security/src/lib.rs
@@ -49,6 +49,7 @@
 #![warn(missing_docs)]
 
 use regex::Regex;
+use std::borrow::Cow;
 use std::net::IpAddr;
 use std::sync::LazyLock;
 use thiserror::Error;
@@ -368,11 +369,14 @@ static SANITIZE_PATTERNS: LazyLock<[(Regex, &str); 5]> = LazyLock::new(|| {
 /// ```
 #[must_use]
 pub fn sanitize_for_logging(s: &str) -> String {
-    let mut result = s.to_string();
+    let mut result = Cow::Borrowed(s);
     for (re, replacement) in SANITIZE_PATTERNS.iter() {
-        result = re.replace_all(&result, *replacement).to_string();
+        match re.replace_all(&result, *replacement) {
+            Cow::Borrowed(_) => {} // No match — keep existing result
+            Cow::Owned(replaced) => result = Cow::Owned(replaced),
+        }
     }
-    result
+    result.into_owned()
 }
 
 #[cfg(test)]

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -306,7 +306,8 @@ impl Format {
     /// Subsequent calls return a reference to the cached value.
     pub fn description(&self) -> &str {
         self.cached_description.get_or_init(|| {
-            let mut parts = Vec::new();
+            // At most 6 parts: note, resolution, fps, vcodec, acodec, ext
+            let mut parts = Vec::with_capacity(6);
 
             if let Some(note) = &self.format_note {
                 parts.push(note.clone());

--- a/crates/rdlp-types/src/format/selector.rs
+++ b/crates/rdlp-types/src/format/selector.rs
@@ -87,7 +87,7 @@ struct Filter {
 }
 
 /// Format fields that can be filtered on.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FilterField {
     Height,
     Width,
@@ -105,7 +105,7 @@ enum FilterField {
 }
 
 /// Comparison operators for filters.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FilterOp {
     Eq,
     Ne,
@@ -417,6 +417,7 @@ fn compare_str(val: &str, op: &FilterOp, filter_val: &FilterValue) -> bool {
     }
 }
 
+#[derive(Clone, Copy)]
 enum SortDirection {
     Best,
     Worst,

--- a/crates/rdlp-types/src/subtitle_selection.rs
+++ b/crates/rdlp-types/src/subtitle_selection.rs
@@ -80,15 +80,13 @@ pub fn select_subtitles(
             }
         }
         // Also include auto-captions languages not already covered
-        if include_auto {
-            if let Some(auto) = auto_captions {
-                for (lang, subs) in auto {
-                    let already_have = result.iter().any(|(l, _)| l.eq_ignore_ascii_case(lang));
-                    if !already_have {
-                        if let Some(sub) = pick_subtitle(subs, preferred_format) {
-                            result.push((lang.clone(), sub));
-                        }
-                    }
+        if include_auto && let Some(auto) = auto_captions {
+            for (lang, subs) in auto {
+                if result.iter().any(|(l, _)| l.eq_ignore_ascii_case(lang)) {
+                    continue;
+                }
+                if let Some(sub) = pick_subtitle(subs, preferred_format) {
+                    result.push((lang.clone(), sub));
                 }
             }
         }
@@ -98,20 +96,18 @@ pub fn select_subtitles(
             let manual = find_lang(subtitles, requested);
             if let Some((lang, subs)) = manual {
                 if let Some(sub) = pick_subtitle(subs, preferred_format) {
-                    result.push((lang.clone(), sub));
+                    result.push((lang.to_owned(), sub));
                     continue;
                 }
             }
 
             // Fallback to auto-captions if enabled
-            if include_auto {
-                if let Some(auto) = auto_captions {
-                    if let Some((lang, subs)) = find_lang(auto, requested) {
-                        if let Some(sub) = pick_subtitle(subs, preferred_format) {
-                            result.push((lang.clone(), sub));
-                        }
-                    }
-                }
+            if include_auto
+                && let Some(auto) = auto_captions
+                && let Some((lang, subs)) = find_lang(auto, requested)
+                && let Some(sub) = pick_subtitle(subs, preferred_format)
+            {
+                result.push((lang.to_owned(), sub));
             }
         }
     }
@@ -151,8 +147,10 @@ pub fn subtitle_filename(base_stem: &str, lang: &str, ext: &str) -> String {
 fn find_lang<'a>(
     map: &'a HashMap<String, Vec<Subtitle>>,
     lang: &str,
-) -> Option<(&'a String, &'a Vec<Subtitle>)> {
-    map.iter().find(|(k, _)| k.eq_ignore_ascii_case(lang))
+) -> Option<(&'a str, &'a [Subtitle])> {
+    map.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(lang))
+        .map(|(k, v)| (k.as_str(), v.as_slice()))
 }
 
 /// Pick the best subtitle entry from a list based on preferred format.
@@ -160,10 +158,6 @@ fn find_lang<'a>(
 /// If `preferred_format` is set, returns the first entry matching that format.
 /// Otherwise, returns the first entry in the list.
 fn pick_subtitle(subs: &[Subtitle], preferred_format: Option<SubtitleFormat>) -> Option<Subtitle> {
-    if subs.is_empty() {
-        return None;
-    }
-
     if let Some(pref) = preferred_format {
         let ext = pref.as_ext();
         if let Some(sub) = subs.iter().find(|s| s.ext.eq_ignore_ascii_case(ext)) {
@@ -172,7 +166,7 @@ fn pick_subtitle(subs: &[Subtitle], preferred_format: Option<SubtitleFormat>) ->
     }
 
     // Fallback to first available
-    Some(subs[0].clone())
+    subs.first().cloned()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Fix playlist subtitle bug**: Subtitle download was reusing the first episode's URLs for all episodes. Now stores only language names during selection and resolves per-episode URLs during download.
- **Downgrade 9anime server-fallback to debug**: Not all servers host every episode — expected behavior, not errors.
- **Workspace-wide code simplification**: Idiomatic Rust patterns applied across all 15 crates (~100 lines removed, 61 files). Includes `let-else`, `find_map`, `matches!()`, `eq_ignore_ascii_case`, clone-to-move, visibility narrowing, and allocation optimizations.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test` passes (all tests green)
- [x] Manual test: 9anime single episode — 6 formats with full resolution (SUB+DUB 360p/720p/1080p)
- [x] Manual test: 9anime playlist — per-episode subtitle resolution confirmed