### PR TITLE
chore: gitignore media and subtitle files before going public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,26 @@ CLAUDE.md
 debug_tnaflix.rs
 .claude/
 
+# Downloaded media files (never commit)
+*.mkv
+*.mp4
+*.avi
+*.mov
+*.flv
+*.ts
+*.webm
+*.ogg
+*.m4a
+*.mp3
+*.flac
+*.wav
 
+# Downloaded subtitle files
+*.vtt
+*.srt
+*.ass
+*.ssa
+*.lrc
+
+# Windows null device redirect artifact
+nul


### PR DESCRIPTION
## Summary
- Add media file extensions (`.mkv`, `.mp4`, `.avi`, `.mov`, `.flv`, `.ts`, `.webm`, `.ogg`, `.m4a`, `.mp3`, `.flac`, `.wav`) to `.gitignore`
- Add subtitle file extensions (`.vtt`, `.srt`, `.ass`, `.ssa`, `.lrc`) to `.gitignore`
- Add Windows `nul` device redirect artifact to `.gitignore`
- Prevents accidental commits of downloaded content before making the repository public

## Test plan
- [x] `git status` shows clean working tree (no untracked media/subtitle files)
- [x] `git check-ignore` confirms media and subtitle files are ignored
- [ ] Verify no existing tracked files are affected