### PR TITLE
docs: simplify README and add BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,128 @@
+# Building from Source
+
+## Requirements
+
+- **Rust 1.85+** (2024 edition)
+- **FFmpeg 5-8 shared libraries** (headers and `.lib`/`.so`/`.dylib`)
+- **C compiler** (MSVC on Windows, gcc on Linux, clang on macOS) — needed to compile bundled SQLite
+
+TLS is handled by Rustls. No OpenSSL or system TLS libraries are required.
+
+## FFmpeg
+
+The build links dynamically against FFmpeg. The libraries must be installed
+and discoverable before running `cargo build`.
+
+### Linux
+
+Install the development packages for your distribution:
+
+```
+# Debian/Ubuntu
+apt install libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libswscale-dev libswresample-dev
+
+# Fedora
+dnf install ffmpeg-devel
+
+# Arch
+pacman -S ffmpeg
+```
+
+`pkg-config` must be able to find the FFmpeg libraries.
+
+### macOS
+
+```
+brew install ffmpeg
+```
+
+### Windows
+
+Install a shared FFmpeg build. The build script auto-detects these locations
+in order:
+
+1. `FFMPEG_DIR` environment variable (highest priority)
+2. WinGet package (`Gyan.FFmpeg.Shared`)
+3. Chocolatey (`ffmpeg-shared` or `ffmpeg` package)
+4. Program Files directories
+5. Derived from `ffmpeg.exe` in `PATH`
+
+The directory must contain `include/libavcodec/` and `lib/` subdirectories.
+
+To set explicitly:
+
+```
+set FFMPEG_DIR=C:\path\to\ffmpeg-shared
+```
+
+Or install via WinGet:
+
+```
+winget install Gyan.FFmpeg.Shared
+```
+
+## Clone
+
+```
+git clone https://github.com/crippledgeek/rdlp.git
+cd rdlp
+```
+
+## Build
+
+```
+cargo build --release
+```
+
+The binary is at `target/release/rdlp` (`rdlp.exe` on Windows).
+
+Debug build:
+
+```
+cargo build
+```
+
+## Run
+
+```
+./target/release/rdlp --help
+```
+
+## Tests
+
+```
+cargo test
+```
+
+Single crate:
+
+```
+cargo test -p rdlp-extractor
+```
+
+Lint and format checks:
+
+```
+cargo clippy -- -D warnings
+cargo fmt --check
+```
+
+## Troubleshooting
+
+**FFmpeg not found (Windows)**
+
+The build script prints warnings if it cannot locate FFmpeg. Set `FFMPEG_DIR`
+to the root of your shared FFmpeg build and ensure it contains `include/` and
+`lib/` subdirectories.
+
+**Linker errors for avcodec/avformat/avutil**
+
+FFmpeg shared libraries are not installed or not on the library search path.
+On Linux, verify with `pkg-config --libs libavcodec`. On macOS, verify
+Homebrew's FFmpeg is linked: `brew link ffmpeg`.
+
+**`cc` crate fails to find a C compiler**
+
+Bundled SQLite compilation requires a C compiler. On Windows, install the
+Visual Studio Build Tools (MSVC). On Linux, install `build-essential` or
+equivalent. On macOS, install Xcode Command Line Tools: `xcode-select --install`.

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -70,6 +70,7 @@ rdlp/
 ├── tests/                   # Integration tests
 ├── Cargo.toml               # Workspace manifest
 ├── README.md                # Project overview
+├── BUILDING.md              # Building from source
 ├── CLAUDE.md                # AI assistant guidance
 ├── CODING_RULES.md          # This file
 └── CONTRIBUTING.md          # Contribution guidelines
