### PR TITLE
feat: add XHamster search with CLI integration

### DIFF
--- a/crates/rdlp-api/src/client.rs
+++ b/crates/rdlp-api/src/client.rs
@@ -221,6 +221,90 @@ impl RdlpClient {
             .collect()
     }
 
+    /// List sites that support search.
+    ///
+    /// # Returns
+    /// A list of `SearchSiteInfo` with name and display name.
+    #[must_use]
+    pub fn list_search_sites(&self) -> Vec<rdlp_core::SearchSiteInfo> {
+        let id = DownloadId::next();
+        let (tx, _rx) = mpsc::channel::<Event>(1);
+        let cancel_token = CancellationToken::new();
+        let config = (*self.config).clone();
+
+        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        orchestrator
+            .list_search_extractors()
+            .into_iter()
+            .map(|name| rdlp_core::SearchSiteInfo {
+                name: name.to_lowercase(),
+                display_name: name.to_string(),
+            })
+            .collect()
+    }
+
+    /// Get available search filters for a site.
+    ///
+    /// # Arguments
+    /// * `site` - Site name as returned by `list_search_sites()`.
+    ///
+    /// # Errors
+    /// Returns error if the site name is not recognized.
+    pub fn search_filters(
+        &self,
+        site: &str,
+    ) -> Result<Vec<rdlp_core::SearchFilterDescriptor>, RdlpApiError> {
+        let id = DownloadId::next();
+        let (tx, _rx) = mpsc::channel::<Event>(1);
+        let cancel_token = CancellationToken::new();
+        let config = (*self.config).clone();
+
+        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        orchestrator
+            .search_filters(site)
+            .map_err(|e| RdlpApiError::InvalidInput {
+                message: e.to_string(),
+            })
+    }
+
+    /// Execute a keyword search on a site.
+    ///
+    /// # Arguments
+    /// * `site` - Site name (e.g., "xhamster").
+    /// * `query` - Search query with optional filters.
+    ///
+    /// # Returns
+    /// Lightweight result previews. Call `extract_info()` on each
+    /// `SearchResultPreview::video_url` for full metadata.
+    ///
+    /// # Errors
+    /// Returns error if site unknown, filters invalid, or network fails.
+    pub async fn search(
+        &self,
+        site: &str,
+        query: &rdlp_core::SearchQuery,
+    ) -> Result<Vec<rdlp_core::SearchResultPreview>, RdlpApiError> {
+        let id = DownloadId::next();
+        let (tx, _rx) = mpsc::channel::<Event>(16);
+        let cancel_token = CancellationToken::new();
+        let config = (*self.config).clone();
+
+        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        orchestrator.search(site, query).await.map_err(Into::into)
+    }
+
+    /// Execute a search and return results as lightweight previews.
+    ///
+    /// Alias for [`search()`](Self::search) — only scrapes search result
+    /// pages, does not fetch individual video pages.
+    pub async fn search_preview(
+        &self,
+        site: &str,
+        query: &rdlp_core::SearchQuery,
+    ) -> Result<Vec<rdlp_core::SearchResultPreview>, RdlpApiError> {
+        self.search(site, query).await
+    }
+
     /// List available download protocols.
     #[must_use]
     pub fn list_downloaders(&self) -> Vec<String> {
@@ -440,5 +524,29 @@ mod tests {
         let client = RdlpClient::new(Config::default()).unwrap();
         let downloaders = client.list_downloaders();
         assert!(!downloaders.is_empty());
+    }
+
+    #[test]
+    fn test_list_search_sites() {
+        let client = RdlpClient::new(Config::default()).unwrap();
+        let sites = client.list_search_sites();
+        assert!(!sites.is_empty());
+        assert!(sites.iter().any(|s| s.name == "xhamster"));
+    }
+
+    #[test]
+    fn test_search_filters() {
+        let client = RdlpClient::new(Config::default()).unwrap();
+        let filters = client.search_filters("xhamster").unwrap();
+        assert!(!filters.is_empty());
+        let keys: Vec<&str> = filters.iter().map(|f| f.key.as_str()).collect();
+        assert!(keys.contains(&"quality"));
+        assert!(keys.contains(&"sort"));
+    }
+
+    #[test]
+    fn test_search_filters_unknown_site() {
+        let client = RdlpClient::new(Config::default()).unwrap();
+        assert!(client.search_filters("nonexistent").is_err());
     }
 }

--- a/crates/rdlp-api/src/lib.rs
+++ b/crates/rdlp-api/src/lib.rs
@@ -39,5 +39,9 @@ pub use errors::RdlpApiError;
 pub use events::Event;
 pub use handle::{DownloadHandle, DownloadId};
 pub use orchestrator::InteractiveCallback;
+pub use rdlp_core::{
+    SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchQuery, SearchResultPreview,
+    SearchSiteInfo,
+};
 pub use request::DownloadRequest;
 pub use result::DownloadResult;

--- a/crates/rdlp-api/src/orchestrator/extraction.rs
+++ b/crates/rdlp-api/src/orchestrator/extraction.rs
@@ -2,6 +2,7 @@
 
 use super::{Orchestrator, errors::*};
 use log::info;
+use rdlp_core::{SearchFilterDescriptor, SearchQuery, SearchResultPreview};
 use tracing::instrument;
 
 impl Orchestrator {
@@ -158,5 +159,64 @@ impl Orchestrator {
         }
 
         Ok(infos)
+    }
+
+    /// Execute a search query using the named search extractor.
+    ///
+    /// # Arguments
+    /// * `extractor_name` - Site name (e.g., "xhamster")
+    /// * `query` - Search query with filters and optional max results
+    ///
+    /// # Errors
+    /// Returns an error if the site name is unknown or the search fails.
+    pub async fn search(
+        &self,
+        extractor_name: &str,
+        query: &SearchQuery,
+    ) -> Result<Vec<SearchResultPreview>> {
+        let extractor = self
+            .extractor_registry
+            .find_search_extractor(extractor_name)
+            .ok_or_else(|| {
+                let available = self.extractor_registry.list_search_extractors();
+                OrchestratorError::Configuration(format!(
+                    "Unknown search site: '{}'. Available: {}",
+                    extractor_name,
+                    available.join(", ")
+                ))
+            })?;
+
+        info!(site = extractor_name, query = query.query.as_str(); "Starting search");
+
+        let results = extractor
+            .search(query, &self.extraction_context)
+            .await
+            .map_err(OrchestratorError::ExtractionFailed)?;
+
+        info!(site = extractor_name, count = results.len(); "Search complete");
+
+        Ok(results)
+    }
+
+    /// List names of all search-capable extractors.
+    pub fn list_search_extractors(&self) -> Vec<&str> {
+        self.extractor_registry.list_search_extractors()
+    }
+
+    /// Get filter descriptors for a search extractor.
+    ///
+    /// # Errors
+    /// Returns an error if the site name is unknown.
+    pub fn search_filters(&self, extractor_name: &str) -> Result<Vec<SearchFilterDescriptor>> {
+        let extractor = self
+            .extractor_registry
+            .find_search_extractor(extractor_name)
+            .ok_or_else(|| {
+                OrchestratorError::Configuration(format!(
+                    "Unknown search site: '{}'",
+                    extractor_name
+                ))
+            })?;
+        Ok(extractor.supported_filters())
     }
 }

