### PR TITLE
Redesign FormatDialog, harden error handling, and fix desktop bugs

### DIFF
--- a/crates/rdlp-api/src/client.rs
+++ b/crates/rdlp-api/src/client.rs
@@ -334,6 +334,9 @@ impl RdlpClient {
         request.subtitles.merge_into(&mut config);
         request.postprocess.merge_into(&mut config);
         request.network.merge_into(&mut config);
+        if let Some(v) = request.verbose {
+            config.verbose = v;
+        }
         config
     }
 }
@@ -519,6 +522,44 @@ mod tests {
             config.normalize_audio,
             "normalize_audio must be preserved from base config"
         );
+    }
+
+    #[test]
+    fn test_build_config_verbose_none_preserves_base() {
+        let base_config = Config {
+            verbose: true,
+            ..Config::default()
+        };
+        let client = RdlpClient::builder().config(base_config).build().unwrap();
+        let request = DownloadRequest::new("http://example.com");
+        let config = client.build_config(&request);
+        assert!(config.verbose, "verbose must be preserved when request.verbose is None");
+    }
+
+    #[test]
+    fn test_build_config_verbose_some_overrides() {
+        let base_config = Config {
+            verbose: false,
+            ..Config::default()
+        };
+        let client = RdlpClient::builder().config(base_config).build().unwrap();
+        let mut request = DownloadRequest::new("http://example.com");
+        request.verbose = Some(true);
+        let config = client.build_config(&request);
+        assert!(config.verbose, "verbose must be overridden by request.verbose = Some(true)");
+    }
+
+    #[test]
+    fn test_build_config_verbose_false_overrides() {
+        let base_config = Config {
+            verbose: true,
+            ..Config::default()
+        };
+        let client = RdlpClient::builder().config(base_config).build().unwrap();
+        let mut request = DownloadRequest::new("http://example.com");
+        request.verbose = Some(false);
+        let config = client.build_config(&request);
+        assert!(!config.verbose, "verbose must be overridden by request.verbose = Some(false)");
     }
 
     #[test]

--- a/crates/rdlp-api/src/client.rs
+++ b/crates/rdlp-api/src/client.rs
@@ -31,6 +31,7 @@ use crate::merge::MergeOverrides;
 use crate::orchestrator::{InteractiveCallback, Orchestrator};
 use crate::request::DownloadRequest;
 use crate::result::DownloadResult;
+use log::error;
 use rdlp_core::{Config, DownloadStats, InfoDict};
 use std::sync::Arc;
 use std::time::Duration;
