### PR TITLE
Add TNAFlix category browse with search UX improvements

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/commands/search.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/search.rs
@@ -57,7 +57,8 @@ pub async fn search_content(
     state: State<'_, AppState>,
 ) -> Result<SearchPageResponse, AppError> {
     let sanitized = sanitize_query(&query);
-    if sanitized.is_empty() {
+    let has_category = filters.iter().any(|f| f.key == "category");
+    if sanitized.is_empty() && !has_category {
         return Err(AppError::InvalidInput {
             field: "query".to_owned(),
             message: "Search query must not be empty".to_owned(),
@@ -185,5 +186,12 @@ mod tests {
         assert_eq!(sanitize_query(""), "");
         assert_eq!(sanitize_query("   "), "");
         assert_eq!(sanitize_query("\x00\x01\x02"), "");
+    }
+
+    #[test]
+    fn test_sanitize_query_allows_empty_with_category_context() {
+        // Verifies the sanitize function still returns empty for empty input;
+        // the category bypass is in search_content, not sanitize_query.
+        assert_eq!(sanitize_query(""), "");
     }
 }

--- a/crates/rdlp-desktop/src/api/invokeClient.ts
+++ b/crates/rdlp-desktop/src/api/invokeClient.ts
@@ -13,6 +13,32 @@ export interface InvokeError {
 }
 
 /**
+ * Extract a human-readable message from a Tauri command rejection.
+ *
+ * Tauri serializes Rust errors as plain JSON objects (no Error wrapper).
+ * Our AppError uses `#[serde(tag = "kind", content = "data")]`, so the
+ * JS rejection value looks like:
+ *   `{ kind: "SearchFailed", data: { message: "...", retryable: true } }`
+ */
+function extractErrorMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    if (typeof err === "string") return err;
+    if (typeof err === "object" && err !== null) {
+        const obj = err as Record<string, unknown>;
+        // AppError adjacently-tagged: { kind, data: { message } }
+        if (typeof obj.data === "object" && obj.data !== null) {
+            const data = obj.data as Record<string, unknown>;
+            if (typeof data.message === "string") return data.message;
+        }
+        // Plain object with top-level message
+        if (typeof obj.message === "string") return obj.message;
+        // Last resort: readable JSON instead of [object Object]
+        try { return JSON.stringify(err); } catch { /* fall through */ }
+    }
+    return String(err);
+}
+
+/**
  * Type-safe invoke wrapper with error normalization.
  *
  * @param command - The Rust `#[tauri::command]` name.
@@ -27,7 +53,7 @@ export async function invokeTyped<T>(
     try {
         return await invoke<T>(command, args);
     } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = extractErrorMessage(err);
         throw { code: "INVOKE_ERROR", message, details: err } satisfies InvokeError;
     }
 }

--- a/crates/rdlp-desktop/src/components/CommandBar.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.tsx
@@ -61,7 +61,9 @@ export function CommandBar({ inputRef, activeTab, isFetching, onSearch }: Comman
         inputRef.current?.focus();
     };
 
-    const isDisabled = isFetching || query.trim() === "";
+    const filters = useStore(searchParamsAtom, (s) => s.filters);
+    const hasCategoryFilter = filters.some((f) => f.key === "category" && f.value !== "");
+    const isDisabled = isFetching || (query.trim() === "" && !hasCategoryFilter);
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();

--- a/crates/rdlp-desktop/src/components/FilterBar.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.tsx
@@ -23,7 +23,7 @@ const NONE_SENTINEL = "none";
 
 const DEFAULT_FILTER_KEYS = new Set([
     "sort", "quality", "orientations", "date", "min-duration", "max-duration",
-    "ordering", "period",
+    "ordering", "period", "category",
 ]);
 
 /** Check if a filter value differs from its descriptor default. */
@@ -75,7 +75,8 @@ export function FilterBar({ isFetching, hasSearchData, onSearch }: FilterBarProp
         if (!hasUserFilters) return;
         // Only auto-search if a search has already been performed
         if (!hasSearchData) return;
-        if (query.trim() === "" || site === "") return;
+        const hasCategory = filters.some((f) => f.key === "category" && f.value !== "");
+        if ((query.trim() === "" && !hasCategory) || site === "") return;
         onSearch();
     }, [filters, hasUserFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -39,6 +39,7 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         isPending: isLoading,
         isError: isQueryError,
         error: queryError,
+        isFetching,
         refetch,
     } = useQuery(formatsQueryOptions(url));
     const { data: settings = null } = useQuery(settingsQueryOptions());
@@ -51,7 +52,6 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
     const [expr, setExpr] = useState("");
     const [exprError, setExprError] = useState<string | null>(null);
     const [exprMatches, setExprMatches] = useState<Set<string>>(new Set());
-    const [error, setError] = useState<string | null>(null);
     const [settingsApplied, setSettingsApplied] = useState(false);
     const [showOptions, setShowOptions] = useState(false);
     const [presetId, setPresetId] = useState<string | null>(null);
@@ -82,12 +82,8 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         }
     }, [settings, settingsApplied]);
 
