### PR TITLE
feat: implement stdout streaming with -o - flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "boa_ast"
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
 
 [[package]]
 name = "bytemuck"
@@ -410,9 +410,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
 dependencies = [
  "anstream",
  "anstyle",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
@@ -685,9 +685,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -934,6 +934,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -959,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -974,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -997,15 +1003,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1014,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -1033,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,21 +1050,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1068,7 +1074,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1116,6 +1121,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1176,13 +1194,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1444,6 +1471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,13 +1505,15 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1583,10 +1618,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -2061,6 +2102,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2730,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
@@ -2998,9 +3049,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3041,12 +3092,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3212,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3248,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3387,15 +3438,21 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -3507,6 +3564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3632,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3664,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -3880,6 +3980,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "write16"
@@ -4005,6 +4187,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ license = "MIT"
 
 [workspace.dependencies]
 # Async runtime
-tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "fs", "process", "io-util", "signal"] }
+tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "fs", "process", "io-util", "io-std", "signal"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 async-trait = "0.1"
 

--- a/crates/rdlp-api/src/client.rs
+++ b/crates/rdlp-api/src/client.rs
@@ -110,9 +110,16 @@ impl RdlpClient {
 
             match orchestrator.download(&url, interactive_flag).await {
                 Ok(Some(path)) => {
+                    // Stdout mode returns "-" sentinel — don't expose it
+                    // as a real file path to API consumers.
+                    let output_files = if path.as_os_str() == "-" {
+                        vec![]
+                    } else {
+                        vec![path]
+                    };
                     let result = DownloadResult {
                         id,
-                        output_files: vec![path],
+                        output_files,
                         info: InfoDict::new("", "", "", &url),
                         stats: DownloadStats::new(0, Duration::ZERO, 0),
                     };

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -179,6 +179,7 @@ impl From<RdlpError> for RdlpApiError {
                 message: format!("Regex error: {err}"),
                 source_url: String::new(),
             },
+            RdlpError::Unsupported(msg) => Self::InvalidInput { message: msg },
             RdlpError::Other(msg) => Self::Soft { message: msg },
         }
     }

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -211,7 +211,7 @@ impl From<OrchestratorError> for RdlpApiError {
             OrchestratorError::Io(io_err) => Self::IoError {
                 message: io_err.to_string(),
             },
-            OrchestratorError::Configuration(msg) => Self::BuilderError { message: msg },
+            OrchestratorError::Configuration(msg) => Self::InvalidInput { message: msg },
         }
     }
 }

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -179,7 +179,7 @@ impl From<RdlpError> for RdlpApiError {
                 message: format!("Regex error: {err}"),
                 source_url: String::new(),
             },
-            RdlpError::Unsupported(msg) => Self::InvalidInput { message: msg },
+            RdlpError::Unsupported(msg) => Self::UnsupportedPlatform { feature: msg },
             RdlpError::Other(msg) => Self::Soft { message: msg },
         }
     }

--- a/crates/rdlp-api/src/merge.rs
+++ b/crates/rdlp-api/src/merge.rs
@@ -28,6 +28,13 @@ impl MergeOverrides for OutputOptions {
         }
         if let Some(v) = self.stdout {
             config.output_to_stdout = v;
+            if v {
+                // Mirror CLI behaviour: silence output and disable incompatible
+                // defaults so Config::validate() won't reject the combination.
+                config.quiet = true;
+                config.progress = false;
+                config.embed_thumbnail = false;
+            }
         }
     }
 }
@@ -158,6 +165,21 @@ mod tests {
         let opts = OutputOptions::default();
         opts.merge_into(&mut config);
         assert_eq!(config.output_template, "kept.%(ext)s");
+    }
+
+    #[test]
+    fn test_output_stdout_disables_incompatible_defaults() {
+        let mut config = Config::default();
+        config.embed_thumbnail = true;
+        let opts = OutputOptions {
+            stdout: Some(true),
+            ..OutputOptions::default()
+        };
+        opts.merge_into(&mut config);
+        assert!(config.output_to_stdout);
+        assert!(config.quiet);
+        assert!(!config.progress);
+        assert!(!config.embed_thumbnail);
     }
 
     #[test]

--- a/crates/rdlp-api/src/merge.rs
+++ b/crates/rdlp-api/src/merge.rs
@@ -26,6 +26,9 @@ impl MergeOverrides for OutputOptions {
         if let Some(ref v) = self.template {
             config.output_template = v.clone();
         }
+        if let Some(v) = self.stdout {
+            config.output_to_stdout = v;
+        }
     }
 }
 

