### PR TITLE
feat(desktop): search filter UI, format dialog, and settings enhancements

### DIFF
--- a/crates/rdlp-api/src/merge.rs
+++ b/crates/rdlp-api/src/merge.rs
@@ -104,6 +104,9 @@ impl MergeOverrides for PostProcessOptions {
         if let Some(ref v) = self.loudnorm_preset {
             config.loudnorm_preset = Some(v.clone());
         }
+        if let Some(v) = self.recode_video {
+            config.recode_video = Some(v);
+        }
     }
 }
 
@@ -569,6 +572,33 @@ mod tests {
         };
         opts.merge_into(&mut config);
         assert_eq!(config.loudnorm_preset.as_deref(), Some("streaming"));
+    }
+
+    #[test]
+    fn test_postprocess_none_preserves_recode_video() {
+        let mut config = Config::default();
+        config.recode_video = Some(rdlp_core::ContainerFormat::Mkv);
+        let opts = PostProcessOptions::default();
+        opts.merge_into(&mut config);
+        assert_eq!(
+            config.recode_video,
+            Some(rdlp_core::ContainerFormat::Mkv)
+        );
+    }
+
+    #[test]
+    fn test_postprocess_some_overrides_recode_video() {
+        let mut config = Config::default();
+        config.recode_video = None;
+        let opts = PostProcessOptions {
+            recode_video: Some(rdlp_core::ContainerFormat::Mp4),
+            ..PostProcessOptions::default()
+        };
+        opts.merge_into(&mut config);
+        assert_eq!(
+            config.recode_video,
+            Some(rdlp_core::ContainerFormat::Mp4)
+        );
     }
 
     // ─── NetworkOptions ──────────────────────────────────────────────

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -187,6 +187,8 @@ pub struct PostProcessOptions {
     pub loudnorm: Option<bool>,
     /// Loudness normalization preset name (e.g. `"streaming"`).
     pub loudnorm_preset: Option<String>,
+    /// Recode (transcode) video into a different container format.
+    pub recode_video: Option<ContainerFormat>,
 }
 
 /// Network, retry, and cookie options.
