### PR TITLE
feat: add merge download for parallel video+audio

### DIFF
--- a/crates/rdlp-api/src/orchestrator/merge_download.rs
+++ b/crates/rdlp-api/src/orchestrator/merge_download.rs
@@ -92,6 +92,7 @@ impl Orchestrator {
             }
             Ok(None) => {
                 self.cleanup_merge_file(&video_path).await;
+                self.cleanup_merge_file(&audio_path).await;
                 Ok(None)
             }
             Err(e) => {

--- a/crates/rdlp-api/src/orchestrator/merge_download.rs
+++ b/crates/rdlp-api/src/orchestrator/merge_download.rs
@@ -11,7 +11,6 @@ use rdlp_core::Format;
 use std::path::{Path, PathBuf};
 
 /// Result of a successful merge download
-#[allow(dead_code)]
 pub(super) struct MergeDownloadOutcome {
     /// Path to the downloaded video file
     pub video_path: PathBuf,
@@ -21,7 +20,6 @@ pub(super) struct MergeDownloadOutcome {
     pub is_hls: bool,
 }
 
-#[allow(dead_code)]
 impl Orchestrator {
     /// Download video and audio streams in parallel for merge.
     ///

--- a/crates/rdlp-api/src/orchestrator/merge_download.rs
+++ b/crates/rdlp-api/src/orchestrator/merge_download.rs
@@ -1,0 +1,130 @@
+//! Parallel download coordination for merge (video + audio) downloads
+//!
+//! Downloads video-only and audio-only streams in parallel via `tokio::join!`,
+//! then passes both files to the postprocessor pipeline where `FFmpegMerger`
+//! handles the actual muxing.
+
+use super::Orchestrator;
+use super::errors::*;
+use log::{debug, info, warn};
+use rdlp_core::Format;
+use std::path::{Path, PathBuf};
+
+/// Result of a successful merge download
+#[allow(dead_code)]
+pub(super) struct MergeDownloadOutcome {
+    /// Path to the downloaded video file
+    pub video_path: PathBuf,
+    /// Path to the downloaded audio file
+    pub audio_path: PathBuf,
+    /// Whether either stream was HLS
+    pub is_hls: bool,
+}
+
+#[allow(dead_code)]
+impl Orchestrator {
+    /// Download video and audio streams in parallel for merge.
+    ///
+    /// Uses `tokio::join!` to download both streams concurrently via the
+    /// existing `download_with_cdn_fallback()` method. The actual FFmpeg
+    /// merge is handled downstream by the `FFmpegMerger` postprocessor.
+    ///
+    /// # Arguments
+    /// * `video` - Video-only format to download
+    /// * `audio` - Audio-only format to download
+    /// * `base_output_path` - Base output path (used to derive per-stream filenames)
+    ///
+    /// # Returns
+    /// - `Ok(Some(outcome))` -- both downloads succeeded
+    /// - `Ok(None)` -- user cancelled
+    /// - `Err(e)` -- one or both downloads failed
+    pub(super) async fn download_merge_pair(
+        &self,
+        video: &Format,
+        audio: &Format,
+        base_output_path: &Path,
+    ) -> Result<Option<MergeDownloadOutcome>> {
+        let video_path = self.merge_stream_path(base_output_path, video, "video");
+        let audio_path = self.merge_stream_path(base_output_path, audio, "audio");
+
+        info!(
+            video_format = video.format_id.as_str(),
+            audio_format = audio.format_id.as_str(),
+            video_path:? = video_path.display(),
+            audio_path:? = audio_path.display();
+            "Starting parallel merge download"
+        );
+
+        // Download both streams in parallel
+        let (video_result, audio_result) = tokio::join!(
+            self.download_with_cdn_fallback(video, &video_path, 0),
+            self.download_with_cdn_fallback(audio, &audio_path, 0),
+        );
+
+        // Handle results — clean up on failure
+        let video_outcome = match video_result {
+            Ok(Some(outcome)) => outcome,
+            Ok(None) => {
+                self.cleanup_merge_file(&audio_path).await;
+                return Ok(None);
+            }
+            Err(e) => {
+                warn!("Video download failed: {e}");
+                self.cleanup_merge_file(&video_path).await;
+                self.cleanup_merge_file(&audio_path).await;
+                return Err(e);
+            }
+        };
+
+        match audio_result {
+            Ok(Some(audio_outcome)) => {
+                let is_hls = video_outcome.is_hls || audio_outcome.is_hls;
+                debug!(
+                    video_hls = video_outcome.is_hls,
+                    audio_hls = audio_outcome.is_hls;
+                    "Merge download complete"
+                );
+                Ok(Some(MergeDownloadOutcome {
+                    video_path,
+                    audio_path,
+                    is_hls,
+                }))
+            }
+            Ok(None) => {
+                self.cleanup_merge_file(&video_path).await;
+                Ok(None)
+            }
+            Err(e) => {
+                warn!("Audio download failed: {e}");
+                self.cleanup_merge_file(&video_path).await;
+                self.cleanup_merge_file(&audio_path).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Derive the output path for one stream of a merge download.
+    ///
+    /// Produces paths like `/output/dir/Title.video.f137.mp4` for the video
+    /// stream and `/output/dir/Title.audio.f140.m4a` for the audio stream.
+    fn merge_stream_path(&self, base_output_path: &Path, format: &Format, label: &str) -> PathBuf {
+        let stem = base_output_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("output");
+        let ext = &format.ext;
+        let dir = base_output_path.parent().unwrap_or(Path::new("."));
+        dir.join(format!("{stem}.{label}.{}.{ext}", format.format_id))
+    }
+
+    /// Clean up a partially downloaded merge stream file.
+    async fn cleanup_merge_file(&self, path: &Path) {
+        if path.exists() {
+            if let Err(e) = tokio::fs::remove_file(path).await {
+                warn!(path:? = path.display(); "Failed to clean up merge temp file: {e}");
+            } else {
+                debug!(path:? = path.display(); "Cleaned up merge temp file");
+            }
+        }
+    }
+}

--- a/crates/rdlp-api/src/orchestrator/merge_download.rs
+++ b/crates/rdlp-api/src/orchestrator/merge_download.rs
@@ -11,6 +11,7 @@ use rdlp_core::Format;
 use std::path::{Path, PathBuf};
 
 /// Result of a successful merge download
+#[derive(Debug, PartialEq, Eq)]
 pub(super) struct MergeDownloadOutcome {
     /// Path to the downloaded video file
     pub video_path: PathBuf,
@@ -63,6 +64,7 @@ impl Orchestrator {
         let video_outcome = match video_result {
             Ok(Some(outcome)) => outcome,
             Ok(None) => {
+                self.cleanup_merge_file(&video_path).await;
                 self.cleanup_merge_file(&audio_path).await;
                 return Ok(None);
             }

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -259,9 +259,10 @@ impl Orchestrator {
     /// This method implements an explicit state machine for the download workflow:
     /// 1. `Extracting` - Find extractor and extract video metadata
     /// 2. `SelectingFormat` - Choose format (interactive or automatic)
-    /// 3. `Preparing` - Detect resume point and prepare for download
-    /// 4. `Downloading` - Execute download with progress tracking
-    /// 5. `Complete` - Return downloaded file path
+    /// 3. `SelectingSubtitles` - Choose subtitles (interactive or config-based)
+    /// 4. `Preparing` - Detect resume point and prepare for download
+    /// 5. `Downloading` - Execute download with progress tracking
+    /// 6. `Complete` - Return downloaded file path
     ///
     /// At any point, user can cancel via `CancellationToken` → `Cancelled` state
     ///

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -317,11 +317,10 @@ impl Orchestrator {
             phase = phase.advance(self, interactive).await?;
 
             match phase {
-                DownloadPhase::Complete { ref path } => {
-                    let result_path = path.clone();
+                DownloadPhase::Complete { path } => {
                     // Record in archive after successful download
                     self.record_in_archive(&infos[0].extractor, &infos[0].id);
-                    return Ok(Some(result_path));
+                    return Ok(Some(path));
                 }
                 DownloadPhase::Cancelled => return Ok(None),
                 _ => continue, // Keep advancing through phases

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -51,6 +51,8 @@ use tracing::instrument;
 /// `Merge` downloads video-only and audio-only in parallel, then
 /// delegates muxing to the `FFmpegMerger` postprocessor.
 #[derive(Debug, Clone)]
+// Format is large but DownloadPlan is always stored as Box<DownloadPlan>
+// in DownloadPhase, so the enum's stack size doesn't affect the state machine.
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum DownloadPlan {
     /// Download a single combined format

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -31,7 +31,7 @@ use crate::events::Event;
 use crate::handle::DownloadId;
 use log::{debug, info, warn};
 use rdlp_cookies::SimpleCookieJar;
-use rdlp_core::{Config, ExtractionContext};
+use rdlp_core::{Config, ExtractionContext, Format};
 use rdlp_downloader::{DownloaderRegistry, DownloaderRegistryTrait};
 use rdlp_extractor::{ExtractorRegistry, ExtractorRegistryTrait};
 use rdlp_http::HttpClientFactory;
@@ -43,6 +43,40 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
+
+/// Plan for how to download the selected format(s).
+///
+/// `Single` downloads one combined format.
+/// `Merge` downloads video-only and audio-only in parallel, then
+/// delegates muxing to the `FFmpegMerger` postprocessor.
+#[derive(Debug, Clone)]
+#[allow(dead_code, clippy::large_enum_variant)]
+pub(crate) enum DownloadPlan {
+    /// Download a single combined format
+    Single(Format),
+    /// Download video and audio separately, then merge
+    Merge {
+        /// Video-only format
+        video: Format,
+        /// Audio-only format
+        audio: Format,
+    },
+}
+
+impl std::fmt::Display for DownloadPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single(format) => write!(f, "single format {}", format.format_id),
+            Self::Merge { video, audio } => {
+                write!(
+                    f,
+                    "merge video {} + audio {}",
+                    video.format_id, audio.format_id
+                )
+            }
+        }
+    }
+}
 
 /// Main orchestrator coordinating extraction, download, and post-processing
 pub struct Orchestrator {
@@ -341,5 +375,54 @@ impl Orchestrator {
                 warn!("Failed to write to download archive: {e}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod download_plan_tests {
+    use super::*;
+    use rdlp_core::{DownloadProtocol, Format};
+
+    fn make_format(id: &str) -> Format {
+        Format::new(id, format!("url_{id}"), "mp4", DownloadProtocol::Https)
+    }
+
+    #[test]
+    fn test_download_plan_single() {
+        let fmt = make_format("f1");
+        let plan = DownloadPlan::Single(fmt);
+        assert!(matches!(plan, DownloadPlan::Single(f) if f.format_id == "f1"));
+    }
+
+    #[test]
+    fn test_download_plan_merge() {
+        let video = make_format("v1");
+        let audio = make_format("a1");
+        let plan = DownloadPlan::Merge { video, audio };
+        match plan {
+            DownloadPlan::Merge { video: v, audio: a } => {
+                assert_eq!(v.format_id, "v1");
+                assert_eq!(a.format_id, "a1");
+            }
+            _ => panic!("Expected Merge variant"),
+        }
+    }
+
+    #[test]
+    fn test_download_plan_display_single() {
+        let fmt = make_format("f1");
+        let plan = DownloadPlan::Single(fmt);
+        let s = format!("{plan}");
+        assert!(s.contains("f1"));
+    }
+
+    #[test]
+    fn test_download_plan_display_merge() {
+        let video = make_format("v1");
+        let audio = make_format("a1");
+        let plan = DownloadPlan::Merge { video, audio };
+        let s = format!("{plan}");
+        assert!(s.contains("v1"));
+        assert!(s.contains("a1"));
     }
 }

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -51,7 +51,7 @@ use tracing::instrument;
 /// `Merge` downloads video-only and audio-only in parallel, then
 /// delegates muxing to the `FFmpegMerger` postprocessor.
 #[derive(Debug, Clone)]
-#[allow(dead_code, clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum DownloadPlan {
     /// Download a single combined format
     Single(Format),

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -7,6 +7,7 @@ mod errors;
 mod execution;
 mod extraction;
 mod interactive;
+mod merge_download;
 mod paths;
 mod playlist;
 mod postprocess;

--- a/crates/rdlp-api/src/orchestrator/playlist.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist.rs
@@ -5,7 +5,7 @@
 
 use super::errors::is_reextractable_error;
 use super::session_state::{self, FailedEpisode, PlaylistState, SessionState};
-use super::{Orchestrator, OrchestratorError, Result, archive};
+use super::{DownloadPlan, Orchestrator, OrchestratorError, Result, archive};
 use futures_util::StreamExt;
 use log::{debug, error, info, warn};
 use rdlp_core::SubtitleFormat;
@@ -1151,11 +1151,18 @@ impl Orchestrator {
             };
 
             // Select format (non-interactive on retry to avoid re-prompting)
-            let Some(mut format) = self
+            let Some(plan) = self
                 .select_format(info_ref, interactive && attempt == 0)
                 .await?
             else {
                 return Ok(None);
+            };
+
+            // Extract the primary format from the plan (merge uses
+            // video track; playlist merge support comes in Task 4).
+            let mut format = match plan {
+                DownloadPlan::Single(f) => f,
+                DownloadPlan::Merge { video, .. } => video,
             };
 
             // Add alternative CDN server URLs as fallbacks.

--- a/crates/rdlp-api/src/orchestrator/playlist.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist.rs
@@ -31,6 +31,7 @@ const RESUME_SUB_FORMATS: &[SubtitleFormat] = &[
 ];
 
 /// Resume detection result for a playlist folder.
+#[derive(Debug)]
 pub(super) struct ResumeDetection {
     /// Completed episodes: sanitized_title -> video file path
     pub completed: HashMap<String, PathBuf>,
@@ -451,7 +452,7 @@ impl Orchestrator {
         let to_download: Vec<(usize, rdlp_core::InfoDict)> = infos
             .iter()
             .enumerate()
-            .filter(|(_, ep)| {
+            .filter_map(|(i, ep)| {
                 let sanitized = self.sanitize_filename(&ep.title);
                 let exists = downloaded.iter().any(|p| {
                     p.file_stem()
@@ -459,16 +460,15 @@ impl Orchestrator {
                         .is_some_and(|name| name == sanitized)
                 });
                 if exists {
-                    return false;
+                    return None;
                 }
                 if let Some(ref archive_set) = archive {
                     if archive::is_in_archive(archive_set, &ep.extractor, &ep.id) {
-                        return false;
+                        return None;
                     }
                 }
-                true
+                Some((i, ep.clone()))
             })
-            .map(|(i, ep)| (i, ep.clone()))
             .collect();
 
         let download_count = to_download.len();
@@ -1024,13 +1024,13 @@ impl Orchestrator {
         infos: &[rdlp_core::InfoDict],
         total: usize,
     ) {
-        for info in infos {
-            let sanitized = self.sanitize_filename(&info.title);
-            if missing_subs.contains_key(&sanitized) {
+        infos
+            .iter()
+            .filter(|info| missing_subs.contains_key(&self.sanitize_filename(&info.title)))
+            .for_each(|info| {
                 let pos = info.playlist_index.unwrap_or(0);
                 warn!("  [{pos}/{total}] {}: no subtitle files found", info.title);
-            }
-        }
+            });
     }
 
     /// Download from pre-extracted InfoDict (internal helper)

--- a/crates/rdlp-api/src/orchestrator/playlist.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist.rs
@@ -13,6 +13,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+/// Download result: (downloaded file paths, is_hls, merge formats if applicable).
+type DownloadResult = Option<(Vec<PathBuf>, bool, Option<Vec<Format>>)>;
+
 /// Maximum age of batch-resolved tokens before proactive re-extraction.
 /// Megacloud/netmagcdn tokens last ~30-60 min; we re-extract at 25 min
 /// to stay well within the window.
@@ -1085,8 +1088,7 @@ impl Orchestrator {
         const RETRY_DELAYS: [u64; MAX_EXTRACT_RETRIES] = [5, 15, 30];
 
         let mut output_path: Option<PathBuf> = None;
-        #[allow(clippy::type_complexity)]
-        let mut download_result: Option<(Vec<PathBuf>, bool, Option<Vec<Format>>)> = None;
+        let mut download_result: DownloadResult = None;
         let mut last_info_ref: Option<rdlp_core::InfoDict> = None;
 
         for attempt in 0..=MAX_EXTRACT_RETRIES {
@@ -1228,7 +1230,42 @@ impl Orchestrator {
                         Err(e) => return Err(e),
                     }
                 }
-                DownloadPlan::Merge { video, audio } => {
+                DownloadPlan::Merge {
+                    mut video,
+                    mut audio,
+                } => {
+                    // Add CDN fallback URLs for both streams
+                    let video_alts: Vec<String> = info_ref
+                        .formats
+                        .iter()
+                        .filter(|f| f.url != video.url && f.has_video() && !f.has_audio())
+                        .map(|f| f.url.clone())
+                        .collect();
+                    if !video_alts.is_empty() {
+                        let primary_host = extract_cdn_host(&video.url);
+                        let mut sorted = video_alts;
+                        sorted.sort_by_key(|u| u8::from(extract_cdn_host(u) != primary_host));
+                        video
+                            .fallback_urls
+                            .get_or_insert_with(Vec::new)
+                            .extend(sorted);
+                    }
+                    let audio_alts: Vec<String> = info_ref
+                        .formats
+                        .iter()
+                        .filter(|f| f.url != audio.url && f.has_audio() && !f.has_video())
+                        .map(|f| f.url.clone())
+                        .collect();
+                    if !audio_alts.is_empty() {
+                        let primary_host = extract_cdn_host(&audio.url);
+                        let mut sorted = audio_alts;
+                        sorted.sort_by_key(|u| u8::from(extract_cdn_host(u) != primary_host));
+                        audio
+                            .fallback_urls
+                            .get_or_insert_with(Vec::new)
+                            .extend(sorted);
+                    }
+
                     // Compute output path on first attempt only
                     if output_path.is_none() {
                         let file_ext = self.determine_file_extension(&video);

--- a/crates/rdlp-api/src/orchestrator/playlist.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist.rs
@@ -8,7 +8,7 @@ use super::session_state::{self, FailedEpisode, PlaylistState, SessionState};
 use super::{DownloadPlan, Orchestrator, OrchestratorError, Result, archive};
 use futures_util::StreamExt;
 use log::{debug, error, info, warn};
-use rdlp_core::SubtitleFormat;
+use rdlp_core::{Format, SubtitleFormat};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -1085,7 +1085,8 @@ impl Orchestrator {
         const RETRY_DELAYS: [u64; MAX_EXTRACT_RETRIES] = [5, 15, 30];
 
         let mut output_path: Option<PathBuf> = None;
-        let mut download_outcome = None;
+        #[allow(clippy::type_complexity)]
+        let mut download_result: Option<(Vec<PathBuf>, bool, Option<Vec<Format>>)> = None;
         let mut last_info_ref: Option<rdlp_core::InfoDict> = None;
 
         for attempt in 0..=MAX_EXTRACT_RETRIES {
@@ -1158,88 +1159,126 @@ impl Orchestrator {
                 return Ok(None);
             };
 
-            // Extract the primary format from the plan (merge uses
-            // video track; playlist merge support comes in Task 4).
-            let mut format = match plan {
-                DownloadPlan::Single(f) => f,
-                DownloadPlan::Merge { video, .. } => video,
-            };
-
-            // Add alternative CDN server URLs as fallbacks.
-            // Sort by CDN host stickiness: same host as primary URL first,
-            // since a working CDN server is more likely to stay healthy.
-            let mut alt_urls: Vec<String> = info_ref
-                .formats
-                .iter()
-                .filter(|f| f.url != format.url)
-                .map(|f| f.url.clone())
-                .collect();
-            if !alt_urls.is_empty() {
-                let primary_host = extract_cdn_host(&format.url);
-                alt_urls.sort_by_key(|url| u8::from(extract_cdn_host(url) != primary_host));
-                format
-                    .fallback_urls
-                    .get_or_insert_with(Vec::new)
-                    .extend(alt_urls);
-            }
-
-            // Compute output path on first attempt only
-            if output_path.is_none() {
-                let file_ext = self.determine_file_extension(&format);
-                let sanitized_title = self.sanitize_filename(&info_ref.title);
-                let filename = format!("{sanitized_title}.{file_ext}");
-                let path = output_dir.join(&filename);
-
-                self.cleanup_leftover_segments(output_dir, &sanitized_title)
-                    .await;
-
-                info!(path:? = path.display(); "Downloading to");
-                output_path = Some(path);
-            }
-
-            let path = output_path.as_ref().unwrap();
-
-            // Detect resume point (recalculate on retry for partial HLS)
-            let resume_offset = self.detect_resume_point(path, format.filesize).await?;
-
-            // Check if file is already complete
-            if let Some(expected_size) = format.filesize {
-                if resume_offset == expected_size {
-                    info!("File already complete, skipping");
-                    return Ok(Some(path.clone()));
-                }
-            }
-
             // Save info for post-download use (thumbnail, subtitles)
             last_info_ref = Some(info_ref.clone());
 
-            // Download with CDN fallback
-            match self
-                .download_with_cdn_fallback(&format, path, resume_offset)
-                .await
-            {
-                Ok(Some(outcome)) => {
-                    download_outcome = Some(outcome);
-                    break;
+            match plan {
+                DownloadPlan::Single(mut format) => {
+                    // Add alternative CDN server URLs as fallbacks.
+                    // Sort by CDN host stickiness: same host as primary URL
+                    // first, since a working CDN server is more likely to
+                    // stay healthy.
+                    let mut alt_urls: Vec<String> = info_ref
+                        .formats
+                        .iter()
+                        .filter(|f| f.url != format.url)
+                        .map(|f| f.url.clone())
+                        .collect();
+                    if !alt_urls.is_empty() {
+                        let primary_host = extract_cdn_host(&format.url);
+                        alt_urls.sort_by_key(|url| u8::from(extract_cdn_host(url) != primary_host));
+                        format
+                            .fallback_urls
+                            .get_or_insert_with(Vec::new)
+                            .extend(alt_urls);
+                    }
+
+                    // Compute output path on first attempt only
+                    if output_path.is_none() {
+                        let file_ext = self.determine_file_extension(&format);
+                        let sanitized_title = self.sanitize_filename(&info_ref.title);
+                        let filename = format!("{sanitized_title}.{file_ext}");
+                        let path = output_dir.join(&filename);
+
+                        self.cleanup_leftover_segments(output_dir, &sanitized_title)
+                            .await;
+
+                        info!(path:? = path.display(); "Downloading to");
+                        output_path = Some(path);
+                    }
+
+                    let path = output_path.as_ref().unwrap();
+
+                    // Detect resume point (recalculate on retry for partial HLS)
+                    let resume_offset = self.detect_resume_point(path, format.filesize).await?;
+
+                    // Check if file is already complete
+                    if let Some(expected_size) = format.filesize {
+                        if resume_offset == expected_size {
+                            info!("File already complete, skipping");
+                            return Ok(Some(path.clone()));
+                        }
+                    }
+
+                    // Download with CDN fallback
+                    match self
+                        .download_with_cdn_fallback(&format, path, resume_offset)
+                        .await
+                    {
+                        Ok(Some(outcome)) => {
+                            download_result = Some((vec![path.clone()], outcome.is_hls, None));
+                            break;
+                        }
+                        Ok(None) => return Ok(None),
+                        Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {
+                            warn!("All CDN URLs failed: {e}");
+                            warn!("Will re-extract fresh URLs after delay");
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    }
                 }
-                Ok(None) => return Ok(None), // User cancelled
-                Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {
-                    warn!("All CDN URLs failed: {e}");
-                    warn!("Will re-extract fresh URLs after delay");
-                    continue;
+                DownloadPlan::Merge { video, audio } => {
+                    // Compute output path on first attempt only
+                    if output_path.is_none() {
+                        let file_ext = self.determine_file_extension(&video);
+                        let sanitized_title = self.sanitize_filename(&info_ref.title);
+                        let filename = format!("{sanitized_title}.{file_ext}");
+                        let path = output_dir.join(&filename);
+
+                        self.cleanup_leftover_segments(output_dir, &sanitized_title)
+                            .await;
+
+                        info!(path:? = path.display(); "Downloading merge to");
+                        output_path = Some(path);
+                    }
+
+                    let path = output_path.as_ref().unwrap();
+
+                    // Parallel download of video + audio
+                    match self.download_merge_pair(&video, &audio, path).await {
+                        Ok(Some(merge_outcome)) => {
+                            download_result = Some((
+                                vec![merge_outcome.video_path, merge_outcome.audio_path],
+                                merge_outcome.is_hls,
+                                Some(vec![video, audio]),
+                            ));
+                            break;
+                        }
+                        Ok(None) => return Ok(None),
+                        Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {
+                            warn!("Merge download failed: {e}");
+                            warn!("Will re-extract fresh URLs after delay");
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    }
                 }
-                Err(e) => return Err(e),
             }
         }
 
-        let outcome = download_outcome.ok_or_else(|| {
+        let (download_files, is_hls, merge_formats) = download_result.ok_or_else(|| {
             OrchestratorError::DownloadFailed(rdlp_core::RdlpError::Extraction(
                 "All extraction retry attempts exhausted".to_string(),
             ))
         })?;
 
         let output_path = output_path.unwrap();
-        let final_info = last_info_ref.as_ref().unwrap_or(info);
+        let mut final_info_owned = last_info_ref.unwrap_or_else(|| info.clone());
+        if let Some(fmts) = merge_formats {
+            final_info_owned.requested_formats = Some(fmts);
+        }
+        let final_info = &final_info_owned;
 
         // Download thumbnail if needed (before post-processing so embed can find it)
         if self.config.embed_thumbnail || self.config.write_thumbnail {
@@ -1276,16 +1315,18 @@ impl Orchestrator {
             );
         }
 
-        // Run post-processing if configured (or automatic for HLS)
+        // Run post-processing if configured (or automatic for HLS).
+        // For merge downloads, passes both video + audio files so
+        // FFmpegMerger (priority 100) can mux them.
         let final_files = self
-            .run_postprocessing(final_info, vec![output_path.clone()], outcome.is_hls)
+            .run_postprocessing(final_info, download_files, is_hls)
             .await?;
         let final_path = final_files.into_iter().next().unwrap_or(output_path);
 
         // HLS downloads produce .ts files that should be remuxed to a proper
         // container. If post-processing left the file as .ts, fail the episode
         // so the retry system can re-attempt (FFmpeg may have been busy/failed).
-        if outcome.is_hls {
+        if is_hls {
             let ext = final_path
                 .extension()
                 .and_then(|e| e.to_str())

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -1,4 +1,4 @@
-//! Format selection logic
+//! Format selection logic and [`DownloadPlan`] construction
 
 use std::collections::BTreeMap;
 
@@ -6,10 +6,7 @@ use super::{DownloadPlan, Orchestrator, errors::*};
 use log::{debug, info, warn};
 use rdlp_core::{Format, FormatSelector, InfoDict};
 
-/// Whether merge download (video + audio muxed via FFmpeg) is supported.
-/// Both `resolve_effective_selector` and `select_format` check this value.
-/// Enabled in Phase 2 — merge download fully supported.
-const MERGE_SUPPORTED: bool = true;
+// Merge download (video + audio muxed via FFmpeg) is fully supported.
 
 impl Orchestrator {
     /// Resolve the effective format selector string based on runtime
@@ -19,10 +16,9 @@ impl Orchestrator {
     /// 1. Explicit user format (`config.format = Some(...)`) always wins
     /// 2. Otherwise, compute default from:
     ///    - `ffmpeg_available` -- from `postprocessor_registry.is_some()`
-    ///    - `merge_supported` -- true (merge download fully supported)
     ///    - `audio_multistreams` -- from `config.audio_multistreams`
     ///
-    /// # Defaults (merge supported)
+    /// # Defaults
     ///
     /// | Condition | Default |
     /// |-----------|---------|
@@ -45,29 +41,20 @@ impl Orchestrator {
         let ffmpeg_available = self.postprocessor_registry.is_some();
         let audio_multistreams = self.config.audio_multistreams;
 
-        let selector = if MERGE_SUPPORTED && ffmpeg_available && !audio_multistreams {
-            // Phase 2+: full merge with star
-            // (video+audio combined included)
+        let selector = if ffmpeg_available && !audio_multistreams {
+            // FFmpeg + merge: prefer best video (including combined) + best audio
             "bv*+ba/b"
-        } else if MERGE_SUPPORTED && ffmpeg_available && audio_multistreams {
-            // Phase 2+: merge without star
-            // (strict video-only + audio-only)
+        } else if ffmpeg_available && audio_multistreams {
+            // FFmpeg + merge + multistreams: strict video-only + audio-only
             "bv+ba/b"
-        } else if ffmpeg_available && !audio_multistreams {
-            // Phase 1: FFmpeg available but no merge -- prefer combined,
-            // fallback to video-star + audio (star allows combined
-            // formats as video candidate)
-            "b/bv*+ba"
         } else {
-            // No FFmpeg OR multistreams -- only combined or strict
-            // video+audio
+            // No FFmpeg: prefer combined, fallback to video+audio
             "b/bv+ba"
         };
 
         debug!(
             selector,
             ffmpeg_available,
-            merge_supported = MERGE_SUPPORTED,
             audio_multistreams,
             reason = "dynamic default";
             "Resolved format selector"
@@ -79,10 +66,12 @@ impl Orchestrator {
     /// Select format from available formats and return a [`DownloadPlan`].
     ///
     /// Uses [`resolve_effective_selector`] to determine the selector
-    /// string. When the selector returns a merge pair (video + audio)
-    /// and [`MERGE_SUPPORTED`] is true, returns
-    /// [`DownloadPlan::Merge`]. Otherwise falls back to the best
-    /// combined format wrapped in [`DownloadPlan::Single`].
+    /// string. When the selector returns a merge pair (video + audio),
+    /// returns [`DownloadPlan::Merge`]. Otherwise returns a single
+    /// format wrapped in [`DownloadPlan::Single`].
+    ///
+    /// **Note**: Interactive mode always returns `DownloadPlan::Single`
+    /// because the user selects a single format from the grouped table.
     ///
     /// Returns `Ok(Some(plan))` on success, `Ok(None)` if the user
     /// cancelled (interactive mode only).
@@ -116,48 +105,16 @@ impl Orchestrator {
                 return Err(OrchestratorError::NoFormat);
             }
 
-            // Merge-fallback safety: if selector returned 2 formats
-            // (video+audio merge) but merge download is not yet
-            // supported, fall back to best combined format.
+            // Selector returned 2+ formats: merge video + audio
             if selected_formats.len() > 1 {
-                if MERGE_SUPPORTED {
-                    let video = selected_formats[0].clone();
-                    let audio = selected_formats[1].clone();
-                    info!(
-                        video = video.format_id.as_str(),
-                        audio = audio.format_id.as_str();
-                        "Selected merge pair"
-                    );
-                    return Ok(Some(DownloadPlan::Merge { video, audio }));
-                } else {
-                    warn!(
-                        video = selected_formats[0].format_id.as_str(),
-                        audio = selected_formats[1].format_id.as_str();
-                        "Merge requested but not supported \
-                         — falling back to best combined format"
-                    );
-                    // Fall back: re-select with "best" (combined only)
-                    let fallback = FormatSelector::parse("b").expect("'b' is a valid selector");
-                    let combined = fallback.select(formats);
-                    if let Some(best_combined) = combined.first() {
-                        info!(
-                            format_id =
-                                best_combined.format_id.as_str();
-                            "Using best combined format \
-                             (has both video and audio)"
-                        );
-                        (*best_combined).clone()
-                    } else {
-                        // No combined format either — use the first
-                        // selected format (video-only is better
-                        // than nothing)
-                        warn!(
-                            "No combined format available \
-                             — using video-only format"
-                        );
-                        selected_formats[0].clone()
-                    }
-                }
+                let video = selected_formats[0].clone();
+                let audio = selected_formats[1].clone();
+                info!(
+                    video = video.format_id.as_str(),
+                    audio = audio.format_id.as_str();
+                    "Selected merge pair"
+                );
+                return Ok(Some(DownloadPlan::Merge { video, audio }));
             } else {
                 selected_formats[0].clone()
             }
@@ -318,7 +275,7 @@ mod tests {
         let info = test_info_with_formats(formats);
 
         let plan = orch.select_format(&info, false).await.unwrap().unwrap();
-        // With MERGE_SUPPORTED = true, should return Merge plan
+        // Should return Merge plan for bv+ba selector
         match plan {
             super::super::DownloadPlan::Merge { video, audio } => {
                 assert!(video.has_video(), "Video format should have video");

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -8,8 +8,8 @@ use rdlp_core::{Format, FormatSelector, InfoDict};
 
 /// Whether merge download (video + audio muxed via FFmpeg) is supported.
 /// Both `resolve_effective_selector` and `select_format` check this value.
-/// Phase 2 will change this to a runtime check.
-const MERGE_SUPPORTED: bool = false;
+/// Enabled in Phase 2 — merge download fully supported.
+const MERGE_SUPPORTED: bool = true;
 
 impl Orchestrator {
     /// Resolve the effective format selector string based on runtime
@@ -19,16 +19,16 @@ impl Orchestrator {
     /// 1. Explicit user format (`config.format = Some(...)`) always wins
     /// 2. Otherwise, compute default from:
     ///    - `ffmpeg_available` -- from `postprocessor_registry.is_some()`
-    ///    - `merge_supported` -- false in Phase 1 (no merge download yet)
+    ///    - `merge_supported` -- true (merge download fully supported)
     ///    - `audio_multistreams` -- from `config.audio_multistreams`
     ///
-    /// # Phase 1 defaults
+    /// # Defaults (merge supported)
     ///
     /// | Condition | Default |
     /// |-----------|---------|
-    /// | FFmpeg available, merge not supported | `b/bv*+ba` |
+    /// | FFmpeg available, no multistreams | `bv*+ba/b` |
+    /// | FFmpeg available, multistreams | `bv+ba/b` |
     /// | FFmpeg unavailable | `b/bv+ba` |
-    /// | audio_multistreams enabled | `b/bv+ba` |
     /// | User explicit `-f` | User's value |
     pub(super) fn resolve_effective_selector(&self) -> String {
         // 1. Explicit user format always wins
@@ -302,12 +302,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_merge_selector_falls_back_to_combined() {
-        // When selector returns 2 formats (merge) but merge is not
-        // supported, should fall back to best combined format instead
-        // of silently dropping audio.
+    async fn test_merge_selector_returns_merge_plan() {
         let config = Config {
-            format: Some("bv+ba/b".to_string()),
+            format: Some("bv+ba".to_string()),
             ..Default::default()
         };
         let orch = orchestrator_with_config(config);
@@ -321,14 +318,16 @@ mod tests {
         let info = test_info_with_formats(formats);
 
         let plan = orch.select_format(&info, false).await.unwrap().unwrap();
-        let result = unwrap_single(plan);
-        // Should NOT be v1440 (video-only, no audio!)
-        // Should fall back to c1080 (best combined)
-        assert_eq!(result.format_id, "c1080");
-        assert!(
-            result.acodec.as_deref() != Some("none"),
-            "Fallback format must have audio"
-        );
+        // With MERGE_SUPPORTED = true, should return Merge plan
+        match plan {
+            super::super::DownloadPlan::Merge { video, audio } => {
+                assert!(video.has_video(), "Video format should have video");
+                assert!(audio.has_audio(), "Audio format should have audio");
+            }
+            super::super::DownloadPlan::Single(f) => {
+                panic!("Expected Merge plan, got Single({})", f.format_id);
+            }
+        }
     }
 
     #[tokio::test]
@@ -359,8 +358,8 @@ mod tests {
         let selector = orch.resolve_effective_selector();
         if orch.postprocessor_registry.is_some() {
             assert_eq!(
-                selector, "b/bv*+ba",
-                "FFmpeg available + no merge should give b/bv*+ba"
+                selector, "bv*+ba/b",
+                "FFmpeg available + merge supported should give bv*+ba/b"
             );
         } else {
             assert_eq!(selector, "b/bv+ba", "No FFmpeg should give b/bv+ba");
@@ -386,8 +385,11 @@ mod tests {
         };
         let orch = orchestrator_with_config(config);
         let selector = orch.resolve_effective_selector();
-        // With multistreams, always "b/bv+ba" regardless of FFmpeg
-        assert_eq!(selector, "b/bv+ba");
+        if orch.postprocessor_registry.is_some() {
+            assert_eq!(selector, "bv+ba/b");
+        } else {
+            assert_eq!(selector, "b/bv+ba");
+        }
     }
 
     #[test]
@@ -402,42 +404,50 @@ mod tests {
         assert_eq!(selector, "bestvideo*+bestaudio/best");
     }
 
-    /// Verify the Phase 1 selector truth table:
+    /// Verify the selector truth table (merge supported):
     ///
     /// | Condition                              | Default          |
     /// |----------------------------------------|------------------|
-    /// | FFmpeg available, merge not supported   | `b/bv*+ba`       |
+    /// | FFmpeg available, no multistreams       | `bv*+ba/b`       |
+    /// | FFmpeg available, multistreams          | `bv+ba/b`        |
     /// | FFmpeg unavailable                      | `b/bv+ba`        |
-    /// | audio_multistreams enabled              | `b/bv+ba`        |
     /// | User explicit `-f`                      | User's value     |
     #[test]
-    fn test_phase1_selector_truth_table() {
-        // Case 1: FFmpeg available, merge not supported
+    fn test_selector_truth_table() {
+        // Case 1: FFmpeg available, merge supported
         // (depends on environment -- tested via unit logic)
         let config = Config::default();
         let orch = orchestrator_with_config(config);
         let selector = orch.resolve_effective_selector();
         if orch.postprocessor_registry.is_some() {
             assert_eq!(
-                selector, "b/bv*+ba",
-                "FFmpeg available + no merge should give b/bv*+ba"
+                selector, "bv*+ba/b",
+                "FFmpeg available + merge supported should give bv*+ba/b"
             );
         } else {
             assert_eq!(selector, "b/bv+ba", "No FFmpeg should give b/bv+ba");
         }
 
-        // Case 2: audio_multistreams always gives b/bv+ba regardless
-        // of ffmpeg
+        // Case 2: audio_multistreams with FFmpeg gives bv+ba/b,
+        // without FFmpeg gives b/bv+ba
         let config = Config {
             audio_multistreams: true,
             ..Default::default()
         };
         let orch = orchestrator_with_config(config);
-        assert_eq!(
-            orch.resolve_effective_selector(),
-            "b/bv+ba",
-            "audio_multistreams should give b/bv+ba"
-        );
+        if orch.postprocessor_registry.is_some() {
+            assert_eq!(
+                orch.resolve_effective_selector(),
+                "bv+ba/b",
+                "multistreams + FFmpeg should give bv+ba/b"
+            );
+        } else {
+            assert_eq!(
+                orch.resolve_effective_selector(),
+                "b/bv+ba",
+                "multistreams + no FFmpeg should give b/bv+ba"
+            );
+        }
 
         // Case 3: Explicit format always wins
         let config = Config {

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use super::{Orchestrator, errors::*};
+use super::{DownloadPlan, Orchestrator, errors::*};
 use log::{debug, info, warn};
 use rdlp_core::{Format, FormatSelector, InfoDict};
 
@@ -76,14 +76,15 @@ impl Orchestrator {
         selector.to_string()
     }
 
-    /// Select format from available formats.
+    /// Select format from available formats and return a [`DownloadPlan`].
     ///
     /// Uses [`resolve_effective_selector`] to determine the selector
-    /// string, then applies merge-fallback safety: if the selector
-    /// returns a merge pair but merge is not supported, falls back to
-    /// the best combined format (or video-only as last resort).
+    /// string. When the selector returns a merge pair (video + audio)
+    /// and [`MERGE_SUPPORTED`] is true, returns
+    /// [`DownloadPlan::Merge`]. Otherwise falls back to the best
+    /// combined format wrapped in [`DownloadPlan::Single`].
     ///
-    /// Returns `Ok(Some(format))` on success, `Ok(None)` if the user
+    /// Returns `Ok(Some(plan))` on success, `Ok(None)` if the user
     /// cancelled (interactive mode only).
     ///
     /// # Errors
@@ -94,15 +95,18 @@ impl Orchestrator {
         &self,
         info: &InfoDict,
         interactive: bool,
-    ) -> Result<Option<Format>> {
+    ) -> Result<Option<DownloadPlan>> {
         let formats = &info.formats;
-        let format = if interactive && self.interactive.is_some() {
+        if interactive && self.interactive.is_some() {
             let Some(format) = self.select_format_interactive(info).await? else {
                 info!("Selection cancelled by user");
                 return Ok(None);
             };
-            format
-        } else {
+            info!(format:?; "Selected format");
+            return Ok(Some(DownloadPlan::Single(format)));
+        }
+
+        let format = {
             let selector_str = self.resolve_effective_selector();
             let format_selector = FormatSelector::parse(&selector_str)
                 .map_err(OrchestratorError::InvalidFormatSelector)?;
@@ -117,9 +121,14 @@ impl Orchestrator {
             // supported, fall back to best combined format.
             if selected_formats.len() > 1 {
                 if MERGE_SUPPORTED {
-                    // Phase 2: return the video format
-                    // (merge handled downstream)
-                    selected_formats[0].clone()
+                    let video = selected_formats[0].clone();
+                    let audio = selected_formats[1].clone();
+                    info!(
+                        video = video.format_id.as_str(),
+                        audio = audio.format_id.as_str();
+                        "Selected merge pair"
+                    );
+                    return Ok(Some(DownloadPlan::Merge { video, audio }));
                 } else {
                     warn!(
                         video = selected_formats[0].format_id.as_str(),
@@ -155,7 +164,7 @@ impl Orchestrator {
         };
 
         info!(format:?; "Selected format");
-        Ok(Some(format))
+        Ok(Some(DownloadPlan::Single(format)))
     }
 
     /// Interactive format selection via [`InteractiveCallback`]
@@ -234,6 +243,14 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
+    /// Unwrap a `DownloadPlan::Single`, panicking on `Merge`.
+    fn unwrap_single(plan: super::super::DownloadPlan) -> Format {
+        match plan {
+            super::super::DownloadPlan::Single(f) => f,
+            other => panic!("Expected Single, got {other}"),
+        }
+    }
+
     /// Create orchestrator with specific config for testing.
     fn orchestrator_with_config(config: Config) -> Orchestrator {
         let (tx, _rx) = mpsc::channel::<Event>(64);
@@ -303,7 +320,8 @@ mod tests {
         ];
         let info = test_info_with_formats(formats);
 
-        let result = orch.select_format(&info, false).await.unwrap().unwrap();
+        let plan = orch.select_format(&info, false).await.unwrap().unwrap();
+        let result = unwrap_single(plan);
         // Should NOT be v1440 (video-only, no audio!)
         // Should fall back to c1080 (best combined)
         assert_eq!(result.format_id, "c1080");
@@ -325,7 +343,8 @@ mod tests {
         let info = test_info_with_formats(formats);
 
         // Should succeed using the dynamic default selector
-        let result = orch.select_format(&info, false).await.unwrap().unwrap();
+        let plan = orch.select_format(&info, false).await.unwrap().unwrap();
+        let result = unwrap_single(plan);
         // Best combined should be selected (c1080)
         assert_eq!(result.format_id, "c1080");
     }

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -474,4 +474,80 @@ mod tests {
             "Explicit complex format should be preserved exactly"
         );
     }
+
+    #[tokio::test]
+    async fn test_merge_plan_returned_for_explicit_merge_selector() {
+        // Force selector to request merge (bv+ba)
+        let config = Config {
+            format: Some("bv+ba".to_string()),
+            ..Default::default()
+        };
+        let orch = orchestrator_with_config(config);
+
+        let formats = vec![
+            make_combined("c720", 720, 2),
+            make_video_only("v1080", 1080),
+            make_audio_only("a256", 256.0),
+        ];
+        let info = test_info_with_formats(formats);
+
+        let plan = orch.select_format(&info, false).await.unwrap().unwrap();
+        match plan {
+            super::super::DownloadPlan::Merge { video, audio } => {
+                assert!(video.has_video(), "Merge video format should have video");
+                assert!(audio.has_audio(), "Merge audio format should have audio");
+            }
+            super::super::DownloadPlan::Single(f) => {
+                panic!("Expected Merge plan, got Single({})", f.format_id);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_format_returns_single_plan() {
+        let config = Config {
+            format: Some("b".to_string()),
+            ..Default::default()
+        };
+        let orch = orchestrator_with_config(config);
+
+        let formats = vec![
+            make_combined("c720", 720, 2),
+            make_combined("c1080", 1080, 3),
+        ];
+        let info = test_info_with_formats(formats);
+
+        let plan = orch.select_format(&info, false).await.unwrap().unwrap();
+        let format = unwrap_single(plan);
+        assert_eq!(
+            format.format_id, "c1080",
+            "Best single format should be c1080"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_selector_returns_merge_with_ffmpeg() {
+        // Default (no explicit format) with FFmpeg should use bv*+ba/b
+        // which prefers merge when better video-only exists
+        let config = Config::default();
+        let orch = orchestrator_with_config(config);
+
+        if orch.postprocessor_registry.is_none() {
+            // Skip if no FFmpeg
+            return;
+        }
+
+        let formats = vec![
+            make_combined("c720", 720, 2),
+            make_video_only("v1080", 1080),
+            make_audio_only("a256", 256.0),
+        ];
+        let info = test_info_with_formats(formats);
+
+        let plan = orch.select_format(&info, false).await.unwrap().unwrap();
+        assert!(
+            matches!(plan, super::super::DownloadPlan::Merge { .. }),
+            "Default selector with FFmpeg should prefer merge when better quality available"
+        );
+    }
 }

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -105,7 +105,7 @@ impl Orchestrator {
                 return Err(OrchestratorError::NoFormat);
             }
 
-            // Selector returned 2+ formats: merge video + audio
+            // Selector returned a merge pair: first = video, second = audio
             if selected_formats.len() > 1 {
                 let video = selected_formats[0].clone();
                 let audio = selected_formats[1].clone();

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -1,5 +1,6 @@
 //! Format selection logic and [`DownloadPlan`] construction
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use super::{DownloadPlan, Orchestrator, errors::*};
@@ -26,7 +27,7 @@ impl Orchestrator {
     /// | FFmpeg available, multistreams | `bv+ba/b` |
     /// | FFmpeg unavailable | `b/bv+ba` |
     /// | User explicit `-f` | User's value |
-    pub(super) fn resolve_effective_selector(&self) -> String {
+    pub(super) fn resolve_effective_selector(&self) -> Cow<'_, str> {
         // 1. Explicit user format always wins
         if let Some(ref user_format) = self.config.format {
             debug!(
@@ -34,7 +35,7 @@ impl Orchestrator {
                 reason = "explicit user format";
                 "Resolved format selector"
             );
-            return user_format.clone();
+            return Cow::Borrowed(user_format.as_str());
         }
 
         // 2. Compute dynamic default
@@ -60,7 +61,7 @@ impl Orchestrator {
             "Resolved format selector"
         );
 
-        selector.to_string()
+        Cow::Borrowed(selector)
     }
 
     /// Select format from available formats and return a [`DownloadPlan`].
@@ -156,11 +157,9 @@ impl Orchestrator {
             }
         }
 
-        let grouped: Vec<&Format> = by_key.values().copied().collect();
-
         // Delegate to the interactive callback
         let callback = self.interactive.as_ref().unwrap();
-        let grouped_owned: Vec<Format> = grouped.iter().map(|f| (*f).clone()).collect();
+        let grouped_owned: Vec<Format> = by_key.values().map(|f| (*f).clone()).collect();
 
         let selection = callback.select_format(&grouped_owned, info).await;
 
@@ -195,15 +194,15 @@ fn pick_better(candidate: &Format, current: &Format) -> bool {
 mod tests {
     use crate::events::Event;
     use crate::handle::DownloadId;
-    use crate::orchestrator::Orchestrator;
+    use crate::orchestrator::{DownloadPlan, Orchestrator};
     use rdlp_core::{Config, DownloadProtocol, Format, InfoDict};
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
     /// Unwrap a `DownloadPlan::Single`, panicking on `Merge`.
-    fn unwrap_single(plan: super::super::DownloadPlan) -> Format {
+    fn unwrap_single(plan: DownloadPlan) -> Format {
         match plan {
-            super::super::DownloadPlan::Single(f) => f,
+            DownloadPlan::Single(f) => f,
             other => panic!("Expected Single, got {other}"),
         }
     }
@@ -277,11 +276,11 @@ mod tests {
         let plan = orch.select_format(&info, false).await.unwrap().unwrap();
         // Should return Merge plan for bv+ba selector
         match plan {
-            super::super::DownloadPlan::Merge { video, audio } => {
+            DownloadPlan::Merge { video, audio } => {
                 assert!(video.has_video(), "Video format should have video");
                 assert!(audio.has_audio(), "Audio format should have audio");
             }
-            super::super::DownloadPlan::Single(f) => {
+            DownloadPlan::Single(f) => {
                 panic!("Expected Merge plan, got Single({})", f.format_id);
             }
         }
@@ -450,11 +449,11 @@ mod tests {
 
         let plan = orch.select_format(&info, false).await.unwrap().unwrap();
         match plan {
-            super::super::DownloadPlan::Merge { video, audio } => {
+            DownloadPlan::Merge { video, audio } => {
                 assert!(video.has_video(), "Merge video format should have video");
                 assert!(audio.has_audio(), "Merge audio format should have audio");
             }
-            super::super::DownloadPlan::Single(f) => {
+            DownloadPlan::Single(f) => {
                 panic!("Expected Merge plan, got Single({})", f.format_id);
             }
         }
@@ -503,7 +502,7 @@ mod tests {
 
         let plan = orch.select_format(&info, false).await.unwrap().unwrap();
         assert!(
-            matches!(plan, super::super::DownloadPlan::Merge { .. }),
+            matches!(plan, DownloadPlan::Merge { .. }),
             "Default selector with FFmpeg should prefer merge when better quality available"
         );
     }

--- a/crates/rdlp-api/src/orchestrator/session_state.rs
+++ b/crates/rdlp-api/src/orchestrator/session_state.rs
@@ -20,7 +20,7 @@ const STATE_VERSION: u32 = 1;
 /// which variant to deserialize into.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "state_type")]
-pub(crate) enum SessionState {
+pub(super) enum SessionState {
     /// State for a single video download
     #[serde(rename = "single_video")]
     SingleVideo(SingleVideoState),
@@ -31,7 +31,7 @@ pub(crate) enum SessionState {
 
 /// Persisted selections for a single video download.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub(crate) struct SingleVideoState {
+pub(super) struct SingleVideoState {
     /// Schema version for forward compatibility
     pub version: u32,
     /// URL path (no host/query) for CDN-tolerant matching
@@ -53,7 +53,7 @@ pub(crate) struct SingleVideoState {
 
 /// Persisted selections for a playlist download.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub(crate) struct PlaylistState {
+pub(super) struct PlaylistState {
     /// Schema version for forward compatibility
     pub version: u32,
     /// URL path (no host/query) for CDN-tolerant matching
@@ -78,7 +78,7 @@ pub(crate) struct PlaylistState {
 
 /// Record of a failed episode for cross-run retry tracking.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub(crate) struct FailedEpisode {
+pub(super) struct FailedEpisode {
     /// 1-based position in the playlist
     pub position: usize,
     /// Episode title at time of failure
@@ -259,14 +259,14 @@ impl SessionState {
 /// Compute the state file path for a single video download.
 ///
 /// Pattern: `{output_dir}/{sanitized_title}.rdlp_state.json`
-pub(crate) fn single_video_state_path(output_dir: &Path, sanitized_title: &str) -> PathBuf {
+pub(super) fn single_video_state_path(output_dir: &Path, sanitized_title: &str) -> PathBuf {
     output_dir.join(format!("{sanitized_title}.rdlp_state.json"))
 }
 
 /// Compute the state file path for a playlist download.
 ///
 /// Pattern: `{playlist_dir}/.rdlp_playlist_state.json`
-pub(crate) fn playlist_state_path(playlist_dir: &Path) -> PathBuf {
+pub(super) fn playlist_state_path(playlist_dir: &Path) -> PathBuf {
     playlist_dir.join(".rdlp_playlist_state.json")
 }
 

--- a/crates/rdlp-api/src/orchestrator/session_state.rs
+++ b/crates/rdlp-api/src/orchestrator/session_state.rs
@@ -40,6 +40,9 @@ pub(crate) struct SingleVideoState {
     pub title: String,
     /// Selected format identifier (matched against available formats on resume)
     pub format_id: String,
+    /// Audio format ID for merge downloads (None for single-format downloads)
+    #[serde(default)]
+    pub audio_format_id: Option<String>,
     /// Selected subtitle language codes (empty if none)
     pub subtitle_langs: Vec<String>,
     /// When this state was first created
@@ -91,6 +94,7 @@ impl SingleVideoState {
         title: impl Into<String>,
         format_id: impl Into<String>,
         subtitle_langs: Vec<String>,
+        audio_format_id: Option<String>,
     ) -> Self {
         let now = Utc::now();
         Self {
@@ -98,6 +102,7 @@ impl SingleVideoState {
             source_url: extract_url_path(url),
             title: title.into(),
             format_id: format_id.into(),
+            audio_format_id,
             subtitle_langs,
             created_at: now,
             updated_at: now,
@@ -281,6 +286,7 @@ mod tests {
             "Test Video",
             "720p-hls",
             vec!["en".to_string(), "ja".to_string()],
+            None,
         ));
 
         state.save(&path).await;
@@ -339,6 +345,7 @@ mod tests {
             "Test",
             "720p",
             vec![],
+            None,
         ));
         state.save(&path).await;
 
@@ -399,6 +406,7 @@ mod tests {
             "Test",
             "720p",
             vec![],
+            None,
         ));
         state.save(&path).await;
         assert!(path.exists());
@@ -437,6 +445,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_plan_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.rdlp_state.json");
+        let url = "https://cdn1.example.com/watch/video-123?token=abc";
+
+        let state = SessionState::SingleVideo(SingleVideoState::new(
+            url,
+            "Test Video",
+            "v1080",
+            vec!["en".to_string()],
+            Some("a256".to_string()),
+        ));
+
+        state.save(&path).await;
+
+        let loaded =
+            SessionState::load(&path, "https://cdn2.example.com/watch/video-123?token=xyz").await;
+        assert!(loaded.is_some());
+        match loaded.unwrap() {
+            SessionState::SingleVideo(s) => {
+                assert_eq!(s.format_id, "v1080");
+                assert_eq!(s.audio_format_id, Some("a256".to_string()));
+                assert_eq!(s.subtitle_langs, vec!["en"]);
+            }
+            _ => panic!("Expected SingleVideo variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_plan_has_no_audio_format_id() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.rdlp_state.json");
+        let url = "https://example.com/watch/video-123";
+
+        let state = SessionState::SingleVideo(SingleVideoState::new(
+            url,
+            "Test Video",
+            "c720",
+            vec![],
+            None,
+        ));
+
+        state.save(&path).await;
+
+        let loaded = SessionState::load(&path, url).await;
+        assert!(loaded.is_some());
+        match loaded.unwrap() {
+            SessionState::SingleVideo(s) => {
+                assert_eq!(s.format_id, "c720");
+                assert!(s.audio_format_id.is_none());
+            }
+            _ => panic!("Expected SingleVideo variant"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_cdn_tolerant_url_matching() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.rdlp_state.json");
@@ -447,6 +511,7 @@ mod tests {
             "Test",
             "720p",
             vec![],
+            None,
         ));
         state.save(&path).await;
 

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -12,6 +12,7 @@ use tracing::instrument;
 
 /// Download state for resume logic
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DownloadState {
     /// Fresh download with no resume
     Fresh,
@@ -53,6 +54,7 @@ impl fmt::Display for DownloadState {
 /// performance when the enum is moved/copied. This reduces stack usage and
 /// prevents unnecessary copying of large structs.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DownloadPhase {
     /// Extracting video information from URL
     Extracting {

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -96,7 +96,7 @@ pub enum DownloadPhase {
         state: DownloadState,
         /// Subtitles selected for download (empty if none)
         subtitle_selection: Vec<(String, rdlp_core::Subtitle)>,
-        /// Download plan (single or merge — used by Task 4)
+        /// Download plan (single or merge)
         plan: Box<DownloadPlan>,
     },
     /// Download completed successfully
@@ -192,7 +192,33 @@ impl DownloadPhase {
                         // Resolve subtitles from saved language codes
                         let subtitle_selection = orchestrator
                             .resolve_subtitles_for_episode(&info, &saved.subtitle_langs);
-                        let plan = DownloadPlan::Single(format.clone());
+                        // Reconstruct plan: merge if audio format was saved
+                        let plan = if let Some(ref audio_id) = saved.audio_format_id {
+                            if let Some(audio) = info
+                                .formats
+                                .iter()
+                                .find(|f| f.format_id == *audio_id)
+                                .cloned()
+                            {
+                                info!(
+                                    audio_id = audio_id.as_str();
+                                    "Resuming merge plan with saved audio format"
+                                );
+                                DownloadPlan::Merge {
+                                    video: format.clone(),
+                                    audio,
+                                }
+                            } else {
+                                warn!(
+                                    audio_id = audio_id.as_str();
+                                    "Saved audio format no longer available, \
+                                     falling back to single format"
+                                );
+                                DownloadPlan::Single(format.clone())
+                            }
+                        } else {
+                            DownloadPlan::Single(format.clone())
+                        };
                         return Ok(Self::Preparing {
                             info: Box::new(info),
                             format: Box::new(format),
@@ -262,11 +288,16 @@ impl DownloadPhase {
                     .iter()
                     .map(|(lang, _)| lang.clone())
                     .collect();
+                let audio_format_id = match &*plan {
+                    DownloadPlan::Merge { audio, .. } => Some(audio.format_id.clone()),
+                    DownloadPlan::Single(_) => None,
+                };
                 let state = SessionState::SingleVideo(SingleVideoState::new(
                     &info.webpage_url,
                     &info.title,
                     &format.format_id,
                     sub_langs,
+                    audio_format_id,
                 ));
                 state.save(&state_path).await;
 

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -1,5 +1,6 @@
 //! State machine types for the download workflow
 
+use super::DownloadPlan;
 use super::session_state::{self, SessionState, SingleVideoState};
 use super::{Orchestrator, errors::*};
 use crate::events::Event;
@@ -69,6 +70,8 @@ pub enum DownloadPhase {
         info: Box<rdlp_core::InfoDict>,
         /// Selected format for download
         format: Box<Format>,
+        /// Download plan (single or merge)
+        plan: Box<DownloadPlan>,
     },
     /// Preparing download (checking for resume state)
     Preparing {
@@ -78,6 +81,8 @@ pub enum DownloadPhase {
         format: Box<Format>,
         /// Subtitles selected for download (empty if none)
         subtitle_selection: Vec<(String, rdlp_core::Subtitle)>,
+        /// Download plan (single or merge)
+        plan: Box<DownloadPlan>,
     },
     /// Downloading with progress tracking
     Downloading {
@@ -91,6 +96,8 @@ pub enum DownloadPhase {
         state: DownloadState,
         /// Subtitles selected for download (empty if none)
         subtitle_selection: Vec<(String, rdlp_core::Subtitle)>,
+        /// Download plan (single or merge — used by Task 4)
+        plan: Box<DownloadPlan>,
     },
     /// Download completed successfully
     Complete {
@@ -185,10 +192,12 @@ impl DownloadPhase {
                         // Resolve subtitles from saved language codes
                         let subtitle_selection = orchestrator
                             .resolve_subtitles_for_episode(&info, &saved.subtitle_langs);
+                        let plan = DownloadPlan::Single(format.clone());
                         return Ok(Self::Preparing {
                             info: Box::new(info),
                             format: Box::new(format),
                             subtitle_selection,
+                            plan: Box::new(plan),
                         });
                     }
                     warn!(
@@ -203,17 +212,22 @@ impl DownloadPhase {
             }
 
             Self::SelectingFormat { info } => {
-                let Some(format) = orchestrator.select_format(&info, interactive).await? else {
+                let Some(plan) = orchestrator.select_format(&info, interactive).await? else {
                     orchestrator.emit(Event::Cancelled {
                         id: orchestrator.download_id,
                     });
                     return Ok(Self::Cancelled);
                 };
 
+                let primary_format = match &plan {
+                    DownloadPlan::Single(f) => f.clone(),
+                    DownloadPlan::Merge { video, .. } => video.clone(),
+                };
+
                 orchestrator.emit(Event::FormatSelected {
                     id: orchestrator.download_id,
-                    format_id: format.format_id.clone(),
-                    quality: format
+                    format_id: primary_format.format_id.clone(),
+                    quality: primary_format
                         .format_note
                         .clone()
                         .unwrap_or_else(|| "unknown".to_string()),
@@ -221,11 +235,12 @@ impl DownloadPhase {
 
                 Ok(Self::SelectingSubtitles {
                     info,
-                    format: Box::new(format),
+                    format: Box::new(primary_format),
+                    plan: Box::new(plan),
                 })
             }
 
-            Self::SelectingSubtitles { info, format } => {
+            Self::SelectingSubtitles { info, format, plan } => {
                 let list_subs = orchestrator.config.list_subs;
                 let Some(subtitle_selection) = orchestrator
                     .select_subtitles_if_needed(&info, interactive, list_subs)
@@ -259,6 +274,7 @@ impl DownloadPhase {
                     info,
                     format,
                     subtitle_selection,
+                    plan,
                 })
             }
 
@@ -266,6 +282,7 @@ impl DownloadPhase {
                 info,
                 format,
                 subtitle_selection,
+                plan,
             } => {
                 let output_path = orchestrator.generate_output_path(&info, &format)?;
                 info!(path:? = output_path.display(); "Downloading to");
@@ -293,6 +310,7 @@ impl DownloadPhase {
                     format,
                     state,
                     subtitle_selection,
+                    plan,
                 })
             }
 
@@ -302,6 +320,7 @@ impl DownloadPhase {
                 format,
                 state,
                 subtitle_selection,
+                plan: _plan,
             } => {
                 // Execute download with CDN fallback (shared implementation)
                 let Some(outcome) = orchestrator
@@ -368,6 +387,12 @@ mod tests {
                 "mp4",
                 rdlp_core::DownloadProtocol::Https,
             )),
+            plan: Box::new(super::super::DownloadPlan::Single(rdlp_core::Format::new(
+                "f1",
+                "http://example.com/v.mp4",
+                "mp4",
+                rdlp_core::DownloadProtocol::Https,
+            ))),
         };
 
         assert_eq!(format!("{phase}"), "selecting subtitles");

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -68,7 +68,7 @@ pub enum DownloadPhase {
     SelectingSubtitles {
         /// Extracted video metadata
         info: Box<rdlp_core::InfoDict>,
-        /// Selected format for download
+        /// Primary format (video format for merge, combined format for single)
         format: Box<Format>,
         /// Download plan (single or merge)
         plan: Box<DownloadPlan>,
@@ -77,7 +77,7 @@ pub enum DownloadPhase {
     Preparing {
         /// Extracted video metadata
         info: Box<rdlp_core::InfoDict>,
-        /// Selected format for download
+        /// Primary format (video format for merge, combined format for single)
         format: Box<Format>,
         /// Subtitles selected for download (empty if none)
         subtitle_selection: Vec<(String, rdlp_core::Subtitle)>,
@@ -90,7 +90,7 @@ pub enum DownloadPhase {
         info: Box<rdlp_core::InfoDict>,
         /// Path where the file will be saved
         output_path: PathBuf,
-        /// Selected format being downloaded
+        /// Primary format (video format for merge, combined format for single)
         format: Box<Format>,
         /// Resume state (fresh or resuming from offset)
         state: DownloadState,
@@ -318,21 +318,29 @@ impl DownloadPhase {
                 let output_path = orchestrator.generate_output_path(&info, &format)?;
                 info!(path:? = output_path.display(); "Downloading to");
 
-                let resume_offset = orchestrator
-                    .detect_resume_point(&output_path, format.filesize)
-                    .await?;
+                // Resume detection only applies to Single downloads.
+                // Merge downloads create separate stream files (video + audio)
+                // at derived paths and always start fresh.
+                let state = match *plan {
+                    DownloadPlan::Merge { .. } => DownloadState::Fresh,
+                    DownloadPlan::Single(_) => {
+                        let resume_offset = orchestrator
+                            .detect_resume_point(&output_path, format.filesize)
+                            .await?;
 
-                // Check if file is already complete
-                if let Some(expected_size) = format.filesize {
-                    if resume_offset == expected_size {
-                        return Ok(Self::Complete { path: output_path });
+                        // Check if file is already complete
+                        if let Some(expected_size) = format.filesize {
+                            if resume_offset == expected_size {
+                                return Ok(Self::Complete { path: output_path });
+                            }
+                        }
+
+                        if resume_offset > 0 {
+                            DownloadState::Resume(resume_offset)
+                        } else {
+                            DownloadState::Fresh
+                        }
                     }
-                }
-
-                let state = if resume_offset > 0 {
-                    DownloadState::Resume(resume_offset)
-                } else {
-                    DownloadState::Fresh
                 };
 
                 Ok(Self::Downloading {

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -315,22 +315,49 @@ impl DownloadPhase {
             }
 
             Self::Downloading {
-                info,
+                mut info,
                 output_path,
                 format,
                 state,
                 subtitle_selection,
-                plan: _plan,
+                plan,
             } => {
-                // Execute download with CDN fallback (shared implementation)
-                let Some(outcome) = orchestrator
-                    .download_with_cdn_fallback(&format, &output_path, state.offset())
-                    .await?
-                else {
-                    orchestrator.emit(Event::Cancelled {
-                        id: orchestrator.download_id,
-                    });
-                    return Ok(Self::Cancelled);
+                // Branch on download plan
+                let (download_files, is_hls) = match *plan {
+                    DownloadPlan::Single(_) => {
+                        // Single format: existing path
+                        let Some(outcome) = orchestrator
+                            .download_with_cdn_fallback(&format, &output_path, state.offset())
+                            .await?
+                        else {
+                            orchestrator.emit(Event::Cancelled {
+                                id: orchestrator.download_id,
+                            });
+                            return Ok(Self::Cancelled);
+                        };
+                        (vec![output_path.clone()], outcome.is_hls)
+                    }
+                    DownloadPlan::Merge {
+                        ref video,
+                        ref audio,
+                    } => {
+                        // Merge: parallel video + audio download
+                        let Some(outcome) = orchestrator
+                            .download_merge_pair(video, audio, &output_path)
+                            .await?
+                        else {
+                            orchestrator.emit(Event::Cancelled {
+                                id: orchestrator.download_id,
+                            });
+                            return Ok(Self::Cancelled);
+                        };
+
+                        // Set requested_formats so FFmpegMerger::should_run()
+                        // returns true
+                        info.requested_formats = Some(vec![video.clone(), audio.clone()]);
+
+                        (vec![outcome.video_path, outcome.audio_path], outcome.is_hls)
+                    }
                 };
 
                 // Download thumbnail for embedding or standalone use
@@ -343,9 +370,10 @@ impl DownloadPhase {
                     .download_subtitles(&info, &output_path, &subtitle_selection)
                     .await?;
 
-                // Run post-processing (automatic for HLS, optional for others)
+                // Run post-processing (FFmpegMerger at priority 100 will
+                // merge when it detects 2 files with requested_formats set)
                 let final_files = orchestrator
-                    .run_postprocessing(&info, vec![output_path.clone()], outcome.is_hls)
+                    .run_postprocessing(&info, download_files, is_hls)
                     .await?;
                 let final_path = final_files.into_iter().next().unwrap_or(output_path);
 

--- a/crates/rdlp-api/src/orchestrator/tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 /// Helper function to create a test orchestrator with event channel
-pub(crate) fn create_test_orchestrator() -> Orchestrator {
+pub(super) fn create_test_orchestrator() -> Orchestrator {
     let config = Config::default();
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let id = DownloadId::next();

--- a/crates/rdlp-api/src/orchestrator/tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests.rs
@@ -256,7 +256,11 @@ async fn test_select_format_automatic_mode() {
     let selected = result.unwrap();
     assert!(selected.is_some());
     // Default selector should pick best quality
-    let format = selected.unwrap();
+    let plan = selected.unwrap();
+    let format = match plan {
+        DownloadPlan::Single(f) => f,
+        other => panic!("Expected Single, got {other}"),
+    };
     assert_eq!(format.format_id, "1080p");
 }
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -54,7 +54,7 @@ impl std::error::Error for ConfigValidationError {}
 ///
 /// For file I/O operations (loading from TOML/YAML), use the extension
 /// functions in `rdlp_core::config_io`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     // === Output options ===

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -86,7 +86,7 @@ pub struct Config {
     pub merge_output_format: Option<ContainerFormat>,
 
     /// Require strict video-only + audio-only streams for merge selection.
-    /// When true, default selector changes from `b/bv*+ba` to `b/bv+ba`.
+    /// When true, default selector changes from `bv*+ba/b` to `bv+ba/b`.
     pub audio_multistreams: bool,
 
     // === Download options ===


### PR DESCRIPTION
## Summary

- Add `DownloadPlan` enum (`Single` / `Merge { video, audio }`) to represent single-format vs merge downloads
- Update `select_format()` to return `DownloadPlan` — when the selector returns 2 formats (video+audio), produces a `Merge` plan
- Add `merge_download.rs` module that downloads video and audio streams in parallel via `tokio::join!`
- Wire merge download into the state machine — sets `info.requested_formats` so `FFmpegMerger` postprocessor (priority 100) handles the actual muxing
- Flip `MERGE_SUPPORTED` to `true`, unlocking `bv*+ba/b` as the default selector when FFmpeg is available

### Phase 2 Selector Truth Table

| Condition | Default |
|-----------|---------|
| FFmpeg available, no multistreams | `bv*+ba/b` |
| FFmpeg available, multistreams | `bv+ba/b` |
| FFmpeg unavailable | `b/bv+ba` |
| User explicit `-f` | User's value |

## Test Plan

- [ ] `cargo test --lib --tests` — all pass
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — clean

### DownloadPlan tests (`rdlp-api::orchestrator::download_plan_tests`)

- [ ] `test_download_plan_single` — Single variant construction
- [ ] `test_download_plan_merge` — Merge variant field access
- [ ] `test_download_plan_display_single` — Display for single format
- [ ] `test_download_plan_display_merge` — Display for merge pair

### Selector resolution tests (`rdlp-api::orchestrator::selection`)

- [ ] `test_resolve_default_selector_matches_environment` — FFmpeg gives `bv*+ba/b`, no FFmpeg gives `b/bv+ba`
- [ ] `test_resolve_explicit_format_always_wins` — explicit `-f` overrides
- [ ] `test_resolve_audio_multistreams_with_ffmpeg` — multistreams with FFmpeg gives `bv+ba/b`
- [ ] `test_resolve_explicit_format_ignores_multistreams` — explicit format wins over multistreams
- [ ] `test_selector_truth_table` — full truth table verification

### Format selection / merge plan tests (`rdlp-api::orchestrator::selection`)

- [ ] `test_merge_selector_returns_merge_plan` — explicit `bv+ba` returns Merge plan
- [ ] `test_default_selector_used_when_format_is_none` — dynamic default works
- [ ] `test_merge_plan_returned_for_explicit_merge_selector` — Merge plan has video+audio
- [ ] `test_single_format_returns_single_plan` — `b` selector returns Single plan
- [ ] `test_default_selector_returns_merge_with_ffmpeg` — default prefers merge when better quality available