### PR TITLE
feat(playlist): lazy extraction with CDN resilience

### DIFF
--- a/crates/rdlp-cli/src/orchestrator/errors.rs
+++ b/crates/rdlp-cli/src/orchestrator/errors.rs
@@ -86,5 +86,22 @@ pub enum OrchestratorError {
     Configuration(String),
 }
 
+/// Check if an error warrants re-extracting fresh URLs.
+///
+/// CDN failures (Cloudflare challenges, expired tokens, server errors)
+/// return `Extraction` errors containing "invalid M3U8". These can be
+/// resolved by calling `extract_lazy()` again for a fresh CDN assignment.
+pub(super) fn is_reextractable_error(err: &OrchestratorError) -> bool {
+    match err {
+        OrchestratorError::DownloadFailed(RdlpError::Extraction(msg)) => {
+            msg.contains("invalid M3U8")
+        }
+        OrchestratorError::DownloadFailed(RdlpError::Http {
+            status: 403 | 503, ..
+        }) => true,
+        _ => false,
+    }
+}
+
 /// Result type for orchestrator operations
 pub type Result<T> = std::result::Result<T, OrchestratorError>;

--- a/crates/rdlp-cli/src/orchestrator/extraction.rs
+++ b/crates/rdlp-cli/src/orchestrator/extraction.rs
@@ -77,6 +77,41 @@ impl Orchestrator {
         Ok(info)
     }
 