@@ -261,6 +263,7 @@ mod tests {
         assert!(req.postprocess.normalize_audio.is_none());
         assert!(req.postprocess.loudnorm.is_none());
         assert!(req.postprocess.loudnorm_preset.is_none());
+        assert!(req.postprocess.recode_video.is_none());
 
         // NetworkOptions defaults
         assert!(req.network.retries.is_none());

--- a/crates/rdlp-desktop/package.json
+++ b/crates/rdlp-desktop/package.json
@@ -13,6 +13,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-shell": "^2",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zustand": "^5"

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -41,6 +41,10 @@ pub struct DownloadOptions {
     pub extract_audio: Option<AudioFormat>,
     /// Whether to embed a thumbnail in the output file.
     pub embed_thumbnail: bool,
+    /// Allow downloading multiple audio streams for merge.
+    pub audio_multistreams: bool,
+    /// Container format to recode video into (transcodes, not just remux).
+    pub recode_video: Option<ContainerFormat>,
 }
 
 /// Start a new download for the given URL.
@@ -110,6 +114,11 @@ pub async fn start_download(
         },
         format: FormatOptions {
             selector: options.format,
+            audio_multistreams: if options.audio_multistreams {
+                Some(true)
+            } else {
+                None
+            },
             ..FormatOptions::default()
         },
         subtitles: SubtitleOptions {

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -130,6 +130,7 @@ pub async fn start_download(
         postprocess: PostProcessOptions {
             remux,
             extract_audio,
+            recode_video: options.recode_video,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
             ..PostProcessOptions::default()

--- a/crates/rdlp-desktop/src-tauri/src/commands/formats.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/formats.rs
@@ -40,6 +40,14 @@ pub struct FormatInfo {
     pub acodec: Option<String>,
     /// File size in bytes (exact or approximate).
     pub filesize: Option<u64>,
+    /// Video bitrate in kbps.
+    pub vbr: Option<f64>,
+    /// Audio bitrate in kbps.
+    pub abr: Option<f64>,
+    /// Audio sampling rate in Hz.
+    pub asr: Option<u32>,
+    /// Download protocol (e.g. "https", "m3u8_native").
+    pub protocol: String,
     /// Whether this format contains a video stream.
     pub has_video: bool,
     /// Whether this format contains an audio stream.
@@ -135,6 +143,10 @@ pub async fn get_formats(
             vcodec: f.vcodec.clone(),
             acodec: f.acodec.clone(),
             filesize: f.get_filesize(),
+            vbr: f.vbr,
+            abr: f.abr,
+            asr: f.asr,
+            protocol: f.protocol.to_string(),
             has_video: f.has_video(),
             has_audio: f.has_audio(),
         })
@@ -164,6 +176,61 @@ pub async fn get_formats(
     })
 }
 
+/// Validate a yt-dlp format expression and return the matching format IDs.
+///
+/// Parses the expression using [`rdlp_types::FormatSelector`] and, when
+/// `format_ids` is non-empty, builds minimal [`rdlp_types::Format`]
+/// stubs to determine which IDs the expression would select.
+///
+/// # Arguments
+///
+/// * `expression` - A yt-dlp format selector expression (e.g. `bv[height<=1080]+ba`).
+/// * `format_ids` - The list of format IDs available for matching.
+///
+/// # Returns
+///
+/// A list of matching format IDs on success, or an [`AppError`] on
+/// parse failure.
+#[tauri::command]
+pub async fn validate_format_expression(
+    expression: String,
+    format_ids: Vec<String>,
+) -> Result<Vec<String>, AppError> {
+    tokio::task::spawn_blocking(move || {
+        use rdlp_types::FormatSelector;
+
+        let selector =
+            FormatSelector::parse(&expression).map_err(|e| AppError::InvalidInput {
+                field: "expression".to_owned(),
+                message: e,
+            })?;
+
+        if format_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build minimal Format stubs so the selector can match by format_id.
+        use rdlp_types::protocol::DownloadProtocol;
+        use rdlp_types::Format;
+
+        let formats: Vec<Format> = format_ids
+            .iter()
+            .map(|id| {
+                Format::new(id, format!("stub://{id}"), "mp4", DownloadProtocol::Https)
+            })
+            .collect();
+
+        let selected = selector.select(&formats);
+        let matched: Vec<String> =
+            selected.iter().map(|f| f.format_id.clone()).collect();
+        Ok(matched)
+    })
+    .await
+    .map_err(|e| AppError::Internal {
+        message: format!("Format validation task failed: {e}"),
+    })?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +248,10 @@ mod tests {
             vcodec: Some("h264".to_owned()),
             acodec: Some("aac".to_owned()),
             filesize: Some(524_288_000),
+            vbr: Some(4000.0),
+            abr: Some(128.0),
+            asr: Some(44100),
+            protocol: "https".to_owned(),
             has_video: true,
             has_audio: true,
         };
@@ -193,6 +264,10 @@ mod tests {
         assert_eq!(json["has_video"], true);
         assert_eq!(json["has_audio"], true);
         assert_eq!(json["filesize"], 524_288_000u64);
+        assert_eq!(json["vbr"], 4000.0);
+        assert_eq!(json["abr"], 128.0);
+        assert_eq!(json["asr"], 44100);
+        assert_eq!(json["protocol"], "https");
     }
 
     #[test]
@@ -208,6 +283,10 @@ mod tests {
             vcodec: None,
             acodec: None,
             filesize: None,
+            vbr: None,
+            abr: None,
+            asr: None,
+            protocol: "m3u8_native".to_owned(),
             has_video: false,
             has_audio: true,
         };
@@ -216,6 +295,10 @@ mod tests {
         assert!(json["format_note"].is_null());
         assert!(json["width"].is_null());
         assert!(json["filesize"].is_null());
+        assert!(json["vbr"].is_null());
+        assert!(json["abr"].is_null());
+        assert!(json["asr"].is_null());
+        assert_eq!(json["protocol"], "m3u8_native");
         assert!(!json["has_video"].as_bool().unwrap());
         assert!(json["has_audio"].as_bool().unwrap());
     }
@@ -250,6 +333,10 @@ mod tests {
                 vcodec: Some("h264".to_owned()),
                 acodec: Some("aac".to_owned()),
                 filesize: Some(100_000_000),
+                vbr: Some(2000.0),
+                abr: Some(128.0),
+                asr: Some(44100),
+                protocol: "https".to_owned(),
                 has_video: true,
                 has_audio: true,
             }],
@@ -285,5 +372,48 @@ mod tests {
         assert!(json["subtitles"].as_array().unwrap().is_empty());
         assert!(json["thumbnail_url"].is_null());
         assert!(json["duration"].is_null());
+    }
+
+    #[tokio::test]
+    async fn test_validate_format_expression_valid() {
+        let result = super::validate_format_expression(
+            "best".to_owned(),
+            vec!["137".to_owned(), "140".to_owned()],
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_format_expression_invalid() {
+        let result = super::validate_format_expression(
+            "".to_owned(),
+            vec![],
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_validate_format_expression_empty_ids() {
+        let result = super::validate_format_expression(
+            "bv+ba".to_owned(),
+            vec![],
+        )
+        .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_validate_format_expression_format_id_match() {
+        let result = super::validate_format_expression(
+            "137".to_owned(),
+            vec!["137".to_owned(), "140".to_owned()],
+        )
+        .await;
+        assert!(result.is_ok());
+        let matches = result.unwrap();
+        assert_eq!(matches, vec!["137"]);
     }
 }

--- a/crates/rdlp-desktop/src-tauri/src/commands/formats.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/formats.rs
@@ -7,7 +7,7 @@
 //! serialisable [`FormatListResponse`] containing format details,
 //! subtitles, thumbnail URL, and duration.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::error::AppError;
@@ -16,8 +16,7 @@ use crate::state::AppState;
 /// Frontend-facing format information.
 ///
 /// A simplified projection of [`rdlp_types::Format`] that exposes
-/// only the fields the UI needs, without internal download URLs or
-/// protocol details.
+/// only the fields the UI needs, without internal download URLs.
 #[derive(Debug, Serialize)]
 pub struct FormatInfo {
     /// Unique format identifier (e.g. "137", "hls-720").
@@ -176,16 +175,52 @@ pub async fn get_formats(
     })
 }
 
+/// Format metadata sent from the frontend for expression validation.
+///
+/// Mirrors the fields from [`FormatInfo`] that the format selector
+/// uses for filtering and ranking, allowing expressions like
+/// `bv[height<=1080]+ba` to match correctly.
+#[derive(Debug, Deserialize)]
+pub struct FormatData {
+    /// Unique format identifier.
+    pub(crate) format_id: String,
+    /// File extension (e.g. "mp4", "webm").
+    pub(crate) ext: String,
+    /// Video width in pixels.
+    pub(crate) width: Option<u32>,
+    /// Video height in pixels.
+    pub(crate) height: Option<u32>,
+    /// Frames per second.
+    pub(crate) fps: Option<f64>,
+    /// Total bitrate in kbps.
+    pub(crate) tbr: Option<f64>,
+    /// Video codec name.
+    pub(crate) vcodec: Option<String>,
+    /// Audio codec name.
+    pub(crate) acodec: Option<String>,
+    /// File size in bytes.
+    pub(crate) filesize: Option<u64>,
+    /// Video bitrate in kbps.
+    pub(crate) vbr: Option<f64>,
+    /// Audio bitrate in kbps.
+    pub(crate) abr: Option<f64>,
+    /// Audio sampling rate in Hz.
+    pub(crate) asr: Option<u32>,
+    /// Download protocol string (e.g. "https", "m3u8_native").
+    pub(crate) protocol: String,
+}
+
 /// Validate a yt-dlp format expression and return the matching format IDs.
 ///
 /// Parses the expression using [`rdlp_types::FormatSelector`] and, when
-/// `format_ids` is non-empty, builds minimal [`rdlp_types::Format`]
-/// stubs to determine which IDs the expression would select.
+/// `formats` is non-empty, builds [`rdlp_types::Format`] values with
+/// full metadata so filter predicates (e.g. `[height<=1080]`) can
+/// match correctly.
 ///
 /// # Arguments
 ///
 /// * `expression` - A yt-dlp format selector expression (e.g. `bv[height<=1080]+ba`).
-/// * `format_ids` - The list of format IDs available for matching.
+/// * `formats` - Format metadata from the frontend for matching.
 ///
 /// # Returns
 ///
@@ -194,7 +229,7 @@ pub async fn get_formats(
 #[tauri::command]
 pub async fn validate_format_expression(
     expression: String,
-    format_ids: Vec<String>,
+    formats: Vec<FormatData>,
 ) -> Result<Vec<String>, AppError> {
     tokio::task::spawn_blocking(move || {
         use rdlp_types::FormatSelector;
@@ -205,22 +240,39 @@ pub async fn validate_format_expression(
                 message: e,
             })?;
 
-        if format_ids.is_empty() {
+        if formats.is_empty() {
             return Ok(Vec::new());
         }
 
-        // Build minimal Format stubs so the selector can match by format_id.
         use rdlp_types::protocol::DownloadProtocol;
         use rdlp_types::Format;
 
-        let formats: Vec<Format> = format_ids
+        let format_list: Vec<Format> = formats
             .iter()
-            .map(|id| {
-                Format::new(id, format!("stub://{id}"), "mp4", DownloadProtocol::Https)
+            .map(|fd| {
+                let protocol = fd.protocol.parse::<DownloadProtocol>()
+                    .unwrap_or(DownloadProtocol::Https);
+                let mut f = Format::new(
+                    &fd.format_id,
+                    format!("stub://{}", fd.format_id),
+                    &fd.ext,
+                    protocol,
+                );
+                f.width = fd.width;
+                f.height = fd.height;
+                f.fps = fd.fps;
+                f.tbr = fd.tbr;
+                f.vbr = fd.vbr;
+                f.abr = fd.abr;
+                f.asr = fd.asr;
+                f.filesize = fd.filesize;
+                f.vcodec = fd.vcodec.clone();
+                f.acodec = fd.acodec.clone();
+                f
             })
             .collect();
 
-        let selected = selector.select(&formats);
+        let selected = selector.select(&format_list);
         let matched: Vec<String> =
             selected.iter().map(|f| f.format_id.clone()).collect();
         Ok(matched)
@@ -374,11 +426,39 @@ mod tests {
         assert!(json["duration"].is_null());
     }
 
+    fn make_format_data(
+        format_id: &str,
+        ext: &str,
+        vcodec: Option<&str>,
+        acodec: Option<&str>,
+        height: Option<u32>,
+    ) -> FormatData {
+        FormatData {
+            format_id: format_id.to_owned(),
+            ext: ext.to_owned(),
+            width: height.map(|h| h * 16 / 9),
+            height,
+            fps: None,
+            tbr: None,
+            vcodec: vcodec.map(|s| s.to_owned()),
+            acodec: acodec.map(|s| s.to_owned()),
+            filesize: None,
+            vbr: None,
+            abr: None,
+            asr: None,
+            protocol: "https".to_owned(),
+        }
+    }
+
     #[tokio::test]
     async fn test_validate_format_expression_valid() {
+        let formats = vec![
+            make_format_data("137", "mp4", Some("h264"), Some("aac"), Some(1080)),
+            make_format_data("140", "m4a", Some("none"), Some("aac"), None),
+        ];
         let result = super::validate_format_expression(
             "best".to_owned(),
-            vec!["137".to_owned(), "140".to_owned()],
+            formats,
         )
         .await;
         assert!(result.is_ok());
@@ -395,7 +475,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_format_expression_empty_ids() {
+    async fn test_validate_format_expression_empty_formats() {
         let result = super::validate_format_expression(
             "bv+ba".to_owned(),
             vec![],
@@ -407,13 +487,50 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_format_expression_format_id_match() {
+        let formats = vec![
+            make_format_data("137", "mp4", Some("h264"), Some("aac"), Some(1080)),
+            make_format_data("140", "m4a", Some("none"), Some("aac"), None),
+        ];
         let result = super::validate_format_expression(
             "137".to_owned(),
-            vec!["137".to_owned(), "140".to_owned()],
+            formats,
         )
         .await;
         assert!(result.is_ok());
         let matches = result.unwrap();
         assert_eq!(matches, vec!["137"]);
+    }
+
+    #[tokio::test]
+    async fn test_validate_format_expression_height_filter() {
+        let formats = vec![
+            make_format_data("v720", "mp4", Some("h264"), Some("none"), Some(720)),
+            make_format_data("v1080", "mp4", Some("h264"), Some("none"), Some(1080)),
+            make_format_data("a128", "m4a", Some("none"), Some("aac"), None),
+        ];
+        let result = super::validate_format_expression(
+            "bv[height<=720]+ba".to_owned(),
+            formats,
+        )
+        .await;
+        assert!(result.is_ok());
+        let matches = result.unwrap();
+        assert_eq!(matches, vec!["v720", "a128"]);
+    }
+
+    #[tokio::test]
+    async fn test_validate_format_expression_ext_filter() {
+        let formats = vec![
+            make_format_data("v1", "mp4", Some("h264"), Some("none"), Some(720)),
+            make_format_data("v2", "webm", Some("vp9"), Some("none"), Some(720)),
+        ];
+        let result = super::validate_format_expression(
+            "bv[ext=webm]".to_owned(),
+            formats,
+        )
+        .await;
+        assert!(result.is_ok());
+        let matches = result.unwrap();
+        assert_eq!(matches, vec!["v2"]);
     }
 }

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -111,8 +111,7 @@ pub(crate) fn format_eta(eta: &std::time::Duration) -> String {
 ///
 /// Maps each relevant event variant to the appropriate frontend event
 /// name and payload. Events that have no frontend representation
-/// (e.g. `Started`, `FormatSelected`, `SubtitlesFound`) are silently
-/// ignored.
+/// (e.g. `Started`, `SubtitlesFound`) are silently ignored.
 ///
 /// # Arguments
 ///

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -62,6 +62,21 @@ pub(crate) enum LogLevel {
     Warn,
 }
 
+/// Format-selected payload emitted as `"format-selected"`.
+///
+/// Sent when the download engine selects a format, informing the
+/// frontend of the chosen quality and format identifier.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FormatSelectedPayload {
+    /// The UUID of the download job.
+    pub(crate) job_id: String,
+    /// The selected format identifier (e.g. `"hls-720"`).
+    pub(crate) format_id: String,
+    /// Human-readable quality description (e.g. `"1080p"`).
+    pub(crate) quality: String,
+}
+
 /// Log message payload emitted as `"download-log"`.
 ///
 /// Used for informational events (metadata ready, post-processing
@@ -194,6 +209,27 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             let _ = app.emit("download-log", &payload);
         }
 
+        Event::FormatSelected {
+            format_id,
+            quality,
+            ..
+        } => {
+            let payload = FormatSelectedPayload {
+                job_id: job_id.to_owned(),
+                format_id: format_id.clone(),
+                quality: quality.clone(),
+            };
+            let _ = app.emit("format-selected", &payload);
+
+            // Also emit as a log message for the status bar
+            let log = DownloadLogPayload {
+                job_id: job_id.to_owned(),
+                level: LogLevel::Info,
+                message: format!("Format selected: {quality} ({format_id})"),
+            };
+            let _ = app.emit("download-log", &log);
+        }
+
         // All other events are not forwarded to the frontend.
         _ => {}
     }
@@ -262,6 +298,19 @@ mod tests {
         assert_eq!(json["jobId"], "abc-123");
         assert_eq!(json["error"], "connection timeout");
         assert_eq!(json["retryable"], true);
+    }
+
+    #[test]
+    fn test_format_selected_payload_serializes() {
+        let payload = FormatSelectedPayload {
+            job_id: "abc-123".to_owned(),
+            format_id: "hls-720".to_owned(),
+            quality: "720p".to_owned(),
+        };
+        let json = serde_json::to_value(&payload).expect("serialization should succeed");
+        assert_eq!(json["jobId"], "abc-123");
+        assert_eq!(json["formatId"], "hls-720");
+        assert_eq!(json["quality"], "720p");
     }
 
     #[test]

--- a/crates/rdlp-desktop/src-tauri/src/lib.rs
+++ b/crates/rdlp-desktop/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ pub fn run() {
             commands::download::get_queue,
             commands::download::remove_job,
             commands::formats::get_formats,
+            commands::formats::validate_format_expression,
             commands::settings::get_settings,
             commands::settings::update_settings,
             commands::settings::pick_directory,

--- a/crates/rdlp-desktop/src/App.css
+++ b/crates/rdlp-desktop/src/App.css
@@ -300,6 +300,147 @@ body {
   cursor: not-allowed;
 }
 
+/* ========== Search Filter Row ========== */
+
+.search-bar-container {
+  margin-bottom: var(--gap-xl);
+}
+
+.search-bar-container .search-bar {
+  margin-bottom: 0;
+}
+
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  margin-top: var(--gap-sm);
+  flex-wrap: wrap;
+}
+
+.filter-select {
+  padding: 7px 12px;
+  padding-right: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--text-0);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--duration-fast);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238b8d93' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+.filter-select:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--text-1);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast),
+    color var(--duration-fast),
+    background var(--duration-fast);
+}
+
+.filter-toggle:hover {
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--text-0);
+}
+
+.filter-toggle.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.filter-badge {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--surface-0);
+  font-size: 10px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Space Mono", monospace;
+}
+
+.filter-advanced {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-md);
+  margin-top: var(--gap-sm);
+  padding: var(--gap-md) var(--gap-lg);
+  background: var(--surface-3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  animation: card-enter var(--duration-normal) var(--ease-out) both;
+}
+
+.filter-advanced-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+}
+
+.filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-2);
+  letter-spacing: 0.02em;
+}
+
+/* Clear filters button in empty state */
+.clear-filters-btn {
+  margin-top: var(--gap-md);
+  padding: 7px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-1);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast),
+    color var(--duration-fast),
+    border-color var(--duration-fast);
+}
+
+.clear-filters-btn:hover {
+  background: var(--surface-3);
+  color: var(--text-0);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
 /* ========== Results Grid ========== */
 
 .results-grid {

--- a/crates/rdlp-desktop/src/App.css
+++ b/crates/rdlp-desktop/src/App.css
@@ -315,25 +315,36 @@ body {
   align-items: center;
   gap: var(--gap-sm);
   margin-top: var(--gap-sm);
+  padding-top: var(--gap-sm);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
   flex-wrap: wrap;
 }
 
 .filter-select {
-  padding: 7px 12px;
+  padding: 6px 12px;
   padding-right: 28px;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--radius-md);
   background: var(--surface-2);
-  color: var(--text-0);
+  color: var(--text-1);
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: border-color var(--duration-fast);
+  transition:
+    border-color var(--duration-fast),
+    color var(--duration-fast),
+    background var(--duration-fast),
+    box-shadow var(--duration-fast);
   appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238b8d93' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2352545a' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 8px center;
+}
+
+.filter-select:hover {
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--text-0);
 }
 
 .filter-select:focus {
@@ -347,11 +358,19 @@ body {
   cursor: not-allowed;
 }
 
+/* Active filter — value differs from default */
+.filter-select.filter-active {
+  border-color: rgba(16, 185, 129, 0.35);
+  color: var(--text-0);
+  background-color: rgba(16, 185, 129, 0.06);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2310b981' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+}
+
 .filter-toggle {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 14px;
+  padding: 6px 14px;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--radius-md);
   background: var(--surface-2);
@@ -366,15 +385,28 @@ body {
     background var(--duration-fast);
 }
 
+.filter-toggle svg {
+  opacity: 0.6;
+  transition: opacity var(--duration-fast);
+}
+
 .filter-toggle:hover {
   border-color: rgba(255, 255, 255, 0.12);
   color: var(--text-0);
+}
+
+.filter-toggle:hover svg {
+  opacity: 1;
 }
 
 .filter-toggle.active {
   border-color: var(--accent);
   color: var(--accent);
   background: var(--accent-dim);
+}
+
+.filter-toggle.active svg {
+  opacity: 1;
 }
 
 .filter-badge {
@@ -389,7 +421,29 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: "Space Mono", monospace;
+}
+
+.filter-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-2);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast),
+    background var(--duration-fast);
+}
+
+.filter-reset:hover {
+  color: var(--text-0);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .filter-advanced {
@@ -398,7 +452,7 @@ body {
   gap: var(--gap-md);
   margin-top: var(--gap-sm);
   padding: var(--gap-md) var(--gap-lg);
-  background: var(--surface-3);
+  background: var(--surface-2);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--radius-lg);
   animation: card-enter var(--duration-normal) var(--ease-out) both;
@@ -411,10 +465,11 @@ body {
 }
 
 .filter-label {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
   color: var(--text-2);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 /* Clear filters button in empty state */
@@ -921,6 +976,27 @@ body {
   border-color: rgba(255, 255, 255, 0.12);
 }
 
+/* Settings text input */
+.settings-text-input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--text-0);
+  font-family: inherit;
+  font-size: 13px;
+  transition:
+    border-color var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+
+.settings-text-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
 /* Save button */
 .save-btn {
   padding: 10px 28px;
@@ -1079,6 +1155,551 @@ body {
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+/* ========== Download Button Group (ResultCard) ========== */
+
+.download-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  width: 100%;
+}
+
+.download-btn-group {
+  display: flex;
+  gap: 1px;
+}
+
+.download-btn-group .download-btn {
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  flex: 1;
+}
+
+.download-btn-group .download-btn-options {
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: 7px 8px;
+  flex: 0;
+  min-width: 28px;
+  justify-content: center;
+}
+
+.download-btn-options svg {
+  width: 12px;
+  height: 12px;
+}
+
+.choose-format-btn {
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: center;
+  padding: 4px 8px;
+  transition: color var(--duration-fast);
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 2px;
+}
+
+.choose-format-btn:hover {
+  color: var(--text-0);
+  text-decoration-color: var(--text-1);
+}
+
+/* ========== Options Popover (ResultCard) ========== */
+
+.options-popover {
+  position: absolute;
+  bottom: calc(100% + var(--gap-sm));
+  right: 0;
+  width: 280px;
+  background: var(--surface-3);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 16px 48px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  padding: var(--gap-md);
+  z-index: 50;
+  animation: card-enter var(--duration-normal) var(--ease-out) both;
+}
+
+.options-popover-confirm {
+  width: 100%;
+  margin-top: var(--gap-md);
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: var(--surface-0);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.options-popover-confirm:hover:not(:disabled) {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.options-popover-confirm:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.options-popover-confirm:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ========== Format Options Panel ========== */
+
+.format-options-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
+.options-popover-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+}
+
+.options-popover-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-2);
+  letter-spacing: 0.02em;
+}
+
+.preset-radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-xs);
+}
+
+.preset-radio-group label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  font-size: 12px;
+  color: var(--text-1);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast),
+    color var(--duration-fast),
+    background var(--duration-fast);
+}
+
+.preset-radio-group label:hover {
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--text-0);
+}
+
+.preset-radio-group label:has(input:checked) {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.preset-radio-group input[type="radio"] {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--surface-5);
+  border-radius: 50%;
+  background: var(--surface-3);
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  transition:
+    border-color var(--duration-fast),
+    background var(--duration-fast);
+}
+
+.preset-radio-group input[type="radio"]:checked {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.preset-radio-group input[type="radio"]:checked::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--surface-0);
+}
+
+/* ========== Format Dialog (Modal) ========== */
+
+.format-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  animation: fade-in var(--duration-fast) var(--ease-out);
+}
+
+.format-dialog {
+  width: 90vw;
+  max-width: 860px;
+  max-height: 85vh;
+  background: var(--surface-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 24px 72px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  animation: card-enter var(--duration-normal) var(--ease-out) both;
+}
+
+.format-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--gap-lg) var(--gap-xl);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  flex-shrink: 0;
+}
+
+.format-dialog-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.format-dialog-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: var(--radius-sm);
+  transition:
+    color var(--duration-fast),
+    background var(--duration-fast);
+}
+
+.format-dialog-close:hover {
+  color: var(--text-0);
+  background: var(--surface-4);
+}
+
+.format-dialog-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--gap-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-lg);
+}
+
+.format-dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--gap-sm);
+  padding: var(--gap-md) var(--gap-xl);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  flex-shrink: 0;
+}
+
+.format-dialog-cancel {
+  padding: 8px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-1);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast),
+    color var(--duration-fast),
+    border-color var(--duration-fast);
+}
+
+.format-dialog-cancel:hover {
+  background: var(--surface-4);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--text-0);
+}
+
+.format-dialog-submit {
+  padding: 8px 24px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: var(--surface-0);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.format-dialog-submit:hover:not(:disabled) {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.format-dialog-submit:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.format-dialog-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ========== Format Table ========== */
+
+.format-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  animation: card-enter var(--duration-normal) var(--ease-out) both;
+}
+
+.format-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-family: "Space Mono", monospace;
+}
+
+.format-table th {
+  position: sticky;
+  top: 0;
+  padding: 8px 10px;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-2);
+  background: var(--surface-3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.format-table th.sortable {
+  cursor: pointer;
+  transition: color var(--duration-fast);
+}
+
+.format-table th.sortable:hover {
+  color: var(--text-0);
+}
+
+.format-table th.sorted {
+  color: var(--accent);
+}
+
+.format-table td {
+  padding: 6px 10px;
+  color: var(--text-1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+  white-space: nowrap;
+}
+
+.format-table tbody tr {
+  cursor: pointer;
+  transition: background var(--duration-fast);
+}
+
+.format-table tbody tr:hover {
+  background: var(--surface-3);
+}
+
+.format-table tbody tr.format-row-selected {
+  background: var(--accent-dim);
+}
+
+.format-table tbody tr.format-row-selected td {
+  color: var(--accent);
+}
+
+.format-table tbody tr.format-row-expr-match {
+  background: rgba(234, 179, 8, 0.08);
+}
+
+.format-table tbody tr.format-row-expr-match td {
+  color: var(--status-pending);
+}
+
+/* Type badges */
+.format-type-badge {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 20px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-family: "Space Mono", monospace;
+}
+
+.format-type-av {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--accent);
+}
+
+.format-type-video {
+  background: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+}
+
+.format-type-audio {
+  background: rgba(168, 85, 247, 0.12);
+  color: #c084fc;
+}
+
+.format-type-hls {
+  background: rgba(234, 179, 8, 0.12);
+  color: var(--status-pending);
+}
+
+/* Selection hint */
+.format-selection-hint {
+  padding: var(--gap-sm) var(--gap-md);
+  font-size: 12px;
+  color: var(--text-1);
+  background: var(--surface-3);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.format-selection-hint strong {
+  color: var(--accent);
+  font-family: "Space Mono", monospace;
+}
+
+.hint-text {
+  color: var(--text-2);
+  font-style: italic;
+}
+
+/* ========== Expert Mode ========== */
+
+.expert-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-2);
+  cursor: pointer;
+  user-select: none;
+  transition: color var(--duration-fast);
+}
+
+.expert-toggle:hover {
+  color: var(--text-1);
+}
+
+.expert-toggle input[type="checkbox"] {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--surface-5);
+  border-radius: 3px;
+  background: var(--surface-3);
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  transition:
+    background var(--duration-fast),
+    border-color var(--duration-fast);
+}
+
+.expert-toggle input[type="checkbox"]:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.expert-toggle input[type="checkbox"]:checked::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 0px;
+  width: 5px;
+  height: 8px;
+  border: solid var(--surface-0);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.format-expr-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  animation: card-enter var(--duration-normal) var(--ease-out) both;
+}
+
+.format-expr-input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  background: var(--surface-3);
+  color: var(--text-0);
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  transition:
+    border-color var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+
+.format-expr-input::placeholder {
+  color: var(--text-2);
+}
+
+.format-expr-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+.format-expr-input.expr-error {
+  border-color: var(--status-failed);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+}
+
+.format-expr-error {
+  font-size: 11px;
+  color: var(--status-failed);
 }
 
 /* ========== Selection & Focus ========== */

