### PR TITLE
refactor(api): eliminate unnecessary Config clones via Arc

### DIFF
--- a/crates/rdlp-api/src/client.rs
+++ b/crates/rdlp-api/src/client.rs
@@ -89,7 +89,7 @@ impl RdlpClient {
         let (tx, rx) = mpsc::channel::<Event>(256);
         let cancel_token = CancellationToken::new();
 
-        let config = self.build_config(&request);
+        let config = Arc::new(self.build_config(&request));
         let interactive_flag = request.format.interactive;
         let url = request.url.clone();
         let interactive_cb = self.interactive.clone();
@@ -164,9 +164,8 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(16);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
         orchestrator
             .load_cookies()
             .await
@@ -198,10 +197,14 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(16);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator =
-            Orchestrator::new(config, tx, id, cancel_token, self.interactive.clone());
+        let orchestrator = Orchestrator::new(
+            Arc::clone(&self.config),
+            tx,
+            id,
+            cancel_token,
+            self.interactive.clone(),
+        );
         orchestrator
             .load_cookies()
             .await
@@ -218,9 +221,8 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(1);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
         orchestrator
             .list_extractors()
             .into_iter()
@@ -237,9 +239,8 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(1);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
         orchestrator
             .list_search_extractors()
             .into_iter()
@@ -264,9 +265,8 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(1);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
         orchestrator
             .search_filters(site)
             .map_err(|e| RdlpApiError::InvalidInput {
@@ -294,9 +294,8 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(16);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
         orchestrator.search(site, query).await.map_err(Into::into)
     }
 
@@ -318,9 +317,8 @@ impl RdlpClient {
         let id = DownloadId::next();
         let (tx, _rx) = mpsc::channel::<Event>(1);
         let cancel_token = CancellationToken::new();
-        let config = (*self.config).clone();
 
-        let orchestrator = Orchestrator::new(config, tx, id, cancel_token, None);
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
         orchestrator
             .list_downloaders()
             .into_iter()

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -102,14 +102,14 @@ impl Orchestrator {
     /// Create a new orchestrator with default registries
     ///
     /// # Arguments
-    /// * `config` - Download configuration
+    /// * `config` - Download configuration (Arc-wrapped for cheap sharing)
     /// * `event_tx` - Channel sender for lifecycle events
     /// * `download_id` - Unique identifier for this download
     /// * `cancel_token` - Token for cooperative cancellation
     /// * `interactive` - Optional callback for interactive user input
     #[must_use]
     pub fn new(
-        config: Config,
+        config: Arc<Config>,
         event_tx: mpsc::Sender<Event>,
         download_id: DownloadId,
         cancel_token: CancellationToken,
@@ -120,9 +120,6 @@ impl Orchestrator {
         let http_client =
             HttpClientFactory::from_rdlp_config(&config).build_arc_with_cookies(raw_jar.clone());
         let js_engine = Arc::new(BoaJsEngine::new());
-
-        // Wrap config in Arc once and share it
-        let config = Arc::new(config);
 
         let extraction_context = Arc::new(ExtractionContext::new(
             http_client,
@@ -181,7 +178,7 @@ impl Orchestrator {
     #[doc(hidden)]
     #[allow(dead_code)]
     pub fn with_registries(
-        config: Config,
+        config: Arc<Config>,
         extractor_registry: Arc<dyn ExtractorRegistryTrait>,
         downloader_registry: Arc<dyn DownloaderRegistryTrait>,
         event_tx: mpsc::Sender<Event>,
@@ -193,8 +190,6 @@ impl Orchestrator {
         let http_client =
             HttpClientFactory::from_rdlp_config(&config).build_arc_with_cookies(cookie_jar.jar());
         let js_engine = Arc::new(BoaJsEngine::new());
-
-        let config = Arc::new(config);
 
         let extraction_context = Arc::new(ExtractionContext::new(
             http_client,

--- a/crates/rdlp-api/src/orchestrator/selection.rs
+++ b/crates/rdlp-api/src/orchestrator/selection.rs
@@ -199,6 +199,7 @@ mod tests {
     use crate::handle::DownloadId;
     use crate::orchestrator::{DownloadPlan, Orchestrator};
     use rdlp_core::{Config, DownloadProtocol, Format, InfoDict};
+    use std::sync::Arc;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
@@ -214,7 +215,7 @@ mod tests {
     fn orchestrator_with_config(config: Config) -> Orchestrator {
         let (tx, _rx) = mpsc::channel::<Event>(64);
         Orchestrator::new(
-            config,
+            Arc::new(config),
             tx,
             DownloadId::next(),
             CancellationToken::new(),

--- a/crates/rdlp-api/src/orchestrator/tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests.rs
@@ -6,12 +6,13 @@ use crate::events::Event;
 use crate::handle::DownloadId;
 use rdlp_core::{Config, Format, InfoDict};
 use std::path::Path;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 /// Helper function to create a test orchestrator with event channel
 pub(super) fn create_test_orchestrator() -> Orchestrator {
-    let config = Config::default();
+    let config = Arc::new(Config::default());
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let id = DownloadId::next();
     let token = CancellationToken::new();
@@ -776,7 +777,7 @@ fn test_generate_output_path_custom_template() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -797,7 +798,7 @@ fn test_generate_output_path_subdirectory_template() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -832,7 +833,7 @@ fn test_generate_output_path_field_with_default() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -857,7 +858,7 @@ fn test_generate_output_path_sanitizes_template_field_values() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -888,7 +889,7 @@ fn test_generate_output_path_with_format_fields() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -912,7 +913,7 @@ fn test_generate_output_path_numeric_padding() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -937,7 +938,7 @@ fn test_generate_output_path_missing_field_defaults_to_na() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),
@@ -960,7 +961,7 @@ fn test_generate_output_path_with_output_directory() {
     };
     let (tx, _rx) = mpsc::channel::<Event>(64);
     let orchestrator = Orchestrator::new(
-        config,
+        Arc::new(config),
         tx,
         DownloadId::next(),
         CancellationToken::new(),


### PR DESCRIPTION
## Summary

- `Orchestrator::new()` and `with_registries()` now accept `Arc<Config>` instead of `Config`
- Eliminates 7 `(*self.config).clone()` deep copies in `RdlpClient` methods (`extract`, `extract_interactive`, `list_extractors`, `list_search_extractors`, `search_filters`, `search`, `list_downloaders`)
- Each call site now uses `Arc::clone(&self.config)` (cheap atomic increment) instead of cloning the entire Config struct

Follow-up to PR #66 (Rust idioms cleanup).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --lib --all` — 100 tests passed