### PR TITLE
chore: add default-members for selective CLI/desktop/lib compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,23 @@ members = [
     "crates/rdlp-cli",
     "crates/rdlp-desktop/src-tauri",
 ]
+default-members = [
+    "crates/rdlp-types",
+    "crates/rdlp-core",
+    "crates/rdlp-api",
+    "crates/rdlp-http",
+    "crates/rdlp-security",
+    "crates/rdlp-crypto",
+    "crates/rdlp-extractor",
+    "crates/rdlp-downloader",
+    "crates/rdlp-jsinterp",
+    "crates/rdlp-ffmpeg",
+    "crates/rdlp-postprocess",
+    "crates/rdlp-cookies",
+    "crates/rdlp-ratelimit",
+    "crates/rdlp-table",
+    "crates/rdlp-plugin",
+]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -29,8 +29,14 @@ Requires Rust 1.85+ and FFmpeg shared libraries.
 ```
 git clone https://github.com/crippledgeek/rdlp.git
 cd rdlp
-cargo build --release
+cargo build --release                    # library crates only
+cargo build --release -p rdlp-cli        # CLI binary
+cargo build --release -p rdlp-desktop    # Tauri desktop app
+cargo build --release --workspace        # everything
 ```
+
+The workspace uses `default-members` so `cargo build` compiles only library
+crates. Use `-p` to target a specific binary.
 
 See [BUILDING.md](BUILDING.md) for platform-specific FFmpeg setup and troubleshooting.
 


### PR DESCRIPTION
## Summary
- Add `default-members` to workspace `Cargo.toml` listing only the 15 library crates
- `cargo build` now compiles libraries only, avoiding unnecessary CLI/desktop compilation
- Binary crates require explicit `-p rdlp-cli` or `-p rdlp-desktop`
- Update README with all four build targets

## Usage after merge
```bash
cargo build                        # 15 library crates only
cargo build -p rdlp-cli            # CLI binary
cargo build -p rdlp-desktop        # Tauri desktop app
cargo build --workspace            # everything
```

## Test plan
- [x] `cargo build` compiles only library crates (verified)
- [x] `cargo build -p rdlp-cli` compiles CLI (verified)
- [x] `cargo build -p rdlp-desktop` compiles desktop (verified)
- [x] `cargo test` runs lib tests only (verified)
- [x] `cargo clippy` clean (verified)