--- a/crates/rdlp-desktop/src/App.tsx
+++ b/crates/rdlp-desktop/src/App.tsx
@@ -8,6 +8,7 @@ import {
     onDownloadComplete,
     onDownloadError,
     onDownloadLog,
+    onFormatSelected,
 } from "./lib/tauri";
 
 type Tab = "search" | "queue" | "settings";
@@ -65,6 +66,17 @@ function App() {
             });
             if (!mounted) { unLog(); return; }
             unlisteners.push(unLog);
+
+            const unFormatSelected = await onFormatSelected((payload) => {
+                useQueueStore
+                    .getState()
+                    .updateJobStatus(
+                        payload.jobId,
+                        `Format: ${payload.quality}`,
+                    );
+            });
+            if (!mounted) { unFormatSelected(); return; }
+            unlisteners.push(unFormatSelected);
         };
 
         void setup();

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -1,0 +1,453 @@
+import { useEffect, useRef, useState } from "react";
+import { useQueueStore, useSettingsStore } from "../lib/store";
+import * as api from "../lib/tauri";
+import { FormatOptionsPanel, PRESETS } from "./FormatOptionsPanel";
+import type {
+    DownloadOptions,
+    FormatInfo,
+} from "../types";
+
+type SortKey = "height" | "ext" | "fps" | "tbr" | "vcodec" | "acodec" | "filesize";
+type SortDir = "asc" | "desc";
+
+interface FormatDialogProps {
+    url: string;
+    onConfirm: (options: DownloadOptions) => void;
+    onClose: () => void;
+}
+
+/** Format bytes into a human-readable string. */
+function formatSize(bytes: number | null): string {
+    if (bytes === null) return "-";
+    if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+    if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+    if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(0)} KB`;
+    return `${bytes} B`;
+}
+
+/** Format bitrate (kbps). */
+function formatBitrate(kbps: number | null): string {
+    if (kbps === null) return "-";
+    if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+    return `${Math.round(kbps)} kbps`;
+}
+
+/** Resolution display string. */
+function formatResolution(f: FormatInfo): string {
+    if (f.height && f.width) return `${f.width}x${f.height}`;
+    if (f.height) return `${f.height}p`;
+    return f.format_note ?? "-";
+}
+
+/** Type badge label. */
+function formatType(f: FormatInfo): { label: string; className: string } {
+    if (f.protocol.includes("m3u8")) return { label: "HLS", className: "format-type-hls" };
+    if (f.has_video && f.has_audio) return { label: "V+A", className: "format-type-av" };
+    if (f.has_video) return { label: "Video", className: "format-type-video" };
+    return { label: "Audio", className: "format-type-audio" };
+}
+
+/** Compare helper for sorting nullable fields. */
+function cmpNullable(a: number | null, b: number | null, dir: SortDir): number {
+    if (a === null && b === null) return 0;
+    if (a === null) return 1;
+    if (b === null) return -1;
+    return dir === "asc" ? a - b : b - a;
+}
+
+/** Sort formats by a given key and direction. */
+function sortFormats(formats: FormatInfo[], key: SortKey, dir: SortDir): FormatInfo[] {
+    const sorted = [...formats];
+    sorted.sort((a, b) => {
+        switch (key) {
+            case "height":
+                return cmpNullable(a.height, b.height, dir);
+            case "ext":
+                return dir === "asc"
+                    ? a.ext.localeCompare(b.ext)
+                    : b.ext.localeCompare(a.ext);
+            case "fps":
+                return cmpNullable(a.fps, b.fps, dir);
+            case "tbr":
+                return cmpNullable(a.tbr, b.tbr, dir);
+            case "vcodec":
+                return dir === "asc"
+                    ? (a.vcodec ?? "").localeCompare(b.vcodec ?? "")
+                    : (b.vcodec ?? "").localeCompare(a.vcodec ?? "");
+            case "acodec":
+                return dir === "asc"
+                    ? (a.acodec ?? "").localeCompare(b.acodec ?? "")
+                    : (b.acodec ?? "").localeCompare(a.acodec ?? "");
+            case "filesize":
+                return cmpNullable(a.filesize, b.filesize, dir);
+            default:
+                return 0;
+        }
+    });
+    return sorted;
+}
+
+/** Full-screen modal for format selection, presets, options, and expert mode. */
+export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
+    const loadFormats = useQueueStore((s) => s.loadFormats);
+    const clearFormats = useQueueStore((s) => s.clearFormats);
+    const formatData = useQueueStore((s) => s.selectedFormat);
+    const isLoading = useQueueStore((s) => s.formatDialogLoading);
+    const settings = useSettingsStore((s) => s.settings);
+
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [mergeId, setMergeId] = useState<string | null>(null);
+    const [sortKey, setSortKey] = useState<SortKey>("height");
+    const [sortDir, setSortDir] = useState<SortDir>("desc");
+    const [showTable, setShowTable] = useState(false);
+    const [expertMode, setExpertMode] = useState(false);
+    const [expr, setExpr] = useState("");
+    const [exprError, setExprError] = useState<string | null>(null);
+    const [exprMatches, setExprMatches] = useState<Set<string>>(new Set());
+    const [error, setError] = useState<string | null>(null);
+    const [options, setOptions] = useState<DownloadOptions>({
+        format: null,
+        outputDir: null,
+        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
+        subtitleLangs: settings?.default_subtitle_langs ?? [],
+        remux: settings?.default_remux ?? null,
+        extractAudio: settings?.default_extract_audio ?? null,
+        embedThumbnail: settings?.embed_thumbnail ?? true,
+        audioMultistreams: false,
+        recodeVideo: null,
+    });
+
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const exprTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Load formats on mount
+    useEffect(() => {
+        loadFormats(url).catch((err) => {
+            setError(err instanceof Error ? err.message : String(err));
+        });
+        return () => {
+            clearFormats();
+            if (exprTimerRef.current) clearTimeout(exprTimerRef.current);
+        };
+    }, [url, loadFormats, clearFormats]);
+
+    // Close on Escape
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        document.addEventListener("keydown", handler);
+        return () => document.removeEventListener("keydown", handler);
+    }, [onClose]);
+
+    // Close on backdrop click
+    const handleBackdropClick = (e: React.MouseEvent) => {
+        if (e.target === e.currentTarget) onClose();
+    };
+
+    // Sort header click
+    const handleSortClick = (key: SortKey) => {
+        if (key === sortKey) {
+            setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+        } else {
+            setSortKey(key);
+            setSortDir("desc");
+        }
+    };
+
+    // Row click (single or shift for merge pair)
+    const handleRowClick = (id: string, e: React.MouseEvent) => {
+        if (e.shiftKey && selectedId !== null && selectedId !== id) {
+            setMergeId(id);
+        } else {
+            setSelectedId(id);
+            setMergeId(null);
+        }
+    };
+
+    // Preset selection
+    const handlePresetSelect = (selector: string) => {
+        setSelectedId(null);
+        setMergeId(null);
+        setOptions((prev) => ({ ...prev, format: selector }));
+    };
+
+    // Expert expression change with debounced validation
+    const handleExprChange = (value: string) => {
+        setExpr(value);
+        if (exprTimerRef.current) clearTimeout(exprTimerRef.current);
+        if (value.trim() === "") {
+            setExprError(null);
+            setExprMatches(new Set());
+            return;
+        }
+        exprTimerRef.current = setTimeout(async () => {
+            try {
+                const ids = formatData?.formats.map((f) => f.format_id) ?? [];
+                const matches = await api.validateFormatExpression(value, ids);
+                setExprMatches(new Set(matches));
+                setExprError(null);
+            } catch (err) {
+                setExprError(err instanceof Error ? err.message : String(err));
+                setExprMatches(new Set());
+            }
+        }, 400);
+    };
+
+    // Build the final format selector from current state
+    const buildFormatSelector = (): string | null => {
+        if (expertMode && expr.trim()) return expr.trim();
+        if (selectedId && mergeId) return `${selectedId}+${mergeId}`;
+        if (selectedId) return selectedId;
+        return options.format;
+    };
+
+    const handleConfirm = () => {
+        const format = buildFormatSelector();
+        onConfirm({ ...options, format });
+    };
+
+    const sorted = formatData
+        ? sortFormats(formatData.formats, sortKey, sortDir)
+        : [];
+
+    const subtitleLangs = formatData?.subtitles.map((s) => s.lang) ?? [];
+
+    const renderSortIndicator = (key: SortKey) => {
+        if (sortKey !== key) return null;
+        return sortDir === "asc" ? " \u25B2" : " \u25BC";
+    };
+
+    // Derive active preset from selected state
+    const activePresetId = (!selectedId && !mergeId && !expertMode)
+        ? PRESETS.find((p) => p.selector === options.format)?.id ?? "best"
+        : null;
+
+    return (
+        <div className="format-dialog-overlay" onClick={handleBackdropClick}>
+            <div className="format-dialog" ref={dialogRef}>
+                <div className="format-dialog-header">
+                    <span className="format-dialog-title">
+                        {formatData?.title ?? "Choose Format"}
+                    </span>
+                    <button
+                        className="format-dialog-close"
+                        onClick={onClose}
+                        aria-label="Close"
+                    >
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div className="format-dialog-body">
+                    {isLoading && (
+                        <div className="status-message">
+                            <div className="loading-dots">
+                                <span />
+                                <span />
+                                <span />
+                            </div>
+                            <p>Loading formats...</p>
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className="error-banner">
+                            <p>{error}</p>
+                            <button onClick={() => {
+                                setError(null);
+                                loadFormats(url).catch((err) =>
+                                    setError(err instanceof Error ? err.message : String(err)),
+                                );
+                            }}>
+                                Retry
+                            </button>
+                        </div>
+                    )}
+
+                    {!isLoading && !error && formatData && (
+                        <>
+                            {/* Preset tier */}
+                            <div className="options-popover-section">
+                                <div className="options-popover-label">Quality Preset</div>
+                                <div className="preset-radio-group">
+                                    {PRESETS.map((p) => (
+                                        <label key={p.id}>
+                                            <input
+                                                type="radio"
+                                                name="dialog-preset"
+                                                checked={activePresetId === p.id}
+                                                onChange={() => handlePresetSelect(p.selector)}
+                                            />
+                                            {p.label}
+                                        </label>
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Format table toggle */}
+                            <button
+                                className="filter-toggle"
+                                onClick={() => setShowTable((v) => !v)}
+                                aria-expanded={showTable}
+                            >
+                                {showTable ? "Hide all formats" : `Show all formats (${sorted.length})`}
+                            </button>
+
+                            {showTable && (
+                                <div className="format-table-wrapper">
+                                    <table className="format-table">
+                                        <thead>
+                                            <tr>
+                                                <th
+                                                    className={`sortable ${sortKey === "height" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("height")}
+                                                >
+                                                    Resolution{renderSortIndicator("height")}
+                                                </th>
+                                                <th
+                                                    className={`sortable ${sortKey === "ext" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("ext")}
+                                                >
+                                                    Ext{renderSortIndicator("ext")}
+                                                </th>
+                                                <th
+                                                    className={`sortable ${sortKey === "fps" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("fps")}
+                                                >
+                                                    FPS{renderSortIndicator("fps")}
+                                                </th>
+                                                <th
+                                                    className={`sortable ${sortKey === "tbr" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("tbr")}
+                                                >
+                                                    Bitrate{renderSortIndicator("tbr")}
+                                                </th>
+                                                <th
+                                                    className={`sortable ${sortKey === "vcodec" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("vcodec")}
+                                                >
+                                                    Video{renderSortIndicator("vcodec")}
+                                                </th>
+                                                <th
+                                                    className={`sortable ${sortKey === "acodec" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("acodec")}
+                                                >
+                                                    Audio{renderSortIndicator("acodec")}
+                                                </th>
+                                                <th
+                                                    className={`sortable ${sortKey === "filesize" ? "sorted" : ""}`}
+                                                    onClick={() => handleSortClick("filesize")}
+                                                >
+                                                    Size{renderSortIndicator("filesize")}
+                                                </th>
+                                                <th>Type</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {sorted.map((f) => {
+                                                const type = formatType(f);
+                                                const isSelected =
+                                                    f.format_id === selectedId ||
+                                                    f.format_id === mergeId;
+                                                const isExprMatch = exprMatches.has(f.format_id);
+                                                let rowClass = "";
+                                                if (isSelected) rowClass += " format-row-selected";
+                                                if (isExprMatch) rowClass += " format-row-expr-match";
+                                                return (
+                                                    <tr
+                                                        key={f.format_id}
+                                                        className={rowClass}
+                                                        onClick={(e) => handleRowClick(f.format_id, e)}
+                                                    >
+                                                        <td>{formatResolution(f)}</td>
+                                                        <td>{f.ext}</td>
+                                                        <td>{f.fps !== null ? Math.round(f.fps) : "-"}</td>
+                                                        <td>{formatBitrate(f.tbr)}</td>
+                                                        <td>{f.vcodec ?? "-"}</td>
+                                                        <td>{f.acodec ?? "-"}</td>
+                                                        <td>{formatSize(f.filesize)}</td>
+                                                        <td>
+                                                            <span className={`format-type-badge ${type.className}`}>
+                                                                {type.label}
+                                                            </span>
+                                                        </td>
+                                                    </tr>
+                                                );
+                                            })}
+                                        </tbody>
+                                    </table>
+
+                                    {selectedId && (
+                                        <div className="format-selection-hint">
+                                            Selected: <strong>{selectedId}</strong>
+                                            {mergeId && (
+                                                <> + <strong>{mergeId}</strong> (merge)</>
+                                            )}
+                                            <span className="hint-text">
+                                                {!mergeId && " — Shift+click another format to merge"}
+                                            </span>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* Expert mode */}
+                            <label className="expert-toggle">
+                                <input
+                                    type="checkbox"
+                                    checked={expertMode}
+                                    onChange={(e) => setExpertMode(e.target.checked)}
+                                />
+                                Expert Mode
+                            </label>
+
+                            {expertMode && (
+                                <div className="format-expr-section">
+                                    <div className="options-popover-label">Format Expression</div>
+                                    <input
+                                        className={`format-expr-input ${exprError ? "expr-error" : ""}`}
+                                        type="text"
+                                        placeholder="e.g. bestvideo[height<=1080]+bestaudio/best"
+                                        value={expr}
+                                        onChange={(e) => handleExprChange(e.target.value)}
+                                    />
+                                    {exprError && (
+                                        <span className="format-expr-error">{exprError}</span>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* Download options */}
+                            <FormatOptionsPanel
+                                value={options}
+                                onChange={setOptions}
+                                availableSubtitleLangs={subtitleLangs}
+                                hidePresets
+                            />
+                        </>
+                    )}
+                </div>
+
+                <div className="format-dialog-footer">
+                    <button
+                        className="format-dialog-cancel"
+                        onClick={onClose}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className="format-dialog-submit"
+                        onClick={handleConfirm}
+                        disabled={isLoading || !!error}
+                    >
+                        Download
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -183,8 +183,22 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         }
         exprTimerRef.current = setTimeout(async () => {
             try {
-                const ids = formatData?.formats.map((f) => f.format_id) ?? [];
-                const matches = await api.validateFormatExpression(value, ids);
+                const fmts = formatData?.formats.map((f) => ({
+                    format_id: f.format_id,
+                    ext: f.ext,
+                    width: f.width,
+                    height: f.height,
+                    fps: f.fps,
+                    tbr: f.tbr,
+                    vcodec: f.vcodec,
+                    acodec: f.acodec,
+                    filesize: f.filesize,
+                    vbr: f.vbr,
+                    abr: f.abr,
+                    asr: f.asr,
+                    protocol: f.protocol,
+                })) ?? [];
+                const matches = await api.validateFormatExpression(value, fmts);
                 setExprMatches(new Set(matches));
                 setExprError(null);
             } catch (err) {

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -1,0 +1,199 @@
+import type { AudioFormat, ContainerFormat, DownloadOptions } from "../types";
+
+/** A format preset with a human-readable label and yt-dlp selector string. */
+export interface FormatPreset {
+    id: string;
+    label: string;
+    selector: string;
+}
+
+/** Shared preset definitions used by both the popover and FormatDialog. */
+export const PRESETS: FormatPreset[] = [
+    { id: "best", label: "Best Quality", selector: "bestvideo+bestaudio/best" },
+    { id: "1080p", label: "1080p", selector: "bestvideo[height<=1080]+bestaudio/best[height<=1080]" },
+    { id: "720p", label: "720p", selector: "bestvideo[height<=720]+bestaudio/best[height<=720]" },
+    { id: "audio-only", label: "Audio Only", selector: "bestaudio/best" },
+];
+
+/** Common remux options shown in the UI. */
+const REMUX_OPTIONS: Array<{ value: ContainerFormat; label: string }> = [
+    { value: "mp4", label: "MP4" },
+    { value: "mkv", label: "MKV" },
+    { value: "webm", label: "WebM" },
+];
+
+/** Common audio extraction options shown in the UI. */
+const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
+    { value: "mp3", label: "MP3" },
+    { value: "aac", label: "AAC" },
+    { value: "opus", label: "Opus" },
+    { value: "flac", label: "FLAC" },
+];
+
+interface FormatOptionsPanelProps {
+    value: DownloadOptions;
+    onChange: (next: DownloadOptions) => void;
+    availableSubtitleLangs?: string[];
+    /** Hide presets (e.g. when the FormatDialog manages format selection). */
+    hidePresets?: boolean;
+}
+
+/** Derive which preset ID matches the current format selector, if any. */
+function activePreset(format: string | null): string | null {
+    if (!format) return "best";
+    const match = PRESETS.find((p) => p.selector === format);
+    return match?.id ?? null;
+}
+
+/** Controlled panel for download options: presets, remux, audio, subs, thumbnail. */
+export function FormatOptionsPanel({
+    value,
+    onChange,
+    availableSubtitleLangs = [],
+    hidePresets = false,
+}: FormatOptionsPanelProps) {
+    const currentPreset = activePreset(value.format);
+
+    const handlePreset = (preset: FormatPreset) => {
+        onChange({ ...value, format: preset.selector });
+    };
+
+    const handleRemux = (val: string) => {
+        onChange({
+            ...value,
+            remux: val === "" ? null : (val as ContainerFormat),
+        });
+    };
+
+    const handleAudio = (val: string) => {
+        onChange({
+            ...value,
+            extractAudio: val === "" ? null : (val as AudioFormat),
+        });
+    };
+
+    const handleSubtitles = (checked: boolean) => {
+        onChange({ ...value, subtitles: checked });
+    };
+
+    const handleSubLangs = (raw: string) => {
+        const langs = raw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        onChange({ ...value, subtitleLangs: langs });
+    };
+
+    return (
+        <div className="format-options-panel">
+            {!hidePresets && (
+                <div className="options-popover-section">
+                    <div className="options-popover-label">Quality Preset</div>
+                    <div className="preset-radio-group">
+                        {PRESETS.map((p) => (
+                            <label key={p.id}>
+                                <input
+                                    type="radio"
+                                    name="preset"
+                                    checked={currentPreset === p.id}
+                                    onChange={() => handlePreset(p)}
+                                />
+                                {p.label}
+                            </label>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div className="options-popover-section">
+                <div className="options-popover-label">Remux</div>
+                <select
+                    className="filter-select"
+                    value={value.remux ?? ""}
+                    onChange={(e) => handleRemux(e.target.value)}
+                >
+                    <option value="">None</option>
+                    {REMUX_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                            {o.label}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <div className="options-popover-section">
+                <div className="options-popover-label">Extract Audio</div>
+                <select
+                    className="filter-select"
+                    value={value.extractAudio ?? ""}
+                    onChange={(e) => handleAudio(e.target.value)}
+                >
+                    <option value="">None</option>
+                    {AUDIO_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                            {o.label}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <div className="options-popover-section">
+                <label className="options-popover-label" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                    <input
+                        type="checkbox"
+                        checked={value.subtitles}
+                        onChange={(e) => handleSubtitles(e.target.checked)}
+                    />
+                    Download Subtitles
+                </label>
+                {value.subtitles && (
+                    <div style={{ marginTop: "6px" }}>
+                        {availableSubtitleLangs.length > 0 ? (
+                            <select
+                                className="filter-select"
+                                multiple
+                                value={value.subtitleLangs}
+                                onChange={(e) => {
+                                    const selected = Array.from(
+                                        e.target.selectedOptions,
+                                        (o) => o.value,
+                                    );
+                                    onChange({ ...value, subtitleLangs: selected });
+                                }}
+                                style={{ minHeight: "60px", width: "100%" }}
+                            >
+                                {availableSubtitleLangs.map((lang) => (
+                                    <option key={lang} value={lang}>
+                                        {lang}
+                                    </option>
+                                ))}
+                            </select>
+                        ) : (
+                            <input
+                                className="format-expr-input"
+                                type="text"
+                                placeholder="en,sv,ja"
+                                value={value.subtitleLangs.join(",")}
+                                onChange={(e) => handleSubLangs(e.target.value)}
+                                style={{ fontSize: "12px", padding: "7px 10px" }}
+                            />
+                        )}
+                    </div>
+                )}
+            </div>
+
+            <div className="options-popover-section">
+                <label className="options-popover-label" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                    <input
+                        type="checkbox"
+                        checked={value.embedThumbnail}
+                        onChange={(e) =>
+                            onChange({ ...value, embedThumbnail: e.target.checked })
+                        }
+                    />
+                    Embed Thumbnail
+                </label>
+            </div>
+        </div>
+    );
+}

--- a/crates/rdlp-desktop/src/components/ResultCard.tsx
+++ b/crates/rdlp-desktop/src/components/ResultCard.tsx
@@ -1,8 +1,19 @@
-import type { SearchResultPreview } from "../types";
+import { useEffect, useRef, useState } from "react";
+import { formatDistanceToNow, fromUnixTime } from "date-fns";
+import { useSettingsStore } from "../lib/store";
+import { FormatOptionsPanel } from "./FormatOptionsPanel";
+import type {
+    AudioFormat,
+    ContainerFormat,
+    DownloadOptions,
+    SearchResultPreview,
+} from "../types";
 
 interface ResultCardProps {
     result: SearchResultPreview;
     onDownload: (url: string) => void;
+    onDownloadWithOptions: (url: string, options: Partial<DownloadOptions>) => void;
+    onOpenFormatDialog: (url: string) => void;
 }
 
 /** Format seconds into "M:SS" display string. */
@@ -13,6 +24,14 @@ function formatDuration(seconds: number | null): string {
     return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
+/** Format a Unix timestamp string into a relative date (e.g. "3 days ago"). */
+function formatUploadDate(timestamp: string | null): string {
+    if (timestamp === null) return "";
+    const ts = Number(timestamp);
+    if (Number.isNaN(ts)) return "";
+    return formatDistanceToNow(fromUnixTime(ts), { addSuffix: true });
+}
+
 /** Format a view count into a human-readable string (e.g. "1.2K views"). */
 function formatViews(count: number | null): string {
     if (count === null) return "";
@@ -21,10 +40,65 @@ function formatViews(count: number | null): string {
     return `${count} views`;
 }
 
+/** Build default DownloadOptions from settings for the popover initial state. */
+function buildOptionsFromSettings(settings: {
+    default_remux: ContainerFormat | null;
+    default_extract_audio: AudioFormat | null;
+    default_subtitle_langs: string[];
+    embed_thumbnail: boolean;
+} | null): DownloadOptions {
+    return {
+        format: null,
+        outputDir: null,
+        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
+        subtitleLangs: settings?.default_subtitle_langs ?? [],
+        remux: settings?.default_remux ?? null,
+        extractAudio: settings?.default_extract_audio ?? null,
+        embedThumbnail: settings?.embed_thumbnail ?? true,
+        audioMultistreams: false,
+        recodeVideo: null,
+    };
+}
+
 /** Displays a single search result as a card with thumbnail, title, and metadata. */
-export function ResultCard({ result, onDownload }: ResultCardProps) {
+export function ResultCard({
+    result,
+    onDownload,
+    onDownloadWithOptions,
+    onOpenFormatDialog,
+}: ResultCardProps) {
     const duration = formatDuration(result.duration);
     const views = formatViews(result.view_count);
+    const uploadDate = formatUploadDate(result.upload_date);
+    const settings = useSettingsStore((s) => s.settings);
+
+    const [showOptions, setShowOptions] = useState(false);
+    const [panelOptions, setPanelOptions] = useState<DownloadOptions>(() =>
+        buildOptionsFromSettings(settings),
+    );
+    const popoverRef = useRef<HTMLDivElement>(null);
+
+    // Update panel defaults when settings change
+    useEffect(() => {
+        if (!showOptions) {
+            setPanelOptions(buildOptionsFromSettings(settings));
+        }
+    }, [settings, showOptions]);
+
+    // Dismiss popover on outside click
+    useEffect(() => {
+        if (!showOptions) return;
+        const handler = (e: MouseEvent) => {
+            if (
+                popoverRef.current &&
+                !popoverRef.current.contains(e.target as Node)
+            ) {
+                setShowOptions(false);
+            }
+        };
+        document.addEventListener("mousedown", handler);
+        return () => document.removeEventListener("mousedown", handler);
+    }, [showOptions]);
 
     return (
         <div className="result-card">
@@ -44,20 +118,70 @@ export function ResultCard({ result, onDownload }: ResultCardProps) {
                     <span className="duration-badge">{duration}</span>
                 )}
                 <div className="thumbnail-overlay">
-                    <button
-                        className="download-btn"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            onDownload(result.video_url);
-                        }}
-                    >
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                            <polyline points="7 10 12 15 17 10" />
-                            <line x1="12" y1="15" x2="12" y2="3" />
-                        </svg>
-                        Download
-                    </button>
+                    <div className="download-actions">
+                        <div className="download-btn-group">
+                            <button
+                                className="download-btn"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onDownload(result.video_url);
+                                }}
+                            >
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                    <polyline points="7 10 12 15 17 10" />
+                                    <line x1="12" y1="15" x2="12" y2="3" />
+                                </svg>
+                                Download
+                            </button>
+                            <button
+                                className="download-btn download-btn-options"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setShowOptions((v) => !v);
+                                }}
+                                aria-label="Download options"
+                            >
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M6 9l6 6 6-6" />
+                                </svg>
+                            </button>
+                        </div>
+                        <button
+                            className="choose-format-btn"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onOpenFormatDialog(result.video_url);
+                            }}
+                        >
+                            Choose Format
+                        </button>
+                    </div>
+
+                    {showOptions && (
+                        <div
+                            className="options-popover"
+                            ref={popoverRef}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <FormatOptionsPanel
+                                value={panelOptions}
+                                onChange={setPanelOptions}
+                            />
+                            <button
+                                className="options-popover-confirm"
+                                onClick={() => {
+                                    onDownloadWithOptions(
+                                        result.video_url,
+                                        panelOptions,
+                                    );
+                                    setShowOptions(false);
+                                }}
+                            >
+                                Download with Options
+                            </button>
+                        </div>
+                    )}
                 </div>
             </div>
 
@@ -65,12 +189,12 @@ export function ResultCard({ result, onDownload }: ResultCardProps) {
                 <h3 className="result-title">{result.title}</h3>
                 <div className="result-meta">
                     {views && <span className="result-views">{views}</span>}
-                    {views && result.upload_date && (
+                    {views && uploadDate && (
                         <span className="result-separator">&middot;</span>
                     )}
-                    {result.upload_date && (
+                    {uploadDate && (
                         <span className="result-date">
-                            {result.upload_date}
+                            {uploadDate}
                         </span>
                     )}
                 </div>

--- a/crates/rdlp-desktop/src/components/SearchBar.tsx
+++ b/crates/rdlp-desktop/src/components/SearchBar.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState } from "react";
 import { useSearchStore } from "../lib/store";
 import type { SearchFilter } from "../types";
 
-const DEFAULT_FILTER_KEYS = new Set(["sort", "quality", "duration-min", "duration-max"]);
+const DEFAULT_FILTER_KEYS = new Set([
+    "sort", "quality", "orientations", "date", "min-duration", "max-duration",
+]);
+
+/** Check if a filter value differs from its descriptor default. */
+function isFilterActive(value: string, defaultValue: string | null): boolean {
+    if (value === "") return false;
+    return value !== (defaultValue ?? "");
+}
 
 /** Search form with site selector, query input, filters, and submit button. */
 export function SearchBar() {
@@ -16,10 +24,12 @@ export function SearchBar() {
     const setFilters = useSearchStore((s) => s.setFilters);
     const filterDescriptors = useSearchStore((s) => s.filterDescriptors);
     const loadFilters = useSearchStore((s) => s.loadFilters);
+    const resetFiltersToDefaults = useSearchStore((s) => s.resetFiltersToDefaults);
     const search = useSearchStore((s) => s.search);
     const status = useSearchStore((s) => s.status);
 
     const [showAdvanced, setShowAdvanced] = useState(false);
+    const hasUserFilters = useSearchStore((s) => s.hasUserFilters);
 
     useEffect(() => {
         void loadProviders();
@@ -31,6 +41,14 @@ export function SearchBar() {
             void loadFilters(site);
         }
     }, [site, loadFilters]);
+
+    // Auto-search when user changes filters (only if results are showing)
+    useEffect(() => {
+        if (!hasUserFilters) return;
+        if (status !== "results" && status !== "empty") return;
+        if (query.trim() === "" || site === "") return;
+        void search();
+    }, [filters, hasUserFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const isDisabled = status === "loading" || query.trim() === "";
 
@@ -65,11 +83,11 @@ export function SearchBar() {
     const defaultFilters = filterDescriptors.filter((d) => DEFAULT_FILTER_KEYS.has(d.key));
     const advancedFilters = filterDescriptors.filter((d) => !DEFAULT_FILTER_KEYS.has(d.key));
     const activeAdvancedCount = advancedFilters.filter(
-        (d) => {
-            const val = getFilterValue(d.key);
-            return val !== "" && val !== (d.default ?? "");
-        },
+        (d) => isFilterActive(getFilterValue(d.key), d.default),
     ).length;
+    const hasAnyActiveFilter = [...defaultFilters, ...advancedFilters].some(
+        (d) => isFilterActive(getFilterValue(d.key), d.default),
+    );
 
     return (
         <div className="search-bar-container">
@@ -116,25 +134,29 @@ export function SearchBar() {
 
             {filterDescriptors.length > 0 && (
                 <div className="filter-row">
-                    {defaultFilters.map((desc) => (
-                        <select
-                            key={desc.key}
-                            className="filter-select"
-                            value={getFilterValue(desc.key)}
-                            onChange={(e) => handleFilterChange(desc.key, e.target.value)}
-                            disabled={status === "loading"}
-                            aria-label={desc.display_name}
-                        >
-                            <option value="">
-                                {desc.display_name}: Any
-                            </option>
-                            {desc.allowed_values.map((v) => (
-                                <option key={v.value} value={v.value}>
-                                    {v.label}
+                    {defaultFilters.map((desc) => {
+                        const value = getFilterValue(desc.key);
+                        const active = isFilterActive(value, desc.default);
+                        return (
+                            <select
+                                key={desc.key}
+                                className={`filter-select${active ? " filter-active" : ""}`}
+                                value={value}
+                                onChange={(e) => handleFilterChange(desc.key, e.target.value)}
+                                disabled={status === "loading"}
+                                aria-label={desc.display_name}
+                            >
+                                <option value="">
+                                    {desc.display_name}: Any
                                 </option>
-                            ))}
-                        </select>
-                    ))}
+                                {desc.allowed_values.map((v) => (
+                                    <option key={v.value} value={v.value}>
+                                        {v.label}
+                                    </option>
+                                ))}
+                            </select>
+                        );
+                    })}
 
                     {advancedFilters.length > 0 && (
                         <button
@@ -144,6 +166,17 @@ export function SearchBar() {
                             aria-expanded={showAdvanced}
                             aria-label="Advanced filters"
                         >
+                            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <line x1="4" y1="21" x2="4" y2="14" />
+                                <line x1="4" y1="10" x2="4" y2="3" />
+                                <line x1="12" y1="21" x2="12" y2="12" />
+                                <line x1="12" y1="8" x2="12" y2="3" />
+                                <line x1="20" y1="21" x2="20" y2="16" />
+                                <line x1="20" y1="12" x2="20" y2="3" />
+                                <line x1="1" y1="14" x2="7" y2="14" />
+                                <line x1="9" y1="8" x2="15" y2="8" />
+                                <line x1="17" y1="16" x2="23" y2="16" />
+                            </svg>
                             Filters
                             {activeAdvancedCount > 0 && (
                                 <span className="filter-badge">
@@ -152,32 +185,51 @@ export function SearchBar() {
                             )}
                         </button>
                     )}
+
+                    {hasAnyActiveFilter && (
+                        <button
+                            type="button"
+                            className="filter-reset"
+                            onClick={resetFiltersToDefaults}
+                            aria-label="Reset all filters"
+                        >
+                            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <path d="M18 6L6 18" />
+                                <path d="M6 6l12 12" />
+                            </svg>
+                            Reset
+                        </button>
+                    )}
                 </div>
             )}
 
             {showAdvanced && advancedFilters.length > 0 && (
                 <div className="filter-advanced">
-                    {advancedFilters.map((desc) => (
-                        <div key={desc.key} className="filter-advanced-item">
-                            <label className="filter-label">
-                                {desc.display_name}
-                            </label>
-                            <select
-                                className="filter-select"
-                                value={getFilterValue(desc.key)}
-                                onChange={(e) => handleFilterChange(desc.key, e.target.value)}
-                                disabled={status === "loading"}
-                                aria-label={desc.display_name}
-                            >
-                                <option value="">Any</option>
-                                {desc.allowed_values.map((v) => (
-                                    <option key={v.value} value={v.value}>
-                                        {v.label}
-                                    </option>
-                                ))}
-                            </select>
-                        </div>
-                    ))}
+                    {advancedFilters.map((desc) => {
+                        const value = getFilterValue(desc.key);
+                        const active = isFilterActive(value, desc.default);
+                        return (
+                            <div key={desc.key} className="filter-advanced-item">
+                                <label className="filter-label">
+                                    {desc.display_name}
+                                </label>
+                                <select
+                                    className={`filter-select${active ? " filter-active" : ""}`}
+                                    value={value}
+                                    onChange={(e) => handleFilterChange(desc.key, e.target.value)}
+                                    disabled={status === "loading"}
+                                    aria-label={desc.display_name}
+                                >
+                                    <option value="">Any</option>
+                                    {desc.allowed_values.map((v) => (
+                                        <option key={v.value} value={v.value}>
+                                            {v.label}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                        );
+                    })}
                 </div>
             )}
         </div>

--- a/crates/rdlp-desktop/src/components/SearchBar.tsx
+++ b/crates/rdlp-desktop/src/components/SearchBar.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useSearchStore } from "../lib/store";
 import type { SearchFilter } from "../types";
 
+const DEFAULT_FILTER_KEYS = new Set(["sort", "quality", "duration-min", "duration-max"]);
+
 /** Search form with site selector, query input, filters, and submit button. */
 export function SearchBar() {
     const query = useSearchStore((s) => s.query);
@@ -41,6 +43,7 @@ export function SearchBar() {
 
     const handleSiteChange = (newSite: string) => {
         setSite(newSite);
+        setShowAdvanced(false);
         // loadFilters will fire via the useEffect above, resetting filters to defaults
     };
 
@@ -59,9 +62,8 @@ export function SearchBar() {
     };
 
     // Split descriptors into default (sort, quality, duration) and advanced
-    const defaultKeys = new Set(["sort", "quality", "duration-min", "duration-max"]);
-    const defaultFilters = filterDescriptors.filter((d) => defaultKeys.has(d.key));
-    const advancedFilters = filterDescriptors.filter((d) => !defaultKeys.has(d.key));
+    const defaultFilters = filterDescriptors.filter((d) => DEFAULT_FILTER_KEYS.has(d.key));
+    const advancedFilters = filterDescriptors.filter((d) => !DEFAULT_FILTER_KEYS.has(d.key));
     const activeAdvancedCount = advancedFilters.filter(
         (d) => {
             const val = getFilterValue(d.key);
@@ -140,7 +142,7 @@ export function SearchBar() {
                             className={`filter-toggle ${showAdvanced ? "active" : ""}`}
                             onClick={() => setShowAdvanced(!showAdvanced)}
                             aria-expanded={showAdvanced}
-                            aria-label={`${activeAdvancedCount} active filters`}
+                            aria-label="Advanced filters"
                         >
                             Filters
                             {activeAdvancedCount > 0 && (

--- a/crates/rdlp-desktop/src/components/SearchBar.tsx
+++ b/crates/rdlp-desktop/src/components/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSearchStore } from "../lib/store";
+import type { SearchFilter } from "../types";
 
-/** Search form with site selector, query input, and submit button. */
+/** Search form with site selector, query input, filters, and submit button. */
 export function SearchBar() {
     const query = useSearchStore((s) => s.query);
     const setQuery = useSearchStore((s) => s.setQuery);
@@ -9,12 +10,25 @@ export function SearchBar() {
     const setSite = useSearchStore((s) => s.setSite);
     const providers = useSearchStore((s) => s.providers);
     const loadProviders = useSearchStore((s) => s.loadProviders);
+    const filters = useSearchStore((s) => s.filters);
+    const setFilters = useSearchStore((s) => s.setFilters);
+    const filterDescriptors = useSearchStore((s) => s.filterDescriptors);
+    const loadFilters = useSearchStore((s) => s.loadFilters);
     const search = useSearchStore((s) => s.search);
     const status = useSearchStore((s) => s.status);
+
+    const [showAdvanced, setShowAdvanced] = useState(false);
 
     useEffect(() => {
         void loadProviders();
     }, [loadProviders]);
+
+    // Load filter descriptors when site changes
+    useEffect(() => {
+        if (site !== "") {
+            void loadFilters(site);
+        }
+    }, [site, loadFilters]);
 
     const isDisabled = status === "loading" || query.trim() === "";
 
@@ -25,45 +39,145 @@ export function SearchBar() {
         }
     };
 
+    const handleSiteChange = (newSite: string) => {
+        setSite(newSite);
+        // loadFilters will fire via the useEffect above, resetting filters to defaults
+    };
+
+    const handleFilterChange = (key: string, value: string) => {
+        const updated: SearchFilter[] = filters.filter((f) => f.key !== key);
+        // Only add filter if value is non-empty (empty = "any"/unset)
+        if (value !== "") {
+            updated.push({ key, value });
+        }
+        setFilters(updated);
+    };
+
+    const getFilterValue = (key: string): string => {
+        const filter = filters.find((f) => f.key === key);
+        return filter?.value ?? "";
+    };
+
+    // Split descriptors into default (sort, quality, duration) and advanced
+    const defaultKeys = new Set(["sort", "quality", "duration-min", "duration-max"]);
+    const defaultFilters = filterDescriptors.filter((d) => defaultKeys.has(d.key));
+    const advancedFilters = filterDescriptors.filter((d) => !defaultKeys.has(d.key));
+    const activeAdvancedCount = advancedFilters.filter(
+        (d) => {
+            const val = getFilterValue(d.key);
+            return val !== "" && val !== (d.default ?? "");
+        },
+    ).length;
+
     return (
-        <form className="search-bar" onSubmit={handleSubmit}>
-            <select
-                className="site-selector"
-                value={site}
-                onChange={(e) => setSite(e.target.value)}
-                disabled={status === "loading"}
-            >
-                {providers.length === 0 && (
-                    <option value="">Loading sites...</option>
-                )}
-                {providers.map((p) => (
-                    <option key={p.name} value={p.name}>
-                        {p.display_name}
-                    </option>
-                ))}
-            </select>
-
-            <div className="search-input-wrapper">
-                <svg className="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="M21 21l-4.3-4.3" />
-                </svg>
-                <input
-                    className="search-input"
-                    type="text"
-                    placeholder="Search videos..."
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
+        <div className="search-bar-container">
+            <form className="search-bar" onSubmit={handleSubmit}>
+                <select
+                    className="site-selector"
+                    value={site}
+                    onChange={(e) => handleSiteChange(e.target.value)}
                     disabled={status === "loading"}
-                />
-            </div>
+                    aria-label="Search site"
+                >
+                    {providers.length === 0 && (
+                        <option value="">Loading sites...</option>
+                    )}
+                    {providers.map((p) => (
+                        <option key={p.name} value={p.name}>
+                            {p.display_name}
+                        </option>
+                    ))}
+                </select>
 
-            <button
-                type="submit"
-                disabled={isDisabled}
-            >
-                {status === "loading" ? "Searching..." : "Search"}
-            </button>
-        </form>
+                <div className="search-input-wrapper">
+                    <svg className="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <circle cx="11" cy="11" r="8" />
+                        <path d="M21 21l-4.3-4.3" />
+                    </svg>
+                    <input
+                        className="search-input"
+                        type="text"
+                        placeholder="Search videos..."
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        disabled={status === "loading"}
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={isDisabled}
+                >
+                    {status === "loading" ? "Searching..." : "Search"}
+                </button>
+            </form>
+
+            {filterDescriptors.length > 0 && (
+                <div className="filter-row">
+                    {defaultFilters.map((desc) => (
+                        <select
+                            key={desc.key}
+                            className="filter-select"
+                            value={getFilterValue(desc.key)}
+                            onChange={(e) => handleFilterChange(desc.key, e.target.value)}
+                            disabled={status === "loading"}
+                            aria-label={desc.display_name}
+                        >
+                            <option value="">
+                                {desc.display_name}: Any
+                            </option>
+                            {desc.allowed_values.map((v) => (
+                                <option key={v.value} value={v.value}>
+                                    {v.label}
+                                </option>
+                            ))}
+                        </select>
+                    ))}
+
+                    {advancedFilters.length > 0 && (
+                        <button
+                            type="button"
+                            className={`filter-toggle ${showAdvanced ? "active" : ""}`}
+                            onClick={() => setShowAdvanced(!showAdvanced)}
+                            aria-expanded={showAdvanced}
+                            aria-label={`${activeAdvancedCount} active filters`}
+                        >
+                            Filters
+                            {activeAdvancedCount > 0 && (
+                                <span className="filter-badge">
+                                    {activeAdvancedCount}
+                                </span>
+                            )}
+                        </button>
+                    )}
+                </div>
+            )}
+
+            {showAdvanced && advancedFilters.length > 0 && (
+                <div className="filter-advanced">
+                    {advancedFilters.map((desc) => (
+                        <div key={desc.key} className="filter-advanced-item">
+                            <label className="filter-label">
+                                {desc.display_name}
+                            </label>
+                            <select
+                                className="filter-select"
+                                value={getFilterValue(desc.key)}
+                                onChange={(e) => handleFilterChange(desc.key, e.target.value)}
+                                disabled={status === "loading"}
+                                aria-label={desc.display_name}
+                            >
+                                <option value="">Any</option>
+                                {desc.allowed_values.map((v) => (
+                                    <option key={v.value} value={v.value}>
+                                        {v.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
     );
 }

--- a/crates/rdlp-desktop/src/lib/store.ts
+++ b/crates/rdlp-desktop/src/lib/store.ts
@@ -77,12 +77,18 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     loadFilters: async (site) => {
         try {
             const filterDescriptors = await api.getSearchFilters(site);
-            set({ filterDescriptors });
-        } catch (err) {
-            set({
-                error: err instanceof Error ? err.message : String(err),
-                status: "error",
-            });
+            // Initialize filters to descriptor defaults
+            const filters: SearchFilter[] = [];
+            for (const desc of filterDescriptors) {
+                if (desc.default !== null) {
+                    filters.push({ key: desc.key, value: desc.default });
+                }
+            }
+            set({ filterDescriptors, filters });
+        } catch {
+            // Silently clear descriptors — do not set status: "error"
+            // to avoid conflating filter-load failures with search errors.
+            set({ filterDescriptors: [], filters: [] });
         }
     },
 

--- a/crates/rdlp-desktop/src/lib/store.ts
+++ b/crates/rdlp-desktop/src/lib/store.ts
@@ -149,22 +149,28 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
 // ========== Queue Store ==========
 
-const DEFAULT_DOWNLOAD_OPTIONS: DownloadOptions = {
-    format: null,
-    outputDir: null,
-    subtitles: false,
-    subtitleLangs: [],
-    remux: null,
-    extractAudio: null,
-    embedThumbnail: true,
-};
+/** Build default DownloadOptions from AppSettings. */
+function buildDefaultOptions(settings: AppSettings | null): DownloadOptions {
+    return {
+        format: null,
+        outputDir: null,
+        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
+        subtitleLangs: settings?.default_subtitle_langs ?? [],
+        remux: settings?.default_remux ?? null,
+        extractAudio: settings?.default_extract_audio ?? null,
+        embedThumbnail: settings?.embed_thumbnail ?? true,
+        audioMultistreams: false,
+        recodeVideo: null,
+    };
+}
 
 interface QueueState {
     jobs: DownloadJob[];
     selectedFormat: FormatListResponse | null;
+    formatDialogLoading: boolean;
 
     refreshQueue: () => Promise<void>;
-    startDownload: (url: string) => Promise<string>;
+    startDownload: (url: string, options?: Partial<DownloadOptions>) => Promise<string>;
     cancelDownload: (jobId: string) => Promise<void>;
     removeJob: (jobId: string) => Promise<void>;
     updateJobFromProgress: (
@@ -183,14 +189,18 @@ interface QueueState {
 export const useQueueStore = create<QueueState>()((set, get) => ({
     jobs: [],
     selectedFormat: null,
+    formatDialogLoading: false,
 
     refreshQueue: async () => {
         const jobs = await api.getQueue();
         set({ jobs });
     },
 
-    startDownload: async (url) => {
-        const jobId = await api.startDownload(url, DEFAULT_DOWNLOAD_OPTIONS);
+    startDownload: async (url, options) => {
+        const settings = useSettingsStore.getState().settings;
+        const defaults = buildDefaultOptions(settings);
+        const merged: DownloadOptions = { ...defaults, ...options };
+        const jobId = await api.startDownload(url, merged);
         await get().refreshQueue();
         return jobId;
     },
@@ -251,12 +261,18 @@ export const useQueueStore = create<QueueState>()((set, get) => ({
         })),
 
     loadFormats: async (url) => {
-        const formats = await api.getFormats(url);
-        set({ selectedFormat: formats });
-        return formats;
+        set({ formatDialogLoading: true });
+        try {
+            const formats = await api.getFormats(url);
+            set({ selectedFormat: formats, formatDialogLoading: false });
+            return formats;
+        } catch (err) {
+            set({ formatDialogLoading: false });
+            throw err;
+        }
     },
 
-    clearFormats: () => set({ selectedFormat: null }),
+    clearFormats: () => set({ selectedFormat: null, formatDialogLoading: false }),
 }));
 
 // ========== Settings Store ==========

--- a/crates/rdlp-desktop/src/lib/store.ts
+++ b/crates/rdlp-desktop/src/lib/store.ts
@@ -27,6 +27,7 @@ interface SearchState {
     query: string;
     site: string;
     filters: SearchFilter[];
+    hasUserFilters: boolean;
     results: SearchResultPreview[];
     providers: SearchSiteInfo[];
     filterDescriptors: SearchFilterDescriptor[];
@@ -35,6 +36,7 @@ interface SearchState {
     setQuery: (query: string) => void;
     setSite: (site: string) => void;
     setFilters: (filters: SearchFilter[]) => void;
+    resetFiltersToDefaults: () => void;
     loadProviders: () => Promise<void>;
     loadFilters: (site: string) => Promise<void>;
     search: () => Promise<void>;
@@ -46,6 +48,7 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     query: "",
     site: "",
     filters: [],
+    hasUserFilters: false,
     results: [],
     providers: [],
     filterDescriptors: [],
@@ -55,7 +58,18 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
     setSite: (site) => set({ site }),
 
-    setFilters: (filters) => set({ filters }),
+    setFilters: (filters) => set({ filters, hasUserFilters: true }),
+
+    resetFiltersToDefaults: () => {
+        const descs = get().filterDescriptors;
+        const defaults: SearchFilter[] = [];
+        for (const desc of descs) {
+            if (desc.default !== null) {
+                defaults.push({ key: desc.key, value: desc.default });
+            }
+        }
+        set({ filters: defaults, hasUserFilters: false });
+    },
 
     loadProviders: async () => {
         try {
@@ -77,6 +91,8 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     loadFilters: async (site) => {
         try {
             const filterDescriptors = await api.getSearchFilters(site);
+            // Discard stale response if site changed during the async call
+            if (get().site !== site) return;
             // Initialize filters to descriptor defaults
             const filters: SearchFilter[] = [];
             for (const desc of filterDescriptors) {
@@ -84,11 +100,14 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
                     filters.push({ key: desc.key, value: desc.default });
                 }
             }
-            set({ filterDescriptors, filters });
-        } catch {
+            set({ filterDescriptors, filters, hasUserFilters: false });
+        } catch (err) {
+            // Discard stale error if site changed during the async call
+            if (get().site !== site) return;
+            console.warn("Failed to load filters:", err);
             // Silently clear descriptors — do not set status: "error"
             // to avoid conflating filter-load failures with search errors.
-            set({ filterDescriptors: [], filters: [] });
+            set({ filterDescriptors: [], filters: [], hasUserFilters: false });
         }
     },
 
@@ -122,6 +141,7 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
             status: "idle",
             query: "",
             filters: [],
+            hasUserFilters: false,
             results: [],
             error: null,
         }),

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -14,6 +14,7 @@ import type {
     DownloadOptions,
     DownloadProgressPayload,
     FormatListResponse,
+    FormatSelectedPayload,
     SearchFilter,
     SearchFilterDescriptor,
     SearchResponse,
@@ -128,4 +129,24 @@ export function onDownloadLog(
     return listen<DownloadLogPayload>("download-log", (event) =>
         callback(event.payload),
     );
+}
+
+/** Subscribe to format-selected events. Returns an unlisten function. */
+export function onFormatSelected(
+    callback: (payload: FormatSelectedPayload) => void,
+): Promise<UnlistenFn> {
+    return listen<FormatSelectedPayload>("format-selected", (event) =>
+        callback(event.payload),
+    );
+}
+
+/** Validate a format expression and return matching format IDs. */
+export async function validateFormatExpression(
+    expression: string,
+    formatIds: string[],
+): Promise<string[]> {
+    return invoke<string[]>("validate_format_expression", {
+        expression,
+        formatIds,
+    });
 }

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -143,10 +143,32 @@ export function onFormatSelected(
 /** Validate a format expression and return matching format IDs. */
 export async function validateFormatExpression(
     expression: string,
-    formatIds: string[],
+    formats: FormatData[],
 ): Promise<string[]> {
     return invoke<string[]>("validate_format_expression", {
         expression,
-        formatIds,
+        formats,
     });
+}
+
+/**
+ * Format metadata for expression validation.
+ *
+ * Mirrors the Rust `FormatData` struct. Sent to the backend so
+ * format filter predicates (e.g. `[height<=1080]`) can match.
+ */
+export interface FormatData {
+    format_id: string;
+    ext: string;
+    width: number | null;
+    height: number | null;
+    fps: number | null;
+    tbr: number | null;
+    vcodec: string | null;
+    acodec: string | null;
+    filesize: number | null;
+    vbr: number | null;
+    abr: number | null;
+    asr: number | null;
+    protocol: string;
 }

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -8,8 +8,8 @@ export function SearchPage() {
     const results = useSearchStore((s) => s.results);
     const error = useSearchStore((s) => s.error);
     const search = useSearchStore((s) => s.search);
-    const filters = useSearchStore((s) => s.filters);
-    const setFilters = useSearchStore((s) => s.setFilters);
+    const hasUserFilters = useSearchStore((s) => s.hasUserFilters);
+    const resetFiltersToDefaults = useSearchStore((s) => s.resetFiltersToDefaults);
     const startDownload = useQueueStore((s) => s.startDownload);
 
     const handleDownload = (url: string) => {
@@ -52,11 +52,11 @@ export function SearchPage() {
                         <line x1="8" y1="11" x2="14" y2="11" />
                     </svg>
                     <p>No results found.</p>
-                    {filters.length > 0 && (
+                    {hasUserFilters && (
                         <button
                             className="clear-filters-btn"
                             onClick={() => {
-                                setFilters([]);
+                                resetFiltersToDefaults();
                                 void search();
                             }}
                         >

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -1,7 +1,6 @@
 import { SearchBar } from "../components/SearchBar";
 import { ResultCard } from "../components/ResultCard";
-import { useSearchStore } from "../lib/store";
-import { useQueueStore } from "../lib/store";
+import { useSearchStore, useQueueStore } from "../lib/store";
 
 /** Search page composing the search bar and results grid. */
 export function SearchPage() {
@@ -9,6 +8,8 @@ export function SearchPage() {
     const results = useSearchStore((s) => s.results);
     const error = useSearchStore((s) => s.error);
     const search = useSearchStore((s) => s.search);
+    const filters = useSearchStore((s) => s.filters);
+    const setFilters = useSearchStore((s) => s.setFilters);
     const startDownload = useQueueStore((s) => s.startDownload);
 
     const handleDownload = (url: string) => {
@@ -51,6 +52,17 @@ export function SearchPage() {
                         <line x1="8" y1="11" x2="14" y2="11" />
                     </svg>
                     <p>No results found.</p>
+                    {filters.length > 0 && (
+                        <button
+                            className="clear-filters-btn"
+                            onClick={() => {
+                                setFilters([]);
+                                void search();
+                            }}
+                        >
+                            Clear filters and retry
+                        </button>
+                    )}
                 </div>
             )}
 

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { SearchBar } from "../components/SearchBar";
 import { ResultCard } from "../components/ResultCard";
+import { FormatDialog } from "../components/FormatDialog";
 import { useSearchStore, useQueueStore } from "../lib/store";
+import type { DownloadOptions } from "../types";
 
-/** Search page composing the search bar and results grid. */
+/** Search page composing the search bar, results grid, and format dialog. */
 export function SearchPage() {
     const status = useSearchStore((s) => s.status);
     const results = useSearchStore((s) => s.results);
@@ -12,8 +15,25 @@ export function SearchPage() {
     const resetFiltersToDefaults = useSearchStore((s) => s.resetFiltersToDefaults);
     const startDownload = useQueueStore((s) => s.startDownload);
 
+    const [formatDialogUrl, setFormatDialogUrl] = useState<string | null>(null);
+
     const handleDownload = (url: string) => {
         void startDownload(url);
+    };
+
+    const handleDownloadWithOptions = (url: string, options: Partial<DownloadOptions>) => {
+        void startDownload(url, options);
+    };
+
+    const handleOpenFormatDialog = (url: string) => {
+        setFormatDialogUrl(url);
+    };
+
+    const handleFormatDialogConfirm = (options: DownloadOptions) => {
+        if (formatDialogUrl) {
+            void startDownload(formatDialogUrl, options);
+        }
+        setFormatDialogUrl(null);
     };
 
     return (
@@ -83,9 +103,19 @@ export function SearchPage() {
                             key={`${idx}-${result.video_url}`}
                             result={result}
                             onDownload={handleDownload}
+                            onDownloadWithOptions={handleDownloadWithOptions}
+                            onOpenFormatDialog={handleOpenFormatDialog}
                         />
                     ))}
                 </div>
+            )}
+
+            {formatDialogUrl && (
+                <FormatDialog
+                    url={formatDialogUrl}
+                    onConfirm={handleFormatDialogConfirm}
+                    onClose={() => setFormatDialogUrl(null)}
+                />
             )}
         </div>
     );

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -1,91 +1,210 @@
 import { useEffect, useState } from "react";
-import { useSettingsStore } from "../lib/store";
-import type { AppSettings } from "../types";
+import { useSettingsStore, useSearchStore } from "../lib/store";
+import type {
+    AppSettings,
+    AudioFormat,
+    ContainerFormat,
+    SubtitleFormat,
+} from "../types";
 
 export function SettingsPage() {
-  const { settings, loading, loadSettings, updateSettings, pickDirectory } =
-    useSettingsStore();
-  const [draft, setDraft] = useState<AppSettings | null>(null);
+    const { settings, loading, loadSettings, updateSettings, pickDirectory } =
+        useSettingsStore();
+    const providers = useSearchStore((s) => s.providers);
+    const loadProviders = useSearchStore((s) => s.loadProviders);
+    const [draft, setDraft] = useState<AppSettings | null>(null);
 
-  useEffect(() => {
-    loadSettings();
-  }, [loadSettings]);
+    useEffect(() => {
+        loadSettings();
+        void loadProviders();
+    }, [loadSettings, loadProviders]);
 
-  useEffect(() => {
-    if (settings) {
-      setDraft(settings);
+    useEffect(() => {
+        if (settings) {
+            setDraft(settings);
+        }
+    }, [settings]);
+
+    if (loading || !draft) {
+        return <div className="status-message">Loading settings...</div>;
     }
-  }, [settings]);
 
-  if (loading || !draft) {
-    return <div className="status-message">Loading settings...</div>;
-  }
+    const handleSave = async () => {
+        await updateSettings(draft);
+    };
 
-  const handleSave = async () => {
-    await updateSettings(draft);
-  };
+    const handlePickDir = async () => {
+        const dir = await pickDirectory();
+        if (dir) {
+            setDraft({ ...draft, output_dir: dir });
+        }
+    };
 
-  const handlePickDir = async () => {
-    const dir = await pickDirectory();
-    if (dir) {
-      setDraft({ ...draft, output_dir: dir });
-    }
-  };
+    return (
+        <div className="settings-page">
+            <h2>Settings</h2>
 
-  return (
-    <div className="settings-page">
-      <h2>Settings</h2>
+            <div className="setting-row">
+                <label>Output Directory</label>
+                <div className="dir-picker">
+                    <input type="text" value={draft.output_dir} readOnly />
+                    <button onClick={handlePickDir}>Browse</button>
+                </div>
+            </div>
 
-      <div className="setting-row">
-        <label>Output Directory</label>
-        <div className="dir-picker">
-          <input type="text" value={draft.output_dir} readOnly />
-          <button onClick={handlePickDir}>Browse</button>
+            <div className="setting-row">
+                <label>Default Remux Format</label>
+                <select
+                    className="filter-select"
+                    value={draft.default_remux ?? ""}
+                    onChange={(e) =>
+                        setDraft({
+                            ...draft,
+                            default_remux:
+                                (e.target.value as ContainerFormat) || null,
+                        })
+                    }
+                >
+                    <option value="">None</option>
+                    <option value="mp4">MP4</option>
+                    <option value="mkv">MKV</option>
+                    <option value="webm">WebM</option>
+                </select>
+            </div>
+
+            <div className="setting-row">
+                <label>Default Audio Extraction</label>
+                <select
+                    className="filter-select"
+                    value={draft.default_extract_audio ?? ""}
+                    onChange={(e) =>
+                        setDraft({
+                            ...draft,
+                            default_extract_audio:
+                                (e.target.value as AudioFormat) || null,
+                        })
+                    }
+                >
+                    <option value="">None</option>
+                    <option value="mp3">MP3</option>
+                    <option value="aac">AAC</option>
+                    <option value="opus">Opus</option>
+                    <option value="flac">FLAC</option>
+                </select>
+            </div>
+
+            <div className="setting-row">
+                <label>Default Subtitle Format</label>
+                <select
+                    className="filter-select"
+                    value={draft.default_subtitle_format ?? ""}
+                    onChange={(e) =>
+                        setDraft({
+                            ...draft,
+                            default_subtitle_format:
+                                (e.target.value as SubtitleFormat) || null,
+                        })
+                    }
+                >
+                    <option value="">None</option>
+                    <option value="srt">SRT</option>
+                    <option value="vtt">VTT</option>
+                    <option value="ass">ASS</option>
+                </select>
+            </div>
+
+            <div className="setting-row">
+                <label>Default Subtitle Languages</label>
+                <input
+                    className="settings-text-input"
+                    type="text"
+                    placeholder="en,sv,ja"
+                    value={draft.default_subtitle_langs.join(",")}
+                    onChange={(e) =>
+                        setDraft({
+                            ...draft,
+                            default_subtitle_langs: e.target.value
+                                .split(",")
+                                .map((s) => s.trim())
+                                .filter(Boolean),
+                        })
+                    }
+                />
+            </div>
+
+            <div className="setting-row">
+                <label>Default Search Provider</label>
+                <select
+                    className="filter-select"
+                    value={draft.default_search_provider ?? ""}
+                    onChange={(e) =>
+                        setDraft({
+                            ...draft,
+                            default_search_provider:
+                                e.target.value || null,
+                        })
+                    }
+                >
+                    <option value="">Auto</option>
+                    {providers.map((p) => (
+                        <option key={p.name} value={p.name}>
+                            {p.display_name}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <div className="setting-row">
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={draft.embed_thumbnail}
+                        onChange={(e) =>
+                            setDraft({
+                                ...draft,
+                                embed_thumbnail: e.target.checked,
+                            })
+                        }
+                    />
+                    Embed thumbnails
+                </label>
+            </div>
+
+            <div className="setting-row">
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={draft.embed_metadata}
+                        onChange={(e) =>
+                            setDraft({
+                                ...draft,
+                                embed_metadata: e.target.checked,
+                            })
+                        }
+                    />
+                    Embed metadata
+                </label>
+            </div>
+
+            <div className="setting-row">
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={draft.verbose}
+                        onChange={(e) =>
+                            setDraft({
+                                ...draft,
+                                verbose: e.target.checked,
+                            })
+                        }
+                    />
+                    Verbose logging
+                </label>
+            </div>
+
+            <button className="save-btn" onClick={handleSave}>
+                Save Settings
+            </button>
         </div>
-      </div>
-
-      <div className="setting-row">
-        <label>
-          <input
-            type="checkbox"
-            checked={draft.embed_thumbnail}
-            onChange={(e) =>
-              setDraft({ ...draft, embed_thumbnail: e.target.checked })
-            }
-          />
-          Embed thumbnails
-        </label>
-      </div>
-
-      <div className="setting-row">
-        <label>
-          <input
-            type="checkbox"
-            checked={draft.embed_metadata}
-            onChange={(e) =>
-              setDraft({ ...draft, embed_metadata: e.target.checked })
-            }
-          />
-          Embed metadata
-        </label>
-      </div>
-
-      <div className="setting-row">
-        <label>
-          <input
-            type="checkbox"
-            checked={draft.verbose}
-            onChange={(e) =>
-              setDraft({ ...draft, verbose: e.target.checked })
-            }
-          />
-          Verbose logging
-        </label>
-      </div>
-
-      <button className="save-btn" onClick={handleSave}>
-        Save Settings
-      </button>
-    </div>
-  );
+    );
 }

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -112,6 +112,22 @@ export interface DownloadJob {
 }
 
 /**
+ * Container formats matching Rust `ContainerFormat` (#[serde(rename_all = "lowercase")]).
+ */
+export type ContainerFormat =
+    | "mp4" | "mkv" | "webm" | "mov" | "ts" | "flv" | "avi"
+    | "threegp" | "mpg" | "f4v" | "asf" | "mxf" | "vob" | "dv"
+    | "nut" | "ivf" | "ogg" | "m4a" | "mp3" | "wav" | "flac"
+    | "opus" | "aac" | "aiff" | "mka" | "wv" | "caf" | "ac3";
+
+/**
+ * Audio formats matching Rust `AudioFormat` (#[serde(rename_all = "lowercase")]).
+ */
+export type AudioFormat =
+    | "mp3" | "aac" | "m4a" | "opus" | "vorbis" | "flac" | "alac"
+    | "wav" | "ac3" | "eac3" | "dts" | "mp2" | "wavpack" | "tta";
+
+/**
  * Frontend-supplied download options.
  *
  * Uses camelCase because the Rust struct has #[serde(rename_all = "camelCase")].
@@ -121,8 +137,8 @@ export interface DownloadOptions {
     outputDir: string | null;
     subtitles: boolean;
     subtitleLangs: string[];
-    remux: string | null;
-    extractAudio: string | null;
+    remux: ContainerFormat | null;
+    extractAudio: AudioFormat | null;
     embedThumbnail: boolean;
 }
 

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -64,6 +64,10 @@ export interface FormatInfo {
     vcodec: string | null;
     acodec: string | null;
     filesize: number | null;
+    vbr: number | null;
+    abr: number | null;
+    asr: number | null;
+    protocol: string;
     has_video: boolean;
     has_audio: boolean;
 }
@@ -128,6 +132,11 @@ export type AudioFormat =
     | "wav" | "ac3" | "eac3" | "dts" | "mp2" | "wavpack" | "tta";
 
 /**
+ * Subtitle formats matching Rust `SubtitleFormat` (#[serde(rename_all = "lowercase")]).
+ */
+export type SubtitleFormat = "srt" | "vtt" | "ass" | "ssa" | "lrc";
+
+/**
  * Frontend-supplied download options.
  *
  * Uses camelCase because the Rust struct has #[serde(rename_all = "camelCase")].
@@ -140,6 +149,8 @@ export interface DownloadOptions {
     remux: ContainerFormat | null;
     extractAudio: AudioFormat | null;
     embedThumbnail: boolean;
+    audioMultistreams: boolean;
+    recodeVideo: ContainerFormat | null;
 }
 
 // ========== Event Payloads (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========
@@ -167,6 +178,13 @@ export interface DownloadErrorPayload {
     retryable: boolean;
 }
 
+/** Format-selected payload emitted as "format-selected". */
+export interface FormatSelectedPayload {
+    jobId: string;
+    formatId: string;
+    quality: string;
+}
+
 /** Log message payload emitted as "download-log". */
 export interface DownloadLogPayload {
     jobId: string;
@@ -183,9 +201,9 @@ export interface DownloadLogPayload {
  */
 export interface AppSettings {
     output_dir: string;
-    default_remux: string | null;
-    default_extract_audio: string | null;
-    default_subtitle_format: string | null;
+    default_remux: ContainerFormat | null;
+    default_extract_audio: AudioFormat | null;
+    default_subtitle_format: SubtitleFormat | null;
     default_subtitle_langs: string[];
     embed_thumbnail: boolean;
     embed_metadata: boolean;

--- a/crates/rdlp-extractor/src/extractors/xhamster/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/patterns.rs
@@ -257,29 +257,6 @@ pub fn search_filter_descriptors() -> Vec<rdlp_core::SearchFilterDescriptor> {
             default: Some("relevance".to_string()),
         },
         rdlp_core::SearchFilterDescriptor {
-            key: "date".to_string(),
-            display_name: "Upload date".to_string(),
-            allowed_values: vec![
-                rdlp_core::SearchFilterValue {
-                    value: "latest".to_string(),
-                    label: "Latest".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "weekly".to_string(),
-                    label: "Last week".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "monthly".to_string(),
-                    label: "Last month".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "yearly".to_string(),
-                    label: "Last year".to_string(),
-                },
-            ],
-            default: None,
-        },
-        rdlp_core::SearchFilterDescriptor {
             key: "orientations".to_string(),
             display_name: "Orientation".to_string(),
             allowed_values: vec![
@@ -299,118 +276,73 @@ pub fn search_filter_descriptors() -> Vec<rdlp_core::SearchFilterDescriptor> {
             default: None,
         },
         rdlp_core::SearchFilterDescriptor {
-            key: "format".to_string(),
-            display_name: "Format".to_string(),
+            key: "date".to_string(),
+            display_name: "Upload date".to_string(),
             allowed_values: vec![
                 rdlp_core::SearchFilterValue {
-                    value: "any".to_string(),
-                    label: "Any".to_string(),
+                    value: "daily".to_string(),
+                    label: "Last 24 hours".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
-                    value: "vr".to_string(),
-                    label: "VR".to_string(),
-                },
-            ],
-            default: Some("any".to_string()),
-        },
-        rdlp_core::SearchFilterDescriptor {
-            key: "production".to_string(),
-            display_name: "Production".to_string(),
-            allowed_values: vec![
-                rdlp_core::SearchFilterValue {
-                    value: "studios".to_string(),
-                    label: "Producers".to_string(),
+                    value: "weekly".to_string(),
+                    label: "This week".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
-                    value: "creators".to_string(),
-                    label: "xHamster Creators".to_string(),
+                    value: "monthly".to_string(),
+                    label: "This month".to_string(),
                 },
             ],
             default: None,
         },
         rdlp_core::SearchFilterDescriptor {
-            key: "fps".to_string(),
-            display_name: "Frame rate".to_string(),
+            key: "min-duration".to_string(),
+            display_name: "Min duration".to_string(),
             allowed_values: vec![
                 rdlp_core::SearchFilterValue {
-                    value: "30".to_string(),
-                    label: "30 FPS".to_string(),
+                    value: "2".to_string(),
+                    label: "2 min".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
-                    value: "60".to_string(),
-                    label: "60 FPS".to_string(),
+                    value: "5".to_string(),
+                    label: "5 min".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "10".to_string(),
+                    label: "10 min".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "30".to_string(),
+                    label: "30 min".to_string(),
                 },
             ],
             default: None,
         },
         rdlp_core::SearchFilterDescriptor {
-            key: "full-videos".to_string(),
-            display_name: "Full videos only".to_string(),
-            allowed_values: vec![
-                rdlp_core::SearchFilterValue {
-                    value: "true".to_string(),
-                    label: "Yes".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "false".to_string(),
-                    label: "No".to_string(),
-                },
-            ],
-            default: Some("false".to_string()),
-        },
-        rdlp_core::SearchFilterDescriptor {
-            key: "duration-min".to_string(),
-            display_name: "Min duration (minutes)".to_string(),
-            allowed_values: vec![
-                rdlp_core::SearchFilterValue {
-                    value: "0".to_string(),
-                    label: "0".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "2".to_string(),
-                    label: "2".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "5".to_string(),
-                    label: "5".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "10".to_string(),
-                    label: "10".to_string(),
-                },
-                rdlp_core::SearchFilterValue {
-                    value: "30".to_string(),
-                    label: "30".to_string(),
-                },
-            ],
-            default: Some("0".to_string()),
-        },
-        rdlp_core::SearchFilterDescriptor {
-            key: "duration-max".to_string(),
-            display_name: "Max duration (minutes)".to_string(),
+            key: "max-duration".to_string(),
+            display_name: "Max duration".to_string(),
             allowed_values: vec![
                 rdlp_core::SearchFilterValue {
                     value: "2".to_string(),
-                    label: "2".to_string(),
+                    label: "2 min".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
                     value: "5".to_string(),
-                    label: "5".to_string(),
+                    label: "5 min".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
                     value: "10".to_string(),
-                    label: "10".to_string(),
+                    label: "10 min".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
                     value: "30".to_string(),
-                    label: "30".to_string(),
+                    label: "30 min".to_string(),
                 },
                 rdlp_core::SearchFilterValue {
                     value: "40".to_string(),
-                    label: "40+".to_string(),
+                    label: "40+ min".to_string(),
                 },
             ],
-            default: Some("40".to_string()),
+            default: None,
         },
     ]
 }
@@ -634,14 +566,13 @@ mod tests {
     #[test]
     fn test_search_filter_descriptors_not_empty() {
         let filters = search_filter_descriptors();
-        assert_eq!(filters.len(), 10);
+        assert_eq!(filters.len(), 6);
         let keys: Vec<&str> = filters.iter().map(|f| f.key.as_str()).collect();
         assert!(keys.contains(&"quality"));
         assert!(keys.contains(&"sort"));
-        assert!(keys.contains(&"date"));
-        assert!(keys.contains(&"production"));
-        assert!(keys.contains(&"fps"));
-        assert!(keys.contains(&"full-videos"));
+        assert!(keys.contains(&"orientations"));
+        assert!(keys.contains(&"min-duration"));
+        assert!(keys.contains(&"max-duration"));
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -99,7 +99,7 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
             }
             Some(desc) => {
                 // Duration min/max are numeric, allow any reasonable value
-                if filter.key == "duration-min" || filter.key == "duration-max" {
+                if filter.key == "min-duration" || filter.key == "max-duration" {
                     if filter.value.parse::<u32>().is_err() {
                         return Err(RdlpError::Extraction(format!(
                             "Invalid value '{}' for filter '{}'. Must be a number.",


### PR DESCRIPTION
## Summary
- Add search filter UI: default filters (sort, quality, duration) inline, advanced filters behind a toggle with active-count badge, reset button, and auto-search on filter change
- Add format selection dialog with sortable table, quality presets, expert mode (yt-dlp expression with live validation), shift-click merge pairs, and download options panel
- Add format options popover on result card download button (remux, extract audio, subtitles, thumbnail)
- Enhance settings page with subtitle format, subtitle language tags, embed metadata toggle, and recode video option
- Fix XHamster filter keys and values to match actual API; remove unverified filters
- Wire `recode_video` end-to-end from frontend through `PostProcessOptions` to `Config`
- Enrich `validate_format_expression` to accept full format metadata (`FormatData` struct) so filter predicates like `bv[height<=1080]+ba` match correctly
- Use date-fns for relative timestamp formatting on result cards
- Fix stale doc comments in `emit_event` and `FormatInfo`

## Files changed
- **Frontend**: SearchBar, ResultCard, FormatDialog, FormatOptionsPanel, SettingsPage, QueuePage, store, tauri API, types, App.css
- **Backend**: commands (download, formats, search, settings), events, state, error
- **API layer**: PostProcessOptions.recode_video field + merge logic

## Test plan
- [x] `cargo check -p rdlp-desktop` passes
- [x] `cargo test -p rdlp-desktop` — 42/42 tests pass
- [x] `cargo test -p rdlp-api` — 314/317 pass (3 pre-existing flaky mockito tests)
- [x] `cargo clippy -p rdlp-desktop -p rdlp-api -- -D warnings` — zero warnings
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [ ] Manual: select site, filter row renders, change filters triggers re-search
- [ ] Manual: open format dialog, sort table, select format, use expert mode expression
- [ ] Manual: download with options popover (remux, audio extraction)
- [ ] Manual: settings page saves and persists all new options