--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -131,7 +131,7 @@ impl Orchestrator {
     /// - `Ok(Some(stats))` — download succeeded
     /// - `Ok(None)` — user cancelled
     /// - `Err(e)` — download failed, token expired, or unsupported format
-    pub(super) async fn download_to_stdout_with_cdn_fallback(
+    pub(super) async fn download_to_stdout(
         &self,
         format: &Format,
     ) -> Result<Option<DownloadStats>> {

--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -113,6 +113,74 @@ impl Orchestrator {
         Ok(Some(DownloadOutcome { stats, is_hls }))
     }
 
+    /// Execute a download to stdout with CDN fallback retry and token validation.
+    ///
+    /// Like `download_with_cdn_fallback` but streams to stdout instead of a file.
+    /// HLS formats are rejected (not yet supported for stdout streaming).
+    ///
+    /// # Returns
+    /// - `Ok(Some(stats))` — download succeeded
+    /// - `Ok(None)` — user cancelled
+    /// - `Err(e)` — all URLs failed, token expired, or unsupported format
+    pub(super) async fn download_to_stdout_with_cdn_fallback(
+        &self,
+        format: &Format,
+    ) -> Result<Option<DownloadStats>> {
+        if format.is_hls() {
+            return Err(OrchestratorError::Configuration(
+                "HLS is not yet supported with -o - (stdout output); \
+                 select an HTTP format instead"
+                    .to_string(),
+            ));
+        }
+
+        let downloader = self
+            .downloader_registry
+            .find_downloader_with_headers(&format.url, format.http_headers.as_ref())
+            .ok_or_else(|| OrchestratorError::NoDownloader {
+                url: format.url.clone(),
+            })?;
+
+        self.check_cdn_token_expiry(&format.url)?;
+
+        let download_urls: Vec<&str> = std::iter::once(format.url.as_str())
+            .chain(format.fallback_urls.iter().flatten().map(String::as_str))
+            .collect();
+
+        let mut last_err = None;
+        for (i, download_url) in download_urls.iter().enumerate() {
+            if i > 0 {
+                warn!(
+                    fallback = i,
+                    url:? = download_url;
+                    "Primary CDN failed, trying fallback (stdout)"
+                );
+            }
+
+            let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> =
+                Box::new(tokio::io::stdout());
+
+            match self
+                .execute_download_to_writer(&downloader, download_url, writer)
+                .await
+            {
+                Ok(Some(stats)) => {
+                    info!("Stdout download completed: {stats:?}");
+                    return Ok(Some(stats));
+                }
+                Ok(None) => return Ok(None),
+                Err(e) => {
+                    if i < download_urls.len() - 1 {
+                        warn!("Stdout download failed: {e}, will try fallback CDN");
+                    }
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        Err(last_err.unwrap())
+    }
+
     /// Check if the CDN token in a URL has expired.
     ///
     /// Supports two URL token formats:

--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -143,6 +143,17 @@ impl Orchestrator {
             ));
         }
 
+        // Log when fallback URLs exist but can't be used for pipe output
+        if let Some(ref fallbacks) = format.fallback_urls {
+            if !fallbacks.is_empty() {
+                info!(
+                    count = fallbacks.len();
+                    "Format has fallback CDN URLs but they cannot be used \
+                     with stdout (partial pipe writes are irreversible)"
+                );
+            }
+        }
+
         let downloader = self
             .downloader_registry
             .find_downloader_with_headers(&format.url, format.http_headers.as_ref())

--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -113,15 +113,24 @@ impl Orchestrator {
         Ok(Some(DownloadOutcome { stats, is_hls }))
     }
 
-    /// Execute a download to stdout with CDN fallback retry and token validation.
+    /// Execute a download to stdout with token validation (no CDN fallback).
     ///
-    /// Like `download_with_cdn_fallback` but streams to stdout instead of a file.
+    /// Unlike `download_with_cdn_fallback`, this does **not** try fallback URLs.
+    /// Once bytes have been written to a pipe, retrying with a different CDN URL
+    /// would corrupt the stream (the consumer would see partial data from URL 1
+    /// followed by a full stream from URL 2).
+    ///
     /// HLS formats are rejected (not yet supported for stdout streaming).
+    /// Merge downloads are rejected at the state machine level.
+    ///
+    /// **Note on stdout validation split:** HLS and Merge checks happen here at
+    /// runtime rather than in `Config::validate()` because they depend on the
+    /// selected format, which is only known after extraction.
     ///
     /// # Returns
     /// - `Ok(Some(stats))` — download succeeded
     /// - `Ok(None)` — user cancelled
-    /// - `Err(e)` — all URLs failed, token expired, or unsupported format
+    /// - `Err(e)` — download failed, token expired, or unsupported format
     pub(super) async fn download_to_stdout_with_cdn_fallback(
         &self,
         format: &Format,
@@ -143,42 +152,19 @@ impl Orchestrator {
 
         self.check_cdn_token_expiry(&format.url)?;
 
-        let download_urls: Vec<&str> = std::iter::once(format.url.as_str())
-            .chain(format.fallback_urls.iter().flatten().map(String::as_str))
-            .collect();
+        let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(tokio::io::stdout());
 
-        let mut last_err = None;
-        for (i, download_url) in download_urls.iter().enumerate() {
-            if i > 0 {
-                warn!(
-                    fallback = i,
-                    url:? = download_url;
-                    "Primary CDN failed, trying fallback (stdout)"
-                );
+        match self
+            .execute_download_to_writer(&downloader, &format.url, writer)
+            .await
+        {
+            Ok(Some(stats)) => {
+                info!("Stdout download completed: {stats:?}");
+                Ok(Some(stats))
             }
-
-            let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> =
-                Box::new(tokio::io::stdout());
-
-            match self
-                .execute_download_to_writer(&downloader, download_url, writer)
-                .await
-            {
-                Ok(Some(stats)) => {
-                    info!("Stdout download completed: {stats:?}");
-                    return Ok(Some(stats));
-                }
-                Ok(None) => return Ok(None),
-                Err(e) => {
-                    if i < download_urls.len() - 1 {
-                        warn!("Stdout download failed: {e}, will try fallback CDN");
-                    }
-                    last_err = Some(e);
-                }
-            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
         }
-
-        Err(last_err.unwrap())
     }
 
     /// Check if the CDN token in a URL has expired.

--- a/crates/rdlp-api/src/orchestrator/errors.rs
+++ b/crates/rdlp-api/src/orchestrator/errors.rs
@@ -76,7 +76,12 @@ pub enum OrchestratorError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// Configuration error (invalid options, missing files, etc.)
+    /// Configuration or runtime capability error.
+    ///
+    /// Covers both static misconfiguration (invalid options, missing files)
+    /// and runtime rejections that depend on the selected format (e.g.
+    /// "HLS not yet supported with stdout", "Merge downloads not supported
+    /// with stdout").
     #[error("{0}")]
     Configuration(String),
 }

--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -7,6 +7,7 @@ use log::info;
 use rdlp_core::{DownloadProgress, DownloadStats, Downloader, ProgressCallback};
 use std::path::Path;
 use std::sync::Arc;
+use tokio::io::AsyncWrite;
 use tokio::sync::mpsc;
 use tracing::instrument;
 
@@ -89,6 +90,37 @@ impl Orchestrator {
             () = self.cancel_token.cancelled() => {
                 info!("Download interrupted by cancellation");
                 info!("Progress saved. Run the same command again to resume.");
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(stats))
+    }
+
+    /// Execute download to an async writer (stdout) with cancellation support
+    ///
+    /// Returns Ok(Some(stats)) on success, Ok(None) if user cancelled
+    #[instrument(skip(self, downloader, writer), fields(url = %url))]
+    pub(super) async fn execute_download_to_writer(
+        &self,
+        downloader: &Arc<dyn Downloader>,
+        url: &str,
+        writer: Box<dyn AsyncWrite + Unpin + Send>,
+    ) -> Result<Option<DownloadStats>> {
+        let progress_callback: Option<Box<dyn ProgressCallback>> = Some(Box::new(
+            EventProgressCallback::new(self.event_tx.clone(), self.download_id),
+        ));
+
+        info!("Starting stdout download (cancel via CancellationToken)");
+
+        let download_future = downloader.download_to_writer(url, writer, progress_callback);
+
+        let stats = tokio::select! {
+            result = download_future => {
+                result.map_err(OrchestratorError::DownloadFailed)?
+            }
+            () = self.cancel_token.cancelled() => {
+                info!("Download to stdout interrupted by cancellation");
                 return Ok(None);
             }
         };

--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -97,9 +97,23 @@ impl Orchestrator {
         Ok(Some(stats))
     }
 
-    /// Execute download to an async writer (stdout) with cancellation support
+    /// Execute download to an async writer (stdout) with cancellation support.
     ///
-    /// Returns Ok(Some(stats)) on success, Ok(None) if user cancelled
+    /// Streams bytes directly to `writer` instead of writing to disk.
+    /// Used for `-o -` (stdout) mode.
+    ///
+    /// # Arguments
+    /// * `downloader` - The downloader to use
+    /// * `url` - URL to download
+    /// * `writer` - Async writer to stream bytes to (e.g. `tokio::io::stdout()`)
+    ///
+    /// # Returns
+    /// - `Ok(Some(stats))` on success
+    /// - `Ok(None)` if user cancelled via `CancellationToken`
+    ///
+    /// # Errors
+    /// Returns an error if the download fails or the downloader does not
+    /// support writer-based output.
     #[instrument(skip(self, downloader, writer), fields(url = %url))]
     pub(super) async fn execute_download_to_writer(
         &self,

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -289,6 +289,13 @@ impl Orchestrator {
         // Playlist prints its own summary, so return None to suppress
         // the single-video "Success!" message in main.
         if infos.len() > 1 {
+            if self.config.output_to_stdout {
+                return Err(OrchestratorError::Configuration(
+                    "Playlists are not supported with -o - (stdout output); \
+                     provide a single video URL instead"
+                        .to_string(),
+                ));
+            }
             return self
                 .download_playlist_internal(infos, interactive, archive)
                 .await

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -317,6 +317,19 @@ impl DownloadPhase {
                 subtitle_selection,
                 plan,
             } => {
+                // Stdout mode: skip path generation and resume detection
+                if orchestrator.config.output_to_stdout {
+                    info!("Downloading to stdout");
+                    return Ok(Self::Downloading {
+                        info,
+                        output_path: PathBuf::from("-"),
+                        format,
+                        state: DownloadState::Fresh,
+                        subtitle_selection,
+                        plan,
+                    });
+                }
+
                 let output_path = orchestrator.generate_output_path(&info, &format)?;
                 info!(path:? = output_path.display(); "Downloading to");
 
@@ -363,6 +376,31 @@ impl DownloadPhase {
                 subtitle_selection,
                 plan,
             } => {
+                // Stdout mode: stream directly, skip post-processing
+                if orchestrator.config.output_to_stdout {
+                    if matches!(*plan, DownloadPlan::Merge { .. }) {
+                        return Err(OrchestratorError::Configuration(
+                            "Merge downloads (video+audio) are not supported \
+                             with -o - (stdout output)"
+                                .to_string(),
+                        ));
+                    }
+
+                    let Some(_stats) = orchestrator
+                        .download_to_stdout_with_cdn_fallback(&format)
+                        .await?
+                    else {
+                        orchestrator.emit(Event::Cancelled {
+                            id: orchestrator.download_id,
+                        });
+                        return Ok(Self::Cancelled);
+                    };
+
+                    return Ok(Self::Complete {
+                        path: PathBuf::from("-"),
+                    });
+                }
+
                 // Branch on download plan
                 let (download_files, is_hls) = match *plan {
                     DownloadPlan::Single(_) => {

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -171,14 +171,17 @@ impl DownloadPhase {
                     info: Box::new(info.clone()),
                 });
 
-                // Try loading saved session state to skip interactive selection
+                // Try loading saved session state to skip interactive selection.
+                // Skip in stdout mode — session state is irrelevant for pipe output
+                // and a stale merge state could produce a confusing error.
                 let sanitized = orchestrator.sanitize_filename(&info.title);
                 let state_path = session_state::single_video_state_path(
                     &orchestrator.config.output_directory,
                     &sanitized,
                 );
-                if let Some(SessionState::SingleVideo(saved)) =
-                    SessionState::load(&state_path, &url).await
+                if !orchestrator.config.output_to_stdout
+                    && let Some(SessionState::SingleVideo(saved)) =
+                        SessionState::load(&state_path, &url).await
                 {
                     // Try to match the saved format_id against available formats
                     if let Some(format) = info
@@ -386,7 +389,7 @@ impl DownloadPhase {
                         ));
                     }
 
-                    let Some(_stats) = orchestrator
+                    let Some(_) = orchestrator
                         .download_to_stdout_with_cdn_fallback(&format)
                         .await?
                     else {
@@ -395,6 +398,14 @@ impl DownloadPhase {
                         });
                         return Ok(Self::Cancelled);
                     };
+
+                    // Delete session state on successful stdout completion
+                    let sanitized = orchestrator.sanitize_filename(&info.title);
+                    let state_path = session_state::single_video_state_path(
+                        &orchestrator.config.output_directory,
+                        &sanitized,
+                    );
+                    SessionState::delete(&state_path).await;
 
                     return Ok(Self::Complete {
                         path: PathBuf::from("-"),

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -101,9 +101,12 @@ pub enum DownloadPhase {
         /// Download plan (single or merge)
         plan: Box<DownloadPlan>,
     },
-    /// Download completed successfully
+    /// Download completed successfully.
+    ///
+    /// For file downloads, `path` is the real output path.
+    /// For stdout mode (`-o -`), `path` is the sentinel `"-"`.
     Complete {
-        /// Path to the downloaded file
+        /// Path to the downloaded file, or `"-"` for stdout output.
         path: PathBuf,
     },
     /// User cancelled the operation
@@ -147,6 +150,10 @@ impl DownloadPhase {
     /// - `Preparing` → `Downloading` (after determining resume state)
     /// - `Downloading` → `Complete` (after successful download) OR `Cancelled` (Ctrl+C)
     /// - `Complete` / `Cancelled` → Self (terminal states)
+    ///
+    /// **Stdout fast-path:** When `config.output_to_stdout` is true, the
+    /// `Downloading` phase streams directly to stdout and transitions straight
+    /// to `Complete`, skipping subtitles, thumbnails, and all post-processing.
     ///
     /// # Errors
     ///
@@ -283,28 +290,32 @@ impl DownloadPhase {
                     return Ok(Self::Cancelled);
                 };
 
-                // Save session state so selections survive interruption
-                let sanitized = orchestrator.sanitize_filename(&info.title);
-                let state_path = session_state::single_video_state_path(
-                    &orchestrator.config.output_directory,
-                    &sanitized,
-                );
-                let sub_langs: Vec<String> = subtitle_selection
-                    .iter()
-                    .map(|(lang, _)| lang.clone())
-                    .collect();
-                let audio_format_id = match &*plan {
-                    DownloadPlan::Merge { audio, .. } => Some(audio.format_id.clone()),
-                    DownloadPlan::Single(_) => None,
-                };
-                let state = SessionState::SingleVideo(SingleVideoState::new(
-                    &info.webpage_url,
-                    &info.title,
-                    &format.format_id,
-                    sub_langs,
-                    audio_format_id,
-                ));
-                state.save(&state_path).await;
+                // Save session state so selections survive interruption.
+                // Skip for stdout mode — no file to resume, and the state
+                // would just be deleted on completion anyway.
+                if !orchestrator.config.output_to_stdout {
+                    let sanitized = orchestrator.sanitize_filename(&info.title);
+                    let state_path = session_state::single_video_state_path(
+                        &orchestrator.config.output_directory,
+                        &sanitized,
+                    );
+                    let sub_langs: Vec<String> = subtitle_selection
+                        .iter()
+                        .map(|(lang, _)| lang.clone())
+                        .collect();
+                    let audio_format_id = match &*plan {
+                        DownloadPlan::Merge { audio, .. } => Some(audio.format_id.clone()),
+                        DownloadPlan::Single(_) => None,
+                    };
+                    let state = SessionState::SingleVideo(SingleVideoState::new(
+                        &info.webpage_url,
+                        &info.title,
+                        &format.format_id,
+                        sub_langs,
+                        audio_format_id,
+                    ));
+                    state.save(&state_path).await;
+                }
 
                 Ok(Self::Preparing {
                     info,
@@ -389,23 +400,12 @@ impl DownloadPhase {
                         ));
                     }
 
-                    let Some(_) = orchestrator
-                        .download_to_stdout_with_cdn_fallback(&format)
-                        .await?
-                    else {
+                    let Some(_) = orchestrator.download_to_stdout(&format).await? else {
                         orchestrator.emit(Event::Cancelled {
                             id: orchestrator.download_id,
                         });
                         return Ok(Self::Cancelled);
                     };
-
-                    // Delete session state on successful stdout completion
-                    let sanitized = orchestrator.sanitize_filename(&info.title);
-                    let state_path = session_state::single_video_state_path(
-                        &orchestrator.config.output_directory,
-                        &sanitized,
-                    );
-                    SessionState::delete(&state_path).await;
 
                     return Ok(Self::Complete {
                         path: PathBuf::from("-"),

--- a/crates/rdlp-api/src/orchestrator/state.rs
+++ b/crates/rdlp-api/src/orchestrator/state.rs
@@ -151,9 +151,14 @@ impl DownloadPhase {
     /// - `Downloading` → `Complete` (after successful download) OR `Cancelled` (Ctrl+C)
     /// - `Complete` / `Cancelled` → Self (terminal states)
     ///
-    /// **Stdout fast-path:** When `config.output_to_stdout` is true, the
-    /// `Downloading` phase streams directly to stdout and transitions straight
-    /// to `Complete`, skipping subtitles, thumbnails, and all post-processing.
+    /// **Stdout fast-path (`-o -`):** When `config.output_to_stdout` is true:
+    /// - `Extracting` skips loading saved session state (no file to resume).
+    /// - `SelectingSubtitles` skips persisting session state.
+    /// - `Preparing` skips path generation (uses `"-"` sentinel), rejects merge
+    ///   plans, and always starts fresh (no resume).
+    /// - `Downloading` streams directly to stdout via `download_to_stdout()`,
+    ///   then transitions straight to `Complete`, skipping subtitles,
+    ///   thumbnails, and all post-processing.
     ///
     /// # Errors
     ///
@@ -331,8 +336,17 @@ impl DownloadPhase {
                 subtitle_selection,
                 plan,
             } => {
-                // Stdout mode: skip path generation and resume detection
+                // Stdout mode: skip path generation and resume detection.
+                // Reject merge plans early — the Downloading phase would
+                // also reject, but failing here gives a clearer context.
                 if orchestrator.config.output_to_stdout {
+                    if matches!(*plan, DownloadPlan::Merge { .. }) {
+                        return Err(OrchestratorError::Configuration(
+                            "Merge downloads (video+audio) are not supported \
+                             with -o - (stdout output)"
+                                .to_string(),
+                        ));
+                    }
                     info!("Downloading to stdout");
                     return Ok(Self::Downloading {
                         info,

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -86,6 +86,8 @@ pub struct OutputOptions {
     pub template: Option<String>,
     /// Prefix prepended to all output paths.
     pub paths_prefix: Option<PathBuf>,
+    /// Stream output to stdout (`-o -`). `None` preserves base config.
+    pub stdout: Option<bool>,
 }
 
 /// Format selection options.

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -72,9 +72,16 @@ impl DownloadRequest {
 /// use rdlp_api::request::OutputOptions;
 /// use std::path::PathBuf;
 ///
+/// // File output with template
 /// let opts = OutputOptions {
 ///     output_dir: Some(PathBuf::from("/tmp/downloads")),
 ///     template: Some("%(title)s.%(ext)s".into()),
+///     ..OutputOptions::default()
+/// };
+///
+/// // Stdout streaming (-o -)
+/// let stdout_opts = OutputOptions {
+///     stdout: Some(true),
 ///     ..OutputOptions::default()
 /// };
 /// ```
@@ -228,6 +235,7 @@ mod tests {
         assert!(req.output.output_dir.is_none());
         assert!(req.output.template.is_none());
         assert!(req.output.paths_prefix.is_none());
+        assert!(req.output.stdout.is_none());
 
         // FormatOptions defaults
         assert!(req.format.selector.is_none());

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -554,7 +554,9 @@ fn merge_config(
         // Disable embed_thumbnail before validation: the default is `true`, and
         // Config::validate() would reject stdout + embed-thumbnail.
         if config.embed_thumbnail {
-            warn!("Disabling --embed-thumbnail (incompatible with -o -)");
+            // Use eprintln, not warn!(): the tracing subscriber is not
+            // initialised yet (it happens after build_config returns).
+            eprintln!("Warning: disabling --embed-thumbnail (incompatible with -o -)");
             config.embed_thumbnail = false;
         }
     } else if let Some(ref output) = args.output {

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -542,9 +542,13 @@ fn merge_config(
 ) -> Result<Config> {
     let mut config = file_config;
 
-    // Output: -o always sets output_template (the template engine handles
-    // both template fields like "%(title)s" and plain filenames like "video.mp4")
-    if let Some(ref output) = args.output {
+    // Output: -o - means stdout streaming
+    if args.output.as_deref() == Some("-") {
+        config.output_to_stdout = true;
+        config.quiet = true;
+        config.progress = false;
+        config.embed_thumbnail = false;
+    } else if let Some(ref output) = args.output {
         config.output_template = output.clone();
     }
     if let Some(ref dir) = args.output_dir {
@@ -1425,5 +1429,86 @@ mod tests {
             merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
 
         assert!(!config.audio_multistreams);
+    }
+
+    // === Stdout streaming tests ===
+
+    #[test]
+    fn test_merge_config_stdout_sets_flags() {
+        let mut args = default_args();
+        args.output = Some("-".to_string());
+
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+
+        assert!(config.output_to_stdout);
+        assert!(config.quiet);
+        assert!(!config.progress);
+        assert!(!config.embed_thumbnail);
+    }
+
+    #[test]
+    fn test_merge_config_stdout_does_not_set_output_template() {
+        let mut args = default_args();
+        args.output = Some("-".to_string());
+
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+
+        // output_template should remain the default, not "-"
+        assert_eq!(config.output_template, "%(title)s.%(ext)s");
+    }
+
+    #[test]
+    fn test_merge_config_stdout_with_remux_fails() {
+        let mut args = default_args();
+        args.output = Some("-".to_string());
+        args.remux = Some("mp4".to_string());
+
+        let result = merge_config(&args, Config::default(), no_interactive());
+        assert!(result.is_err(), "-o - with --remux should fail validation");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("remux"),
+            "Error should mention remux: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_merge_config_stdout_with_extract_audio_fails() {
+        let mut args = default_args();
+        args.output = Some("-".to_string());
+        args.extract_audio = true;
+
+        let result = merge_config(&args, Config::default(), no_interactive());
+        assert!(
+            result.is_err(),
+            "-o - with --extract-audio should fail validation"
+        );
+    }
+
+    #[test]
+    fn test_merge_config_stdout_with_embed_metadata_fails() {
+        let mut args = default_args();
+        args.output = Some("-".to_string());
+        args.embed_metadata = true;
+
+        let result = merge_config(&args, Config::default(), no_interactive());
+        assert!(
+            result.is_err(),
+            "-o - with --embed-metadata should fail validation"
+        );
+    }
+
+    #[test]
+    fn test_merge_config_normal_output_not_stdout() {
+        let mut args = default_args();
+        args.output = Some("%(title)s.%(ext)s".to_string());
+
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+
+        assert!(!config.output_to_stdout);
+        assert_eq!(config.output_template, "%(title)s.%(ext)s");
     }
 }

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -546,12 +546,17 @@ fn merge_config(
     if args.output.as_deref() == Some("-") {
         config.output_to_stdout = true;
         // Force quiet mode — progress/log output would corrupt the byte stream.
-        // config.progress is derived from config.quiet below, so no need to set it here.
         config.quiet = true;
+        // Explicitly suppress progress as well: config.progress is derived from
+        // config.quiet further below, but setting it here guards against future
+        // refactors that might add an early return between here and the derivation.
+        config.progress = false;
         // Disable embed_thumbnail before validation: the default is `true`, and
-        // Config::validate() would reject stdout + embed-thumbnail. This is a
-        // pre-validation fixup, not a silent override of a user flag.
-        config.embed_thumbnail = false;
+        // Config::validate() would reject stdout + embed-thumbnail.
+        if config.embed_thumbnail {
+            warn!("Disabling --embed-thumbnail (incompatible with -o -)");
+            config.embed_thumbnail = false;
+        }
     } else if let Some(ref output) = args.output {
         config.output_template = output.clone();
     }

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -545,8 +545,12 @@ fn merge_config(
     // Output: -o - means stdout streaming
     if args.output.as_deref() == Some("-") {
         config.output_to_stdout = true;
+        // Force quiet mode — progress/log output would corrupt the byte stream.
+        // config.progress is derived from config.quiet below, so no need to set it here.
         config.quiet = true;
-        config.progress = false;
+        // Disable embed_thumbnail before validation: the default is `true`, and
+        // Config::validate() would reject stdout + embed-thumbnail. This is a
+        // pre-validation fixup, not a silent override of a user flag.
         config.embed_thumbnail = false;
     } else if let Some(ref output) = args.output {
         config.output_template = output.clone();

--- a/crates/rdlp-core/src/error.rs
+++ b/crates/rdlp-core/src/error.rs
@@ -76,6 +76,10 @@ pub enum RdlpError {
     #[error("Regex error: {0}")]
     Regex(#[from] regex::Error),
 
+    /// Operation not supported by this component
+    #[error("Unsupported: {0}")]
+    Unsupported(String),
+
     /// Generic errors
     #[error("{0}")]
     Other(String),

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use std::fmt;
 use std::path::Path;
 use std::time::Duration;
+use tokio::io::AsyncWrite;
 
 use crate::Result;
 
@@ -91,6 +92,32 @@ pub trait Downloader: Send + Sync {
     ) -> Result<DownloadStats> {
         // Default implementation doesn't support resume, just downloads normally
         self.download_to_file(url, path, progress).await
+    }
+
+    /// Download content to an arbitrary async writer (e.g. stdout)
+    ///
+    /// Used for pipe output (`-o -`). Streams bytes directly to the writer
+    /// without writing to disk.
+    ///
+    /// # Arguments
+    /// * `url` - The URL to download from
+    /// * `writer` - Async writer to stream bytes to
+    /// * `progress` - Optional progress callback
+    ///
+    /// # Returns
+    /// Download statistics
+    ///
+    /// # Default Implementation
+    /// Returns an error -- downloaders that support streaming must override.
+    async fn download_to_writer(
+        &self,
+        _url: &str,
+        _writer: Box<dyn AsyncWrite + Unpin + Send>,
+        _progress: Option<Box<dyn ProgressCallback>>,
+    ) -> Result<DownloadStats> {
+        Err(crate::RdlpError::Download(
+            "download_to_writer not supported by this downloader".to_string(),
+        ))
     }
 }
 
@@ -418,5 +445,17 @@ mod tests {
         assert_eq!(progress.percentage, Some(50.0));
         assert!(progress.eta.is_some());
         assert_eq!(progress.eta.unwrap().as_secs(), 5);
+    }
+
+    #[test]
+    fn test_downloader_trait_has_download_to_writer() {
+        // Verify the trait method signature exists at compile time.
+        // We test this indirectly by ensuring a mock struct implementing
+        // Downloader can call the default download_to_writer and get an error.
+
+        // Type-check only: the default impl should return an error
+        fn _assert_method_exists<D: Downloader>(_d: &D) {
+            // This function only needs to compile, not run
+        }
     }
 }

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -115,7 +115,7 @@ pub trait Downloader: Send + Sync {
         _writer: Box<dyn AsyncWrite + Unpin + Send>,
         _progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
-        Err(crate::RdlpError::Download(
+        Err(crate::RdlpError::Unsupported(
             "download_to_writer not supported by this downloader".to_string(),
         ))
     }

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -447,15 +447,42 @@ mod tests {
         assert_eq!(progress.eta.unwrap().as_secs(), 5);
     }
 
-    #[test]
-    fn test_downloader_trait_has_download_to_writer() {
-        // Verify the trait method signature exists at compile time.
-        // We test this indirectly by ensuring a mock struct implementing
-        // Downloader can call the default download_to_writer and get an error.
+    #[tokio::test]
+    async fn test_download_to_writer_default_returns_unsupported() {
+        use crate::RdlpError;
 
-        // Type-check only: the default impl should return an error
-        fn _assert_method_exists<D: Downloader>(_d: &D) {
-            // This function only needs to compile, not run
+        struct StubDownloader;
+
+        #[async_trait]
+        impl Downloader for StubDownloader {
+            fn protocol(&self) -> &str {
+                "stub"
+            }
+            async fn download_to_file(
+                &self,
+                _url: &str,
+                _path: &Path,
+                _progress: Option<Box<dyn ProgressCallback>>,
+            ) -> Result<DownloadStats> {
+                unimplemented!()
+            }
+            fn supports(&self, _url: &str) -> bool {
+                false
+            }
+            async fn get_size(&self, _url: &str) -> Result<Option<u64>> {
+                Ok(None)
+            }
         }
+
+        let d = StubDownloader;
+        let writer: Box<dyn AsyncWrite + Unpin + Send> = Box::new(Vec::<u8>::new());
+        let err = d
+            .download_to_writer("http://example.com", writer, None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, RdlpError::Unsupported(_)),
+            "expected Unsupported, got: {err:?}"
+        );
     }
 }

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -547,6 +547,9 @@ impl Downloader for HttpDownloader {
                 }
             }
 
+            // Note: on BrokenPipe, `downloaded` may overcount by up to
+            // `buffer_size` bytes that were counted but not flushed to the pipe.
+            // This is inherent to BufWriter and acceptable for stats purposes.
             match buf_writer.flush().await {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -466,6 +466,110 @@ impl Downloader for HttpDownloader {
         })?
     }
 
+    async fn download_to_writer(
+        &self,
+        url: &str,
+        writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+        progress: Option<Box<dyn ProgressCallback>>,
+    ) -> Result<DownloadStats> {
+        let timeout = self.config.download_timeout;
+        tokio::time::timeout(timeout, async {
+            let start_time = Instant::now();
+            let client = self.client.clone();
+            let url_string = url.to_string();
+            let hdrs = self.headers();
+
+            let response =
+                with_retry(&self.config.retry_config, "HTTP GET (stdout)", || {
+                    let client = client.clone();
+                    let url = url_string.clone();
+                    let hdrs = hdrs.clone();
+                    async move {
+                        let response =
+                            client.get(&url).headers(hdrs).send().await.map_err(|e| {
+                                RdlpError::Network(format!("GET request failed: {e}"))
+                            })?;
+
+                        check_http_response(&response)?;
+                        Ok(response)
+                    }
+                })
+                .await?;
+
+            let total_size = response.content_length();
+            let mut buf_writer = BufWriter::with_capacity(self.config.buffer_size, writer);
+
+            let mut stream = response.bytes_stream();
+            let mut downloaded: u64 = 0;
+            let mut last_update = Instant::now();
+            let update_interval = PROGRESS_UPDATE_INTERVAL;
+            let read_timeout = self.config.read_timeout;
+
+            while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
+                .await
+                .map_err(|_| {
+                RdlpError::Network(format!(
+                    "Read timed out (no data for {}s)",
+                    read_timeout.as_secs()
+                ))
+            })? {
+                let chunk = chunk_result
+                    .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
+
+                match buf_writer.write_all(&chunk).await {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                        debug!("Broken pipe on stdout, stopping gracefully");
+                        break;
+                    }
+                    Err(e) => return Err(RdlpError::Io(e)),
+                }
+                downloaded += chunk.len() as u64;
+
+                if let Some(ref callback) = progress {
+                    let now = Instant::now();
+                    if now.duration_since(last_update) >= update_interval {
+                        let elapsed = now.duration_since(start_time).as_secs_f64();
+                        let speed = if elapsed > 0.0 {
+                            downloaded as f64 / elapsed
+                        } else {
+                            0.0
+                        };
+
+                        let progress_info = DownloadProgress::new(downloaded, total_size, speed);
+                        callback.on_progress(&progress_info);
+                        last_update = now;
+                    }
+                }
+
+                if let Some(ref limiter) = self.rate_limiter {
+                    limiter.acquire(chunk.len()).await;
+                }
+            }
+
+            match buf_writer.flush().await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                    debug!("Broken pipe on flush, ignoring");
+                }
+                Err(e) => return Err(RdlpError::Io(e)),
+            }
+
+            let duration = start_time.elapsed();
+            let stats = DownloadStats::new(downloaded, duration, 0);
+
+            if let Some(callback) = progress {
+                callback.on_complete(&stats);
+            }
+
+            Ok(stats)
+        })
+        .await
+        .map_err(|_| {
+            RdlpError::Download(format!("Download timed out after {}s", timeout.as_secs()))
+        })?
+    }
+
     fn supports(&self, url: &str) -> bool {
         url.starts_with("http://") || url.starts_with("https://")
     }

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -547,8 +547,10 @@ impl Downloader for HttpDownloader {
                 }
             }
 
-            // Note: on BrokenPipe, `downloaded` may overcount by up to
-            // `buffer_size` bytes that were counted but not flushed to the pipe.
+            // Note: on BrokenPipe the current chunk is NOT counted (break
+            // fires before `downloaded +=`), but prior chunks written to the
+            // BufWriter may not have been flushed, so `downloaded` can exceed
+            // the bytes actually delivered to the pipe by up to `buffer_size`.
             // This is inherent to BufWriter and acceptable for stats purposes.
             match buf_writer.flush().await {
                 Ok(()) => {}

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -466,6 +466,11 @@ impl Downloader for HttpDownloader {
         })?
     }
 
+    /// Stream an HTTP download into an arbitrary async writer (e.g. stdout).
+    ///
+    /// Unlike `download_to_file`, this always uses sequential I/O (no parallel
+    /// chunks) because the destination is not seekable. On `BrokenPipe` the
+    /// download stops gracefully and returns the bytes written so far.
     async fn download_to_writer(
         &self,
         url: &str,
@@ -547,11 +552,14 @@ impl Downloader for HttpDownloader {
                 }
             }
 
-            // Note: on BrokenPipe the current chunk is NOT counted (break
-            // fires before `downloaded +=`), but prior chunks written to the
-            // BufWriter may not have been flushed, so `downloaded` can exceed
-            // the bytes actually delivered to the pipe by up to `buffer_size`.
-            // This is inherent to BufWriter and acceptable for stats purposes.
+            // BrokenPipe accounting: when `write_all` hits BrokenPipe, we
+            // break before `downloaded +=`, so the failing chunk is excluded.
+            // However, earlier chunks that were written to the BufWriter's
+            // internal buffer may not have reached the pipe yet (up to
+            // `buffer_size` bytes). This means `downloaded` can *overstate*
+            // the bytes actually delivered to the consumer by up to one
+            // buffer's worth. This is inherent to buffered I/O and
+            // acceptable for stats/logging purposes.
             match buf_writer.flush().await {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -210,6 +210,49 @@ async fn test_parallel_download_error_propagation() {
 }
 
 #[tokio::test]
+async fn test_download_to_writer_streams_bytes() {
+    use mockito::Server;
+    use tokio::io::AsyncWrite;
+
+    let mut server = Server::new_async().await;
+    let body = b"hello stdout stream";
+
+    let _mock = server
+        .mock("GET", "/pipe.mp4")
+        .with_status(200)
+        .with_header("content-type", "video/mp4")
+        .with_body(body.as_slice())
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new();
+
+    // Use DuplexStream as writer: one end writes, we read from the other
+    let (client_stream, mut server_stream) = tokio::io::duplex(64 * 1024);
+
+    // Spawn reader to drain the duplex
+    let reader_handle = tokio::spawn(async move {
+        let mut collected = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut server_stream, &mut collected)
+            .await
+            .unwrap();
+        collected
+    });
+
+    let writer: Box<dyn AsyncWrite + Unpin + Send> = Box::new(client_stream);
+    let result = downloader
+        .download_to_writer(&format!("{}/pipe.mp4", server.url()), writer, None)
+        .await;
+
+    assert!(result.is_ok(), "download_to_writer should succeed");
+    let stats = result.unwrap();
+    assert_eq!(stats.bytes_downloaded, body.len() as u64);
+
+    let received = reader_handle.await.unwrap();
+    assert_eq!(received, body.as_slice());
+}
+
+#[tokio::test]
 async fn test_parallel_resume() {
     use mockito::Server;
     use tempfile::TempDir;

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -25,9 +25,13 @@ pub enum ConfigValidationError {
         /// Configured end
         end: usize,
     },
-    /// A post-processing option is incompatible with stdout output (`-o -`)
+    /// A post-processing option is incompatible with stdout output (`-o -`).
+    ///
+    /// Uses `String` rather than a typed enum because these are CLI flag names
+    /// (`--extract-audio`, `--remux`, etc.) used only for error display. The set
+    /// grows as new post-processing flags are added.
     StdoutIncompatible {
-        /// The incompatible option name
+        /// The incompatible CLI option name (e.g. `"extract-audio"`)
         option: String,
     },
 }
@@ -445,6 +449,7 @@ impl Config {
                 ("loudnorm", self.loudnorm),
                 ("write-subtitles", self.write_subtitles),
                 ("write-thumbnail", self.write_thumbnail),
+                ("normalize-boost", self.normalize_boost),
             ];
             for &(option, active) in incompatible {
                 if active {
@@ -595,6 +600,21 @@ mod tests {
             err,
             ConfigValidationError::StdoutIncompatible {
                 option: "normalize-audio".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_stdout_rejects_normalize_boost() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        config.embed_thumbnail = false;
+        config.normalize_boost = true;
+        let err = config.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ConfigValidationError::StdoutIncompatible {
+                option: "normalize-boost".to_string()
             }
         );
     }

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -25,6 +25,11 @@ pub enum ConfigValidationError {
         /// Configured end
         end: usize,
     },
+    /// A post-processing option is incompatible with stdout output (`-o -`)
+    StdoutIncompatible {
+        /// The incompatible option name
+        option: String,
+    },
 }
 
 impl fmt::Display for ConfigValidationError {
@@ -40,6 +45,9 @@ impl fmt::Display for ConfigValidationError {
                     f,
                     "playlist_end ({end}) must be >= playlist_start ({start})"
                 )
+            }
+            Self::StdoutIncompatible { option } => {
+                write!(f, "--{option} is not compatible with -o - (stdout output)")
             }
         }
     }
@@ -58,6 +66,9 @@ impl std::error::Error for ConfigValidationError {}
 #[serde(default)]
 pub struct Config {
     // === Output options ===
+    /// Stream output to stdout instead of a file (`-o -`)
+    pub output_to_stdout: bool,
+
     /// Output filename template (e.g., "%(title)s.%(ext)s")
     pub output_template: String,
 
@@ -295,6 +306,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             // Output options
+            output_to_stdout: false,
             output_template: "%(title)s.%(ext)s".to_string(),
             output_directory: PathBuf::from("."),
             restrict_filenames: false,
@@ -419,6 +431,30 @@ impl Config {
                 });
             }
         }
+
+        // Stdout mode rejects post-processing options that require file I/O
+        if self.output_to_stdout {
+            let incompatible: &[(&str, bool)] = &[
+                ("extract-audio", self.extract_audio),
+                ("remux", self.remux_container.is_some()),
+                ("recode-video", self.recode_video.is_some()),
+                ("embed-metadata", self.embed_metadata),
+                ("embed-thumbnail", self.embed_thumbnail),
+                ("embed-subtitles", self.embed_subtitles),
+                ("normalize-audio", self.normalize_audio),
+                ("loudnorm", self.loudnorm),
+                ("write-subtitles", self.write_subtitles),
+                ("write-thumbnail", self.write_thumbnail),
+            ];
+            for &(option, active) in incompatible {
+                if active {
+                    return Err(ConfigValidationError::StdoutIncompatible {
+                        option: option.to_string(),
+                    });
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -472,5 +508,105 @@ mod tests {
         config.playlist_start = 10;
         config.playlist_end = Some(5);
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_default_output_to_stdout_is_false() {
+        let config = Config::default();
+        assert!(!config.output_to_stdout);
+    }
+
+    #[test]
+    fn test_stdout_valid_when_no_postprocessing() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        config.embed_thumbnail = false;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_stdout_rejects_extract_audio() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        config.embed_thumbnail = false;
+        config.extract_audio = true;
+        let err = config.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ConfigValidationError::StdoutIncompatible {
+                option: "extract-audio".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_stdout_rejects_remux() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        config.embed_thumbnail = false;
+        config.remux_container = Some(ContainerFormat::Mp4);
+        let err = config.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ConfigValidationError::StdoutIncompatible {
+                option: "remux".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_stdout_rejects_embed_thumbnail() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        // embed_thumbnail defaults to true, which should fail
+        assert!(config.embed_thumbnail);
+        let err = config.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ConfigValidationError::StdoutIncompatible {
+                option: "embed-thumbnail".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_stdout_rejects_embed_metadata() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        config.embed_thumbnail = false;
+        config.embed_metadata = true;
+        let err = config.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ConfigValidationError::StdoutIncompatible {
+                option: "embed-metadata".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_stdout_rejects_normalize_audio() {
+        let mut config = Config::default();
+        config.output_to_stdout = true;
+        config.embed_thumbnail = false;
+        config.normalize_audio = true;
+        let err = config.validate().unwrap_err();
+        assert_eq!(
+            err,
+            ConfigValidationError::StdoutIncompatible {
+                option: "normalize-audio".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_stdout_incompatible_error_display() {
+        let err = ConfigValidationError::StdoutIncompatible {
+            option: "remux".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "--remux is not compatible with -o - (stdout output)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds `-o -` support for piping downloaded media directly to stdout (e.g., `rdlp -o - URL | ffplay -`).

**Scope**: HTTP direct downloads only. HLS stdout streaming is deferred.

### Changes

- `Config.output_to_stdout` flag with validation rejecting incompatible post-processing options
- `Downloader::download_to_writer()` trait method with `RdlpError::Unsupported` default
- `HttpDownloader::download_to_writer()` implementation with BufWriter and BrokenPipe handling
- `OutputOptions.stdout` field in request API
- CLI `-o -` detection: forces quiet mode, warns when clearing embed_thumbnail, explicitly sets progress=false
- State machine stdout fast-path: streams directly, skips subtitles/thumbnails/post-processing
- `download_to_stdout()` orchestrator method (single attempt, no CDN fallback for pipes)
- Playlist rejection for stdout mode

### Code review fixes (round 1 — 15 issues)

1. Session state deleted on stdout completion (was leaked)
2. CDN fallback removed from stdout path (partial pipe writes irreversible)
3. Dead `config.progress = false` removed (derived from quiet)
4. `normalize-boost` added to stdout incompatibility list
5. `last_err.unwrap()` panic eliminated (single-attempt rewrite)
6. `StdoutIncompatible` documented (why String over enum)
7. Session state loading skipped in stdout mode (Extracting phase)
8. `execute_download_to_writer` given full rustdoc
9. `RdlpError::Unsupported` variant added (not `Download`)
10. BufWriter stats comment added for BrokenPipe
11. CDN fallback doc removed from stdout function
12. Unused `_stats` binding simplified to `_`
13. `OutputOptions` doc example updated with stdout
14. `embed_thumbnail = false` fixup documented
15. Playlist rejection added for stdout mode

### Code review fixes (round 2 — 9 issues)

1. Renamed `download_to_stdout_with_cdn_fallback` → `download_to_stdout` (misleading name)
2. Mapped `RdlpError::Unsupported` to `UnsupportedPlatform` instead of `InvalidInput`
3. Replaced empty `download_to_writer` test with real async test
4. Skip session state save in `SelectingSubtitles` for stdout (removes pointless I/O + delete cycle)
5. Fixed BrokenPipe comment accuracy (current chunk not counted, prior buffered chunks may not flush)
6. Added `warn!()` when clearing `embed_thumbnail` for stdout
7. Explicitly set `config.progress = false` in stdout block (guards against refactoring)
8. Updated `advance()` doc to document stdout fast-path
9. Updated `Complete` variant doc to mention `"-"` sentinel for stdout

### Code review fixes (round 3 — 13 issues, 2 false positives skipped)

1. API `OutputOptions::merge_into()` now mirrors CLI stdout defaults (quiet, progress=false, embed_thumbnail=false)
2. Filter `"-"` sentinel from `DownloadResult.output_files` for stdout mode
3. Added rustdoc on `HttpDownloader::download_to_writer` implementation
4. Added `download_to_writer` integration test (mockito + tokio duplex stream)
5. ~~StdoutIncompatible uses raw String~~ — false positive (score 0)
6. Expanded `OrchestratorError::Configuration` doc to clarify runtime rejection coverage
7. ~~Vec<u8> AsyncWrite concern~~ — false positive (score 0)
8. Moved merge-plan rejection from `Downloading` to `Preparing` phase (earlier, clearer context)
9. Clarified BrokenPipe accounting comment (overstatement direction and cause)
10. Changed `warn!()` to `eprintln!()` for embed_thumbnail message (fires before tracing subscriber init)
11. Added `info!()` log when fallback CDN URLs exist but are skipped for stdout
12. Expanded `advance()` rustdoc with per-phase stdout behavior (Extracting, SelectingSubtitles, Preparing, Downloading)
13. Mapped `OrchestratorError::Configuration` to `InvalidInput` instead of `BuilderError` (semantically correct for runtime rejections)

## Test plan

- [ ] `cargo fmt --check` — pass
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo test` — all pass
- [ ] `rdlp -o - URL | ffplay -` — plays video from pipe
- [ ] `rdlp -o - --remux URL` — rejected with clear error
- [ ] `rdlp -o - PLAYLIST_URL` — rejected with clear error