+    /// Lightweight format extraction for lazily-resolved playlist entries.
+    ///
+    /// Uses `extract_lazy()` instead of `extract()` to skip expensive
+    /// operations like re-fetching the watch page. Auto-sets `Referer`
+    /// headers on all resolved formats.
+    pub(super) async fn extract_lazy_formats(&self, url: &str) -> Result<rdlp_core::InfoDict> {
+        let extractor = self.extractor_registry.find_extractor(url).ok_or_else(|| {
+            OrchestratorError::NoExtractor {
+                url: url.to_string(),
+            }
+        })?;
+
+        let mut info = extractor
+            .extract_lazy(url, &self.extraction_context)
+            .await
+            .map_err(OrchestratorError::ExtractionFailed)?;
+
+        info!(formats = info.formats.len(); "Lazily resolved formats");
+
+        // Auto-set Referer header on all formats
+        if !info.webpage_url.is_empty() {
+            let referer = info.webpage_url.clone();
+            for fmt in &mut info.formats {
+                let headers = fmt
+                    .http_headers
+                    .get_or_insert_with(std::collections::HashMap::new);
+                headers
+                    .entry("Referer".to_string())
+                    .or_insert(referer.clone());
+            }
+        }
+
+        Ok(info)
+    }
+
     /// Extract playlist information from URL
     ///
     /// Finds the appropriate extractor and attempts playlist extraction.

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -52,8 +52,9 @@ impl Orchestrator {
     #[must_use]
     pub fn new(config: Config, multi_progress: MultiProgress) -> Self {
         let cookie_jar = Arc::new(SimpleCookieJar::new());
+        let raw_jar = cookie_jar.jar(); // Capture before cookie_jar moves into ExtractionContext
         let http_client =
-            HttpClientFactory::from_rdlp_config(&config).build_arc_with_cookies(cookie_jar.jar());
+            HttpClientFactory::from_rdlp_config(&config).build_arc_with_cookies(raw_jar.clone());
         let js_engine = Arc::new(BoaJsEngine::new());
 
         // Wrap config in Arc once and share it
@@ -71,7 +72,9 @@ impl Orchestrator {
 
         Self {
             extractor_registry: Arc::new(ExtractorRegistry::new()),
-            downloader_registry: Arc::new(DownloaderRegistry::with_config(&config)),
+            downloader_registry: Arc::new(DownloaderRegistry::with_config_and_cookies(
+                &config, raw_jar,
+            )),
             postprocessor_registry,
             extraction_context,
             config,

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -9,7 +9,12 @@ use futures_util::StreamExt;
 use log::{debug, error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+/// Maximum age of batch-resolved tokens before proactive re-extraction.
+/// Megacloud/netmagcdn tokens last ~30-60 min; we re-extract at 25 min
+/// to stay well within the window.
+const TOKEN_MAX_AGE: Duration = Duration::from_secs(25 * 60);
 
 impl Orchestrator {
     /// Download all videos from a playlist
@@ -234,8 +239,7 @@ impl Orchestrator {
 
                     // Apply audio type filter
                     if let Some(ref lang) = selected_audio {
-                        formats
-                            .retain(|f| f.language.as_deref() == Some(lang.as_str()));
+                        formats.retain(|f| f.language.as_deref() == Some(lang.as_str()));
                     }
 
                     infos[i].formats = formats;
@@ -263,6 +267,9 @@ impl Orchestrator {
             }
         }
 
+        // Track when batch resolution completed for token freshness guard.
+        // Episodes downloaded >25 min after this point will re-extract fresh URLs.
+        let batch_resolved_at = Instant::now();
         info!("Batch resolution complete ({resolve_count} episodes)");
 
         // Create playlist directory if it doesn't exist
@@ -278,69 +285,113 @@ impl Orchestrator {
             info!(path:? = playlist_dir.display(); "Created folder");
         }
 
-        // Download each video with progress tracking
-        // Use tokio::select! to properly catch Ctrl+C during downloads
+        // Download episodes with bounded parallelism (2 concurrent).
+        // Pre-filter to skip already-downloaded and archived episodes.
+        const DOWNLOAD_CONCURRENCY: usize = 2;
         let mut downloaded: Vec<PathBuf> = existing_files.into_values().collect();
         let mut failed = Vec::new();
         let mut interrupted = false;
 
-        for (index, info) in infos.iter().enumerate() {
-            let position = index + 1;
-
-            // Check if this video is already downloaded
-            let sanitized_title = self.sanitize_filename(&info.title);
-            let already_exists = downloaded.iter().any(|p| {
-                p.file_stem()
-                    .and_then(|s| s.to_str())
-                    .is_some_and(|name| name == sanitized_title)
-            });
-
-            if already_exists {
-                info!(position, total, title:? = info.title; "Already downloaded");
-                continue;
-            }
-
-            // Check download archive
-            if let Some(ref archive_set) = archive {
-                if archive::is_in_archive(archive_set, &info.extractor, &info.id) {
-                    info!(position, total, title:? = info.title; "Already in archive, skipping");
-                    continue;
+        // Collect episodes that still need downloading
+        let to_download: Vec<(usize, &rdlp_core::InfoDict)> = infos
+            .iter()
+            .enumerate()
+            .filter(|(_, ep)| {
+                let sanitized = self.sanitize_filename(&ep.title);
+                let exists = downloaded.iter().any(|p| {
+                    p.file_stem()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|name| name == sanitized)
+                });
+                if exists {
+                    return false;
                 }
-            }
-
-            info!("{}", "─".repeat(60));
-            info!(position, total, title:? = info.title; "Downloading");
-            info!("{}", "─".repeat(60));
-
-            // Race download against Ctrl+C signal
-            tokio::select! {
-                // Download single video to playlist folder (non-interactive)
-                result = self.download_from_info_to_dir(info, false, &playlist_dir, &selected_sub_langs, selected_audio.as_deref()) => {
-                    match result {
-                        Ok(Some(path)) => {
-                            info!(position, total, path:? = path.display(); "Saved");
-                            downloaded.push(path);
-                            self.record_in_archive(&info.extractor, &info.id);
-                        }
-                        Ok(None) => {
-                            info!(position, total; "Skipped by user");
-                        }
-                        Err(e) => {
-                            error!(position, total; "Failed: {e}");
-                            failed.push((position, info.title.clone(), e.to_string()));
-                        }
+                if let Some(ref archive_set) = archive {
+                    if archive::is_in_archive(archive_set, &ep.extractor, &ep.id) {
+                        return false;
                     }
                 }
-                // Catch Ctrl+C immediately during download
-                _ = tokio::signal::ctrl_c() => {
+                true
+            })
+            .collect();
+
+        let download_count = to_download.len();
+        if download_count > 0 {
+            info!(
+                count = download_count,
+                concurrency = DOWNLOAD_CONCURRENCY;
+                "Downloading episodes"
+            );
+        }
+
+        // Build concurrent download stream.
+        // Each future clones the data it needs so lifetimes are straightforward.
+        let batch_ts = Some(batch_resolved_at);
+        let futs = to_download.into_iter().map(|(index, info)| {
+            let position = index + 1;
+            let info_owned = info.clone();
+            let dir = playlist_dir.clone();
+            let sub_langs = selected_sub_langs.clone();
+            let audio = selected_audio.clone();
+            async move {
+                info!("{}", "─".repeat(60));
+                info!(position, total, title:? = info_owned.title; "Downloading");
+                let result = self
+                    .download_from_info_to_dir(
+                        &info_owned,
+                        false,
+                        &dir,
+                        &sub_langs,
+                        audio.as_deref(),
+                        batch_ts,
+                    )
+                    .await;
+                (position, info_owned, result)
+            }
+        });
+
+        let mut stream = futures_util::stream::iter(futs).buffer_unordered(DOWNLOAD_CONCURRENCY);
+
+        // Consume download stream with Ctrl+C support
+        let ctrl_c = tokio::signal::ctrl_c();
+        tokio::pin!(ctrl_c);
+
+        loop {
+            tokio::select! {
+                next = stream.next() => {
+                    match next {
+                        Some((position, info_owned, result)) => {
+                            match result {
+                                Ok(Some(path)) => {
+                                    info!(position, total, path:? = path.display(); "Saved");
+                                    downloaded.push(path);
+                                    self.record_in_archive(
+                                        &info_owned.extractor,
+                                        &info_owned.id,
+                                    );
+                                }
+                                Ok(None) => {
+                                    info!(position, total; "Skipped by user");
+                                }
+                                Err(e) => {
+                                    error!(position, total; "Failed: {e}");
+                                    failed.push((
+                                        position,
+                                        info_owned.title,
+                                        e.to_string(),
+                                    ));
+                                }
+                            }
+                        }
+                        None => break, // All downloads complete
+                    }
+                }
+                _ = &mut ctrl_c => {
                     info!("Playlist download interrupted by user");
                     info!("Run the same command again to resume");
                     interrupted = true;
+                    break;
                 }
-            }
-
-            if interrupted {
-                break;
             }
         }
 
@@ -493,8 +544,15 @@ impl Orchestrator {
         info: &rdlp_core::InfoDict,
         interactive: bool,
     ) -> Result<Option<PathBuf>> {
-        self.download_from_info_to_dir(info, interactive, &self.config.output_directory, &[], None)
-            .await
+        self.download_from_info_to_dir(
+            info,
+            interactive,
+            &self.config.output_directory,
+            &[],
+            None,
+            None,
+        )
+        .await
     }
 
     /// Download from pre-extracted InfoDict to a specific directory
@@ -523,6 +581,7 @@ impl Orchestrator {
         output_dir: &std::path::Path,
         subtitle_langs: &[String],
         audio_type_filter: Option<&str>,
+        batch_resolved_at: Option<Instant>,
     ) -> Result<Option<PathBuf>> {
         const MAX_EXTRACT_RETRIES: usize = 3;
         /// Exponential backoff delays: 5s, 15s, 30s — gives Cloudflare time
@@ -547,43 +606,53 @@ impl Orchestrator {
 
             // Lazy resolve: always re-extract on retry, only if empty on first
             let resolved_info;
-            let info_ref =
-                if (attempt > 0 || info.formats.is_empty()) && !info.webpage_url.is_empty() {
-                    info!(title:? = info.title; "Lazily resolving episode formats");
-                    let mut resolved = match self.extract_lazy_formats(&info.webpage_url).await {
-                        Ok(r) => r,
-                        Err(e) if attempt < MAX_EXTRACT_RETRIES => {
-                            warn!(
-                                attempt = attempt + 1;
-                                "Extraction failed: {e}, will retry"
-                            );
-                            continue;
-                        }
-                        Err(e) => return Err(e),
-                    };
-
-                    // Preserve all episode metadata from the original stub
-                    resolved.id = info.id.clone();
-                    resolved.title = info.title.clone();
-                    resolved.thumbnail = info.thumbnail.clone();
-                    resolved.description = info.description.clone();
-                    resolved.playlist = info.playlist.clone();
-                    resolved.playlist_title = info.playlist_title.clone();
-                    resolved.playlist_index = info.playlist_index;
-                    resolved.playlist_count = info.playlist_count;
-
-                    // Apply audio type filter to lazily-resolved formats
-                    if let Some(lang) = audio_type_filter {
-                        resolved
-                            .formats
-                            .retain(|f| f.language.as_deref() == Some(lang));
+            // Re-extract if: retry attempt, no formats, or batch tokens expired
+            let tokens_stale =
+                attempt == 0 && batch_resolved_at.is_some_and(|t| t.elapsed() > TOKEN_MAX_AGE);
+            if tokens_stale {
+                info!(
+                    "Batch-resolved tokens stale (>{} min), forcing re-extraction",
+                    TOKEN_MAX_AGE.as_secs() / 60
+                );
+            }
+            let info_ref = if (attempt > 0 || info.formats.is_empty() || tokens_stale)
+                && !info.webpage_url.is_empty()
+            {
+                info!(title:? = info.title; "Lazily resolving episode formats");
+                let mut resolved = match self.extract_lazy_formats(&info.webpage_url).await {
+                    Ok(r) => r,
+                    Err(e) if attempt < MAX_EXTRACT_RETRIES => {
+                        warn!(
+                            attempt = attempt + 1;
+                            "Extraction failed: {e}, will retry"
+                        );
+                        continue;
                     }
-
-                    resolved_info = resolved;
-                    &resolved_info
-                } else {
-                    info
+                    Err(e) => return Err(e),
                 };
+
+                // Preserve all episode metadata from the original stub
+                resolved.id = info.id.clone();
+                resolved.title = info.title.clone();
+                resolved.thumbnail = info.thumbnail.clone();
+                resolved.description = info.description.clone();
+                resolved.playlist = info.playlist.clone();
+                resolved.playlist_title = info.playlist_title.clone();
+                resolved.playlist_index = info.playlist_index;
+                resolved.playlist_count = info.playlist_count;
+
+                // Apply audio type filter to lazily-resolved formats
+                if let Some(lang) = audio_type_filter {
+                    resolved
+                        .formats
+                        .retain(|f| f.language.as_deref() == Some(lang));
+                }
+
+                resolved_info = resolved;
+                &resolved_info
+            } else {
+                info
+            };
 
             // Select format (non-interactive on retry to avoid re-prompting)
             let Some(mut format) = self
@@ -593,14 +662,18 @@ impl Orchestrator {
                 return Ok(None);
             };
 
-            // Add alternative CDN server URLs as fallbacks
-            let alt_urls: Vec<String> = info_ref
+            // Add alternative CDN server URLs as fallbacks.
+            // Sort by CDN host stickiness: same host as primary URL first,
+            // since a working CDN server is more likely to stay healthy.
+            let mut alt_urls: Vec<String> = info_ref
                 .formats
                 .iter()
                 .filter(|f| f.url != format.url)
                 .map(|f| f.url.clone())
                 .collect();
             if !alt_urls.is_empty() {
+                let primary_host = extract_cdn_host(&format.url);
+                alt_urls.sort_by_key(|url| u8::from(extract_cdn_host(url) != primary_host));
                 format
                     .fallback_urls
                     .get_or_insert_with(Vec::new)
@@ -706,6 +779,17 @@ fn detect_audio_types(infos: &[rdlp_core::InfoDict]) -> Vec<String> {
     result
 }
 
+/// Extract the hostname from a URL for CDN server stickiness.
+///
+/// Returns the host portion (e.g., "s2.netmagcdn.com") so fallback
+/// URLs on the same CDN server can be prioritized.
+fn extract_cdn_host(url: &str) -> Option<&str> {
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    after_scheme.split('/').next()
+}
+
 /// Filter episode formats to only include the selected audio/language type.
 ///
 /// Removes all formats whose `language` field does not match the given value.
@@ -799,5 +883,35 @@ mod tests {
 
         assert_eq!(infos[0].formats.len(), 1);
         assert_eq!(infos[0].formats[0].language.as_deref(), Some("SUB"));
+    }
+
+    #[test]
+    fn test_extract_cdn_host() {
+        assert_eq!(
+            extract_cdn_host("https://s2.netmagcdn.com/hls/master.m3u8"),
+            Some("s2.netmagcdn.com")
+        );
+        assert_eq!(
+            extract_cdn_host("http://cdn.example.com/video.mp4"),
+            Some("cdn.example.com")
+        );
+        assert_eq!(extract_cdn_host("not-a-url"), None);
+    }
+
+    #[test]
+    fn test_extract_cdn_host_stickiness_sort() {
+        let primary = "https://s2.netmagcdn.com/hls/ep1/master.m3u8";
+        let primary_host = extract_cdn_host(primary);
+
+        let mut urls = vec![
+            "https://s1.netmagcdn.com/hls/ep1/alt.m3u8".to_string(),
+            "https://s2.netmagcdn.com/hls/ep1/alt2.m3u8".to_string(),
+            "https://s3.netmagcdn.com/hls/ep1/alt3.m3u8".to_string(),
+        ];
+
+        urls.sort_by_key(|url| u8::from(extract_cdn_host(url) != primary_host));
+
+        // s2 (same host) should sort first
+        assert!(urls[0].contains("s2.netmagcdn.com"));
     }
 }

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -3,10 +3,13 @@
 //! Provides batch download support with progress tracking, resume capability,
 //! and graceful degradation for failed videos.
 
+use super::errors::is_reextractable_error;
 use super::{Orchestrator, OrchestratorError, Result, archive};
-use log::{debug, error, info};
+use futures_util::StreamExt;
+use log::{debug, error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::time::Duration;
 
 impl Orchestrator {
     /// Download all videos from a playlist
@@ -106,6 +109,7 @@ impl Orchestrator {
         }
 
         // Audio type selection for playlists with multiple language tracks
+        let mut selected_audio: Option<String> = None;
         if interactive && audio_types.len() > 1 && remaining > 0 {
             use dialoguer::Select;
 
@@ -127,6 +131,7 @@ impl Orchestrator {
             if selection < type_count {
                 let selected = &audio_types[selection];
                 info!(audio:% = selected; "Filtering to selected audio type");
+                selected_audio = Some(selected.clone());
                 filter_formats_by_language(&mut infos, selected);
             }
         }
@@ -183,6 +188,83 @@ impl Orchestrator {
             }
         }
 
+        // Batch-resolve all episode URLs upfront with bounded parallelism.
+        // Resolving 3 episodes concurrently keeps CDN tokens fresh while
+        // avoiding rate-limits. Layer 3 retry handles any that expire later.
+        const RESOLVE_CONCURRENCY: usize = 4;
+
+        // Collect work items: (index, url, title) for episodes needing resolution
+        let to_resolve: Vec<(usize, String, String)> = infos
+            .iter()
+            .enumerate()
+            .filter_map(|(i, ep)| {
+                let sanitized = self.sanitize_filename(&ep.title);
+                if existing_files.contains_key(&sanitized) || ep.webpage_url.is_empty() {
+                    None
+                } else {
+                    Some((i, ep.webpage_url.clone(), ep.title.clone()))
+                }
+            })
+            .collect();
+
+        let resolve_count = to_resolve.len();
+        info!(count = resolve_count, concurrency = RESOLVE_CONCURRENCY; "Resolving episode URLs");
+
+        // Resolve with buffer_unordered: starts the next future as soon as
+        // any one completes, keeping the pipeline always full at N concurrent.
+        let futs = to_resolve.iter().map(|(i, url, title)| {
+            let i = *i;
+            let url = url.clone();
+            let title = title.clone();
+            async move {
+                info!(position = i + 1, title:? = title; "Resolving episode");
+                (i, self.extract_lazy_formats(&url).await)
+            }
+        });
+
+        let results: Vec<_> = futures_util::stream::iter(futs)
+            .buffer_unordered(RESOLVE_CONCURRENCY)
+            .collect()
+            .await;
+
+        for (i, result) in results {
+            match result {
+                Ok(resolved) => {
+                    let mut formats = resolved.formats;
+
+                    // Apply audio type filter
+                    if let Some(ref lang) = selected_audio {
+                        formats
+                            .retain(|f| f.language.as_deref() == Some(lang.as_str()));
+                    }
+
+                    infos[i].formats = formats;
+
+                    // Carry over subtitles from lazy resolution
+                    if infos[i].subtitles.is_none() {
+                        infos[i].subtitles = resolved.subtitles;
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        title:? = infos[i].title;
+                        "Failed to resolve: {e} — will retry at download time"
+                    );
+                    infos[i].formats.clear();
+                }
+            }
+        }
+
+        // Clear formats for already-downloaded episodes
+        for ep in infos.iter_mut() {
+            let sanitized = self.sanitize_filename(&ep.title);
+            if existing_files.contains_key(&sanitized) {
+                ep.formats.clear();
+            }
+        }
+
+        info!("Batch resolution complete ({resolve_count} episodes)");
+
         // Create playlist directory if it doesn't exist
         if !playlist_dir.exists() {
             tokio::fs::create_dir_all(&playlist_dir)
@@ -233,7 +315,7 @@ impl Orchestrator {
             // Race download against Ctrl+C signal
             tokio::select! {
                 // Download single video to playlist folder (non-interactive)
-                result = self.download_from_info_to_dir(info, false, &playlist_dir, &selected_sub_langs) => {
+                result = self.download_from_info_to_dir(info, false, &playlist_dir, &selected_sub_langs, selected_audio.as_deref()) => {
                     match result {
                         Ok(Some(path)) => {
                             info!(position, total, path:? = path.display(); "Saved");
@@ -411,7 +493,7 @@ impl Orchestrator {
         info: &rdlp_core::InfoDict,
         interactive: bool,
     ) -> Result<Option<PathBuf>> {
-        self.download_from_info_to_dir(info, interactive, &self.config.output_directory, &[])
+        self.download_from_info_to_dir(info, interactive, &self.config.output_directory, &[], None)
             .await
     }
 
@@ -420,73 +502,186 @@ impl Orchestrator {
     /// This method is used by playlist downloads to save files to the playlist folder.
     /// Uses the shared CDN fallback loop via `download_with_cdn_fallback()`.
     ///
+    /// Supports lazy format resolution: if `info.formats` is empty and
+    /// `info.webpage_url` is set, formats are resolved on-the-fly via
+    /// `extract_video_info()`.
+    ///
+    /// On CDN failure (invalid M3U8, 403/503), re-extracts fresh URLs up to
+    /// `MAX_EXTRACT_RETRIES` times with a delay between attempts. This mirrors
+    /// yt-dlp's `--extractor-retries` behavior.
+    ///
     /// # Arguments
     /// * `info` - Pre-extracted video metadata
     /// * `interactive` - Whether interactive mode is active
     /// * `output_dir` - Directory to save the file in
     /// * `subtitle_langs` - Pre-selected subtitle language names (empty = config-based)
+    /// * `audio_type_filter` - If set, filter lazily-resolved formats to this language
     pub(super) async fn download_from_info_to_dir(
         &self,
         info: &rdlp_core::InfoDict,
         interactive: bool,
         output_dir: &std::path::Path,
         subtitle_langs: &[String],
+        audio_type_filter: Option<&str>,
     ) -> Result<Option<PathBuf>> {
-        // Select format
-        let Some(format) = self.select_format(info, interactive).await? else {
-            return Ok(None);
-        };
+        const MAX_EXTRACT_RETRIES: usize = 3;
+        /// Exponential backoff delays: 5s, 15s, 30s — gives Cloudflare time
+        /// to clear rate-limits between re-extraction attempts.
+        const RETRY_DELAYS: [u64; MAX_EXTRACT_RETRIES] = [5, 15, 30];
 
-        // Generate output path in the specified directory
-        let file_ext = self.determine_file_extension(&format);
-        let sanitized_title = self.sanitize_filename(&info.title);
-        let filename = format!("{sanitized_title}.{file_ext}");
-        let output_path = output_dir.join(&filename);
+        let mut output_path: Option<PathBuf> = None;
+        let mut download_outcome = None;
+        let mut last_info_ref: Option<rdlp_core::InfoDict> = None;
 
-        // Clean up any leftover HLS segment files from interrupted downloads
-        self.cleanup_leftover_segments(output_dir, &sanitized_title)
-            .await;
+        for attempt in 0..=MAX_EXTRACT_RETRIES {
+            if attempt > 0 {
+                let delay = Duration::from_secs(RETRY_DELAYS[attempt - 1]);
+                warn!(
+                    attempt = attempt + 1,
+                    max = MAX_EXTRACT_RETRIES + 1,
+                    delay_secs = delay.as_secs();
+                    "Re-extracting fresh CDN URLs after backoff"
+                );
+                tokio::time::sleep(delay).await;
+            }
 
-        info!(path:? = output_path.display(); "Downloading to");
+            // Lazy resolve: always re-extract on retry, only if empty on first
+            let resolved_info;
+            let info_ref =
+                if (attempt > 0 || info.formats.is_empty()) && !info.webpage_url.is_empty() {
+                    info!(title:? = info.title; "Lazily resolving episode formats");
+                    let mut resolved = match self.extract_lazy_formats(&info.webpage_url).await {
+                        Ok(r) => r,
+                        Err(e) if attempt < MAX_EXTRACT_RETRIES => {
+                            warn!(
+                                attempt = attempt + 1;
+                                "Extraction failed: {e}, will retry"
+                            );
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    };
 
-        // Detect resume point
-        let resume_offset = self
-            .detect_resume_point(&output_path, format.filesize)
-            .await?;
+                    // Preserve all episode metadata from the original stub
+                    resolved.id = info.id.clone();
+                    resolved.title = info.title.clone();
+                    resolved.thumbnail = info.thumbnail.clone();
+                    resolved.description = info.description.clone();
+                    resolved.playlist = info.playlist.clone();
+                    resolved.playlist_title = info.playlist_title.clone();
+                    resolved.playlist_index = info.playlist_index;
+                    resolved.playlist_count = info.playlist_count;
 
-        // Check if file is already complete
-        if let Some(expected_size) = format.filesize {
-            if resume_offset == expected_size {
-                info!("File already complete, skipping");
-                return Ok(Some(output_path));
+                    // Apply audio type filter to lazily-resolved formats
+                    if let Some(lang) = audio_type_filter {
+                        resolved
+                            .formats
+                            .retain(|f| f.language.as_deref() == Some(lang));
+                    }
+
+                    resolved_info = resolved;
+                    &resolved_info
+                } else {
+                    info
+                };
+
+            // Select format (non-interactive on retry to avoid re-prompting)
+            let Some(mut format) = self
+                .select_format(info_ref, interactive && attempt == 0)
+                .await?
+            else {
+                return Ok(None);
+            };
+
+            // Add alternative CDN server URLs as fallbacks
+            let alt_urls: Vec<String> = info_ref
+                .formats
+                .iter()
+                .filter(|f| f.url != format.url)
+                .map(|f| f.url.clone())
+                .collect();
+            if !alt_urls.is_empty() {
+                format
+                    .fallback_urls
+                    .get_or_insert_with(Vec::new)
+                    .extend(alt_urls);
+            }
+
+            // Compute output path on first attempt only
+            if output_path.is_none() {
+                let file_ext = self.determine_file_extension(&format);
+                let sanitized_title = self.sanitize_filename(&info_ref.title);
+                let filename = format!("{sanitized_title}.{file_ext}");
+                let path = output_dir.join(&filename);
+
+                self.cleanup_leftover_segments(output_dir, &sanitized_title)
+                    .await;
+
+                info!(path:? = path.display(); "Downloading to");
+                output_path = Some(path);
+            }
+
+            let path = output_path.as_ref().unwrap();
+
+            // Detect resume point (recalculate on retry for partial HLS)
+            let resume_offset = self.detect_resume_point(path, format.filesize).await?;
+
+            // Check if file is already complete
+            if let Some(expected_size) = format.filesize {
+                if resume_offset == expected_size {
+                    info!("File already complete, skipping");
+                    return Ok(Some(path.clone()));
+                }
+            }
+
+            // Save info for post-download use (thumbnail, subtitles)
+            last_info_ref = Some(info_ref.clone());
+
+            // Download with CDN fallback
+            match self
+                .download_with_cdn_fallback(&format, path, resume_offset)
+                .await
+            {
+                Ok(Some(outcome)) => {
+                    download_outcome = Some(outcome);
+                    break;
+                }
+                Ok(None) => return Ok(None), // User cancelled
+                Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {
+                    warn!("All CDN URLs failed: {e}");
+                    warn!("Will re-extract fresh URLs after delay");
+                    continue;
+                }
+                Err(e) => return Err(e),
             }
         }
 
-        // Execute download with CDN fallback (shared implementation)
-        let Some(outcome) = self
-            .download_with_cdn_fallback(&format, &output_path, resume_offset)
-            .await?
-        else {
-            return Ok(None);
-        };
+        let outcome = download_outcome.ok_or_else(|| {
+            OrchestratorError::DownloadFailed(rdlp_core::RdlpError::Extraction(
+                "All extraction retry attempts exhausted".to_string(),
+            ))
+        })?;
+
+        let output_path = output_path.unwrap();
+        let final_info = last_info_ref.as_ref().unwrap_or(info);
 
         // Download thumbnail if needed (before post-processing so embed can find it)
         if self.config.embed_thumbnail || self.config.write_thumbnail {
-            self.download_thumbnail(info, &output_path).await;
+            self.download_thumbnail(final_info, &output_path).await;
         }
 
         // Download subtitles: resolve per-episode URLs from language names
         let episode_subs = if !subtitle_langs.is_empty() {
-            self.resolve_subtitles_for_episode(info, subtitle_langs)
+            self.resolve_subtitles_for_episode(final_info, subtitle_langs)
         } else {
             Vec::new()
         };
-        self.download_subtitles(info, &output_path, &episode_subs)
+        self.download_subtitles(final_info, &output_path, &episode_subs)
             .await?;
 
         // Run post-processing if configured (or automatic for HLS)
         let final_files = self
-            .run_postprocessing(info, vec![output_path.clone()], outcome.is_hls)
+            .run_postprocessing(final_info, vec![output_path.clone()], outcome.is_hls)
             .await?;
         let final_path = final_files.into_iter().next().unwrap_or(output_path);
 

--- a/crates/rdlp-core/src/traits/extractor.rs
+++ b/crates/rdlp-core/src/traits/extractor.rs
@@ -82,6 +82,17 @@ pub trait InfoExtractor: Send + Sync {
         Ok(vec![self.extract(url, ctx).await?])
     }
 
+    /// Lightweight format extraction for lazily-resolved playlist entries.
+    ///
+    /// Called by the orchestrator when a playlist entry has empty formats and
+    /// needs resolution at download time. The default implementation delegates
+    /// to `extract()`. Extractors may override this to skip expensive
+    /// operations (e.g., re-fetching the watch page HTML) when only format
+    /// resolution is needed.
+    async fn extract_lazy(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
+        self.extract(url, ctx).await
+    }
+
     /// Check if this extractor can handle the given URL
     ///
     /// The default implementation checks against the valid_url() regex.

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -299,9 +299,23 @@ impl DownloaderRegistry {
     /// Create a new registry with custom configuration
     #[must_use]
     pub fn with_config(config: &Config) -> Self {
-        // Create optimized HTTP client using shared factory
         let client = HttpClientFactory::from_rdlp_config(config).build();
+        Self::build_registry(config, client)
+    }
 
+    /// Create a new registry with custom configuration and shared cookie jar
+    ///
+    /// The cookie jar is shared with the extraction HTTP client so that
+    /// cookies obtained during extraction (including Cloudflare clearance
+    /// and session cookies) are automatically sent during downloads.
+    #[must_use]
+    pub fn with_config_and_cookies(config: &Config, cookie_jar: Arc<reqwest::cookie::Jar>) -> Self {
+        let client = HttpClientFactory::from_rdlp_config(config).build_with_cookies(cookie_jar);
+        Self::build_registry(config, client)
+    }
+
+    /// Internal helper to build registry from a pre-configured HTTP client
+    fn build_registry(config: &Config, client: reqwest::Client) -> Self {
         // Create rate limiter if configured
         let rate_limiter = config.rate_limit.map(|bps| Arc::new(RateLimiter::new(bps)));
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -160,25 +160,34 @@ pub(crate) async fn resolve_episode_formats(
                         Some(format!("{} ({})", server.audio_type, server.server_name));
                     format.language = Some(audio_label);
 
+                    // Set Referer to the embed URL so CDN M3U8 fetches aren't
+                    // blocked by Cloudflare during HLS variant detection.
+                    let mut headers = HashMap::new();
+                    headers.insert("Referer".to_string(), source.embed_url.clone());
+                    format.http_headers = Some(headers);
+
                     all_formats.push(format);
                 }
 
-                // Stop trying servers once we have both SUB and DUB (or no
-                // remaining servers offer the missing type).
+                // Stop trying servers once we have both SUB and DUB with
+                // CDN redundancy (≥2 formats per type for fallback).
                 if !mega_sources.sources.is_empty() {
-                    let has_sub = all_formats
+                    let sub_count = all_formats
                         .iter()
-                        .any(|f| f.format_note.as_ref().is_some_and(|n| n.contains("SUB")));
-                    let has_dub = all_formats
+                        .filter(|f| f.format_note.as_ref().is_some_and(|n| n.contains("SUB")))
+                        .count();
+                    let dub_count = all_formats
                         .iter()
-                        .any(|f| f.format_note.as_ref().is_some_and(|n| n.contains("DUB")));
-                    let remaining_has_other_type = servers.iter().any(|s| {
+                        .filter(|f| f.format_note.as_ref().is_some_and(|n| n.contains("DUB")))
+                        .count();
+
+                    let remaining_provides_value = servers.iter().any(|s| {
                         s.data_id != server.data_id
-                            && ((s.audio_type == api::AudioType::Sub && !has_sub)
-                                || (s.audio_type == api::AudioType::Dub && !has_dub))
+                            && ((s.audio_type == api::AudioType::Sub && sub_count < 2)
+                                || (s.audio_type == api::AudioType::Dub && dub_count < 2))
                     });
 
-                    if !remaining_has_other_type {
+                    if !remaining_provides_value {
                         break;
                     }
                 }
@@ -331,6 +340,37 @@ impl InfoExtractor for NineAnimeExtractor {
             // No ?ep= parameter — extract all episodes as a playlist
             playlist::extract_season(url, ctx).await
         }
+    }
+
+    /// Lightweight format resolution for lazily-extracted playlist entries.
+    ///
+    /// Skips the watch page fetch and episode info AJAX call (metadata is
+    /// already available from playlist extraction). Only resolves Megacloud
+    /// video sources and subtitles, avoiding Cloudflare rate-limiting.
+    async fn extract_lazy(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
+        let episode_id = patterns::extract_episode_id(url).ok_or_else(|| {
+            RdlpError::Extraction(format!(
+                "Could not extract episode ID from URL: {url}. \
+                 Use a URL with ?ep= parameter."
+            ))
+        })?;
+
+        info!(episode_id:%; "Lazily resolving 9anime episode formats");
+
+        let (formats, hls_flags, subtitle_tracks) =
+            resolve_episode_formats(&episode_id, ctx).await?;
+
+        let mut info = InfoDict::new("", "", "9anime", url);
+        info.formats = formats;
+        info.is_live = Some(hls_flags.is_live);
+
+        if !subtitle_tracks.is_empty() {
+            info.subtitles = Some(build_subtitle_map(&subtitle_tracks));
+        }
+
+        info.propagate_duration();
+
+        Ok(info)
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
@@ -1,47 +1,46 @@
 //! Season/playlist extraction for 9anime.
 //!
 //! Downloads all episodes of an anime when the URL has no `?ep=` parameter.
-//! Uses parallel extraction with bounded concurrency to resolve each episode's
-//! video sources through the Megacloud/Rapid-Cloud chain.
+//! One episode is fully resolved during extraction (for audio type detection
+//! and subtitle info). If the first episode fails (CDN error, Cloudflare),
+//! up to 3 episodes are tried in order. Remaining episodes are built as
+//! lightweight `InfoDict` stubs with `webpage_url` set, enabling lazy
+//! resolution at download time.
 //!
 //! # Performance
 //!
-//! - Concurrency: 3 parallel episode extractions (lower than PornHub's 4
-//!   due to Megacloud's tighter rate limits)
-//! - Per-episode timeout: 60 seconds (accounts for cipher decryption)
+//! - Playlist prompt appears in ~5 seconds (vs ~68s with eager extraction)
+//! - Each episode resolves formats just before download (~3-5s per episode)
 
 use crate::base::common::MAX_PLAYLIST_SIZE;
-use futures::stream::{self, StreamExt};
 use log::{debug, info, warn};
 use rdlp_core::{ExtractionContext, InfoDict, RdlpError, Result};
 use scraper::Html;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
-use tokio::time::timeout;
 
 use super::{api, build_subtitle_map, metadata, patterns, resolve_episode_formats};
 use crate::base::common::BaseExtractor;
 
-/// Timeout for extracting a single episode (60 seconds).
-const EPISODE_EXTRACTION_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Number of concurrent episode extractions.
-const CONCURRENT_EXTRACTIONS: usize = 3;
-
 /// Extract all episodes of an anime as a playlist.
+///
+/// One episode is fully resolved (formats + subtitles) for audio type detection.
+/// If the first episode's CDN resolution fails, up to 3 episodes are tried.
+/// Remaining episodes are returned as metadata-only stubs with `webpage_url`
+/// set so the orchestrator can lazily resolve them at download time.
 ///
 /// # Flow
 ///
-/// 1. Parse anime_id from URL
+/// 1. Parse anime_id and slug from URL
 /// 2. Fetch watch page for shared metadata (title, thumbnail, description)
 /// 3. Fetch full episode list via AJAX
-/// 4. Resolve formats for each episode in parallel
-/// 5. Return sorted `Vec<InfoDict>` with playlist fields set
+/// 4. Fully resolve **one episode** via `resolve_episode_formats()` (tries up to 3)
+/// 5. Build remaining episodes as lightweight `InfoDict` with proper `webpage_url`
+/// 6. Return `Vec<InfoDict>` with playlist fields set
 pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<InfoDict>> {
     let anime_id = patterns::extract_anime_id(url).ok_or_else(|| {
         RdlpError::Extraction(format!("Could not extract anime ID from URL: {url}"))
     })?;
+
+    let slug = patterns::extract_slug(url).unwrap_or_default();
 
     info!(anime_id:%; "Extracting 9anime season (all episodes)");
 
@@ -74,115 +73,89 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
         )));
     }
 
-    // Progress counter
-    let completed = Arc::new(AtomicUsize::new(0));
+    // Resolve one episode fully for audio type detection + subtitles.
+    // Try episodes in order until one succeeds — CDN failures on the first
+    // episode shouldn't prevent SUB/DUB and subtitle selection.
+    const MAX_PROBE_EPISODES: usize = 3;
+    let probe_limit = MAX_PROBE_EPISODES.min(total);
+    let mut probe_result = None;
+    let mut probe_index = 0;
 
-    // Build extraction futures for each episode
-    let extraction_futures = episodes.into_iter().enumerate().map(|(index, episode)| {
-        let position = index + 1;
-        let anime_title = anime_title.clone();
-        let thumbnail = anime_metadata.thumbnail.clone();
-        let description = anime_metadata.description.clone();
-        let completed = Arc::clone(&completed);
+    for (i, ep) in episodes.iter().enumerate().take(probe_limit) {
+        let label = format!(
+            "Episode {} ({})",
+            ep.info.number,
+            ep.info.title.as_deref().unwrap_or("untitled")
+        );
+        debug!(episode:% = label; "Resolving episode for type detection");
 
-        async move {
-            let ep_label = format!(
-                "Episode {} ({})",
-                episode.info.number,
-                episode.info.title.as_deref().unwrap_or("untitled")
-            );
-
-            debug!(position, total, episode:% = ep_label; "Extracting episode");
-
-            let result = timeout(
-                EPISODE_EXTRACTION_TIMEOUT,
-                resolve_episode_formats(&episode.data_id, ctx),
-            )
-            .await;
-
-            let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
-
-            match result {
-                Ok(Ok((formats, hls_flags, subtitle_tracks))) => {
-                    if formats.is_empty() {
-                        warn!(
-                            done, total, episode:% = ep_label;
-                            "No formats resolved for episode"
-                        );
-                        return None;
-                    }
-
-                    // Build episode title
-                    let title = match &episode.info.title {
-                        Some(ep_title) => format!(
-                            "{anime_title} - Episode {} - {ep_title}",
-                            episode.info.number
-                        ),
-                        None => format!("{anime_title} - Episode {}", episode.info.number),
-                    };
-
-                    let video_id = format!("{}-ep{}", episode.data_id, episode.info.number);
-
-                    let mut info = InfoDict::new(
-                        &video_id,
-                        &title,
-                        "9anime",
-                        format!("https://9animetv.to/watch/episode-{}", episode.data_id),
-                    );
-                    info.formats = formats;
-                    info.thumbnail = thumbnail;
-                    info.description = description;
-                    info.is_live = Some(hls_flags.is_live);
-
-                    // Populate subtitles from Megacloud tracks
-                    if !subtitle_tracks.is_empty() {
-                        info.subtitles = Some(build_subtitle_map(&subtitle_tracks));
-                    }
-
-                    info.propagate_duration();
-
-                    // Set playlist fields
-                    info.playlist = Some(anime_title.clone());
-                    info.playlist_title = Some(anime_title);
-                    info.playlist_index = Some(position);
-                    info.playlist_count = Some(total);
-
-                    debug!(
-                        done, total, episode:% = ep_label;
-                        "Episode extraction succeeded"
-                    );
-
-                    Some((position, info))
-                }
-                Ok(Err(e)) => {
-                    warn!(
-                        done, total, episode:% = ep_label;
-                        "Failed to extract episode: {e}"
-                    );
-                    None
-                }
-                Err(_) => {
-                    warn!(
-                        done, total, episode:% = ep_label;
-                        "Timed out extracting episode"
-                    );
-                    None
-                }
+        match resolve_episode_formats(&ep.data_id, ctx).await {
+            Ok((formats, hls_flags, subtitle_tracks)) if !formats.is_empty() => {
+                info!(
+                    episode:% = label,
+                    formats = formats.len();
+                    "Episode resolved successfully for type detection"
+                );
+                probe_result = Some((formats, hls_flags, subtitle_tracks));
+                probe_index = i;
+                break;
+            }
+            Ok(_) => {
+                warn!(episode:% = label; "No formats resolved, trying next episode");
+            }
+            Err(e) => {
+                warn!(episode:% = label; "Failed to resolve episode: {e}");
             }
         }
-    });
+    }
 
-    // Process extractions concurrently with bounded parallelism
-    let results: Vec<Option<(usize, InfoDict)>> = stream::iter(extraction_futures)
-        .buffer_unordered(CONCURRENT_EXTRACTIONS)
-        .collect()
-        .await;
+    let mut results: Vec<InfoDict> = Vec::with_capacity(total);
 
-    // Collect successful extractions and sort by playlist position
-    let mut extracted: Vec<(usize, InfoDict)> = results.into_iter().flatten().collect();
-    extracted.sort_by_key(|(pos, _)| *pos);
+    // Build InfoDict for each episode
+    for (index, episode) in episodes.iter().enumerate() {
+        let position = index + 1;
 
-    let results: Vec<InfoDict> = extracted.into_iter().map(|(_, info)| info).collect();
+        let title = match &episode.info.title {
+            Some(ep_title) => format!(
+                "{anime_title} - Episode {} - {ep_title}",
+                episode.info.number
+            ),
+            None => format!("{anime_title} - Episode {}", episode.info.number),
+        };
+
+        let video_id = format!("{}-ep{}", episode.data_id, episode.info.number);
+        let webpage_url = format!(
+            "https://9animetv.to/watch/{slug}-{anime_id}?ep={}",
+            episode.data_id
+        );
+
+        let mut info = InfoDict::new(&video_id, &title, "9anime", &webpage_url);
+        info.thumbnail = anime_metadata.thumbnail.clone();
+        info.description = anime_metadata.description.clone();
+
+        // The probed episode gets full formats + subtitles
+        if index == probe_index {
+            if let Some((ref formats, ref hls_flags, ref subtitle_tracks)) = probe_result {
+                info.formats = formats.clone();
+                info.is_live = Some(hls_flags.is_live);
+
+                if !subtitle_tracks.is_empty() {
+                    info.subtitles = Some(build_subtitle_map(subtitle_tracks));
+                }
+
+                info.propagate_duration();
+            }
+        }
+        // All other episodes: empty formats (lazy resolution marker)
+
+        // Set playlist fields
+        info.playlist = Some(anime_title.clone());
+        info.playlist_title = Some(anime_title.clone());
+        info.playlist_index = Some(position);
+        info.playlist_count = Some(total);
+
+        results.push(info);
+    }
 
     if results.is_empty() {
         return Err(RdlpError::Extraction(format!(
@@ -191,8 +164,9 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
     }
 
     info!(
-        extracted = results.len(), total;
-        "Successfully extracted episodes"
+        total = results.len(),
+        probed = probe_result.is_some();
+        "Playlist extraction complete (one episode probed, rest deferred)"
     );
 
     Ok(results)
@@ -203,8 +177,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_constants() {
-        assert_eq!(CONCURRENT_EXTRACTIONS, 3);
-        assert_eq!(EPISODE_EXTRACTION_TIMEOUT, Duration::from_secs(60));
+    fn test_webpage_url_format() {
+        let slug = "sword-art-online";
+        let anime_id = "2274";
+        let data_id = "26565";
+        let url = format!("https://9animetv.to/watch/{slug}-{anime_id}?ep={data_id}");
+        assert!(patterns::has_episode_param(&url));
+        assert_eq!(patterns::extract_anime_id(&url), Some("2274".to_string()));
+        assert_eq!(
+            patterns::extract_episode_id(&url),
+            Some("26565".to_string())
+        );
     }
 }

--- a/crates/rdlp-extractor/src/hls.rs
+++ b/crates/rdlp-extractor/src/hls.rs
@@ -144,6 +144,8 @@ pub struct HlsSizeDetector {
     http_client: Arc<reqwest::Client>,
     concurrent_requests: usize,
     verbose: bool,
+    /// Optional default headers applied to every M3U8 fetch (e.g., Referer).
+    default_headers: Option<reqwest::header::HeaderMap>,
 }
 
 impl HlsSizeDetector {
@@ -158,6 +160,7 @@ impl HlsSizeDetector {
             http_client,
             concurrent_requests: DEFAULT_CONCURRENCY,
             verbose,
+            default_headers: None,
         }
     }
 
@@ -168,6 +171,15 @@ impl HlsSizeDetector {
     #[must_use = "builder methods consume self and return a new instance"]
     pub fn with_concurrency(mut self, count: usize) -> Self {
         self.concurrent_requests = count.max(1);
+        self
+    }
+
+    /// Set default HTTP headers applied to every M3U8 playlist fetch.
+    ///
+    /// Useful for CDNs that require a `Referer` header to avoid challenges.
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_default_headers(mut self, headers: reqwest::header::HeaderMap) -> Self {
+        self.default_headers = Some(headers);
         self
     }
 
@@ -599,7 +611,11 @@ impl HlsSizeDetector {
 
     /// Fetch M3U8 playlist text from a URL
     async fn fetch_playlist_text(&self, m3u8_url: &str) -> Result<String> {
-        let response = self.http_client.get(m3u8_url).send().await.map_err(|e| {
+        let mut request = self.http_client.get(m3u8_url);
+        if let Some(headers) = &self.default_headers {
+            request = request.headers(headers.clone());
+        }
+        let response = request.send().await.map_err(|e| {
             if e.is_timeout() {
                 RdlpError::Network(format!("Timeout fetching playlist: {m3u8_url}"))
             } else if e.is_connect() {
@@ -1078,7 +1094,25 @@ pub async fn detect_format_sizes(
     use tokio::time::timeout;
 
     let verbose = ctx.config.verbose;
-    let hls_detector = HlsSizeDetector::new(ctx.http_client.clone(), verbose);
+    let mut hls_detector = HlsSizeDetector::new(ctx.http_client.clone(), verbose);
+
+    // Propagate HTTP headers from formats (e.g., Referer) to the HLS detector.
+    // Many CDNs (Megacloud/douvid.xyz) require a Referer to serve M3U8 content.
+    if let Some(headers_map) = formats.iter().find_map(|f| f.http_headers.as_ref()) {
+        let mut header_map = reqwest::header::HeaderMap::new();
+        for (key, value) in headers_map {
+            if let (Ok(name), Ok(val)) = (
+                reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+                reqwest::header::HeaderValue::from_str(value),
+            ) {
+                header_map.insert(name, val);
+            }
+        }
+        if !header_map.is_empty() {
+            hls_detector = hls_detector.with_default_headers(header_map);
+        }
+    }
+
     let http_client = ctx.http_client.clone();
     let extractor_name = extractor_name.to_string();
 


### PR DESCRIPTION
## Summary
- **Lazy playlist extraction**: Only the first episode is fully resolved during `extract_season()`; remaining episodes are lightweight stubs with `webpage_url` only, resolved on-demand before download via `extract_lazy_formats()`
- **4-layer CDN retry strategy**: (1) multiple server URLs as fallbacks, (2) CDN fallback loop in downloader, (3) extractor-level re-extraction with exponential backoff (5s/15s/30s), (4) token freshness guard re-extracts when batch-resolved tokens exceed 25 min
- **Parallel episode downloads**: `buffer_unordered(2)` for concurrent episode processing with Ctrl+C support
- **CDN server stickiness**: Fallback URLs sorted to prefer same CDN host as primary (healthy servers more likely to stay healthy)
- **Cookie jar sharing**: `reqwest::cookie::Jar` shared between extractor and downloader HTTP clients via `Arc` for authenticated CDN access
- **`is_reextractable_error()`** classifies CDN failures (invalid M3U8, 403/503) warranting fresh URL extraction

## Test plan
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` — all 189 tests pass
- [ ] `cargo build --release` succeeds
- [ ] Manual test: `rdlp --remux -i "https://9animetv.to/watch/sword-art-online-2274"` downloads playlist with parallel episodes, CDN fallback, and token refresh working