### PR TITLE
refactor(desktop): replace native selects with shadcn Select

### DIFF
--- a/crates/rdlp-desktop/src/components/CommandBar.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.tsx
@@ -8,6 +8,13 @@ import { Search, ArrowRight, Loader2, X } from "lucide-react";
 import { searchParamsAtom, setSearchParam, resetSearchParams } from "../stores/searchParamsStore";
 import { providersQueryOptions, searchQueryOptions } from "../api/search";
 import { Button } from "@/components/ui/button";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 
 interface CommandBarProps {
     /** Ref exposed so keyboard nav can focus the input externally. */
@@ -69,27 +76,25 @@ export function CommandBar({ inputRef, activeTab }: CommandBarProps) {
 
     return (
         <form className="flex items-center gap-1.5" onSubmit={handleSubmit} ref={formRef}>
-            <select
-                className="h-9 rounded-md border border-input bg-card px-2.5 pr-7 text-xs font-medium text-foreground cursor-pointer appearance-none transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
+            <Select
                 value={site}
-                onChange={(e) => handleSiteChange(e.target.value)}
+                onValueChange={handleSiteChange}
                 disabled={isFetching}
-                aria-label="Search site"
-                style={{
-                    backgroundImage: "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
-                    backgroundRepeat: "no-repeat",
-                    backgroundPosition: "right 8px center",
-                }}
             >
-                {providers.length === 0 && (
-                    <option value="">Loading...</option>
-                )}
-                {providers.map((p) => (
-                    <option key={p.name} value={p.name}>
-                        {p.display_name}
-                    </option>
-                ))}
-            </select>
+                <SelectTrigger
+                    className="h-9 w-auto rounded-md border border-input bg-card px-2.5 text-xs font-medium text-foreground cursor-pointer transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
+                    aria-label="Search site"
+                >
+                    <SelectValue placeholder="Loading..." />
+                </SelectTrigger>
+                <SelectContent>
+                    {providers.map((p) => (
+                        <SelectItem key={p.name} value={p.name}>
+                            {p.display_name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
 
             <div className="flex-1 relative flex items-center group">
                 <Search className="absolute left-2.5 h-3.5 w-3.5 text-muted-foreground pointer-events-none transition-colors group-focus-within:text-primary" />

--- a/crates/rdlp-desktop/src/components/FilterBar.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.tsx
@@ -7,9 +7,19 @@ import { useQuery } from "@tanstack/react-query";
 import { Settings, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 import { searchParamsAtom } from "../stores/searchParamsStore";
 import { filtersQueryOptions, searchQueryOptions } from "../api/search";
 import type { SearchFilter } from "../types";
+
+/** Sentinel value for "no selection" since Radix Select does not support empty string values. */
+const NONE_SENTINEL = "none";
 
 const DEFAULT_FILTER_KEYS = new Set([
     "sort", "quality", "orientations", "date", "min-duration", "max-duration",
@@ -66,7 +76,8 @@ export function FilterBar() {
         refetch().catch((e) => console.error("Refetch failed:", e));
     }, [filters, hasUserFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const handleFilterChange = (key: string, value: string) => {
+    const handleFilterChange = (key: string, rawValue: string) => {
+        const value = rawValue === NONE_SENTINEL ? "" : rawValue;
         const updated: SearchFilter[] = filters.filter((f) => f.key !== key);
         if (value !== "") {
             updated.push({ key, value });
@@ -115,36 +126,35 @@ export function FilterBar() {
                     const value = getFilterValue(desc.key);
                     const active = isFilterActive(value, desc.default);
                     return (
-                        <select
+                        <Select
                             key={desc.key}
-                            className={cn(
-                                "h-7 rounded-md border border-border/50 bg-transparent px-2.5 pr-6 text-[11px] font-medium text-muted-foreground cursor-pointer appearance-none transition-colors",
-                                "hover:border-white/[0.08] hover:text-foreground/70",
-                                "focus:outline-none focus:ring-1 focus:ring-ring",
-                                "disabled:opacity-40 disabled:cursor-not-allowed",
-                                active && "border-primary/30 text-foreground bg-primary/[0.06]",
-                            )}
-                            value={value}
-                            onChange={(e) => handleFilterChange(desc.key, e.target.value)}
+                            value={value === "" ? NONE_SENTINEL : value}
+                            onValueChange={(val) => handleFilterChange(desc.key, val)}
                             disabled={isFetching}
-                            aria-label={desc.display_name}
-                            style={{
-                                backgroundImage: active
-                                    ? "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2322c55e' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")"
-                                    : "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
-                                backgroundRepeat: "no-repeat",
-                                backgroundPosition: "right 6px center",
-                            }}
                         >
-                            <option value="">
-                                {desc.display_name}
-                            </option>
-                            {desc.allowed_values.map((v) => (
-                                <option key={v.value} value={v.value}>
-                                    {v.label}
-                                </option>
-                            ))}
-                        </select>
+                            <SelectTrigger
+                                className={cn(
+                                    "h-7 w-auto rounded-md border border-border/50 bg-transparent px-2.5 text-[11px] font-medium text-muted-foreground cursor-pointer transition-colors",
+                                    "hover:border-white/[0.08] hover:text-foreground/70",
+                                    "focus:outline-none focus:ring-1 focus:ring-ring",
+                                    "disabled:opacity-40 disabled:cursor-not-allowed",
+                                    active && "border-primary/30 text-foreground bg-primary/[0.06]",
+                                )}
+                                aria-label={desc.display_name}
+                            >
+                                <SelectValue placeholder={desc.display_name} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={NONE_SENTINEL}>
+                                    {desc.display_name}
+                                </SelectItem>
+                                {desc.allowed_values.map((v) => (
+                                    <SelectItem key={v.value} value={v.value}>
+                                        {v.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
                     );
                 })}
 
@@ -194,33 +204,32 @@ export function FilterBar() {
                                 <label className="text-[10px] font-semibold text-muted-foreground tracking-wide uppercase">
                                     {desc.display_name}
                                 </label>
-                                <select
-                                    className={cn(
-                                        "h-7 rounded-md border border-border/50 bg-transparent px-2.5 pr-6 text-[11px] font-medium text-muted-foreground cursor-pointer appearance-none transition-colors",
-                                        "hover:border-white/[0.08] hover:text-foreground/70",
-                                        "focus:outline-none focus:ring-1 focus:ring-ring",
-                                        "disabled:opacity-40 disabled:cursor-not-allowed",
-                                        active && "border-primary/30 text-foreground bg-primary/[0.06]",
-                                    )}
-                                    value={value}
-                                    onChange={(e) => handleFilterChange(desc.key, e.target.value)}
+                                <Select
+                                    value={value === "" ? NONE_SENTINEL : value}
+                                    onValueChange={(val) => handleFilterChange(desc.key, val)}
                                     disabled={isFetching}
-                                    aria-label={desc.display_name}
-                                    style={{
-                                        backgroundImage: active
-                                            ? "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2322c55e' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")"
-                                            : "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
-                                        backgroundRepeat: "no-repeat",
-                                        backgroundPosition: "right 6px center",
-                                    }}
                                 >
-                                    <option value="">Any</option>
-                                    {desc.allowed_values.map((v) => (
-                                        <option key={v.value} value={v.value}>
-                                            {v.label}
-                                        </option>
-                                    ))}
-                                </select>
+                                    <SelectTrigger
+                                        className={cn(
+                                            "h-7 w-auto rounded-md border border-border/50 bg-transparent px-2.5 text-[11px] font-medium text-muted-foreground cursor-pointer transition-colors",
+                                            "hover:border-white/[0.08] hover:text-foreground/70",
+                                            "focus:outline-none focus:ring-1 focus:ring-ring",
+                                            "disabled:opacity-40 disabled:cursor-not-allowed",
+                                            active && "border-primary/30 text-foreground bg-primary/[0.06]",
+                                        )}
+                                        aria-label={desc.display_name}
+                                    >
+                                        <SelectValue placeholder="Any" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={NONE_SENTINEL}>Any</SelectItem>
+                                        {desc.allowed_values.map((v) => (
+                                            <SelectItem key={v.value} value={v.value}>
+                                                {v.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
                             </div>
                         );
                     })}

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -13,6 +13,16 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+/** Sentinel value for "no selection" since Radix Select does not support empty string values. */
+const NONE_SENTINEL = "none";
 
 export function SettingsPage() {
     const { data: settings, isLoading: settingsLoading } = useQuery(settingsQueryOptions());
@@ -61,63 +71,75 @@ export function SettingsPage() {
 
             <div className="mb-4">
                 <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Remux Format</Label>
-                <select
-                    className="flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm text-foreground shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={draft.default_remux ?? ""}
-                    onChange={(e) =>
+                <Select
+                    value={draft.default_remux ?? NONE_SENTINEL}
+                    onValueChange={(val) =>
                         setDraft({
                             ...draft,
                             default_remux:
-                                (e.target.value as ContainerFormat) || null,
+                                val === NONE_SENTINEL ? null : (val as ContainerFormat),
                         })
                     }
                 >
-                    <option value="">None</option>
-                    <option value="mp4">MP4</option>
-                    <option value="mkv">MKV</option>
-                    <option value="webm">WebM</option>
-                </select>
+                    <SelectTrigger className="w-full text-sm">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                        <SelectItem value="mp4">MP4</SelectItem>
+                        <SelectItem value="mkv">MKV</SelectItem>
+                        <SelectItem value="webm">WebM</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
 
             <div className="mb-4">
                 <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Audio Extraction</Label>
-                <select
-                    className="flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm text-foreground shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={draft.default_extract_audio ?? ""}
-                    onChange={(e) =>
+                <Select
+                    value={draft.default_extract_audio ?? NONE_SENTINEL}
+                    onValueChange={(val) =>
                         setDraft({
                             ...draft,
                             default_extract_audio:
-                                (e.target.value as AudioFormat) || null,
+                                val === NONE_SENTINEL ? null : (val as AudioFormat),
                         })
                     }
                 >
-                    <option value="">None</option>
-                    <option value="mp3">MP3</option>
-                    <option value="aac">AAC</option>
-                    <option value="opus">Opus</option>
-                    <option value="flac">FLAC</option>
-                </select>
+                    <SelectTrigger className="w-full text-sm">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                        <SelectItem value="mp3">MP3</SelectItem>
+                        <SelectItem value="aac">AAC</SelectItem>
+                        <SelectItem value="opus">Opus</SelectItem>
+                        <SelectItem value="flac">FLAC</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
 
             <div className="mb-4">
                 <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Subtitle Format</Label>
-                <select
-                    className="flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm text-foreground shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={draft.default_subtitle_format ?? ""}
-                    onChange={(e) =>
+                <Select
+                    value={draft.default_subtitle_format ?? NONE_SENTINEL}
+                    onValueChange={(val) =>
                         setDraft({
                             ...draft,
                             default_subtitle_format:
-                                (e.target.value as SubtitleFormat) || null,
+                                val === NONE_SENTINEL ? null : (val as SubtitleFormat),
                         })
                     }
                 >
-                    <option value="">None</option>
-                    <option value="srt">SRT</option>
-                    <option value="vtt">VTT</option>
-                    <option value="ass">ASS</option>
-                </select>
+                    <SelectTrigger className="w-full text-sm">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={NONE_SENTINEL}>None</SelectItem>
+                        <SelectItem value="srt">SRT</SelectItem>
+                        <SelectItem value="vtt">VTT</SelectItem>
+                        <SelectItem value="ass">ASS</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
 
             <div className="mb-4">
@@ -140,24 +162,28 @@ export function SettingsPage() {
 
             <div className="mb-4">
                 <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Search Provider</Label>
-                <select
-                    className="flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm text-foreground shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={draft.default_search_provider ?? ""}
-                    onChange={(e) =>
+                <Select
+                    value={draft.default_search_provider ?? NONE_SENTINEL}
+                    onValueChange={(val) =>
                         setDraft({
                             ...draft,
                             default_search_provider:
-                                e.target.value || null,
+                                val === NONE_SENTINEL ? null : val,
                         })
                     }
                 >
-                    <option value="">Auto</option>
-                    {providers.map((p) => (
-                        <option key={p.name} value={p.name}>
-                            {p.display_name}
-                        </option>
-                    ))}
-                </select>
+                    <SelectTrigger className="w-full text-sm">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={NONE_SENTINEL}>Auto</SelectItem>
+                        {providers.map((p) => (
+                            <SelectItem key={p.name} value={p.name}>
+                                {p.display_name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
             </div>
 
             <div


### PR DESCRIPTION
## Summary
- Replace all 7 native `<select>` elements with shadcn Select components across FilterBar, CommandBar, and SettingsPage
- Fixes white dropdown backgrounds on Windows dark theme (native `<option>` elements cannot be CSS-styled)
- Uses NONE_SENTINEL pattern for Radix empty-value compatibility (matching existing FormatOptionsPanel convention)

## Files changed
- `FilterBar.tsx` — 2 native selects replaced (default + advanced filter dropdowns)
- `CommandBar.tsx` — 1 native select replaced (site selector)
- `SettingsPage.tsx` — 4 native selects replaced (remux, audio, subtitle, search provider)

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] No native `<select>` elements remain in modified files
- [x] NONE_SENTINEL mapped back to `""` or `null` in all change handlers
- [x] Verified shadcn Select uses `bg-popover text-popover-foreground` for dark theme
- [x] Code review passed (QA sign-off)