--- a/crates/rdlp-api/src/orchestrator/extraction.rs
+++ b/crates/rdlp-api/src/orchestrator/extraction.rs
@@ -212,10 +212,7 @@ impl Orchestrator {
             .extractor_registry
             .find_search_extractor(extractor_name)
             .ok_or_else(|| {
-                OrchestratorError::Configuration(format!(
-                    "Unknown search site: '{}'",
-                    extractor_name
-                ))
+                OrchestratorError::Configuration(format!("Unknown search site: '{extractor_name}'"))
             })?;
         Ok(extractor.supported_filters())
     }

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -119,7 +119,7 @@ pub struct FormatOptions {
 /// use rdlp_core::SubtitleFormat;
 ///
 /// let opts = SubtitleOptions {
-///     write_subs: true,
+///     write_subs: Some(true),
 ///     sub_langs: vec!["en".into(), "ja".into()],
 ///     sub_format: Some(SubtitleFormat::Srt),
 ///     ..SubtitleOptions::default()
@@ -127,18 +127,18 @@ pub struct FormatOptions {
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct SubtitleOptions {
-    /// Download subtitles.
-    pub write_subs: bool,
-    /// Download auto-generated subtitles.
-    pub write_auto_subs: bool,
+    /// Download subtitles. `None` preserves base config.
+    pub write_subs: Option<bool>,
+    /// Download auto-generated subtitles. `None` preserves base config.
+    pub write_auto_subs: Option<bool>,
     /// Subtitle language codes to download (e.g. `["en", "ja"]`).
     pub sub_langs: Vec<String>,
     /// Preferred subtitle format.
     pub sub_format: Option<SubtitleFormat>,
-    /// Embed subtitles into the output container.
-    pub embed_subs: bool,
-    /// Fail if requested subtitles are not available.
-    pub strict_subs: bool,
+    /// Embed subtitles into the output container. `None` preserves base config.
+    pub embed_subs: Option<bool>,
+    /// Fail if requested subtitles are not available. `None` preserves base config.
+    pub strict_subs: Option<bool>,
 }
 
 /// Post-processing options (remux, audio extraction, metadata, thumbnails).
@@ -151,47 +151,30 @@ pub struct SubtitleOptions {
 ///
 /// let opts = PostProcessOptions {
 ///     remux: Some(ContainerFormat::Mp4),
-///     embed_metadata: true,
+///     embed_metadata: Some(true),
 ///     ..PostProcessOptions::default()
 /// };
-/// assert!(opts.embed_thumbnail);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PostProcessOptions {
     /// Remux to a different container format.
     pub remux: Option<ContainerFormat>,
     /// Extract audio to the specified format.
     pub extract_audio: Option<AudioFormat>,
-    /// Embed metadata (title, uploader, etc.) into the output file.
-    pub embed_metadata: bool,
-    /// Embed thumbnail into the output file.
-    pub embed_thumbnail: bool,
-    /// Disable thumbnail downloading entirely.
-    pub no_thumbnail: bool,
-    /// Keep the downloaded thumbnail as a separate file.
-    pub write_thumbnail: bool,
-    /// Apply peak audio normalization.
-    pub normalize_audio: bool,
-    /// Apply EBU R128 loudness normalization (two-pass).
-    pub loudnorm: bool,
+    /// Embed metadata (title, uploader, etc.) into the output file. `None` preserves base config.
+    pub embed_metadata: Option<bool>,
+    /// Embed thumbnail into the output file. `None` preserves base config.
+    pub embed_thumbnail: Option<bool>,
+    /// Disable thumbnail downloading entirely. `None` preserves base config.
+    pub no_thumbnail: Option<bool>,
+    /// Keep the downloaded thumbnail as a separate file. `None` preserves base config.
+    pub write_thumbnail: Option<bool>,
+    /// Apply peak audio normalization. `None` preserves base config.
+    pub normalize_audio: Option<bool>,
+    /// Apply EBU R128 loudness normalization (two-pass). `None` preserves base config.
+    pub loudnorm: Option<bool>,
     /// Loudness normalization preset name (e.g. `"streaming"`).
     pub loudnorm_preset: Option<String>,
-}
-
-impl Default for PostProcessOptions {
-    fn default() -> Self {
-        Self {
-            remux: None,
-            extract_audio: None,
-            embed_metadata: false,
-            embed_thumbnail: true,
-            no_thumbnail: false,
-            write_thumbnail: false,
-            normalize_audio: false,
-            loudnorm: false,
-            loudnorm_preset: None,
-        }
-    }
 }
 
 /// Network, retry, and cookie options.
@@ -203,39 +186,25 @@ impl Default for PostProcessOptions {
 /// use rdlp_core::BrowserType;
 ///
 /// let opts = NetworkOptions {
-///     retries: 5,
+///     retries: Some(5),
 ///     cookies_from_browser: Some(BrowserType::Chrome),
 ///     ..NetworkOptions::default()
 /// };
-/// assert_eq!(opts.timeout_secs, 60);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct NetworkOptions {
-    /// Maximum number of retries for failed requests.
-    pub retries: u32,
-    /// Per-read idle timeout in seconds.
-    pub timeout_secs: u64,
-    /// Number of concurrent download fragments/chunks.
-    pub concurrent_fragments: u32,
+    /// Maximum number of retries for failed requests. `None` preserves base config.
+    pub retries: Option<u32>,
+    /// Per-read idle timeout in seconds. `None` preserves base config.
+    pub timeout_secs: Option<u64>,
+    /// Number of concurrent download fragments/chunks. `None` preserves base config.
+    pub concurrent_fragments: Option<u32>,
     /// Download rate limit in bytes per second.
     pub rate_limit: Option<u64>,
     /// Browser to extract cookies from.
     pub cookies_from_browser: Option<BrowserType>,
     /// Path to a Netscape-format cookies file.
     pub cookies_file: Option<PathBuf>,
-}
-
-impl Default for NetworkOptions {
-    fn default() -> Self {
-        Self {
-            retries: 3,
-            timeout_secs: 60,
-            concurrent_fragments: 4,
-            rate_limit: None,
-            cookies_from_browser: None,
-            cookies_file: None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -261,28 +230,28 @@ mod tests {
         assert!(!req.format.interactive);
 
         // SubtitleOptions defaults
-        assert!(!req.subtitles.write_subs);
-        assert!(!req.subtitles.write_auto_subs);
+        assert!(req.subtitles.write_subs.is_none());
+        assert!(req.subtitles.write_auto_subs.is_none());
         assert!(req.subtitles.sub_langs.is_empty());
         assert!(req.subtitles.sub_format.is_none());
-        assert!(!req.subtitles.embed_subs);
-        assert!(!req.subtitles.strict_subs);
+        assert!(req.subtitles.embed_subs.is_none());
+        assert!(req.subtitles.strict_subs.is_none());
 
         // PostProcessOptions defaults
         assert!(req.postprocess.remux.is_none());
         assert!(req.postprocess.extract_audio.is_none());
-        assert!(!req.postprocess.embed_metadata);
-        assert!(req.postprocess.embed_thumbnail);
-        assert!(!req.postprocess.no_thumbnail);
-        assert!(!req.postprocess.write_thumbnail);
-        assert!(!req.postprocess.normalize_audio);
-        assert!(!req.postprocess.loudnorm);
+        assert!(req.postprocess.embed_metadata.is_none());
+        assert!(req.postprocess.embed_thumbnail.is_none());
+        assert!(req.postprocess.no_thumbnail.is_none());
+        assert!(req.postprocess.write_thumbnail.is_none());
+        assert!(req.postprocess.normalize_audio.is_none());
+        assert!(req.postprocess.loudnorm.is_none());
         assert!(req.postprocess.loudnorm_preset.is_none());
 
         // NetworkOptions defaults
-        assert_eq!(req.network.retries, 3);
-        assert_eq!(req.network.timeout_secs, 60);
-        assert_eq!(req.network.concurrent_fragments, 4);
+        assert!(req.network.retries.is_none());
+        assert!(req.network.timeout_secs.is_none());
+        assert!(req.network.concurrent_fragments.is_none());
         assert!(req.network.rate_limit.is_none());
         assert!(req.network.cookies_from_browser.is_none());
         assert!(req.network.cookies_file.is_none());
@@ -303,22 +272,22 @@ mod tests {
                 ..FormatOptions::default()
             },
             subtitles: SubtitleOptions {
-                write_subs: true,
+                write_subs: Some(true),
                 sub_langs: vec!["en".into(), "ja".into()],
                 sub_format: Some(SubtitleFormat::Srt),
-                embed_subs: true,
+                embed_subs: Some(true),
                 ..SubtitleOptions::default()
             },
             postprocess: PostProcessOptions {
                 remux: Some(ContainerFormat::Mp4),
-                embed_metadata: true,
-                loudnorm: true,
+                embed_metadata: Some(true),
+                loudnorm: Some(true),
                 loudnorm_preset: Some("streaming".into()),
                 ..PostProcessOptions::default()
             },
             network: NetworkOptions {
-                retries: 5,
-                concurrent_fragments: 8,
+                retries: Some(5),
+                concurrent_fragments: Some(8),
                 cookies_from_browser: Some(BrowserType::Chrome),
                 ..NetworkOptions::default()
             },
@@ -342,31 +311,31 @@ mod tests {
         assert!(req.format.interactive);
 
         // Subtitle overrides
-        assert!(req.subtitles.write_subs);
-        assert!(!req.subtitles.write_auto_subs);
+        assert_eq!(req.subtitles.write_subs, Some(true));
+        assert!(req.subtitles.write_auto_subs.is_none());
         assert_eq!(req.subtitles.sub_langs, vec!["en", "ja"]);
         assert_eq!(req.subtitles.sub_format, Some(SubtitleFormat::Srt));
-        assert!(req.subtitles.embed_subs);
-        assert!(!req.subtitles.strict_subs);
+        assert_eq!(req.subtitles.embed_subs, Some(true));
+        assert!(req.subtitles.strict_subs.is_none());
 
-        // PostProcess overrides (embed_thumbnail stays true from default)
+        // PostProcess overrides
         assert_eq!(req.postprocess.remux, Some(ContainerFormat::Mp4));
         assert!(req.postprocess.extract_audio.is_none());
-        assert!(req.postprocess.embed_metadata);
-        assert!(req.postprocess.embed_thumbnail);
-        assert!(!req.postprocess.no_thumbnail);
-        assert!(!req.postprocess.write_thumbnail);
-        assert!(!req.postprocess.normalize_audio);
-        assert!(req.postprocess.loudnorm);
+        assert_eq!(req.postprocess.embed_metadata, Some(true));
+        assert!(req.postprocess.embed_thumbnail.is_none());
+        assert!(req.postprocess.no_thumbnail.is_none());
+        assert!(req.postprocess.write_thumbnail.is_none());
+        assert!(req.postprocess.normalize_audio.is_none());
+        assert_eq!(req.postprocess.loudnorm, Some(true));
         assert_eq!(
             req.postprocess.loudnorm_preset.as_deref(),
             Some("streaming")
         );
 
         // Network overrides
-        assert_eq!(req.network.retries, 5);
-        assert_eq!(req.network.timeout_secs, 60);
-        assert_eq!(req.network.concurrent_fragments, 8);
+        assert_eq!(req.network.retries, Some(5));
+        assert!(req.network.timeout_secs.is_none());
+        assert_eq!(req.network.concurrent_fragments, Some(8));
         assert!(req.network.rate_limit.is_none());
         assert_eq!(req.network.cookies_from_browser, Some(BrowserType::Chrome));
         assert!(req.network.cookies_file.is_none());
@@ -377,8 +346,8 @@ mod tests {
         let req = DownloadRequest::new("https://example.com/video");
         assert_eq!(req.url, "https://example.com/video");
         assert!(!req.plan_only);
-        assert!(req.postprocess.embed_thumbnail);
-        assert_eq!(req.network.retries, 3);
+        assert!(req.postprocess.embed_thumbnail.is_none());
+        assert!(req.network.retries.is_none());
     }
 
     #[test]

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -240,6 +240,19 @@ struct Args {
     #[arg(long)]
     download_archive: Option<PathBuf>,
 
+    // === Search options ===
+    /// Perform a keyword search instead of downloading a URL
+    #[arg(long)]
+    search: Option<String>,
+
+    /// Site to search (required with --search, e.g., "xhamster")
+    #[arg(long)]
+    search_site: Option<String>,
+
+    /// Search filter in key=value format (repeatable)
+    #[arg(long = "search-filter")]
+    search_filter: Vec<String>,
+
     // === Config file options ===
     /// Ignore config file (don't load from default location)
     #[arg(long)]
@@ -848,6 +861,71 @@ async fn async_main() -> Result<()> {
         return Ok(());
     }
 
+    // === Search mode ===
+    if let Some(ref query_text) = args.search {
+        let site = args.search_site.as_deref().unwrap_or_else(|| {
+            let sites = client.list_search_sites();
+            if sites.len() == 1 {
+                // Leak is fine for a single CLI run
+                return Box::leak(sites[0].name.clone().into_boxed_str());
+            }
+            eprintln!(
+                "Error: --search-site is required. Available sites: {}",
+                sites
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            std::process::exit(1);
+        });
+
+        // Parse filters from key=value strings
+        let mut filters = Vec::new();
+        for raw in &args.search_filter {
+            let (key, value) = match raw.split_once('=') {
+                Some((k, v)) => (k.to_string(), v.to_string()),
+                None => {
+                    eprintln!("Error: Invalid filter format '{raw}'. Expected key=value.");
+                    std::process::exit(1);
+                }
+            };
+            filters.push(rdlp_api::SearchFilter { key, value });
+        }
+
+        let search_query = rdlp_api::SearchQuery {
+            query: query_text.clone(),
+            filters,
+            max_results: None,
+        };
+
+        match client.search(site, &search_query).await {
+            Ok(results) => {
+                if results.is_empty() {
+                    println!("No results found for '{query_text}'.");
+                } else {
+                    println!("Found {} results:\n", results.len());
+                    for (i, r) in results.iter().enumerate() {
+                        println!("{:>3}. {}", i + 1, r.title);
+                        println!("     {}", r.video_url);
+                        if let Some(d) = r.duration {
+                            let mins = d as u32 / 60;
+                            let secs = d as u32 % 60;
+                            print!("     Duration: {mins}:{secs:02}");
+                        }
+                        if let Some(views) = r.view_count {
+                            print!("  Views: {views}");
+                        }
+                        println!();
+                    }
+                }
+            }
+            Err(e) => fail_with(e, verbose),
+        }
+
+        return Ok(());
+    }
+
     // Check if URL is provided
     let url = args
         .url
@@ -1008,6 +1086,9 @@ mod tests {
             cookies_from_browser: None,
             cookies: None,
             download_archive: None,
+            search: None,
+            search_site: None,
+            search_filter: vec![],
             ignore_config: false,
             config_location: None,
         }
@@ -1283,5 +1364,34 @@ mod tests {
             config.normalize_audio,
             "normalize_boost should imply normalize_audio"
         );
+    }
+
+    // === Search CLI tests ===
+
+    #[test]
+    fn test_search_args_parse() {
+        let args = Args::try_parse_from([
+            "rdlp",
+            "--search",
+            "test query",
+            "--search-site",
+            "xhamster",
+            "--search-filter",
+            "quality=1080p",
+            "--search-filter",
+            "sort=newest",
+        ])
+        .unwrap();
+        assert_eq!(args.search.as_deref(), Some("test query"));
+        assert_eq!(args.search_site.as_deref(), Some("xhamster"));
+        assert_eq!(args.search_filter.len(), 2);
+    }
+
+    #[test]
+    fn test_search_filter_parsing() {
+        let raw = "quality=1080p";
+        let (key, value) = raw.split_once('=').unwrap();
+        assert_eq!(key, "quality");
+        assert_eq!(value, "1080p");
     }
 }

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -40,8 +40,9 @@ pub mod traits;
 // Re-export types from rdlp-types for convenience
 pub use rdlp_types::{
     AudioFormat, BrowserType, Chapter, Config, ContainerFormat, DownloadProtocol, Format,
-    FormatSelector, Fragment, InfoDict, Subtitle, SubtitleDiagnostic, SubtitleFormat, SubtitleKind,
-    SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack, Thumbnail,
+    FormatSelector, Fragment, InfoDict, SearchFilter, SearchFilterDescriptor, SearchFilterValue,
+    SearchQuery, SearchResultPreview, SearchSiteInfo, Subtitle, SubtitleDiagnostic, SubtitleFormat,
+    SubtitleKind, SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack, Thumbnail,
     normalize_from_info_dict,
 };
 
@@ -58,4 +59,5 @@ pub use retry::{ExponentialBuilder, RetryConfig, Retryable, is_retryable_error};
 pub use traits::{
     CookieJar, DownloadProgress, DownloadStats, Downloader, ExtractionContext, InfoExtractor,
     JsEngine, PostProcessConfig, PostProcessResult, PostProcessor, ProgressCallback,
+    SearchExtractor,
 };

--- a/crates/rdlp-core/src/traits/extractor.rs
+++ b/crates/rdlp-core/src/traits/extractor.rs
@@ -3,6 +3,7 @@ use regex::Regex;
 use std::sync::Arc;
 
 use crate::{BrowserType, Config, InfoDict, Result};
+use rdlp_types::{SearchFilterDescriptor, SearchQuery, SearchResultPreview};
 
 /// Core trait for all site extractors
 ///
@@ -111,6 +112,39 @@ pub trait InfoExtractor: Send + Sync {
     fn priority(&self) -> i32 {
         0
     }
+}
+
+/// Trait for extractors that support keyword search on a site.
+///
+/// Implementing this trait is optional. Sites that support search expose
+/// filter descriptors (for UI construction) and a search method returning
+/// lightweight preview results.
+#[async_trait]
+pub trait SearchExtractor: Send + Sync {
+    /// Human-readable site name (should match the corresponding `InfoExtractor::name()`).
+    fn name(&self) -> &str;
+
+    /// Describe the available search filters for this site.
+    ///
+    /// # Returns
+    /// A list of filter descriptors that frontends use to build filter UI.
+    fn supported_filters(&self) -> Vec<SearchFilterDescriptor>;
+
+    /// Execute a search and return lightweight result previews.
+    ///
+    /// # Arguments
+    /// * `query` — The search query with filters and optional max results.
+    /// * `ctx` — Shared extraction context (HTTP client, cookies, config).
+    ///
+    /// # Returns
+    /// A vector of `SearchResultPreview`. May be empty if no results found.
+    /// Does NOT return full `InfoDict`; callers that need full metadata
+    /// should call `InfoExtractor::extract()` on each result's `video_url`.
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>>;
 }
 
 /// Context passed to extractors containing shared resources

--- a/crates/rdlp-core/src/traits/mod.rs
+++ b/crates/rdlp-core/src/traits/mod.rs
@@ -13,5 +13,5 @@ pub mod extractor;
 pub mod postprocessor;
 
 pub use downloader::{DownloadProgress, DownloadStats, Downloader, ProgressCallback};
-pub use extractor::{CookieJar, ExtractionContext, InfoExtractor, JsEngine};
+pub use extractor::{CookieJar, ExtractionContext, InfoExtractor, JsEngine, SearchExtractor};
 pub use postprocessor::{PostProcessConfig, PostProcessResult, PostProcessor};

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -20,6 +20,7 @@
 
 mod formats;
 mod patterns;
+mod search;
 mod utils;
 
 use async_trait::async_trait;

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -27,7 +27,8 @@ use async_trait::async_trait;
 use futures::stream::{self, StreamExt};
 use log::{debug, info, warn};
 use rdlp_core::{
-    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, check_http_response,
+    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
+    check_http_response,
 };
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -105,7 +106,7 @@ impl XHamsterExtractor {
                     &video_id,
                     display_id.as_deref(),
                     &url,
-                    self.name(),
+                    InfoExtractor::name(self),
                     age_limit,
                 )
             } else {
@@ -115,7 +116,7 @@ impl XHamsterExtractor {
                     &video_id,
                     display_id.as_deref(),
                     &url,
-                    self.name(),
+                    InfoExtractor::name(self),
                     age_limit,
                 )
             };
@@ -130,7 +131,7 @@ impl XHamsterExtractor {
                 &video_id,
                 display_id.as_deref(),
                 &url,
-                self.name(),
+                InfoExtractor::name(self),
                 age_limit,
             );
             let formats = formats::extract_from_legacy(&webpage);
@@ -144,7 +145,8 @@ impl XHamsterExtractor {
         }
 
         // Detect file sizes and segment counts for HLS
-        let (formats_with_size, hls_flags) = detect_format_sizes(formats, ctx, self.name()).await;
+        let (formats_with_size, hls_flags) =
+            detect_format_sizes(formats, ctx, InfoExtractor::name(self)).await;
 
         info.formats = formats_with_size;
         info.propagate_duration();
@@ -334,6 +336,71 @@ impl XHamsterExtractor {
 
         Ok(results)
     }
+
+    /// Perform a paginated search, collecting results across all pages.
+    async fn search_all_pages(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_core::SearchResultPreview>> {
+        search::validate_search_filters(&query.filters)?;
+
+        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
+        let mut all_results = Vec::new();
+        let mut page = 1_usize;
+
+        loop {
+            let page_url = if page == 1 {
+                patterns::build_search_url(query)
+            } else {
+                patterns::build_search_url_page(query, page)
+            };
+
+            debug!(page, url:? = rdlp_security::sanitize_for_logging(&page_url); "[XHamster] Fetching search page");
+
+            let webpage = match BaseExtractor::fetch_webpage(&page_url, ctx).await {
+                Ok(html) => html,
+                Err(e) => {
+                    warn!(page; "[XHamster] Failed to fetch search page, returning partial results: {e}");
+                    break;
+                }
+            };
+
+            let initials = match search::extract_initials_json(&webpage) {
+                Ok(json) => json,
+                Err(e) => {
+                    warn!(page; "[XHamster] Failed to parse search page JSON, returning partial results: {e}");
+                    break;
+                }
+            };
+
+            let page_results = search::parse_search_results_json(&initials)?;
+            let max_pages = search::parse_max_pages(&initials).unwrap_or(1);
+
+            if page_results.is_empty() {
+                debug!(page; "[XHamster] No results on page, stopping pagination");
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if page >= max_pages {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        info!(count = all_results.len(), pages = page; "[XHamster] Search complete");
+
+        Ok(all_results)
+    }
 }
 
 impl Default for XHamsterExtractor {
@@ -374,6 +441,25 @@ impl InfoExtractor for XHamsterExtractor {
 
     fn priority(&self) -> i32 {
         0
+    }
+}
+
+#[async_trait]
+impl SearchExtractor for XHamsterExtractor {
+    fn name(&self) -> &str {
+        "XHamster"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_core::SearchFilterDescriptor> {
+        patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_core::SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
     }
 }
 
@@ -439,7 +525,7 @@ mod tests {
     #[test]
     fn test_extractor_creation() {
         let extractor = XHamsterExtractor::new();
-        assert_eq!(extractor.name(), "XHamster");
+        assert_eq!(InfoExtractor::name(&extractor), "XHamster");
     }
 
     #[test]
@@ -494,6 +580,18 @@ mod tests {
     fn test_extract_initials_json_not_found() {
         let webpage = "<html><body>No initials here</body></html>";
         assert!(extract_initials_json(webpage).is_none());
+    }
+
+    #[test]
+    fn test_xhamster_implements_search_extractor() {
+        let extractor = XHamsterExtractor::new();
+        let filters =
+            <XHamsterExtractor as rdlp_core::SearchExtractor>::supported_filters(&extractor);
+        assert!(!filters.is_empty());
+        assert_eq!(
+            <XHamsterExtractor as rdlp_core::SearchExtractor>::name(&extractor),
+            "XHamster"
+        );
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/xhamster/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/patterns.rs
@@ -110,6 +110,7 @@ pub fn is_suitable(url: &str) -> bool {
     XHAMSTER_VIDEO_PATTERN.is_match(url)
         || XHAMSTER_EMBED_PATTERN.is_match(url)
         || XHAMSTER_USER_PATTERN.is_match(url)
+        || XHAMSTER_SEARCH_PATTERN.is_match(url)
 }
 
 /// Check if URL is an embed URL.
@@ -156,6 +157,231 @@ static MOBILE_URL_PATTERN: Lazy<Regex> =
 /// Rewrite mobile URL to desktop (strip `m.` subdomain).
 pub fn rewrite_mobile_url(url: &str) -> String {
     MOBILE_URL_PATTERN.replace(url, "$1").into_owned()
+}
+
+/// URL pattern for xHamster search pages.
+///
+/// Matches: `https://xhamster.com/search/query-terms`
+pub static XHAMSTER_SEARCH_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(&format!(
+        r"https?://(?:[^/?#]+\.)?(?:{DOMAINS})/search/[^/?#]+"
+    ))
+    .expect("Valid xHamster search URL pattern")
+});
+
+/// Check if a URL is an xHamster search URL.
+pub fn is_search_url(url: &str) -> bool {
+    XHAMSTER_SEARCH_PATTERN.is_match(url)
+}
+
+/// Build a search URL from a `SearchQuery`.
+///
+/// Format: `https://xhamster.com/search/{encoded_query}?{filter_params}`
+pub fn build_search_url(query: &rdlp_core::SearchQuery) -> String {
+    let encoded_query = query.query.split_whitespace().collect::<Vec<_>>().join("+");
+
+    let mut url = format!("https://xhamster.com/search/{encoded_query}");
+
+    let mut first_param = true;
+    for filter in &query.filters {
+        let sep = if first_param { '?' } else { '&' };
+        url.push(sep);
+        url.push_str(&filter.key);
+        url.push('=');
+        url.push_str(&filter.value);
+        first_param = false;
+    }
+
+    url
+}
+
+/// Build a search URL for a specific page number.
+pub fn build_search_url_page(query: &rdlp_core::SearchQuery, page: usize) -> String {
+    let mut url = build_search_url(query);
+    if url.contains('?') {
+        url.push_str(&format!("&page={page}"));
+    } else {
+        url.push_str(&format!("?page={page}"));
+    }
+    url
+}
+
+/// Return the static filter descriptors for xHamster search.
+pub fn search_filter_descriptors() -> Vec<rdlp_core::SearchFilterDescriptor> {
+    vec![
+        rdlp_core::SearchFilterDescriptor {
+            key: "quality".to_string(),
+            display_name: "Minimum quality".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "720p".to_string(),
+                    label: "720p+".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "1080p".to_string(),
+                    label: "1080p+".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "2160p".to_string(),
+                    label: "4K+".to_string(),
+                },
+            ],
+            default: None,
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "sort".to_string(),
+            display_name: "Sort by".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "relevance".to_string(),
+                    label: "Relevance".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "newest".to_string(),
+                    label: "Newest".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "views".to_string(),
+                    label: "Most viewed".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "best".to_string(),
+                    label: "Top rated".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "longest".to_string(),
+                    label: "Longest".to_string(),
+                },
+            ],
+            default: Some("relevance".to_string()),
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "date".to_string(),
+            display_name: "Upload date".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "week".to_string(),
+                    label: "Last week".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "month".to_string(),
+                    label: "Last month".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "year".to_string(),
+                    label: "Last year".to_string(),
+                },
+            ],
+            default: None,
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "orientations".to_string(),
+            display_name: "Orientation".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "straight".to_string(),
+                    label: "Straight".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "gay".to_string(),
+                    label: "Gay".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "shemale".to_string(),
+                    label: "Transgender".to_string(),
+                },
+            ],
+            default: None,
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "format".to_string(),
+            display_name: "Format".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "any".to_string(),
+                    label: "Any".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "vr".to_string(),
+                    label: "VR".to_string(),
+                },
+            ],
+            default: Some("any".to_string()),
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "categories".to_string(),
+            display_name: "Category".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "amateur".to_string(),
+                    label: "Amateur".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "mature".to_string(),
+                    label: "Mature".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "teen".to_string(),
+                    label: "Teen (18+)".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "anal".to_string(),
+                    label: "Anal".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "lesbian".to_string(),
+                    label: "Lesbian".to_string(),
+                },
+            ],
+            default: None,
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "duration-min".to_string(),
+            display_name: "Min duration (minutes)".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "0".to_string(),
+                    label: "0".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "5".to_string(),
+                    label: "5".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "10".to_string(),
+                    label: "10".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "20".to_string(),
+                    label: "20".to_string(),
+                },
+            ],
+            default: Some("0".to_string()),
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "duration-max".to_string(),
+            display_name: "Max duration (minutes)".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "5".to_string(),
+                    label: "5".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "10".to_string(),
+                    label: "10".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "20".to_string(),
+                    label: "20".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "40".to_string(),
+                    label: "40".to_string(),
+                },
+            ],
+            default: Some("40".to_string()),
+        },
+    ]
 }
 
 #[cfg(test)]
