### PR TITLE
feat(extractor): add RedTube API-first metadata extraction

### DIFF
--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -1,10 +1,12 @@
 //! Format extraction for RedTube
 //!
-//! Extracts video formats from JavaScript sources and mediaDefinition arrays.
+//! Extracts video formats from JavaScript sources, mediaDefinition arrays,
+//! and the `getVideoById` JSON API response.
 
 use log::{debug, warn};
-use rdlp_core::{ExtractionContext, Format};
+use rdlp_core::{ExtractionContext, Format, RdlpError, Result, Thumbnail};
 use regex::Regex;
+use serde::Deserialize;
 use serde_json::Value;
 use std::sync::LazyLock;
 
@@ -12,6 +14,164 @@ use crate::base::common::BaseExtractor;
 use crate::utils::{extract_extension_from_url, make_absolute_url};
 
 use super::patterns::{MEDIA_DEF_PATTERN, SOURCES_PATTERN};
+use super::search::parse_duration_string;
+
+// ============================================================================
+// API Video Info response types (getVideoById)
+// ============================================================================
+
+/// Top-level API response from `redtube.Videos.getVideoById`.
+///
+/// The response wraps the video in a `video` object inside a one-element array.
+/// Example: `{"video": {"video_id": "123", "title": "...", ...}}`
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiVideoInfoResponse {
+    /// The nested video object.
+    pub video: ApiVideoInfo,
+}
+
+/// Video info returned by the `getVideoById` API endpoint.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiVideoInfo {
+    /// Video title.
+    pub title: String,
+    /// Duration string in "MM:SS" or "H:MM:SS" format.
+    #[serde(default)]
+    pub duration: Option<String>,
+    /// Publish date string.
+    #[serde(default)]
+    pub publish_date: Option<String>,
+    /// View count (may be number or string).
+    #[serde(default, deserialize_with = "super::search::deserialize_views")]
+    pub views: Option<String>,
+    /// Tag list.
+    #[serde(default)]
+    pub tags: Vec<ApiVideoTag>,
+    /// Thumbnail list (requested via `thumbsize=all`).
+    #[serde(default)]
+    pub thumbs: Vec<ApiThumb>,
+}
+
+/// A single tag entry from the video info API.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiVideoTag {
+    /// Tag display name.
+    pub tag_name: String,
+}
+
+/// A single thumbnail entry from the video info API.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiThumb {
+    /// Size descriptor (e.g. "small", "medium", "big", "all").
+    pub size: String,
+    /// Width in pixels as a string.
+    #[serde(default)]
+    pub width: Option<String>,
+    /// Height in pixels as a string.
+    #[serde(default)]
+    pub height: Option<String>,
+    /// Thumbnail image URL.
+    #[serde(default)]
+    pub src: Option<String>,
+}
+
+/// Parsed metadata extracted from the `getVideoById` API response.
+///
+/// Contains the fields needed to populate `InfoDict` metadata.
+#[derive(Debug)]
+pub(crate) struct ApiVideoMetadata {
+    /// Video title.
+    pub title: String,
+    /// Duration in seconds.
+    pub duration: Option<f64>,
+    /// Primary thumbnail URL (largest available).
+    pub thumbnail: Option<String>,
+    /// All available thumbnails with dimensions.
+    pub thumbnails: Option<Vec<Thumbnail>>,
+    /// Tag names.
+    pub tags: Option<Vec<String>>,
+    /// View count.
+    pub view_count: Option<u64>,
+    /// Publish date string.
+    pub upload_date: Option<String>,
+}
+
+/// Parse the `getVideoById` API JSON response into metadata.
+///
+/// # Arguments
+/// * `json` - Raw JSON response body from the API.
+///
+/// # Returns
+/// Parsed `ApiVideoMetadata` or an error if JSON parsing fails.
+pub(crate) fn parse_api_video_response(json: &str) -> Result<ApiVideoMetadata> {
+    let response: ApiVideoInfoResponse = serde_json::from_str(json).map_err(|e| {
+        RdlpError::Extraction(format!("Failed to parse RedTube video API response: {e}"))
+    })?;
+
+    let video = response.video;
+
+    let duration = video
+        .duration
+        .as_deref()
+        .and_then(parse_duration_string)
+        .map(|s| s as f64);
+
+    let view_count = video
+        .views
+        .as_deref()
+        .and_then(super::search::parse_view_count);
+
+    let tags = if video.tags.is_empty() {
+        None
+    } else {
+        Some(video.tags.into_iter().map(|t| t.tag_name).collect())
+    };
+
+    // Build thumbnail list — pick the largest as primary
+    let mut thumbnails = Vec::new();
+    let mut best_thumb: Option<String> = None;
+    let mut best_width: u32 = 0;
+
+    for thumb in &video.thumbs {
+        if let Some(src) = &thumb.src {
+            let width = thumb.width.as_deref().and_then(|w| w.parse::<u32>().ok());
+            let height = thumb.height.as_deref().and_then(|h| h.parse::<u32>().ok());
+
+            thumbnails.push(Thumbnail {
+                url: src.clone(),
+                id: Some(thumb.size.clone()),
+                width,
+                height,
+                preference: None,
+            });
+
+            let w = width.unwrap_or(0);
+            if w > best_width {
+                best_width = w;
+                best_thumb = Some(src.clone());
+            }
+        }
+    }
+
+    // If no thumb was selected by width, use the first available
+    if best_thumb.is_none() && !thumbnails.is_empty() {
+        best_thumb = Some(thumbnails[0].url.clone());
+    }
+
+    Ok(ApiVideoMetadata {
+        title: video.title,
+        duration,
+        thumbnail: best_thumb,
+        thumbnails: if thumbnails.is_empty() {
+            None
+        } else {
+            Some(thumbnails)
+        },
+        tags,
+        view_count,
+        upload_date: video.publish_date,
+    })
+}
 
 /// Extract quality string from JSON value (handles both string and number types)
 pub fn parse_quality(item: &Value) -> String {
@@ -452,5 +612,191 @@ mod tests {
         // vbr and abr not set - we only know total bitrate from URL
         assert_eq!(format.vbr, None);
         assert_eq!(format.abr, None);
+    }
+
+    // ====================================================================
+    // API video info (getVideoById) parsing tests
+    // ====================================================================
+
+    /// Sample API response matching the `getVideoById` endpoint shape.
+    fn sample_api_video_response() -> &'static str {
+        r#"{
+            "video": {
+                "video_id": "123456",
+                "title": "Test API Video",
+                "url": "https://www.redtube.com/123456",
+                "duration": "15:30",
+                "publish_date": "2024-03-10",
+                "views": 42000,
+                "tags": [
+                    {"tag_name": "amateur"},
+                    {"tag_name": "hd"}
+                ],
+                "thumbs": [
+                    {
+                        "size": "small",
+                        "width": "130",
+                        "height": "97",
+                        "src": "https://thumb-small.jpg"
+                    },
+                    {
+                        "size": "medium",
+                        "width": "320",
+                        "height": "240",
+                        "src": "https://thumb-medium.jpg"
+                    },
+                    {
+                        "size": "big",
+                        "width": "640",
+                        "height": "480",
+                        "src": "https://thumb-big.jpg"
+                    }
+                ]
+            }
+        }"#
+    }
+
+    #[test]
+    fn test_parse_api_video_response_full() {
+        let meta = parse_api_video_response(sample_api_video_response()).unwrap();
+        assert_eq!(meta.title, "Test API Video");
+        assert_eq!(meta.duration, Some(930.0)); // 15*60 + 30
+        assert_eq!(meta.view_count, Some(42000));
+        assert_eq!(meta.upload_date, Some("2024-03-10".to_string()));
+        assert_eq!(
+            meta.tags,
+            Some(vec!["amateur".to_string(), "hd".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_api_video_response_thumbnails() {
+        let meta = parse_api_video_response(sample_api_video_response()).unwrap();
+        let thumbs = meta.thumbnails.as_ref().unwrap();
+        assert_eq!(thumbs.len(), 3);
+
+        // Primary thumbnail should be the largest (640px wide)
+        assert_eq!(meta.thumbnail, Some("https://thumb-big.jpg".to_string()));
+
+        // Check individual thumbnail entries
+        let small = thumbs.iter().find(|t| t.id == Some("small".to_string()));
+        assert!(small.is_some());
+        assert_eq!(small.unwrap().width, Some(130));
+        assert_eq!(small.unwrap().height, Some(97));
+    }
+
+    #[test]
+    fn test_parse_api_video_response_minimal() {
+        let json = r#"{
+            "video": {
+                "video_id": "999",
+                "title": "Minimal Video",
+                "tags": [],
+                "thumbs": []
+            }
+        }"#;
+        let meta = parse_api_video_response(json).unwrap();
+        assert_eq!(meta.title, "Minimal Video");
+        assert_eq!(meta.duration, None);
+        assert_eq!(meta.view_count, None);
+        assert_eq!(meta.upload_date, None);
+        assert_eq!(meta.thumbnail, None);
+        assert_eq!(meta.thumbnails, None);
+        assert_eq!(meta.tags, None); // empty vec becomes None
+    }
+
+    #[test]
+    fn test_parse_api_video_response_string_views() {
+        let json = r#"{
+            "video": {
+                "video_id": "111",
+                "title": "String Views",
+                "views": "1,234,567",
+                "tags": [],
+                "thumbs": []
+            }
+        }"#;
+        let meta = parse_api_video_response(json).unwrap();
+        assert_eq!(meta.view_count, Some(1234567));
+    }
+
+    #[test]
+    fn test_parse_api_video_response_invalid_json() {
+        let result = parse_api_video_response("not json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to parse"));
+    }
+
+    #[test]
+    fn test_parse_api_video_response_wrong_structure() {
+        // Valid JSON but wrong structure (missing video wrapper)
+        let json = r#"{"error": "Video not found"}"#;
+        let result = parse_api_video_response(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_api_video_response_hms_duration() {
+        let json = r#"{
+            "video": {
+                "video_id": "222",
+                "title": "Long Video",
+                "duration": "1:30:45",
+                "tags": [],
+                "thumbs": []
+            }
+        }"#;
+        let meta = parse_api_video_response(json).unwrap();
+        // 1*3600 + 30*60 + 45 = 5445
+        assert_eq!(meta.duration, Some(5445.0));
+    }
+
+    #[test]
+    fn test_parse_api_video_response_thumb_without_dimensions() {
+        let json = r#"{
+            "video": {
+                "video_id": "333",
+                "title": "No Dimensions",
+                "tags": [],
+                "thumbs": [
+                    {
+                        "size": "default",
+                        "src": "https://thumb-default.jpg"
+                    }
+                ]
+            }
+        }"#;
+        let meta = parse_api_video_response(json).unwrap();
+        let thumbs = meta.thumbnails.as_ref().unwrap();
+        assert_eq!(thumbs.len(), 1);
+        assert_eq!(thumbs[0].width, None);
+        assert_eq!(thumbs[0].height, None);
+        // Still selected as primary since it's the only one
+        assert_eq!(
+            meta.thumbnail,
+            Some("https://thumb-default.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_api_video_response_thumb_without_src() {
+        let json = r#"{
+            "video": {
+                "video_id": "444",
+                "title": "No Src",
+                "tags": [],
+                "thumbs": [
+                    {
+                        "size": "empty",
+                        "width": "100",
+                        "height": "75"
+                    }
+                ]
+            }
+        }"#;
+        let meta = parse_api_video_response(json).unwrap();
+        // Thumb without src is skipped
+        assert_eq!(meta.thumbnails, None);
+        assert_eq!(meta.thumbnail, None);
     }
 }

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -5,13 +5,14 @@
 //! - https://www.redtube.com.br/123456
 //! - https://embed.redtube.com/?id=123456
 //!
-//! RedTube embeds video sources in JavaScript objects rather than HTML `<source>` tags,
-//! so this extractor uses regex to extract JSON from the page source.
+//! Uses the RedTube public API (`api.redtube.com`) as the primary source for
+//! video metadata, with HTML scraping as a fallback. Video format URLs are
+//! always extracted from the webpage since the API does not expose them.
 //!
 //! ## Module Structure
 //!
-//! - `patterns` - URL and extraction regex patterns
-//! - `formats` - Format extraction from JavaScript sources and mediaDefinition
+//! - `patterns` - URL and extraction regex patterns, API URL builders
+//! - `formats` - Format extraction from JavaScript sources, mediaDefinition, and API
 //! - `search` - Search result parsing and filter validation
 
 mod formats;
@@ -52,6 +53,126 @@ impl RedTubeExtractor {
     fn extract_id(&self, url: &str) -> Option<String> {
         BaseExtractor::extract_id_from_url(url, &REDTUBE_URL_PATTERN, "id")
     }
+
+    /// Fetch video metadata from the RedTube API (`getVideoById`).
+    ///
+    /// Returns parsed metadata on success, or an error if the API is
+    /// unreachable or returns an unexpected response.
+    async fn fetch_api_video_info(
+        &self,
+        video_id: &str,
+        ctx: &ExtractionContext,
+    ) -> Result<formats::ApiVideoMetadata> {
+        let api_url = patterns::build_api_video_url(video_id);
+
+        debug!("[RedTube] Fetching API video info: {api_url}");
+
+        let response =
+            ctx.http_client.get(&api_url).send().await.map_err(|e| {
+                RdlpError::Network(format!("Failed to fetch RedTube video API: {e}"))
+            })?;
+
+        rdlp_core::check_http_response(&response)?;
+
+        let body = response.text().await.map_err(|e| {
+            RdlpError::Network(format!("Failed to read RedTube video API response: {e}"))
+        })?;
+
+        BaseExtractor::log_content_if_verbose(ctx, "RedTube", "API video response", &body, 500);
+
+        formats::parse_api_video_response(&body)
+    }
+
+    /// Build `InfoDict` using API metadata as the primary source.
+    ///
+    /// Falls back to HTML scraping for fields the API does not provide
+    /// (description, uploader, channel, like_count, average_rating, categories).
+    fn build_info_from_api(
+        &self,
+        video_id: &str,
+        url: &str,
+        api_meta: formats::ApiVideoMetadata,
+        webpage: &str,
+        formats: Vec<rdlp_core::Format>,
+        hls_flags: &crate::hls::HlsStreamFlags,
+    ) -> InfoDict {
+        let mut info = InfoDict::new(video_id, &api_meta.title, InfoExtractor::name(self), url);
+        info.thumbnail = api_meta.thumbnail;
+        info.thumbnails = api_meta.thumbnails;
+        info.duration = api_meta.duration;
+        info.upload_date = api_meta.upload_date;
+        info.view_count = api_meta.view_count;
+        info.tags = api_meta.tags;
+        info.age_limit = Some(18);
+        info.formats = formats;
+
+        // Supplement with HTML-scraped fields the API does not return
+        if let Ok(html_meta) = {
+            let html = Html::parse_document(webpage);
+            self.base.extract_metadata(&html)
+        } {
+            info.description = html_meta.description;
+            info.uploader = html_meta.uploader;
+            info.uploader_id = html_meta.uploader_id;
+            info.uploader_url = html_meta.uploader_url;
+            info.channel = html_meta.channel;
+            info.channel_id = html_meta.channel_id;
+            info.channel_url = html_meta.channel_url;
+            info.like_count = html_meta.like_count;
+            info.average_rating = html_meta.average_rating;
+            info.categories = html_meta.categories;
+        }
+
+        info.propagate_duration();
+
+        if hls_flags.is_live {
+            info.is_live = Some(true);
+        }
+
+        info
+    }
+
+    /// Build `InfoDict` entirely from HTML-scraped metadata (fallback path).
+    fn build_info_from_html(
+        &self,
+        video_id: &str,
+        url: &str,
+        webpage: &str,
+        formats: Vec<rdlp_core::Format>,
+        hls_flags: &crate::hls::HlsStreamFlags,
+    ) -> Result<InfoDict> {
+        let metadata = {
+            let html = Html::parse_document(webpage);
+            self.base.extract_metadata(&html)?
+        };
+
+        let mut info = InfoDict::new(video_id, metadata.title, InfoExtractor::name(self), url);
+        info.description = metadata.description;
+        info.uploader = metadata.uploader;
+        info.uploader_id = metadata.uploader_id;
+        info.uploader_url = metadata.uploader_url;
+        info.channel = metadata.channel;
+        info.channel_id = metadata.channel_id;
+        info.channel_url = metadata.channel_url;
+        info.thumbnail = metadata.thumbnail;
+        info.thumbnails = metadata.thumbnails;
+        info.duration = metadata.duration;
+        info.upload_date = metadata.upload_date;
+        info.view_count = metadata.view_count;
+        info.like_count = metadata.like_count;
+        info.average_rating = metadata.average_rating;
+        info.tags = metadata.tags;
+        info.categories = metadata.categories;
+        info.age_limit = Some(18);
+        info.formats = formats;
+        info.propagate_duration();
+
+        if hls_flags.is_live {
+            info.is_live = Some(true);
+        }
+
+        Ok(info)
+    }
 }
 
 impl Default for RedTubeExtractor {
@@ -71,19 +192,16 @@ impl InfoExtractor for RedTubeExtractor {
     }
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
-        // Fetch the webpage using BaseExtractor (handles errors, verbose logging)
-        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
-
         // Get video ID using BaseExtractor
         let video_id = self.extract_id(url).ok_or_else(|| {
             RdlpError::Extraction(format!("Could not extract video ID from URL: {url}"))
         })?;
 
-        // Extract all data from HTML before any async operations
-        let metadata = {
-            let html = Html::parse_document(&webpage);
-            self.base.extract_metadata(&html)?
-        }; // html is dropped here
+        // Try API first for metadata
+        let api_metadata = self.fetch_api_video_info(&video_id, ctx).await;
+
+        // Always fetch webpage for format extraction (API does not return video URLs)
+        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 
         // Try to extract video formats from JavaScript sources
         let mut formats = formats::extract_from_sources(&webpage);
@@ -108,7 +226,8 @@ impl InfoExtractor for RedTubeExtractor {
         // Return error if still no sources found
         if formats.is_empty() {
             return Err(RdlpError::Extraction(format!(
-                "No video sources found in JavaScript or HTML. Video may be unavailable. URL: {url}"
+                "No video sources found in JavaScript or HTML. \
+                 Video may be unavailable. URL: {url}"
             )));
         }
 
@@ -123,32 +242,14 @@ impl InfoExtractor for RedTubeExtractor {
         let (formats, hls_flags) =
             detect_format_sizes(formats, ctx, InfoExtractor::name(self)).await;
 
-        // Build InfoDict with all extracted metadata
-        let mut info = InfoDict::new(video_id, metadata.title, InfoExtractor::name(self), url);
-        info.description = metadata.description;
-        info.uploader = metadata.uploader;
-        info.uploader_id = metadata.uploader_id;
-        info.uploader_url = metadata.uploader_url;
-        info.channel = metadata.channel;
-        info.channel_id = metadata.channel_id;
-        info.channel_url = metadata.channel_url;
-        info.thumbnail = metadata.thumbnail;
-        info.thumbnails = metadata.thumbnails;
-        info.duration = metadata.duration;
-        info.upload_date = metadata.upload_date;
-        info.view_count = metadata.view_count;
-        info.like_count = metadata.like_count;
-        info.average_rating = metadata.average_rating;
-        info.tags = metadata.tags;
-        info.categories = metadata.categories;
-        info.age_limit = Some(18); // RedTube is adult content
-        info.formats = formats;
-        info.propagate_duration();
-
-        // Set stream-level flags from HLS detection
-        if hls_flags.is_live {
-            info.is_live = Some(true);
-        }
+        // Build InfoDict — prefer API metadata, fall back to HTML scrape
+        let info = if let Ok(api_meta) = api_metadata {
+            debug!("[RedTube] Using API metadata for video {video_id}");
+            self.build_info_from_api(&video_id, url, api_meta, &webpage, formats, &hls_flags)
+        } else {
+            debug!("[RedTube] API unavailable, using HTML metadata for video {video_id}");
+            self.build_info_from_html(&video_id, url, &webpage, formats, &hls_flags)?
+        };
 
         Ok(info)
     }

--- a/crates/rdlp-extractor/src/extractors/redtube/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/patterns.rs
@@ -98,6 +98,17 @@ pub(crate) fn build_api_search_url_page(base_url: &str, page: u32) -> String {
     format!("{base_url}&page={page}")
 }
 
+/// Build the API URL for fetching video info by ID.
+///
+/// Format: `https://api.redtube.com/?data=redtube.Videos.getVideoById
+///          &video_id={id}&output=json&thumbsize=all`
+pub(crate) fn build_api_video_url(video_id: &str) -> String {
+    format!(
+        "https://api.redtube.com/?data=redtube.Videos.getVideoById\
+         &video_id={video_id}&output=json&thumbsize=all"
+    )
+}
+
 /// Build the HTML search fallback URL.
 ///
 /// Format: `https://www.redtube.com/?search={query}`
@@ -517,5 +528,24 @@ mod tests {
         assert!(values.contains(&"amateur"));
         assert!(values.contains(&"homemade"));
         assert!(values.contains(&"compilation"));
+    }
+
+    #[test]
+    fn test_build_api_video_url() {
+        let url = build_api_video_url("123456");
+        assert!(url.starts_with("https://api.redtube.com/"));
+        assert!(url.contains("data=redtube.Videos.getVideoById"));
+        assert!(url.contains("video_id=123456"));
+        assert!(url.contains("output=json"));
+        assert!(url.contains("thumbsize=all"));
+    }
+
+    #[test]
+    fn test_build_api_video_url_different_ids() {
+        let url1 = build_api_video_url("1");
+        assert!(url1.contains("video_id=1"));
+
+        let url2 = build_api_video_url("99999999");
+        assert!(url2.contains("video_id=99999999"));
     }
 }

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -66,7 +66,9 @@ pub(crate) struct ApiTag {
 ///
 /// The RedTube API returns `views` as a number (e.g. `571096`), but some
 /// responses may use a string. This accepts both and normalises to `Option<String>`.
-fn deserialize_views<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+pub(crate) fn deserialize_views<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -158,7 +160,7 @@ pub(crate) fn parse_duration_string(duration: &str) -> Option<u64> {
 }
 
 /// Parse a view count string that may contain commas (e.g. "1,234,567").
-fn parse_view_count(views: &str) -> Option<u64> {
+pub(crate) fn parse_view_count(views: &str) -> Option<u64> {
     let cleaned: String = views.chars().filter(|c| c.is_ascii_digit()).collect();
     cleaned.parse::<u64>().ok()
 }


### PR DESCRIPTION
## Summary
- Use `api.redtube.com` `getVideoById` endpoint as primary metadata source (title, duration, views, tags, thumbnails, publish_date)
- Fall back to HTML scraping when API fails (existing behavior preserved)
- Video format/URL extraction from webpage JS unchanged (API doesn't expose video URLs)
- 9 new unit tests for API response parsing, +528/-42 lines across 4 files

## Files changed
- `formats.rs` — API response structs, `parse_api_video_response()`, thumbnail selection, 9 tests
- `mod.rs` — Refactored `extract()` with API-first flow, `build_info_from_api()`, `build_info_from_html()`
- `patterns.rs` — `build_api_video_url()` + 2 tests
- `search.rs` — `deserialize_views` changed to `pub(crate)` for reuse

## Test plan
- [x] `cargo test -p rdlp-extractor` — 283 passed, 0 failed
- [x] `cargo clippy -p rdlp-extractor -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] No regressions in existing tests
- [x] QA sign-off ✅