### PR TITLE
fix(ffmpeg): resolve all audit findings in rdlp-ffmpeg

### DIFF
--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -93,9 +93,11 @@ pub enum PostProcessError {
 
     /// Mux/write operation failed with diagnostic packet context
     #[error(
-        "Mux write failed ({operation}): {message} [stream={stream_index}, pts={pts:?}, dts={dts:?}, size={packet_size}, tb={time_base_num}/{time_base_den}]"
+        "Mux write failed ({operation}): {message} [stream={stream_index}, pts={pts:?}, dts={dts:?}, size={packet_size}, tb={time_base_num}/{time_base_den}, code={code}]"
     )]
     MuxWriteError {
+        /// Raw FFmpeg/AVERROR return code (e.g. -12 for ENOMEM, -5 for EIO).
+        code: i32,
         message: String,
         operation: String,
         stream_index: usize,
@@ -178,13 +180,13 @@ impl PostProcessError {
     /// True if this error indicates memory exhaustion (ENOMEM/-12).
     #[must_use]
     pub fn is_enomem(&self) -> bool {
-        matches!(self, Self::MuxWriteError { message, .. } if message.contains("ret=-12"))
+        matches!(self, Self::MuxWriteError { code, .. } if *code == -12)
     }
 
     /// True if this error indicates an I/O error (EIO/-5).
     #[must_use]
     pub fn is_eio(&self) -> bool {
-        matches!(self, Self::MuxWriteError { message, .. } if message.contains("ret=-5"))
+        matches!(self, Self::MuxWriteError { code, .. } if *code == -5)
     }
 
     /// True if this error indicates a mux stall (watchdog abort).
@@ -236,6 +238,7 @@ mod tests {
     #[test]
     fn test_mux_write_error_display() {
         let err = PostProcessError::MuxWriteError {
+            code: -28,
             message: "Not enough space".into(),
             operation: "av_interleaved_write_frame".into(),
             stream_index: 0,
@@ -258,6 +261,7 @@ mod tests {
     #[test]
     fn test_mux_write_error_display_none_timestamps() {
         let err = PostProcessError::MuxWriteError {
+            code: -5,
             message: "write failed".into(),
             operation: "av_write_frame".into(),
             stream_index: 1,
@@ -277,6 +281,7 @@ mod tests {
     #[test]
     fn test_mux_write_error_direct_write_display() {
         let err = PostProcessError::MuxWriteError {
+            code: -12,
             message: "ret=-12 (Cannot allocate memory), dur=1024".into(),
             operation: "av_write_frame".into(),
             stream_index: 0,
@@ -296,6 +301,7 @@ mod tests {
     #[test]
     fn test_mux_write_error_converts_to_rdlp_ffmpeg() {
         let err = PostProcessError::MuxWriteError {
+            code: 0,
             message: "test".into(),
             operation: "av_interleaved_write_frame".into(),
             stream_index: 0,
@@ -315,6 +321,7 @@ mod tests {
     #[test]
     fn test_is_mux_write_error() {
         let mux_err = PostProcessError::MuxWriteError {
+            code: -12,
             message: "ENOMEM".into(),
             operation: "av_write_frame".into(),
             stream_index: 0,
@@ -335,6 +342,7 @@ mod tests {
     #[test]
     fn test_is_enomem() {
         let err = PostProcessError::MuxWriteError {
+            code: -12,
             message: "ret=-12 (Cannot allocate memory), dur=23, pb->pos=1024".into(),
             operation: "av_write_frame".into(),
             stream_index: 0,
@@ -349,6 +357,7 @@ mod tests {
         assert!(err.is_salvage_retryable());
 
         let non_enomem = PostProcessError::MuxWriteError {
+            code: -28,
             message: "ret=-28 (No space left on device)".into(),
             operation: "av_write_frame".into(),
             stream_index: 0,
@@ -369,6 +378,7 @@ mod tests {
     #[test]
     fn test_is_salvage_retryable() {
         let mux_err = PostProcessError::MuxWriteError {
+            code: -12,
             message: "ENOMEM".into(),
             operation: "av_write_frame".into(),
             stream_index: 0,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -11,20 +11,23 @@ use crate::error::PostProcessError;
 
 /// RAII guard that suppresses FFmpeg's internal C log messages.
 ///
-/// Sets `av_log_set_level` to `AV_LOG_FATAL` on creation, restoring
-/// `AV_LOG_ERROR` on drop. Used during audio normalization decode loops
-/// to prevent the AAC decoder from spamming stderr with per-packet
-/// `get_buffer() failed` lines — we handle those errors at the Rust level.
+/// Saves the current log level on creation, sets the requested suppression
+/// level, then restores the saved level on drop. Used during audio
+/// normalization decode loops to prevent the AAC decoder from spamming
+/// stderr with per-packet `get_buffer() failed` lines — we handle those
+/// errors at the Rust level.
 pub(crate) struct LogSuppressGuard {
-    _private: (),
+    /// Log level that was active before this guard was created; restored on drop.
+    saved_level: std::ffi::c_int,
 }
 
 impl LogSuppressGuard {
     pub(crate) fn new() -> Self {
+        let saved_level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
         unsafe {
             ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_FATAL);
         }
-        Self { _private: () }
+        Self { saved_level }
     }
 
     /// Suppress decoder WARNING spam while keeping muxer ERROR messages visible.
@@ -33,17 +36,18 @@ impl LogSuppressGuard {
     /// Use this during encode loops where muxer errors must remain diagnosable
     /// but decoder `get_buffer() failed` spam should be suppressed.
     pub(crate) fn error_level() -> Self {
+        let saved_level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
         unsafe {
             ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR);
         }
-        Self { _private: () }
+        Self { saved_level }
     }
 }
 
 impl Drop for LogSuppressGuard {
     fn drop(&mut self) {
         unsafe {
-            ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR);
+            ffmpeg_the_third::ffi::av_log_set_level(self.saved_level);
         }
     }
 }
@@ -51,6 +55,14 @@ impl Drop for LogSuppressGuard {
 /// Global buffer for captured FFmpeg log messages.
 ///
 /// Protected by a Mutex. Only populated when a `LogCaptureGuard` is active.
+///
+/// # Single-session invariant
+///
+/// At most **one** `LogCaptureGuard` may be active at any time. Nested or
+/// concurrent `begin()` calls would silently overwrite the in-progress buffer,
+/// corrupting the capture results. The invariant is enforced by:
+/// - Callers using `spawn_blocking` serialization (primary guarantee).
+/// - A `debug_assert!` in `begin()` that fires in debug builds if violated.
 static LOG_BUFFER: Mutex<Option<Vec<String>>> = Mutex::new(None);
 
 /// RAII guard for FFmpeg log capture.
@@ -75,6 +87,9 @@ impl LogCaptureGuard {
             .map_err(|e| PostProcessError::LogCaptureFailed {
                 message: format!("failed to lock log buffer: {e}"),
             })?;
+        // Single-session invariant: nested capture overwrites the active buffer.
+        // This fires in debug builds to catch misuse early.
+        debug_assert!(buf.is_none(), "LogCaptureGuard: nested capture detected");
         *buf = Some(Vec::new());
         drop(buf);
 
@@ -201,23 +216,31 @@ mod tests {
 
     #[test]
     fn test_log_suppress_guard_error_level() {
-        // error_level() sets AV_LOG_ERROR; drop restores AV_LOG_ERROR (no-op restore)
+        // error_level() sets AV_LOG_ERROR; drop restores the saved level
+        unsafe { ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_WARNING) };
         let guard = LogSuppressGuard::error_level();
         let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
         assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_ERROR);
         drop(guard);
+        // Must restore the level that was active before construction
         let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
-        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_ERROR);
+        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_WARNING);
+        // Restore process-wide level to a clean state
+        unsafe { ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR) };
     }
 
     #[test]
     fn test_log_suppress_guard_fatal_level() {
-        // new() sets AV_LOG_FATAL; drop restores AV_LOG_ERROR
+        // new() sets AV_LOG_FATAL; drop restores the saved level
+        unsafe { ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_WARNING) };
         let guard = LogSuppressGuard::new();
         let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
         assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_FATAL);
         drop(guard);
+        // Must restore the level that was active before construction
         let level = unsafe { ffmpeg_the_third::ffi::av_log_get_level() };
-        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_ERROR);
+        assert_eq!(level, ffmpeg_the_third::ffi::AV_LOG_WARNING);
+        // Restore process-wide level to a clean state
+        unsafe { ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_ERROR) };
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -151,6 +151,12 @@ impl FFmpegRunner {
             }
 
             // 6. Add video output stream with full property copying
+            // Safety: avformat_find_stream_info guarantees streams is non-null and
+            // has at least nb_streams valid entries.
+            assert!(
+                !(*ifmt_video).streams.is_null(),
+                "streams must be non-null after avformat_find_stream_info"
+            );
             let in_video_stream = *(*ifmt_video).streams.add(video_stream_idx);
 
             let out_video_stream = ffi::avformat_new_stream(ofmt_ctx, ptr::null());
@@ -196,6 +202,12 @@ impl FFmpegRunner {
             );
 
             // 7. Add audio output stream with full property copying
+            // Safety: avformat_find_stream_info guarantees streams is non-null and
+            // has at least nb_streams valid entries.
+            assert!(
+                !(*ifmt_audio).streams.is_null(),
+                "streams must be non-null after avformat_find_stream_info"
+            );
             let in_audio_stream = *(*ifmt_audio).streams.add(audio_stream_idx);
 
             let out_audio_stream = ffi::avformat_new_stream(ofmt_ctx, ptr::null());

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -171,7 +171,7 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
             let mut attempt = 1u32;
             loop {
                 let candidate = input.with_file_name(format!("{stem}.salvage{attempt}.{ext}"));
-                if !candidate.exists() || attempt > 99 {
+                if !candidate.exists() || attempt >= 99 {
                     break candidate;
                 }
                 attempt += 1;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -141,7 +141,17 @@ impl FFmpegRunner {
                 }
 
                 // Copy codec parameters
-                ffi::avcodec_parameters_copy((*out_stream).codecpar, codecpar);
+                let ret = ffi::avcodec_parameters_copy((*out_stream).codecpar, codecpar);
+                if ret < 0 {
+                    ffi::avformat_close_input(&mut media_ctx);
+                    ffi::avformat_close_input(&mut thumb_ctx);
+                    ffi::avformat_free_context(ofmt_ctx);
+                    return Err(PostProcessError::FFmpegLibraryError {
+                        message: format!(
+                            "Failed to copy codec params for stream {i}: error code {ret}"
+                        ),
+                    });
+                }
                 (*(*out_stream).codecpar).codec_tag = 0;
 
                 // Copy stream properties (critical for VLC)
@@ -290,79 +300,85 @@ impl FFmpegRunner {
             // 9. Thumbnail data is in attachment extradata — no packets to write
 
             // 10. Copy media packets
-            let mut pkt = ffi::AVPacket {
-                buf: ptr::null_mut(),
-                pts: ffi::AV_NOPTS_VALUE,
-                dts: ffi::AV_NOPTS_VALUE,
-                data: ptr::null_mut(),
-                size: 0,
-                stream_index: 0,
-                flags: 0,
-                side_data: ptr::null_mut(),
-                side_data_elems: 0,
-                duration: 0,
-                pos: -1,
-                opaque: ptr::null_mut(),
-                opaque_ref: ptr::null_mut(),
-                time_base: ffi::AVRational { num: 0, den: 1 },
-            };
+            // Errors are captured and propagated after cleanup.
+            let copy_result: Result<()> = (|| {
+                let mut pkt = ffi::AVPacket {
+                    buf: ptr::null_mut(),
+                    pts: ffi::AV_NOPTS_VALUE,
+                    dts: ffi::AV_NOPTS_VALUE,
+                    data: ptr::null_mut(),
+                    size: 0,
+                    stream_index: 0,
+                    flags: 0,
+                    side_data: ptr::null_mut(),
+                    side_data_elems: 0,
+                    duration: 0,
+                    pos: -1,
+                    opaque: ptr::null_mut(),
+                    opaque_ref: ptr::null_mut(),
+                    time_base: ffi::AVRational { num: 0, den: 1 },
+                };
 
-            loop {
-                let ret = ffi::av_read_frame(media_ctx, &mut pkt);
-                if ret < 0 {
-                    break;
-                }
+                loop {
+                    let ret = ffi::av_read_frame(media_ctx, &mut pkt);
+                    if ret < 0 {
+                        break;
+                    }
 
-                let in_stream_idx = pkt.stream_index as usize;
-                if in_stream_idx >= nb_media_streams || stream_mapping[in_stream_idx] < 0 {
+                    let in_stream_idx = pkt.stream_index as usize;
+                    if in_stream_idx >= nb_media_streams || stream_mapping[in_stream_idx] < 0 {
+                        ffi::av_packet_unref(&mut pkt);
+                        continue;
+                    }
+
+                    let out_stream_idx = stream_mapping[in_stream_idx];
+                    pkt.stream_index = out_stream_idx;
+
+                    let in_stream = *(*media_ctx).streams.add(in_stream_idx);
+                    let out_stream = *(*ofmt_ctx).streams.add(out_stream_idx as usize);
+
+                    // Guard against AV_NOPTS_VALUE before rescaling (MKV demuxer may
+                    // not infer DTS for B-frame content, leaving it as AV_NOPTS_VALUE;
+                    // rescaling INT64_MIN overflows and causes the muxer to reject packets)
+                    if pkt.pts != ffi::AV_NOPTS_VALUE {
+                        pkt.pts = ffi::av_rescale_q_rnd(
+                            pkt.pts,
+                            (*in_stream).time_base,
+                            (*out_stream).time_base,
+                            ffi::AVRounding::AV_ROUND_NEAR_INF,
+                        );
+                    }
+                    if pkt.dts != ffi::AV_NOPTS_VALUE {
+                        pkt.dts = ffi::av_rescale_q_rnd(
+                            pkt.dts,
+                            (*in_stream).time_base,
+                            (*out_stream).time_base,
+                            ffi::AVRounding::AV_ROUND_NEAR_INF,
+                        );
+                    }
+                    if pkt.duration > 0 {
+                        pkt.duration = ffi::av_rescale_q(
+                            pkt.duration,
+                            (*in_stream).time_base,
+                            (*out_stream).time_base,
+                        );
+                    }
+                    pkt.pos = -1;
+
+                    let ret = ffi::av_interleaved_write_frame(ofmt_ctx, &mut pkt);
                     ffi::av_packet_unref(&mut pkt);
-                    continue;
+
+                    if ret < 0 {
+                        return Err(PostProcessError::FFmpegLibraryError {
+                            message: format!("av_interleaved_write_frame failed: error code {ret}"),
+                        });
+                    }
                 }
 
-                let out_stream_idx = stream_mapping[in_stream_idx];
-                pkt.stream_index = out_stream_idx;
+                Ok(())
+            })();
 
-                let in_stream = *(*media_ctx).streams.add(in_stream_idx);
-                let out_stream = *(*ofmt_ctx).streams.add(out_stream_idx as usize);
-
-                // Guard against AV_NOPTS_VALUE before rescaling (MKV demuxer may
-                // not infer DTS for B-frame content, leaving it as AV_NOPTS_VALUE;
-                // rescaling INT64_MIN overflows and causes the muxer to reject packets)
-                if pkt.pts != ffi::AV_NOPTS_VALUE {
-                    pkt.pts = ffi::av_rescale_q_rnd(
-                        pkt.pts,
-                        (*in_stream).time_base,
-                        (*out_stream).time_base,
-                        ffi::AVRounding::AV_ROUND_NEAR_INF,
-                    );
-                }
-                if pkt.dts != ffi::AV_NOPTS_VALUE {
-                    pkt.dts = ffi::av_rescale_q_rnd(
-                        pkt.dts,
-                        (*in_stream).time_base,
-                        (*out_stream).time_base,
-                        ffi::AVRounding::AV_ROUND_NEAR_INF,
-                    );
-                }
-                if pkt.duration > 0 {
-                    pkt.duration = ffi::av_rescale_q(
-                        pkt.duration,
-                        (*in_stream).time_base,
-                        (*out_stream).time_base,
-                    );
-                }
-                pkt.pos = -1;
-
-                let ret = ffi::av_interleaved_write_frame(ofmt_ctx, &mut pkt);
-                ffi::av_packet_unref(&mut pkt);
-
-                if ret < 0 {
-                    log::error!("Error writing packet: {ret}");
-                    break;
-                }
-            }
-
-            // 11. Cleanup
+            // 11. Cleanup (always runs, even on copy error)
             ffi::av_write_trailer(ofmt_ctx);
 
             if !(*ofmt_ctx).pb.is_null() {
@@ -371,6 +387,9 @@ impl FFmpegRunner {
             ffi::avformat_close_input(&mut media_ctx);
             ffi::avformat_close_input(&mut thumb_ctx);
             ffi::avformat_free_context(ofmt_ctx);
+
+            // Propagate copy errors after cleanup
+            copy_result?;
         }
 
         Ok(())

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_pipeline.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_pipeline.rs
@@ -166,6 +166,7 @@ impl FFmpegRunner {
                 // SAFETY: octx owns a valid format context
                 let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                 return Err(PostProcessError::MuxWriteError {
+                    code: ret,
                     message: format!("ret={ret} ({strerr}), dur={dur}, {io_diag}"),
                     operation: "av_interleaved_write_frame".into(),
                     stream_index: ost_index,
@@ -200,6 +201,7 @@ impl FFmpegRunner {
                     if timing.stall_count >= 3 {
                         let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                         return Err(PostProcessError::MuxWriteError {
+                            code: 0,
                             message: format!(
                                 "mux stall detected: pb->pos={current_pos} unchanged for {} packets, {io_diag}",
                                 timing.stall_count * 256

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_pipeline_direct.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_pipeline_direct.rs
@@ -259,6 +259,7 @@ impl FFmpegRunner {
                 // SAFETY: octx owns a valid format context
                 let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                 return Err(PostProcessError::MuxWriteError {
+                    code: ret,
                     message: format!("ret={ret} ({strerr}), dur={dur}, {io_diag}"),
                     operation: "av_write_frame".into(),
                     stream_index: ost_index,
@@ -342,6 +343,7 @@ impl FFmpegRunner {
                         }
                         let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                         return Err(PostProcessError::MuxWriteError {
+                            code: 0,
                             message: format!(
                                 "mux stall detected: pb->pos={current_pos}, file_size={file_size} unchanged for {} packets, {io_diag}",
                                 timing.stall_count * 256

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_pipeline_interleaved.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_pipeline_interleaved.rs
@@ -185,6 +185,7 @@ impl FFmpegRunner {
                 let strerr = av_strerror_string(ret);
                 let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                 return Err(PostProcessError::MuxWriteError {
+                    code: ret,
                     message: format!("ret={ret} ({strerr}), dur={dur}, {io_diag}"),
                     operation: "av_interleaved_write_frame (normalize)".into(),
                     stream_index: ost_index,
@@ -262,6 +263,7 @@ impl FFmpegRunner {
                         }
                         let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                         return Err(PostProcessError::MuxWriteError {
+                            code: 0,
                             message: format!(
                                 "mux stall detected: pb->pos={current_pos}, file_size={file_size} unchanged for {} packets, {io_diag}",
                                 timing.stall_count * 256

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_pipeline.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_pipeline.rs
@@ -191,6 +191,7 @@ impl FFmpegRunner {
                 let strerr = av_strerror_string(ret);
                 let io_diag = unsafe { diagnose_mux_io(octx.as_mut_ptr()) };
                 return Err(PostProcessError::MuxWriteError {
+                    code: ret,
                     message: format!("ret={ret} ({strerr}), {io_diag}"),
                     operation: "av_interleaved_write_frame (video)".into(),
                     stream_index: ost_index,


### PR DESCRIPTION
## Summary

- Fix 7 issues found during a comprehensive FFmpeg audit of `rdlp-ffmpeg` crate
- 2 MEDIUM severity (silent error swallowing, unchecked return value)
- 3 LOW severity (concurrency guard, off-by-one, null assertion)
- 2 INFO severity (log level restore, structured error codes)

## Changes

| # | Severity | Fix | File(s) |
|---|----------|-----|---------|
| 1 | MEDIUM | Propagate packet-write errors in thumbnail MKV FFI via error-capture closure | `thumbnail/mkv_raw_ffi.rs` |
| 2 | MEDIUM | Check `avcodec_parameters_copy` return in thumbnail stream copy loop | `thumbnail/mkv_raw_ffi.rs` |
| 3 | LOW | Add `debug_assert` concurrency guard in `LogCaptureGuard::begin()` | `log_capture.rs` |
| 4 | LOW | Fix off-by-one in salvage temp file dedup (`> 99` → `>= 99`) | `salvage.rs` |
| 5 | LOW | Add null assertions for streams pointer in merge MKV FFI | `merge/mkv_raw_ffi.rs` |
| 6 | INFO | Save/restore previous log level in `LogSuppressGuard` Drop | `log_capture.rs` |
| 7 | INFO | Add structured `code: i32` field to `MuxWriteError`; replace string matching | `error.rs` + 4 transcode files |

## Test plan

- [x] `cargo fmt --check -p rdlp-ffmpeg` — clean
- [x] `cargo clippy -p rdlp-ffmpeg -- -D warnings` — 0 warnings
- [x] `cargo test -p rdlp-ffmpeg` — 74/74 tests pass
- [x] QA sign-off: PASS