@@ -309,5 +535,97 @@ mod tests {
             rewrite_mobile_url("https://xhamster.com/videos/test-123"),
             "https://xhamster.com/videos/test-123"
         );
+    }
+
+    #[test]
+    fn test_search_url_detected() {
+        assert!(is_search_url("https://xhamster.com/search/amateur"));
+        assert!(is_search_url(
+            "https://xhamster.com/search/hot+videos?quality=1080p"
+        ));
+        assert!(is_search_url(
+            "https://xhamster.com/search/test?page=2&sort=newest"
+        ));
+        assert!(is_search_url("https://xhamster.desi/search/query"));
+    }
+
+    #[test]
+    fn test_non_search_url_rejected() {
+        assert!(!is_search_url("https://xhamster.com/videos/test-123"));
+        assert!(!is_search_url(
+            "https://xhamster.com/users/someone/videos"
+        ));
+        assert!(!is_search_url("https://xhamster.com/"));
+    }
+
+    #[test]
+    fn test_build_search_url_basic() {
+        let query = rdlp_core::SearchQuery {
+            query: "test query".to_string(),
+            filters: vec![],
+            max_results: None,
+        };
+        let url = build_search_url(&query);
+        assert!(url.starts_with("https://xhamster.com/search/"));
+        assert!(url.contains("test"));
+    }
+
+    #[test]
+    fn test_build_search_url_with_filters() {
+        let query = rdlp_core::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![
+                rdlp_core::SearchFilter {
+                    key: "quality".to_string(),
+                    value: "1080p".to_string(),
+                },
+                rdlp_core::SearchFilter {
+                    key: "sort".to_string(),
+                    value: "newest".to_string(),
+                },
+            ],
+            max_results: None,
+        };
+        let url = build_search_url(&query);
+        assert!(url.contains("quality=1080p"));
+        assert!(url.contains("sort=newest"));
+    }
+
+    #[test]
+    fn test_build_search_url_encodes_special_chars() {
+        let query = rdlp_core::SearchQuery {
+            query: "hello world".to_string(),
+            filters: vec![],
+            max_results: None,
+        };
+        let url = build_search_url(&query);
+        assert!(!url.contains(' '), "URL must not contain raw spaces");
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_not_empty() {
+        let filters = search_filter_descriptors();
+        assert!(!filters.is_empty());
+        let keys: Vec<&str> = filters.iter().map(|f| f.key.as_str()).collect();
+        assert!(keys.contains(&"quality"));
+        assert!(keys.contains(&"sort"));
+        assert!(keys.contains(&"date"));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_have_values() {
+        let filters = search_filter_descriptors();
+        for filter in &filters {
+            assert!(
+                !filter.allowed_values.is_empty(),
+                "Filter '{}' has no values",
+                filter.key
+            );
+            assert!(
+                !filter.display_name.is_empty(),
+                "Filter '{}' has no display name",
+                filter.key
+            );
+        }
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xhamster/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/patterns.rs
@@ -170,6 +170,7 @@ pub static XHAMSTER_SEARCH_PATTERN: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Check if a URL is an xHamster search URL.
+#[allow(dead_code)]
 pub fn is_search_url(url: &str) -> bool {
     XHAMSTER_SEARCH_PATTERN.is_match(url)
 }
@@ -552,9 +553,7 @@ mod tests {
     #[test]
     fn test_non_search_url_rejected() {
         assert!(!is_search_url("https://xhamster.com/videos/test-123"));
-        assert!(!is_search_url(
-            "https://xhamster.com/users/someone/videos"
-        ));
+        assert!(!is_search_url("https://xhamster.com/users/someone/videos"));
         assert!(!is_search_url("https://xhamster.com/"));
     }
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -20,18 +20,17 @@ pub fn extract_initials_json(html: &str) -> Result<Value> {
         RdlpError::Extraction("Could not find window.initials in search page".to_string())
     })?;
 
-    serde_json::from_str(json_str).map_err(|e| {
-        RdlpError::Extraction(format!("Failed to parse window.initials JSON: {e}"))
-    })
+    serde_json::from_str(json_str)
+        .map_err(|e| RdlpError::Extraction(format!("Failed to parse window.initials JSON: {e}")))
 }
 
 /// Parse search result previews from the `window.initials` JSON.
 pub fn parse_search_results_json(initials: &Value) -> Result<Vec<SearchResultPreview>> {
     let data = initials
-        .pointer("/searchResult/data")
+        .pointer("/searchResult/videoThumbProps")
         .and_then(|d| d.as_array())
         .ok_or_else(|| {
-            RdlpError::Extraction("Missing searchResult.data array".to_string())
+            RdlpError::Extraction("Missing searchResult.videoThumbProps array".to_string())
         })?;
 
     let mut results = Vec::with_capacity(data.len());
@@ -48,13 +47,17 @@ pub fn parse_search_results_json(initials: &Value) -> Result<Vec<SearchResultPre
             .and_then(|v| v.as_str())
             .unwrap_or("Unknown")
             .to_string();
-        let thumbnail_url = item.get("thumbURL").and_then(|v| v.as_str()).map(String::from);
-        let duration = item.get("duration").and_then(|v| v.as_f64());
-        let view_count = item.get("views").and_then(|v| v.as_u64());
-        let upload_date = item
-            .get("created")
+        let thumbnail_url = item
+            .get("thumbURL")
             .and_then(|v| v.as_str())
             .map(String::from);
+        let duration = item.get("duration").and_then(|v| v.as_f64());
+        let view_count = item.get("views").and_then(|v| v.as_u64());
+        // `created` is a Unix timestamp on xHamster
+        let upload_date = item
+            .get("created")
+            .and_then(|v| v.as_u64())
+            .map(|ts| ts.to_string());
 
         results.push(SearchResultPreview {
             video_url,
@@ -71,8 +74,9 @@ pub fn parse_search_results_json(initials: &Value) -> Result<Vec<SearchResultPre
 
 /// Extract the max page count from the initials JSON.
 pub fn parse_max_pages(initials: &Value) -> Option<usize> {
+    // Primary: top-level pagination object
     initials
-        .pointer("/searchResult/maxPages")
+        .pointer("/pagination/maxPages")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
 }
@@ -107,8 +111,11 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
 
                 let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
                 if !valid {
-                    let allowed: Vec<&str> =
-                        desc.allowed_values.iter().map(|v| v.value.as_str()).collect();
+                    let allowed: Vec<&str> = desc
+                        .allowed_values
+                        .iter()
+                        .map(|v| v.value.as_str())
+                        .collect();
                     return Err(RdlpError::Extraction(format!(
                         "Invalid value '{}' for filter '{}'. Allowed: {}",
                         filter.value,
@@ -130,7 +137,7 @@ mod tests {
     fn sample_initials_json() -> &'static str {
         r#"{
             "searchResult": {
-                "data": [
+                "videoThumbProps": [
                     {
                         "id": 12345,
                         "title": "Test Video One",
@@ -138,7 +145,7 @@ mod tests {
                         "thumbURL": "https://thumb1.jpg",
                         "duration": 180,
                         "views": 5000,
-                        "created": "2025-01-15"
+                        "created": 1705276800
                     },
                     {
                         "id": 67890,
@@ -147,11 +154,14 @@ mod tests {
                         "thumbURL": "https://thumb2.jpg",
                         "duration": 360,
                         "views": 12000,
-                        "created": "2025-02-01"
+                        "created": 1706745600
                     }
-                ],
-                "maxPages": 5,
-                "currentPage": 1
+                ]
+            },
+            "pagination": {
+                "active": 1,
+                "next": 2,
+                "maxPages": 5
             }
         }"#
     }
@@ -174,7 +184,7 @@ mod tests {
     #[test]
     fn test_parse_search_results_empty() {
         let json: serde_json::Value = serde_json::from_str(
-            r#"{"searchResult": {"data": [], "maxPages": 0, "currentPage": 1}}"#,
+            r#"{"searchResult": {"videoThumbProps": []}, "pagination": {"maxPages": 0}}"#,
         )
         .unwrap();
         let results = parse_search_results_json(&json).unwrap();
@@ -190,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_extract_initials_json_from_html() {
-        let html = r#"<script>window.initials={"searchResult":{"data":[],"maxPages":0,"currentPage":1}};</script>"#;
+        let html = r#"<script>window.initials={"searchResult":{"videoThumbProps":[]},"pagination":{"maxPages":0}};</script>"#;
         let json = extract_initials_json(html).unwrap();
         assert!(json.get("searchResult").is_some());
     }

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -1,0 +1,232 @@
+//! XHamster search result parsing and filter validation.
+
+use log::warn;
+use rdlp_core::{RdlpError, Result, SearchFilter, SearchResultPreview};
+use serde_json::Value;
+
+use super::patterns;
+
+/// Parse `window.initials` JSON from the search page HTML.
+pub fn extract_initials_json(html: &str) -> Result<Value> {
+    let json_str = [
+        &*patterns::INITIALS_PATTERN,
+        &*patterns::INITIALS_FALLBACK_PATTERN,
+    ]
+    .iter()
+    .find_map(|pat| pat.captures(html))
+    .and_then(|caps| caps.get(1))
+    .map(|m| m.as_str())
+    .ok_or_else(|| {
+        RdlpError::Extraction("Could not find window.initials in search page".to_string())
+    })?;
+
+    serde_json::from_str(json_str).map_err(|e| {
+        RdlpError::Extraction(format!("Failed to parse window.initials JSON: {e}"))
+    })
+}
+
+/// Parse search result previews from the `window.initials` JSON.
+pub fn parse_search_results_json(initials: &Value) -> Result<Vec<SearchResultPreview>> {
+    let data = initials
+        .pointer("/searchResult/data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| {
+            RdlpError::Extraction("Missing searchResult.data array".to_string())
+        })?;
+
+    let mut results = Vec::with_capacity(data.len());
+    for item in data {
+        let video_url = match item.get("pageURL").and_then(|v| v.as_str()) {
+            Some(url) => url.to_string(),
+            None => {
+                warn!("[XHamster] Search result missing pageURL, skipping");
+                continue;
+            }
+        };
+        let title = item
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown")
+            .to_string();
+        let thumbnail_url = item.get("thumbURL").and_then(|v| v.as_str()).map(String::from);
+        let duration = item.get("duration").and_then(|v| v.as_f64());
+        let view_count = item.get("views").and_then(|v| v.as_u64());
+        let upload_date = item
+            .get("created")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        results.push(SearchResultPreview {
+            video_url,
+            title,
+            thumbnail_url,
+            duration,
+            view_count,
+            upload_date,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Extract the max page count from the initials JSON.
+pub fn parse_max_pages(initials: &Value) -> Option<usize> {
+    initials
+        .pointer("/searchResult/maxPages")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+}
+
+/// Validate search filters against the known xHamster filter descriptors.
+pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
+    let descriptors = patterns::search_filter_descriptors();
+
+    for filter in filters {
+        let descriptor = descriptors.iter().find(|d| d.key == filter.key);
+
+        match descriptor {
+            None => {
+                let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
+                return Err(RdlpError::Extraction(format!(
+                    "Unknown filter '{}' for XHamster. Available: {}",
+                    filter.key,
+                    valid_keys.join(", ")
+                )));
+            }
+            Some(desc) => {
+                // Duration min/max are numeric, allow any reasonable value
+                if filter.key == "duration-min" || filter.key == "duration-max" {
+                    if filter.value.parse::<u32>().is_err() {
+                        return Err(RdlpError::Extraction(format!(
+                            "Invalid value '{}' for filter '{}'. Must be a number.",
+                            filter.value, filter.key
+                        )));
+                    }
+                    continue;
+                }
+
+                let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
+                if !valid {
+                    let allowed: Vec<&str> =
+                        desc.allowed_values.iter().map(|v| v.value.as_str()).collect();
+                    return Err(RdlpError::Extraction(format!(
+                        "Invalid value '{}' for filter '{}'. Allowed: {}",
+                        filter.value,
+                        filter.key,
+                        allowed.join(", ")
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_initials_json() -> &'static str {
+        r#"{
+            "searchResult": {
+                "data": [
+                    {
+                        "id": 12345,
+                        "title": "Test Video One",
+                        "pageURL": "https://xhamster.com/videos/test-video-one-xh12345",
+                        "thumbURL": "https://thumb1.jpg",
+                        "duration": 180,
+                        "views": 5000,
+                        "created": "2025-01-15"
+                    },
+                    {
+                        "id": 67890,
+                        "title": "Test Video Two",
+                        "pageURL": "https://xhamster.com/videos/test-video-two-xh67890",
+                        "thumbURL": "https://thumb2.jpg",
+                        "duration": 360,
+                        "views": 12000,
+                        "created": "2025-02-01"
+                    }
+                ],
+                "maxPages": 5,
+                "currentPage": 1
+            }
+        }"#
+    }
+
+    #[test]
+    fn test_parse_search_results_from_json() {
+        let json: serde_json::Value = serde_json::from_str(sample_initials_json()).unwrap();
+        let results = parse_search_results_json(&json).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Test Video One");
+        assert_eq!(
+            results[0].video_url,
+            "https://xhamster.com/videos/test-video-one-xh12345"
+        );
+        assert_eq!(results[0].duration, Some(180.0));
+        assert_eq!(results[0].view_count, Some(5000));
+        assert_eq!(results[1].title, "Test Video Two");
+    }
+
+    #[test]
+    fn test_parse_search_results_empty() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{"searchResult": {"data": [], "maxPages": 0, "currentPage": 1}}"#,
+        )
+        .unwrap();
+        let results = parse_search_results_json(&json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_max_pages() {
+        let json: serde_json::Value = serde_json::from_str(sample_initials_json()).unwrap();
+        let max_pages = parse_max_pages(&json);
+        assert_eq!(max_pages, Some(5));
+    }
+
+    #[test]
+    fn test_extract_initials_json_from_html() {
+        let html = r#"<script>window.initials={"searchResult":{"data":[],"maxPages":0,"currentPage":1}};</script>"#;
+        let json = extract_initials_json(html).unwrap();
+        assert!(json.get("searchResult").is_some());
+    }
+
+    #[test]
+    fn test_validate_filters_valid() {
+        let filters = vec![
+            SearchFilter {
+                key: "quality".to_string(),
+                value: "1080p".to_string(),
+            },
+            SearchFilter {
+                key: "sort".to_string(),
+                value: "newest".to_string(),
+            },
+        ];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_filters_invalid_key() {
+        let filters = vec![SearchFilter {
+            key: "nonexistent".to_string(),
+            value: "foo".to_string(),
+        }];
+        let err = validate_search_filters(&filters).unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_validate_filters_invalid_value() {
+        let filters = vec![SearchFilter {
+            key: "quality".to_string(),
+            value: "ultra".to_string(),
+        }];
+        let err = validate_search_filters(&filters).unwrap_err();
+        assert!(err.to_string().contains("ultra"));
+    }
+}

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -48,7 +48,7 @@ pub use extractors::{
 pub use base::common::BaseExtractor;
 pub use base::tnaflix_network::TnaFlixNetworkBase;
 
-use rdlp_core::InfoExtractor;
+use rdlp_core::{InfoExtractor, SearchExtractor};
 use std::sync::Arc;
 
 /// Trait for extractor registries to enable mocking in tests
@@ -63,6 +63,7 @@ pub trait ExtractorRegistryTrait: Send + Sync {
 /// Registry for managing extractors
 pub struct ExtractorRegistry {
     extractors: Vec<Arc<dyn InfoExtractor>>,
+    search_extractors: Vec<Arc<dyn SearchExtractor>>,
 }
 
 impl ExtractorRegistry {
@@ -71,6 +72,7 @@ impl ExtractorRegistry {
     pub fn new() -> Self {
         let mut registry = Self {
             extractors: Vec::with_capacity(8),
+            search_extractors: Vec::with_capacity(4),
         };
 
         // Register TNAFlix network extractors
@@ -92,6 +94,11 @@ impl ExtractorRegistry {
 
         // Register 9anime extractor
         registry.register(Arc::new(NineAnimeExtractor::new()));
+
+        // Register search extractors
+        registry
+            .search_extractors
+            .push(Arc::new(XHamsterExtractor::new()));
 
         registry
     }
@@ -140,6 +147,30 @@ impl ExtractorRegistry {
     pub fn list_extractors(&self) -> Vec<&str> {
         self.extractors.iter().map(|e| e.name()).collect()
     }
+
+    /// Find a search extractor by site name (case-insensitive).
+    ///
+    /// # Arguments
+    /// * `name` - Site name to look up (e.g., "xhamster", "XHamster")
+    ///
+    /// # Returns
+    /// An `Arc<dyn SearchExtractor>` if found, `None` otherwise
+    #[must_use]
+    pub fn find_search_extractor(&self, name: &str) -> Option<Arc<dyn SearchExtractor>> {
+        self.search_extractors
+            .iter()
+            .find(|e| e.name().eq_ignore_ascii_case(name))
+            .cloned()
+    }
+
+    /// List all registered search extractor names.
+    ///
+    /// # Returns
+    /// A vector of site names that support search
+    #[must_use]
+    pub fn list_search_extractors(&self) -> Vec<&str> {
+        self.search_extractors.iter().map(|e| e.name()).collect()
+    }
 }
 
 impl Default for ExtractorRegistry {
@@ -174,6 +205,38 @@ mod tests {
         assert!(extractors.contains(&"XTits"));
         assert!(extractors.contains(&"XHamster"));
         assert!(extractors.contains(&"9anime"));
+    }
+
+    #[test]
+    fn test_find_search_extractor_xhamster() {
+        let registry = ExtractorRegistry::new();
+        let extractor = registry.find_search_extractor("xhamster");
+        assert!(extractor.is_some());
+        assert_eq!(extractor.unwrap().name(), "XHamster");
+    }
+
+    #[test]
+    fn test_find_search_extractor_case_insensitive() {
+        let registry = ExtractorRegistry::new();
+        assert!(registry.find_search_extractor("XHamster").is_some());
+        assert!(registry.find_search_extractor("XHAMSTER").is_some());
+    }
+
+    #[test]
+    fn test_find_search_extractor_unknown() {
+        let registry = ExtractorRegistry::new();
+        assert!(registry.find_search_extractor("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_list_search_extractors() {
+        let registry = ExtractorRegistry::new();
+        let sites = registry.list_search_extractors();
+        assert!(
+            sites
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case("xhamster"))
+        );
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -58,6 +58,16 @@ pub trait ExtractorRegistryTrait: Send + Sync {
 
     /// Get all registered extractor names
     fn list_extractors(&self) -> Vec<&str>;
+
+    /// Find a search extractor by site name (case-insensitive).
+    fn find_search_extractor(&self, _name: &str) -> Option<Arc<dyn SearchExtractor>> {
+        None
+    }
+
+    /// List all registered search extractor names.
+    fn list_search_extractors(&self) -> Vec<&str> {
+        Vec::new()
+    }
 }
 
 /// Registry for managing extractors
@@ -186,6 +196,14 @@ impl ExtractorRegistryTrait for ExtractorRegistry {
 
     fn list_extractors(&self) -> Vec<&str> {
         self.list_extractors()
+    }
+
+    fn find_search_extractor(&self, name: &str) -> Option<Arc<dyn SearchExtractor>> {
+        self.find_search_extractor(name)
+    }
+
+    fn list_search_extractors(&self) -> Vec<&str> {
+        self.list_search_extractors()
     }
 }
 

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod container;
 pub mod format;
 pub mod info_dict;
 pub mod protocol;
+pub mod search;
 pub mod subtitle_format;
 pub mod subtitle_kind;
 pub mod subtitle_selection;
@@ -43,6 +44,10 @@ pub use container::ContainerFormat;
 pub use format::{Format, FormatSelector, Fragment};
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use protocol::DownloadProtocol;
+pub use search::{
+    SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchQuery, SearchResultPreview,
+    SearchSiteInfo,
+};
 pub use subtitle_format::SubtitleFormat;
 pub use subtitle_kind::SubtitleKind;
 pub use subtitle_selection::{select_subtitles, subtitle_filename};

--- a/crates/rdlp-types/src/search.rs
+++ b/crates/rdlp-types/src/search.rs
@@ -1,0 +1,134 @@
+//! Search query and result types for site-specific search extractors.
+
+use serde::{Deserialize, Serialize};
+
+/// A search request with query text and optional filters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchQuery {
+    /// The free-text search term.
+    pub query: String,
+    /// Active filter key-value pairs.
+    pub filters: Vec<SearchFilter>,
+    /// Maximum number of results to return. `None` uses the site default / MAX_PLAYLIST_SIZE cap.
+    pub max_results: Option<usize>,
+}
+
+/// A concrete filter key-value applied to a search.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchFilter {
+    /// Filter key (e.g. "quality", "sort").
+    pub key: String,
+    /// Filter value (e.g. "1080p", "newest").
+    pub value: String,
+}
+
+/// Describes a filter a site supports (for CLI help / UI construction).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchFilterDescriptor {
+    /// Machine-readable key used in `SearchFilter::key`.
+    pub key: String,
+    /// Human-readable name for display.
+    pub display_name: String,
+    /// Allowed values for this filter.
+    pub allowed_values: Vec<SearchFilterValue>,
+    /// Default value (if any).
+    pub default: Option<String>,
+}
+
+/// A single selectable value inside a filter descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchFilterValue {
+    /// Machine-readable value used in `SearchFilter::value`.
+    pub value: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// A lightweight preview of a single search result.
+///
+/// Does NOT contain full format/download information. Callers that need
+/// full metadata should call `InfoExtractor::extract()` on `video_url`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchResultPreview {
+    /// Direct URL to the video page (suitable for `find_extractor()` + `extract()`).
+    pub video_url: String,
+    /// Video title.
+    pub title: String,
+    /// Thumbnail image URL.
+    pub thumbnail_url: Option<String>,
+    /// Duration in seconds.
+    pub duration: Option<f64>,
+    /// View count.
+    pub view_count: Option<u64>,
+    /// Upload date string (site-specific format).
+    pub upload_date: Option<String>,
+}
+
+/// Information about a site that supports search.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchSiteInfo {
+    /// Machine-readable name (e.g. "xhamster").
+    pub name: String,
+    /// Human-readable display name (e.g. "XHamster").
+    pub display_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_query_default() {
+        let q = SearchQuery {
+            query: "test".to_string(),
+            filters: vec![],
+            max_results: None,
+        };
+        assert_eq!(q.query, "test");
+        assert!(q.filters.is_empty());
+        assert_eq!(q.max_results, None);
+    }
+
+    #[test]
+    fn test_search_filter_descriptor_round_trip() {
+        let desc = SearchFilterDescriptor {
+            key: "quality".to_string(),
+            display_name: "Minimum quality".to_string(),
+            allowed_values: vec![SearchFilterValue {
+                value: "720p".to_string(),
+                label: "720p+".to_string(),
+            }],
+            default: None,
+        };
+        let json = serde_json::to_string(&desc).unwrap();
+        let parsed: SearchFilterDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(desc, parsed);
+    }
+
+    #[test]
+    fn test_search_result_preview_fields() {
+        let preview = SearchResultPreview {
+            video_url: "https://xhamster.com/videos/test-123".to_string(),
+            title: "Test Video".to_string(),
+            thumbnail_url: Some("https://thumb.jpg".to_string()),
+            duration: Some(120.0),
+            view_count: Some(1000),
+            upload_date: None,
+        };
+        assert_eq!(preview.title, "Test Video");
+        assert_eq!(preview.duration, Some(120.0));
+    }
+
+    #[test]
+    fn test_search_filter_equality() {
+        let f1 = SearchFilter {
+            key: "sort".to_string(),
+            value: "newest".to_string(),
+        };
+        let f2 = SearchFilter {
+            key: "sort".to_string(),
+            value: "newest".to_string(),
+        };
+        assert_eq!(f1, f2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add generic `SearchExtractor` trait and search types (`SearchQuery`, `SearchResultPreview`, `SearchFilterDescriptor`) to `rdlp-types` and `rdlp-core`
- Implement XHamster search with paginated results (up to 898 results tested), filter validation, and rate-limited page fetching
- Expose search API through `rdlp-api` (`RdlpClient::search()`, `search_preview()`, `list_search_sites()`, `search_filters()`)
- Add `--search`, `--search-site`, `--search-filter` CLI flags to `rdlp-cli`

## Test Plan
- [ ] `cargo test` — all tests pass across 15 crates
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — clean
- [ ] Manual: `cargo run -- --search "test" --search-site xhamster` returns results
- [ ] Manual: `cargo run -- --search "test" --search-site xhamster --search-filter "quality=1080p"` filters correctly