@@ -324,7 +325,7 @@ pub async fn extract_info(&self, url: &str, ctx: &ExtractContext) -> Result<Info
 ```
 
 ### Project Documentation
-- **Root**: Only `README.md`, `CLAUDE.md`, `CODING_RULES.md`, `CONTRIBUTING.md`
+- **Root**: Only `README.md`, `BUILDING.md`, `CLAUDE.md`, `CODING_RULES.md`, `CONTRIBUTING.md`
 - **All other docs**: In `docs/` subdirectory
 - **Governance**: See `docs/documentation-standards.md` (not committed to git)
 - **No auto-generated docs**: Keep docs intentional and maintained

--- a/README.md
+++ b/README.md
@@ -1,386 +1,79 @@
 # rdlp
 
-**Rust Download Program** - A fast, extensible video downloader written in Rust.
-
-[![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/crippledgeek/rdlp)
-[![Rust Version](https://img.shields.io/badge/rust-2024%20edition-orange.svg)](https://www.rust-lang.org/)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
-
-Inspired by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Built on tokio, reqwest, and FFmpeg library bindings.
+A video downloader that extracts metadata and media from supported
+sites, downloads via HTTP or HLS with parallel chunking, and
+post-processes with FFmpeg library bindings. Inspired by
+[yt-dlp](https://github.com/yt-dlp/yt-dlp).
 
 ## Features
 
-- **Performance** - 10+ MB/s downloads with parallel chunking and power-of-two sizing
-- **HLS support** - Full streaming with duration-based progress, DRM detection, live stream warnings, resume validation, PTS normalization
-- **Post-processing** - FFmpeg library bindings for remux, audio extraction, video conversion, metadata embedding
-- **Thumbnails** - Auto-download and embed cover art; MP4 uses iTunes `covr` atom for Windows Explorer visibility
-- **28 container formats** - MP4, MKV, WebM, MOV, AVI, TS, FLV, 3GP, MPG, ASF/WMV, MXF, VOB, IVF, and audio containers (MP3, FLAC, WAV, Opus, AAC, AIFF, etc.)
-- **16 video codecs** - H.264, H.265, VP8, VP9, AV1, VVC/H.266, MPEG-1/2/4, ProRes, DNxHD, Theora, FFV1, Xvid, WMV2
-- **14 audio codecs** - MP3, AAC, M4A, Opus, Vorbis, FLAC, ALAC, WAV, AC-3, E-AC-3, DTS, MP2, WavPack, TTA
-- **Resume** - Ctrl+C to pause, re-run to resume automatically
-- **Output templates** - Full yt-dlp `%(field)s` syntax with fallbacks, arithmetic, date formatting, slicing, 13 format types
-- **Format selection** - yt-dlp-compatible DSL with filters, merge (`+`), and fallback chains (`/`)
-- **Interactive** - Arrow-key format selection, container remux menu
-- **Playlists** - Batch downloads with pagination (PornHub)
-- **Cookie support** - Browser extraction (Chrome, Firefox) and Netscape cookie files
-- **Rate limiting** - Global bandwidth throttle with human-readable rates (`1M`, `500K`, `2.5G`)
-- **Download archive** - Skip already-downloaded videos on re-run (`--download-archive`)
-- **JSON metadata** - `--dump-json` and `--print` for scripting (`rdlp --dump-json URL | jq .title`)
+- HTTP and HLS downloads with resume support
+- Parallel chunked transfers
+- FFmpeg-based post-processing (remux, transcode, audio extraction, metadata/thumbnail embedding)
+- yt-dlp-compatible format selection and output templates
+- Browser cookie extraction (Chrome, Firefox) and Netscape cookie files
+- Rate limiting, download archive, JSON metadata export
+- Interactive format and container selection
 
-### Supported Sites
+## Supported Sites
 
-| Site | Formats | Features |
-|------|---------|----------|
-| PornHub | HLS + MP4 | Multi-quality (240p-1080p), playlist support, CDN Referer auth |
-| XHamster | HLS + MP4 | Multi-quality (144p-2160p), AV1 + H.264, encrypted URL decryption, user playlists |
-| RedTube | HLS + MP4 | Multi-quality (240p-1080p), segment-based progress |
-| XTits | MP4 | Direct download, multi-quality (480p-720p) |
-| TNAFlix | MP4 | Multi-quality (144p-480p) |
-| EMPFlix | MP4 | Multi-quality (144p-1080p) |
-| MovieFap | MP4 | Multi-quality (144p-1080p) |
+PornHub, XHamster, RedTube, XTits, TNAFlix, EMPFlix, MovieFap.
 
-## Installation
+See `rdlp --list-extractors` for the current list.
 
-Requires **Rust 2024 Edition** (1.85+).
+## Building
 
-```bash
+Requires Rust 1.85+ and FFmpeg shared libraries.
+
+```
 git clone https://github.com/crippledgeek/rdlp.git
 cd rdlp
 cargo build --release
-# Binary: ./target/release/rdlp
 ```
+
+See [BUILDING.md](BUILDING.md) for platform-specific FFmpeg setup and troubleshooting.
 
 ## Usage
 