@@ -95,11 +96,32 @@ impl RdlpClient {
         let interactive_cb = self.interactive.clone();
         let token = cancel_token.clone();
 
+        // Capture whether the user explicitly requested cookies.
+        // When explicit, cookie loading failure must be fatal.
+        let cookies_explicitly_requested =
+            config.cookies_from_browser.is_some() || config.cookies_file.is_some();
+
         let join_handle = tokio::spawn(async move {
             let orchestrator = Orchestrator::new(config, tx.clone(), id, token, interactive_cb);
 
-            // Load cookies (non-fatal on failure — warn but continue)
+            // Load cookies: fatal when explicitly requested, non-fatal otherwise
             if let Err(e) = orchestrator.load_cookies().await {
+                if cookies_explicitly_requested {
+                    // Sanitize the error message to avoid leaking DPAPI
+                    // errors, decryption keys, or raw cookie values
+                    let safe_msg = "Failed to load cookies: browser cookie extraction \
+                         failed. Check browser is installed and not running."
+                        .to_string();
+                    error!("Cookie loading failed (explicit request): {e}");
+                    let api_err = RdlpApiError::IoError { message: safe_msg };
+                    let _ = tx
+                        .send(Event::Failed {
+                            id,
+                            error: api_err.clone(),
+                        })
+                        .await;
+                    return Err(api_err);
+                }
                 let _ = tx
                     .send(Event::Warning {
                         id,
@@ -533,7 +555,10 @@ mod tests {
         let client = RdlpClient::builder().config(base_config).build().unwrap();
         let request = DownloadRequest::new("http://example.com");
         let config = client.build_config(&request);
-        assert!(config.verbose, "verbose must be preserved when request.verbose is None");
+        assert!(
+            config.verbose,
+            "verbose must be preserved when request.verbose is None"
+        );
     }
 
     #[test]
@@ -546,7 +571,10 @@ mod tests {
         let mut request = DownloadRequest::new("http://example.com");
         request.verbose = Some(true);
         let config = client.build_config(&request);
-        assert!(config.verbose, "verbose must be overridden by request.verbose = Some(true)");
+        assert!(
+            config.verbose,
+            "verbose must be overridden by request.verbose = Some(true)"
+        );
     }
 
     #[test]
@@ -559,7 +587,10 @@ mod tests {
         let mut request = DownloadRequest::new("http://example.com");
         request.verbose = Some(false);
         let config = client.build_config(&request);
-        assert!(!config.verbose, "verbose must be overridden by request.verbose = Some(false)");
+        assert!(
+            !config.verbose,
+            "verbose must be overridden by request.verbose = Some(false)"
+        );
     }
 
     #[test]
@@ -598,5 +629,112 @@ mod tests {
     fn test_search_filters_unknown_site() {
         let client = RdlpClient::new(Config::default()).unwrap();
         assert!(client.search_filters("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_cookies_explicitly_requested_flag() {
+        use rdlp_core::BrowserType;
+        use std::path::PathBuf;
+
+        // No cookies requested — flag should be false
+        let config_none = Config::default();
+        assert!(
+            config_none.cookies_from_browser.is_none() && config_none.cookies_file.is_none(),
+            "Default config should not have cookies explicitly requested"
+        );
+
+        // Browser cookies requested — flag should be true
+        let config_browser = Config {
+            cookies_from_browser: Some(BrowserType::Chrome),
+            ..Config::default()
+        };
+        assert!(
+            config_browser.cookies_from_browser.is_some() || config_browser.cookies_file.is_some(),
+            "Config with browser cookie should be explicitly requested"
+        );
+
+        // Cookie file requested — flag should be true
+        let config_file = Config {
+            cookies_file: Some(PathBuf::from("/tmp/cookies.txt")),
+            ..Config::default()
+        };
+        assert!(
+            config_file.cookies_from_browser.is_some() || config_file.cookies_file.is_some(),
+            "Config with cookie file should be explicitly requested"
+        );
+
+        // Verify merge propagates cookies_from_browser from request
+        let client = RdlpClient::new(Config::default()).unwrap();
+        let mut request = DownloadRequest::new("http://example.com");
+        request.network.cookies_from_browser = Some(BrowserType::Firefox);
+        let merged = client.build_config(&request);
+        assert_eq!(
+            merged.cookies_from_browser,
+            Some(BrowserType::Firefox),
+            "cookies_from_browser must propagate through build_config"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_without_explicit_cookies_warns_on_cookie_error() {
+        // Default config — no explicit cookies requested.
+        // Cookie loading won't fail with default config (no browser, no
+        // file), so this verifies the non-fatal path doesn't produce a
+        // Failed event. The download will proceed to extraction and fail
+        // there (unsupported URL), which is expected.
+        let client = RdlpClient::new(Config::default()).unwrap();
+        let request = DownloadRequest::new("http://example.com/video");
+        let mut handle = client.download(request);
+
+        let mut got_cookie_failed = false;
+        while let Some(event) = handle.events().recv().await {
+            if let Event::Failed { error, .. } = &event {
+                // If we get a failure, it should NOT be about cookies
+                if let RdlpApiError::IoError { message } = error {
+                    if message.contains("cookie") {
+                        got_cookie_failed = true;
+                    }
+                }
+            }
+        }
+        assert!(
+            !got_cookie_failed,
+            "Should not get a cookie-related Failed event when cookies are not explicitly requested"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_explicit_cookies_file_fatal_on_missing() {
+        use std::path::PathBuf;
+
+        // Config with explicit cookie file that doesn't exist
+        let config = Config {
+            cookies_file: Some(PathBuf::from("/nonexistent/path/cookies.txt")),
+            ..Config::default()
+        };
+        let client = RdlpClient::new(config).unwrap();
+
+        let request = DownloadRequest::new("http://example.com/video");
+        let mut handle = client.download(request);
+
+        let mut got_failed = false;
+        while let Some(event) = handle.events().recv().await {
+            if let Event::Failed { error, .. } = &event {
+                got_failed = true;
+                // The error should be about cookie loading
+                let msg = error.user_message();
+                assert!(
+                    msg.to_lowercase().contains("cookie") || msg.to_lowercase().contains("file"),
+                    "Error message should reference cookies or file, got: {msg}"
+                );
+                break;
+            }
+        }
+        assert!(
+            got_failed,
+            "Expected a Failed event when explicit cookie file is missing"
+        );
+
+        handle.cancel();
     }
 }

--- a/crates/rdlp-api/src/dto.rs
+++ b/crates/rdlp-api/src/dto.rs
@@ -139,6 +139,8 @@ impl From<&Event> for EventDto {
                     "reason": reason,
                 }),
             ),
+
+            Event::Debug { message, .. } => ("debug", json!({ "message": message })),
         };
 
         Self {

--- a/crates/rdlp-api/src/events.rs
+++ b/crates/rdlp-api/src/events.rs
@@ -135,6 +135,18 @@ pub enum Event {
         /// Reason for the retry.
         reason: String,
     },
+
+    /// Debug-level log message emitted when verbose mode is enabled.
+    ///
+    /// These messages provide detailed internal state for troubleshooting
+    /// (e.g. available processors, output file paths). Only emitted when
+    /// `config.verbose` is `true`.
+    Debug {
+        /// The download this event belongs to.
+        id: DownloadId,
+        /// Debug message.
+        message: String,
+    },
 }
 
 impl Event {
@@ -155,7 +167,8 @@ impl Event {
             | Self::Cancelled { id }
             | Self::PlaylistDetected { id, .. }
             | Self::PlaylistItemStarted { id, .. }
-            | Self::Retrying { id, .. } => *id,
+            | Self::Retrying { id, .. }
+            | Self::Debug { id, .. } => *id,
         }
     }
 }
@@ -230,6 +243,10 @@ mod tests {
                 attempt: 2,
                 max_attempts: 5,
                 reason: "connection reset".into(),
+            },
+            Event::Debug {
+                id,
+                message: "Available processors: remux, thumbnail".into(),
             },
         ];
 

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -3,6 +3,7 @@
 //! Handles FFmpeg remuxing, metadata embedding, and audio extraction.
 
 use super::{Orchestrator, Result};
+use crate::events::Event;
 use log::{debug, info, warn};
 use rdlp_core::PostProcessConfig;
 use std::path::PathBuf;
@@ -108,7 +109,12 @@ impl Orchestrator {
 
         if self.config.verbose {
             let processors = registry.list_processors();
-            debug!("Available processors: {}", processors.join(", "));
+            let msg = format!("Available processors: {}", processors.join(", "));
+            debug!("{msg}");
+            self.emit(Event::Debug {
+                id: self.download_id,
+                message: msg,
+            });
         }
 
         // Run FFmpeg remux to fix container (faststart, timestamps)
@@ -129,7 +135,12 @@ impl Orchestrator {
                     info!("Post-processing complete");
                     if self.config.verbose {
                         for file in &result.files {
-                            debug!(path:? = file.display(); "Output");
+                            let msg = format!("Output: {}", file.display());
+                            debug!("{msg}");
+                            self.emit(Event::Debug {
+                                id: self.download_id,
+                                message: msg,
+                            });
                         }
                     }
                 }

--- a/crates/rdlp-api/src/orchestrator/template.rs
+++ b/crates/rdlp-api/src/orchestrator/template.rs
@@ -507,10 +507,26 @@ impl OutputTemplate {
                 Segment::Literal(text) => output.push_str(text),
                 Segment::Field(spec) => {
                     let value = self.resolve_field(spec, &info_json, &format_json, ext, ctx)?;
-                    // Sanitize path separators from field values so they don't
-                    // create unintended subdirectories. Only literal `/` in
-                    // the template string should create directory structure.
-                    let sanitized = value.replace(['/', '\\'], "_");
+                    // Sanitize Windows-restricted characters from field values
+                    // so they don't create invalid paths or unintended
+                    // subdirectories. Also strip null bytes and non-whitespace
+                    // control characters which are invalid in filenames on
+                    // all platforms. Only literal `/` in the template string
+                    // should create directory structure.
+                    let sanitized = value
+                        .chars()
+                        .filter(|c| {
+                            // Strip null byte and non-whitespace C0/C1 controls.
+                            // Keep \t, \n, \r (whitespace) for formats like
+                            // pretty-JSON and newline-separated lists.
+                            *c != '\0'
+                                && (!c.is_control() || *c == '\t' || *c == '\n' || *c == '\r')
+                        })
+                        .map(|c| match c {
+                            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+                            _ => c,
+                        })
+                        .collect::<String>();
                     output.push_str(&sanitized);
                 }
             }
@@ -1608,7 +1624,9 @@ mod tests {
         let result = t
             .render(&test_info(), &test_format(), "mp4", &test_ctx())
             .unwrap();
-        assert_eq!(result, "\"My Video Title\"");
+        // JSON wraps strings in `"`, which are Windows-restricted
+        // chars and get sanitized to `_` by render()
+        assert_eq!(result, "_My Video Title_");
     }
 
     #[test]
@@ -1840,5 +1858,48 @@ mod tests {
             .render(&test_info(), &test_format(), "mp4", &test_ctx())
             .unwrap();
         assert_eq!(result, "TestExtractor/005 - My Video Title [abc123].mp4");
+    }
+
+    #[test]
+    fn test_render_field_sanitizes_windows_chars() {
+        // All 9 Windows-restricted path characters must be replaced
+        // with `_` in field values: / \ : * ? " < > |
+        let t = OutputTemplate::parse("%(title)s").unwrap();
+        let info = {
+            let mut i = test_info();
+            i.title = r#"a/b\c:d*e?f"g<h>i|j"#.to_string();
+            i
+        };
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
+        assert_eq!(result, "a_b_c_d_e_f_g_h_i_j");
+    }
+
+    #[test]
+    fn test_render_literal_slash_preserved_as_directory_separator() {
+        // Literal `/` in the template string creates directories
+        // and must NOT be sanitized — only field values are sanitized
+        let t = OutputTemplate::parse("%(extractor)s/%(title)s.%(ext)s").unwrap();
+        let info = {
+            let mut i = test_info();
+            i.title = "safe-title".to_string();
+            i
+        };
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
+        assert_eq!(result, "TestExtractor/safe-title.mp4");
+    }
+
+    #[test]
+    fn test_render_field_strips_null_and_control_chars() {
+        // Null bytes and control characters are stripped entirely
+        // (not replaced) because they are invalid in filenames on
+        // all platforms
+        let t = OutputTemplate::parse("%(title)s").unwrap();
+        let info = {
+            let mut i = test_info();
+            i.title = "hello\0world\x01\x1f!".to_string();
+            i
+        };
+        let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
+        assert_eq!(result, "helloworld!");
     }
 }

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -34,6 +34,8 @@ pub struct DownloadRequest {
     pub network: NetworkOptions,
     /// If `true`, only extract metadata without downloading.
     pub plan_only: bool,
+    /// Enable verbose logging. `None` preserves base config.
+    pub verbose: Option<bool>,
 }
 
 impl DownloadRequest {
@@ -232,6 +234,7 @@ mod tests {
         // Top-level defaults
         assert!(req.url.is_empty());
         assert!(!req.plan_only);
+        assert!(req.verbose.is_none());
 
         // OutputOptions defaults
         assert!(req.output.output_dir.is_none());
@@ -309,10 +312,12 @@ mod tests {
                 ..NetworkOptions::default()
             },
             plan_only: true,
+            verbose: Some(true),
         };
 
         assert_eq!(req.url, "https://example.com/video");
         assert!(req.plan_only);
+        assert_eq!(req.verbose, Some(true));
 
         // Output overrides
         assert_eq!(

--- a/crates/rdlp-api/tests/api_integration.rs
+++ b/crates/rdlp-api/tests/api_integration.rs
@@ -38,6 +38,7 @@ fn event_tag(event: &Event) -> &'static str {
         Event::PlaylistDetected { .. } => "playlist_detected",
         Event::PlaylistItemStarted { .. } => "playlist_item_started",
         Event::Retrying { .. } => "retrying",
+        Event::Debug { .. } => "debug",
     }
 }
 

--- a/crates/rdlp-cli/src/event_handler.rs
+++ b/crates/rdlp-cli/src/event_handler.rs
@@ -8,7 +8,7 @@ use rdlp_api::Event;
 use rdlp_core::DownloadProgress;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Handles download lifecycle events for CLI display.
 pub struct CliEventHandler {
@@ -98,6 +98,9 @@ impl CliEventHandler {
                 ..
             } => {
                 warn!("Retry {attempt}/{max_attempts}: {reason}");
+            }
+            Event::Debug { message, .. } => {
+                debug!("{message}");
             }
         }
     }

--- a/crates/rdlp-desktop/src-tauri/Cargo.toml
+++ b/crates/rdlp-desktop/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tauri-plugin-shell = "2"
 
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 thiserror = { workspace = true }
 log = { workspace = true }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -135,6 +135,7 @@ pub async fn start_download(
             embed_metadata: Some(settings.embed_metadata),
             ..PostProcessOptions::default()
         },
+        verbose: if settings.verbose { Some(true) } else { None },
         ..DownloadRequest::default()
     };
 

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -139,30 +139,31 @@ pub async fn start_download(
         ..DownloadRequest::default()
     };
 
-    // Start the download via rdlp-api
+    // Start the download via rdlp-api (must be outside any lock scope)
     let mut handle = state.client.download(request);
 
-    // Extract cancel token BEFORE moving handle into the spawned task
+    // Atomically store the cancel token and transition to Running in a
+    // single lock acquisition. This prevents concurrent commands from
+    // observing the job in a Pending-with-cancel or Running-without-cancel
+    // intermediate state.
     let cancel_token = handle.cancel_token();
-    {
-        let mut queue = state.queue.lock().unwrap_or_else(|e| e.into_inner());
-        queue.set_cancel(&job_id, Box::new(move || cancel_token.cancel()));
-    }
-
-    // Mark job as running and set started_at
     let now = chrono::Utc::now().timestamp();
     {
         let mut queue = state.queue.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(job) = queue.get_job_mut(&job_id) {
-            job.status = JobStatus::Running;
-            job.started_at = Some(now);
-        }
+        queue.start_job(&job_id, Box::new(move || cancel_token.cancel()), now);
     }
 
     let queue = state.queue.clone();
     let id = job_id.clone();
 
-    // Spawn background event loop
+    // Spawn background event loop.
+    //
+    // Lock safety: The `MutexGuard` acquired below is dropped at the
+    // end of each loop iteration before `.recv().await` yields. This
+    // ensures the lock is never held across an await point, avoiding
+    // both deadlocks and prolonged contention. The pattern is sound
+    // because `MutexGuard` (from `std::sync::Mutex`) is `!Send`, and
+    // Rust prevents it from being held across `.await` at compile time.
     tokio::spawn(async move {
         while let Some(event) = handle.events().recv().await {
             // Forward to frontend

--- a/crates/rdlp-desktop/src-tauri/src/commands/settings.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/settings.rs
@@ -5,6 +5,8 @@
 //! [`pick_directory`] command uses the native OS folder picker via
 //! `tauri-plugin-dialog`.
 
+use std::time::Duration;
+
 use tauri::{AppHandle, State};
 use tauri_plugin_dialog::DialogExt;
 
@@ -26,15 +28,14 @@ use crate::state::{AppSettings, AppState};
 ///
 /// # Errors
 ///
-/// Returns [`AppError::Internal`] if the settings mutex is poisoned.
+/// This function does not currently return errors but returns
+/// `Result` for forward-compatible IPC signatures.
 #[tauri::command]
 pub async fn get_settings(state: State<'_, AppState>) -> Result<AppSettings, AppError> {
     let settings = state
         .settings
         .lock()
-        .map_err(|e| AppError::Internal {
-            message: format!("Settings lock poisoned: {e}"),
-        })?
+        .unwrap_or_else(|e| e.into_inner())
         .clone();
 
     Ok(settings)
@@ -52,18 +53,18 @@ pub async fn get_settings(state: State<'_, AppState>) -> Result<AppSettings, App
 ///
 /// # Errors
 ///
-/// Returns [`AppError::Internal`] if the settings mutex is poisoned.
+/// Returns [`AppError::Internal`] if saving settings to disk fails.
 #[tauri::command]
 pub async fn update_settings(
     settings: AppSettings,
     state: State<'_, AppState>,
 ) -> Result<(), AppError> {
-    let mut current = state.settings.lock().map_err(|e| AppError::Internal {
-        message: format!("Settings lock poisoned: {e}"),
-    })?;
+    let mut current = state.settings.lock().unwrap_or_else(|e| e.into_inner());
 
     *current = settings;
-    current.save().ok();
+    current.save().map_err(|e| AppError::Internal {
+        message: format!("Failed to save settings: {e}"),
+    })?;
 
     Ok(())
 }
@@ -96,9 +97,14 @@ pub async fn pick_directory(app: AppHandle) -> Result<Option<String>, AppError> 
         let _ = tx.send(folder);
     });
 
-    let folder = rx.await.map_err(|_| AppError::Internal {
-        message: "Folder picker channel closed unexpectedly".to_owned(),
-    })?;
+    let folder = tokio::time::timeout(Duration::from_secs(300), rx)
+        .await
+        .map_err(|_| AppError::Internal {
+            message: "Folder picker timed out after 5 minutes".to_owned(),
+        })?
+        .map_err(|_| AppError::Internal {
+            message: "Folder picker channel closed unexpectedly".to_owned(),
+        })?;
 
     match folder {
         Some(file_path) => {

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -60,6 +60,8 @@ pub(crate) enum LogLevel {
     Info,
     /// Warning messages (retries, quality fallbacks).
     Warn,
+    /// Debug/verbose messages (detailed extraction and download steps).
+    Debug,
 }
 
 /// Format-selected payload emitted as `"format-selected"`.
@@ -225,6 +227,16 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: format!("Format selected: {quality} ({format_id})"),
             };
             let _ = app.emit("download-log", &log);
+        }
+
+        Event::Debug { message, .. } => {
+            let payload = DownloadLogPayload {
+                job_id: job_id.to_owned(),
+                level: LogLevel::Debug,
+                message: message.clone(),
+            };
+
+            let _ = app.emit("download-log", &payload);
         }
 
         // All other events are not forwarded to the frontend.

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -5,6 +5,7 @@
 //! events. The frontend listens for these events via Tauri's IPC
 //! event system to update the download queue UI in real time.
 
+use log::warn;
 use rdlp_api::Event;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -137,7 +138,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 total_bytes: progress.total_bytes,
             };
 
-            let _ = app.emit("download-progress", &payload);
+            if let Err(e) = app.emit("download-progress", &payload) {
+                warn!("Failed to emit download-progress for job {job_id}: {e}");
+            }
         }
 
         Event::Completed { result, .. } => {
@@ -152,7 +155,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 filepath,
             };
 
-            let _ = app.emit("download-complete", &payload);
+            if let Err(e) = app.emit("download-complete", &payload) {
+                warn!("Failed to emit download-complete for job {job_id}: {e}");
+            }
         }
 
         Event::Failed { error, .. } => {
@@ -162,7 +167,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 retryable: error.is_retryable(),
             };
 
-            let _ = app.emit("download-error", &payload);
+            if let Err(e) = app.emit("download-error", &payload) {
+                warn!("Failed to emit download-error for job {job_id}: {e}");
+            }
         }
 
         Event::MetadataReady { info, .. } => {
@@ -172,7 +179,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: format!("Metadata ready: {}", info.title),
             };
 
-            let _ = app.emit("download-log", &payload);
+            if let Err(e) = app.emit("download-log", &payload) {
+                warn!("Failed to emit download-log (metadata-ready) for job {job_id}: {e}");
+            }
         }
 
         Event::PostProcessing { stage, .. } => {
@@ -182,7 +191,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: format!("Post-processing: {stage}"),
             };
 
-            let _ = app.emit("download-log", &payload);
+            if let Err(e) = app.emit("download-log", &payload) {
+                warn!("Failed to emit download-log (post-processing) for job {job_id}: {e}");
+            }
         }
 
         Event::Warning { message, .. } => {
@@ -192,7 +203,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: message.clone(),
             };
 
-            let _ = app.emit("download-log", &payload);
+            if let Err(e) = app.emit("download-log", &payload) {
+                warn!("Failed to emit download-log (warning) for job {job_id}: {e}");
+            }
         }
 
         Event::Retrying {
@@ -207,7 +220,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: format!("Retrying ({attempt}/{max_attempts}): {reason}"),
             };
 
-            let _ = app.emit("download-log", &payload);
+            if let Err(e) = app.emit("download-log", &payload) {
+                warn!("Failed to emit download-log (retrying) for job {job_id}: {e}");
+            }
         }
 
         Event::FormatSelected {
@@ -218,7 +233,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 format_id: format_id.clone(),
                 quality: quality.clone(),
             };
