### PR TITLE
feat(subtitles): resilient subtitle pipeline with retry + fuzzy language matching

### DIFF
--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -141,6 +141,14 @@ struct Args {
     #[arg(long, alias = "list-subs-only")]
     list_subs_only: bool,
 
+    /// Strict subtitle mode: fail download if requested subs are missing
+    #[arg(long)]
+    strict_subs: bool,
+
+    /// Pre-validate subtitle URLs with HEAD requests before download
+    #[arg(long)]
+    verify_sub_urls: bool,
+
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
@@ -589,6 +597,12 @@ fn merge_config(
     if config.embed_subtitles && !config.write_subtitles {
         config.write_subtitles = true;
     }
+    if args.strict_subs {
+        config.strict_subs = true;
+    }
+    if args.verify_sub_urls {
+        config.verify_sub_urls = true;
+    }
 
     // Recode video: interactive (pre-resolved) or direct parse
     if let Some(fmt) = interactive_values.recode_video {
@@ -946,6 +960,8 @@ mod tests {
             embed_subtitles: false,
             list_subs: false,
             list_subs_only: false,
+            strict_subs: false,
+            verify_sub_urls: false,
             recode_video: None,
             remux: None,
             normalize_audio: false,

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -149,6 +149,10 @@ struct Args {
     #[arg(long)]
     verify_sub_urls: bool,
 
+    /// Retry subtitle downloads for already-downloaded videos missing subs
+    #[arg(long)]
+    retry_subs: bool,
+
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
@@ -603,6 +607,9 @@ fn merge_config(
     if args.verify_sub_urls {
         config.verify_sub_urls = true;
     }
+    if args.retry_subs {
+        config.retry_subs = true;
+    }
 
     // Recode video: interactive (pre-resolved) or direct parse
     if let Some(fmt) = interactive_values.recode_video {
@@ -813,6 +820,13 @@ async fn async_main() -> Result<()> {
         info!("Rate limit: {rate} bytes/s");
     }
 
+    if config.verify_sub_urls && !config.strict_subs {
+        warn!(
+            "--verify-sub-urls validates URLs but missing subs \
+             won't fail the download without --strict-subs"
+        );
+    }
+
     let interactive = args.interactive;
 
     // Create orchestrator with shared MultiProgress
@@ -962,6 +976,7 @@ mod tests {
             list_subs_only: false,
             strict_subs: false,
             verify_sub_urls: false,
+            retry_subs: false,
             recode_video: None,
             remux: None,
             normalize_audio: false,

--- a/crates/rdlp-cli/src/orchestrator/mod.rs
+++ b/crates/rdlp-cli/src/orchestrator/mod.rs
@@ -13,6 +13,7 @@ mod selection;
 mod session_state;
 mod state;
 mod subtitle;
+mod subtitle_pipeline;
 mod template;
 mod thumbnail;
 

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -8,6 +8,7 @@ use super::session_state::{self, FailedEpisode, PlaylistState, SessionState};
 use super::{Orchestrator, OrchestratorError, Result, archive};
 use futures_util::StreamExt;
 use log::{debug, error, info, warn};
+use rdlp_core::SubtitleFormat;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -16,6 +17,68 @@ use std::time::{Duration, Instant};
 /// Megacloud/netmagcdn tokens last ~30-60 min; we re-extract at 25 min
 /// to stay well within the window.
 const TOKEN_MAX_AGE: Duration = Duration::from_secs(25 * 60);
+
+/// All subtitle formats checked during resume detection.
+const RESUME_SUB_FORMATS: &[SubtitleFormat] = &[
+    SubtitleFormat::Srt,
+    SubtitleFormat::Vtt,
+    SubtitleFormat::Ass,
+    SubtitleFormat::Ssa,
+    SubtitleFormat::Lrc,
+];
+
+/// Resume detection result for a playlist folder.
+pub(super) struct ResumeDetection {
+    /// Completed episodes: sanitized_title -> video file path
+    pub completed: HashMap<String, PathBuf>,
+    /// Count of episodes with leftover segment files
+    pub partial_count: usize,
+    /// Episodes with video complete but subtitle files missing:
+    /// sanitized_title -> video file path
+    pub missing_subs: HashMap<String, PathBuf>,
+}
+
+/// Check if any subtitle file exists for the given language (exact or fuzzy).
+///
+/// Checks `{stem}.{lang}.{ext}` for all subtitle formats. If no exact match,
+/// scans `{stem}.*.{ext}` patterns for fuzzy prefix matches (e.g., `"en"` finds
+/// `title.English.vtt`).
+fn has_subtitle_file(dir: &std::path::Path, stem: &str, lang: &str) -> bool {
+    // Exact match: {stem}.{lang}.{ext}
+    for fmt in RESUME_SUB_FORMATS {
+        if dir.join(format!("{stem}.{lang}.{}", fmt.as_ext())).exists() {
+            return true;
+        }
+    }
+
+    // Fuzzy match: scan for {stem}.*.{ext} and prefix-match the middle segment
+    if lang.len() <= 3 {
+        let lang_lower = lang.to_ascii_lowercase();
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                // Must start with "{stem}." and have at least one more dot
+                if let Some(rest) = name_str
+                    .strip_prefix(stem)
+                    .and_then(|r| r.strip_prefix('.'))
+                {
+                    // rest = "English.vtt" → split into ("English", "vtt")
+                    if let Some((mid, ext)) = rest.rsplit_once('.') {
+                        let is_sub_ext = RESUME_SUB_FORMATS
+                            .iter()
+                            .any(|f| f.as_ext().eq_ignore_ascii_case(ext));
+                        if is_sub_ext && mid.to_ascii_lowercase().starts_with(&lang_lower) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
 
 impl Orchestrator {
     /// Download all videos from a playlist
@@ -89,17 +152,37 @@ impl Orchestrator {
         let saved_state = SessionState::load(&state_path, &source_url).await;
         let resuming = matches!(&saved_state, Some(SessionState::Playlist(_)));
 
-        // Extract subtitle langs from saved state (empty on first run)
-        let saved_sub_langs: Vec<String> = match &saved_state {
-            Some(SessionState::Playlist(s)) => s.selected_sub_langs.clone(),
-            _ => Vec::new(),
+        // Extract subtitle langs and strict_subs from saved state.
+        // When no saved state exists (first run or previous run completed cleanly),
+        // fall back to the current CLI config so resume detection can still find
+        // missing subtitle files.
+        let (saved_sub_langs, saved_strict_subs) = match &saved_state {
+            Some(SessionState::Playlist(s)) => (s.selected_sub_langs.clone(), s.strict_subs),
+            _ => (self.config.subtitle_langs.clone(), self.config.strict_subs),
         };
 
+        // Warn if saved strict_subs differs from current CLI flag
+        if resuming && saved_strict_subs != self.config.strict_subs {
+            warn!(
+                saved = saved_strict_subs,
+                current = self.config.strict_subs;
+                "strict_subs changed since last run — using saved value for resume"
+            );
+        }
+
         // Check for existing files (resume detection)
-        // Pass subtitle langs so detection can verify VTT files exist.
-        let (existing_files, partial_count) = self
-            .detect_existing_playlist_files(&playlist_dir, &infos, &saved_sub_langs)
+        // Pass subtitle langs and strict_subs so detection can verify VTT files exist.
+        let resume = self
+            .detect_existing_playlist_files(
+                &playlist_dir,
+                &infos,
+                &saved_sub_langs,
+                saved_strict_subs,
+            )
             .await;
+        let existing_files = resume.completed;
+        let partial_count = resume.partial_count;
+        let missing_subs = resume.missing_subs;
         let already_downloaded = existing_files.len();
         let remaining = total - already_downloaded;
 
@@ -139,9 +222,36 @@ impl Orchestrator {
 
         info!("{}", "=".repeat(60));
 
-        // If all videos are already downloaded, return early
+        // If all videos are already downloaded, handle subtitle retry or return
         if remaining == 0 {
-            info!("All videos already downloaded");
+            let need_sub_retry =
+                self.config.retry_subs && !saved_sub_langs.is_empty() && !missing_subs.is_empty();
+            if !need_sub_retry {
+                if !missing_subs.is_empty() && !saved_sub_langs.is_empty() {
+                    // Report missing subs even when not retrying
+                    warn!("Missing subtitles for {} episode(s)", missing_subs.len());
+                    self.log_missing_subs(&missing_subs, &infos, total);
+                    if !self.config.retry_subs {
+                        info!("Hint: re-run with --retry-subs to attempt subtitle download");
+                    }
+                }
+                info!("All videos already downloaded");
+                SessionState::delete(&state_path).await;
+                let paths: Vec<PathBuf> = existing_files.into_values().collect();
+                return Ok(Some(paths));
+            }
+            // Fall through to subtitle retry pass below
+            info!("All videos already downloaded — retrying missing subtitles");
+            let sub_recovered = self
+                .retry_missing_subtitles(&missing_subs, &infos, &saved_sub_langs)
+                .await;
+            if sub_recovered > 0 {
+                info!("Recovered subtitles for {sub_recovered} episode(s)");
+            }
+            let still_missing = missing_subs.len() - sub_recovered;
+            if still_missing > 0 {
+                warn!("Still missing subtitles for {still_missing} episode(s)");
+            }
             SessionState::delete(&state_path).await;
             let paths: Vec<PathBuf> = existing_files.into_values().collect();
             return Ok(Some(paths));
@@ -593,6 +703,18 @@ impl Orchestrator {
             }
         }
 
+        // ── Subtitle retry for completed episodes missing subs ──
+        let mut sub_retried_ok = 0usize;
+        if !interrupted
+            && self.config.retry_subs
+            && !selected_sub_langs.is_empty()
+            && !missing_subs.is_empty()
+        {
+            sub_retried_ok = self
+                .retry_missing_subtitles(&missing_subs, &infos, &selected_sub_langs)
+                .await;
+        }
+
         // Summary report
         let newly_downloaded = downloaded.len() - already_downloaded;
         let dl_count = downloaded.len();
@@ -620,6 +742,24 @@ impl Orchestrator {
             error!("Failed: {}", failed.len());
             for (pos, title, err) in &failed {
                 error!("  [{pos}/{total}] {title}: {err}");
+            }
+        }
+
+        // Report missing subtitles
+        if !missing_subs.is_empty() && !selected_sub_langs.is_empty() {
+            let still_missing = missing_subs.len() - sub_retried_ok;
+            if sub_retried_ok > 0 {
+                info!(
+                    "Subtitles recovered: {sub_retried_ok}/{}",
+                    missing_subs.len()
+                );
+            }
+            if still_missing > 0 {
+                warn!("Missing subtitles: {still_missing}");
+                self.log_missing_subs(&missing_subs, &infos, total);
+                if !self.config.retry_subs {
+                    info!("Hint: re-run with --retry-subs to attempt subtitle download");
+                }
             }
         }
 
@@ -668,9 +808,10 @@ impl Orchestrator {
 
     /// Detect existing files in playlist folder that match video titles
     ///
-    /// Returns a tuple of:
-    /// - HashMap of sanitized title -> file path for completed downloads
-    /// - Count of videos with leftover segment files (will be cleaned up)
+    /// Returns a [`ResumeDetection`] containing:
+    /// - `completed`: sanitized title -> file path for completed downloads
+    /// - `partial_count`: videos with leftover segment files
+    /// - `missing_subs`: completed videos missing expected subtitle files
     ///
     /// # Note on .part files
     ///
@@ -684,18 +825,30 @@ impl Orchestrator {
         playlist_dir: &std::path::Path,
         infos: &[rdlp_core::InfoDict],
         subtitle_langs: &[String],
-    ) -> (HashMap<String, PathBuf>, usize) {
+        strict_subs: bool,
+    ) -> ResumeDetection {
         let mut completed = HashMap::new();
         let mut partial_count = 0;
+        let mut missing_subs = HashMap::new();
 
         if !playlist_dir.exists() {
-            return (completed, partial_count);
+            return ResumeDetection {
+                completed,
+                partial_count,
+                missing_subs,
+            };
         }
 
         // Get all files in the playlist directory
         let mut dir_entries = match tokio::fs::read_dir(playlist_dir).await {
             Ok(entries) => entries,
-            Err(_) => return (completed, partial_count),
+            Err(_) => {
+                return ResumeDetection {
+                    completed,
+                    partial_count,
+                    missing_subs,
+                };
+            }
         };
 
         let mut files: Vec<PathBuf> = Vec::new();
@@ -749,26 +902,31 @@ impl Orchestrator {
                         // Check if file has reasonable size (> 1MB to avoid empty/corrupted files)
                         if let Ok(metadata) = file_path.metadata() {
                             if metadata.len() > 1_000_000 {
-                                // If subtitles were selected AND strict mode is
-                                // enabled, verify subtitle files exist alongside
-                                // the video. In lenient mode (default), missing
-                                // subs don't invalidate a completed video.
-                                if self.config.strict_subs && !subtitle_langs.is_empty() {
-                                    let stem = &sanitized_title;
+                                // Check subtitle file existence once for both
+                                // strict and lenient paths. Uses fuzzy matching
+                                // so "en" finds "title.English.vtt".
+                                let subs_missing = if !subtitle_langs.is_empty() {
                                     let dir = file_path.parent().unwrap_or(playlist_dir);
-                                    let any_sub_exists = subtitle_langs.iter().any(|lang| {
-                                        ["vtt", "srt", "ass"].iter().any(|ext| {
-                                            dir.join(format!("{stem}.{lang}.{ext}")).exists()
-                                        })
-                                    });
-                                    if !any_sub_exists {
-                                        debug!(
-                                            file:% = filename;
-                                            "Skipping: missing subtitle file (strict mode)"
-                                        );
-                                        found_partial = true;
-                                        continue;
-                                    }
+                                    !subtitle_langs
+                                        .iter()
+                                        .any(|lang| has_subtitle_file(dir, &sanitized_title, lang))
+                                } else {
+                                    false
+                                };
+
+                                // Strict mode: missing subs invalidate the video
+                                if strict_subs && subs_missing {
+                                    debug!(
+                                        file:% = filename;
+                                        "Skipping: missing subtitle file (strict mode)"
+                                    );
+                                    found_partial = true;
+                                    continue;
+                                }
+
+                                // Lenient mode: track for reporting / --retry-subs
+                                if subs_missing {
+                                    missing_subs.insert(sanitized_title.clone(), file_path.clone());
                                 }
 
                                 completed.insert(sanitized_title.clone(), file_path.clone());
@@ -788,7 +946,113 @@ impl Orchestrator {
             }
         }
 
-        (completed, partial_count)
+        ResumeDetection {
+            completed,
+            partial_count,
+            missing_subs,
+        }
+    }
+
+    /// Retry subtitle downloads for completed videos that are missing subs.
+    ///
+    /// Re-extracts fresh metadata for each episode and downloads subtitles
+    /// using the structured pipeline. Returns the count of episodes that
+    /// had subtitles successfully recovered.
+    async fn retry_missing_subtitles(
+        &self,
+        missing_subs: &HashMap<String, PathBuf>,
+        infos: &[rdlp_core::InfoDict],
+        sub_langs: &[String],
+    ) -> usize {
+        let count = missing_subs.len();
+        info!("Retrying subtitle download for {count} episode(s) with missing subs");
+
+        let mut recovered = 0usize;
+        for (sanitized_title, video_path) in missing_subs {
+            // Find the matching InfoDict by sanitized title
+            let Some(ep_info) = infos
+                .iter()
+                .find(|i| self.sanitize_filename(&i.title) == *sanitized_title)
+            else {
+                warn!(
+                    title:% = sanitized_title;
+                    "Could not find episode metadata for subtitle retry"
+                );
+                continue;
+            };
+
+            // Re-extract fresh metadata to get fresh subtitle URLs
+            let fresh_info = match self.extract_lazy_formats(&ep_info.webpage_url).await {
+                Ok(mut resolved) => {
+                    // Preserve episode metadata from original stub
+                    resolved.id = ep_info.id.clone();
+                    resolved.title = ep_info.title.clone();
+                    resolved.playlist = ep_info.playlist.clone();
+                    resolved.playlist_title = ep_info.playlist_title.clone();
+                    resolved.playlist_index = ep_info.playlist_index;
+                    resolved.playlist_count = ep_info.playlist_count;
+                    resolved
+                }
+                Err(e) => {
+                    warn!(
+                        title:? = ep_info.title;
+                        "Failed to re-extract for subtitle retry: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            // Resolve per-episode subtitle URLs from language names
+            let episode_subs = self.resolve_subtitles_for_episode(&fresh_info, sub_langs);
+
+            let downloaded_subs = match self
+                .download_subtitles(&fresh_info, video_path, &episode_subs)
+                .await
+            {
+                Ok(subs) => subs,
+                Err(e) => {
+                    warn!(
+                        title:? = ep_info.title;
+                        "Subtitle retry download failed: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            if !downloaded_subs.is_empty() {
+                info!(
+                    title:? = ep_info.title,
+                    count = downloaded_subs.len();
+                    "Subtitle retry succeeded"
+                );
+                recovered += 1;
+            } else {
+                warn!(
+                    title:? = ep_info.title;
+                    "Subtitle retry: no subtitles downloaded"
+                );
+            }
+        }
+
+        recovered
+    }
+
+    /// Log per-episode missing subtitle details.
+    ///
+    /// Uses `sanitize_filename` to match infos against `missing_subs` keys.
+    fn log_missing_subs(
+        &self,
+        missing_subs: &HashMap<String, PathBuf>,
+        infos: &[rdlp_core::InfoDict],
+        total: usize,
+    ) {
+        for info in infos {
+            let sanitized = self.sanitize_filename(&info.title);
+            if missing_subs.contains_key(&sanitized) {
+                let pos = info.playlist_index.unwrap_or(0);
+                warn!("  [{pos}/{total}] {}: no subtitle files found", info.title);
+            }
+        }
     }
 
     /// Download from pre-extracted InfoDict (internal helper)

--- a/crates/rdlp-cli/src/orchestrator/playlist.rs
+++ b/crates/rdlp-cli/src/orchestrator/playlist.rs
@@ -252,6 +252,7 @@ impl Orchestrator {
                 &playlist_title,
                 selected_audio.clone(),
                 selected_sub_langs.clone(),
+                self.config.strict_subs,
             ));
             state.save(&state_path).await;
         }
@@ -648,6 +649,7 @@ impl Orchestrator {
                 &playlist_title,
                 selected_audio.clone(),
                 selected_sub_langs.clone(),
+                self.config.strict_subs,
             );
             state.failed_episodes = failed_eps;
             SessionState::Playlist(state).save(&state_path).await;
@@ -747,13 +749,14 @@ impl Orchestrator {
                         // Check if file has reasonable size (> 1MB to avoid empty/corrupted files)
                         if let Ok(metadata) = file_path.metadata() {
                             if metadata.len() > 1_000_000 {
-                                // If subtitles were selected, verify subtitle
-                                // files exist. Pattern: {stem}.{lang}.{ext}
-                                if !subtitle_langs.is_empty() {
+                                // If subtitles were selected AND strict mode is
+                                // enabled, verify subtitle files exist alongside
+                                // the video. In lenient mode (default), missing
+                                // subs don't invalidate a completed video.
+                                if self.config.strict_subs && !subtitle_langs.is_empty() {
                                     let stem = &sanitized_title;
                                     let dir = file_path.parent().unwrap_or(playlist_dir);
                                     let any_sub_exists = subtitle_langs.iter().any(|lang| {
-                                        // Check common extensions (vtt, srt, ass)
                                         ["vtt", "srt", "ass"].iter().any(|ext| {
                                             dir.join(format!("{stem}.{lang}.{ext}")).exists()
                                         })
@@ -761,7 +764,7 @@ impl Orchestrator {
                                     if !any_sub_exists {
                                         debug!(
                                             file:% = filename;
-                                            "Skipping: missing subtitle file"
+                                            "Skipping: missing subtitle file (strict mode)"
                                         );
                                         found_partial = true;
                                         continue;
@@ -1010,14 +1013,21 @@ impl Orchestrator {
             .await?;
 
         if !subtitle_langs.is_empty() && downloaded_subs.is_empty() {
-            return Err(OrchestratorError::DownloadFailed(
-                rdlp_core::RdlpError::Extraction(format!(
-                    "Subtitle download failed for '{}': \
-                     expected [{}] but none downloaded",
-                    final_info.title,
-                    subtitle_langs.join(", ")
-                )),
-            ));
+            if self.config.strict_subs {
+                return Err(OrchestratorError::DownloadFailed(
+                    rdlp_core::RdlpError::Extraction(format!(
+                        "Strict subtitle mode: no subtitles downloaded for '{}' \
+                         (expected [{}])",
+                        final_info.title,
+                        subtitle_langs.join(", ")
+                    )),
+                ));
+            }
+            warn!(
+                title:? = final_info.title,
+                expected:% = subtitle_langs.join(", ");
+                "Subtitles unavailable for this episode, continuing without"
+            );
         }
 
         // Run post-processing if configured (or automatic for HLS)

--- a/crates/rdlp-cli/src/orchestrator/session_state.rs
+++ b/crates/rdlp-cli/src/orchestrator/session_state.rs
@@ -61,6 +61,9 @@ pub(crate) struct PlaylistState {
     pub selected_audio: Option<String>,
     /// Selected subtitle language codes (empty if none)
     pub selected_sub_langs: Vec<String>,
+    /// Whether strict subtitle mode was active
+    #[serde(default)]
+    pub strict_subs: bool,
     /// Episodes that failed in the previous run (empty if none)
     #[serde(default)]
     pub failed_episodes: Vec<FailedEpisode>,
@@ -109,6 +112,7 @@ impl PlaylistState {
         playlist_title: impl Into<String>,
         selected_audio: Option<String>,
         selected_sub_langs: Vec<String>,
+        strict_subs: bool,
     ) -> Self {
         let now = Utc::now();
         Self {
@@ -117,6 +121,7 @@ impl PlaylistState {
             playlist_title: playlist_title.into(),
             selected_audio,
             selected_sub_langs,
+            strict_subs,
             failed_episodes: Vec::new(),
             created_at: now,
             updated_at: now,
@@ -307,6 +312,7 @@ mod tests {
             "Season 1",
             Some("SUB".to_string()),
             vec!["en".to_string()],
+            false,
         ));
 
         state.save(&path).await;

--- a/crates/rdlp-cli/src/orchestrator/subtitle.rs
+++ b/crates/rdlp-cli/src/orchestrator/subtitle.rs
@@ -135,9 +135,14 @@ pub(super) fn preselect_indices(items: &[SubtitleMenuItem], config_langs: &[Stri
             if want_all {
                 true
             } else {
-                config_langs
-                    .iter()
-                    .any(|l| l.eq_ignore_ascii_case(&item.lang))
+                config_langs.iter().any(|l| {
+                    item.lang.eq_ignore_ascii_case(l)
+                        || (l.len() <= 3
+                            && item
+                                .lang
+                                .to_ascii_lowercase()
+                                .starts_with(&l.to_ascii_lowercase()))
+                })
             }
         })
         .collect()
@@ -262,7 +267,23 @@ impl Orchestrator {
             info.subtitles.as_ref()
         };
 
-        let entries = source?.get(lang)?;
+        let map = source?;
+
+        // Try exact key first, then fuzzy (ISO prefix) match on keys.
+        // 9anime uses labels ("English") as keys while --sub-langs uses
+        // codes ("en"), so we need prefix matching.
+        let entries = map.get(lang).or_else(|| {
+            map.iter()
+                .find(|(key, _)| {
+                    key.eq_ignore_ascii_case(lang)
+                        || (lang.len() <= 3
+                            && key
+                                .to_ascii_lowercase()
+                                .starts_with(&lang.to_ascii_lowercase()))
+                })
+                .map(|(_, v)| v)
+        })?;
+
         if entries.is_empty() {
             return None;
         }
@@ -370,6 +391,12 @@ impl Orchestrator {
         for (lang, sub) in selected {
             let sub_filename = format!("{stem}.{lang}.{}", sub.ext);
             let sub_path = parent.join(&sub_filename);
+
+            if sub_path.exists() {
+                debug!(path:? = sub_path.display(); "Subtitle already exists, skipping");
+                downloaded.push((lang.clone(), sub_path));
+                continue;
+            }
 
             info!("Downloading subtitle: lang={lang}, url={}", sub.url);
 
@@ -483,6 +510,12 @@ impl Orchestrator {
         for track in &outcome.selected {
             let sub_filename = format!("{stem}.{}.{}", track.language, track.ext);
             let sub_path = parent.join(&sub_filename);
+
+            if sub_path.exists() {
+                debug!(path:? = sub_path.display(); "Subtitle already exists, skipping");
+                downloaded.push((track.language.clone(), sub_path));
+                continue;
+            }
 
             info!(
                 lang:% = track.language,

--- a/crates/rdlp-cli/src/orchestrator/subtitle.rs
+++ b/crates/rdlp-cli/src/orchestrator/subtitle.rs
@@ -11,7 +11,6 @@
 use super::{Orchestrator, Result};
 use log::{debug, info, warn};
 use rdlp_core::InfoDict;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// A single item in the interactive subtitle selection menu.
@@ -336,62 +335,14 @@ impl Orchestrator {
                 .await;
         }
 
-        // Config-based path: check flags and select based on config
+        // Config-based path: delegate to the structured pipeline
         if !self.config.write_subtitles && !self.config.embed_subtitles {
             return Ok(Vec::new());
         }
 
-        let subtitles = info.subtitles.as_ref();
-        let auto_captions = info.automatic_captions.as_ref();
-
-        if subtitles.is_none_or(|s| s.is_empty()) && auto_captions.is_none_or(|a| a.is_empty()) {
-            debug!("No subtitles available");
-            return Ok(Vec::new());
-        }
-
-        let empty = HashMap::new();
-        let subs = subtitles.unwrap_or(&empty);
-        let auto = auto_captions.unwrap_or(&empty);
-
-        // Select which subtitles to download based on config
-        let selected = select_subtitles_for_download(
-            subs,
-            auto,
-            &self.config.subtitle_langs,
-            self.config.subtitle_format,
-            self.config.write_auto_subtitles,
-        );
-
-        if selected.is_empty() {
-            debug!("No matching subtitles for requested languages");
-            return Ok(Vec::new());
-        }
-
-        let stem = output_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("video");
-        let parent = output_path.parent().unwrap_or(Path::new("."));
-
-        let mut downloaded = Vec::new();
-
-        for (lang, url, ext) in &selected {
-            let sub_filename = format!("{stem}.{lang}.{ext}");
-            let sub_path = parent.join(&sub_filename);
-
-            info!("Downloading subtitle: lang={lang}, url={url}");
-
-            match self.download_subtitle_file(url, &sub_path).await {
-                Ok(()) => {
-                    info!("Subtitle downloaded: {}", sub_path.display());
-                    downloaded.push((lang.clone(), sub_path));
-                }
-                Err(e) => {
-                    warn!("Failed to download subtitle for {lang}: {e}");
-                }
-            }
-        }
-
+        let (downloaded, _warnings) = self
+            .download_subtitles_with_pipeline(info, output_path)
+            .await?;
         Ok(downloaded)
     }
 
@@ -475,6 +426,88 @@ impl Orchestrator {
         Ok(Some(paths))
     }
 
+    /// Download subtitles using the structured pipeline with status reporting.
+    ///
+    /// Normalizes InfoDict subtitles into [`SubtitleResult`], optionally
+    /// validates URLs, applies policy (language filtering, strict mode),
+    /// and downloads. Returns downloaded paths and any warnings.
+    pub(super) async fn download_subtitles_with_pipeline(
+        &self,
+        info: &InfoDict,
+        output_path: &Path,
+    ) -> Result<(Vec<(String, PathBuf)>, Vec<String>)> {
+        use super::subtitle_pipeline::{
+            apply_subtitle_policy, normalize_subtitles, validate_subtitle_urls,
+        };
+
+        // Stage 3: Normalize
+        let mut result = normalize_subtitles(info);
+
+        // Stage 2: Validate (optional, only if verify_sub_urls is true)
+        if self.config.verify_sub_urls && result.has_tracks() {
+            result = validate_subtitle_urls(result, &self.extraction_context.http_client).await;
+        }
+
+        // Stage 4: Policy
+        let outcome = apply_subtitle_policy(
+            &result,
+            &self.config.subtitle_langs,
+            self.config.subtitle_format,
+            self.config.write_auto_subtitles,
+            self.config.strict_subs,
+        );
+
+        // Log warnings
+        for warning in &outcome.warnings {
+            warn!("{warning}");
+        }
+
+        // Hard error in strict mode
+        if outcome.should_fail {
+            let msg = outcome
+                .error_message
+                .unwrap_or_else(|| "Subtitle policy check failed".to_string());
+            return Err(super::OrchestratorError::DownloadFailed(
+                rdlp_core::RdlpError::Extraction(msg),
+            ));
+        }
+
+        // Download selected tracks
+        let stem = output_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("video");
+        let parent = output_path.parent().unwrap_or(Path::new("."));
+        let mut downloaded = Vec::new();
+
+        for track in &outcome.selected {
+            let sub_filename = format!("{stem}.{}.{}", track.language, track.ext);
+            let sub_path = parent.join(&sub_filename);
+
+            info!(
+                lang:% = track.language,
+                ext:% = track.ext;
+                "Downloading subtitle"
+            );
+
+            match self.download_subtitle_file(&track.url, &sub_path).await {
+                Ok(()) => {
+                    info!("Subtitle downloaded: {}", sub_path.display());
+                    downloaded.push((track.language.clone(), sub_path));
+                }
+                Err(e) => {
+                    warn!(
+                        lang:% = track.language;
+                        "Failed to download subtitle: {e}"
+                    );
+                }
+            }
+        }
+
+        let warnings = outcome.warnings;
+        Ok((downloaded, warnings))
+    }
+
     /// Download a single subtitle file via HTTP.
     async fn download_subtitle_file(
         &self,
@@ -504,9 +537,10 @@ impl Orchestrator {
 /// * `requested_langs` - Languages to download (empty = all)
 /// * `preferred_format` - Preferred subtitle format (None = any)
 /// * `include_auto` - Whether to include auto-generated captions
+#[cfg(test)]
 fn select_subtitles_for_download(
-    subtitles: &HashMap<String, Vec<rdlp_core::Subtitle>>,
-    auto_captions: &HashMap<String, Vec<rdlp_core::Subtitle>>,
+    subtitles: &std::collections::HashMap<String, Vec<rdlp_core::Subtitle>>,
+    auto_captions: &std::collections::HashMap<String, Vec<rdlp_core::Subtitle>>,
     requested_langs: &[String],
     preferred_format: Option<rdlp_core::SubtitleFormat>,
     include_auto: bool,

--- a/crates/rdlp-cli/src/orchestrator/subtitle_pipeline.rs
+++ b/crates/rdlp-cli/src/orchestrator/subtitle_pipeline.rs
@@ -182,7 +182,7 @@ pub(super) fn apply_subtitle_policy(
             let manual: Vec<&SubtitleTrack> = result
                 .tracks
                 .iter()
-                .filter(|t| !t.is_auto && t.language.eq_ignore_ascii_case(lang))
+                .filter(|t| !t.is_auto && track_matches_lang(t, lang))
                 .collect();
 
             if let Some(track) = pick_best_track(&manual, preferred_format) {
@@ -195,7 +195,7 @@ pub(super) fn apply_subtitle_policy(
                 let auto: Vec<&SubtitleTrack> = result
                     .tracks
                     .iter()
-                    .filter(|t| t.is_auto && t.language.eq_ignore_ascii_case(lang))
+                    .filter(|t| t.is_auto && track_matches_lang(t, lang))
                     .collect();
 
                 if let Some(track) = pick_best_track(&auto, preferred_format) {
@@ -226,6 +226,40 @@ pub(super) fn apply_subtitle_policy(
         should_fail,
         error_message,
     }
+}
+
+/// Check whether a subtitle track matches a requested language.
+///
+/// Supports exact match (`"English"` == `"English"`), ISO code prefix
+/// (`"en"` matches `"English"`), and name field fallback.
+fn track_matches_lang(track: &SubtitleTrack, lang: &str) -> bool {
+    // Exact case-insensitive match on the language key
+    if track.language.eq_ignore_ascii_case(lang) {
+        return true;
+    }
+    // ISO code prefix: "en" starts "English", "ja" starts "Japanese"
+    if lang.len() <= 3
+        && track
+            .language
+            .to_ascii_lowercase()
+            .starts_with(&lang.to_ascii_lowercase())
+    {
+        return true;
+    }
+    // Check the optional name field (e.g., name: Some("English"))
+    if let Some(ref name) = track.name {
+        if name.eq_ignore_ascii_case(lang) {
+            return true;
+        }
+        if lang.len() <= 3
+            && name
+                .to_ascii_lowercase()
+                .starts_with(&lang.to_ascii_lowercase())
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Pick the best track from candidates based on format preference.
@@ -401,5 +435,50 @@ mod tests {
         let outcome = apply_subtitle_policy(&result, &langs, None, false, false);
         assert_eq!(outcome.selected.len(), 1);
         assert_eq!(outcome.selected[0].ext, "srt");
+    }
+
+    // ── Language matching tests ─────────────────────────────
+
+    #[test]
+    fn test_track_matches_lang_exact() {
+        let t = track("en", "srt", false);
+        assert!(track_matches_lang(&t, "en"));
+        assert!(track_matches_lang(&t, "EN"));
+    }
+
+    #[test]
+    fn test_track_matches_lang_prefix() {
+        let t = track("English", "vtt", false);
+        assert!(track_matches_lang(&t, "en"));
+        assert!(track_matches_lang(&t, "En"));
+        assert!(!track_matches_lang(&t, "es"));
+    }
+
+    #[test]
+    fn test_track_matches_lang_name_field() {
+        let mut t = track("en", "srt", false);
+        t.name = Some("English".to_string());
+        assert!(track_matches_lang(&t, "English"));
+        assert!(track_matches_lang(&t, "en"));
+    }
+
+    #[test]
+    fn test_track_matches_lang_no_false_positive() {
+        let t = track("Japanese", "vtt", false);
+        assert!(!track_matches_lang(&t, "en"));
+        // "ja" should match "Japanese"
+        assert!(track_matches_lang(&t, "ja"));
+    }
+
+    #[test]
+    fn test_policy_iso_code_matches_label() {
+        // Simulates 9anime: tracks keyed by "English" label,
+        // user passes --sub-langs en
+        let result = result_with(vec![track("English", "vtt", false)]);
+        let langs = vec!["en".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, false);
+        assert_eq!(outcome.selected.len(), 1);
+        assert_eq!(outcome.selected[0].language, "English");
+        assert!(outcome.warnings.is_empty());
     }
 }

--- a/crates/rdlp-cli/src/orchestrator/subtitle_pipeline.rs
+++ b/crates/rdlp-cli/src/orchestrator/subtitle_pipeline.rs
@@ -481,4 +481,91 @@ mod tests {
         assert_eq!(outcome.selected[0].language, "English");
         assert!(outcome.warnings.is_empty());
     }
+
+    #[test]
+    fn test_strict_subs_error_message_content() {
+        let result = result_with(vec![track("ja", "srt", false)]);
+        let langs = vec!["en".to_string(), "de".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, true);
+        assert!(outcome.should_fail);
+        let msg = outcome.error_message.unwrap();
+        assert!(msg.contains("2 language(s) unavailable"));
+    }
+
+    #[test]
+    fn test_strict_subs_passes_when_all_found() {
+        let result = result_with(vec![track("en", "srt", false), track("ja", "vtt", false)]);
+        let langs = vec!["en".to_string(), "ja".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, true);
+        assert!(!outcome.should_fail);
+        assert_eq!(outcome.selected.len(), 2);
+        assert!(outcome.warnings.is_empty());
+    }
+
+    // ── URL validation tests ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_validate_urls_keeps_reachable() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("HEAD", "/en.vtt")
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let mut t = track("en", "vtt", false);
+        t.url = server.url() + "/en.vtt";
+        let result = result_with(vec![t]);
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let validated = validate_subtitle_urls(result, &client).await;
+
+        assert_eq!(validated.tracks.len(), 1);
+        assert_eq!(validated.status, SubtitleStatus::Available);
+    }
+
+    #[tokio::test]
+    async fn test_validate_urls_filters_unreachable() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("HEAD", "/en.vtt")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let mut t = track("en", "vtt", false);
+        t.url = server.url() + "/en.vtt";
+        let result = result_with(vec![t]);
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let validated = validate_subtitle_urls(result, &client).await;
+
+        assert!(validated.tracks.is_empty());
+        assert_eq!(validated.status, SubtitleStatus::ErrorSoft);
+        assert!(
+            validated
+                .reasons
+                .contains(&SubtitleReason::UrlNotReachable(404))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_urls_auth_reason_on_403() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("HEAD", "/en.vtt")
+            .with_status(403)
+            .create_async()
+            .await;
+
+        let mut t = track("en", "vtt", false);
+        t.url = server.url() + "/en.vtt";
+        let result = result_with(vec![t]);
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let validated = validate_subtitle_urls(result, &client).await;
+
+        assert!(validated.tracks.is_empty());
+        assert!(validated.reasons.contains(&SubtitleReason::RequiresAuth));
+    }
 }

--- a/crates/rdlp-cli/src/orchestrator/subtitle_pipeline.rs
+++ b/crates/rdlp-cli/src/orchestrator/subtitle_pipeline.rs
@@ -1,0 +1,405 @@
+//! Subtitle pipeline: validation, normalization, and policy application
+//!
+//! Implements stages 2–4 of the subtitle pipeline:
+//! 1. **Extractor** — site-specific, handled by extractors (not this module)
+//! 2. **Validator** — HEAD/GET URL pre-checks ([`validate_subtitle_urls`])
+//! 3. **Normalizer** — InfoDict → SubtitleResult ([`normalize_subtitles`])
+//! 4. **Policy** — apply user flags, decide warn vs error ([`apply_subtitle_policy`])
+
+use log::{debug, warn};
+use rdlp_core::{
+    InfoDict, SubtitleDiagnostic, SubtitleFormat, SubtitleReason, SubtitleResult, SubtitleStatus,
+    SubtitleTrack, normalize_from_info_dict,
+};
+use std::time::Duration;
+
+// ─── Stage 2: Validator ─────────────────────────────────────
+
+const VALIDATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Validate subtitle URLs via HEAD requests.
+///
+/// Only called when `config.verify_sub_urls` is true. Filters out
+/// tracks with unreachable URLs and records reasons/diagnostics.
+pub(super) async fn validate_subtitle_urls(
+    result: SubtitleResult,
+    client: &reqwest::Client,
+) -> SubtitleResult {
+    let mut valid_tracks = Vec::new();
+    let mut reasons = result.reasons;
+    let mut diagnostics = result.diagnostics;
+
+    for track in result.tracks {
+        match validate_single_url(&track.url, client).await {
+            UrlValidation::Reachable => {
+                valid_tracks.push(track);
+            }
+            UrlValidation::Unreachable(status) => {
+                warn!(
+                    lang:% = track.language,
+                    status;
+                    "Subtitle URL unreachable"
+                );
+                if status == 401 || status == 403 {
+                    reasons.push(SubtitleReason::RequiresAuth);
+                } else {
+                    reasons.push(SubtitleReason::UrlNotReachable(status));
+                }
+                diagnostics.push(SubtitleDiagnostic {
+                    key: format!("unreachable_{}", track.language),
+                    value: format!("HTTP {status}: {}", track.url),
+                });
+            }
+            UrlValidation::NetworkError(e) => {
+                warn!(
+                    lang:% = track.language;
+                    "Subtitle URL validation error: {e}"
+                );
+                diagnostics.push(SubtitleDiagnostic {
+                    key: format!("validation_error_{}", track.language),
+                    value: e,
+                });
+            }
+        }
+    }
+
+    let status = if valid_tracks.is_empty() && !reasons.is_empty() {
+        SubtitleStatus::ErrorSoft
+    } else if valid_tracks.is_empty() {
+        SubtitleStatus::NotAvailable
+    } else {
+        SubtitleStatus::Available
+    };
+
+    SubtitleResult {
+        tracks: valid_tracks,
+        status,
+        reasons,
+        diagnostics,
+    }
+}
+
+enum UrlValidation {
+    Reachable,
+    Unreachable(u16),
+    NetworkError(String),
+}
+
+async fn validate_single_url(url: &str, client: &reqwest::Client) -> UrlValidation {
+    // Try HEAD first
+    match client.head(url).timeout(VALIDATION_TIMEOUT).send().await {
+        Ok(resp) if resp.status().is_success() => return UrlValidation::Reachable,
+        Ok(resp) if resp.status().as_u16() == 405 => {
+            // HEAD not allowed — fallback to GET with range
+            debug!("HEAD 405 for subtitle URL, falling back to ranged GET");
+        }
+        Ok(resp) => return UrlValidation::Unreachable(resp.status().as_u16()),
+        Err(e) => return UrlValidation::NetworkError(e.to_string()),
+    }
+
+    // Fallback: GET with range header (0-1KB)
+    match client
+        .get(url)
+        .header("Range", "bytes=0-1023")
+        .timeout(VALIDATION_TIMEOUT)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 206 => {
+            UrlValidation::Reachable
+        }
+        Ok(resp) => UrlValidation::Unreachable(resp.status().as_u16()),
+        Err(e) => UrlValidation::NetworkError(e.to_string()),
+    }
+}
+
+// ─── Stage 3: Normalizer ────────────────────────────────────
+
+/// Normalize InfoDict subtitle maps into a [`SubtitleResult`].
+///
+/// Converts the legacy `HashMap<String, Vec<Subtitle>>` fields into
+/// [`SubtitleTrack`] entries with proper status and reason inference.
+pub(super) fn normalize_subtitles(info: &InfoDict) -> SubtitleResult {
+    normalize_from_info_dict(info.subtitles.as_ref(), info.automatic_captions.as_ref())
+}
+
+// ─── Stage 4: Policy ────────────────────────────────────────
+
+/// Outcome of subtitle policy evaluation.
+#[derive(Debug)]
+pub(super) struct SubtitlePolicyOutcome {
+    /// Tracks selected for download
+    pub selected: Vec<SubtitleTrack>,
+    /// Warning messages to display (non-fatal)
+    pub warnings: Vec<String>,
+    /// Whether the download should be aborted
+    pub should_fail: bool,
+    /// Error message if should_fail is true
+    pub error_message: Option<String>,
+}
+
+/// Apply subtitle policy based on user config.
+///
+/// Filters tracks by requested languages, format preference,
+/// and auto-caption inclusion. Decides whether missing subtitles
+/// should warn or error based on `strict_subs`.
+pub(super) fn apply_subtitle_policy(
+    result: &SubtitleResult,
+    requested_langs: &[String],
+    preferred_format: Option<SubtitleFormat>,
+    include_auto: bool,
+    strict_subs: bool,
+) -> SubtitlePolicyOutcome {
+    let mut selected = Vec::new();
+    let mut warnings = Vec::new();
+
+    // No languages requested → noop
+    if requested_langs.is_empty() {
+        return SubtitlePolicyOutcome {
+            selected,
+            warnings,
+            should_fail: false,
+            error_message: None,
+        };
+    }
+
+    let want_all = requested_langs
+        .iter()
+        .any(|l| l.eq_ignore_ascii_case("all"));
+
+    if want_all {
+        for track in &result.tracks {
+            if !include_auto && track.is_auto {
+                continue;
+            }
+            selected.push(track.clone());
+        }
+        // Deduplicate: keep best format per language
+        selected = deduplicate_by_language(selected, preferred_format);
+    } else {
+        for lang in requested_langs {
+            // Try manual first
+            let manual: Vec<&SubtitleTrack> = result
+                .tracks
+                .iter()
+                .filter(|t| !t.is_auto && t.language.eq_ignore_ascii_case(lang))
+                .collect();
+
+            if let Some(track) = pick_best_track(&manual, preferred_format) {
+                selected.push(track);
+                continue;
+            }
+
+            // Fallback to auto if included
+            if include_auto {
+                let auto: Vec<&SubtitleTrack> = result
+                    .tracks
+                    .iter()
+                    .filter(|t| t.is_auto && t.language.eq_ignore_ascii_case(lang))
+                    .collect();
+
+                if let Some(track) = pick_best_track(&auto, preferred_format) {
+                    selected.push(track);
+                    continue;
+                }
+            }
+
+            warnings.push(format!(
+                "Requested subtitle language '{lang}' not available"
+            ));
+        }
+    }
+
+    let should_fail = strict_subs && !warnings.is_empty();
+    let error_message = if should_fail {
+        Some(format!(
+            "Strict subtitle mode: {} language(s) unavailable",
+            warnings.len()
+        ))
+    } else {
+        None
+    };
+
+    SubtitlePolicyOutcome {
+        selected,
+        warnings,
+        should_fail,
+        error_message,
+    }
+}
+
+/// Pick the best track from candidates based on format preference.
+fn pick_best_track(
+    candidates: &[&SubtitleTrack],
+    preferred_format: Option<SubtitleFormat>,
+) -> Option<SubtitleTrack> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // Prefer user-requested format
+    if let Some(pref) = preferred_format {
+        let ext = pref.as_ext();
+        if let Some(track) = candidates.iter().find(|t| t.ext.eq_ignore_ascii_case(ext)) {
+            return Some((*track).clone());
+        }
+    }
+
+    // Fallback order: srt > vtt > ass > ssa > lrc > first
+    const FALLBACK_ORDER: &[&str] = &["srt", "vtt", "ass", "ssa", "lrc"];
+    for pref in FALLBACK_ORDER {
+        if let Some(track) = candidates.iter().find(|t| t.ext.eq_ignore_ascii_case(pref)) {
+            return Some((*track).clone());
+        }
+    }
+
+    Some(candidates[0].clone())
+}
+
+/// Keep only one track per language (best format wins).
+fn deduplicate_by_language(
+    tracks: Vec<SubtitleTrack>,
+    preferred_format: Option<SubtitleFormat>,
+) -> Vec<SubtitleTrack> {
+    use std::collections::HashMap;
+    let mut best: HashMap<String, SubtitleTrack> = HashMap::new();
+    let pref_ext = preferred_format.map(|f| f.as_ext().to_string());
+
+    for track in tracks {
+        let key = track.language.to_ascii_lowercase();
+        let entry = best.entry(key);
+        match entry {
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(track);
+            }
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                let existing = e.get();
+                let new_is_better = if let Some(ref pref) = pref_ext {
+                    track.ext.eq_ignore_ascii_case(pref) && !existing.ext.eq_ignore_ascii_case(pref)
+                } else {
+                    // Prefer manual over auto
+                    !track.is_auto && existing.is_auto
+                };
+                if new_is_better {
+                    e.insert(track);
+                }
+            }
+        }
+    }
+
+    best.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rdlp_core::SubtitleKind;
+
+    fn track(lang: &str, ext: &str, is_auto: bool) -> SubtitleTrack {
+        SubtitleTrack {
+            language: lang.to_string(),
+            url: format!("https://example.com/{lang}.{ext}"),
+            ext: ext.to_string(),
+            is_auto,
+            kind: SubtitleKind::Normal,
+            name: None,
+        }
+    }
+
+    fn result_with(tracks: Vec<SubtitleTrack>) -> SubtitleResult {
+        SubtitleResult::available(tracks)
+    }
+
+    // ── Policy tests ────────────────────────────────────────
+
+    #[test]
+    fn test_no_requested_langs() {
+        let result = result_with(vec![track("en", "srt", false)]);
+        let outcome = apply_subtitle_policy(&result, &[], None, false, false);
+        assert!(outcome.selected.is_empty());
+        assert!(outcome.warnings.is_empty());
+        assert!(!outcome.should_fail);
+    }
+
+    #[test]
+    fn test_requested_lang_found_manual() {
+        let result = result_with(vec![track("en", "srt", false)]);
+        let langs = vec!["en".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, false);
+        assert_eq!(outcome.selected.len(), 1);
+        assert_eq!(outcome.selected[0].language, "en");
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_requested_lang_auto_only_include_auto() {
+        let result = result_with(vec![track("en", "vtt", true)]);
+        let langs = vec!["en".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, true, false);
+        assert_eq!(outcome.selected.len(), 1);
+        assert!(outcome.selected[0].is_auto);
+    }
+
+    #[test]
+    fn test_requested_lang_auto_only_exclude_auto() {
+        let result = result_with(vec![track("en", "vtt", true)]);
+        let langs = vec!["en".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, false);
+        assert!(outcome.selected.is_empty());
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(!outcome.should_fail);
+    }
+
+    #[test]
+    fn test_requested_lang_missing_lenient() {
+        let result = result_with(vec![track("ja", "srt", false)]);
+        let langs = vec!["en".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, false);
+        assert!(outcome.selected.is_empty());
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(!outcome.should_fail);
+    }
+
+    #[test]
+    fn test_requested_lang_missing_strict() {
+        let result = result_with(vec![track("ja", "srt", false)]);
+        let langs = vec!["en".to_string()];
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, true);
+        assert!(outcome.selected.is_empty());
+        assert!(outcome.should_fail);
+        assert!(outcome.error_message.is_some());
+    }
+
+    #[test]
+    fn test_all_keyword() {
+        let result = result_with(vec![
+            track("en", "srt", false),
+            track("ja", "vtt", false),
+            track("es", "srt", true),
+        ]);
+        let langs = vec!["all".to_string()];
+        // include_auto = true → all 3 tracks
+        let outcome = apply_subtitle_policy(&result, &langs, None, true, false);
+        assert_eq!(outcome.selected.len(), 3);
+    }
+
+    #[test]
+    fn test_preferred_format_respected() {
+        let result = result_with(vec![track("en", "vtt", false), track("en", "srt", false)]);
+        let langs = vec!["en".to_string()];
+        let outcome =
+            apply_subtitle_policy(&result, &langs, Some(SubtitleFormat::Srt), false, false);
+        assert_eq!(outcome.selected.len(), 1);
+        assert_eq!(outcome.selected[0].ext, "srt");
+    }
+
+    #[test]
+    fn test_format_fallback_srt_over_vtt() {
+        let result = result_with(vec![track("en", "vtt", false), track("en", "srt", false)]);
+        let langs = vec!["en".to_string()];
+        // No preferred format → fallback order prefers srt
+        let outcome = apply_subtitle_policy(&result, &langs, None, false, false);
+        assert_eq!(outcome.selected.len(), 1);
+        assert_eq!(outcome.selected[0].ext, "srt");
+    }
+}

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -40,7 +40,9 @@ pub mod traits;
 // Re-export types from rdlp-types for convenience
 pub use rdlp_types::{
     AudioFormat, BrowserType, Chapter, Config, ContainerFormat, DownloadProtocol, Format,
-    FormatSelector, Fragment, InfoDict, Subtitle, SubtitleFormat, Thumbnail,
+    FormatSelector, Fragment, InfoDict, Subtitle, SubtitleDiagnostic, SubtitleFormat, SubtitleKind,
+    SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack, Thumbnail,
+    normalize_from_info_dict,
 };
 
 // Re-export codec utilities

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -207,6 +207,12 @@ pub struct Config {
     /// Show interactive subtitle selection (--list-subs)
     pub list_subs: bool,
 
+    /// Strict subtitle mode: fail download if requested subs are missing
+    pub strict_subs: bool,
+
+    /// Verify subtitle URLs via HEAD request before download
+    pub verify_sub_urls: bool,
+
     // === Thumbnail ===
     /// Write thumbnail image to disk
     pub write_thumbnail: bool,
@@ -340,6 +346,8 @@ impl Default for Config {
             subtitle_langs: Vec::new(),
             subtitle_format: None,
             list_subs: false,
+            strict_subs: false,
+            verify_sub_urls: false,
 
             // Thumbnail
             write_thumbnail: false,

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -213,6 +213,9 @@ pub struct Config {
     /// Verify subtitle URLs via HEAD request before download
     pub verify_sub_urls: bool,
 
+    /// Re-attempt subtitle downloads for completed videos missing subtitle files
+    pub retry_subs: bool,
+
     // === Thumbnail ===
     /// Write thumbnail image to disk
     pub write_thumbnail: bool,
@@ -348,6 +351,7 @@ impl Default for Config {
             list_subs: false,
             strict_subs: false,
             verify_sub_urls: false,
+            retry_subs: false,
 
             // Thumbnail
             write_thumbnail: false,

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -31,7 +31,9 @@ pub mod format;
 pub mod info_dict;
 pub mod protocol;
 pub mod subtitle_format;
+pub mod subtitle_kind;
 pub mod subtitle_selection;
+pub mod subtitle_track;
 
 // Re-export main types
 pub use audio_format::AudioFormat;
@@ -42,4 +44,9 @@ pub use format::{Format, FormatSelector, Fragment};
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use protocol::DownloadProtocol;
 pub use subtitle_format::SubtitleFormat;
+pub use subtitle_kind::SubtitleKind;
 pub use subtitle_selection::{select_subtitles, subtitle_filename};
+pub use subtitle_track::{
+    SubtitleDiagnostic, SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack,
+    normalize_from_info_dict,
+};

--- a/crates/rdlp-types/src/subtitle_kind.rs
+++ b/crates/rdlp-types/src/subtitle_kind.rs
@@ -25,6 +25,17 @@ pub enum SubtitleKind {
 
 impl SubtitleKind {
     /// String identifier for this kind.
+    ///
+    /// # Returns
+    ///
+    /// A static string slice matching the serde `snake_case` representation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rdlp_types::SubtitleKind;
+    /// assert_eq!(SubtitleKind::HearingImpaired.as_str(), "hearing_impaired");
+    /// ```
     #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/crates/rdlp-types/src/subtitle_kind.rs
+++ b/crates/rdlp-types/src/subtitle_kind.rs
@@ -1,0 +1,108 @@
+//! Subtitle track kind classification
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Classification of subtitle track purpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SubtitleKind {
+    /// Standard dialogue subtitles
+    #[default]
+    Normal,
+    /// Forced/burn-in subtitles (foreign language parts only)
+    Forced,
+    /// Subtitles for deaf/hard-of-hearing (includes sound effects)
+    HearingImpaired,
+    /// Director/cast commentary track
+    Commentary,
+    /// Lyrics (music content)
+    Lyrics,
+    /// Karaoke-style timed lyrics
+    Karaoke,
+}
+
+impl SubtitleKind {
+    /// String identifier for this kind.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Forced => "forced",
+            Self::HearingImpaired => "hearing_impaired",
+            Self::Commentary => "commentary",
+            Self::Lyrics => "lyrics",
+            Self::Karaoke => "karaoke",
+        }
+    }
+}
+
+impl fmt::Display for SubtitleKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SubtitleKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "normal" => Ok(Self::Normal),
+            "forced" => Ok(Self::Forced),
+            "hearing_impaired" | "hearingimpaired" | "hi" | "sdh" => Ok(Self::HearingImpaired),
+            "commentary" => Ok(Self::Commentary),
+            "lyrics" => Ok(Self::Lyrics),
+            "karaoke" => Ok(Self::Karaoke),
+            _ => Err(format!("unsupported subtitle kind: {s}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_is_normal() {
+        assert_eq!(SubtitleKind::default(), SubtitleKind::Normal);
+    }
+
+    #[test]
+    fn test_display_from_str_roundtrip() {
+        for kind in [
+            SubtitleKind::Normal,
+            SubtitleKind::Forced,
+            SubtitleKind::HearingImpaired,
+            SubtitleKind::Commentary,
+            SubtitleKind::Lyrics,
+            SubtitleKind::Karaoke,
+        ] {
+            let s = kind.to_string();
+            let parsed: SubtitleKind = s.parse().unwrap();
+            assert_eq!(kind, parsed);
+        }
+    }
+
+    #[test]
+    fn test_from_str_aliases() {
+        assert_eq!(
+            "hi".parse::<SubtitleKind>().unwrap(),
+            SubtitleKind::HearingImpaired
+        );
+        assert_eq!(
+            "sdh".parse::<SubtitleKind>().unwrap(),
+            SubtitleKind::HearingImpaired
+        );
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let kind = SubtitleKind::HearingImpaired;
+        let json = serde_json::to_string(&kind).unwrap();
+        assert_eq!(json, "\"hearing_impaired\"");
+        let parsed: SubtitleKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(kind, parsed);
+    }
+}

--- a/crates/rdlp-types/src/subtitle_track.rs
+++ b/crates/rdlp-types/src/subtitle_track.rs
@@ -96,6 +96,22 @@ pub struct SubtitleResult {
 
 impl SubtitleResult {
     /// Create a result indicating subtitles are available.
+    ///
+    /// # Arguments
+    ///
+    /// * `tracks` - Extracted subtitle tracks to include in the result
+    ///
+    /// # Returns
+    ///
+    /// A `SubtitleResult` with status [`SubtitleStatus::Available`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rdlp_types::SubtitleResult;
+    /// let result = SubtitleResult::available(vec![]);
+    /// assert_eq!(result.status, rdlp_types::SubtitleStatus::Available);
+    /// ```
     #[must_use]
     pub fn available(tracks: Vec<SubtitleTrack>) -> Self {
         Self {
@@ -107,6 +123,23 @@ impl SubtitleResult {
     }
 
     /// Create a result indicating no subtitles are available.
+    ///
+    /// # Arguments
+    ///
+    /// * `reasons` - Why subtitles are unavailable (e.g., field missing, empty)
+    ///
+    /// # Returns
+    ///
+    /// A `SubtitleResult` with status [`SubtitleStatus::NotAvailable`] and
+    /// no tracks.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rdlp_types::{SubtitleReason, SubtitleResult};
+    /// let result = SubtitleResult::not_available(vec![SubtitleReason::EmptyList]);
+    /// assert!(!result.has_tracks());
+    /// ```
     #[must_use]
     pub fn not_available(reasons: Vec<SubtitleReason>) -> Self {
         Self {
@@ -118,6 +151,27 @@ impl SubtitleResult {
     }
 
     /// Create a result indicating a soft error.
+    ///
+    /// # Arguments
+    ///
+    /// * `reasons` - Why the error occurred
+    /// * `diagnostics` - Key-value pairs for debugging
+    ///
+    /// # Returns
+    ///
+    /// A `SubtitleResult` with status [`SubtitleStatus::ErrorSoft`] and
+    /// no tracks.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rdlp_types::{SubtitleDiagnostic, SubtitleReason, SubtitleResult};
+    /// let result = SubtitleResult::error_soft(
+    ///     vec![SubtitleReason::RequiresAuth],
+    ///     vec![SubtitleDiagnostic { key: "status".into(), value: "401".into() }],
+    /// );
+    /// assert!(!result.has_tracks());
+    /// ```
     #[must_use]
     pub fn error_soft(reasons: Vec<SubtitleReason>, diagnostics: Vec<SubtitleDiagnostic>) -> Self {
         Self {
@@ -129,6 +183,17 @@ impl SubtitleResult {
     }
 
     /// Whether any downloadable tracks exist.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `tracks` is non-empty, `false` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rdlp_types::SubtitleResult;
+    /// assert!(!SubtitleResult::available(vec![]).has_tracks());
+    /// ```
     #[must_use]
     pub fn has_tracks(&self) -> bool {
         !self.tracks.is_empty()
@@ -139,6 +204,25 @@ impl SubtitleResult {
 ///
 /// Bridges the existing `Subtitle` wire format to the richer pipeline types.
 /// Manual subtitles get `is_auto = false`; automatic captions get `is_auto = true`.
+///
+/// # Arguments
+///
+/// * `subtitles` - Manual subtitle map from `InfoDict.subtitles`
+/// * `automatic_captions` - Auto-generated caption map from
+///   `InfoDict.automatic_captions`
+///
+/// # Returns
+///
+/// A [`SubtitleResult`] with status `Available` (when tracks exist) or
+/// `NotAvailable` (when both maps are `None` or empty).
+///
+/// # Example
+///
+/// ```
+/// use rdlp_types::subtitle_track::normalize_from_info_dict;
+/// let result = normalize_from_info_dict(None, None);
+/// assert!(!result.has_tracks());
+/// ```
 #[must_use]
 pub fn normalize_from_info_dict(
     subtitles: Option<&HashMap<String, Vec<Subtitle>>>,

--- a/crates/rdlp-types/src/subtitle_track.rs
+++ b/crates/rdlp-types/src/subtitle_track.rs
@@ -1,0 +1,305 @@
+//! Rich subtitle track metadata and extraction result types
+//!
+//! Provides [`SubtitleTrack`] (richer than the legacy [`Subtitle`](crate::info_dict::Subtitle)
+//! wire format), [`SubtitleResult`] for pipeline status reporting, and the
+//! [`normalize_from_info_dict`] bridge function.
+
+use crate::info_dict::Subtitle;
+use crate::subtitle_kind::SubtitleKind;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Rich subtitle track with full metadata.
+///
+/// Internal pipeline format — richer than [`Subtitle`] which remains the
+/// `InfoDict` serialization contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubtitleTrack {
+    /// Language code (e.g., "en", "ja") or human-readable label
+    pub language: String,
+    /// URL to the subtitle file
+    pub url: String,
+    /// File extension (e.g., "srt", "vtt")
+    pub ext: String,
+    /// Whether this is an auto-generated caption
+    pub is_auto: bool,
+    /// Track purpose classification
+    #[serde(default)]
+    pub kind: SubtitleKind,
+    /// Optional human-readable name (e.g., "English", "CC")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Status of subtitle availability for a video.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubtitleStatus {
+    /// Subtitles were found and are available
+    Available,
+    /// No subtitles exist for this content
+    NotAvailable,
+    /// Subtitles exist but are restricted (auth required, geo-blocked)
+    Restricted,
+    /// Could not determine subtitle availability
+    Unknown,
+    /// A non-fatal error occurred during extraction or validation
+    ErrorSoft,
+}
+
+/// Reason why subtitles are missing or restricted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubtitleReason {
+    /// The subtitle fields in InfoDict were None
+    FieldMissing,
+    /// The subtitle map was present but empty
+    EmptyList,
+    /// Subtitles exist but none matched requested languages
+    FilteredOutByLanguage,
+    /// Authentication required to access subtitles
+    RequiresAuth,
+    /// Subtitle URL contains an expired or signed token
+    UrlExpiredOrSigned,
+    /// Server-side selection required (cannot pre-fetch)
+    ServerSelectionRequired,
+    /// Subtitles embedded in HLS/DASH manifest (not standalone files)
+    ManifestEmbedded,
+    /// Subtitle URL returned a non-success HTTP status
+    UrlNotReachable(u16),
+}
+
+/// Diagnostic key-value pair for debugging subtitle issues.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubtitleDiagnostic {
+    /// Diagnostic key (e.g., "extractor", "field_checked")
+    pub key: String,
+    /// Diagnostic value
+    pub value: String,
+}
+
+/// Result of subtitle extraction and normalization.
+///
+/// Wraps extracted tracks with status information so the policy
+/// layer can decide whether to warn, skip, or fail.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubtitleResult {
+    /// Successfully extracted/normalized tracks
+    pub tracks: Vec<SubtitleTrack>,
+    /// Overall subtitle availability status
+    pub status: SubtitleStatus,
+    /// Reasons explaining the status (may be multiple)
+    pub reasons: Vec<SubtitleReason>,
+    /// Diagnostic metadata for debugging
+    pub diagnostics: Vec<SubtitleDiagnostic>,
+}
+
+impl SubtitleResult {
+    /// Create a result indicating subtitles are available.
+    #[must_use]
+    pub fn available(tracks: Vec<SubtitleTrack>) -> Self {
+        Self {
+            tracks,
+            status: SubtitleStatus::Available,
+            reasons: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// Create a result indicating no subtitles are available.
+    #[must_use]
+    pub fn not_available(reasons: Vec<SubtitleReason>) -> Self {
+        Self {
+            tracks: Vec::new(),
+            status: SubtitleStatus::NotAvailable,
+            reasons,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// Create a result indicating a soft error.
+    #[must_use]
+    pub fn error_soft(reasons: Vec<SubtitleReason>, diagnostics: Vec<SubtitleDiagnostic>) -> Self {
+        Self {
+            tracks: Vec::new(),
+            status: SubtitleStatus::ErrorSoft,
+            reasons,
+            diagnostics,
+        }
+    }
+
+    /// Whether any downloadable tracks exist.
+    #[must_use]
+    pub fn has_tracks(&self) -> bool {
+        !self.tracks.is_empty()
+    }
+}
+
+/// Convert legacy `InfoDict` subtitle maps into a [`SubtitleResult`].
+///
+/// Bridges the existing `Subtitle` wire format to the richer pipeline types.
+/// Manual subtitles get `is_auto = false`; automatic captions get `is_auto = true`.
+#[must_use]
+pub fn normalize_from_info_dict(
+    subtitles: Option<&HashMap<String, Vec<Subtitle>>>,
+    automatic_captions: Option<&HashMap<String, Vec<Subtitle>>>,
+) -> SubtitleResult {
+    let has_manual = subtitles.is_some_and(|s| !s.is_empty());
+    let has_auto = automatic_captions.is_some_and(|a| !a.is_empty());
+
+    if !has_manual && !has_auto {
+        let reason = if subtitles.is_none() && automatic_captions.is_none() {
+            SubtitleReason::FieldMissing
+        } else {
+            SubtitleReason::EmptyList
+        };
+        return SubtitleResult::not_available(vec![reason]);
+    }
+
+    let mut tracks = Vec::new();
+
+    if let Some(subs) = subtitles {
+        for (lang, entries) in subs {
+            for entry in entries {
+                tracks.push(SubtitleTrack {
+                    language: lang.clone(),
+                    url: entry.url.clone(),
+                    ext: entry.ext.clone(),
+                    is_auto: false,
+                    kind: SubtitleKind::Normal,
+                    name: entry.name.clone(),
+                });
+            }
+        }
+    }
+
+    if let Some(auto) = automatic_captions {
+        for (lang, entries) in auto {
+            for entry in entries {
+                tracks.push(SubtitleTrack {
+                    language: lang.clone(),
+                    url: entry.url.clone(),
+                    ext: entry.ext.clone(),
+                    is_auto: true,
+                    kind: SubtitleKind::Normal,
+                    name: entry.name.clone(),
+                });
+            }
+        }
+    }
+
+    SubtitleResult::available(tracks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sub(url: &str, ext: &str) -> Subtitle {
+        Subtitle {
+            url: url.to_string(),
+            ext: ext.to_string(),
+            name: None,
+        }
+    }
+
+    #[test]
+    fn test_both_fields_none() {
+        let result = normalize_from_info_dict(None, None);
+        assert_eq!(result.status, SubtitleStatus::NotAvailable);
+        assert_eq!(result.reasons, vec![SubtitleReason::FieldMissing]);
+        assert!(result.tracks.is_empty());
+    }
+
+    #[test]
+    fn test_both_fields_empty() {
+        let empty: HashMap<String, Vec<Subtitle>> = HashMap::new();
+        let result = normalize_from_info_dict(Some(&empty), Some(&empty));
+        assert_eq!(result.status, SubtitleStatus::NotAvailable);
+        assert_eq!(result.reasons, vec![SubtitleReason::EmptyList]);
+    }
+
+    #[test]
+    fn test_manual_subs_only() {
+        let mut subs = HashMap::new();
+        subs.insert(
+            "en".to_string(),
+            vec![sub("https://example.com/en.srt", "srt")],
+        );
+        let result = normalize_from_info_dict(Some(&subs), None);
+        assert_eq!(result.status, SubtitleStatus::Available);
+        assert!(result.reasons.is_empty());
+        assert_eq!(result.tracks.len(), 1);
+        assert!(!result.tracks[0].is_auto);
+        assert_eq!(result.tracks[0].language, "en");
+    }
+
+    #[test]
+    fn test_auto_captions_only() {
+        let mut auto = HashMap::new();
+        auto.insert(
+            "ja".to_string(),
+            vec![sub("https://example.com/ja.vtt", "vtt")],
+        );
+        let result = normalize_from_info_dict(None, Some(&auto));
+        assert_eq!(result.status, SubtitleStatus::Available);
+        assert_eq!(result.tracks.len(), 1);
+        assert!(result.tracks[0].is_auto);
+    }
+
+    #[test]
+    fn test_mixed_manual_and_auto() {
+        let mut subs = HashMap::new();
+        subs.insert(
+            "en".to_string(),
+            vec![sub("https://example.com/en.srt", "srt")],
+        );
+        let mut auto = HashMap::new();
+        auto.insert(
+            "ja".to_string(),
+            vec![sub("https://example.com/ja.vtt", "vtt")],
+        );
+        let result = normalize_from_info_dict(Some(&subs), Some(&auto));
+        assert_eq!(result.status, SubtitleStatus::Available);
+        assert_eq!(result.tracks.len(), 2);
+
+        let manual_count = result.tracks.iter().filter(|t| !t.is_auto).count();
+        let auto_count = result.tracks.iter().filter(|t| t.is_auto).count();
+        assert_eq!(manual_count, 1);
+        assert_eq!(auto_count, 1);
+    }
+
+    #[test]
+    fn test_manual_empty_auto_has_tracks() {
+        let empty: HashMap<String, Vec<Subtitle>> = HashMap::new();
+        let mut auto = HashMap::new();
+        auto.insert(
+            "en".to_string(),
+            vec![sub("https://example.com/en.vtt", "vtt")],
+        );
+        let result = normalize_from_info_dict(Some(&empty), Some(&auto));
+        assert_eq!(result.status, SubtitleStatus::Available);
+        assert_eq!(result.tracks.len(), 1);
+        assert!(result.tracks[0].is_auto);
+    }
+
+    #[test]
+    fn test_convenience_constructors() {
+        let avail = SubtitleResult::available(vec![]);
+        assert_eq!(avail.status, SubtitleStatus::Available);
+
+        let na = SubtitleResult::not_available(vec![SubtitleReason::FieldMissing]);
+        assert_eq!(na.status, SubtitleStatus::NotAvailable);
+        assert!(!na.has_tracks());
+
+        let err = SubtitleResult::error_soft(
+            vec![SubtitleReason::RequiresAuth],
+            vec![SubtitleDiagnostic {
+                key: "http_status".into(),
+                value: "401".into(),
+            }],
+        );
+        assert_eq!(err.status, SubtitleStatus::ErrorSoft);
+        assert_eq!(err.diagnostics.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- **Critical fix**: Missing subtitles no longer crash video downloads — episodes continue with a warning instead of hard-failing (the old behavior is available via `--strict-subs`)
- **Subtitle retry**: `--retry-subs` re-downloads subtitles for already-downloaded videos missing subtitle files, with `ResumeDetection` struct for structured resume state
- **Fuzzy language matching**: `--sub-langs en` now matches tracks keyed by labels like "English" (9anime) via ISO-code prefix matching in both the pipeline policy layer and interactive menu pre-selection
- **Duplicate prevention**: Both subtitle download paths skip files already present on disk; resume detection uses fuzzy file scanning (`has_subtitle_file()`) so `title.English.vtt` satisfies a check for lang `en`
- **New types**: `SubtitleTrack`, `SubtitleResult`, `SubtitleStatus`, `SubtitleReason`, `SubtitleKind`, `SubtitleDiagnostic` in `rdlp-types` for structured subtitle pipeline data
- **Pipeline stages**: `normalize_subtitles` (InfoDict → SubtitleResult), `validate_subtitle_urls` (optional HEAD pre-check), `apply_subtitle_policy` (language filtering + strict mode) in `subtitle_pipeline.rs`
- **New CLI flags**: `--strict-subs` (fail on missing subs), `--verify-sub-urls` (HEAD pre-validation), `--retry-subs` (retry missing subtitle downloads)
- **Resume hardening**: Subtitle file verification during resume, `--verify-sub-urls` warning without `--strict-subs`
- **Session state**: Persists `strict_subs` flag; falls back to current CLI config when no saved state exists
- **Structured rustdoc**: Arguments/Returns/Example sections on `SubtitleResult`, `SubtitleKind` public APIs

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all tests pass including 19 subtitle pipeline tests and 9 doc-tests
- [x] Playlist download where some episodes lack subs → video downloads succeed, warning logged
- [x] `--retry-subs` re-downloads missing subs on re-run without re-downloading video
- [x] `--sub-langs en` fuzzy-matches "English" label tracks (9anime tested)
- [x] Duplicate prevention: existing subtitle files are skipped, not re-downloaded
- [x] Resume detection finds `title.English.vtt` when checking for lang `en`
- [x] `--strict-subs` → fails on episodes without subs (unit tested: policy sets should_fail + error message)
- [x] `--verify-sub-urls` with valid/invalid subtitle URLs (mockito tests: 200 kept, 404 filtered, 403 → RequiresAuth)
- [x] Session state resume preserves `strict_subs` flag