-    // Surface query errors in local state
-    useEffect(() => {
-        if (isQueryError && queryError) {
-            setError(queryError.message);
-        }
-    }, [isQueryError, queryError]);
+    // Derived error: show query error when not retrying
+    const error = isQueryError && !isFetching && queryError ? queryError.message : null;
 
     // Cleanup debounce timer
     useEffect(() => {
@@ -262,7 +258,6 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
                                         size="sm"
                                         className="ml-auto h-6 text-[11px]"
                                         onClick={() => {
-                                            setError(null);
                                             refetch().catch((e) => console.error("Refetch failed:", e));
                                         }}
                                     >

--- a/crates/rdlp-desktop/src/components/ResultRowActions.tsx
+++ b/crates/rdlp-desktop/src/components/ResultRowActions.tsx
@@ -44,7 +44,7 @@ export function ResultRowActions({
     return (
         <>
             <div className={cn(
-                "flex gap-0.5 shrink-0 opacity-0 transition-opacity",
+                "flex gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity",
                 visible && "opacity-100",
             )}>
                 <Button

--- a/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
+++ b/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
@@ -1,7 +1,7 @@
 // Search results table with TanStack Table: column visibility toggle, sortable
 // headers with resize handles, checkbox selection, and result count footer.
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { Table as TanStackTable, ColumnDef } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
 import { ChevronUp, ChevronDown, Columns3 } from "lucide-react";
@@ -46,6 +46,13 @@ export function ResultsTableSection({
     resultCount,
 }: ResultsTableSectionProps) {
     const rowRefs = useRef<Map<number, HTMLTableRowElement>>(new Map());
+
+    // Compute total size from visible columns only (so percentages stay correct when columns hide)
+    const visibleTotalSize = useMemo(
+        () => table.getVisibleFlatColumns().reduce((sum, col) => sum + col.getSize(), 0),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [table, totalColumnSize, table.getState().columnVisibility],
+    );
 
     // Scroll focused row into view
     useEffect(() => {
@@ -104,7 +111,7 @@ export function ResultsTableSection({
                                     return (
                                         <TableHead
                                             key={header.id}
-                                            style={{ width: `${(header.getSize() / totalColumnSize * 100).toFixed(1)}%` }}
+                                            style={{ width: `${(header.getSize() / visibleTotalSize * 100).toFixed(1)}%` }}
                                             className={cn(
                                                 "h-8 px-3 text-[10px] font-bold tracking-wider uppercase select-none transition-colors relative",
                                                 header.column.getCanSort() && "cursor-pointer hover:text-foreground",

--- a/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
+++ b/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
@@ -158,6 +158,7 @@ export function ResultsTableSection({
                                         row.index === focusIndex && "bg-card border-l-primary",
                                         row.getIsSelected() && "bg-primary/15 border-l-primary",
                                     )}
+                                    onClick={() => row.toggleSelected()}
                                     data-focused={row.index === focusIndex || undefined}
                                 >
                                     {row.getVisibleCells().map((cell) => {

--- a/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
+++ b/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
@@ -156,7 +156,7 @@ export function ResultsTableSection({
                                         "group h-[52px] border-b border-white/[0.03] border-l-2 border-l-transparent transition-colors",
                                         "hover:bg-card",
                                         row.index === focusIndex && "bg-card border-l-primary",
-                                        row.getIsSelected() && "bg-primary/10",
+                                        row.getIsSelected() && "bg-primary/15 border-l-primary",
                                     )}
                                     data-focused={row.index === focusIndex || undefined}
                                 >

--- a/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
+++ b/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
@@ -97,15 +97,8 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
             sortingFn: "text",
             enableResizing: true,
             cell: ({ row }) => (
-                <div className="flex flex-col gap-px min-w-0">
-                    <div className="text-[13px] font-medium text-foreground truncate" title={row.original.title}>
-                        {row.original.title}
-                    </div>
-                    {row.original.view_count !== null && (
-                        <div className="text-[11px] text-muted-foreground">
-                            {formatViews(row.original.view_count)}
-                        </div>
-                    )}
+                <div className="text-[13px] font-medium text-foreground truncate" title={row.original.title}>
+                    {row.original.title}
                 </div>
             ),
         }),
@@ -119,6 +112,21 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
             cell: ({ row }) => (
                 <span className="font-mono text-xs text-muted-foreground">
                     {formatDuration(row.original.duration)}
+                </span>
+            ),
+            meta: { align: "right" as const },
+        }),
+        columnHelper.accessor("view_count", {
+            id: "views",
+            header: "Views",
+            size: 90,
+            sortDescFirst: true,
+            sortUndefined: "last",
+            sortingFn: "basic",
+            enableResizing: true,
+            cell: ({ row }) => (
+                <span className="font-mono text-xs text-muted-foreground">
+                    {formatViews(row.original.view_count)}
                 </span>
             ),
             meta: { align: "right" as const },

--- a/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
+++ b/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
@@ -3,12 +3,13 @@
 // Mirrors the formatColumns.tsx pattern: a hook returning stable column
 // definitions and the total column size for percentage-based layout.
 
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { createColumnHelper } from "@tanstack/react-table";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, Row } from "@tanstack/react-table";
 import { Checkbox } from "@/components/ui/checkbox";
+import { parseUploadTimestamp } from "@/lib/utils";
 import { ResultRowActions } from "../ResultRowActions";
-import { formatDuration, formatViews } from "./searchUtils";
+import { formatDuration, formatCompactDate, formatViews } from "./searchUtils";
 import type { DownloadOptions, SearchResultPreview } from "../../types";
 
 interface SearchColumnCallbacks {
@@ -28,6 +29,23 @@ interface SearchColumnsResult {
 export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumnsResult {
     const { onDownload, onDownloadWithOptions, onOpenFormatDialog, focusIndex } = callbacks;
     const columnHelper = useMemo(() => createColumnHelper<SearchResultPreview>(), []);
+
+    const ageSortFn = useCallback(
+        (rowA: Row<SearchResultPreview>, rowB: Row<SearchResultPreview>) => {
+            const a = rowA.original.upload_date;
+            const b = rowB.original.upload_date;
+            if (a === null && b === null) return 0;
+            if (a === null) return 1;
+            if (b === null) return -1;
+            const dateA = parseUploadTimestamp(a);
+            const dateB = parseUploadTimestamp(b);
+            if (dateA === null && dateB === null) return 0;
+            if (dateA === null) return 1;
+            if (dateB === null) return -1;
+            return dateA.getTime() - dateB.getTime();
+        },
+        [],
+    );
 
     const columns = useMemo(() => [
         columnHelper.display({
@@ -105,6 +123,19 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
             ),
             meta: { align: "right" as const },
         }),
+        columnHelper.accessor("upload_date", {
+            id: "age",
+            header: "Age",
+            size: 80,
+            sortingFn: ageSortFn,
+            enableResizing: true,
+            cell: ({ row }) => (
+                <span className="font-mono text-xs text-muted-foreground">
+                    {formatCompactDate(row.original.upload_date)}
+                </span>
+            ),
+            meta: { align: "right" as const },
+        }),
         columnHelper.display({
             id: "actions",
             header: "",
@@ -121,7 +152,7 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
                 />
             ),
         }),
-    ], [columnHelper, focusIndex, onDownload, onDownloadWithOptions, onOpenFormatDialog]);
+    ], [columnHelper, ageSortFn, focusIndex, onDownload, onDownloadWithOptions, onOpenFormatDialog]);
 
     const totalColumnSize = useMemo(
         () => columns.reduce((sum, col) => sum + (col.size ?? 0), 0),

--- a/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
+++ b/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
@@ -3,13 +3,12 @@
 // Mirrors the formatColumns.tsx pattern: a hook returning stable column
 // definitions and the total column size for percentage-based layout.
 
-import { useMemo, useCallback } from "react";
+import { useMemo } from "react";
 import { createColumnHelper } from "@tanstack/react-table";
-import type { ColumnDef, Row } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 import { Checkbox } from "@/components/ui/checkbox";
-import { parseUploadTimestamp } from "@/lib/utils";
 import { ResultRowActions } from "../ResultRowActions";
-import { formatDuration, formatCompactDate, formatViews } from "./searchUtils";
+import { formatDuration, formatViews } from "./searchUtils";
 import type { DownloadOptions, SearchResultPreview } from "../../types";
 
 interface SearchColumnCallbacks {
@@ -29,23 +28,6 @@ interface SearchColumnsResult {
 export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumnsResult {
     const { onDownload, onDownloadWithOptions, onOpenFormatDialog, focusIndex } = callbacks;
     const columnHelper = useMemo(() => createColumnHelper<SearchResultPreview>(), []);
-
-    const ageSortFn = useCallback(
-        (rowA: Row<SearchResultPreview>, rowB: Row<SearchResultPreview>) => {
-            const a = rowA.original.upload_date;
-            const b = rowB.original.upload_date;
-            if (a === null && b === null) return 0;
-            if (a === null) return 1;
-            if (b === null) return -1;
-            const dateA = parseUploadTimestamp(a);
-            const dateB = parseUploadTimestamp(b);
-            if (dateA === null && dateB === null) return 0;
-            if (dateA === null) return 1;
-            if (dateB === null) return -1;
-            return dateA.getTime() - dateB.getTime();
-        },
-        [],
-    );
 
     const columns = useMemo(() => [
         columnHelper.display({
@@ -123,19 +105,6 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
             ),
             meta: { align: "right" as const },
         }),
-        columnHelper.accessor("upload_date", {
-            id: "age",
-            header: "Age",
-            size: 80,
-            sortingFn: ageSortFn,
-            enableResizing: true,
-            cell: ({ row }) => (
-                <span className="font-mono text-xs text-muted-foreground">
-                    {formatCompactDate(row.original.upload_date)}
-                </span>
-            ),
-            meta: { align: "right" as const },
-        }),
         columnHelper.display({
             id: "actions",
             header: "",
@@ -152,7 +121,7 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
                 />
             ),
         }),
-    ], [columnHelper, ageSortFn, focusIndex, onDownload, onDownloadWithOptions, onOpenFormatDialog]);
+    ], [columnHelper, focusIndex, onDownload, onDownloadWithOptions, onOpenFormatDialog]);
 
     const totalColumnSize = useMemo(
         () => columns.reduce((sum, col) => sum + (col.size ?? 0), 0),

--- a/crates/rdlp-desktop/src/components/utils/searchUtils.ts
+++ b/crates/rdlp-desktop/src/components/utils/searchUtils.ts
@@ -1,11 +1,33 @@
 // Pure formatting functions for search result display.
 
+import { formatDistanceToNowStrict } from "date-fns";
+import { parseUploadTimestamp } from "@/lib/utils";
+
 /** Format duration in seconds as "m:ss". Returns em-dash for null. */
 export function formatDuration(seconds: number | null): string {
     if (seconds === null) return "\u2014";
     const m = Math.floor(seconds / 60);
     const s = Math.floor(seconds % 60);
     return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+/** Format an upload timestamp as compact relative age (e.g. "3d", "2mo", "1y"). */
+export function formatCompactDate(timestamp: string | null): string {
+    if (timestamp === null) return "";
+    const date = parseUploadTimestamp(timestamp);
+    if (date === null) return "";
+    try {
+        return formatDistanceToNowStrict(date, { addSuffix: false })
+            .replace(" seconds", "s").replace(" second", "s")
+            .replace(" minutes", "m").replace(" minute", "m")
+            .replace(" hours", "h").replace(" hour", "h")
+            .replace(" days", "d").replace(" day", "d")
+            .replace(" weeks", "w").replace(" week", "w")
+            .replace(" months", "mo").replace(" month", "mo")
+            .replace(" years", "y").replace(" year", "y");
+    } catch {
+        return "";
+    }
 }
 
 /** Format view count as compact string (e.g. "1.2M views", "3.4K views"). */

--- a/crates/rdlp-desktop/src/components/utils/searchUtils.ts
+++ b/crates/rdlp-desktop/src/components/utils/searchUtils.ts
@@ -1,33 +1,11 @@
 // Pure formatting functions for search result display.
 
-import { formatDistanceToNowStrict } from "date-fns";
-import { parseUploadTimestamp } from "@/lib/utils";
-
 /** Format duration in seconds as "m:ss". Returns em-dash for null. */
 export function formatDuration(seconds: number | null): string {
     if (seconds === null) return "\u2014";
     const m = Math.floor(seconds / 60);
     const s = Math.floor(seconds % 60);
     return `${m}:${s.toString().padStart(2, "0")}`;
-}
-
-/** Format an upload timestamp as compact relative age (e.g. "3d", "2mo", "1y"). */
-export function formatCompactDate(timestamp: string | null): string {
-    if (timestamp === null) return "";
-    const date = parseUploadTimestamp(timestamp);
-    if (date === null) return "";
-    try {
-        return formatDistanceToNowStrict(date, { addSuffix: false })
-            .replace(" seconds", "s").replace(" second", "s")
-            .replace(" minutes", "m").replace(" minute", "m")
-            .replace(" hours", "h").replace(" hour", "h")
-            .replace(" days", "d").replace(" day", "d")
-            .replace(" weeks", "w").replace(" week", "w")
-            .replace(" months", "mo").replace(" month", "mo")
-            .replace(" years", "y").replace(" year", "y");
-    } catch {
-        return "";
-    }
 }
 
 /** Format view count as compact string (e.g. "1.2M views", "3.4K views"). */

--- a/crates/rdlp-desktop/src/hooks/useKeyboardNavigation.ts
+++ b/crates/rdlp-desktop/src/hooks/useKeyboardNavigation.ts
@@ -1,11 +1,13 @@
 // Virtual focus keyboard navigation for the search results table.
 // Manages focusIndex; selection is delegated to the TanStack Table instance.
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import type { Table } from "@tanstack/react-table";
 import type { SearchResultPreview } from "../types";
 
 interface UseKeyboardNavigationOptions {
+    focusIndex: number;
+    setFocusIndex: React.Dispatch<React.SetStateAction<number>>;
     resultCount: number;
     enabled: boolean;
     table: Table<SearchResultPreview> | null;
@@ -16,6 +18,8 @@ interface UseKeyboardNavigationOptions {
 
 /** Hook providing virtual focus for the results table. Selection is owned by TanStack Table. */
 export function useKeyboardNavigation({
+    focusIndex,
+    setFocusIndex,
     resultCount,
     enabled,
     table,
@@ -23,12 +27,10 @@ export function useKeyboardNavigation({
     onOpenFormatDialog,
     onOpenInBrowser,
 }: UseKeyboardNavigationOptions) {
-    const [focusIndex, setFocusIndex] = useState(-1);
-
     // Reset when results change
     useEffect(() => {
         setFocusIndex(-1);
-    }, [resultCount]);
+    }, [resultCount, setFocusIndex]);
 
     useEffect(() => {
         if (!enabled || resultCount === 0) return;
@@ -135,8 +137,4 @@ export function useKeyboardNavigation({
         onOpenInBrowser,
     ]);
 
-    return {
-        focusIndex,
-        setFocusIndex,
-    };
 }

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -98,22 +98,28 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     // --- TanStack Table state ---
     const [sorting, setSorting] = useState<SortingState>([]);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-    const [columnVisibility, setColumnVisibility] = useState({});
+    const [userColumnVisibility, setUserColumnVisibility] = useState<Record<string, boolean>>({});
+
+    // Data-driven visibility: hide columns when no result has data for them
+    const dataColumnVisibility = useMemo(() => {
+        if (results.length === 0) return {} as Record<string, boolean>;
+        return {
+            age: results.some((r) => r.upload_date !== null),
+        } as Record<string, boolean>;
+    }, [results]);
+
+    // Merge: data defaults overridden by explicit user toggles
+    const columnVisibility = useMemo(
+        () => ({ ...dataColumnVisibility, ...userColumnVisibility }),
+        [dataColumnVisibility, userColumnVisibility],
+    );
 
     // Reset table state when query/site/filters change (not on Load More page appends)
     useEffect(() => {
         setSorting([]);
         setRowSelection({});
+        setUserColumnVisibility({});
     }, [query, site, filters]);
-
-    // Dynamic column visibility: hide columns when no result has data for them
-    useEffect(() => {
-        if (results.length === 0) return;
-        setColumnVisibility((prev) => ({
-            ...prev,
-            age: results.some((r) => r.upload_date !== null),
-        }));
-    }, [results]);
 
     // Focus "All results loaded" message when Load More button disappears (fix 8)
     useEffect(() => {
@@ -217,7 +223,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
         },
         onSortingChange: setSorting,
         onRowSelectionChange: setRowSelection,
-        onColumnVisibilityChange: setColumnVisibility,
+        onColumnVisibilityChange: setUserColumnVisibility,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         columnResizeMode: COLUMN_RESIZE_MODE,

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -106,6 +106,15 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
         setRowSelection({});
     }, [query, site, filters]);
 
+    // Dynamic column visibility: hide columns when no result has data for them
+    useEffect(() => {
+        if (results.length === 0) return;
+        setColumnVisibility((prev) => ({
+            ...prev,
+            age: results.some((r) => r.upload_date !== null),
+        }));
+    }, [results]);
+
     // Focus "All results loaded" message when Load More button disappears (fix 8)
     useEffect(() => {
         if (!hasNextPage && !isFetchingNextPage && isSuccess && results.length > 0) {

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -84,7 +84,11 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
                     : "idle";
 
     const error = isError
-        ? (queryError instanceof Error ? queryError.message : String(queryError))
+        ? (queryError instanceof Error
+            ? queryError.message
+            : (typeof queryError === "object" && queryError !== null && "message" in queryError)
+                ? String((queryError as Record<string, unknown>).message)
+                : String(queryError))
         : null;
 
     const { addEntry } = useSearchHistory();
@@ -130,7 +134,8 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
 
     // Record search history when results arrive
     useEffect(() => {
-        if (status === "results" && query.trim() !== "" && site !== "") {
+        const hasCategoryFilter = filters.some((f) => f.key === "category" && f.value !== "");
+        if (status === "results" && (query.trim() !== "" || hasCategoryFilter) && site !== "") {
             const displayName =
                 providers.find((p) => p.name === site)?.display_name ?? site;
             addEntry({ query, site, siteDisplayName: displayName, filters: [] });

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -252,7 +252,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     const handleBatchDownload = useCallback(() => {
         const selectedRows = table.getSelectedRowModel().rows;
         for (const row of selectedRows) {
-            handleDownload(row.original.video_url);
+            handleDownload(row.original.video_url, row.original.title);
         }
         setRowSelection({});
     }, [table, handleDownload]);

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -233,7 +233,9 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     // Keep ref current for index-based callbacks
     tableRef.current = table;
 
-    const kbNav = useKeyboardNavigation({
+    useKeyboardNavigation({
+        focusIndex,
+        setFocusIndex,
         resultCount: results.length,
         enabled: status === "results" && activeTab === "search",
         table,
@@ -241,11 +243,6 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
         onOpenFormatDialog: handleFormatByIndex,
         onOpenInBrowser: handleOpenInBrowser,
     });
-
-    // Sync focusIndex from keyboard nav hook
-    useEffect(() => {
-        setFocusIndex(kbNav.focusIndex);
-    }, [kbNav.focusIndex]);
 
     const selectedCount = Object.keys(rowSelection).length;
 

--- a/crates/rdlp-desktop/src/pages/SearchPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SearchPage.tsx
@@ -108,6 +108,7 @@ export function SearchPage({ activeTab, viewMode }: SearchPageProps) {
     const dataColumnVisibility = useMemo(() => {
         if (results.length === 0) return {} as Record<string, boolean>;
         return {
+            views: results.some((r) => r.view_count !== null),
             age: results.some((r) => r.upload_date !== null),
         } as Record<string, boolean>;
     }, [results]);

--- a/crates/rdlp-extractor/src/extractors/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/mod.rs
@@ -14,6 +14,6 @@ pub mod xtits;
 pub use nine_anime::NineAnimeExtractor;
 pub use pornhub::PornHubExtractor;
 pub use redtube::RedTubeExtractor;
-pub use tnaflix::TNAFlixExtractor;
+pub use tnaflix::{TNAFlixExtractor, TNAFlixSearchExtractor};
 pub use xhamster::XHamsterExtractor;
 pub use xtits::XTitsExtractor;

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -9,18 +9,30 @@
 //!
 //! - `patterns` - URL regex patterns for each site
 //! - `ajax` - AJAX/XML data fetching for EMPFlix and MovieFap
+//! - `search` - HTML search result parsing for TNAFlix
+//! - `search_patterns` - Search URL builders and filter descriptors
 
 mod ajax;
 mod patterns;
+mod search;
+mod search_patterns;
 
 use async_trait::async_trait;
-use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result};
+use log::{debug, info, warn};
+use rdlp_core::{
+    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
+    SearchPageResponse,
+};
 use regex::Regex;
 use scraper::Html;
+use std::time::Duration;
 
-use crate::base::common::BaseExtractor;
+use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
 use crate::base::tnaflix_network::TnaFlixNetworkBase;
 use patterns::{EMPFLIX_URL_PATTERN, MOVIEFAP_URL_PATTERN, TNAFLIX_URL_PATTERN};
+
+/// Rate limit delay between search page fetches (500 ms)
+const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// TNAFlix network extractor (supports TNAFlix, EMPFlix, MovieFap)
 ///
@@ -186,6 +198,139 @@ impl InfoExtractor for TNAFlixExtractor {
     }
 }
 
+/// TNAFlix search extractor
+///
+/// Provides keyword search across TNAFlix with optional ordering filters.
+/// Supports both single-page (`search_page`) and collect-all (`search`) modes.
+pub struct TNAFlixSearchExtractor;
+
+impl TNAFlixSearchExtractor {
+    /// Create a new TNAFlix search extractor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Fetch a single search results page and return `(results, max_page_number)`.
+    async fn fetch_single_search_page(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        page: usize,
+        ctx: &ExtractionContext,
+    ) -> Result<(Vec<rdlp_core::SearchResultPreview>, usize)> {
+        let page_url = search_patterns::build_search_url_page(query, page);
+        debug!(page; "[TNAFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
+
+        let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+        let page_results = search::parse_search_results(&webpage);
+        let max_pages = search::parse_pagination(&webpage).unwrap_or(1);
+
+        debug!(
+            count = page_results.len(),
+            max_pages;
+            "[TNAFlix] Search page {page} returned {} results",
+            page_results.len()
+        );
+
+        Ok((page_results, max_pages))
+    }
+
+    /// Collect all pages up to `MAX_PLAYLIST_SIZE` results.
+    async fn search_all_pages(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_core::SearchResultPreview>> {
+        search::validate_search_filters(&query.filters)?;
+
+        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
+
+        let mut all_results = Vec::new();
+        let mut page = 1usize;
+
+        loop {
+            let (page_results, max_pages) = match self
+                .fetch_single_search_page(query, page, ctx)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(page; "[TNAFlix] Failed to fetch search page, returning partial results: {e}");
+                    break;
+                }
+            };
+
+            if page_results.is_empty() {
+                debug!(page; "[TNAFlix] No results on page, stopping pagination");
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if page >= max_pages {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        info!(count = all_results.len(), pages = page; "[TNAFlix] Search complete");
+
+        Ok(all_results)
+    }
+}
+
+impl Default for TNAFlixSearchExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SearchExtractor for TNAFlixSearchExtractor {
+    fn name(&self) -> &str {
+        "TNAFlix"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_core::SearchFilterDescriptor> {
+        search_patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_core::SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &rdlp_core::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        search::validate_search_filters(&query.filters)?;
+
+        let page = query.page.unwrap_or(1) as usize;
+        let (page_results, max_pages) = self.fetch_single_search_page(query, page, ctx).await?;
+
+        let has_more = page < max_pages && !page_results.is_empty();
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page: page as u32,
+            has_more,
+            total_estimate: None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,5 +409,19 @@ mod tests {
         assert_eq!(TEST_TNAFLIX.priority(), 0);
         assert_eq!(TEST_EMPFLIX.priority(), 0);
         assert_eq!(TEST_MOVIEFAP.priority(), 0);
+    }
+
+    #[test]
+    fn test_search_extractor_name() {
+        let extractor = TNAFlixSearchExtractor::new();
+        assert_eq!(SearchExtractor::name(&extractor), "TNAFlix");
+    }
+
+    #[test]
+    fn test_search_extractor_supported_filters() {
+        let extractor = TNAFlixSearchExtractor::new();
+        let filters = extractor.supported_filters();
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].key, "ordering");
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -211,6 +211,26 @@ impl TNAFlixSearchExtractor {
         Self
     }
 
+    /// Build the URL for a given page, dispatching to browse or search URL builders.
+    ///
+    /// When a `category` filter is present, builds a browse URL (ignoring the query text).
+    /// Otherwise, builds a search URL from the query.
+    ///
+    /// # Arguments
+    /// * `query` - The search query with optional filters.
+    /// * `page` - 1-based page number.
+    fn build_page_url(query: &rdlp_core::SearchQuery, page: usize) -> String {
+        if let Some(cat) = query.filters.iter().find(|f| f.key == "category") {
+            if page <= 1 {
+                search_patterns::build_browse_url(&cat.value)
+            } else {
+                search_patterns::build_browse_url_page(&cat.value, page)
+            }
+        } else {
+            search_patterns::build_search_url_page(query, page)
+        }
+    }
+
     /// Fetch a single search results page and return `(results, max_page_number)`.
     async fn fetch_single_search_page(
         &self,
@@ -218,7 +238,7 @@ impl TNAFlixSearchExtractor {
         page: usize,
         ctx: &ExtractionContext,
     ) -> Result<(Vec<rdlp_core::SearchResultPreview>, usize)> {
-        let page_url = search_patterns::build_search_url_page(query, page);
+        let page_url = Self::build_page_url(query, page);
         debug!(page; "[TNAFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
         let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
@@ -421,7 +441,7 @@ mod tests {
     fn test_search_extractor_supported_filters() {
         let extractor = TNAFlixSearchExtractor::new();
         let filters = extractor.supported_filters();
-        assert_eq!(filters.len(), 1);
+        assert_eq!(filters.len(), 2);
         assert_eq!(filters[0].key, "ordering");
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -1,0 +1,457 @@
+//! HTML search result parsing for TNAFlix.
+//!
+//! Provides scraper-based extraction of search result thumbnails,
+//! pagination detection, and filter validation.
+//!
+//! ## Real HTML Structure (as of 2026-02)
+//!
+//! Each video item is a Bootstrap grid column with `data-vid` attribute:
+//! ```html
+//! <div data-vid="123" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+//!   <a class="thumb video-thumb bg-dark" href="/category/title/video123">
+//!     <img class="lazyload" data-src="thumb.jpg" />
+//!     <div class="thumb-icon video-duration">12:34</div>
+//!   </a>
+//!   <a class="video-title text-break" href="...">Title</a>
+//!   <div class="d-flex">
+//!     <div class="text-small d-flex">
+//!       <div><i class="icon-eye"></i>1.2K</div>
+//!     </div>
+//!   </div>
+//! </div>
+//! ```
+
+use rdlp_core::{RdlpError, Result, SearchFilter, SearchResultPreview};
+use scraper::{Html, Selector};
+use std::sync::LazyLock;
+
+/// Video item container: `<div data-vid="...">` grid columns.
+static VIDEO_ITEM_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("div[data-vid]").expect("Valid TNAFlix video item selector"));
+
+/// Thumbnail anchor: `<a class="video-thumb">` inside each item.
+static VIDEO_THUMB_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a.video-thumb").expect("Valid TNAFlix thumb selector"));
+
+/// Title anchor: `<a class="video-title">` with text content as title.
+static VIDEO_TITLE_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a.video-title").expect("Valid TNAFlix title selector"));
+
+/// Duration overlay: `<div class="video-duration">`.
+static DURATION_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse(".video-duration").expect("Valid duration selector"));
+
+/// View count icon: `<i class="icon-eye">` — views text is in the parent div.
+static VIEWS_ICON_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("i.icon-eye").expect("Valid views icon selector"));
+
+/// Pagination links: Bootstrap `.pagination .page-link` anchors.
+static PAGE_LINK_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(".pagination a.page-link").expect("Valid TNAFlix pagination selector")
+});
+
+/// Parse search results from a TNAFlix search results HTML page.
+///
+/// Returns a `Vec` of [`SearchResultPreview`] items; an empty vec indicates
+/// no results were found.
+///
+/// # Arguments
+/// * `html` - Raw HTML string of the search results page.
+pub fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
+    let document = Html::parse_document(html);
+    let img_selector = Selector::parse("img").expect("img");
+
+    let mut results = Vec::new();
+
+    for item in document.select(&VIDEO_ITEM_SELECTOR) {
+        // Video URL from the thumbnail anchor (<a class="video-thumb">)
+        let thumb_link = item.select(&VIDEO_THUMB_SELECTOR).next();
+
+        let video_url = thumb_link
+            .and_then(|a| a.value().attr("href"))
+            .filter(|href| !href.is_empty())
+            .map(str::to_string);
+
+        let Some(video_url) = video_url else {
+            continue;
+        };
+
+        // Title from the separate title anchor (<a class="video-title">)
+        // Falls back to the img alt attribute or thumbnail anchor title
+        let title = item
+            .select(&VIDEO_TITLE_SELECTOR)
+            .next()
+            .map(|a| a.text().collect::<String>())
+            .map(|s| s.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .or_else(|| {
+                thumb_link
+                    .and_then(|a| a.select(&img_selector).next())
+                    .and_then(|img| img.value().attr("alt"))
+                    .filter(|a| !a.is_empty())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        // Thumbnail URL from <img> inside the thumb link (prefers data-src for lazy-loaded)
+        let thumbnail_url = thumb_link
+            .and_then(|a| a.select(&img_selector).next())
+            .and_then(|img| {
+                img.value()
+                    .attr("data-src")
+                    .or_else(|| img.value().attr("src"))
+            })
+            .filter(|url| !url.contains("placeholder"))
+            .map(str::to_string);
+
+        // Duration from <div class="video-duration">
+        let duration = item
+            .select(&DURATION_SELECTOR)
+            .next()
+            .map(|el| el.text().collect::<String>())
+            .and_then(|s| parse_duration_secs(s.trim()));
+
+        // View count: text next to <i class="icon-eye"> (e.g. "11.7K")
+        let view_count = item
+            .select(&VIEWS_ICON_SELECTOR)
+            .next()
+            .and_then(|icon| icon.parent())
+            .and_then(scraper::ElementRef::wrap)
+            .map(|el| el.text().collect::<String>())
+            .and_then(|s| parse_view_count(s.trim()));
+
+        results.push(SearchResultPreview {
+            video_url,
+            title,
+            thumbnail_url,
+            duration,
+            view_count,
+            upload_date: None,
+        });
+    }
+
+    results
+}
+
+/// Detect the maximum page number available from a TNAFlix pagination bar.
+///
+/// Returns `None` when no pagination links are found (single-page results).
+///
+/// # Arguments
+/// * `html` - Raw HTML string of the search results page.
+pub fn parse_pagination(html: &str) -> Option<usize> {
+    let document = Html::parse_document(html);
+    document
+        .select(&PAGE_LINK_SELECTOR)
+        .filter_map(|a| a.text().collect::<String>().trim().parse::<usize>().ok())
+        .max()
+}
+
+/// Validate that all supplied search filters are recognised TNAFlix keys and values.
+///
+/// # Arguments
+/// * `filters` - Slice of [`SearchFilter`] items to validate.
+///
+/// # Errors
+/// Returns [`RdlpError::Extraction`] if an unrecognised key or value is encountered.
+pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
+    const VALID_ORDERINGS: &[&str] = &["featured", "newest", "duration", "rating"];
+
+    for filter in filters {
+        match filter.key.as_str() {
+            "ordering" => {
+                if !VALID_ORDERINGS.contains(&filter.value.as_str()) {
+                    return Err(RdlpError::Extraction(format!(
+                        "Invalid TNAFlix ordering value '{}'. Valid values: {}",
+                        filter.value,
+                        VALID_ORDERINGS.join(", ")
+                    )));
+                }
+            }
+            other => {
+                return Err(RdlpError::Extraction(format!(
+                    "Unknown TNAFlix search filter key '{other}'"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse a duration string like `"12:34"` or `"1:23:45"` into seconds.
+fn parse_duration_secs(s: &str) -> Option<f64> {
+    let parts: Vec<u64> = s
+        .split(':')
+        .map(|p| p.trim().parse::<u64>().ok())
+        .collect::<Option<Vec<_>>>()?;
+
+    let secs = match parts.as_slice() {
+        [m, s] => m * 60 + s,
+        [h, m, s] => h * 3600 + m * 60 + s,
+        _ => return None,
+    };
+
+    Some(secs as f64)
+}
+
+/// Parse a human-readable view count like `"1,234"` or `"5.6K"` into a raw number.
+fn parse_view_count(s: &str) -> Option<u64> {
+    let s = s
+        .trim()
+        .to_ascii_lowercase()
+        .replace(',', "")
+        .replace("views", "")
+        .trim()
+        .to_string();
+
+    if let Some(rest) = s.strip_suffix('k') {
+        return rest
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .map(|n| (n * 1_000.0) as u64);
+    }
+    if let Some(rest) = s.strip_suffix('m') {
+        return rest
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .map(|n| (n * 1_000_000.0) as u64);
+    }
+
+    s.trim().parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a test HTML page mimicking the real TNAFlix search layout.
+    fn make_search_html(items: &[&str], with_pagination: bool) -> String {
+        let items_html = items.join("\n");
+        let pagination = if with_pagination {
+            r#"<ul class="pagination justify-content-center mt-4">
+                <li class="page-item active"><span class="page-link">1</span></li>
+                <li class="page-item"><a class="page-link" href="?page=2">2</a></li>
+                <li class="page-item"><a class="page-link" href="?page=3">3</a></li>
+            </ul>"#
+        } else {
+            ""
+        };
+        format!(
+            r#"<html><body>
+            <div class="row">
+                {items_html}
+            </div>
+            {pagination}
+            </body></html>"#
+        )
+    }
+
+    /// Build a single video item matching the real TNAFlix HTML structure.
+    fn sample_item(url: &str, title: &str, duration: &str, views: &str) -> String {
+        format!(
+            r#"<div data-vid="123" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+                <a class="thumb video-thumb bg-dark" href="{url}">
+                    <img class="lazyload" data-src="thumb.jpg"
+                         alt="{title}" width="300" height="150" />
+                    <div class="thumb-icon video-duration">{duration}</div>
+                </a>
+                <a href="{url}" class="video-title text-break">{title}</a>
+                <div class="d-flex">
+                    <div class="text-small d-flex">
+                        <div><i class="icon-eye"></i>{views}</div>
+                    </div>
+                </div>
+            </div>"#
+        )
+    }
+
+    #[test]
+    fn test_parse_search_results_basic() {
+        let item = sample_item(
+            "https://www.tnaflix.com/category/title/video123",
+            "Test Video",
+            "12:34",
+            "1,234",
+        );
+        let html = make_search_html(&[&item], false);
+        let results = parse_search_results(&html);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Test Video");
+        assert_eq!(
+            results[0].video_url,
+            "https://www.tnaflix.com/category/title/video123"
+        );
+    }
+
+    #[test]
+    fn test_parse_search_results_empty_no_items() {
+        let html = make_search_html(&[], false);
+        let results = parse_search_results(&html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_search_results_duration() {
+        let item = sample_item(
+            "https://www.tnaflix.com/category/title/video123",
+            "Test",
+            "1:23:45",
+            "0",
+        );
+        let html = make_search_html(&[&item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results[0].duration, Some(5025.0));
+    }
+
+    #[test]
+    fn test_parse_search_results_multiple() {
+        let item1 = sample_item(
+            "https://www.tnaflix.com/a/b/video1",
+            "Title 1",
+            "01:00",
+            "100",
+        );
+        let item2 = sample_item(
+            "https://www.tnaflix.com/a/b/video2",
+            "Title 2",
+            "02:00",
+            "200",
+        );
+        let html = make_search_html(&[&item1, &item2], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Title 1");
+        assert_eq!(results[1].title, "Title 2");
+    }
+
+    #[test]
+    fn test_parse_search_results_thumbnail() {
+        let item = sample_item("https://www.tnaflix.com/a/b/video1", "Test", "01:00", "100");
+        let html = make_search_html(&[&item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results[0].thumbnail_url, Some("thumb.jpg".to_string()));
+    }
+
+    #[test]
+    fn test_parse_search_results_view_count() {
+        let item = sample_item(
+            "https://www.tnaflix.com/a/b/video1",
+            "Test",
+            "01:00",
+            "11.7K",
+        );
+        let html = make_search_html(&[&item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results[0].view_count, Some(11700));
+    }
+
+    #[test]
+    fn test_parse_search_results_title_from_alt_fallback() {
+        // Item where video-title anchor is missing, falls back to img alt
+        let item = r#"<div data-vid="456" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="thumb video-thumb bg-dark" href="https://www.tnaflix.com/a/b/video456">
+                <img alt="Alt Title" data-src="thumb.jpg" />
+                <div class="thumb-icon video-duration">05:00</div>
+            </a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Alt Title");
+    }
+
+    #[test]
+    fn test_parse_pagination() {
+        let html = make_search_html(&[], true);
+        let max_pages = parse_pagination(&html);
+        assert_eq!(max_pages, Some(3));
+    }
+
+    #[test]
+    fn test_parse_pagination_no_pager() {
+        let html = "<html><body><p>No pagination</p></body></html>";
+        let max_pages = parse_pagination(html);
+        assert_eq!(max_pages, None);
+    }
+
+    #[test]
+    fn test_validate_search_filters_valid() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "newest".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_search_filters_invalid_value() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "invalid_value".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_search_filters_unknown_key() {
+        let filters = vec![SearchFilter {
+            key: "unknown_key".to_string(),
+            value: "value".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_search_filters_empty() {
+        assert!(validate_search_filters(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_parse_duration_secs_mm_ss() {
+        assert_eq!(parse_duration_secs("12:34"), Some(754.0));
+    }
+
+    #[test]
+    fn test_parse_duration_secs_hh_mm_ss() {
+        assert_eq!(parse_duration_secs("1:23:45"), Some(5025.0));
+    }
+
+    #[test]
+    fn test_parse_duration_secs_invalid() {
+        assert_eq!(parse_duration_secs("not-a-duration"), None);
+    }
+
+    #[test]
+    fn test_parse_view_count_plain() {
+        assert_eq!(parse_view_count("1234"), Some(1234));
+    }
+
+    #[test]
+    fn test_parse_view_count_with_commas() {
+        assert_eq!(parse_view_count("1,234"), Some(1234));
+    }
+
+    #[test]
+    fn test_parse_view_count_k_suffix() {
+        assert_eq!(parse_view_count("5.6K"), Some(5600));
+    }
+
+    #[test]
+    fn test_parse_view_count_m_suffix() {
+        assert_eq!(parse_view_count("2M"), Some(2_000_000));
+    }
+
+    #[test]
+    fn test_parse_view_count_with_views_text() {
+        assert_eq!(parse_view_count("1,234 views"), Some(1234));
+    }
+
+    #[test]
+    fn test_parse_view_count_invalid() {
+        assert_eq!(parse_view_count("N/A"), None);
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -25,6 +25,8 @@ use rdlp_core::{RdlpError, Result, SearchFilter, SearchResultPreview};
 use scraper::{Html, Selector};
 use std::sync::LazyLock;
 
+use super::search_patterns;
+
 /// Video item container: `<div data-vid="...">` grid columns.
 static VIDEO_ITEM_SELECTOR: LazyLock<Selector> =
     LazyLock::new(|| Selector::parse("div[data-vid]").expect("Valid TNAFlix video item selector"));
@@ -165,6 +167,14 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
                         "Invalid TNAFlix ordering value '{}'. Valid values: {}",
                         filter.value,
                         VALID_ORDERINGS.join(", ")
+                    )));
+                }
+            }
+            "category" => {
+                if !search_patterns::is_valid_category(&filter.value) {
+                    return Err(RdlpError::Extraction(format!(
+                        "Invalid TNAFlix category '{}'. Use search_filters() to see valid values.",
+                        filter.value
                     )));
                 }
             }
@@ -453,5 +463,47 @@ mod tests {
     #[test]
     fn test_parse_view_count_invalid() {
         assert_eq!(parse_view_count("N/A"), None);
+    }
+
+    #[test]
+    fn test_validate_search_filters_valid_category() {
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "teen-porn".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_search_filters_valid_category_section() {
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "new".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_search_filters_invalid_category() {
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "not-a-real-category".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_search_filters_category_and_ordering() {
+        let filters = vec![
+            SearchFilter {
+                key: "ordering".to_string(),
+                value: "newest".to_string(),
+            },
+            SearchFilter {
+                key: "category".to_string(),
+                value: "milf-porn".to_string(),
+            },
+        ];
+        assert!(validate_search_filters(&filters).is_ok());
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -23,6 +23,7 @@
 
 use rdlp_core::{RdlpError, Result, SearchFilter, SearchResultPreview};
 use scraper::{Html, Selector};
+use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use super::search_patterns;
@@ -64,6 +65,7 @@ pub fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
     let img_selector = Selector::parse("img").expect("img");
 
     let mut results = Vec::new();
+    let mut seen_urls = HashSet::new();
 
     for item in document.select(&VIDEO_ITEM_SELECTOR) {
         // Video URL from the thumbnail anchor (<a class="video-thumb">)
@@ -77,6 +79,12 @@ pub fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
         let Some(video_url) = video_url else {
             continue;
         };
+
+        // Category pages repeat the same videos in multiple page sections;
+        // deduplicate by URL so each video appears only once.
+        if !seen_urls.insert(video_url.clone()) {
+            continue;
+        }
 
         // Title from the separate title anchor (<a class="video-title">)
         // Falls back to the img alt attribute or thumbnail anchor title
@@ -336,6 +344,21 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].title, "Title 1");
         assert_eq!(results[1].title, "Title 2");
+    }
+
+    #[test]
+    fn test_parse_search_results_deduplicates_by_url() {
+        let item = sample_item(
+            "https://www.tnaflix.com/a/b/video1",
+            "Same Video",
+            "01:00",
+            "100",
+        );
+        // Simulate category pages that repeat the same items in multiple sections
+        let html = make_search_html(&[&item, &item, &item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Same Video");
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -3,6 +3,87 @@
 //! Contains the search URL builder, page URL builder, and filter descriptor
 //! definitions used by `TNAFlixSearchExtractor`.
 
+/// Built-in browse sections (non-category pages).
+const BROWSE_SECTIONS: &[&str] = &["new", "toprated", "featured"];
+
+/// Known TNAFlix category slugs (sourced from `/categories` page).
+const BROWSE_CATEGORIES: &[&str] = &[
+    "amateur-porn",
+    "anal-porn",
+    "arabian-porn",
+    "asian-porn",
+    "babe-videos",
+    "bbw-porn",
+    "bdsm-porn",
+    "big-boobs",
+    "big-cock",
+    "bizarre-porn",
+    "blonde-porn",
+    "blowjob-videos",
+    "brunette-porn",
+    "bukkake-porn",
+    "cartoon-porn",
+    "celebrity-porn",
+    "classic-porn",
+    "creampie-videos",
+    "cum-videos",
+    "czech-porn",
+    "double-penetration",
+    "ebony-porn",
+    "euro-porn",
+    "facial-porn",
+    "fat-porn",
+    "feet-porn",
+    "fetish-videos",
+    "fisting-videos",
+    "french-porn",
+    "gang-bang",
+    "gay-porn",
+    "german-porn",
+    "granny-porn",
+    "group-sex",
+    "hairy-porn",
+    "handjobs-porn",
+    "hardcore-porn",
+    "hd-videos",
+    "hentai-porn",
+    "homemade-porn",
+    "indian-porn",
+    "interracial-porn",
+    "japanese-porn",
+    "latina-porn",
+    "lesbian-porn",
+    "massage-porn",
+    "masturbation-videos",
+    "mature-porn",
+    "milf-porn",
+    "oral-sex",
+    "petite-porn",
+    "piss-videos",
+    "porn-compilations",
+    "porn-stars",
+    "pov-porn",
+    "pregnant-porn",
+    "public-porn",
+    "reality-porn",
+    "redhead-porn",
+    "russian-porn",
+    "shemale-porn",
+    "softcore-videos",
+    "solo-porn",
+    "spanking-videos",
+    "squirting-videos",
+    "storyline-porn",
+    "strapon-sex",
+    "teen-porn",
+    "thai-porn",
+    "threesome-sex",
+    "toy-videos",
+    "vintage-sex",
+    "vr-porn",
+    "webcam-shows",
+];
+
 /// Build a TNAFlix search URL from a [`SearchQuery`](rdlp_core::SearchQuery).
 ///
 /// Format: `https://www.tnaflix.com/search?what={encoded_query}&tab=`
@@ -45,34 +126,128 @@ pub fn build_search_url_page(query: &rdlp_core::SearchQuery, page: usize) -> Str
     url
 }
 
+/// Check whether a value is a valid browse section or category slug.
+///
+/// # Arguments
+/// * `value` - The slug to validate.
+///
+/// # Returns
+/// `true` if the value matches a known browse section or category slug.
+pub fn is_valid_category(value: &str) -> bool {
+    BROWSE_SECTIONS.contains(&value) || BROWSE_CATEGORIES.contains(&value)
+}
+
+/// Build a TNAFlix browse URL for page 1 of a section or category.
+///
+/// # Arguments
+/// * `slug` - A browse section ("new") or category slug ("teen-porn").
+///
+/// # Returns
+/// `https://www.tnaflix.com/{slug}`
+pub fn build_browse_url(slug: &str) -> String {
+    format!("https://www.tnaflix.com/{slug}")
+}
+
+/// Build a TNAFlix browse URL for a specific page number.
+///
+/// Sections use `/{slug}/{page}`, categories use `/{slug}?page={page}`.
+///
+/// # Arguments
+/// * `slug` - A browse section or category slug.
+/// * `page` - 1-based page number.
+pub fn build_browse_url_page(slug: &str, page: usize) -> String {
+    if BROWSE_SECTIONS.contains(&slug) {
+        format!("https://www.tnaflix.com/{slug}/{page}")
+    } else {
+        format!("https://www.tnaflix.com/{slug}?page={page}")
+    }
+}
+
+/// Convert a kebab-case slug to a human-readable label.
+///
+/// Strips noise suffixes (`-porn`, `-videos`, `-sex`, `-shows`), title-cases
+/// words, and uppercases known abbreviations (HD, VR, BDSM, POV, BBW).
+///
+/// `"teen-porn"` → `"Teen"`, `"hd-videos"` → `"HD"`, `"threesome-sex"` → `"Threesome"`
+pub fn slug_to_label(slug: &str) -> String {
+    const NOISE_SUFFIXES: &[&str] = &["-porn", "-videos", "-sex", "-shows"];
+    const UPPERCASE_WORDS: &[&str] = &["hd", "vr", "bdsm", "pov", "bbw"];
+
+    let mut stripped = slug;
+    for suffix in NOISE_SUFFIXES {
+        if let Some(s) = stripped.strip_suffix(suffix) {
+            stripped = s;
+            break;
+        }
+    }
+
+    stripped
+        .split('-')
+        .map(|word| {
+            if UPPERCASE_WORDS.contains(&word) {
+                word.to_ascii_uppercase()
+            } else {
+                let mut chars = word.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(c) => {
+                        let mut s = c.to_uppercase().to_string();
+                        s.extend(chars);
+                        s
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Return the static filter descriptors for TNAFlix search.
 ///
 /// # Supported Filters
 /// - `ordering` - Sort order (featured, newest, duration, rating)
+/// - `category` - Browse section or category slug
 pub fn search_filter_descriptors() -> Vec<rdlp_core::SearchFilterDescriptor> {
-    vec![rdlp_core::SearchFilterDescriptor {
-        key: "ordering".to_string(),
-        display_name: "Sort by".to_string(),
-        allowed_values: vec![
-            rdlp_core::SearchFilterValue {
-                value: "featured".to_string(),
-                label: "Featured".to_string(),
-            },
-            rdlp_core::SearchFilterValue {
-                value: "newest".to_string(),
-                label: "Newest".to_string(),
-            },
-            rdlp_core::SearchFilterValue {
-                value: "duration".to_string(),
-                label: "Longest".to_string(),
-            },
-            rdlp_core::SearchFilterValue {
-                value: "rating".to_string(),
-                label: "Top rated".to_string(),
-            },
-        ],
-        default: Some("featured".to_string()),
-    }]
+    let category_values: Vec<rdlp_core::SearchFilterValue> = BROWSE_SECTIONS
+        .iter()
+        .chain(BROWSE_CATEGORIES.iter())
+        .map(|&slug| rdlp_core::SearchFilterValue {
+            value: slug.to_string(),
+            label: slug_to_label(slug),
+        })
+        .collect();
+
+    vec![
+        rdlp_core::SearchFilterDescriptor {
+            key: "ordering".to_string(),
+            display_name: "Sort by".to_string(),
+            allowed_values: vec![
+                rdlp_core::SearchFilterValue {
+                    value: "featured".to_string(),
+                    label: "Featured".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "newest".to_string(),
+                    label: "Newest".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "duration".to_string(),
+                    label: "Longest".to_string(),
+                },
+                rdlp_core::SearchFilterValue {
+                    value: "rating".to_string(),
+                    label: "Top rated".to_string(),
+                },
+            ],
+            default: Some("featured".to_string()),
+        },
+        rdlp_core::SearchFilterDescriptor {
+            key: "category".to_string(),
+            display_name: "Category".to_string(),
+            allowed_values: category_values,
+            default: None,
+        },
+    ]
 }
 
 #[cfg(test)]
@@ -151,7 +326,7 @@ mod tests {
     #[test]
     fn test_search_filter_descriptors_not_empty() {
         let filters = search_filter_descriptors();
-        assert_eq!(filters.len(), 1);
+        assert_eq!(filters.len(), 2);
         assert_eq!(filters[0].key, "ordering");
         assert_eq!(filters[0].allowed_values.len(), 4);
     }
@@ -174,5 +349,127 @@ mod tests {
         assert!(values.contains(&"newest"));
         assert!(values.contains(&"duration"));
         assert!(values.contains(&"rating"));
+    }
+
+    #[test]
+    fn test_is_valid_category_sections() {
+        assert!(is_valid_category("new"));
+        assert!(is_valid_category("toprated"));
+        assert!(is_valid_category("featured"));
+    }
+
+    #[test]
+    fn test_is_valid_category_slugs() {
+        assert!(is_valid_category("teen-porn"));
+        assert!(is_valid_category("milf-porn"));
+        assert!(is_valid_category("hd-videos"));
+        assert!(is_valid_category("threesome-sex"));
+        assert!(is_valid_category("webcam-shows"));
+        assert!(is_valid_category("big-boobs"));
+    }
+
+    #[test]
+    fn test_is_valid_category_rejects_unknown() {
+        assert!(!is_valid_category("unknown"));
+        assert!(!is_valid_category(""));
+        assert!(!is_valid_category("not-a-category"));
+    }
+
+    #[test]
+    fn test_build_browse_url() {
+        assert_eq!(build_browse_url("new"), "https://www.tnaflix.com/new");
+        assert_eq!(
+            build_browse_url("teen-porn"),
+            "https://www.tnaflix.com/teen-porn"
+        );
+    }
+
+    #[test]
+    fn test_build_browse_url_page_section() {
+        // Sections use /{slug}/{page}
+        assert_eq!(
+            build_browse_url_page("new", 3),
+            "https://www.tnaflix.com/new/3"
+        );
+        assert_eq!(
+            build_browse_url_page("toprated", 1),
+            "https://www.tnaflix.com/toprated/1"
+        );
+    }
+
+    #[test]
+    fn test_build_browse_url_page_category() {
+        // Categories use /{slug}?page={page}
+        assert_eq!(
+            build_browse_url_page("teen-porn", 2),
+            "https://www.tnaflix.com/teen-porn?page=2"
+        );
+        assert_eq!(
+            build_browse_url_page("milf-porn", 5),
+            "https://www.tnaflix.com/milf-porn?page=5"
+        );
+    }
+
+    #[test]
+    fn test_slug_to_label_basic() {
+        assert_eq!(slug_to_label("teen-porn"), "Teen");
+        assert_eq!(slug_to_label("milf-porn"), "Milf");
+        assert_eq!(slug_to_label("amateur-porn"), "Amateur");
+    }
+
+    #[test]
+    fn test_slug_to_label_multi_word() {
+        assert_eq!(slug_to_label("big-boobs"), "Big Boobs");
+        assert_eq!(slug_to_label("big-cock"), "Big Cock");
+        assert_eq!(slug_to_label("double-penetration"), "Double Penetration");
+        assert_eq!(slug_to_label("gang-bang"), "Gang Bang");
+        assert_eq!(slug_to_label("porn-compilations"), "Porn Compilations");
+        assert_eq!(slug_to_label("porn-stars"), "Porn Stars");
+    }
+
+    #[test]
+    fn test_slug_to_label_uppercase_abbreviations() {
+        assert_eq!(slug_to_label("hd-videos"), "HD");
+        assert_eq!(slug_to_label("vr-porn"), "VR");
+        assert_eq!(slug_to_label("bdsm-porn"), "BDSM");
+        assert_eq!(slug_to_label("pov-porn"), "POV");
+        assert_eq!(slug_to_label("bbw-porn"), "BBW");
+    }
+
+    #[test]
+    fn test_slug_to_label_video_suffix() {
+        assert_eq!(slug_to_label("babe-videos"), "Babe");
+        assert_eq!(slug_to_label("blowjob-videos"), "Blowjob");
+        assert_eq!(slug_to_label("creampie-videos"), "Creampie");
+    }
+
+    #[test]
+    fn test_slug_to_label_sex_suffix() {
+        assert_eq!(slug_to_label("threesome-sex"), "Threesome");
+        assert_eq!(slug_to_label("oral-sex"), "Oral");
+        assert_eq!(slug_to_label("vintage-sex"), "Vintage");
+        assert_eq!(slug_to_label("strapon-sex"), "Strapon");
+    }
+
+    #[test]
+    fn test_slug_to_label_shows_suffix() {
+        assert_eq!(slug_to_label("webcam-shows"), "Webcam");
+    }
+
+    #[test]
+    fn test_slug_to_label_sections() {
+        assert_eq!(slug_to_label("new"), "New");
+        assert_eq!(slug_to_label("toprated"), "Toprated");
+        assert_eq!(slug_to_label("featured"), "Featured");
+    }
+
+    #[test]
+    fn test_category_filter_descriptor() {
+        let filters = search_filter_descriptors();
+        let cat = &filters[1];
+        assert_eq!(cat.key, "category");
+        assert_eq!(cat.display_name, "Category");
+        assert!(cat.default.is_none());
+        assert!(cat.allowed_values.len() > 74); // sections + categories
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -1,0 +1,178 @@
+//! Search URL patterns and filter descriptors for TNAFlix.
+//!
+//! Contains the search URL builder, page URL builder, and filter descriptor
+//! definitions used by `TNAFlixSearchExtractor`.
+
+/// Build a TNAFlix search URL from a [`SearchQuery`](rdlp_core::SearchQuery).
+///
+/// Format: `https://www.tnaflix.com/search?what={encoded_query}&tab=`
+///
+/// Filters are appended as additional query parameters.
+///
+/// # Arguments
+/// * `query` - The search query with optional filters.
+///
+/// # Returns
+/// A fully-formed search URL string.
+pub fn build_search_url(query: &rdlp_core::SearchQuery) -> String {
+    let encoded_query = query.query.split_whitespace().collect::<Vec<_>>().join("+");
+
+    let mut url = format!("https://www.tnaflix.com/search?what={encoded_query}&tab=");
+
+    for filter in &query.filters {
+        url.push('&');
+        url.push_str(&filter.key);
+        url.push('=');
+        url.push_str(&filter.value);
+    }
+
+    url
+}
+
+/// Build a TNAFlix search URL for a specific page number.
+///
+/// Appends `&page={page}` to the base search URL.
+///
+/// # Arguments
+/// * `query` - The search query with optional filters.
+/// * `page` - 1-based page number.
+///
+/// # Returns
+/// A fully-formed search URL string for the given page.
+pub fn build_search_url_page(query: &rdlp_core::SearchQuery, page: usize) -> String {
+    let mut url = build_search_url(query);
+    url.push_str(&format!("&page={page}"));
+    url
+}
+
+/// Return the static filter descriptors for TNAFlix search.
+///
+/// # Supported Filters
+/// - `ordering` - Sort order (featured, newest, duration, rating)
+pub fn search_filter_descriptors() -> Vec<rdlp_core::SearchFilterDescriptor> {
+    vec![rdlp_core::SearchFilterDescriptor {
+        key: "ordering".to_string(),
+        display_name: "Sort by".to_string(),
+        allowed_values: vec![
+            rdlp_core::SearchFilterValue {
+                value: "featured".to_string(),
+                label: "Featured".to_string(),
+            },
+            rdlp_core::SearchFilterValue {
+                value: "newest".to_string(),
+                label: "Newest".to_string(),
+            },
+            rdlp_core::SearchFilterValue {
+                value: "duration".to_string(),
+                label: "Longest".to_string(),
+            },
+            rdlp_core::SearchFilterValue {
+                value: "rating".to_string(),
+                label: "Top rated".to_string(),
+            },
+        ],
+        default: Some("featured".to_string()),
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_search_url_basic() {
+        let query = rdlp_core::SearchQuery {
+            query: "test query".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query);
+        assert_eq!(url, "https://www.tnaflix.com/search?what=test+query&tab=");
+    }
+
+    #[test]
+    fn test_build_search_url_with_filter() {
+        let query = rdlp_core::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![rdlp_core::SearchFilter {
+                key: "ordering".to_string(),
+                value: "newest".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query);
+        assert!(url.contains("what=test"));
+        assert!(url.contains("ordering=newest"));
+    }
+
+    #[test]
+    fn test_build_search_url_no_raw_spaces() {
+        let query = rdlp_core::SearchQuery {
+            query: "hello world test".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query);
+        assert!(!url.contains(' '), "URL must not contain raw spaces");
+        assert!(url.contains("hello+world+test"));
+    }
+
+    #[test]
+    fn test_build_search_url_page() {
+        let query = rdlp_core::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url_page(&query, 3);
+        assert!(url.contains("&page=3"));
+    }
+
+    #[test]
+    fn test_build_search_url_page_with_filter() {
+        let query = rdlp_core::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![rdlp_core::SearchFilter {
+                key: "ordering".to_string(),
+                value: "rating".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url_page(&query, 5);
+        assert!(url.contains("ordering=rating"));
+        assert!(url.contains("&page=5"));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_not_empty() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].key, "ordering");
+        assert_eq!(filters[0].allowed_values.len(), 4);
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_have_default() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters[0].default, Some("featured".to_string()));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_values() {
+        let filters = search_filter_descriptors();
+        let values: Vec<&str> = filters[0]
+            .allowed_values
+            .iter()
+            .map(|v| v.value.as_str())
+            .collect();
+        assert!(values.contains(&"featured"));
+        assert!(values.contains(&"newest"));
+        assert!(values.contains(&"duration"));
+        assert!(values.contains(&"rating"));
+    }
+}

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -40,8 +40,8 @@ pub mod utils;
 
 // Re-export extractors
 pub use extractors::{
-    NineAnimeExtractor, PornHubExtractor, RedTubeExtractor, TNAFlixExtractor, XHamsterExtractor,
-    XTitsExtractor,
+    NineAnimeExtractor, PornHubExtractor, RedTubeExtractor, TNAFlixExtractor,
+    TNAFlixSearchExtractor, XHamsterExtractor, XTitsExtractor,
 };
 
 // Re-export base utilities for convenient access
@@ -112,6 +112,9 @@ impl ExtractorRegistry {
         registry
             .search_extractors
             .push(Arc::new(RedTubeExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(TNAFlixSearchExtractor::new()));
 
         registry
     }
@@ -241,6 +244,14 @@ mod tests {
         let registry = ExtractorRegistry::new();
         assert!(registry.find_search_extractor("XHamster").is_some());
         assert!(registry.find_search_extractor("XHAMSTER").is_some());
+    }
+
+    #[test]
+    fn test_find_search_extractor_tnaflix() {
+        let registry = ExtractorRegistry::new();
+        let extractor = registry.find_search_extractor("tnaflix");
+        assert!(extractor.is_some());
+        assert_eq!(extractor.unwrap().name(), "TNAFlix");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **TNAFlix category browsing**: Browse 74 categories (e.g., Creampie, Teen, MILF) and 3 sections (New, Top Rated, Featured) via a new `category` filter dropdown. Category pages use dedicated browse URLs with proper pagination.
- **Deduplication fix**: TNAFlix category pages repeat videos in multiple HTML sections; parser now deduplicates by URL.
- **Views column**: Dedicated sortable Views column in search results table, replacing inline text under title. Auto-hides when no results have view counts.
- **Search UX polish**: Row selection on click, visible selected row styling (green tint + border), hover-visible action icons, dynamic AGE column visibility, batch download title passthrough, useEffect anti-pattern removal, column width computed from visible columns only.

## Test plan

- [ ] Search TNAFlix with a category filter — results should be unique (no duplicates)
- [ ] Views column appears and sorts by click; hides when no view data
- [ ] Row selection toggles on click; selected rows show green tint
- [ ] Batch download passes titles correctly (no "Untitled" jobs)
- [ ] `cargo test -p rdlp-extractor` — all TNAFlix search tests pass
- [ ] `npx tsc --noEmit` from `crates/rdlp-desktop/` — zero errors