-```bash
-# Basic download (auto-selects best quality)
-rdlp "https://www.redtube.com/12345678"
-
-# Interactive format selection
-rdlp -i "https://www.redtube.com/12345678"
-
-# Remux HLS to MP4/MKV for better seeking
-rdlp --remux "https://www.redtube.com/12345678"
-rdlp --remux=mp4 "https://www.redtube.com/12345678"
-
-# Playlist download
-rdlp "https://www.pornhub.com/playlist/123456"
-
-# With browser cookies
-rdlp --cookies-from-browser chrome "https://www.pornhub.com/view_video.php?viewkey=..."
-
-# With cookie file (Netscape format)
-rdlp --cookies cookies.txt "https://www.pornhub.com/view_video.php?viewkey=..."
-
-# Format selection (yt-dlp compatible syntax)
-rdlp -f "bv[height<=720]+ba" "https://www.redtube.com/12345678"
-rdlp -f "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]" "https://www.redtube.com/12345678"
-rdlp -f "worst" "https://www.redtube.com/12345678"
-
-# Limit download speed
-rdlp -r 1M "https://www.redtube.com/12345678"
-rdlp --limit-rate 500K "https://www.redtube.com/12345678"
-
-# Extract audio (interactive format selection)
-rdlp -x --audio-format "https://www.redtube.com/12345678"
-rdlp -x --audio-format=flac "https://www.redtube.com/12345678"
-
-# Re-encode video (interactive codec selection)
-rdlp --recode-video "https://www.redtube.com/12345678"
-rdlp --recode-video=webm "https://www.redtube.com/12345678"
-
-# List supported codecs
-rdlp --list-codecs
-
-# Thumbnail control
-rdlp --no-thumbnail "https://www.redtube.com/12345678"       # Skip thumbnail download/embed
-rdlp --write-thumbnail "https://www.redtube.com/12345678"     # Keep thumbnail file on disk
-
-# Skip already-downloaded videos (playlist or repeated runs)
-rdlp --download-archive archive.txt "https://www.pornhub.com/playlist/123456"
-
-# Dump metadata as JSON (no download)
-rdlp --dump-json "https://www.redtube.com/12345678"
-rdlp --dump-json "https://www.redtube.com/12345678" | jq .title
-
-# Print specific fields
-rdlp --print title "https://www.redtube.com/12345678"
-rdlp --print "id,title,extractor" "https://www.redtube.com/12345678"
-
-# Verbose mode
-rdlp -v "https://www.redtube.com/12345678"
+```
+rdlp URL                              # download best quality
+rdlp -i URL                           # interactive format selection
+rdlp --remux=mp4 URL                  # remux to MP4
+rdlp -f "bv[height<=720]+ba" URL      # format selection
+rdlp -x --audio-format=flac URL       # extract audio
+rdlp --cookies-from-browser chrome URL # use browser cookies
+rdlp --dump-json URL                  # metadata as JSON
 ```
 
-### Format Selection
-
-Supports yt-dlp-compatible format selection syntax with filters, merge, and fallback chains.
-
-```
-# Syntax
-expression   = format_spec ( "/" format_spec )*     # fallback chain
-format_spec  = selector ( "+" selector )?           # video+audio merge
-selector     = base_name filter*                    # base with optional filters
-filter       = "[" field operator value "]"
-```
-
-| Selector | Meaning |
-|----------|---------|
-| `best`, `b` | Best combined (video+audio) format |
-| `worst`, `w` | Worst combined format |
-| `bestvideo`, `bv` | Best video-only stream |
-| `bestaudio`, `ba` | Best audio-only stream |
-| `bv*`, `ba*` | Best video/audio, may include both |
-| `worstvideo`, `worstaudio` | Worst video/audio-only |
-
-**Filters**: `height`, `width`, `ext`, `vcodec`, `acodec`, `fps`, `tbr`, `vbr`, `abr`, `asr`, `filesize`, `protocol`, `format_id` with operators `=`, `!=`, `<`, `>`, `<=`, `>=`.
-
-```bash
-# Examples
-rdlp -f "best"                          # Best combined format (default)
-rdlp -f "bv+ba"                         # Best video + best audio (merge)
-rdlp -f "bv[height<=720]+ba"            # 720p or lower + best audio
-rdlp -f "ba[abr>=128]"                  # Best audio with bitrate >= 128kbps
-rdlp -f "bv[ext=mp4]+ba[ext=m4a]/b"    # MP4 video + M4A audio, fallback to best
-```
-
-### Output Templates
-
-The `-o` flag accepts yt-dlp-compatible output templates with `%(field)s` substitution.
-
-```
-%(name[.keys][+/-/*÷arith][>strf][,alternate][&replacement][|default])[#][0][width][.precision]type
-```
-
-#### Basic usage
-
-```bash
-# Default template
-rdlp "URL"                                                    # %(title)s.%(ext)s
-
-# Custom filename
-rdlp -o "%(id)s.%(ext)s" "URL"                                # abc123.mp4
-
-# Subdirectories (auto-created)
-rdlp -o "%(extractor)s/%(uploader|Unknown)s/%(title)s.%(ext)s" "URL"
-
-# Output directory + template
-rdlp -P ~/Videos -o "%(extractor)s/%(title)s.%(ext)s" "URL"
-```
-
-#### Field syntax
-
-| Feature | Syntax | Example |
-|---------|--------|---------|
-| Fallback fields | `%(field1,field2)s` | `%(uploader,channel,title)s` |
-| Default value | `%(field\|default)s` | `%(uploader\|Unknown)s` |
-| Missing → `NA` | `%(field)s` | Missing fields produce `"NA"` |
-| Conditional | `%(field&text)s` | Empty if field missing |
-| Date format | `%(field>strftime)s` | `%(upload_date>%Y-%m-%d)s` → `2023-11-14` |
-| Arithmetic | `%(field+N)d` | `%(playlist_index+10)d`, `%(duration/60).0f` |
-| Array index | `%(field.N)s` | `%(tags.0)s`, `%(tags.-1)s` |
-| String slice | `%(field.:N)s` | `%(title.:50)s`, `%(title.-10:)s` |
-| Literal `%` | `%%` | `100%% done` → `100% done` |
-
-#### Format types
-
-| Type | Description | Example |
-|------|-------------|---------|
-| `s` | String (truncate with `.N`, pad with `N`) | `%(title).50s`, `%(id)10s` |
-| `d` | Integer (zero-pad with `0N`) | `%(playlist_index)03d` → `005` |
-| `f` | Float (precision with `.N`) | `%(duration).2f` → `3661.50` |
-| `B` | Human-readable bytes (`#B` = 1024-based) | `%(filesize)B` → `590.00MB` |
-| `D` | Decimal suffixes (`#D` = 1024-based) | `%(view_count)D` → `12.3K` |
-| `R` | Thousands separator | `%(view_count)R` → `12,345` |
-| `S` | Filename-safe (`#S` = ASCII-only) | `%(title)S`, `%(title)#S` |
-| `j` | JSON (`#j` = pretty-printed) | `%(tags)j`, `%(tags)#j` |
-| `l` | List join (`#l` = newline-separated) | `%(tags)l` → `tag1, tag2` |
-| `q` | Shell-quoted | `%(title)q` → `'My Video'` |
-| `h` | HTML-escaped | `%(title)h` |
-| `c` | Int to char | `65` → `A` |
-| `U` | Unicode passthrough | `%(title)U` |
-
-#### Computed fields
-
-| Field | Description |
-|-------|-------------|
-| `epoch` | Current Unix timestamp at render time |
-| `autonumber` | Global download counter (for playlists) |
-| `ext` | Computed file extension (respects `--remux`) |
-
-```bash
-# Playlist with zero-padded numbering
-rdlp -o "%(autonumber)05d - %(title)s.%(ext)s" "URL"
-
-# Date-organized downloads
-rdlp -o "%(upload_date>%Y-%m-%d)s - %(title.:80)s.%(ext)s" "URL"
-
-# With file size in filename
-rdlp -o "%(title)s [%(filesize)B].%(ext)s" "URL"
-```
-
-### CLI Reference
-
-```
-rdlp [OPTIONS] [URL]
-```
-
-#### General
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--output <TEMPLATE>` | `-o` | Output template (default: `%(title)s.%(ext)s`). See [Output Templates](#output-templates) |
-| `--paths <DIR>` | `-P` | Output directory (default: `.`) |
-| `--format <FMT>` | `-f` | Format selection, yt-dlp syntax (default: `best`) |
-| `--interactive` | `-i` | Interactive format selection with arrow keys |
-| `--dump-json` | `-j` | Dump full metadata as JSON to stdout (no download) |
-| `--print <FIELDS>` | | Print specific metadata field(s), comma-separated (no download) |
-| `--simulate` | `-s` | Simulate only, show metadata summary |
-| `--quiet` | `-q` | Minimal output |
-| `--verbose` | `-v` | Detailed debug output |
-| `--list-extractors` | | List all supported site extractors |
-| `--list-downloaders` | | List all supported download protocols |
-| `--list-codecs` | | List all supported audio and video codecs |
-
-#### Network
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--limit-rate <RATE>` | `-r` | Limit download speed (e.g., `1M`, `500K`, `2.5G`) |
-| `--proxy <URL>` | | HTTP/HTTPS/SOCKS proxy (e.g., `socks5://127.0.0.1:1080`) |
-
-Rate limit supports binary unit suffixes: `K` (1024), `M` (1048576), `G` (1073741824). Decimal values work (e.g., `2.5M`). Plain numbers are bytes/s.
-
-#### Post-processing
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--extract-audio` | `-x` | Extract audio only (requires FFmpeg) |
-| `--audio-format[=FMT]` | | Audio format (14 codecs). Use `--audio-format` for interactive, `--audio-format=mp3` for direct |
-| `--audio-quality <Q>` | | VBR level 0-9 or bitrate like `192K` |
-| `--embed-metadata` | | Embed title, artist, etc. in the file |
-| `--embed-thumbnail` | | Embed thumbnail in the file (default: on). MP4 writes both `attached_pic` stream and iTunes `covr` atom |
-| `--no-thumbnail` | | Disable automatic thumbnail download and embedding |
-| `--write-thumbnail` | | Keep thumbnail image file on disk alongside media file |
-| `--recode-video[=FMT]` | | Re-encode video (16 codecs). Use `--recode-video` for interactive, `--recode-video=mp4` for direct |
-| `--remux[=FMT]` | | Remux to container without re-encoding (28 formats). Normalizes timestamps to start at 0. Use `--remux` for interactive, `--remux=mp4` for direct |
-| `--keep-video` | | Keep original file after post-processing |
-| `--ffmpeg-location <PATH>` | | Path to FFmpeg if not in PATH |
-
-#### Audio Normalization
-
-| Flag | Description |
-|------|-------------|
-| `--normalize-audio` | Normalize audio levels (peak mode: volume + limiter) |
-| `--loudnorm` | EBU R128 two-pass normalization (implies `--normalize-audio`) |
-| `--normalize-boost` | Limiter-boost fallback: +12 dB gain + hard limiter for over-compressed content (implies `--loudnorm`) |
-| `--normalize-boost-db <DB>` | Custom gain for limiter-boost (default: `12.0`) |
-| `--audio-gain-target <DB>` | Target peak level in dBFS for peak normalization (default: `-1.0`) |
-| `--loudnorm-preset <PRESET>` | Loudnorm preset: `broadcast` (-23 LUFS), `streaming` (-14 LUFS), `loud` (-11 LUFS) |
-| `--loudnorm-i <LUFS>` | Target integrated loudness (e.g., `-14`) |
-| `--loudnorm-tp <DBTP>` | Target true peak (e.g., `-1`) |
-| `--loudnorm-lra <LU>` | Target loudness range (e.g., `11`) |
-| `--loudnorm-dynamic` | Force dynamic (per-frame compression) mode in loudnorm pass 2 |
-| `--loudnorm-precompress` | Prepend a mild acompressor before loudnorm to tame extreme peaks |
-
-#### Cookies
-
-| Flag | Description |
-|------|-------------|
-| `--cookies-from-browser <BROWSER>` | Load cookies from browser (`chrome`, `firefox`) |
-| `--cookies <FILE>` | Load Netscape-format cookies file |
-
-#### Download Archive
-
-| Flag | Description |
-|------|-------------|
-| `--download-archive <FILE>` | Path to archive file (skip already-downloaded videos) |
-
-Records each completed download as `{extractor} {id}` (one per line) in a plain text file. On subsequent runs, videos already in the archive are skipped. Compatible with yt-dlp's archive format. Blank lines and `#` comments are ignored.
-
-```
-# Example archive file
-PornHub ph6abc123def
-RedTube 12345678
-TNAFlix 456789
-```
-
-#### Configuration
-
-| Flag | Description |
-|------|-------------|
-| `--config-location <FILE>` | Path to config file (TOML format) |
-| `--ignore-config` | Skip loading config file |
-
-rdlp loads configuration from a TOML file at startup. CLI flags override config file values.
-
-**Default location:**
-- Windows: `%APPDATA%\rdlp\config.toml`
-- Linux/macOS: `~/.config/rdlp/config.toml`
-
-**Example config file:**
-
-```toml
-format = "bv[height<=720]+ba/b"
-output_directory = "C:\\Videos"
-proxy = "socks5://127.0.0.1:1080"
-rate_limit = 5242880
-embed_metadata = true
-verbose = false
-quiet = false
-```
-
-All fields are optional — missing fields use defaults. See `Config` struct in `crates/rdlp-types/src/config.rs` for all available fields.
-
-### Resume
-
-Press **Ctrl+C** during download to pause. Re-run the same command to resume from where you left off.
-
-HLS downloads validate segment files on resume — missing or corrupted segments are automatically re-downloaded.
+Run `rdlp --help` for the full option list.
 
 ## Architecture
 
-15-crate workspace with a three-stage pipeline: **Extract** -> **Download** -> **Post-process**.
+16-crate Cargo workspace. Three-stage pipeline: extract, download, post-process.
 
-```
-rdlp/
-├── crates/
-│   ├── rdlp-types/        # Pure data types (Config, Format, InfoDict)
-│   ├── rdlp-table/        # Column layout constants for format selection table
-│   ├── rdlp-core/         # Traits (InfoExtractor, Downloader, PostProcessor)
-│   ├── rdlp-security/     # SSRF protection, URL validation
-│   ├── rdlp-http/         # HTTP client factory
-│   ├── rdlp-ratelimit/    # Async token-bucket rate limiter
-│   ├── rdlp-crypto/       # PRNG-based URL decryption (XHamster)
-│   ├── rdlp-extractor/    # Site extractors
-│   ├── rdlp-downloader/   # HTTP + HLS downloaders
-│   ├── rdlp-ffmpeg/       # FFmpeg library bindings (probe, remux, transcode, metadata)
-│   ├── rdlp-postprocess/  # Post-processing pipeline (processors, registry, mp4ameta)
-│   ├── rdlp-cookies/      # Browser cookie extraction (Chrome, Firefox, Netscape)
-│   ├── rdlp-jsinterp/     # JavaScript interpreter (boa)
-│   ├── rdlp-plugin/       # Plugin system
-│   └── rdlp-cli/          # CLI application and orchestrator
-└── docs/                  # Documentation
-```
+| Crate | Purpose |
+|-------|---------|
+| `rdlp-types` | Data types (Config, Format, InfoDict) |
+| `rdlp-core` | Traits and error types |
+| `rdlp-api` | Frontend-agnostic download engine |
+| `rdlp-security` | SSRF protection, URL validation |
+| `rdlp-http` | HTTP client factory |
+| `rdlp-ratelimit` | Token-bucket rate limiter |
+| `rdlp-crypto` | URL decryption |
+| `rdlp-extractor` | Site extractors |
+| `rdlp-downloader` | HTTP + HLS downloaders |
+| `rdlp-ffmpeg` | FFmpeg library bindings |
+| `rdlp-postprocess` | Post-processing pipeline |
+| `rdlp-cookies` | Browser cookie extraction |
+| `rdlp-jsinterp` | JavaScript interpreter |
+| `rdlp-plugin` | Plugin system |
+| `rdlp-table` | Format selection table layout |
+| `rdlp-cli` | CLI application |
 
+## Contributing
 
-## Development
-
-```bash
-cargo build --release      # Optimized build
-cargo test                 # Run all tests (400+)
-cargo clippy               # Lint check
-cargo fmt                  # Format code
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for adding extractors, code style, and development workflow.
-See [CODING_RULES.md](CODING_RULES.md) for coding standards.
-
-## Legal
-
-We only support sites with permissive Terms of Service. See [CONTRIBUTING.md](CONTRIBUTING.md) for site selection criteria.
-
-Users are responsible for complying with applicable laws and respecting website ToS.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODING_RULES.md](CODING_RULES.md).
 
 ## License
 
-Dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE).
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrote README to be concise and technical, following Linux kernel README style
- Removed CLI reference, format selection grammar, output template spec, codec lists, badges, and marketing language
- Added dedicated BUILDING.md with platform-specific FFmpeg setup (Linux, macOS, Windows) and troubleshooting
- Updated documentation standards allowlist to include BUILDING.md as a permitted root file

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify BUILDING.md renders correctly on GitHub
- [ ] Verify all links in README resolve (BUILDING.md, CONTRIBUTING.md, CODING_RULES.md, LICENSE)
- [ ] Verify build instructions in BUILDING.md are accurate