-            let _ = app.emit("format-selected", &payload);
+            if let Err(e) = app.emit("format-selected", &payload) {
+                warn!("Failed to emit format-selected for job {job_id}: {e}");
+            }
 
             // Also emit as a log message for the status bar
             let log = DownloadLogPayload {
@@ -226,7 +243,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 level: LogLevel::Info,
                 message: format!("Format selected: {quality} ({format_id})"),
             };
-            let _ = app.emit("download-log", &log);
+            if let Err(e) = app.emit("download-log", &log) {
+                warn!("Failed to emit download-log (format-selected) for job {job_id}: {e}");
+            }
         }
 
         Event::Debug { message, .. } => {
@@ -236,7 +255,9 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: message.clone(),
             };
 
-            let _ = app.emit("download-log", &payload);
+            if let Err(e) = app.emit("download-log", &payload) {
+                warn!("Failed to emit download-log (debug) for job {job_id}: {e}");
+            }
         }
 
         // All other events are not forwarded to the frontend.

--- a/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
@@ -144,6 +144,37 @@ impl DownloadQueue {
         self.cancel_fns.insert(id.into(), cancel_fn);
     }
 
+    /// Atomically store the cancel function and transition a job to Running.
+    ///
+    /// Combines `set_cancel` + status transition into a single operation so
+    /// that no concurrent observer can see the job in Pending-with-cancel or
+    /// Running-without-cancel intermediate states.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The job ID to update.
+    /// * `cancel_fn` - A function that cancels the download when called.
+    /// * `started_at` - Unix timestamp (seconds) when the download started.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the job was found and updated, `false` otherwise.
+    pub fn start_job(
+        &mut self,
+        id: &str,
+        cancel_fn: Box<dyn Fn() + Send + Sync>,
+        started_at: i64,
+    ) -> bool {
+        self.cancel_fns.insert(id.to_owned(), cancel_fn);
+        if let Some(job) = self.jobs.get_mut(id) {
+            job.status = JobStatus::Running;
+            job.started_at = Some(started_at);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Take (remove) the cancel function for a job.
     ///
     /// Returns `None` if no cancel function is stored for the given ID.
@@ -258,5 +289,58 @@ mod tests {
         assert!(json["title"].is_null());
         assert!(json["progress"].is_null());
         assert_eq!(json["retryable"], false);
+    }
+
+    #[test]
+    fn test_start_job_sets_running_and_cancel() {
+        let mut queue = DownloadQueue::new();
+        queue.add_job("job-1", "https://example.com/v1");
+
+        let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let called_clone = called.clone();
+        let cancel_fn: Box<dyn Fn() + Send + Sync> = Box::new(move || {
+            called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        let ts = 1700000000;
+        assert!(queue.start_job("job-1", cancel_fn, ts));
+
+        let job = queue.get_job("job-1").expect("job should exist");
+        assert_eq!(job.status, JobStatus::Running);
+        assert_eq!(job.started_at, Some(ts));
+
+        // Cancel function should be stored and invocable
+        let cancel = queue.take_cancel("job-1").expect("cancel fn should exist");
+        cancel();
+        assert!(called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_start_job_returns_false_for_missing_job() {
+        let mut queue = DownloadQueue::new();
+        let cancel_fn: Box<dyn Fn() + Send + Sync> = Box::new(|| {});
+        assert!(!queue.start_job("nonexistent", cancel_fn, 0));
+    }
+
+    #[test]
+    fn test_start_job_no_intermediate_state() {
+        // Verifies that after start_job, the job is atomically
+        // Running with a cancel function — never one without the other
+        let mut queue = DownloadQueue::new();
+        queue.add_job("job-1", "https://example.com/v1");
+
+        // Before start_job: Pending, no cancel
+        assert_eq!(queue.get_job("job-1").unwrap().status, JobStatus::Pending);
+        assert!(queue.take_cancel("job-1").is_none());
+
+        // Re-add job since take_cancel removed nothing
+        let cancel_fn: Box<dyn Fn() + Send + Sync> = Box::new(|| {});
+        queue.start_job("job-1", cancel_fn, 1700000000);
+
+        // After start_job: Running AND has cancel — both set atomically
+        let job = queue.get_job("job-1").unwrap();
+        assert_eq!(job.status, JobStatus::Running);
+        assert_eq!(job.started_at, Some(1700000000));
+        assert!(queue.take_cancel("job-1").is_some());
     }
 }

--- a/crates/rdlp-desktop/src/api/downloads.ts
+++ b/crates/rdlp-desktop/src/api/downloads.ts
@@ -4,7 +4,8 @@ import { queryOptions } from "@tanstack/react-query";
 import { invokeTyped } from "./invokeClient";
 import { queryKeys } from "../query/queryKeys";
 import { queryClient } from "../query/queryClient";
-import type { AppSettings, DownloadJob, DownloadOptions } from "../types";
+import type { DownloadJob, DownloadOptions } from "../types";
+export { buildDefaultOptions } from "../components/FormatOptionsPanel";
 
 /** Fetch the current download queue. */
 export function downloadsQueryOptions() {
@@ -12,21 +13,6 @@ export function downloadsQueryOptions() {
         queryKey: queryKeys.downloads.list(),
         queryFn: () => invokeTyped<DownloadJob[]>("get_queue"),
     });
-}
-
-/** Build default DownloadOptions from AppSettings. */
-export function buildDefaultOptions(settings: AppSettings | null): DownloadOptions {
-    return {
-        format: null,
-        outputDir: null,
-        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
-        subtitleLangs: settings?.default_subtitle_langs ?? [],
-        remux: settings?.default_remux ?? null,
-        extractAudio: settings?.default_extract_audio ?? null,
-        embedThumbnail: settings?.embed_thumbnail ?? true,
-        audioMultistreams: false,
-        recodeVideo: null,
-    };
 }
 
 /** Start a download. Returns the job ID from the backend. */

--- a/crates/rdlp-desktop/src/api/formats.ts
+++ b/crates/rdlp-desktop/src/api/formats.ts
@@ -9,7 +9,10 @@ import type { FormatListResponse } from "../types";
 export function formatsQueryOptions(url: string | null) {
     return queryOptions({
         queryKey: queryKeys.formats(url ?? ""),
-        queryFn: () => invokeTyped<FormatListResponse>("get_formats", { url: url! }),
+        queryFn: () => {
+            if (!url) throw new Error("URL is required for format query");
+            return invokeTyped<FormatListResponse>("get_formats", { url });
+        },
         enabled: url !== null && url !== "",
     });
 }

--- a/crates/rdlp-desktop/src/components/CommandBar.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.tsx
@@ -59,7 +59,7 @@ export function CommandBar({ inputRef, activeTab }: CommandBarProps) {
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!isDisabled) {
-            void refetch();
+            refetch().catch((e) => console.error("Refetch failed:", e));
         }
     };
 

--- a/crates/rdlp-desktop/src/components/FilterBar.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.tsx
@@ -62,7 +62,7 @@ export function FilterBar() {
         // Only auto-search if a search has already been performed
         if (searchData === undefined) return;
         if (query.trim() === "" || site === "") return;
-        void refetch();
+        refetch().catch((e) => console.error("Refetch failed:", e));
     }, [filters, hasUserFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleFilterChange = (key: string, value: string) => {

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2, AlertCircle, ChevronUp, ChevronDown } from "lucide-react";
+import { Loader2, AlertCircle, ChevronUp, ChevronDown, FolderOpen } from "lucide-react";
 import { formatsQueryOptions } from "../api/formats";
-import { settingsQueryOptions } from "../api/settings";
+import { settingsQueryOptions, pickDirectory } from "../api/settings";
 import { invokeTyped } from "../api/invokeClient";
-import { FormatOptionsPanel, PRESETS } from "./FormatOptionsPanel";
+import { FormatOptionsPanel, PRESETS, buildDefaultOptions } from "./FormatOptionsPanel";
 import { cn } from "@/lib/utils";
 import {
     Dialog,
@@ -20,6 +20,9 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import type {
     DownloadOptions,
     FormatInfo,
@@ -130,19 +133,28 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     const [exprError, setExprError] = useState<string | null>(null);
     const [exprMatches, setExprMatches] = useState<Set<string>>(new Set());
     const [error, setError] = useState<string | null>(null);
-    const [options, setOptions] = useState<DownloadOptions>({
-        format: null,
-        outputDir: null,
-        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
-        subtitleLangs: settings?.default_subtitle_langs ?? [],
-        remux: settings?.default_remux ?? null,
-        extractAudio: settings?.default_extract_audio ?? null,
-        embedThumbnail: settings?.embed_thumbnail ?? true,
-        audioMultistreams: false,
-        recodeVideo: null,
-    });
+    const [settingsApplied, setSettingsApplied] = useState(false);
+    const [options, setOptions] = useState<DownloadOptions>(() =>
+        buildDefaultOptions(settings),
+    );
 
     const exprTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Sync options when settings first load (fixes race condition where
+    // useState captures settings at mount before the query resolves)
+    useEffect(() => {
+        if (settings && !settingsApplied) {
+            setOptions((prev) => ({
+                ...prev,
+                subtitles: (settings.default_subtitle_langs ?? []).length > 0,
+                subtitleLangs: settings.default_subtitle_langs ?? [],
+                remux: settings.default_remux ?? prev.remux,
+                extractAudio: settings.default_extract_audio ?? prev.extractAudio,
+                embedThumbnail: settings.embed_thumbnail ?? prev.embedThumbnail,
+            }));
+            setSettingsApplied(true);
+        }
+    }, [settings, settingsApplied]);
 
     // Surface query-level errors in local state
     useEffect(() => {
@@ -178,11 +190,13 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         }
     };
 
-    // Preset selection
-    const handlePresetSelect = (selector: string) => {
+    // Preset selection (uses preset ID, not selector)
+    const handlePresetSelect = (presetId: string) => {
+        const preset = PRESETS.find((p) => p.id === presetId);
+        if (!preset) return;
         setSelectedId(null);
         setMergeId(null);
-        setOptions((prev) => ({ ...prev, format: selector }));
+        setOptions((prev) => ({ ...prev, format: preset.selector }));
     };
 
     // Expert expression change with debounced validation
@@ -242,6 +256,14 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         onConfirm({ ...options, format });
     };
 
+    // Output directory picker
+    const handleBrowseDir = async () => {
+        const dir = await pickDirectory();
+        if (dir) {
+            setOptions((prev) => ({ ...prev, outputDir: dir }));
+        }
+    };
+
     const sorted = formatData
         ? sortFormats(formatData.formats, sortKey, sortDir)
         : [];
@@ -255,9 +277,9 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
             : <ChevronDown className="inline size-3" />;
     };
 
-    // Derive active preset from selected state
+    // Derive active preset from selected state (no fallback to "best")
     const activePresetId = (!selectedId && !mergeId && !expertMode)
-        ? PRESETS.find((p) => p.selector === options.format)?.id ?? "best"
+        ? PRESETS.find((p) => p.selector === options.format)?.id ?? null
         : null;
 
     /** Shared cell class for consistent td styling based on row state. */
@@ -316,133 +338,131 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                 <div className="text-[11px] font-semibold text-muted-foreground tracking-wide">
                                     Quality Preset
                                 </div>
-                                <div className="flex flex-wrap gap-1">
+                                <RadioGroup
+                                    value={activePresetId ?? ""}
+                                    onValueChange={handlePresetSelect}
+                                    className="flex flex-wrap gap-1.5"
+                                >
                                     {PRESETS.map((p) => (
-                                        <label
+                                        <Label
                                             key={p.id}
+                                            htmlFor={`dialog-preset-${p.id}`}
                                             className={cn(
-                                                "inline-flex items-center gap-[5px] px-2.5 py-[5px] border border-white/[0.06] rounded-sm bg-card text-xs text-muted-foreground cursor-pointer transition-colors",
-                                                "hover:border-white/[0.12] hover:text-foreground",
-                                                activePresetId === p.id && "border-primary text-primary bg-primary/[0.12]",
+                                                "inline-flex items-center gap-1.5 px-2.5 py-[5px] border border-border rounded-md bg-card text-xs text-muted-foreground cursor-pointer transition-colors",
+                                                "hover:border-muted-foreground/30 hover:text-foreground",
+                                                activePresetId === p.id && "border-primary text-primary bg-primary/[0.08]",
                                             )}
                                         >
-                                            <input
-                                                type="radio"
-                                                name="dialog-preset"
-                                                checked={activePresetId === p.id}
-                                                onChange={() => handlePresetSelect(p.selector)}
-                                                className={cn(
-                                                    "appearance-none w-3 h-3 border-2 border-muted rounded-full bg-muted cursor-pointer shrink-0 relative transition-colors",
-                                                    activePresetId === p.id && "border-primary bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:w-1 after:h-1 after:rounded-full after:bg-background",
-                                                )}
-                                            />
+                                            <RadioGroupItem value={p.id} id={`dialog-preset-${p.id}`} className="size-3.5" />
                                             {p.label}
-                                        </label>
+                                        </Label>
                                     ))}
-                                </div>
+                                </RadioGroup>
                             </div>
 
                             {/* Format table toggle */}
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="self-start text-xs text-muted-foreground hover:text-foreground"
-                                onClick={() => setShowTable((v) => !v)}
-                                aria-expanded={showTable}
-                            >
-                                {showTable
-                                    ? <><ChevronUp className="size-3.5" />Hide all formats</>
-                                    : <><ChevronDown className="size-3.5" />Show all formats ({sorted.length})</>}
-                            </Button>
-
-                            {showTable && (
-                                <div className="flex flex-col border border-border rounded-md animate-in fade-in-0 zoom-in-95">
-                                    <ScrollArea className="max-h-[40vh]">
-                                        <div className="overflow-x-auto">
-                                            <table className="w-full border-collapse font-mono text-xs">
-                                                <thead>
-                                                    <tr>
-                                                        {([
-                                                            ["height", "Resolution"],
-                                                            ["ext", "Ext"],
-                                                            ["fps", "FPS"],
-                                                            ["tbr", "Bitrate"],
-                                                            ["vcodec", "Video"],
-                                                            ["acodec", "Audio"],
-                                                            ["filesize", "Size"],
-                                                        ] as [SortKey, string][]).map(([key, label]) => (
-                                                            <th
-                                                                key={key}
-                                                                className={cn(
-                                                                    "sticky top-0 px-2.5 py-2 text-left text-[10px] font-bold tracking-wider uppercase text-muted-foreground bg-muted border-b border-border whitespace-nowrap select-none cursor-pointer transition-colors hover:text-foreground",
-                                                                    sortKey === key && "text-primary",
-                                                                )}
-                                                                onClick={() => handleSortClick(key)}
-                                                            >
-                                                                <span className="inline-flex items-center gap-1">
-                                                                    {label}
-                                                                    {renderSortIndicator(key)}
-                                                                </span>
-                                                            </th>
-                                                        ))}
-                                                        <th className="sticky top-0 px-2.5 py-2 text-left text-[10px] font-bold tracking-wider uppercase text-muted-foreground bg-muted border-b border-border whitespace-nowrap select-none">
-                                                            Type
-                                                        </th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {sorted.map((f) => {
-                                                        const type = formatType(f);
-                                                        const isSelected =
-                                                            f.format_id === selectedId ||
-                                                            f.format_id === mergeId;
-                                                        const isExprMatch = exprMatches.has(f.format_id);
-                                                        return (
-                                                            <tr
-                                                                key={f.format_id}
-                                                                className={cn(
-                                                                    "cursor-pointer transition-colors hover:bg-muted",
-                                                                    isSelected && "bg-primary/[0.12]",
-                                                                    isExprMatch && !isSelected && "bg-yellow-500/[0.08]",
-                                                                )}
-                                                                onClick={(e) => handleRowClick(f.format_id, e)}
-                                                            >
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{formatResolution(f)}</td>
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{f.ext}</td>
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{f.fps !== null ? Math.round(f.fps) : "-"}</td>
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{formatBitrate(f.tbr)}</td>
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{f.vcodec ?? "-"}</td>
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{f.acodec ?? "-"}</td>
-                                                                <td className={cellClass(isSelected, isExprMatch)}>{formatSize(f.filesize)}</td>
-                                                                <td className="px-2.5 py-1.5 border-b border-white/[0.02] whitespace-nowrap">
-                                                                    <span className={cn(
-                                                                        "inline-block px-[7px] py-0.5 rounded-full text-[9px] font-bold tracking-wider uppercase font-mono",
-                                                                        type.className,
-                                                                    )}>
-                                                                        {type.label}
+                            <Collapsible open={showTable} onOpenChange={setShowTable}>
+                                <CollapsibleTrigger asChild>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="self-start text-xs text-muted-foreground hover:text-foreground gap-1"
+                                        aria-expanded={showTable}
+                                    >
+                                        {showTable
+                                            ? <><ChevronUp className="size-3.5" />Hide all formats</>
+                                            : <><ChevronDown className="size-3.5" />Show all formats ({sorted.length})</>}
+                                    </Button>
+                                </CollapsibleTrigger>
+                                <CollapsibleContent>
+                                    <div className="flex flex-col border border-border rounded-md mt-1">
+                                        <ScrollArea className="max-h-[40vh]">
+                                            <div className="overflow-x-auto">
+                                                <table className="w-full border-collapse font-mono text-xs">
+                                                    <thead>
+                                                        <tr>
+                                                            {([
+                                                                ["height", "Resolution"],
+                                                                ["ext", "Ext"],
+                                                                ["fps", "FPS"],
+                                                                ["tbr", "Bitrate"],
+                                                                ["vcodec", "Video"],
+                                                                ["acodec", "Audio"],
+                                                                ["filesize", "Size"],
+                                                            ] as [SortKey, string][]).map(([key, label]) => (
+                                                                <th
+                                                                    key={key}
+                                                                    className={cn(
+                                                                        "sticky top-0 px-2.5 py-2 text-left text-[10px] font-bold tracking-wider uppercase text-muted-foreground bg-muted border-b border-border whitespace-nowrap select-none cursor-pointer transition-colors hover:text-foreground",
+                                                                        sortKey === key && "text-primary",
+                                                                    )}
+                                                                    onClick={() => handleSortClick(key)}
+                                                                >
+                                                                    <span className="inline-flex items-center gap-1">
+                                                                        {label}
+                                                                        {renderSortIndicator(key)}
                                                                     </span>
-                                                                </td>
-                                                            </tr>
-                                                        );
-                                                    })}
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </ScrollArea>
+                                                                </th>
+                                                            ))}
+                                                            <th className="sticky top-0 px-2.5 py-2 text-left text-[10px] font-bold tracking-wider uppercase text-muted-foreground bg-muted border-b border-border whitespace-nowrap select-none">
+                                                                Type
+                                                            </th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        {sorted.map((f) => {
+                                                            const type = formatType(f);
+                                                            const isSelected =
+                                                                f.format_id === selectedId ||
+                                                                f.format_id === mergeId;
+                                                            const isExprMatch = exprMatches.has(f.format_id);
+                                                            return (
+                                                                <tr
+                                                                    key={f.format_id}
+                                                                    className={cn(
+                                                                        "cursor-pointer transition-colors hover:bg-muted",
+                                                                        isSelected && "bg-primary/[0.12]",
+                                                                        isExprMatch && !isSelected && "bg-yellow-500/[0.08]",
+                                                                    )}
+                                                                    onClick={(e) => handleRowClick(f.format_id, e)}
+                                                                >
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{formatResolution(f)}</td>
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.ext}</td>
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.fps !== null ? Math.round(f.fps) : "-"}</td>
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{formatBitrate(f.tbr)}</td>
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.vcodec ?? "-"}</td>
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.acodec ?? "-"}</td>
+                                                                    <td className={cellClass(isSelected, isExprMatch)}>{formatSize(f.filesize)}</td>
+                                                                    <td className="px-2.5 py-1.5 border-b border-white/[0.02] whitespace-nowrap">
+                                                                        <span className={cn(
+                                                                            "inline-block px-[7px] py-0.5 rounded-full text-[9px] font-bold tracking-wider uppercase font-mono",
+                                                                            type.className,
+                                                                        )}>
+                                                                            {type.label}
+                                                                        </span>
+                                                                    </td>
+                                                                </tr>
+                                                            );
+                                                        })}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </ScrollArea>
 
-                                    {selectedId && (
-                                        <div className="px-2.5 py-1.5 text-xs text-muted-foreground bg-muted border-t border-border">
-                                            Selected: <strong className="text-primary font-mono">{selectedId}</strong>
-                                            {mergeId && (
-                                                <> + <strong className="text-primary font-mono">{mergeId}</strong> (merge)</>
-                                            )}
-                                            <span className="text-muted-foreground italic">
-                                                {!mergeId && " \u2014 Shift+click another format to merge"}
-                                            </span>
-                                        </div>
-                                    )}
-                                </div>
-                            )}
+                                        {selectedId && (
+                                            <div className="px-2.5 py-1.5 text-xs text-muted-foreground bg-muted border-t border-border">
+                                                Selected: <strong className="text-primary font-mono">{selectedId}</strong>
+                                                {mergeId && (
+                                                    <> + <strong className="text-primary font-mono">{mergeId}</strong> (merge)</>
+                                                )}
+                                                <span className="text-muted-foreground italic">
+                                                    {!mergeId && " \u2014 Shift+click another format to merge"}
+                                                </span>
+                                            </div>
+                                        )}
+                                    </div>
+                                </CollapsibleContent>
+                            </Collapsible>
 
                             {/* Expert mode */}
                             <div className="flex items-center gap-2">
@@ -479,6 +499,33 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                     )}
                                 </div>
                             )}
