### PR TITLE
refactor(desktop): overhaul FormatDialog with hero table and ScrollArea fix

### DIFF
--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -400,7 +400,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     return (
         <Dialog open={true} onOpenChange={(open) => { if (!open) onClose(); }}>
             <DialogContent
-                className="bg-card w-[90vw] max-w-[900px] max-h-[85vh] flex flex-col gap-0 p-0"
+                className="bg-card w-[90vw] max-w-[900px] max-h-[85vh] flex flex-col gap-0 p-0 overflow-hidden"
                 showCloseButton={true}
             >
                 {/* -- Zone 1: Context Header -- */}
@@ -478,10 +478,11 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                             </div>
 
                             {/* Scrollable table */}
-                            <ScrollArea className="flex-1 min-h-0" ref={tableRef}>
+                            <div className="flex-1 min-h-0 overflow-hidden" ref={tableRef}>
+                            <ScrollArea className="h-full">
                                 <Table className="text-xs">
                                     <TableHeader className="sticky top-0 z-10">
-                                        <TableRow className="bg-muted/80 backdrop-blur-sm hover:bg-muted/80">
+                                        <TableRow className="bg-foreground/[0.06] backdrop-blur-sm hover:bg-foreground/[0.06]">
                                             {COLUMNS.map(({ key, label, align }) => (
                                                 <TableHead
                                                     key={key}
@@ -529,20 +530,21 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                     </TableBody>
                                 </Table>
                             </ScrollArea>
+                            </div>
 
                             {/* Selection info bar */}
-                            <div className="px-5 py-2 text-xs text-muted-foreground bg-muted/50 border-t border-border shrink-0 flex items-center gap-2 min-h-[36px]">
+                            <div className="px-5 py-2 text-xs text-muted-foreground bg-card border-t border-border shrink-0 flex items-center gap-2 min-h-[36px]">
                                 {selectedId ? (
                                     <>
                                         <span>
-                                            Selected: <strong className="text-foreground font-mono">{selectedId}</strong>
+                                            Selected: <strong className="text-foreground/70 font-mono">{selectedId}</strong>
                                             {findFormat(selectedId) && (
                                                 <span className="text-muted-foreground"> ({formatBrief(findFormat(selectedId)!)})</span>
                                             )}
                                             {mergeId && (
                                                 <>
                                                     {" + "}
-                                                    <strong className="text-foreground font-mono">{mergeId}</strong>
+                                                    <strong className="text-foreground/70 font-mono">{mergeId}</strong>
                                                     {findFormat(mergeId) && (
                                                         <span className="text-muted-foreground"> ({formatBrief(findFormat(mergeId)!)})</span>
                                                     )}
@@ -571,7 +573,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                             </div>
 
                             {/* Expert mode */}
-                            <div className="px-5 py-2 shrink-0 flex flex-col gap-2 border-t border-border">
+                            <div className="px-5 py-2 shrink-0 flex flex-col gap-2 border-t border-border bg-card">
                                 <div className="flex items-center gap-2">
                                     <Checkbox
                                         checked={expertMode}
@@ -828,12 +830,11 @@ function GroupSection({ group, selectedId, mergeId, exprMatches, onRowClick }: G
                 return (
                     <TableRow
                         key={f.format_id}
-                        data-state={isSelected || isMerge ? "selected" : undefined}
                         className={cn(
-                            "cursor-pointer transition-colors hover:bg-foreground/[0.04]",
-                            isEven ? "bg-transparent" : "bg-foreground/[0.03]",
-                            isSelected && "bg-primary/[0.06] border-l-2 border-l-primary/70",
-                            isMerge && "bg-foreground/[0.05] border-l-2 border-l-foreground/30 border-dashed",
+                            "cursor-pointer transition-colors border-b-foreground/[0.06] hover:bg-foreground/[0.06]",
+                            isEven ? "bg-transparent" : "bg-foreground/[0.02]",
+                            isSelected && "bg-primary/20 border-l-[3px] border-l-primary",
+                            isMerge && "bg-foreground/10 border-l-[3px] border-l-foreground/40",
                             isExprMatch && !isSelected && !isMerge && "bg-yellow-500/5",
                         )}
                         onClick={(e) => onRowClick(f.format_id, e)}

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -273,7 +273,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     );
 
     const filtered = useMemo(() => {
-        if (!activePresetId || activePresetId === "best" || activePresetId === "smallest") {
+        if (!activePresetId || activePresetId === "best") {
             return sorted;
         }
         if (activePresetId === "audio-only") {
@@ -320,7 +320,10 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     }, [selectedId]);
 
     const handlePresetSelect = useCallback((presetId: string) => {
-        if (!presetId) return;
+        if (!presetId) {
+            setOptions((prev) => ({ ...prev, format: null }));
+            return;
+        }
         const preset = PRESETS.find((p) => p.id === presetId);
         if (!preset) return;
         setSelectedId(null);
@@ -516,16 +519,24 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>
-                                        {groups.map((group) => (
-                                            <GroupSection
-                                                key={group.label}
-                                                group={group}
-                                                selectedId={selectedId}
-                                                mergeId={mergeId}
-                                                exprMatches={exprMatches}
-                                                onRowClick={handleRowClick}
-                                            />
-                                        ))}
+                                        {groups.length > 0 ? (
+                                            groups.map((group) => (
+                                                <GroupSection
+                                                    key={group.label}
+                                                    group={group}
+                                                    selectedId={selectedId}
+                                                    mergeId={mergeId}
+                                                    exprMatches={exprMatches}
+                                                    onRowClick={handleRowClick}
+                                                />
+                                            ))
+                                        ) : (
+                                            <TableRow className="hover:bg-transparent">
+                                                <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                                                    No formats match this filter. Try a different preset or click "Best Quality" to see all.
+                                                </TableCell>
+                                            </TableRow>
+                                        )}
                                     </TableBody>
                                 </Table>
                             </ScrollArea>

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -262,22 +262,38 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
 
     // -- Derived data -------------------------------------------------
 
+    // Active preset (only when no manual selection or expert mode)
+    const activePresetId = (!selectedId && !mergeId && !expertMode)
+        ? PRESETS.find((p) => p.selector === options.format)?.id ?? null
+        : null;
+
     const sorted = useMemo(
         () => (formatData ? sortFormats(formatData.formats, sortKey, sortDir) : []),
         [formatData, sortKey, sortDir],
     );
 
-    const groups = useMemo(() => groupFormats(sorted), [sorted]);
+    const filtered = useMemo(() => {
+        if (!activePresetId || activePresetId === "best" || activePresetId === "smallest") {
+            return sorted;
+        }
+        if (activePresetId === "audio-only") {
+            return sorted.filter((f) => !f.has_video);
+        }
+        if (activePresetId === "1080p") {
+            return sorted.filter((f) => !f.has_video || (f.height !== null && f.height <= 1080));
+        }
+        if (activePresetId === "720p") {
+            return sorted.filter((f) => !f.has_video || (f.height !== null && f.height <= 720));
+        }
+        return sorted;
+    }, [sorted, activePresetId]);
+
+    const groups = useMemo(() => groupFormats(filtered), [filtered]);
 
     const subtitleLangs = useMemo(
         () => formatData?.subtitles.map((s) => s.lang) ?? [],
         [formatData],
     );
-
-    // Active preset (only when no manual selection or expert mode)
-    const activePresetId = (!selectedId && !mergeId && !expertMode)
-        ? PRESETS.find((p) => p.selector === options.format)?.id ?? null
-        : null;
 
     // -- Handlers -----------------------------------------------------
 
@@ -390,7 +406,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     return (
         <Dialog open={true} onOpenChange={(open) => { if (!open) onClose(); }}>
             <DialogContent
-                className="w-[90vw] max-w-[900px] max-h-[85vh] flex flex-col gap-0 p-0"
+                className="bg-card w-[90vw] max-w-[900px] max-h-[85vh] flex flex-col gap-0 p-0"
                 showCloseButton={true}
             >
                 {/* -- Zone 1: Context Header -- */}

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -222,6 +222,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     const [error, setError] = useState<string | null>(null);
     const [settingsApplied, setSettingsApplied] = useState(false);
     const [showOptions, setShowOptions] = useState(false);
+    const [presetId, setPresetId] = useState<string | null>(null);
     const [options, setOptions] = useState<DownloadOptions>(() =>
         buildDefaultOptions(settings),
     );
@@ -262,31 +263,18 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
 
     // -- Derived data -------------------------------------------------
 
-    // Active preset (only when no manual selection or expert mode)
-    const activePresetId = (!selectedId && !mergeId && !expertMode)
-        ? PRESETS.find((p) => p.selector === options.format)?.id ?? null
-        : null;
-
     const sorted = useMemo(
         () => (formatData ? sortFormats(formatData.formats, sortKey, sortDir) : []),
         [formatData, sortKey, sortDir],
     );
 
     const filtered = useMemo(() => {
-        if (!activePresetId || activePresetId === "best") {
-            return sorted;
-        }
-        if (activePresetId === "audio-only") {
-            return sorted.filter((f) => !f.has_video);
-        }
-        if (activePresetId === "1080p") {
-            return sorted.filter((f) => !f.has_video || (f.height !== null && f.height <= 1080));
-        }
-        if (activePresetId === "720p") {
-            return sorted.filter((f) => !f.has_video || (f.height !== null && f.height <= 720));
-        }
+        if (!presetId || presetId === "best") return sorted;
+        if (presetId === "audio-only") return sorted.filter((f) => !f.has_video);
+        if (presetId === "1080p") return sorted.filter((f) => !f.has_video || (f.height !== null && f.height <= 1080));
+        if (presetId === "720p") return sorted.filter((f) => !f.has_video || (f.height !== null && f.height <= 720));
         return sorted;
-    }, [sorted, activePresetId]);
+    }, [sorted, presetId]);
 
     const groups = useMemo(() => groupFormats(filtered), [filtered]);
 
@@ -316,16 +304,19 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
             setMergeId(null);
         }
         // Clear preset when manually selecting
+        setPresetId(null);
         setOptions((prev) => ({ ...prev, format: null }));
     }, [selectedId]);
 
-    const handlePresetSelect = useCallback((presetId: string) => {
-        if (!presetId) {
+    const handlePresetSelect = useCallback((newPresetId: string) => {
+        if (!newPresetId) {
+            setPresetId(null);
             setOptions((prev) => ({ ...prev, format: null }));
             return;
         }
-        const preset = PRESETS.find((p) => p.id === presetId);
+        const preset = PRESETS.find((p) => p.id === newPresetId);
         if (!preset) return;
+        setPresetId(newPresetId);
         setSelectedId(null);
         setMergeId(null);
         setOptions((prev) => ({ ...prev, format: preset.selector }));
@@ -470,7 +461,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                             <div className="px-5 pt-3 pb-2 shrink-0">
                                 <ToggleGroup
                                     type="single"
-                                    value={activePresetId ?? ""}
+                                    value={presetId ?? ""}
                                     onValueChange={handlePresetSelect}
                                     className="justify-start gap-0 bg-muted rounded-md p-0.5"
                                 >
@@ -478,9 +469,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                         <ToggleGroupItem
                                             key={p.id}
                                             value={p.id}
-                                            className={cn(
-                                                "px-3 h-7 text-xs rounded-[5px] data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
-                                            )}
+                                            className="px-3 h-7 text-xs rounded-[5px] data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                                         >
                                             {p.label}
                                         </ToggleGroupItem>
@@ -574,8 +563,8 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                     </>
                                 ) : (
                                     <span className="text-muted-foreground/60 italic">
-                                        {activePresetId
-                                            ? `Using preset: ${PRESETS.find((p) => p.id === activePresetId)?.label}`
+                                        {presetId
+                                            ? `Using preset: ${PRESETS.find((p) => p.id === presetId)?.label}`
                                             : "Click a format to select, or choose a preset above"}
                                     </span>
                                 )}

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -1,10 +1,17 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2, AlertCircle, ChevronUp, ChevronDown, FolderOpen } from "lucide-react";
+import {
+    Loader2,
+    AlertCircle,
+    ChevronUp,
+    ChevronDown,
+    FolderOpen,
+    Settings2,
+} from "lucide-react";
 import { formatsQueryOptions } from "../api/formats";
 import { settingsQueryOptions, pickDirectory } from "../api/settings";
 import { invokeTyped } from "../api/invokeClient";
-import { FormatOptionsPanel, PRESETS, buildDefaultOptions } from "./FormatOptionsPanel";
+import { PRESETS, buildDefaultOptions } from "./FormatOptionsPanel";
 import { cn } from "@/lib/utils";
 import {
     Dialog,
@@ -20,13 +27,43 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Collapsible,
+    CollapsibleTrigger,
+    CollapsibleContent,
+} from "@/components/ui/collapsible";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    ToggleGroup,
+    ToggleGroupItem,
+} from "@/components/ui/toggle-group";
 import type {
+    AudioFormat,
+    ContainerFormat,
     DownloadOptions,
     FormatInfo,
 } from "../types";
+
+// -- Types ------------------------------------------------------------
 
 type SortKey = "height" | "ext" | "fps" | "tbr" | "vcodec" | "acodec" | "filesize";
 type SortDir = "asc" | "desc";
@@ -37,41 +74,76 @@ interface FormatDialogProps {
     onClose: () => void;
 }
 
-/** Format bytes into a human-readable string. */
+interface FormatGroup {
+    label: string;
+    formats: FormatInfo[];
+}
+
+// -- Constants --------------------------------------------------------
+
+const COLUMNS: Array<{ key: SortKey; label: string; align: "left" | "right" }> = [
+    { key: "height", label: "Resolution", align: "left" },
+    { key: "ext", label: "Ext", align: "left" },
+    { key: "fps", label: "FPS", align: "right" },
+    { key: "tbr", label: "Bitrate", align: "right" },
+    { key: "vcodec", label: "Video", align: "left" },
+    { key: "acodec", label: "Audio", align: "left" },
+    { key: "filesize", label: "Size", align: "right" },
+];
+
+const REMUX_OPTIONS: Array<{ value: ContainerFormat; label: string }> = [
+    { value: "mp4", label: "MP4" },
+    { value: "mkv", label: "MKV" },
+    { value: "webm", label: "WebM" },
+];
+
+const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
+    { value: "mp3", label: "MP3" },
+    { value: "aac", label: "AAC" },
+    { value: "opus", label: "Opus" },
+    { value: "flac", label: "FLAC" },
+];
+
+const NONE_SENTINEL = "none";
+
+// -- Utility functions ------------------------------------------------
+
 function formatSize(bytes: number | null): string {
-    if (bytes === null) return "-";
+    if (bytes === null) return "\u2014";
     if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
     if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
     if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(0)} KB`;
     return `${bytes} B`;
 }
 
-/** Format bitrate (kbps). */
 function formatBitrate(kbps: number | null): string {
-    if (kbps === null) return "-";
+    if (kbps === null) return "\u2014";
     if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
     return `${Math.round(kbps)} kbps`;
 }
 
-/** Resolution display string. */
 function formatResolution(f: FormatInfo): string {
-    if (f.height && f.width) return `${f.width}x${f.height}`;
+    if (f.height && f.width) return `${f.width}\u00d7${f.height}`;
     if (f.height) return `${f.height}p`;
-    return f.format_note ?? "-";
+    return f.format_note ?? "\u2014";
 }
 
-/** Type badge label and styling. */
 function formatType(f: FormatInfo): { label: string; className: string } {
     if (f.protocol.includes("m3u8"))
-        return { label: "HLS", className: "bg-yellow-500/[0.12] text-yellow-500" };
+        return { label: "HLS", className: "bg-yellow-500/10 text-yellow-500" };
     if (f.has_video && f.has_audio)
-        return { label: "V+A", className: "bg-primary/[0.12] text-primary" };
+        return { label: "V+A", className: "bg-primary/10 text-primary" };
     if (f.has_video)
-        return { label: "Video", className: "bg-blue-500/[0.12] text-blue-400" };
-    return { label: "Audio", className: "bg-purple-500/[0.12] text-purple-400" };
+        return { label: "Video", className: "bg-blue-500/10 text-blue-400" };
+    return { label: "Audio", className: "bg-purple-500/10 text-purple-400" };
 }
 
-/** Compare helper for sorting nullable fields. */
+/** Brief description for the selection info bar. */
+function formatBrief(f: FormatInfo): string {
+    const res = f.height ? `${f.height}p` : f.format_note ?? "";
+    return `${res} ${f.ext}`.trim();
+}
+
 function cmpNullable(a: number | null, b: number | null, dir: SortDir): number {
     if (a === null && b === null) return 0;
     if (a === null) return 1;
@@ -79,41 +151,56 @@ function cmpNullable(a: number | null, b: number | null, dir: SortDir): number {
     return dir === "asc" ? a - b : b - a;
 }
 
-/** Sort formats by a given key and direction. */
 function sortFormats(formats: FormatInfo[], key: SortKey, dir: SortDir): FormatInfo[] {
     const sorted = [...formats];
     sorted.sort((a, b) => {
         switch (key) {
-            case "height":
-                return cmpNullable(a.height, b.height, dir);
-            case "ext":
-                return dir === "asc"
-                    ? a.ext.localeCompare(b.ext)
-                    : b.ext.localeCompare(a.ext);
-            case "fps":
-                return cmpNullable(a.fps, b.fps, dir);
-            case "tbr":
-                return cmpNullable(a.tbr, b.tbr, dir);
-            case "vcodec":
-                return dir === "asc"
-                    ? (a.vcodec ?? "").localeCompare(b.vcodec ?? "")
-                    : (b.vcodec ?? "").localeCompare(a.vcodec ?? "");
-            case "acodec":
-                return dir === "asc"
-                    ? (a.acodec ?? "").localeCompare(b.acodec ?? "")
-                    : (b.acodec ?? "").localeCompare(a.acodec ?? "");
-            case "filesize":
-                return cmpNullable(a.filesize, b.filesize, dir);
-            default:
-                return 0;
+            case "height": return cmpNullable(a.height, b.height, dir);
+            case "ext": return dir === "asc" ? a.ext.localeCompare(b.ext) : b.ext.localeCompare(a.ext);
+            case "fps": return cmpNullable(a.fps, b.fps, dir);
+            case "tbr": return cmpNullable(a.tbr, b.tbr, dir);
+            case "vcodec": return dir === "asc" ? (a.vcodec ?? "").localeCompare(b.vcodec ?? "") : (b.vcodec ?? "").localeCompare(a.vcodec ?? "");
+            case "acodec": return dir === "asc" ? (a.acodec ?? "").localeCompare(b.acodec ?? "") : (b.acodec ?? "").localeCompare(a.acodec ?? "");
+            case "filesize": return cmpNullable(a.filesize, b.filesize, dir);
+            default: return 0;
         }
     });
     return sorted;
 }
 
-/** Full-screen modal for format selection, presets, options, and expert mode. */
+/** Group sorted formats into Video+Audio, Video Only, Audio Only sections. */
+function groupFormats(formats: FormatInfo[]): FormatGroup[] {
+    const videoAudio: FormatInfo[] = [];
+    const videoOnly: FormatInfo[] = [];
+    const audioOnly: FormatInfo[] = [];
+
+    for (const f of formats) {
+        if (f.has_video && f.has_audio) videoAudio.push(f);
+        else if (f.has_video) videoOnly.push(f);
+        else audioOnly.push(f);
+    }
+
+    const groups: FormatGroup[] = [];
+    if (videoAudio.length > 0) groups.push({ label: "Video + Audio", formats: videoAudio });
+    if (videoOnly.length > 0) groups.push({ label: "Video Only", formats: videoOnly });
+    if (audioOnly.length > 0) groups.push({ label: "Audio Only", formats: audioOnly });
+    return groups;
+}
+
+/** Build a summary string for the collapsed options trigger. */
+function optionsSummary(opts: DownloadOptions): string {
+    const parts: string[] = [];
+    if (opts.remux) parts.push(`${opts.remux.toUpperCase()} remux`);
+    if (opts.extractAudio) parts.push(`${opts.extractAudio.toUpperCase()} audio`);
+    if (opts.subtitles && opts.subtitleLangs.length > 0)
+        parts.push(`Subs: ${opts.subtitleLangs.join(", ")}`);
+    if (opts.embedThumbnail) parts.push("Thumbnail");
+    return parts.length > 0 ? parts.join(" \u00b7 ") : "Default settings";
+}
+
+/** Full-screen modal for format selection with hero table, presets, and collapsed options. */
 export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
-    // --- TanStack Query: server state ---
+    // -- Server state -------------------------------------------------
     const {
         data: formatData,
         isPending: isLoading,
@@ -123,25 +210,28 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     } = useQuery(formatsQueryOptions(url));
     const { data: settings = null } = useQuery(settingsQueryOptions());
 
+    // -- Local state --------------------------------------------------
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const [mergeId, setMergeId] = useState<string | null>(null);
     const [sortKey, setSortKey] = useState<SortKey>("height");
     const [sortDir, setSortDir] = useState<SortDir>("desc");
-    const [showTable, setShowTable] = useState(false);
     const [expertMode, setExpertMode] = useState(false);
     const [expr, setExpr] = useState("");
     const [exprError, setExprError] = useState<string | null>(null);
     const [exprMatches, setExprMatches] = useState<Set<string>>(new Set());
     const [error, setError] = useState<string | null>(null);
     const [settingsApplied, setSettingsApplied] = useState(false);
+    const [showOptions, setShowOptions] = useState(false);
     const [options, setOptions] = useState<DownloadOptions>(() =>
         buildDefaultOptions(settings),
     );
 
     const exprTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const tableRef = useRef<HTMLDivElement>(null);
 
-    // Sync options when settings first load (fixes race condition where
-    // useState captures settings at mount before the query resolves)
+    // -- Effects ------------------------------------------------------
+
+    // Sync options when settings first load
     useEffect(() => {
         if (settings && !settingsApplied) {
             setOptions((prev) => ({
@@ -156,51 +246,78 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         }
     }, [settings, settingsApplied]);
 
-    // Surface query-level errors in local state
+    // Surface query errors in local state
     useEffect(() => {
         if (isQueryError && queryError) {
             setError(queryError instanceof Error ? queryError.message : String(queryError));
         }
     }, [isQueryError, queryError]);
 
-    // Cleanup timer on unmount
+    // Cleanup debounce timer
     useEffect(() => {
         return () => {
             if (exprTimerRef.current) clearTimeout(exprTimerRef.current);
         };
     }, []);
 
-    // Sort header click
-    const handleSortClick = (key: SortKey) => {
-        if (key === sortKey) {
-            setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-        } else {
-            setSortKey(key);
-            setSortDir("desc");
-        }
-    };
+    // -- Derived data -------------------------------------------------
 
-    // Row click (single or shift for merge pair)
-    const handleRowClick = (id: string, e: React.MouseEvent) => {
+    const sorted = useMemo(
+        () => (formatData ? sortFormats(formatData.formats, sortKey, sortDir) : []),
+        [formatData, sortKey, sortDir],
+    );
+
+    const groups = useMemo(() => groupFormats(sorted), [sorted]);
+
+    const subtitleLangs = useMemo(
+        () => formatData?.subtitles.map((s) => s.lang) ?? [],
+        [formatData],
+    );
+
+    // Active preset (only when no manual selection or expert mode)
+    const activePresetId = (!selectedId && !mergeId && !expertMode)
+        ? PRESETS.find((p) => p.selector === options.format)?.id ?? null
+        : null;
+
+    // -- Handlers -----------------------------------------------------
+
+    const handleSortClick = useCallback((key: SortKey) => {
+        setSortKey((prev) => {
+            if (prev === key) {
+                setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+                return prev;
+            }
+            setSortDir("desc");
+            return key;
+        });
+    }, []);
+
+    const handleRowClick = useCallback((id: string, e: React.MouseEvent) => {
         if (e.shiftKey && selectedId !== null && selectedId !== id) {
             setMergeId(id);
         } else {
             setSelectedId(id);
             setMergeId(null);
         }
-    };
+        // Clear preset when manually selecting
+        setOptions((prev) => ({ ...prev, format: null }));
+    }, [selectedId]);
 
-    // Preset selection (uses preset ID, not selector)
-    const handlePresetSelect = (presetId: string) => {
+    const handlePresetSelect = useCallback((presetId: string) => {
+        if (!presetId) return;
         const preset = PRESETS.find((p) => p.id === presetId);
         if (!preset) return;
         setSelectedId(null);
         setMergeId(null);
         setOptions((prev) => ({ ...prev, format: preset.selector }));
-    };
+    }, []);
 
-    // Expert expression change with debounced validation
-    const handleExprChange = (value: string) => {
+    const handleClearSelection = useCallback(() => {
+        setSelectedId(null);
+        setMergeId(null);
+    }, []);
+
+    const handleExprChange = useCallback((value: string) => {
         setExpr(value);
         if (exprTimerRef.current) clearTimeout(exprTimerRef.current);
         if (value.trim() === "") {
@@ -211,19 +328,10 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         exprTimerRef.current = setTimeout(async () => {
             try {
                 const fmts = formatData?.formats.map((f) => ({
-                    format_id: f.format_id,
-                    ext: f.ext,
-                    width: f.width,
-                    height: f.height,
-                    fps: f.fps,
-                    tbr: f.tbr,
-                    vcodec: f.vcodec,
-                    acodec: f.acodec,
-                    filesize: f.filesize,
-                    vbr: f.vbr,
-                    abr: f.abr,
-                    asr: f.asr,
-                    protocol: f.protocol,
+                    format_id: f.format_id, ext: f.ext, width: f.width,
+                    height: f.height, fps: f.fps, tbr: f.tbr,
+                    vcodec: f.vcodec, acodec: f.acodec, filesize: f.filesize,
+                    vbr: f.vbr, abr: f.abr, asr: f.asr, protocol: f.protocol,
                 })) ?? [];
                 const matches = await invokeTyped<string[]>(
                     "validate_format_expression",
@@ -241,315 +349,532 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                 setExprMatches(new Set());
             }
         }, 400);
-    };
+    }, [formatData]);
 
-    // Build the final format selector from current state
-    const buildFormatSelector = (): string | null => {
+    const buildFormatSelector = useCallback((): string | null => {
         if (expertMode && expr.trim()) return expr.trim();
         if (selectedId && mergeId) return `${selectedId}+${mergeId}`;
         if (selectedId) return selectedId;
         return options.format;
-    };
+    }, [expertMode, expr, selectedId, mergeId, options.format]);
 
-    const handleConfirm = () => {
+    const handleConfirm = useCallback(() => {
         const format = buildFormatSelector();
         onConfirm({ ...options, format });
-    };
+    }, [buildFormatSelector, onConfirm, options]);
 
-    // Output directory picker
-    const handleBrowseDir = async () => {
+    const handleBrowseDir = useCallback(async () => {
         const dir = await pickDirectory();
-        if (dir) {
-            setOptions((prev) => ({ ...prev, outputDir: dir }));
-        }
-    };
+        if (dir) setOptions((prev) => ({ ...prev, outputDir: dir }));
+    }, []);
 
-    const sorted = formatData
-        ? sortFormats(formatData.formats, sortKey, sortDir)
-        : [];
+    const handleSubLangSelect = useCallback((lang: string) => {
+        setOptions((prev) => {
+            const current = prev.subtitleLangs;
+            const next = current.includes(lang)
+                ? current.filter((l) => l !== lang)
+                : [...current, lang];
+            return { ...prev, subtitleLangs: next };
+        });
+    }, []);
 
-    const subtitleLangs = formatData?.subtitles.map((s) => s.lang) ?? [];
+    // -- Lookup helpers -----------------------------------------------
 
-    const renderSortIndicator = (key: SortKey) => {
-        if (sortKey !== key) return null;
-        return sortDir === "asc"
-            ? <ChevronUp className="inline size-3" />
-            : <ChevronDown className="inline size-3" />;
-    };
-
-    // Derive active preset from selected state (no fallback to "best")
-    const activePresetId = (!selectedId && !mergeId && !expertMode)
-        ? PRESETS.find((p) => p.selector === options.format)?.id ?? null
-        : null;
-
-    /** Shared cell class for consistent td styling based on row state. */
-    const cellClass = (isSelected: boolean, isExprMatch: boolean) => cn(
-        "px-2.5 py-1.5 border-b border-white/[0.02] whitespace-nowrap",
-        isSelected ? "text-primary" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+    const findFormat = useCallback(
+        (id: string) => formatData?.formats.find((f) => f.format_id === id),
+        [formatData],
     );
+
+    // -- Render -------------------------------------------------------
 
     return (
         <Dialog open={true} onOpenChange={(open) => { if (!open) onClose(); }}>
             <DialogContent
-                className="w-[90vw] max-w-[860px] max-h-[85vh] flex flex-col gap-0 p-0"
+                className="w-[90vw] max-w-[900px] max-h-[85vh] flex flex-col gap-0 p-0"
                 showCloseButton={true}
             >
-                <DialogHeader className="px-4 pt-4 pb-3 border-b border-border shrink-0">
-                    <DialogTitle className="text-[15px] font-bold text-foreground truncate pr-8">
-                        {formatData?.title ?? "Choose Format"}
-                    </DialogTitle>
-                    <DialogDescription className="sr-only">
-                        Select a format and download options for this video
-                    </DialogDescription>
+                {/* -- Zone 1: Context Header -- */}
+                <DialogHeader className="px-5 pt-4 pb-3 border-b border-border shrink-0">
+                    <div className="flex items-center gap-3">
+                        {formatData?.thumbnail_url && (
+                            <img
+                                src={formatData.thumbnail_url}
+                                alt=""
+                                className="w-12 h-[27px] object-cover rounded-sm shrink-0 bg-muted"
+                            />
+                        )}
+                        <div className="min-w-0 flex-1">
+                            <DialogTitle className="text-sm font-semibold text-foreground truncate pr-8">
+                                {formatData?.title ?? "Choose Format"}
+                            </DialogTitle>
+                            <DialogDescription className="sr-only">
+                                Select a format and download options for this video
+                            </DialogDescription>
+                        </div>
+                    </div>
                 </DialogHeader>
 
-                <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-3">
+                {/* -- Zone 2: Hero Format Table -- */}
+                <div className="flex-1 min-h-0 flex flex-col">
                     {isLoading && (
-                        <div className="flex flex-col items-center justify-center gap-2.5 py-8 text-muted-foreground">
-                            <Loader2 className="h-6 w-6 animate-spin" />
-                            <p className="text-sm">Loading formats...</p>
+                        <div className="flex flex-col items-center justify-center gap-2.5 py-12 text-muted-foreground">
+                            <Loader2 className="size-5 animate-spin" />
+                            <p className="text-xs">Loading formats...</p>
                         </div>
                     )}
 
                     {error && (
-                        <Alert variant="destructive">
-                            <AlertCircle className="h-4 w-4" />
-                            <AlertDescription className="flex items-center gap-2.5">
-                                <span>{error}</span>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="ml-auto h-6 text-[11px]"
-                                    onClick={() => {
-                                        setError(null);
-                                        refetch().catch((e) => console.error("Refetch failed:", e));
-                                    }}
-                                >
-                                    Retry
-                                </Button>
-                            </AlertDescription>
-                        </Alert>
+                        <div className="p-4">
+                            <Alert variant="destructive">
+                                <AlertCircle className="size-4" />
+                                <AlertDescription className="flex items-center gap-2.5">
+                                    <span className="text-xs">{error}</span>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className="ml-auto h-6 text-[11px]"
+                                        onClick={() => {
+                                            setError(null);
+                                            refetch().catch((e) => console.error("Refetch failed:", e));
+                                        }}
+                                    >
+                                        Retry
+                                    </Button>
+                                </AlertDescription>
+                            </Alert>
+                        </div>
                     )}
 
                     {!isLoading && !error && formatData && (
                         <>
-                            {/* Preset tier */}
-                            <div className="flex flex-col gap-1">
-                                <div className="text-[11px] font-semibold text-muted-foreground tracking-wide">
-                                    Quality Preset
-                                </div>
-                                <RadioGroup
+                            {/* Preset segmented control */}
+                            <div className="px-5 pt-3 pb-2 shrink-0">
+                                <ToggleGroup
+                                    type="single"
                                     value={activePresetId ?? ""}
                                     onValueChange={handlePresetSelect}
-                                    className="flex flex-wrap gap-1.5"
+                                    className="justify-start gap-0 bg-muted rounded-md p-0.5"
                                 >
                                     {PRESETS.map((p) => (
-                                        <Label
+                                        <ToggleGroupItem
                                             key={p.id}
-                                            htmlFor={`dialog-preset-${p.id}`}
+                                            value={p.id}
                                             className={cn(
-                                                "inline-flex items-center gap-1.5 px-2.5 py-[5px] border border-border rounded-md bg-card text-xs text-muted-foreground cursor-pointer transition-colors",
-                                                "hover:border-muted-foreground/30 hover:text-foreground",
-                                                activePresetId === p.id && "border-primary text-primary bg-primary/[0.08]",
+                                                "px-3 h-7 text-xs rounded-[5px] data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
                                             )}
                                         >
-                                            <RadioGroupItem value={p.id} id={`dialog-preset-${p.id}`} className="size-3.5" />
                                             {p.label}
-                                        </Label>
+                                        </ToggleGroupItem>
                                     ))}
-                                </RadioGroup>
+                                </ToggleGroup>
                             </div>
 
-                            {/* Format table toggle */}
-                            <Collapsible open={showTable} onOpenChange={setShowTable}>
-                                <CollapsibleTrigger asChild>
-                                    <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        className="self-start text-xs text-muted-foreground hover:text-foreground gap-1"
-                                        aria-expanded={showTable}
-                                    >
-                                        {showTable
-                                            ? <><ChevronUp className="size-3.5" />Hide all formats</>
-                                            : <><ChevronDown className="size-3.5" />Show all formats ({sorted.length})</>}
-                                    </Button>
-                                </CollapsibleTrigger>
-                                <CollapsibleContent>
-                                    <div className="flex flex-col border border-border rounded-md mt-1">
-                                        <ScrollArea className="max-h-[40vh]">
-                                            <div className="overflow-x-auto">
-                                                <table className="w-full border-collapse font-mono text-xs">
-                                                    <thead>
-                                                        <tr>
-                                                            {([
-                                                                ["height", "Resolution"],
-                                                                ["ext", "Ext"],
-                                                                ["fps", "FPS"],
-                                                                ["tbr", "Bitrate"],
-                                                                ["vcodec", "Video"],
-                                                                ["acodec", "Audio"],
-                                                                ["filesize", "Size"],
-                                                            ] as [SortKey, string][]).map(([key, label]) => (
-                                                                <th
-                                                                    key={key}
-                                                                    className={cn(
-                                                                        "sticky top-0 px-2.5 py-2 text-left text-[10px] font-bold tracking-wider uppercase text-muted-foreground bg-muted border-b border-border whitespace-nowrap select-none cursor-pointer transition-colors hover:text-foreground",
-                                                                        sortKey === key && "text-primary",
-                                                                    )}
-                                                                    onClick={() => handleSortClick(key)}
-                                                                >
-                                                                    <span className="inline-flex items-center gap-1">
-                                                                        {label}
-                                                                        {renderSortIndicator(key)}
-                                                                    </span>
-                                                                </th>
-                                                            ))}
-                                                            <th className="sticky top-0 px-2.5 py-2 text-left text-[10px] font-bold tracking-wider uppercase text-muted-foreground bg-muted border-b border-border whitespace-nowrap select-none">
-                                                                Type
-                                                            </th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        {sorted.map((f) => {
-                                                            const type = formatType(f);
-                                                            const isSelected =
-                                                                f.format_id === selectedId ||
-                                                                f.format_id === mergeId;
-                                                            const isExprMatch = exprMatches.has(f.format_id);
-                                                            return (
-                                                                <tr
-                                                                    key={f.format_id}
-                                                                    className={cn(
-                                                                        "cursor-pointer transition-colors hover:bg-muted",
-                                                                        isSelected && "bg-primary/[0.12]",
-                                                                        isExprMatch && !isSelected && "bg-yellow-500/[0.08]",
-                                                                    )}
-                                                                    onClick={(e) => handleRowClick(f.format_id, e)}
-                                                                >
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{formatResolution(f)}</td>
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.ext}</td>
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.fps !== null ? Math.round(f.fps) : "-"}</td>
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{formatBitrate(f.tbr)}</td>
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.vcodec ?? "-"}</td>
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{f.acodec ?? "-"}</td>
-                                                                    <td className={cellClass(isSelected, isExprMatch)}>{formatSize(f.filesize)}</td>
-                                                                    <td className="px-2.5 py-1.5 border-b border-white/[0.02] whitespace-nowrap">
-                                                                        <span className={cn(
-                                                                            "inline-block px-[7px] py-0.5 rounded-full text-[9px] font-bold tracking-wider uppercase font-mono",
-                                                                            type.className,
-                                                                        )}>
-                                                                            {type.label}
-                                                                        </span>
-                                                                    </td>
-                                                                </tr>
-                                                            );
-                                                        })}
-                                                    </tbody>
-                                                </table>
-                                            </div>
-                                        </ScrollArea>
+                            {/* Scrollable table */}
+                            <ScrollArea className="flex-1 min-h-0" ref={tableRef}>
+                                <Table className="text-xs">
+                                    <TableHeader className="sticky top-0 z-10">
+                                        <TableRow className="bg-muted/80 backdrop-blur-sm hover:bg-muted/80">
+                                            {COLUMNS.map(({ key, label, align }) => (
+                                                <TableHead
+                                                    key={key}
+                                                    className={cn(
+                                                        "h-8 px-3 text-[10px] font-bold tracking-wider uppercase select-none cursor-pointer transition-colors hover:text-foreground",
+                                                        align === "right" && "text-right",
+                                                        sortKey === key ? "text-primary" : "text-muted-foreground",
+                                                    )}
+                                                    onClick={() => handleSortClick(key)}
+                                                >
+                                                    <span className="inline-flex items-center gap-1">
+                                                        {label}
+                                                        {sortKey === key && (
+                                                            sortDir === "asc"
+                                                                ? <ChevronUp className="size-3" />
+                                                                : <ChevronDown className="size-3" />
+                                                        )}
+                                                    </span>
+                                                </TableHead>
+                                            ))}
+                                            <TableHead className="h-8 px-3 text-[10px] font-bold tracking-wider uppercase text-muted-foreground select-none text-center">
+                                                Type
+                                            </TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {groups.map((group) => (
+                                            <GroupSection
+                                                key={group.label}
+                                                group={group}
+                                                selectedId={selectedId}
+                                                mergeId={mergeId}
+                                                exprMatches={exprMatches}
+                                                onRowClick={handleRowClick}
+                                            />
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </ScrollArea>
 
-                                        {selectedId && (
-                                            <div className="px-2.5 py-1.5 text-xs text-muted-foreground bg-muted border-t border-border">
-                                                Selected: <strong className="text-primary font-mono">{selectedId}</strong>
-                                                {mergeId && (
-                                                    <> + <strong className="text-primary font-mono">{mergeId}</strong> (merge)</>
-                                                )}
-                                                <span className="text-muted-foreground italic">
-                                                    {!mergeId && " \u2014 Shift+click another format to merge"}
-                                                </span>
-                                            </div>
+                            {/* Selection info bar */}
+                            <div className="px-5 py-2 text-xs text-muted-foreground bg-muted/50 border-t border-border shrink-0 flex items-center gap-2 min-h-[36px]">
+                                {selectedId ? (
+                                    <>
+                                        <span>
+                                            Selected: <strong className="text-foreground font-mono">{selectedId}</strong>
+                                            {findFormat(selectedId) && (
+                                                <span className="text-muted-foreground"> ({formatBrief(findFormat(selectedId)!)})</span>
+                                            )}
+                                            {mergeId && (
+                                                <>
+                                                    {" + "}
+                                                    <strong className="text-foreground font-mono">{mergeId}</strong>
+                                                    {findFormat(mergeId) && (
+                                                        <span className="text-muted-foreground"> ({formatBrief(findFormat(mergeId)!)})</span>
+                                                    )}
+                                                </>
+                                            )}
+                                        </span>
+                                        <button
+                                            className="text-[11px] text-muted-foreground hover:text-foreground underline underline-offset-2 bg-transparent border-none cursor-pointer"
+                                            onClick={handleClearSelection}
+                                        >
+                                            Clear
+                                        </button>
+                                        {!mergeId && (
+                                            <span className="text-muted-foreground/60 italic ml-auto text-[11px]">
+                                                Shift+click to merge
+                                            </span>
                                         )}
-                                    </div>
-                                </CollapsibleContent>
-                            </Collapsible>
+                                    </>
+                                ) : (
+                                    <span className="text-muted-foreground/60 italic">
+                                        {activePresetId
+                                            ? `Using preset: ${PRESETS.find((p) => p.id === activePresetId)?.label}`
+                                            : "Click a format to select, or choose a preset above"}
+                                    </span>
+                                )}
+                            </div>
 
                             {/* Expert mode */}
-                            <div className="flex items-center gap-2">
-                                <Checkbox
-                                    checked={expertMode}
-                                    onCheckedChange={(checked) => setExpertMode(checked === true)}
-                                    id="expert-mode"
-                                />
-                                <Label
-                                    htmlFor="expert-mode"
-                                    className="text-xs font-semibold text-muted-foreground cursor-pointer select-none transition-colors hover:text-foreground"
-                                >
-                                    Expert Mode
-                                </Label>
-                            </div>
-
-                            {expertMode && (
-                                <div className="flex flex-col gap-1 animate-in fade-in-0 zoom-in-95">
-                                    <div className="text-[11px] font-semibold text-muted-foreground tracking-wide">
-                                        Format Expression
-                                    </div>
-                                    <Input
-                                        className={cn(
-                                            "font-mono text-[13px]",
-                                            exprError && "border-destructive ring-1 ring-destructive/30",
-                                        )}
-                                        type="text"
-                                        placeholder="e.g. bestvideo[height<=1080]+bestaudio/best"
-                                        value={expr}
-                                        onChange={(e) => handleExprChange(e.target.value)}
+                            <div className="px-5 py-2 shrink-0 flex flex-col gap-2 border-t border-border">
+                                <div className="flex items-center gap-2">
+                                    <Checkbox
+                                        checked={expertMode}
+                                        onCheckedChange={(checked) => setExpertMode(checked === true)}
+                                        id="expert-mode"
                                     />
-                                    {exprError && (
-                                        <span className="text-[11px] text-destructive">{exprError}</span>
-                                    )}
-                                </div>
-                            )}
-
-                            <Separator />
-
-                            {/* Output directory picker */}
-                            <div className="flex flex-col gap-1.5">
-                                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
-                                    Save to
-                                </Label>
-                                <div className="flex gap-1.5">
-                                    <Input
-                                        className="flex-1 text-xs h-8"
-                                        type="text"
-                                        readOnly
-                                        value={options.outputDir ?? settings?.output_dir ?? ""}
-                                        placeholder="Default output directory"
-                                    />
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        className="h-8 px-2.5 shrink-0"
-                                        onClick={() => { handleBrowseDir().catch((e) => console.error("Browse directory failed:", e)); }}
+                                    <Label
+                                        htmlFor="expert-mode"
+                                        className="text-[11px] font-semibold text-muted-foreground cursor-pointer select-none"
                                     >
-                                        <FolderOpen className="size-3.5" />
-                                        Browse
-                                    </Button>
+                                        Expert Mode
+                                    </Label>
                                 </div>
+                                {expertMode && (
+                                    <div className="flex flex-col gap-1 animate-in fade-in-0 slide-in-from-top-1 duration-150">
+                                        <Input
+                                            className={cn(
+                                                "font-mono text-xs h-8",
+                                                exprError && "border-destructive ring-1 ring-destructive/30",
+                                            )}
+                                            type="text"
+                                            placeholder="e.g. bestvideo[height<=1080]+bestaudio/best"
+                                            value={expr}
+                                            onChange={(e) => handleExprChange(e.target.value)}
+                                        />
+                                        {exprError && (
+                                            <span className="text-[11px] text-destructive">{exprError}</span>
+                                        )}
+                                    </div>
+                                )}
                             </div>
-
-                            {/* Download options */}
-                            <FormatOptionsPanel
-                                value={options}
-                                onChange={setOptions}
-                                availableSubtitleLangs={subtitleLangs}
-                                hidePresets
-                            />
                         </>
                     )}
                 </div>
 
-                <DialogFooter className="px-4 py-2.5 border-t border-border shrink-0">
-                    <Button variant="outline" onClick={onClose}>
+                {/* -- Zone 3: Collapsed Options + Footer -- */}
+                {!isLoading && !error && formatData && (
+                    <div className="border-t border-border shrink-0">
+                        <Collapsible open={showOptions} onOpenChange={setShowOptions}>
+                            <CollapsibleTrigger asChild>
+                                <button className="w-full px-5 py-2 flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer bg-transparent border-none">
+                                    <Settings2 className="size-3.5" />
+                                    <span className="font-semibold">Download Options</span>
+                                    <span className="text-muted-foreground/60 ml-1 truncate">
+                                        {!showOptions && optionsSummary(options)}
+                                    </span>
+                                    {showOptions
+                                        ? <ChevronUp className="size-3.5 ml-auto shrink-0" />
+                                        : <ChevronDown className="size-3.5 ml-auto shrink-0" />}
+                                </button>
+                            </CollapsibleTrigger>
+                            <CollapsibleContent>
+                                <div className="px-5 pb-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2.5 items-center animate-in fade-in-0 slide-in-from-top-1 duration-150">
+                                    {/* Save to */}
+                                    <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                                        Save to
+                                    </Label>
+                                    <div className="flex gap-1.5">
+                                        <Input
+                                            className="flex-1 text-xs h-7 font-mono"
+                                            type="text"
+                                            readOnly
+                                            value={options.outputDir ?? settings?.output_dir ?? ""}
+                                            placeholder="Default directory"
+                                        />
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="h-7 px-2 shrink-0 text-xs"
+                                            onClick={() => { handleBrowseDir().catch((e) => console.error("Browse directory failed:", e)); }}
+                                        >
+                                            <FolderOpen className="size-3" />
+                                        </Button>
+                                    </div>
+
+                                    {/* Remux */}
+                                    <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                                        Remux
+                                    </Label>
+                                    <Select
+                                        value={options.remux ?? NONE_SENTINEL}
+                                        onValueChange={(val) => setOptions((prev) => ({
+                                            ...prev,
+                                            remux: val === NONE_SENTINEL ? null : (val as ContainerFormat),
+                                        }))}
+                                    >
+                                        <SelectTrigger className="h-7 text-xs">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                                            {REMUX_OPTIONS.map((o) => (
+                                                <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+
+                                    {/* Extract Audio */}
+                                    <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                                        Audio
+                                    </Label>
+                                    <Select
+                                        value={options.extractAudio ?? NONE_SENTINEL}
+                                        onValueChange={(val) => setOptions((prev) => ({
+                                            ...prev,
+                                            extractAudio: val === NONE_SENTINEL ? null : (val as AudioFormat),
+                                        }))}
+                                    >
+                                        <SelectTrigger className="h-7 text-xs">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                                            {AUDIO_OPTIONS.map((o) => (
+                                                <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+
+                                    {/* Subtitles */}
+                                    <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                                        Subtitles
+                                    </Label>
+                                    <div className="flex flex-col gap-1.5">
+                                        <div className="flex items-center gap-2">
+                                            <Checkbox
+                                                checked={options.subtitles}
+                                                onCheckedChange={(checked) => setOptions((prev) => ({
+                                                    ...prev,
+                                                    subtitles: checked === true,
+                                                }))}
+                                                id="dialog-subtitles"
+                                            />
+                                            <Label htmlFor="dialog-subtitles" className="text-xs text-muted-foreground cursor-pointer">
+                                                Download subtitles
+                                            </Label>
+                                        </div>
+                                        {options.subtitles && (
+                                            <div className="animate-in fade-in-0 duration-150">
+                                                {subtitleLangs.length > 0 ? (
+                                                    <Popover>
+                                                        <PopoverTrigger asChild>
+                                                            <Button variant="outline" size="sm" className="w-full justify-between text-xs font-normal h-7">
+                                                                <span className="truncate">
+                                                                    {options.subtitleLangs.length > 0
+                                                                        ? options.subtitleLangs.join(", ")
+                                                                        : "Select languages"}
+                                                                </span>
+                                                            </Button>
+                                                        </PopoverTrigger>
+                                                        <PopoverContent align="start" className="w-(--radix-popover-trigger-width) p-2">
+                                                            <div className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+                                                                {subtitleLangs.map((lang) => (
+                                                                    <Label
+                                                                        key={lang}
+                                                                        htmlFor={`dialog-sub-${lang}`}
+                                                                        className="flex items-center gap-2 rounded-sm px-2 py-1 text-xs cursor-pointer hover:bg-accent"
+                                                                    >
+                                                                        <Checkbox
+                                                                            id={`dialog-sub-${lang}`}
+                                                                            checked={options.subtitleLangs.includes(lang)}
+                                                                            onCheckedChange={() => handleSubLangSelect(lang)}
+                                                                        />
+                                                                        {lang}
+                                                                    </Label>
+                                                                ))}
+                                                            </div>
+                                                        </PopoverContent>
+                                                    </Popover>
+                                                ) : (
+                                                    <Input
+                                                        className="font-mono text-xs h-7"
+                                                        type="text"
+                                                        placeholder="en,sv,ja"
+                                                        value={options.subtitleLangs.join(",")}
+                                                        onChange={(e) => {
+                                                            const langs = e.target.value.split(",").map((s) => s.trim()).filter(Boolean);
+                                                            setOptions((prev) => ({ ...prev, subtitleLangs: langs }));
+                                                        }}
+                                                    />
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    {/* Thumbnail */}
+                                    <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                                        Thumbnail
+                                    </Label>
+                                    <div className="flex items-center gap-2">
+                                        <Checkbox
+                                            checked={options.embedThumbnail}
+                                            onCheckedChange={(checked) => setOptions((prev) => ({
+                                                ...prev,
+                                                embedThumbnail: checked === true,
+                                            }))}
+                                            id="dialog-thumbnail"
+                                        />
+                                        <Label htmlFor="dialog-thumbnail" className="text-xs text-muted-foreground cursor-pointer">
+                                            Embed thumbnail
+                                        </Label>
+                                    </div>
+                                </div>
+                            </CollapsibleContent>
+                        </Collapsible>
+                    </div>
+                )}
+
+                <DialogFooter className="px-5 py-2.5 border-t border-border shrink-0">
+                    <Button variant="outline" size="sm" onClick={onClose}>
                         Cancel
                     </Button>
-                    <Button
-                        onClick={handleConfirm}
-                        disabled={isLoading || !!error}
-                    >
+                    <Button size="sm" onClick={handleConfirm} disabled={isLoading || !!error}>
                         Download
                     </Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>
+    );
+}
+
+// -- Sub-components ---------------------------------------------------
+
+interface GroupSectionProps {
+    group: FormatGroup;
+    selectedId: string | null;
+    mergeId: string | null;
+    exprMatches: Set<string>;
+    onRowClick: (id: string, e: React.MouseEvent) => void;
+}
+
+/** Renders a section header + rows for a format group (Video+Audio, Video Only, Audio Only). */
+function GroupSection({ group, selectedId, mergeId, exprMatches, onRowClick }: GroupSectionProps) {
+    return (
+        <>
+            {/* Section header */}
+            <TableRow className="hover:bg-transparent bg-transparent border-none">
+                <TableCell
+                    colSpan={8}
+                    className="px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60"
+                >
+                    {group.label}
+                </TableCell>
+            </TableRow>
+
+            {/* Format rows */}
+            {group.formats.map((f, i) => {
+                const type = formatType(f);
+                const isSelected = f.format_id === selectedId;
+                const isMerge = f.format_id === mergeId;
+                const isExprMatch = exprMatches.has(f.format_id);
+                const isEven = i % 2 === 0;
+
+                return (
+                    <TableRow
+                        key={f.format_id}
+                        data-state={isSelected || isMerge ? "selected" : undefined}
+                        className={cn(
+                            "cursor-pointer transition-colors",
+                            isEven ? "bg-transparent" : "bg-muted/30",
+                            isSelected && "bg-primary/8 border-l-2 border-l-primary",
+                            isMerge && "bg-primary/5 border-l-2 border-l-primary border-dashed",
+                            isExprMatch && !isSelected && !isMerge && "bg-yellow-500/5",
+                        )}
+                        onClick={(e) => onRowClick(f.format_id, e)}
+                    >
+                        <TableCell className={cn(
+                            "px-3 font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {formatResolution(f)}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {f.ext}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3 text-right font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {f.fps !== null ? Math.round(f.fps) : "\u2014"}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3 text-right font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {formatBitrate(f.tbr)}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {f.vcodec ?? "\u2014"}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {f.acodec ?? "\u2014"}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3 text-right font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                        )}>
+                            {formatSize(f.filesize)}
+                        </TableCell>
+                        <TableCell className="px-3 text-center">
+                            <span className={cn(
+                                "inline-block px-1.5 py-0.5 rounded text-[9px] font-bold tracking-wider uppercase",
+                                type.className,
+                            )}>
+                                {type.label}
+                            </span>
+                        </TableCell>
+                    </TableRow>
+                );
+            })}
+        </>
     );
 }

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -469,7 +469,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                         <ToggleGroupItem
                                             key={p.id}
                                             value={p.id}
-                                            className="px-3 h-7 text-xs rounded-[5px] data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                                            className="px-3 h-7 text-xs rounded-[5px] text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04] data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-sm"
                                         >
                                             {p.label}
                                         </ToggleGroupItem>
@@ -488,7 +488,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                                     className={cn(
                                                         "h-8 px-3 text-[10px] font-bold tracking-wider uppercase select-none cursor-pointer transition-colors hover:text-foreground",
                                                         align === "right" && "text-right",
-                                                        sortKey === key ? "text-primary" : "text-muted-foreground",
+                                                        sortKey === key ? "text-foreground" : "text-muted-foreground",
                                                     )}
                                                     onClick={() => handleSortClick(key)}
                                                 >
@@ -556,13 +556,13 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                             Clear
                                         </button>
                                         {!mergeId && (
-                                            <span className="text-muted-foreground/60 italic ml-auto text-[11px]">
+                                            <span className="text-muted-foreground italic ml-auto text-[11px]">
                                                 Shift+click to merge
                                             </span>
                                         )}
                                     </>
                                 ) : (
-                                    <span className="text-muted-foreground/60 italic">
+                                    <span className="text-muted-foreground italic">
                                         {presetId
                                             ? `Using preset: ${PRESETS.find((p) => p.id === presetId)?.label}`
                                             : "Click a format to select, or choose a preset above"}
@@ -811,7 +811,7 @@ function GroupSection({ group, selectedId, mergeId, exprMatches, onRowClick }: G
             <TableRow className="hover:bg-transparent bg-transparent border-none">
                 <TableCell
                     colSpan={8}
-                    className="px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60"
+                    className="px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-foreground/40"
                 >
                     {group.label}
                 </TableCell>
@@ -830,53 +830,53 @@ function GroupSection({ group, selectedId, mergeId, exprMatches, onRowClick }: G
                         key={f.format_id}
                         data-state={isSelected || isMerge ? "selected" : undefined}
                         className={cn(
-                            "cursor-pointer transition-colors",
-                            isEven ? "bg-transparent" : "bg-muted/30",
-                            isSelected && "bg-primary/8 border-l-2 border-l-primary",
-                            isMerge && "bg-primary/5 border-l-2 border-l-primary border-dashed",
+                            "cursor-pointer transition-colors hover:bg-foreground/[0.04]",
+                            isEven ? "bg-transparent" : "bg-foreground/[0.03]",
+                            isSelected && "bg-primary/[0.06] border-l-2 border-l-primary/70",
+                            isMerge && "bg-foreground/[0.05] border-l-2 border-l-foreground/30 border-dashed",
                             isExprMatch && !isSelected && !isMerge && "bg-yellow-500/5",
                         )}
                         onClick={(e) => onRowClick(f.format_id, e)}
                     >
                         <TableCell className={cn(
                             "px-3 font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {formatResolution(f)}
                         </TableCell>
                         <TableCell className={cn(
                             "px-3",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {f.ext}
                         </TableCell>
                         <TableCell className={cn(
                             "px-3 text-right font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {f.fps !== null ? Math.round(f.fps) : "\u2014"}
                         </TableCell>
                         <TableCell className={cn(
                             "px-3 text-right font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {formatBitrate(f.tbr)}
                         </TableCell>
                         <TableCell className={cn(
                             "px-3",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {f.vcodec ?? "\u2014"}
                         </TableCell>
                         <TableCell className={cn(
                             "px-3",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {f.acodec ?? "\u2014"}
                         </TableCell>
                         <TableCell className={cn(
                             "px-3 text-right font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-muted-foreground",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
                         )}>
                             {formatSize(f.filesize)}
                         </TableCell>

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -12,6 +12,7 @@ import { formatsQueryOptions } from "../api/formats";
 import { settingsQueryOptions, pickDirectory } from "../api/settings";
 import { invokeTyped } from "../api/invokeClient";
 import { PRESETS, buildDefaultOptions } from "./FormatOptionsPanel";
+import { FormatGroupSection, type FormatGroup } from "./FormatGroupSection";
 import { cn } from "@/lib/utils";
 import {
     Dialog,
@@ -74,11 +75,6 @@ interface FormatDialogProps {
     onClose: () => void;
 }
 
-interface FormatGroup {
-    label: string;
-    formats: FormatInfo[];
-}
-
 // -- Constants --------------------------------------------------------
 
 const COLUMNS: Array<{ key: SortKey; label: string; align: "left" | "right" }> = [
@@ -107,36 +103,6 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
 const NONE_SENTINEL = "none";
 
 // -- Utility functions ------------------------------------------------
-
-function formatSize(bytes: number | null): string {
-    if (bytes === null) return "\u2014";
-    if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
-    if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
-    if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(0)} KB`;
-    return `${bytes} B`;
-}
-
-function formatBitrate(kbps: number | null): string {
-    if (kbps === null) return "\u2014";
-    if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
-    return `${Math.round(kbps)} kbps`;
-}
-
-function formatResolution(f: FormatInfo): string {
-    if (f.height && f.width) return `${f.width}\u00d7${f.height}`;
-    if (f.height) return `${f.height}p`;
-    return f.format_note ?? "\u2014";
-}
-
-function formatType(f: FormatInfo): { label: string; className: string } {
-    if (f.protocol.includes("m3u8"))
-        return { label: "HLS", className: "bg-yellow-500/10 text-yellow-500" };
-    if (f.has_video && f.has_audio)
-        return { label: "V+A", className: "bg-primary/10 text-primary" };
-    if (f.has_video)
-        return { label: "Video", className: "bg-blue-500/10 text-blue-400" };
-    return { label: "Audio", className: "bg-purple-500/10 text-purple-400" };
-}
 
 /** Brief description for the selection info bar. */
 function formatBrief(f: FormatInfo): string {
@@ -478,8 +444,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                             </div>
 
                             {/* Scrollable table */}
-                            <div className="flex-1 min-h-0 overflow-hidden" ref={tableRef}>
-                            <ScrollArea className="h-full">
+                            <ScrollArea className="flex-1 min-h-0" type="auto" ref={tableRef}>
                                 <Table className="text-xs">
                                     <TableHeader className="sticky top-0 z-10">
                                         <TableRow className="bg-foreground/[0.06] backdrop-blur-sm hover:bg-foreground/[0.06]">
@@ -511,7 +476,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                     <TableBody>
                                         {groups.length > 0 ? (
                                             groups.map((group) => (
-                                                <GroupSection
+                                                <FormatGroupSection
                                                     key={group.label}
                                                     group={group}
                                                     selectedId={selectedId}
@@ -530,7 +495,6 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                     </TableBody>
                                 </Table>
                             </ScrollArea>
-                            </div>
 
                             {/* Selection info bar */}
                             <div className="px-5 py-2 text-xs text-muted-foreground bg-card border-t border-border shrink-0 flex items-center gap-2 min-h-[36px]">
@@ -795,103 +759,3 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     );
 }
 
-// -- Sub-components ---------------------------------------------------
-
-interface GroupSectionProps {
-    group: FormatGroup;
-    selectedId: string | null;
-    mergeId: string | null;
-    exprMatches: Set<string>;
-    onRowClick: (id: string, e: React.MouseEvent) => void;
-}
-
-/** Renders a section header + rows for a format group (Video+Audio, Video Only, Audio Only). */
-function GroupSection({ group, selectedId, mergeId, exprMatches, onRowClick }: GroupSectionProps) {
-    return (
-        <>
-            {/* Section header */}
-            <TableRow className="hover:bg-transparent bg-transparent border-none">
-                <TableCell
-                    colSpan={8}
-                    className="px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-foreground/40"
-                >
-                    {group.label}
-                </TableCell>
-            </TableRow>
-
-            {/* Format rows */}
-            {group.formats.map((f, i) => {
-                const type = formatType(f);
-                const isSelected = f.format_id === selectedId;
-                const isMerge = f.format_id === mergeId;
-                const isExprMatch = exprMatches.has(f.format_id);
-                const isEven = i % 2 === 0;
-
-                return (
-                    <TableRow
-                        key={f.format_id}
-                        className={cn(
-                            "cursor-pointer transition-colors border-b-foreground/[0.06] hover:bg-foreground/[0.06]",
-                            isEven ? "bg-transparent" : "bg-foreground/[0.02]",
-                            isSelected && "bg-primary/20 border-l-[3px] border-l-primary",
-                            isMerge && "bg-foreground/10 border-l-[3px] border-l-foreground/40",
-                            isExprMatch && !isSelected && !isMerge && "bg-yellow-500/5",
-                        )}
-                        onClick={(e) => onRowClick(f.format_id, e)}
-                    >
-                        <TableCell className={cn(
-                            "px-3 font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {formatResolution(f)}
-                        </TableCell>
-                        <TableCell className={cn(
-                            "px-3",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {f.ext}
-                        </TableCell>
-                        <TableCell className={cn(
-                            "px-3 text-right font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {f.fps !== null ? Math.round(f.fps) : "\u2014"}
-                        </TableCell>
-                        <TableCell className={cn(
-                            "px-3 text-right font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {formatBitrate(f.tbr)}
-                        </TableCell>
-                        <TableCell className={cn(
-                            "px-3",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {f.vcodec ?? "\u2014"}
-                        </TableCell>
-                        <TableCell className={cn(
-                            "px-3",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {f.acodec ?? "\u2014"}
-                        </TableCell>
-                        <TableCell className={cn(
-                            "px-3 text-right font-mono",
-                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
-                        )}>
-                            {formatSize(f.filesize)}
-                        </TableCell>
-                        <TableCell className="px-3 text-center">
-                            <span className={cn(
-                                "inline-block px-1.5 py-0.5 rounded text-[9px] font-bold tracking-wider uppercase",
-                                type.className,
-                            )}>
-                                {type.label}
-                            </span>
-                        </TableCell>
-                    </TableRow>
-                );
-            })}
-        </>
-    );
-}

--- a/crates/rdlp-desktop/src/components/FormatGroupSection.tsx
+++ b/crates/rdlp-desktop/src/components/FormatGroupSection.tsx
@@ -1,0 +1,144 @@
+import { cn } from "@/lib/utils";
+import {
+    TableCell,
+    TableRow,
+} from "@/components/ui/table";
+import type { FormatInfo } from "../types";
+
+// -- Types ----------------------------------------------------------------
+
+export interface FormatGroup {
+    label: string;
+    formats: FormatInfo[];
+}
+
+interface FormatGroupSectionProps {
+    group: FormatGroup;
+    selectedId: string | null;
+    mergeId: string | null;
+    exprMatches: Set<string>;
+    onRowClick: (id: string, e: React.MouseEvent) => void;
+}
+
+// -- Utility functions ----------------------------------------------------
+
+function formatSize(bytes: number | null): string {
+    if (bytes === null) return "\u2014";
+    if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+    if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+    if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(0)} KB`;
+    return `${bytes} B`;
+}
+
+function formatBitrate(kbps: number | null): string {
+    if (kbps === null) return "\u2014";
+    if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+    return `${Math.round(kbps)} kbps`;
+}
+
+function formatResolution(f: FormatInfo): string {
+    if (f.height && f.width) return `${f.width}\u00d7${f.height}`;
+    if (f.height) return `${f.height}p`;
+    return f.format_note ?? "\u2014";
+}
+
+function formatType(f: FormatInfo): { label: string; className: string } {
+    if (f.protocol.includes("m3u8"))
+        return { label: "HLS", className: "bg-yellow-500/10 text-yellow-500" };
+    if (f.has_video && f.has_audio)
+        return { label: "V+A", className: "bg-primary/10 text-primary" };
+    if (f.has_video)
+        return { label: "Video", className: "bg-blue-500/10 text-blue-400" };
+    return { label: "Audio", className: "bg-purple-500/10 text-purple-400" };
+}
+
+/** Renders a section header + rows for a format group (Video+Audio, Video Only, Audio Only). */
+export function FormatGroupSection({ group, selectedId, mergeId, exprMatches, onRowClick }: FormatGroupSectionProps) {
+    return (
+        <>
+            {/* Section header */}
+            <TableRow className="hover:bg-transparent bg-transparent border-none">
+                <TableCell
+                    colSpan={8}
+                    className="px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-foreground/40"
+                >
+                    {group.label}
+                </TableCell>
+            </TableRow>
+
+            {/* Format rows */}
+            {group.formats.map((f, i) => {
+                const type = formatType(f);
+                const isSelected = f.format_id === selectedId;
+                const isMerge = f.format_id === mergeId;
+                const isExprMatch = exprMatches.has(f.format_id);
+                const isEven = i % 2 === 0;
+
+                return (
+                    <TableRow
+                        key={f.format_id}
+                        className={cn(
+                            "cursor-pointer transition-colors border-b-foreground/[0.06] hover:bg-foreground/[0.06]",
+                            isEven ? "bg-transparent" : "bg-foreground/[0.02]",
+                            isSelected && "bg-primary/20 border-l-[3px] border-l-primary",
+                            isMerge && "bg-foreground/10 border-l-[3px] border-l-foreground/40",
+                            isExprMatch && !isSelected && !isMerge && "bg-yellow-500/5",
+                        )}
+                        onClick={(e) => onRowClick(f.format_id, e)}
+                    >
+                        <TableCell className={cn(
+                            "px-3 font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {formatResolution(f)}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {f.ext}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3 text-right font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {f.fps !== null ? Math.round(f.fps) : "\u2014"}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3 text-right font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {formatBitrate(f.tbr)}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {f.vcodec ?? "\u2014"}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {f.acodec ?? "\u2014"}
+                        </TableCell>
+                        <TableCell className={cn(
+                            "px-3 text-right font-mono",
+                            isSelected || isMerge ? "text-foreground" : isExprMatch ? "text-yellow-500" : "text-foreground/60",
+                        )}>
+                            {formatSize(f.filesize)}
+                        </TableCell>
+                        <TableCell className="px-3 text-center">
+                            <span className={cn(
+                                "inline-block px-1.5 py-0.5 rounded text-[9px] font-bold tracking-wider uppercase",
+                                type.className,
+                            )}>
+                                {type.label}
+                            </span>
+                        </TableCell>
+                    </TableRow>
+                );
+            })}
+        </>
+    );
+}

--- a/crates/rdlp-desktop/src/components/ui/dialog.tsx
+++ b/crates/rdlp-desktop/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/95",
         className
       )}
       {...props}

--- a/crates/rdlp-desktop/src/components/ui/scroll-area.tsx
+++ b/crates/rdlp-desktop/src/components/ui/scroll-area.tsx
@@ -11,12 +11,12 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden flex flex-col", className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 w-full flex-1 min-h-0 rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
@@ -47,7 +47,7 @@ function ScrollBar({
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="bg-border relative flex-1 rounded-full"
+        className="bg-foreground/15 hover:bg-foreground/25 relative flex-1 rounded-full transition-colors"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )

--- a/crates/rdlp-desktop/src/components/ui/toggle-group.tsx
+++ b/crates/rdlp-desktop/src/components/ui/toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/crates/rdlp-desktop/src/components/ui/toggle.tsx
+++ b/crates/rdlp-desktop/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/crates/rdlp-desktop/src/index.css
+++ b/crates/rdlp-desktop/src/index.css
@@ -6,9 +6,9 @@
     :root {
         --background: 220 6% 7%;
         --foreground: 240 4% 92%;
-        --card: 220 5% 9%;
+        --card: 220 5% 13%;
         --card-foreground: 240 4% 92%;
-        --popover: 220 5% 9%;
+        --popover: 220 5% 13%;
         --popover-foreground: 240 4% 92%;
         --primary: 160 79% 40%;
         --primary-foreground: 0 0% 100%;


### PR DESCRIPTION
## Summary

- Overhaul FormatDialog into a hero table layout with preset filters, collapsible options, and expert mode
- Fix Radix ScrollArea not scrolling in nested flex layouts by replacing viewport `height: 100%` with `flex-1 min-h-0`
- Fix dialog overflow, WCAG contrast, and content transparency issues
- Add shadcn toggle-group component for preset filter bar
- Extract FormatGroupSection into its own file

## Changes

### FormatDialog overhaul
- Hero format table with sortable columns, grouped sections (Video+Audio, Video Only, Audio Only)
- Preset filter bar (Best Quality, 1080p, 720p, Audio Only) using toggle-group
- Collapsible download options panel (save dir, remux, audio extraction, subtitles, thumbnail)
- Expert mode with format expression input and live validation
- Shift+click merge selection for video+audio format combining
- Empty filter state with guidance text

### ScrollArea fix (scroll-area.tsx)
- Root: add `flex flex-col overflow-hidden` so Viewport can use flex-based sizing
- Viewport: replace `size-full` (height: 100%) with `flex-1 min-h-0 w-full` to avoid percentage height resolution failure in nested flex contexts
- Override Radix internal `display: table` content wrapper with `[&>div]:!block` (radix-ui/primitives#2964)
- Improve scrollbar thumb visibility with `bg-foreground/15` and hover state

### Visual/UX fixes
- WCAG 1.4.11 compliant selected row: `bg-primary/20` + 3px solid primary border (6.19:1 contrast ratio)
- Opaque backgrounds on info bar and expert mode sections (prevent content bleeding)
- Dialog overlay at 95% opacity for dark theme
- Removed `data-state="selected"` from TableRow to avoid base class CSS specificity override

## Test plan
- [ ] Open FormatDialog on video with many formats — verify table scrolls within dialog bounds
- [ ] Click preset filters (1080p, 720p, Audio Only) — verify table filters correctly
- [ ] Click a format row — verify selection highlight with green left border
- [ ] Shift+click another row — verify merge selection
- [ ] Toggle expert mode — verify expression input appears
- [ ] Expand Download Options — verify all controls work
- [ ] Verify dialog stays contained within viewport (no overflow past footer)