### PR TITLE
feat(desktop): paginated search with infinite scroll

### DIFF
--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -324,6 +324,33 @@ impl RdlpClient {
         orchestrator.search(site, query).await.map_err(Into::into)
     }
 
+    /// Execute a paginated search on a site, returning a single page.
+    ///
+    /// # Arguments
+    /// * `site` - Site name (e.g., "xhamster").
+    /// * `query` - Search query with page number set.
+    ///
+    /// # Returns
+    /// A single page of results with pagination metadata.
+    ///
+    /// # Errors
+    /// Returns error if site unknown, filters invalid, or network fails.
+    pub async fn search_page(
+        &self,
+        site: &str,
+        query: &rdlp_core::SearchQuery,
+    ) -> Result<rdlp_core::SearchPageResponse, RdlpApiError> {
+        let id = DownloadId::next();
+        let (tx, _rx) = mpsc::channel::<Event>(16);
+        let cancel_token = CancellationToken::new();
+
+        let orchestrator = Orchestrator::new(Arc::clone(&self.config), tx, id, cancel_token, None);
+        orchestrator
+            .search_page(site, query)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Execute a search and return results as lightweight previews.
     ///
     /// Alias for [`search()`](Self::search) — only scrapes search result

--- a/crates/rdlp-api/src/lib.rs
+++ b/crates/rdlp-api/src/lib.rs
@@ -40,8 +40,8 @@ pub use events::Event;
 pub use handle::{DownloadHandle, DownloadId};
 pub use orchestrator::InteractiveCallback;
 pub use rdlp_core::{
-    SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchQuery, SearchResultPreview,
-    SearchSiteInfo,
+    SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery,
+    SearchResultPreview, SearchSiteInfo,
 };
 pub use request::DownloadRequest;
 pub use result::DownloadResult;

--- a/crates/rdlp-api/src/orchestrator/extraction.rs
+++ b/crates/rdlp-api/src/orchestrator/extraction.rs
@@ -2,7 +2,7 @@
 
 use super::{Orchestrator, errors::*};
 use log::info;
-use rdlp_core::{SearchFilterDescriptor, SearchQuery, SearchResultPreview};
+use rdlp_core::{SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchResultPreview};
 use tracing::instrument;
 
 impl Orchestrator {
@@ -196,6 +196,36 @@ impl Orchestrator {
         info!(site = extractor_name, count = results.len(); "Search complete");
 
         Ok(results)
+    }
+
+    /// Execute a paginated search query, returning a single page of results.
+    pub async fn search_page(
+        &self,
+        extractor_name: &str,
+        query: &SearchQuery,
+    ) -> Result<SearchPageResponse> {
+        let extractor = self
+            .extractor_registry
+            .find_search_extractor(extractor_name)
+            .ok_or_else(|| {
+                let available = self.extractor_registry.list_search_extractors();
+                OrchestratorError::Configuration(format!(
+                    "Unknown search site: '{}'. Available: {}",
+                    extractor_name,
+                    available.join(", ")
+                ))
+            })?;
+
+        info!(site = extractor_name, query = query.query.as_str(); "Starting paginated search");
+
+        let response = extractor
+            .search_page(query, &self.extraction_context)
+            .await
+            .map_err(OrchestratorError::ExtractionFailed)?;
+
+        info!(site = extractor_name, count = response.results.len(), page = response.page; "Search page complete");
+
+        Ok(response)
     }
 
     /// List names of all search-capable extractors.

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -174,6 +174,7 @@ async fn async_main() -> Result<()> {
             query: query_text.clone(),
             filters,
             max_results: None,
+            page: None,
         };
 
         match client.search(site, &search_query).await {

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -41,9 +41,9 @@ pub mod traits;
 pub use rdlp_types::{
     AudioFormat, BrowserType, Chapter, Config, ContainerFormat, DownloadProtocol, Format,
     FormatSelector, Fragment, InfoDict, SearchFilter, SearchFilterDescriptor, SearchFilterValue,
-    SearchQuery, SearchResultPreview, SearchSiteInfo, Subtitle, SubtitleDiagnostic, SubtitleFormat,
-    SubtitleKind, SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack, Thumbnail,
-    normalize_from_info_dict,
+    SearchPageResponse, SearchQuery, SearchResultPreview, SearchSiteInfo, Subtitle,
+    SubtitleDiagnostic, SubtitleFormat, SubtitleKind, SubtitleReason, SubtitleResult,
+    SubtitleStatus, SubtitleTrack, Thumbnail, normalize_from_info_dict,
 };
 
 // Re-export codec utilities

--- a/crates/rdlp-core/src/traits/extractor.rs
+++ b/crates/rdlp-core/src/traits/extractor.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::sync::Arc;
 
 use crate::{BrowserType, Config, InfoDict, Result};
-use rdlp_types::{SearchFilterDescriptor, SearchQuery, SearchResultPreview};
+use rdlp_types::{SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchResultPreview};
 
 /// Core trait for all site extractors
 ///
@@ -145,6 +145,26 @@ pub trait SearchExtractor: Send + Sync {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>>;
+
+    /// Execute a search for a single page, returning pagination metadata.
+    ///
+    /// The default implementation delegates to [`search()`](Self::search)
+    /// and wraps the result with `has_more: false`. Extractors that support
+    /// native pagination should override this.
+    async fn search_page(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        let results = self.search(query, ctx).await?;
+        let page = query.page.unwrap_or(1);
+        Ok(SearchPageResponse {
+            results,
+            page,
+            has_more: false,
+            total_estimate: None,
+        })
+    }
 }
 
 /// Context passed to extractors containing shared resources

--- a/crates/rdlp-desktop/src-tauri/src/commands/search.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/search.rs
@@ -3,24 +3,14 @@
 //! Provides content search, provider listing, and filter discovery
 //! exposed to the frontend via Tauri's command system.
 
-use serde::Serialize;
 use tauri::State;
 
 use rdlp_api::{
-    SearchFilter, SearchFilterDescriptor, SearchQuery, SearchResultPreview, SearchSiteInfo,
+    SearchFilter, SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchSiteInfo,
 };
 
 use crate::error::AppError;
 use crate::state::AppState;
-
-/// Response wrapper for search results.
-#[derive(Debug, Serialize)]
-pub struct SearchResponse {
-    /// The search result items.
-    results: Vec<SearchResultPreview>,
-    /// Optional estimate of total matching results.
-    total_estimate: Option<u64>,
-}
 
 /// Sanitize a user-provided query string.
 ///
@@ -38,19 +28,21 @@ fn sanitize_query(input: &str) -> String {
 
 /// Search a supported site by query string.
 ///
-/// Sanitizes the query, builds a [`SearchQuery`] with up to 40 results,
-/// and delegates to the rdlp-api search engine.
+/// Sanitizes the query and delegates to the rdlp-api search engine.
+/// When `page` is `Some`, fetches a single page via `search_page()`.
+/// When `page` is `None`, collects all pages via `search()` (capped at 40).
 ///
 /// # Arguments
 ///
 /// * `query` - Raw search query from the frontend.
 /// * `site` - Site name as returned by [`get_search_providers`].
 /// * `filters` - Optional search filters for the chosen site.
+/// * `page` - Optional page number for paginated fetching.
 /// * `state` - Managed application state containing the API client.
 ///
 /// # Returns
 ///
-/// A [`SearchResponse`] with results and an optional total estimate.
+/// A [`SearchPageResponse`] with results and pagination metadata.
 ///
 /// # Errors
 ///
@@ -61,8 +53,9 @@ pub async fn search_content(
     query: String,
     site: String,
     filters: Vec<SearchFilter>,
+    page: Option<u32>,
     state: State<'_, AppState>,
-) -> Result<SearchResponse, AppError> {
+) -> Result<SearchPageResponse, AppError> {
     let sanitized = sanitize_query(&query);
     if sanitized.is_empty() {
         return Err(AppError::InvalidInput {
@@ -71,25 +64,48 @@ pub async fn search_content(
         });
     }
 
-    let search_query = SearchQuery {
-        query: sanitized,
-        filters,
-        max_results: Some(40),
-    };
+    if let Some(p) = page {
+        // Paginated mode: fetch a single page
+        let search_query = SearchQuery {
+            query: sanitized,
+            filters,
+            max_results: None,
+            page: Some(p),
+        };
 
-    let results = state
-        .client
-        .search(&site, &search_query)
-        .await
-        .map_err(|e| AppError::SearchFailed {
-            message: e.to_string(),
-            retryable: e.is_retryable(),
-        })?;
+        state
+            .client
+            .search_page(&site, &search_query)
+            .await
+            .map_err(|e| AppError::SearchFailed {
+                message: e.to_string(),
+                retryable: e.is_retryable(),
+            })
+    } else {
+        // Collect-all mode: existing behavior, capped at 40
+        let search_query = SearchQuery {
+            query: sanitized,
+            filters,
+            max_results: Some(40),
+            page: None,
+        };
 
-    Ok(SearchResponse {
-        total_estimate: None,
-        results,
-    })
+        let results = state
+            .client
+            .search(&site, &search_query)
+            .await
+            .map_err(|e| AppError::SearchFailed {
+                message: e.to_string(),
+                retryable: e.is_retryable(),
+            })?;
+
+        Ok(SearchPageResponse {
+            results,
+            page: 1,
+            has_more: false,
+            total_estimate: None,
+        })
+    }
 }
 
 /// List all sites that support search.

--- a/crates/rdlp-desktop/src/App.tsx
+++ b/crates/rdlp-desktop/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { QueryClientProvider, useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useStore } from "@tanstack/react-store";
 import { Search, Download, Settings } from "lucide-react";
 import { SearchPage } from "./pages/SearchPage";
@@ -13,7 +13,7 @@ import {
     searchParamsAtom,
     setSearchParam,
 } from "./stores/searchParamsStore";
-import { searchQueryOptions } from "./api/search";
+import { searchInfiniteQueryOptions } from "./api/search";
 import { queryKeys } from "./query/queryKeys";
 import { downloadsQueryOptions } from "./api/downloads";
 import { cn } from "@/lib/utils";
@@ -47,12 +47,12 @@ function AppContent() {
     const filters = useStore(searchParamsAtom, (s) => s.filters);
 
     // --- TanStack Query: server state ---
-    const { isFetching, data: searchData } = useQuery(
-        searchQueryOptions(query, site, filters),
+    const { isFetching, data: searchData } = useInfiniteQuery(
+        searchInfiniteQueryOptions(query, site, filters),
     );
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
 
-    const results = searchData?.results ?? [];
+    const results = searchData?.pages.flatMap(p => p.results) ?? [];
 
     const activeCount = jobs.filter(
         (j) => j.status === "pending" || j.status === "running",

--- a/crates/rdlp-desktop/src/App.tsx
+++ b/crates/rdlp-desktop/src/App.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { QueryClientProvider, useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { useStore } from "@tanstack/react-store";
+import { useCallback, useEffect, useState } from "react";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Search, Download, Settings } from "lucide-react";
 import { SearchPage } from "./pages/SearchPage";
 import { QueuePage } from "./pages/QueuePage";
@@ -13,7 +12,6 @@ import {
     searchParamsAtom,
     setSearchParam,
 } from "./stores/searchParamsStore";
-import { searchInfiniteQueryOptions } from "./api/search";
 import { queryKeys } from "./query/queryKeys";
 import { downloadsQueryOptions } from "./api/downloads";
 import { cn } from "@/lib/utils";
@@ -39,22 +37,8 @@ function AppContent() {
     const [viewMode, setViewMode] = useState<ViewMode>(() => {
         return (localStorage.getItem(VIEW_MODE_KEY) as ViewMode) || "list";
     });
-    const [searchDuration, setSearchDuration] = useState<number | null>(null);
-
-    // --- TanStack Store: search form state ---
-    const query = useStore(searchParamsAtom, (s) => s.query);
-    const site = useStore(searchParamsAtom, (s) => s.site);
-    const filters = useStore(searchParamsAtom, (s) => s.filters);
-
-    // --- TanStack Query: server state ---
-    const { isFetching, data: searchData } = useInfiniteQuery(
-        searchInfiniteQueryOptions(query, site, filters),
-    );
+    // --- TanStack Query: downloads only (search state lives in SearchPage + StatusBar) ---
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
-
-    const results = searchData?.pages.flatMap(p => p.results) ?? [];
-    const lastPage = searchData?.pages[searchData.pages.length - 1];
-    const totalEstimate = lastPage?.total_estimate ?? null;
 
     const activeCount = jobs.filter(
         (j) => j.status === "pending" || j.status === "running",
@@ -91,24 +75,13 @@ function AppContent() {
             // Invalidate the search query to trigger a re-fetch after atom updates propagate
             setTimeout(() => {
                 void queryClient.invalidateQueries({
-                    queryKey: queryKeys.search(restoredQuery, restoredSite, restoredFilters),
+                    queryKey: queryKeys.search.params(restoredQuery, restoredSite, restoredFilters),
                     refetchType: "all",
                 });
             }, 0);
         },
         [],
     );
-
-    // Track search duration via isFetching transitions
-    const searchStartRef = useRef<number | null>(null);
-    useEffect(() => {
-        if (isFetching) {
-            searchStartRef.current = Date.now();
-        } else if (searchStartRef.current !== null) {
-            setSearchDuration(Date.now() - searchStartRef.current);
-            searchStartRef.current = null;
-        }
-    }, [isFetching]);
 
     // Register all Tauri download event listeners (single wiring point)
     useEffect(() => {
@@ -203,9 +176,6 @@ function AppContent() {
             <StatusBar
                 viewMode={viewMode}
                 onViewModeChange={handleViewModeChange}
-                resultCount={results.length}
-                totalEstimate={totalEstimate}
-                searchDuration={searchDuration}
                 onSwitchToQueue={() => setActiveTab("queue")}
             />
         </div>

--- a/crates/rdlp-desktop/src/App.tsx
+++ b/crates/rdlp-desktop/src/App.tsx
@@ -53,6 +53,8 @@ function AppContent() {
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
 
     const results = searchData?.pages.flatMap(p => p.results) ?? [];
+    const lastPage = searchData?.pages[searchData.pages.length - 1];
+    const totalEstimate = lastPage?.total_estimate ?? null;
 
     const activeCount = jobs.filter(
         (j) => j.status === "pending" || j.status === "running",
@@ -202,6 +204,7 @@ function AppContent() {
                 viewMode={viewMode}
                 onViewModeChange={handleViewModeChange}
                 resultCount={results.length}
+                totalEstimate={totalEstimate}
                 searchDuration={searchDuration}
                 onSwitchToQueue={() => setActiveTab("queue")}
             />

--- a/crates/rdlp-desktop/src/api/search.ts
+++ b/crates/rdlp-desktop/src/api/search.ts
@@ -1,12 +1,12 @@
 // TanStack Query options for search-related Rust commands.
 
-import { queryOptions } from "@tanstack/react-query";
+import { queryOptions, infiniteQueryOptions } from "@tanstack/react-query";
 import { invokeTyped } from "./invokeClient";
 import { queryKeys } from "../query/queryKeys";
 import type {
     SearchFilter,
     SearchFilterDescriptor,
-    SearchResponse,
+    SearchPageResponse,
     SearchSiteInfo,
 } from "../types";
 
@@ -30,18 +30,23 @@ export function filtersQueryOptions(site: string) {
 }
 
 /**
- * Search query. `enabled: false` by default — must be triggered via `refetch()`.
+ * Infinite search query. `enabled: false` by default — must be triggered via `refetch()`.
  * The key includes query/site/filters so each unique combination gets its own cache entry.
+ * pageParam is managed internally by useInfiniteQuery.
  */
-export function searchQueryOptions(
+export function searchInfiniteQueryOptions(
     query: string,
     site: string,
     filters: SearchFilter[],
 ) {
-    return queryOptions({
+    return infiniteQueryOptions({
         queryKey: queryKeys.search(query, site, filters),
-        queryFn: () =>
-            invokeTyped<SearchResponse>("search_content", { query, site, filters }),
+        queryFn: ({ pageParam }) =>
+            invokeTyped<SearchPageResponse>("search_content", { query, site, filters, page: pageParam }),
+        initialPageParam: 1,
+        getNextPageParam: (lastPage) =>
+            lastPage.has_more && lastPage.results.length > 0 ? lastPage.page + 1 : undefined,
         enabled: false,
+        maxPages: 5,
     });
 }

--- a/crates/rdlp-desktop/src/api/search.ts
+++ b/crates/rdlp-desktop/src/api/search.ts
@@ -40,7 +40,7 @@ export function searchInfiniteQueryOptions(
     filters: SearchFilter[],
 ) {
     return infiniteQueryOptions({
-        queryKey: queryKeys.search(query, site, filters),
+        queryKey: queryKeys.search.params(query, site, filters),
         queryFn: ({ pageParam }) =>
             invokeTyped<SearchPageResponse>("search_content", { query, site, filters, page: pageParam }),
         initialPageParam: 1,

--- a/crates/rdlp-desktop/src/components/CommandBar.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.tsx
@@ -3,10 +3,10 @@
 
 import { useEffect, useRef } from "react";
 import { useStore } from "@tanstack/react-store";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Search, ArrowRight, Loader2, X } from "lucide-react";
 import { searchParamsAtom, setSearchParam, resetSearchParams } from "../stores/searchParamsStore";
-import { providersQueryOptions, searchQueryOptions } from "../api/search";
+import { providersQueryOptions, searchInfiniteQueryOptions } from "../api/search";
 import { Button } from "@/components/ui/button";
 import {
     Select,
@@ -29,7 +29,7 @@ export function CommandBar({ inputRef, activeTab }: CommandBarProps) {
     const filters = useStore(searchParamsAtom, (s) => s.filters);
 
     const { data: providers = [] } = useQuery(providersQueryOptions());
-    const { isFetching, refetch } = useQuery(searchQueryOptions(query, site, filters));
+    const { isFetching, refetch } = useInfiniteQuery(searchInfiniteQueryOptions(query, site, filters));
 
     const formRef = useRef<HTMLFormElement>(null);
 

--- a/crates/rdlp-desktop/src/components/CommandBar.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.tsx
@@ -3,10 +3,10 @@
 
 import { useEffect, useRef } from "react";
 import { useStore } from "@tanstack/react-store";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Search, ArrowRight, Loader2, X } from "lucide-react";
 import { searchParamsAtom, setSearchParam, resetSearchParams } from "../stores/searchParamsStore";
-import { providersQueryOptions, searchInfiniteQueryOptions } from "../api/search";
+import { providersQueryOptions } from "../api/search";
 import { Button } from "@/components/ui/button";
 import {
     Select,
@@ -20,16 +20,16 @@ interface CommandBarProps {
     /** Ref exposed so keyboard nav can focus the input externally. */
     inputRef: React.RefObject<HTMLInputElement>;
     activeTab: string;
+    isFetching: boolean;
+    onSearch: () => void;
 }
 
 /** Compact 36px command bar: site selector, search input, submit icon. */
-export function CommandBar({ inputRef, activeTab }: CommandBarProps) {
+export function CommandBar({ inputRef, activeTab, isFetching, onSearch }: CommandBarProps) {
     const query = useStore(searchParamsAtom, (s) => s.query);
     const site = useStore(searchParamsAtom, (s) => s.site);
-    const filters = useStore(searchParamsAtom, (s) => s.filters);
 
     const { data: providers = [] } = useQuery(providersQueryOptions());
-    const { isFetching, refetch } = useInfiniteQuery(searchInfiniteQueryOptions(query, site, filters));
 
     const formRef = useRef<HTMLFormElement>(null);
 
@@ -66,7 +66,7 @@ export function CommandBar({ inputRef, activeTab }: CommandBarProps) {
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!isDisabled) {
-            refetch().catch((e) => console.error("Refetch failed:", e));
+            onSearch();
         }
     };
 

--- a/crates/rdlp-desktop/src/components/FilterBar.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from "react";
 import { useStore } from "@tanstack/react-store";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Settings, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { searchParamsAtom } from "../stores/searchParamsStore";
-import { filtersQueryOptions, searchInfiniteQueryOptions } from "../api/search";
+import { filtersQueryOptions } from "../api/search";
 import type { SearchFilter } from "../types";
 
 /** Sentinel value for "no selection" since Radix Select does not support empty string values. */
@@ -32,17 +32,20 @@ function isFilterActive(value: string, defaultValue: string | null): boolean {
     return value !== (defaultValue ?? "");
 }
 
+interface FilterBarProps {
+    isFetching: boolean;
+    hasSearchData: boolean;
+    onSearch: () => void;
+}
+
 /** Compact chip-styled filter bar with default + advanced filters. */
-export function FilterBar() {
+export function FilterBar({ isFetching, hasSearchData, onSearch }: FilterBarProps) {
     const filters = useStore(searchParamsAtom, (s) => s.filters);
     const site = useStore(searchParamsAtom, (s) => s.site);
     const query = useStore(searchParamsAtom, (s) => s.query);
     const hasUserFilters = useStore(searchParamsAtom, (s) => s.hasUserFilters);
 
     const { data: filterDescriptors = [] } = useQuery(filtersQueryOptions(site));
-    const { isFetching, data: searchData, refetch } = useInfiniteQuery(
-        searchInfiniteQueryOptions(query, site, filters),
-    );
 
     const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -71,9 +74,9 @@ export function FilterBar() {
     useEffect(() => {
         if (!hasUserFilters) return;
         // Only auto-search if a search has already been performed
-        if (searchData === undefined) return;
+        if (!hasSearchData) return;
         if (query.trim() === "" || site === "") return;
-        refetch().catch((e) => console.error("Refetch failed:", e));
+        onSearch();
     }, [filters, hasUserFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleFilterChange = (key: string, rawValue: string) => {

--- a/crates/rdlp-desktop/src/components/FilterBar.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from "react";
 import { useStore } from "@tanstack/react-store";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Settings, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { searchParamsAtom } from "../stores/searchParamsStore";
-import { filtersQueryOptions, searchQueryOptions } from "../api/search";
+import { filtersQueryOptions, searchInfiniteQueryOptions } from "../api/search";
 import type { SearchFilter } from "../types";
 
 /** Sentinel value for "no selection" since Radix Select does not support empty string values. */
@@ -40,8 +40,8 @@ export function FilterBar() {
     const hasUserFilters = useStore(searchParamsAtom, (s) => s.hasUserFilters);
 
     const { data: filterDescriptors = [] } = useQuery(filtersQueryOptions(site));
-    const { isFetching, data: searchData, refetch } = useQuery(
-        searchQueryOptions(query, site, filters),
+    const { isFetching, data: searchData, refetch } = useInfiniteQuery(
+        searchInfiniteQueryOptions(query, site, filters),
     );
 
     const [showAdvanced, setShowAdvanced] = useState(false);

--- a/crates/rdlp-desktop/src/components/StatusBar.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBar.tsx
@@ -12,6 +12,7 @@ interface StatusBarProps {
     viewMode: ViewMode;
     onViewModeChange: (mode: ViewMode) => void;
     resultCount: number;
+    totalEstimate: number | null;
     searchDuration: number | null;
     onSwitchToQueue: () => void;
 }
@@ -20,6 +21,7 @@ export function StatusBar({
     viewMode,
     onViewModeChange,
     resultCount,
+    totalEstimate,
     searchDuration,
     onSwitchToQueue,
 }: StatusBarProps) {
@@ -30,13 +32,16 @@ export function StatusBar({
 
     // --- TanStack Query: server state ---
     const { data: providers = [] } = useQuery(providersQueryOptions());
-    const { isFetching, isError, isSuccess } = useInfiniteQuery(
+    const { isFetching, isFetchingNextPage, isError, isSuccess } = useInfiniteQuery(
         searchInfiniteQueryOptions(query, site, filters),
     );
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
 
+    // Initial loading vs. appending more pages
+    const isInitialLoading = isFetching && !isFetchingNextPage;
+
     // Derive status from query state (same pattern as SearchPage)
-    const status: "idle" | "loading" | "results" | "empty" | "error" = isFetching
+    const status: "idle" | "loading" | "results" | "empty" | "error" = isInitialLoading
         ? "loading"
         : isError
             ? "error"
@@ -55,10 +60,15 @@ export function StatusBar({
 
     let leftText = "Ready";
     if (status === "loading") {
-        leftText = "Searching\u2026";
+        // "Filtering..." when refining results already shown; "Searching..." for initial fetch
+        leftText = isSuccess ? "Filtering\u2026" : "Searching\u2026";
     } else if (status === "results") {
         const dur = searchDuration !== null ? ` \u00b7 ${(searchDuration / 1000).toFixed(1)}s` : "";
-        leftText = `${displaySite} \u00b7 ${resultCount} results${dur}`;
+        const countText =
+            totalEstimate !== null && totalEstimate > resultCount
+                ? `${resultCount} of ~${totalEstimate} results`
+                : `${resultCount} results`;
+        leftText = `${displaySite} \u00b7 ${countText}${dur}`;
     } else if (status === "empty") {
         leftText = `${displaySite} \u00b7 No results`;
     } else if (status === "error") {

--- a/crates/rdlp-desktop/src/components/StatusBar.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBar.tsx
@@ -1,8 +1,8 @@
 import { useStore } from "@tanstack/react-store";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { LayoutList, LayoutGrid } from "lucide-react";
 import { searchParamsAtom } from "../stores/searchParamsStore";
-import { providersQueryOptions, searchQueryOptions } from "../api/search";
+import { providersQueryOptions, searchInfiniteQueryOptions } from "../api/search";
 import { downloadsQueryOptions } from "../api/downloads";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -30,8 +30,8 @@ export function StatusBar({
 
     // --- TanStack Query: server state ---
     const { data: providers = [] } = useQuery(providersQueryOptions());
-    const { isFetching, isError, isSuccess } = useQuery(
-        searchQueryOptions(query, site, filters),
+    const { isFetching, isError, isSuccess } = useInfiniteQuery(
+        searchInfiniteQueryOptions(query, site, filters),
     );
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
 

--- a/crates/rdlp-desktop/src/components/StatusBar.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "@tanstack/react-store";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { LayoutList, LayoutGrid } from "lucide-react";
@@ -11,31 +12,42 @@ import type { ViewMode } from "../types";
 interface StatusBarProps {
     viewMode: ViewMode;
     onViewModeChange: (mode: ViewMode) => void;
-    resultCount: number;
-    totalEstimate: number | null;
-    searchDuration: number | null;
     onSwitchToQueue: () => void;
 }
 
 export function StatusBar({
     viewMode,
     onViewModeChange,
-    resultCount,
-    totalEstimate,
-    searchDuration,
     onSwitchToQueue,
 }: StatusBarProps) {
-    // --- TanStack Store: search form state ---
+    // --- TanStack Store: search form state (for query key) ---
     const query = useStore(searchParamsAtom, (s) => s.query);
     const site = useStore(searchParamsAtom, (s) => s.site);
     const filters = useStore(searchParamsAtom, (s) => s.filters);
 
-    // --- TanStack Query: server state ---
+    // --- TanStack Query: search + downloads state ---
     const { data: providers = [] } = useQuery(providersQueryOptions());
-    const { isFetching, isFetchingNextPage, isError, isSuccess } = useInfiniteQuery(
+    const { isFetching, isFetchingNextPage, isError, isSuccess, data: searchData } = useInfiniteQuery(
         searchInfiniteQueryOptions(query, site, filters),
     );
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
+
+    const results = searchData?.pages.flatMap(p => p.results) ?? [];
+    const resultCount = results.length;
+    const lastPage = searchData?.pages[searchData.pages.length - 1];
+    const totalEstimate = lastPage?.total_estimate ?? null;
+
+    // Track search duration via isFetching transitions
+    const [searchDuration, setSearchDuration] = useState<number | null>(null);
+    const searchStartRef = useRef<number | null>(null);
+    useEffect(() => {
+        if (isFetching) {
+            searchStartRef.current = Date.now();
+        } else if (searchStartRef.current !== null) {
+            setSearchDuration(Date.now() - searchStartRef.current);
+            searchStartRef.current = null;
+        }
+    }, [isFetching]);
 
     // Initial loading vs. appending more pages
     const isInitialLoading = isFetching && !isFetchingNextPage;

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -17,7 +17,7 @@ import type {
     FormatSelectedPayload,
     SearchFilter,
     SearchFilterDescriptor,
-    SearchResponse,
+    SearchPageResponse,
     SearchSiteInfo,
 } from "../types";
 
@@ -28,8 +28,9 @@ export async function searchContent(
     query: string,
     site: string,
     filters: SearchFilter[] = [],
-): Promise<SearchResponse> {
-    return invoke<SearchResponse>("search_content", { query, site, filters });
+    page?: number,
+): Promise<SearchPageResponse> {
+    return invoke<SearchPageResponse>("search_content", { query, site, filters, page });
 }
 
 /** List all sites that support search. */

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -7,7 +7,7 @@ import {
     getSortedRowModel,
 } from "@tanstack/react-table";
 import type { ColumnResizeMode, RowSelectionState, SortingState, Table } from "@tanstack/react-table";
-import { WifiOff, AlertCircle } from "lucide-react";
+import { WifiOff, AlertCircle, Loader2 } from "lucide-react";
 import { CommandBar } from "../components/CommandBar";
 import { FilterBar } from "../components/FilterBar";
 import { ResultsTableSection } from "../components/ResultsTableSection";
@@ -68,7 +68,9 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
 
     // Derive results and status from query state
     const results = searchData?.pages.flatMap(p => p.results) ?? [];
-    const status: "idle" | "loading" | "results" | "empty" | "error" = isFetching
+    // Do not show the initial loading bar when only fetching additional pages
+    const isInitialLoading = isFetching && !isFetchingNextPage;
+    const status: "idle" | "loading" | "results" | "empty" | "error" = isInitialLoading
         ? "loading"
         : isError
             ? "error"
@@ -88,21 +90,25 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     const [formatDialogUrl, setFormatDialogUrl] = useState<string | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const tableRef = useRef<Table<SearchResultPreview> | null>(null);
+    const allResultsLoadedRef = useRef<HTMLParagraphElement>(null);
 
     // --- TanStack Table state ---
     const [sorting, setSorting] = useState<SortingState>([]);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
     const [columnVisibility, setColumnVisibility] = useState({});
 
-    // Reset table state when results change
-    const prevResultsRef = useRef(results);
+    // Reset table state when query/site/filters change (not on Load More page appends)
     useEffect(() => {
-        if (prevResultsRef.current !== results) {
-            prevResultsRef.current = results;
-            setSorting([]);
-            setRowSelection({});
+        setSorting([]);
+        setRowSelection({});
+    }, [query, site, filters]);
+
+    // Focus "All results loaded" message when Load More button disappears (fix 8)
+    useEffect(() => {
+        if (!hasNextPage && !isFetchingNextPage && isSuccess && results.length > 0) {
+            allResultsLoadedRef.current?.focus();
         }
-    }, [results]);
+    }, [hasNextPage, isFetchingNextPage, isSuccess, results.length]);
 
     // Record search history when results arrive
     useEffect(() => {
@@ -339,6 +345,11 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                 </div>
             )}
 
+            {/* aria-live region: announces result count to screen readers when pages are appended */}
+            <div className="sr-only" aria-live="polite" role="status">
+                {results.length > 0 ? `${results.length} results loaded` : ""}
+            </div>
+
             {/* Results: table view */}
             {status === "results" && viewMode === "list" && (
                 <ResultsTableSection
@@ -353,9 +364,9 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
             {/* Results: grid view */}
             {status === "results" && viewMode === "grid" && (
                 <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3">
-                    {results.map((result, idx) => (
+                    {results.map((result) => (
                         <ResultCard
-                            key={`${idx}-${result.video_url}`}
+                            key={result.video_url}
                             result={result}
                             onDownload={handleDownload}
                             onDownloadWithOptions={handleDownloadWithOptions}
@@ -372,11 +383,28 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                         variant="outline"
                         onClick={() => fetchNextPage()}
                         disabled={isFetchingNextPage}
-                        className="min-w-[200px]"
+                        aria-busy={isFetchingNextPage}
+                        className="min-w-[200px] gap-1.5"
                     >
-                        {isFetchingNextPage ? "Loading..." : "Load more results"}
+                        {isFetchingNextPage ? (
+                            <>
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                Loading...
+                            </>
+                        ) : "Load more results"}
                     </Button>
                 </div>
+            )}
+
+            {/* All results loaded */}
+            {status === "results" && !hasNextPage && !isFetchingNextPage && (
+                <p
+                    ref={allResultsLoadedRef}
+                    className="text-center text-muted-foreground text-xs py-3"
+                    tabIndex={-1}
+                >
+                    All results loaded
+                </p>
             )}
 
             {/* Batch action bar */}

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@tanstack/react-store";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
     useReactTable,
     getCoreRowModel,
@@ -23,7 +23,7 @@ import {
 } from "../stores/searchParamsStore";
 import {
     providersQueryOptions,
-    searchQueryOptions,
+    searchInfiniteQueryOptions,
 } from "../api/search";
 import { settingsQueryOptions } from "../api/settings";
 import {
@@ -60,11 +60,14 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
         isSuccess,
         error: queryError,
         refetch,
-    } = useQuery(searchQueryOptions(query, site, filters));
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery(searchInfiniteQueryOptions(query, site, filters));
     const { data: settings = null } = useQuery(settingsQueryOptions());
 
     // Derive results and status from query state
-    const results = searchData?.results ?? [];
+    const results = searchData?.pages.flatMap(p => p.results) ?? [];
     const status: "idle" | "loading" | "results" | "empty" | "error" = isFetching
         ? "loading"
         : isError
@@ -359,6 +362,20 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                             onOpenFormatDialog={handleOpenFormatDialog}
                         />
                     ))}
+                </div>
+            )}
+
+            {/* Load more */}
+            {status === "results" && hasNextPage && (
+                <div className="flex justify-center py-4">
+                    <Button
+                        variant="outline"
+                        onClick={() => fetchNextPage()}
+                        disabled={isFetchingNextPage}
+                        className="min-w-[200px]"
+                    >
+                        {isFetchingNextPage ? "Loading..." : "Load more results"}
+                    </Button>
                 </div>
             )}
 

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "@tanstack/react-store";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
@@ -66,8 +66,11 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     } = useInfiniteQuery(searchInfiniteQueryOptions(query, site, filters));
     const { data: settings = null } = useQuery(settingsQueryOptions());
 
-    // Derive results and status from query state
-    const results = searchData?.pages.flatMap(p => p.results) ?? [];
+    // Derive results — memoized so TanStack Table doesn't reprocess rows on unrelated renders
+    const results = useMemo(
+        () => searchData?.pages.flatMap(p => p.results) ?? [],
+        [searchData],
+    );
     // Do not show the initial loading bar when only fetching additional pages
     const isInitialLoading = isFetching && !isFetchingNextPage;
     const status: "idle" | "loading" | "results" | "empty" | "error" = isInitialLoading
@@ -118,6 +121,10 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
             addEntry({ query, site, siteDisplayName: displayName, filters: [] });
         }
     }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleSearch = useCallback(() => {
+        refetch().catch((e) => console.error("Refetch failed:", e));
+    }, [refetch]);
 
     const handleDownload = useCallback(
         (url: string, title?: string) => {
@@ -278,8 +285,8 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     return (
         <div className="flex flex-col h-full">
             <div className="shrink-0 pb-2.5 border-b border-border mb-1.5">
-                <CommandBar inputRef={inputRef} activeTab={activeTab} />
-                <FilterBar />
+                <CommandBar inputRef={inputRef} activeTab={activeTab} isFetching={isFetching} onSearch={handleSearch} />
+                <FilterBar isFetching={isFetching} hasSearchData={!!searchData} onSearch={handleSearch} />
             </div>
 
             {/* Loading bar */}

--- a/crates/rdlp-desktop/src/query/queryKeys.ts
+++ b/crates/rdlp-desktop/src/query/queryKeys.ts
@@ -3,14 +3,35 @@
 // Every TanStack Query call MUST reference keys from here -- never
 // inline key arrays in components. This prevents key drift and makes
 // invalidation predictable.
+//
+// Search keys are hierarchical for granular invalidation:
+//   search.all()              → ["search"]           — invalidate everything
+//   search.site("xhamster")   → ["search","xhamster"] — invalidate one site
+//   search.params(q, s, f)    → ["search","xhamster","teen","sort=relevance"]
+//
+// Filters are serialized to a stable string so TanStack Query can
+// compare keys with === instead of deep-comparing object arrays.
 
 import type { SearchFilter } from "../types";
+
+/** Deterministic string key for a filter set (sorted for stability). */
+function serializeFilters(filters: SearchFilter[]): string {
+    if (filters.length === 0) return "";
+    return filters
+        .map((f) => `${f.key}=${f.value}`)
+        .sort()
+        .join("&");
+}
 
 export const queryKeys = {
     providers: () => ["providers"] as const,
     filters: (site: string) => ["filters", site] as const,
-    search: (query: string, site: string, filters: SearchFilter[]) =>
-        ["search", query, site, filters] as const,
+    search: {
+        all: () => ["search"] as const,
+        site: (site: string) => ["search", site] as const,
+        params: (query: string, site: string, filters: SearchFilter[]) =>
+            ["search", site, query, serializeFilters(filters)] as const,
+    },
     downloads: {
         list: () => ["downloads"] as const,
     },

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -44,9 +44,11 @@ export interface SearchResultPreview {
     upload_date: string | null;
 }
 
-/** Response wrapper for search results. */
-export interface SearchResponse {
+/** Response for a single search page with pagination metadata. */
+export interface SearchPageResponse {
     results: SearchResultPreview[];
+    page: number;
+    has_more: boolean;
     total_estimate: number | null;
 }
 

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -22,7 +22,10 @@ mod search;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor};
+use rdlp_core::{
+    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
+    SearchPageResponse,
+};
 use regex::Regex;
 use scraper::Html;
 use std::time::Duration;
@@ -405,6 +408,52 @@ impl SearchExtractor for RedTubeExtractor {
         ctx: &ExtractionContext,
     ) -> Result<Vec<rdlp_core::SearchResultPreview>> {
         self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        let descriptors = patterns::search_filter_descriptors();
+        search::validate_search_filters(&query.filters, &descriptors)?;
+
+        let page = query.page.unwrap_or(1);
+        let base_url = patterns::build_api_search_url(&query.query, &query.filters);
+
+        let page_url = if page == 1 {
+            base_url
+        } else {
+            patterns::build_api_search_url_page(&base_url, page)
+        };
+
+        let (page_results, total_count) = match self.fetch_api_search_page(&page_url, ctx).await {
+            Ok(result) => result,
+            Err(e) => {
+                if page == 1 {
+                    warn!("[RedTube] API search failed, falling back to HTML: {e}");
+                    let html_url = patterns::build_html_search_url(&query.query);
+                    let results = self.fetch_html_search_page(&html_url, ctx).await?;
+                    (results, None)
+                } else {
+                    return Err(e);
+                }
+            }
+        };
+
+        let has_more = if let Some(total) = total_count {
+            let fetched_through = u64::from(page) * u64::from(patterns::API_RESULTS_PER_PAGE);
+            fetched_through < total && !page_results.is_empty()
+        } else {
+            false
+        };
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page,
+            has_more,
+            total_estimate: total_count,
+        })
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -27,7 +27,10 @@ mod utils;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor};
+use rdlp_core::{
+    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
+    SearchPageResponse,
+};
 use std::time::Duration;
 
 use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
@@ -187,6 +190,29 @@ impl XHamsterExtractor {
         )))
     }
 
+    /// Fetch a single search page, returning its results and the max page count.
+    async fn fetch_single_search_page(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        page: usize,
+        ctx: &ExtractionContext,
+    ) -> Result<(Vec<rdlp_core::SearchResultPreview>, usize)> {
+        let page_url = if page == 1 {
+            patterns::build_search_url(query)
+        } else {
+            patterns::build_search_url_page(query, page)
+        };
+
+        debug!(page, url:? = rdlp_security::sanitize_for_logging(&page_url); "[XHamster] Fetching search page");
+
+        let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+        let initials = search::extract_initials_json(&webpage)?;
+        let page_results = search::parse_search_results_json(&initials)?;
+        let max_pages = search::parse_max_pages(&initials).unwrap_or(1);
+
+        Ok((page_results, max_pages))
+    }
+
     /// Perform a paginated search, collecting results across all pages.
     async fn search_all_pages(
         &self,
@@ -200,32 +226,16 @@ impl XHamsterExtractor {
         let mut page = 1_usize;
 
         loop {
-            let page_url = if page == 1 {
-                patterns::build_search_url(query)
-            } else {
-                patterns::build_search_url_page(query, page)
-            };
-
-            debug!(page, url:? = rdlp_security::sanitize_for_logging(&page_url); "[XHamster] Fetching search page");
-
-            let webpage = match BaseExtractor::fetch_webpage(&page_url, ctx).await {
-                Ok(html) => html,
+            let (page_results, max_pages) = match self
+                .fetch_single_search_page(query, page, ctx)
+                .await
+            {
+                Ok(result) => result,
                 Err(e) => {
                     warn!(page; "[XHamster] Failed to fetch search page, returning partial results: {e}");
                     break;
                 }
             };
-
-            let initials = match search::extract_initials_json(&webpage) {
-                Ok(json) => json,
-                Err(e) => {
-                    warn!(page; "[XHamster] Failed to parse search page JSON, returning partial results: {e}");
-                    break;
-                }
-            };
-
-            let page_results = search::parse_search_results_json(&initials)?;
-            let max_pages = search::parse_max_pages(&initials).unwrap_or(1);
 
             if page_results.is_empty() {
                 debug!(page; "[XHamster] No results on page, stopping pagination");
@@ -310,6 +320,26 @@ impl SearchExtractor for XHamsterExtractor {
         ctx: &ExtractionContext,
     ) -> Result<Vec<rdlp_core::SearchResultPreview>> {
         self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        search::validate_search_filters(&query.filters)?;
+
+        let page = query.page.unwrap_or(1) as usize;
+        let (page_results, max_pages) = self.fetch_single_search_page(query, page, ctx).await?;
+
+        let has_more = page < max_pages && !page_results.is_empty();
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page: page as u32,
+            has_more,
+            total_estimate: None,
+        })
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search_patterns.rs
@@ -224,6 +224,7 @@ mod tests {
             query: "test query".to_string(),
             filters: vec![],
             max_results: None,
+            page: None,
         };
         let url = build_search_url(&query);
         assert!(url.starts_with("https://xhamster.com/search/"));
@@ -245,6 +246,7 @@ mod tests {
                 },
             ],
             max_results: None,
+            page: None,
         };
         let url = build_search_url(&query);
         assert!(url.contains("quality=1080p"));
@@ -257,6 +259,7 @@ mod tests {
             query: "hello world".to_string(),
             filters: vec![],
             max_results: None,
+            page: None,
         };
         let url = build_search_url(&query);
         assert!(!url.contains(' '), "URL must not contain raw spaces");

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -47,8 +47,8 @@ pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use parse_error::ParseEnumError;
 pub use protocol::DownloadProtocol;
 pub use search::{
-    SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchQuery, SearchResultPreview,
-    SearchSiteInfo,
+    SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery,
+    SearchResultPreview, SearchSiteInfo,
 };
 pub use subtitle_format::SubtitleFormat;
 pub use subtitle_kind::SubtitleKind;

--- a/crates/rdlp-types/src/search.rs
+++ b/crates/rdlp-types/src/search.rs
@@ -11,6 +11,8 @@ pub struct SearchQuery {
     pub filters: Vec<SearchFilter>,
     /// Maximum number of results to return. `None` uses the site default / MAX_PLAYLIST_SIZE cap.
     pub max_results: Option<usize>,
+    /// Specific page to fetch. None = fetch all pages (CLI behavior).
+    pub page: Option<u32>,
 }
 
 /// A concrete filter key-value applied to a search.
@@ -73,6 +75,19 @@ pub struct SearchSiteInfo {
     pub display_name: String,
 }
 
+/// Response for a single search page (used for paginated frontends).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchPageResponse {
+    /// Results on this page.
+    pub results: Vec<SearchResultPreview>,
+    /// The page number that was fetched.
+    pub page: u32,
+    /// Whether more pages exist after this one.
+    pub has_more: bool,
+    /// Optional estimate of total results across all pages.
+    pub total_estimate: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,10 +98,12 @@ mod tests {
             query: "test".to_string(),
             filters: vec![],
             max_results: None,
+            page: None,
         };
         assert_eq!(q.query, "test");
         assert!(q.filters.is_empty());
         assert_eq!(q.max_results, None);
+        assert_eq!(q.page, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `SearchPageResponse` type and `search_page()` method through all layers (types → API → desktop) for single-page fetching
- Switch desktop search from `useQuery` to `useInfiniteQuery` with a "Load More" button for progressive result loading
- Address 10 UX review findings: aria-live announcements, focus management, memoized results, status bar improvements
- Fix cascading re-render hang caused by root-level `useInfiniteQuery` subscription — moved to leaf components (SearchPage, StatusBar)
- Refactor query keys to use serialized filter strings for stable cache identity

## Test plan

- [ ] Search on XHamster and RedTube returns first page of results
- [ ] "Load More" button fetches next page and appends results
- [ ] "All results loaded" message appears when no more pages
- [ ] Changing filters triggers new search (page 1 only, no re-fetch cascade)
- [ ] UI remains responsive during search and pagination (no hang)
- [ ] Status bar shows result count, total estimate, and search duration
- [ ] Sidebar history restore works correctly
- [ ] `npx tsc --noEmit` passes with zero errors