+
+                            <Separator />
+
+                            {/* Output directory picker */}
+                            <div className="flex flex-col gap-1.5">
+                                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                                    Save to
+                                </Label>
+                                <div className="flex gap-1.5">
+                                    <Input
+                                        className="flex-1 text-xs h-8"
+                                        type="text"
+                                        readOnly
+                                        value={options.outputDir ?? settings?.output_dir ?? ""}
+                                        placeholder="Default output directory"
+                                    />
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className="h-8 px-2.5 shrink-0"
+                                        onClick={() => void handleBrowseDir()}
+                                    >
+                                        <FolderOpen className="size-3.5" />
+                                        Browse
+                                    </Button>
+                                </div>
+                            </div>
 
                             {/* Download options */}
                             <FormatOptionsPanel

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -322,7 +322,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                     className="ml-auto h-6 text-[11px]"
                                     onClick={() => {
                                         setError(null);
-                                        void refetch();
+                                        refetch().catch((e) => console.error("Refetch failed:", e));
                                     }}
                                 >
                                     Retry
@@ -519,7 +519,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                         variant="outline"
                                         size="sm"
                                         className="h-8 px-2.5 shrink-0"
-                                        onClick={() => void handleBrowseDir()}
+                                        onClick={() => { handleBrowseDir().catch((e) => console.error("Browse directory failed:", e)); }}
                                     >
                                         <FolderOpen className="size-3.5" />
                                         Browse

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -61,17 +61,16 @@ const NONE_SENTINEL = "none";
 /**
  * Build a `DownloadOptions` from persisted settings.
  *
- * Initializes `format` to the first preset selector so the "Best Quality"
- * preset is genuinely selected rather than appearing selected while sending
- * null to the backend.
+ * Leaves `format` as `null` so the backend applies its smart default
+ * selector (`bv*+ba/b` with FFmpeg, `b/bv+ba` without).
  */
 export function buildDefaultOptions(
     settings: AppSettings | null,
 ): DownloadOptions {
     return {
-        format: PRESETS[0].selector,
+        format: null,
         outputDir: settings?.output_dir ?? null,
-        subtitles: false,
+        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
         subtitleLangs: settings?.default_subtitle_langs ?? [],
         remux: settings?.default_remux ?? null,
         extractAudio: settings?.default_extract_audio ?? null,

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -1,7 +1,13 @@
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
     Select,
@@ -245,48 +251,44 @@ export function FormatOptionsPanel({
                 {value.subtitles && (
                     <div className="mt-1.5">
                         {availableSubtitleLangs.length > 0 ? (
-                            <Select
-                                value={
-                                    value.subtitleLangs.length > 0
-                                        ? value.subtitleLangs[
-                                              value.subtitleLangs.length - 1
-                                          ]
-                                        : NONE_SENTINEL
-                                }
-                                onValueChange={handleSubLangSelect}
-                            >
-                                <SelectTrigger
-                                    size="sm"
-                                    className="w-full text-xs"
-                                >
-                                    <SelectValue
-                                        placeholder="Select languages"
+                            <Popover>
+                                <PopoverTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className="w-full justify-between text-xs font-normal"
                                     >
-                                        {value.subtitleLangs.length > 0
-                                            ? value.subtitleLangs.join(", ")
-                                            : "None"}
-                                    </SelectValue>
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value={NONE_SENTINEL}>
-                                        None
-                                    </SelectItem>
-                                    {availableSubtitleLangs.map((lang) => (
-                                        <SelectItem key={lang} value={lang}>
-                                            <span className="flex items-center gap-2">
-                                                {value.subtitleLangs.includes(
-                                                    lang,
-                                                ) && (
-                                                    <span className="text-primary">
-                                                        *
-                                                    </span>
-                                                )}
+                                        <span className="truncate">
+                                            {value.subtitleLangs.length > 0
+                                                ? value.subtitleLangs.join(", ")
+                                                : "None"}
+                                        </span>
+                                    </Button>
+                                </PopoverTrigger>
+                                <PopoverContent
+                                    align="start"
+                                    className="w-(--radix-popover-trigger-width) p-2"
+                                >
+                                    <div className="flex flex-col gap-1 max-h-48 overflow-y-auto">
+                                        {availableSubtitleLangs.map((lang) => (
+                                            <Label
+                                                key={lang}
+                                                htmlFor={`sub-lang-${lang}`}
+                                                className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-xs cursor-pointer hover:bg-accent"
+                                            >
+                                                <Checkbox
+                                                    id={`sub-lang-${lang}`}
+                                                    checked={value.subtitleLangs.includes(lang)}
+                                                    onCheckedChange={() =>
+                                                        handleSubLangSelect(lang)
+                                                    }
+                                                />
                                                 {lang}
-                                            </span>
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
+                                            </Label>
+                                        ))}
+                                    </div>
+                                </PopoverContent>
+                            </Popover>
                         ) : (
                             <Input
                                 className="font-mono text-xs"

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -2,7 +2,20 @@ import { cn } from "@/lib/utils";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import type { AudioFormat, ContainerFormat, DownloadOptions } from "../types";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import type {
+    AppSettings,
+    AudioFormat,
+    ContainerFormat,
+    DownloadOptions,
+} from "../types";
 
 /** A format preset with a human-readable label and yt-dlp selector string. */
 export interface FormatPreset {
@@ -14,8 +27,16 @@ export interface FormatPreset {
 /** Shared preset definitions used by both the popover and FormatDialog. */
 export const PRESETS: FormatPreset[] = [
     { id: "best", label: "Best Quality", selector: "bestvideo+bestaudio/best" },
-    { id: "1080p", label: "1080p", selector: "bestvideo[height<=1080]+bestaudio/best[height<=1080]" },
-    { id: "720p", label: "720p", selector: "bestvideo[height<=720]+bestaudio/best[height<=720]" },
+    {
+        id: "1080p",
+        label: "1080p",
+        selector: "bestvideo[height<=1080]+bestaudio/best[height<=1080]",
+    },
+    {
+        id: "720p",
+        label: "720p",
+        selector: "bestvideo[height<=720]+bestaudio/best[height<=720]",
+    },
     { id: "audio-only", label: "Audio Only", selector: "bestaudio/best" },
 ];
 
@@ -34,16 +55,31 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
     { value: "flac", label: "FLAC" },
 ];
 
+/** Sentinel value for "no selection" in Radix Select (empty string is not supported). */
+const NONE_SENTINEL = "none";
+
 /**
- * Tailwind classes for native `<select>` elements with a custom chevron icon.
- * Uses a data URI SVG background image to avoid inline style attributes.
+ * Build a `DownloadOptions` from persisted settings.
+ *
+ * Initializes `format` to the first preset selector so the "Best Quality"
+ * preset is genuinely selected rather than appearing selected while sending
+ * null to the backend.
  */
-const selectClasses = cn(
-    "h-8 rounded-md border border-input bg-card px-2.5 pr-7 text-xs font-medium text-muted-foreground",
-    "cursor-pointer appearance-none transition-colors",
-    "bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%2F%3E%3C%2Fsvg%3E')] bg-no-repeat bg-[position:right_8px_center]",
-    "focus:outline-none focus:ring-1 focus:ring-ring",
-);
+export function buildDefaultOptions(
+    settings: AppSettings | null,
+): DownloadOptions {
+    return {
+        format: PRESETS[0].selector,
+        outputDir: settings?.output_dir ?? null,
+        subtitles: false,
+        subtitleLangs: settings?.default_subtitle_langs ?? [],
+        remux: settings?.default_remux ?? null,
+        extractAudio: settings?.default_extract_audio ?? null,
+        embedThumbnail: settings?.embed_thumbnail ?? true,
+        audioMultistreams: false,
+        recodeVideo: null,
+    };
+}
 
 interface FormatOptionsPanelProps {
     value: DownloadOptions;
@@ -55,9 +91,8 @@ interface FormatOptionsPanelProps {
 
 /** Derive which preset ID matches the current format selector, if any. */
 function activePreset(format: string | null): string | null {
-    if (!format) return "best";
-    const match = PRESETS.find((p) => p.selector === format);
-    return match?.id ?? null;
+    if (!format) return null;
+    return PRESETS.find((p) => p.selector === format)?.id ?? null;
 }
 
 /** Controlled panel for download options: presets, remux, audio, subs, thumbnail. */
@@ -69,21 +104,23 @@ export function FormatOptionsPanel({
 }: FormatOptionsPanelProps) {
     const currentPreset = activePreset(value.format);
 
-    const handlePreset = (preset: FormatPreset) => {
-        onChange({ ...value, format: preset.selector });
+    const handlePreset = (presetId: string) => {
+        const preset = PRESETS.find((p) => p.id === presetId);
+        if (preset) onChange({ ...value, format: preset.selector });
     };
 
     const handleRemux = (val: string) => {
         onChange({
             ...value,
-            remux: val === "" ? null : (val as ContainerFormat),
+            remux: val === NONE_SENTINEL ? null : (val as ContainerFormat),
         });
     };
 
     const handleAudio = (val: string) => {
         onChange({
             ...value,
-            extractAudio: val === "" ? null : (val as AudioFormat),
+            extractAudio:
+                val === NONE_SENTINEL ? null : (val as AudioFormat),
         });
     };
 
@@ -99,6 +136,18 @@ export function FormatOptionsPanel({
         onChange({ ...value, subtitleLangs: langs });
     };
 
+    const handleSubLangSelect = (val: string) => {
+        if (val === NONE_SENTINEL) {
+            onChange({ ...value, subtitleLangs: [] });
+            return;
+        }
+        const current = value.subtitleLangs;
+        const next = current.includes(val)
+            ? current.filter((l) => l !== val)
+            : [...current, val];
+        onChange({ ...value, subtitleLangs: next });
+    };
+
     return (
         <div className="flex flex-col gap-1.5">
             {!hidePresets && (
@@ -106,82 +155,85 @@ export function FormatOptionsPanel({
                     <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
                         Quality Preset
                     </Label>
-                    <div className="flex flex-wrap gap-1">
+                    <RadioGroup
+                        value={currentPreset ?? ""}
+                        onValueChange={handlePreset}
+                        className="flex flex-wrap gap-1"
+                    >
                         {PRESETS.map((p) => (
-                            <label
+                            <Label
                                 key={p.id}
+                                htmlFor={`preset-${p.id}`}
                                 className={cn(
                                     "inline-flex items-center gap-[5px] px-2.5 py-[5px] border border-white/[0.06] rounded-sm bg-card text-xs text-muted-foreground cursor-pointer transition-colors",
                                     "hover:border-white/[0.12] hover:text-foreground",
-                                    currentPreset === p.id && "border-primary text-primary bg-primary/[0.12]",
+                                    currentPreset === p.id &&
+                                        "border-primary text-primary bg-primary/[0.12]",
                                 )}
                             >
-                                <input
-                                    type="radio"
-                                    name="preset"
-                                    checked={currentPreset === p.id}
-                                    onChange={() => handlePreset(p)}
-                                    className={cn(
-                                        "appearance-none w-3 h-3 border-2 border-muted rounded-full bg-muted cursor-pointer shrink-0 relative transition-colors",
-                                        currentPreset === p.id && "border-primary bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:w-1 after:h-1 after:rounded-full after:bg-background",
-                                    )}
+                                <RadioGroupItem
+                                    value={p.id}
+                                    id={`preset-${p.id}`}
+                                    className="size-3.5"
                                 />
                                 {p.label}
-                            </label>
+                            </Label>
                         ))}
-                    </div>
+                    </RadioGroup>
                 </div>
             )}
 
             <div className="flex flex-col gap-1">
-                <Label
-                    htmlFor="remux-select"
-                    className="text-[11px] font-semibold text-muted-foreground tracking-wide"
-                >
+                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
                     Remux
                 </Label>
-                <select
-                    id="remux-select"
-                    className={selectClasses}
-                    value={value.remux ?? ""}
-                    onChange={(e) => handleRemux(e.target.value)}
+                <Select
+                    value={value.remux ?? NONE_SENTINEL}
+                    onValueChange={handleRemux}
                 >
-                    <option value="">None</option>
-                    {REMUX_OPTIONS.map((o) => (
-                        <option key={o.value} value={o.value}>
-                            {o.label}
-                        </option>
-                    ))}
-                </select>
+                    <SelectTrigger size="sm" className="w-full text-xs">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                        {REMUX_OPTIONS.map((o) => (
+                            <SelectItem key={o.value} value={o.value}>
+                                {o.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
             </div>
 
             <div className="flex flex-col gap-1">
-                <Label
-                    htmlFor="audio-select"
-                    className="text-[11px] font-semibold text-muted-foreground tracking-wide"
-                >
+                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
                     Extract Audio
                 </Label>
-                <select
-                    id="audio-select"
-                    className={selectClasses}
-                    value={value.extractAudio ?? ""}
-                    onChange={(e) => handleAudio(e.target.value)}
+                <Select
+                    value={value.extractAudio ?? NONE_SENTINEL}
+                    onValueChange={handleAudio}
                 >
-                    <option value="">None</option>
-                    {AUDIO_OPTIONS.map((o) => (
-                        <option key={o.value} value={o.value}>
-                            {o.label}
-                        </option>
-                    ))}
-                </select>
+                    <SelectTrigger size="sm" className="w-full text-xs">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                        {AUDIO_OPTIONS.map((o) => (
+                            <SelectItem key={o.value} value={o.value}>
+                                {o.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
             </div>
 
             <div className="flex flex-col gap-1">
                 <div className="flex items-center gap-2">
                     <Checkbox
                         checked={value.subtitles}
-                        onCheckedChange={(checked) => handleSubtitles(checked === true)}
+                        onCheckedChange={(checked) =>
+                            handleSubtitles(checked === true)
+                        }
                         id="subtitles"
                     />
                     <Label
@@ -194,27 +246,48 @@ export function FormatOptionsPanel({
                 {value.subtitles && (
                     <div className="mt-1.5">
                         {availableSubtitleLangs.length > 0 ? (
-                            <select
-                                className={cn(
-                                    "h-auto min-h-[60px] w-full rounded-md border border-input bg-card px-2.5 py-1.5 text-xs font-medium text-muted-foreground",
-                                    "cursor-pointer transition-colors focus:outline-none focus:ring-1 focus:ring-ring",
-                                )}
-                                multiple
-                                value={value.subtitleLangs}
-                                onChange={(e) => {
-                                    const selected = Array.from(
-                                        e.target.selectedOptions,
-                                        (o) => o.value,
-                                    );
-                                    onChange({ ...value, subtitleLangs: selected });
-                                }}
+                            <Select
+                                value={
+                                    value.subtitleLangs.length > 0
+                                        ? value.subtitleLangs[
+                                              value.subtitleLangs.length - 1
+                                          ]
+                                        : NONE_SENTINEL
+                                }
+                                onValueChange={handleSubLangSelect}
                             >
-                                {availableSubtitleLangs.map((lang) => (
-                                    <option key={lang} value={lang}>
-                                        {lang}
-                                    </option>
-                                ))}
-                            </select>
+                                <SelectTrigger
+                                    size="sm"
+                                    className="w-full text-xs"
+                                >
+                                    <SelectValue
+                                        placeholder="Select languages"
+                                    >
+                                        {value.subtitleLangs.length > 0
+                                            ? value.subtitleLangs.join(", ")
+                                            : "None"}
+                                    </SelectValue>
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value={NONE_SENTINEL}>
+                                        None
+                                    </SelectItem>
+                                    {availableSubtitleLangs.map((lang) => (
+                                        <SelectItem key={lang} value={lang}>
+                                            <span className="flex items-center gap-2">
+                                                {value.subtitleLangs.includes(
+                                                    lang,
+                                                ) && (
+                                                    <span className="text-primary">
+                                                        *
+                                                    </span>
+                                                )}
+                                                {lang}
+                                            </span>
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
                         ) : (
                             <Input
                                 className="font-mono text-xs"
@@ -233,7 +306,10 @@ export function FormatOptionsPanel({
                     <Checkbox
                         checked={value.embedThumbnail}
                         onCheckedChange={(checked) =>
-                            onChange({ ...value, embedThumbnail: checked === true })
+                            onChange({
+                                ...value,
+                                embedThumbnail: checked === true,
+                            })
                         }
                         id="embed-thumbnail"
                     />

--- a/crates/rdlp-desktop/src/components/ResultCard.tsx
+++ b/crates/rdlp-desktop/src/components/ResultCard.tsx
@@ -3,12 +3,10 @@ import { formatDistanceToNow, fromUnixTime } from "date-fns";
 import { useQuery } from "@tanstack/react-query";
 import { Download, ChevronDown } from "lucide-react";
 import { settingsQueryOptions } from "../api/settings";
-import { FormatOptionsPanel } from "./FormatOptionsPanel";
+import { FormatOptionsPanel, buildDefaultOptions } from "./FormatOptionsPanel";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type {
-    AudioFormat,
-    ContainerFormat,
     DownloadOptions,
     SearchResultPreview,
 } from "../types";
@@ -44,25 +42,6 @@ function formatViews(count: number | null): string {
     return `${count} views`;
 }
 
-/** Build default DownloadOptions from settings for the popover initial state. */
-function buildOptionsFromSettings(settings: {
-    default_remux: ContainerFormat | null;
-    default_extract_audio: AudioFormat | null;
-    default_subtitle_langs: string[];
-    embed_thumbnail: boolean;
-} | null): DownloadOptions {
-    return {
-        format: null,
-        outputDir: null,
-        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
-        subtitleLangs: settings?.default_subtitle_langs ?? [],
-        remux: settings?.default_remux ?? null,
-        extractAudio: settings?.default_extract_audio ?? null,
-        embedThumbnail: settings?.embed_thumbnail ?? true,
-        audioMultistreams: false,
-        recodeVideo: null,
-    };
-}
 
 /** Displays a single search result as a card with thumbnail, title, and metadata. */
 export function ResultCard({
@@ -78,14 +57,14 @@ export function ResultCard({
 
     const [showOptions, setShowOptions] = useState(false);
     const [panelOptions, setPanelOptions] = useState<DownloadOptions>(() =>
-        buildOptionsFromSettings(settings),
+        buildDefaultOptions(settings),
     );
     const popoverRef = useRef<HTMLDivElement>(null);
 
     // Update panel defaults when settings change
     useEffect(() => {
         if (!showOptions) {
-            setPanelOptions(buildOptionsFromSettings(settings));
+            setPanelOptions(buildDefaultOptions(settings));
         }
     }, [settings, showOptions]);
 

--- a/crates/rdlp-desktop/src/components/ResultRow.tsx
+++ b/crates/rdlp-desktop/src/components/ResultRow.tsx
@@ -5,13 +5,11 @@ import { formatDistanceToNowStrict, fromUnixTime } from "date-fns";
 import { useQuery } from "@tanstack/react-query";
 import { Download, LayoutGrid, ChevronDown } from "lucide-react";
 import { settingsQueryOptions } from "../api/settings";
-import { FormatOptionsPanel } from "./FormatOptionsPanel";
+import { FormatOptionsPanel, buildDefaultOptions } from "./FormatOptionsPanel";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import type {
-    AudioFormat,
-    ContainerFormat,
     DownloadOptions,
     SearchResultPreview,
 } from "../types";
@@ -58,24 +56,6 @@ function formatViews(count: number | null): string {
     return `${count} views`;
 }
 
-function buildOptionsFromSettings(settings: {
-    default_remux: ContainerFormat | null;
-    default_extract_audio: AudioFormat | null;
-    default_subtitle_langs: string[];
-    embed_thumbnail: boolean;
-} | null): DownloadOptions {
-    return {
-        format: null,
-        outputDir: null,
-        subtitles: (settings?.default_subtitle_langs ?? []).length > 0,
-        subtitleLangs: settings?.default_subtitle_langs ?? [],
-        remux: settings?.default_remux ?? null,
-        extractAudio: settings?.default_extract_audio ?? null,
-        embedThumbnail: settings?.embed_thumbnail ?? true,
-        audioMultistreams: false,
-        recodeVideo: null,
-    };
-}
 
 /** Dense list row for a single search result. */
 export function ResultRow({
@@ -90,14 +70,14 @@ export function ResultRow({
     const { data: settings = null } = useQuery(settingsQueryOptions());
     const [showOptions, setShowOptions] = useState(false);
     const [panelOptions, setPanelOptions] = useState<DownloadOptions>(() =>
-        buildOptionsFromSettings(settings),
+        buildDefaultOptions(settings),
     );
     const popoverRef = useRef<HTMLDivElement>(null);
     const rowRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (!showOptions) {
-            setPanelOptions(buildOptionsFromSettings(settings));
+            setPanelOptions(buildDefaultOptions(settings));
         }
     }, [settings, showOptions]);
 

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -42,17 +42,19 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
         rafId = null;
         if (!mounted || pending.size === 0) return;
 
+        const batch = new Map(pending);
+        pending.clear();
+
         qc.setQueryData<DownloadJob[]>(
             queryKeys.downloads.list(),
             (old) => {
                 if (!old) return old;
                 return old.map((job) => {
-                    const entry = pending.get(job.id);
+                    const entry = batch.get(job.id);
                     return entry ? { ...job, ...entry } : job;
                 });
             },
         );
-        pending.clear();
     }
 
     function scheduleFlush() {

--- a/crates/rdlp-desktop/src/pages/QueuePage.tsx
+++ b/crates/rdlp-desktop/src/pages/QueuePage.tsx
@@ -16,16 +16,22 @@ export function QueuePage() {
     const { data: settings = null } = useQuery(settingsQueryOptions());
 
     const handleCancel = (id: string) => {
-        void cancelDownload(id);
+        cancelDownload(id).catch((e) =>
+            console.error("Failed to cancel download", e),
+        );
     };
 
     const handleRemove = (id: string) => {
-        void removeJob(id);
+        removeJob(id).catch((e) =>
+            console.error("Failed to remove job", e),
+        );
     };
 
     const handleRetry = (url: string) => {
         const options = buildDefaultOptions(settings);
-        void startDownload(url, options);
+        startDownload(url, options).catch((e) =>
+            console.error("Failed to retry download", e),
+        );
     };
 
     const activeJobs = jobs.filter(

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -88,7 +88,9 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     const handleDownload = useCallback(
         (url: string) => {
             const opts = buildDefaultOptions(settings);
-            void apiStartDownload(url, opts);
+            apiStartDownload(url, opts).catch((e) =>
+                console.error("Download failed:", e),
+            );
         },
         [settings],
     );
@@ -96,7 +98,9 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     const handleDownloadWithOptions = useCallback(
         (url: string, options: Partial<DownloadOptions>) => {
             const defaults = buildDefaultOptions(settings);
-            void apiStartDownload(url, { ...defaults, ...options });
+            apiStartDownload(url, { ...defaults, ...options }).catch((e) =>
+                console.error("Download failed:", e),
+            );
         },
         [settings],
     );
@@ -109,7 +113,9 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     const handleFormatDialogConfirm = useCallback(
         (options: DownloadOptions) => {
             if (formatDialogUrl) {
-                void apiStartDownload(formatDialogUrl, options);
+                apiStartDownload(formatDialogUrl, options).catch((e) =>
+                    console.error("Download failed:", e),
+                );
             }
             setFormatDialogUrl(null);
         },
@@ -172,7 +178,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                 }));
             }
             // Trigger search after atom updates propagate
-            setTimeout(() => { void refetch(); }, 0);
+            setTimeout(() => { refetch().catch((e) => console.error("Refetch failed:", e)); }, 0);
         },
         [refetch],
     );
@@ -181,7 +187,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
         (q: string) => {
             setSearchParam("query", q);
             // Trigger search after atom update propagates
-            setTimeout(() => { void refetch(); }, 0);
+            setTimeout(() => { refetch().catch((e) => console.error("Refetch failed:", e)); }, 0);
         },
         [refetch],
     );
@@ -197,7 +203,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
             filters: [],
             hasUserFilters: false,
         }));
-        setTimeout(() => { void refetch(); }, 0);
+        setTimeout(() => { refetch().catch((e) => console.error("Refetch failed:", e)); }, 0);
     }, [refetch]);
 
     return (
@@ -220,7 +226,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                     <WifiOff className="h-4 w-4" />
                     <AlertDescription className="flex items-center gap-2.5">
                         No internet connection
-                        <Button variant="outline" size="sm" onClick={() => void refetch()} className="ml-auto h-6 text-[11px]">Retry</Button>
+                        <Button variant="outline" size="sm" onClick={() => { refetch().catch((e) => console.error("Refetch failed:", e)); }} className="ml-auto h-6 text-[11px]">Retry</Button>
                     </AlertDescription>
                 </Alert>
             )}
@@ -231,7 +237,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                     <AlertCircle className="h-4 w-4" />
                     <AlertDescription className="flex items-center gap-2.5">
                         {error ?? "An unknown error occurred."}
-                        <Button variant="outline" size="sm" onClick={() => void refetch()} className="ml-auto h-6 text-[11px]">Retry</Button>
+                        <Button variant="outline" size="sm" onClick={() => { refetch().catch((e) => console.error("Refetch failed:", e)); }} className="ml-auto h-6 text-[11px]">Retry</Button>
                     </AlertDescription>
                 </Alert>
             )}

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -188,7 +188,7 @@ export interface FormatSelectedPayload {
 /** Log message payload emitted as "download-log". */
 export interface DownloadLogPayload {
     jobId: string;
-    level: "info" | "warn";
+    level: "info" | "warn" | "debug";
     message: string;
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -150,7 +150,7 @@ pub static AUDIO_CODECS: &[(&str, AudioCodecConfig)] = &[
     (
         "flac",
         AudioCodecConfig {
-            encoder: None, // Native FLAC encoder
+            encoder: Some("flac"), // Native FLAC encoder
             extension: "flac",
             quality_scale: None,
             bitrate_range: None, // Lossless
@@ -536,7 +536,7 @@ mod tests {
         assert_eq!(mp3.quality_scale, Some((9, 0)));
 
         let flac = get_audio_codec("flac").unwrap();
-        assert!(flac.encoder.is_none()); // Native codec
+        assert_eq!(flac.encoder, Some("flac")); // Native FLAC encoder
         assert!(flac.bitrate_range.is_none()); // Lossless
     }
 

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use log::{debug, info, warn};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_ffmpeg::RemuxOptions;
 
 /// Supported thumbnail formats.
 const THUMBNAIL_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
@@ -167,16 +168,44 @@ impl PostProcessor for EmbedThumbnail {
             .and_then(|e| e.to_str())
             .unwrap_or("");
 
-        // Check if container supports thumbnails
-        if !Self::supports_thumbnail(extension) {
-            debug!(extension; "Container does not support thumbnail embedding");
-            return Ok(PostProcessResult::new(info.clone(), files));
-        }
+        // Auto-remux unsupported containers (e.g. .ts) to MP4 before embedding
+        let mut temp_files: Vec<PathBuf> = Vec::new();
+        let (media_file, extension, output_files) = if !Self::supports_thumbnail(extension) {
+            let remuxed_path = media_file.with_extension("mp4");
+            info!(
+                from:? = media_file.display(),
+                to:? = remuxed_path.display();
+                "Auto-remuxing unsupported container to MP4 for thumbnail embedding"
+            );
+
+            let opts = RemuxOptions {
+                faststart: true,
+                ..Default::default()
+            };
+            match self.ffmpeg.remux(media_file, &remuxed_path, &opts).await {
+                Ok(()) => {
+                    // Track original file as temp for cleanup
+                    temp_files.push(media_file.clone());
+                    let ext = "mp4";
+                    (remuxed_path.clone(), ext.to_string(), vec![remuxed_path])
+                }
+                Err(e) => {
+                    warn!("Auto-remux to MP4 failed, skipping thumbnail embed: {e}");
+                    return Ok(PostProcessResult::new(info.clone(), files));
+                }
+            }
+        } else {
+            (media_file.clone(), extension.to_string(), files.clone())
+        };
 
         // Find thumbnail file
-        let Some(thumbnail_file) = Self::find_thumbnail(media_file) else {
+        let Some(thumbnail_file) = Self::find_thumbnail(&media_file) else {
             debug!(file:? = media_file.display(); "No thumbnail file found");
-            return Ok(PostProcessResult::new(info.clone(), files));
+            return Ok(PostProcessResult {
+                info: info.clone(),
+                files: output_files,
+                temp_files,
+            });
         };
 
         info!(
@@ -191,28 +220,26 @@ impl PostProcessor for EmbedThumbnail {
         // Embed via library bindings
         match self
             .ffmpeg
-            .embed_thumbnail(media_file, &thumbnail_file, &temp_output, extension)
+            .embed_thumbnail(&media_file, &thumbnail_file, &temp_output, &extension)
             .await
         {
             Ok(()) => {
                 // Replace original with temp
-                tokio::fs::rename(&temp_output, media_file).await?;
+                tokio::fs::rename(&temp_output, &media_file).await?;
                 info!(file:? = media_file.display(); "Thumbnail embedded via FFmpeg");
 
                 // For MP4-family: write covr atom so Windows Explorer shows the thumbnail
-                if Self::is_mp4_family(extension) {
-                    Self::write_covr_atom(media_file, &thumbnail_file).await;
+                if Self::is_mp4_family(&extension) {
+                    Self::write_covr_atom(&media_file, &thumbnail_file).await;
                 }
 
                 // Clean up thumbnail unless --write-thumbnail was requested
-                let temp_files = if config.write_thumbnail {
-                    Vec::new()
-                } else {
-                    vec![thumbnail_file]
-                };
+                if !config.write_thumbnail {
+                    temp_files.push(thumbnail_file);
+                }
                 Ok(PostProcessResult {
                     info: info.clone(),
-                    files,
+                    files: output_files,
                     temp_files,
                 })
             }
@@ -221,8 +248,12 @@ impl PostProcessor for EmbedThumbnail {
                 // Clean up temp file if it exists
                 let _ = tokio::fs::remove_file(&temp_output).await;
 
-                // Non-fatal - return original files
-                Ok(PostProcessResult::new(info.clone(), files))
+                // Non-fatal - return original files (which may be the remuxed file)
+                Ok(PostProcessResult {
+                    info: info.clone(),
+                    files: output_files,
+                    temp_files,
+                })
             }
         }
     }
@@ -243,6 +274,9 @@ mod tests {
         assert!(EmbedThumbnail::supports_thumbnail("opus"));
         assert!(!EmbedThumbnail::supports_thumbnail("txt"));
         assert!(!EmbedThumbnail::supports_thumbnail("avi"));
+        // .ts is NOT in the supported list — triggers auto-remux to MP4
+        assert!(!EmbedThumbnail::supports_thumbnail("ts"));
+        assert!(!EmbedThumbnail::supports_thumbnail("TS"));
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -47,7 +47,9 @@ impl PostProcessor for FFmpegRemuxer {
     }
 
     fn should_run(&self, _info: &InfoDict, config: &PostProcessConfig) -> bool {
-        config.remux_container.is_some()
+        // Skip remux when audio extraction is active — extract_audio produces
+        // a standalone audio file that should not be remuxed into a video container.
+        config.remux_container.is_some() && !config.extract_audio
     }
 
     async fn process(
@@ -154,6 +156,36 @@ mod tests {
             let remuxer = FFmpegRemuxer::new(Arc::new(ffmpeg));
             // Should run after merger (100) but before video convertor (40)
             assert_eq!(remuxer.priority(), 45);
+        }
+    }
+
+    #[test]
+    fn test_should_run_skips_when_extract_audio() {
+        if let Ok(ffmpeg) = FFmpegRunner::new() {
+            let remuxer = FFmpegRemuxer::new(Arc::new(ffmpeg));
+            let info = InfoDict::new("id", "title", "ext", "url");
+
+            // Remux alone — should run
+            let config = PostProcessConfig {
+                remux_container: Some(ContainerFormat::Mkv),
+                ..PostProcessConfig::default()
+            };
+            assert!(remuxer.should_run(&info, &config));
+
+            // Remux + extract_audio — should NOT run
+            let config = PostProcessConfig {
+                remux_container: Some(ContainerFormat::Mkv),
+                extract_audio: true,
+                ..PostProcessConfig::default()
+            };
+            assert!(!remuxer.should_run(&info, &config));
+
+            // extract_audio alone (no remux) — should NOT run
+            let config = PostProcessConfig {
+                extract_audio: true,
+                ..PostProcessConfig::default()
+            };
+            assert!(!remuxer.should_run(&info, &config));
         }
     }
 }

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -196,9 +196,11 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
                 }
                 Err(e) => {
                     warn!(name:? = processor.name(); "Post-processor failed: {e}");
-                    // Continue with other processors on non-fatal errors
-                    // Fatal errors should be propagated
-                    if is_fatal_error(&e) {
+                    // Propagate fatal errors and user-requested primary operations.
+                    // Audio extraction is explicitly requested by the user, so
+                    // failures must surface rather than silently returning the
+                    // original video file.
+                    if is_fatal_error(&e, processor.name()) {
                         return Err(e.into());
                     }
                 }
@@ -245,11 +247,23 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
 }
 
 /// Check if an error is fatal and should stop processing.
-fn is_fatal_error(error: &rdlp_core::RdlpError) -> bool {
-    // Check for fatal error types
+///
+/// An error is fatal when:
+/// - It indicates a missing component ("not found").
+/// - It comes from a user-requested primary operation (audio extraction,
+///   audio normalization) where silently continuing would produce the
+///   wrong output format.
+fn is_fatal_error(error: &rdlp_core::RdlpError, processor_name: &str) -> bool {
+    // Always fatal: missing component
+    if matches!(error, rdlp_core::RdlpError::FFmpeg(msg) if msg.contains("not found")) {
+        return true;
+    }
+
+    // User-requested primary operations: failures must surface so the user
+    // knows the requested conversion did not happen.
     matches!(
-        error,
-        rdlp_core::RdlpError::FFmpeg(msg) if msg.contains("not found"),
+        processor_name,
+        "FFmpegExtractAudio" | "FFmpegNormalizeAudio"
     )
 }
 
@@ -279,5 +293,39 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_is_fatal_error_extract_audio() {
+        // Audio extraction errors are always fatal regardless of error type
+        let err = rdlp_core::RdlpError::PostProcess("audio extraction failed".into());
+        assert!(is_fatal_error(&err, "FFmpegExtractAudio"));
+
+        let err = rdlp_core::RdlpError::FFmpeg("encoder open failed".into());
+        assert!(is_fatal_error(&err, "FFmpegExtractAudio"));
+    }
+
+    #[test]
+    fn test_is_fatal_error_normalize_audio() {
+        let err = rdlp_core::RdlpError::PostProcess("normalization failed".into());
+        assert!(is_fatal_error(&err, "FFmpegNormalizeAudio"));
+    }
+
+    #[test]
+    fn test_is_fatal_error_non_primary_processor() {
+        // Non-primary processor errors are NOT fatal (unless "not found")
+        let err = rdlp_core::RdlpError::PostProcess("metadata embed failed".into());
+        assert!(!is_fatal_error(&err, "FFmpegMetadata"));
+
+        let err = rdlp_core::RdlpError::PostProcess("thumbnail embed failed".into());
+        assert!(!is_fatal_error(&err, "EmbedThumbnail"));
+    }
+
+    #[test]
+    fn test_is_fatal_error_not_found_always_fatal() {
+        // "not found" errors are fatal for ANY processor
+        let err = rdlp_core::RdlpError::FFmpeg("codec not found".into());
+        assert!(is_fatal_error(&err, "FFmpegMetadata"));
+        assert!(is_fatal_error(&err, "EmbedThumbnail"));
     }
 }


### PR DESCRIPTION
## Summary

- Rewrite FormatDialog and FormatOptionsPanel with shadcn components
- Extract shared `buildDefaultOptions` helper used across ResultCard, ResultRow, and downloads.ts
- Wire verbose logging through to desktop UI
- Fix FLAC audio extraction failures in postprocessor
- Fix subtitle multi-select and HLS thumbnail embedding
- Harden error handling across desktop backend and frontend:
  - Standardize mutex poisoning recovery to `unwrap_or_else` pattern
  - Propagate settings save errors to frontend (was silently swallowed)
  - Add 5-minute timeout on folder picker dialog channel
  - Replace silent event emission discards with `warn!()` logging
  - Add atomic `start_job()` to prevent download queue race condition
  - Replace all `void` async calls with `.catch()` handlers (13 sites)
  - Fix memory leak in download event handler pending map
  - Replace unsafe `url!` assertion with runtime guard
- Make cookie loading fatal when explicitly requested via `--cookies-from-browser` or `--cookies`
- Expand output template path sanitization to all 9 Windows-restricted characters

## Test plan
- [x] `cargo check -p rdlp-desktop` passes
- [x] `cargo clippy -p rdlp-desktop -- -D warnings` zero warnings
- [x] `cargo test -p rdlp-desktop` all 45 tests pass
- [x] `npx tsc --noEmit` from `crates/rdlp-desktop/` zero errors
- [x] `cargo test -p rdlp-api` passes (343 tests: 326 unit + 9 integration + 8 doc)
- [ ] FormatDialog opens and functions correctly with new shadcn UI
- [ ] Settings save errors surface in frontend (not silently swallowed)