### PR TITLE
fix(desktop): show Type column in FormatDialog with fixed table layout

### DIFF
--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -77,14 +77,14 @@ interface FormatDialogProps {
 
 // -- Constants --------------------------------------------------------
 
-const COLUMNS: Array<{ key: SortKey; label: string; align: "left" | "right" }> = [
-    { key: "height", label: "Resolution", align: "left" },
-    { key: "ext", label: "Ext", align: "left" },
-    { key: "fps", label: "FPS", align: "right" },
-    { key: "tbr", label: "Bitrate", align: "right" },
-    { key: "vcodec", label: "Video", align: "left" },
-    { key: "acodec", label: "Audio", align: "left" },
-    { key: "filesize", label: "Size", align: "right" },
+const COLUMNS: Array<{ key: SortKey; label: string; align: "left" | "right"; pct: string }> = [
+    { key: "height", label: "Resolution", align: "left", pct: "22%" },
+    { key: "ext", label: "Ext", align: "left", pct: "7%" },
+    { key: "fps", label: "FPS", align: "right", pct: "7%" },
+    { key: "tbr", label: "Bitrate", align: "right", pct: "13%" },
+    { key: "vcodec", label: "Video", align: "left", pct: "12%" },
+    { key: "acodec", label: "Audio", align: "left", pct: "11%" },
+    { key: "filesize", label: "Size", align: "right", pct: "13%" },
 ];
 
 const REMUX_OPTIONS: Array<{ value: ContainerFormat; label: string }> = [
@@ -444,13 +444,14 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                             </div>
 
                             {/* Scrollable table */}
-                            <ScrollArea className="flex-1 min-h-0" type="auto" ref={tableRef}>
-                                <Table className="text-xs">
+                            <ScrollArea className="flex-1 min-h-0" viewportClassName="pr-3" type="auto" ref={tableRef}>
+                                <Table className="text-xs" style={{ tableLayout: "fixed" }}>
                                     <TableHeader className="sticky top-0 z-10">
                                         <TableRow className="bg-foreground/[0.06] backdrop-blur-sm hover:bg-foreground/[0.06]">
-                                            {COLUMNS.map(({ key, label, align }) => (
+                                            {COLUMNS.map(({ key, label, align, pct }) => (
                                                 <TableHead
                                                     key={key}
+                                                    style={{ width: pct }}
                                                     className={cn(
                                                         "h-8 px-3 text-[10px] font-bold tracking-wider uppercase select-none cursor-pointer transition-colors hover:text-foreground",
                                                         align === "right" && "text-right",
@@ -468,7 +469,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                                     </span>
                                                 </TableHead>
                                             ))}
-                                            <TableHead className="h-8 px-3 text-[10px] font-bold tracking-wider uppercase text-muted-foreground select-none text-center">
+                                            <TableHead style={{ width: "15%" }} className="h-8 px-3 text-[10px] font-bold tracking-wider uppercase text-muted-foreground select-none text-center">
                                                 Type
                                             </TableHead>
                                         </TableRow>

--- a/crates/rdlp-desktop/src/components/ui/scroll-area.tsx
+++ b/crates/rdlp-desktop/src/components/ui/scroll-area.tsx
@@ -6,8 +6,9 @@ import { cn } from "@/lib/utils"
 function ScrollArea({
   className,
   children,
+  viewportClassName,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & { viewportClassName?: string }) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -16,7 +17,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 w-full flex-1 min-h-0 rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block"
+        className={cn("focus-visible:ring-ring/50 w-full flex-1 min-h-0 rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block", viewportClassName)}
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## Summary
- Fixed invisible 8th column (Type badges: HLS, V+A, Video, Audio) in FormatDialog format table
- Root cause: Tailwind v4 was not generating the `table-fixed` utility class, so `table-layout: auto` distributed all space to 7 columns, clipping the 8th
- Used inline `style={{ tableLayout: "fixed" }}` with percentage-based column widths to guarantee all 8 columns render deterministically
- Added `viewportClassName` prop to ScrollArea component for passing classes directly to the Radix viewport (used for scrollbar clearance padding)

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All 8 table columns visible (Resolution, Ext, FPS, Bitrate, Video, Audio, Size, Type)
- [x] Type column shows correct badges (HLS, V+A, Video, Audio)
- [x] Scrollbar does not clip rightmost column when scrolling
- [ ] No regressions in other ScrollArea usages