### PR TITLE
feat(desktop): add frontend test suite with Vitest and Cypress e2e

### DIFF
--- a/crates/rdlp-desktop/cypress.config.ts
+++ b/crates/rdlp-desktop/cypress.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    e2e: {
+        baseUrl: "http://localhost:5173",
+        specPattern: "cypress/e2e/**/*.cy.ts",
+        supportFile: "cypress/support/e2e.ts",
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        video: false,
+        screenshotOnRunFailure: false,
+    },
+});

--- a/crates/rdlp-desktop/cypress/e2e/search.cy.ts
+++ b/crates/rdlp-desktop/cypress/e2e/search.cy.ts
@@ -1,0 +1,91 @@
+// E2E tests for the search flow.
+//
+// Covers: typing a query, selecting a site, submitting, viewing results,
+// paginating to the next page, and clearing the search.
+
+import { setupTauriMock } from "../support/e2e";
+
+describe("Search flow", () => {
+    it("shows the search input on app load", () => {
+        cy.get('input[placeholder="Search videos..."]').should("be.visible");
+    });
+
+    it("auto-selects the first search provider", () => {
+        // The site selector should display the first provider from the mock
+        cy.get('[aria-label="Search site"]').should("be.visible");
+        // The SelectTrigger text should contain the first provider name after providers load
+        cy.contains("RedTube").should("exist");
+    });
+
+    it("shows search results after submitting a query", () => {
+        cy.get('input[placeholder="Search videos..."]').type("test query");
+        cy.get('button[aria-label="Search"]').click();
+
+        cy.contains("Test Video One").should("be.visible");
+        cy.contains("Test Video Two").should("be.visible");
+    });
+
+    it("shows 'Load more results' button when there are more pages", () => {
+        cy.get('input[placeholder="Search videos..."]').type("test query");
+        cy.get('button[aria-label="Search"]').click();
+
+        cy.contains("Load more results").should("be.visible");
+    });
+
+    it("loads the next page when 'Load more results' is clicked", () => {
+        cy.get('input[placeholder="Search videos..."]').type("test query");
+        cy.get('button[aria-label="Search"]').click();
+
+        cy.contains("Test Video One").should("be.visible");
+        cy.contains("Load more results").click();
+
+        cy.contains("Test Video Three").should("be.visible");
+        cy.contains("All results loaded").should("be.visible");
+    });
+
+    it("announces result count to screen readers", () => {
+        cy.get('input[placeholder="Search videos..."]').type("test query");
+        cy.get('button[aria-label="Search"]').click();
+
+        cy.get('[aria-live="polite"]').should("contain", "results loaded");
+    });
+
+    it("clears the search when the clear button is clicked", () => {
+        cy.get('input[placeholder="Search videos..."]').type("test query");
+
+        // The clear (X) button appears when there is text in the input
+        cy.get('button[aria-label="Clear search"]').should("be.visible").click();
+
+        cy.get('input[placeholder="Search videos..."]').should("have.value", "");
+    });
+
+    it("shows 'No results' state when search returns empty", () => {
+        // Override the search mock to return empty results
+        cy.visit("/", {
+            onBeforeLoad(win) {
+                setupTauriMock(win, {
+                    search_content: () => ({
+                        results: [],
+                        page: 1,
+                        has_more: false,
+                        total_estimate: 0,
+                    }),
+                });
+            },
+        });
+
+        cy.get('input[placeholder="Search videos..."]').type("no results query");
+        cy.get('button[aria-label="Search"]').click();
+
+        cy.contains("No results for").should("be.visible");
+    });
+
+    it("disables search button when input is empty", () => {
+        cy.get('button[aria-label="Search"]').should("be.disabled");
+    });
+
+    it("enables search button after typing a query", () => {
+        cy.get('input[placeholder="Search videos..."]').type("hello");
+        cy.get('button[aria-label="Search"]').should("not.be.disabled");
+    });
+});

--- a/crates/rdlp-desktop/cypress/e2e/settings.cy.ts
+++ b/crates/rdlp-desktop/cypress/e2e/settings.cy.ts
@@ -1,0 +1,96 @@
+// E2E tests for the Settings page.
+//
+// Covers: loading settings, changing values, saving, and error handling.
+
+import { setupTauriMock } from "../support/e2e";
+
+describe("Settings page", () => {
+    beforeEach(() => {
+        // Navigate to Settings — find the settings nav link in the sidebar
+        cy.contains("Settings").click();
+    });
+
+    it("shows the Settings heading", () => {
+        cy.contains("h2", "Settings").should("be.visible");
+    });
+
+    it("displays the output directory field", () => {
+        cy.get('label').contains("Output Directory").should("be.visible");
+        cy.get('input[type="text"]').first().should("have.value", "/home/user/Downloads");
+    });
+
+    it("shows the Browse button for output directory", () => {
+        cy.contains("button", "Browse").should("be.visible");
+    });
+
+    it("shows the Save Settings button", () => {
+        cy.contains("button", "Save Settings").scrollIntoView().should("be.visible");
+    });
+
+    it("shows the embed thumbnail checkbox checked by default", () => {
+        cy.contains("Embed thumbnails")
+            .closest("div")
+            .find('button[role="checkbox"]')
+            .should("have.attr", "aria-checked", "true");
+    });
+
+    it("shows the embed metadata checkbox checked by default", () => {
+        cy.contains("Embed metadata")
+            .closest("div")
+            .find('button[role="checkbox"]')
+            .should("have.attr", "aria-checked", "true");
+    });
+
+    it("shows the verbose logging checkbox unchecked by default", () => {
+        cy.contains("Verbose logging")
+            .closest("div")
+            .find('button[role="checkbox"]')
+            .should("have.attr", "aria-checked", "false");
+    });
+
+    it("toggles the verbose logging checkbox", () => {
+        cy.contains("Verbose logging")
+            .closest("div")
+            .find('button[role="checkbox"]')
+            .click()
+            .should("have.attr", "aria-checked", "true");
+    });
+
+    it("saves settings without error on clicking Save Settings", () => {
+        cy.contains("button", "Save Settings").scrollIntoView().click();
+
+        // No error alert should appear
+        cy.get('[role="alert"]').should("not.exist");
+    });
+
+    it("updates output directory when Browse is clicked and directory is returned", () => {
+        cy.contains("button", "Browse").click();
+        // The pick_directory mock returns "/home/user/Videos"
+        cy.get('input[type="text"]').first().should("have.value", "/home/user/Videos");
+    });
+
+    it("shows error alert when save fails", () => {
+        cy.visit("/", {
+            onBeforeLoad(win) {
+                setupTauriMock(win, {
+                    update_settings: () => {
+                        throw new Error("Disk full");
+                    },
+                });
+            },
+        });
+
+        cy.contains("Settings").click();
+        cy.contains("button", "Save Settings").scrollIntoView().click();
+
+        cy.get('[role="alert"]').should("contain", "Disk full");
+    });
+
+    it("shows all format options in Default Remux Format dropdown", () => {
+        cy.contains("Default Remux Format").should("be.visible");
+    });
+
+    it("shows subtitle format options", () => {
+        cy.contains("Default Subtitle Format").should("be.visible");
+    });
+});

--- a/crates/rdlp-desktop/cypress/fixtures/filters.json
+++ b/crates/rdlp-desktop/cypress/fixtures/filters.json
@@ -1,0 +1,22 @@
+[
+    {
+        "key": "ordering",
+        "display_name": "Sort",
+        "allowed_values": [
+            { "value": "relevance", "label": "Relevance" },
+            { "value": "newest", "label": "Newest" },
+            { "value": "mostviewed", "label": "Most Viewed" }
+        ],
+        "default": "relevance"
+    },
+    {
+        "key": "period",
+        "display_name": "Period",
+        "allowed_values": [
+            { "value": "alltime", "label": "All Time" },
+            { "value": "weekly", "label": "This Week" },
+            { "value": "monthly", "label": "This Month" }
+        ],
+        "default": "alltime"
+    }
+]

--- a/crates/rdlp-desktop/cypress/fixtures/formats.json
+++ b/crates/rdlp-desktop/cypress/fixtures/formats.json
@@ -1,0 +1,44 @@
+{
+    "title": "Test Video",
+    "formats": [
+        {
+            "format_id": "137",
+            "ext": "mp4",
+            "format_note": "1080p",
+            "width": 1920,
+            "height": 1080,
+            "fps": 30.0,
+            "tbr": 4000.0,
+            "vcodec": "avc1",
+            "acodec": null,
+            "filesize": 524288000,
+            "vbr": 4000.0,
+            "abr": null,
+            "asr": null,
+            "protocol": "https",
+            "has_video": true,
+            "has_audio": false
+        },
+        {
+            "format_id": "140",
+            "ext": "m4a",
+            "format_note": "audio",
+            "width": null,
+            "height": null,
+            "fps": null,
+            "tbr": 128.0,
+            "vcodec": null,
+            "acodec": "mp4a",
+            "filesize": 10485760,
+            "vbr": null,
+            "abr": 128.0,
+            "asr": 44100.0,
+            "protocol": "https",
+            "has_video": false,
+            "has_audio": true
+        }
+    ],
+    "subtitles": [],
+    "thumbnail_url": "https://example.com/thumb.jpg",
+    "duration": 600
+}

--- a/crates/rdlp-desktop/cypress/fixtures/providers.json
+++ b/crates/rdlp-desktop/cypress/fixtures/providers.json
@@ -1,0 +1,5 @@
+[
+    { "name": "redtube", "display_name": "RedTube" },
+    { "name": "xhamster", "display_name": "xHamster" },
+    { "name": "tnaflix", "display_name": "TNAFlix" }
+]

--- a/crates/rdlp-desktop/cypress/fixtures/search-results-page2.json
+++ b/crates/rdlp-desktop/cypress/fixtures/search-results-page2.json
@@ -1,0 +1,15 @@
+{
+    "results": [
+        {
+            "video_url": "https://example.com/video/4",
+            "title": "Test Video Four",
+            "thumbnail_url": "https://example.com/thumb4.jpg",
+            "duration": 120,
+            "view_count": 999,
+            "upload_date": "2024-03-10"
+        }
+    ],
+    "page": 2,
+    "has_more": false,
+    "total_estimate": 42
+}

--- a/crates/rdlp-desktop/cypress/fixtures/search-results.json
+++ b/crates/rdlp-desktop/cypress/fixtures/search-results.json
@@ -1,0 +1,31 @@
+{
+    "results": [
+        {
+            "video_url": "https://example.com/video/1",
+            "title": "Test Video One",
+            "thumbnail_url": "https://example.com/thumb1.jpg",
+            "duration": 300,
+            "view_count": 12345,
+            "upload_date": "2024-01-15"
+        },
+        {
+            "video_url": "https://example.com/video/2",
+            "title": "Test Video Two",
+            "thumbnail_url": "https://example.com/thumb2.jpg",
+            "duration": 600,
+            "view_count": 67890,
+            "upload_date": "2024-02-20"
+        },
+        {
+            "video_url": "https://example.com/video/3",
+            "title": "Test Video Three",
+            "thumbnail_url": null,
+            "duration": null,
+            "view_count": null,
+            "upload_date": null
+        }
+    ],
+    "page": 1,
+    "has_more": true,
+    "total_estimate": 42
+}

--- a/crates/rdlp-desktop/cypress/fixtures/settings.json
+++ b/crates/rdlp-desktop/cypress/fixtures/settings.json
@@ -1,0 +1,11 @@
+{
+    "output_dir": "/home/user/Downloads",
+    "default_remux": null,
+    "default_extract_audio": null,
+    "default_subtitle_format": null,
+    "default_subtitle_langs": [],
+    "embed_thumbnail": true,
+    "embed_metadata": true,
+    "verbose": false,
+    "default_search_provider": null
+}

--- a/crates/rdlp-desktop/cypress/support/commands.ts
+++ b/crates/rdlp-desktop/cypress/support/commands.ts
@@ -1,0 +1,42 @@
+// Custom Cypress commands for rdlp-desktop E2E tests.
+//
+// Commands added here are available as cy.commandName() in all tests.
+
+/// <reference types="cypress" />
+
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            /**
+             * Type a search query into the search input and submit.
+             * @param query - The search query string.
+             */
+            search(query: string): Chainable<void>;
+
+            /**
+             * Navigate to the Settings tab in the sidebar.
+             */
+            goToSettings(): Chainable<void>;
+
+            /**
+             * Navigate to the Search tab in the sidebar.
+             */
+            goToSearch(): Chainable<void>;
+        }
+    }
+}
+
+Cypress.Commands.add("search", (query: string) => {
+    cy.get('input[placeholder="Search videos..."]').clear().type(query);
+    cy.get('button[aria-label="Search"]').click();
+});
+
+Cypress.Commands.add("goToSettings", () => {
+    cy.contains("nav button", "Settings").click();
+});
+
+Cypress.Commands.add("goToSearch", () => {
+    cy.contains("nav button", "Search").click();
+});
+
+export {};

--- a/crates/rdlp-desktop/cypress/support/e2e.ts
+++ b/crates/rdlp-desktop/cypress/support/e2e.ts
@@ -1,0 +1,236 @@
+// E2E support file — loaded before every test.
+//
+// Mocks window.__TAURI_INTERNALS__ so the Tauri invoke() calls in invokeClient.ts
+// resolve with fixture data during Cypress-driven browser tests.
+
+import "./commands";
+
+// ---------------------------------------------------------------------------
+// Tauri IPC mock
+// ---------------------------------------------------------------------------
+
+/**
+ * Default fixture responses keyed by Tauri command name.
+ * Tests can override individual commands by passing overrides to
+ * `setupTauriMock()` or `cy.visitWithMock()`.
+ */
+type InvokeHandler = (args: Record<string, unknown>) => unknown;
+
+const defaultHandlers: Record<string, InvokeHandler> = {
+    get_search_providers: () => [
+        { name: "redtube", display_name: "RedTube" },
+        { name: "xhamster", display_name: "xHamster" },
+        { name: "tnaflix", display_name: "TNAFlix" },
+    ],
+
+    get_search_filters: (_args) => [
+        {
+            key: "ordering",
+            display_name: "Sort",
+            allowed_values: [
+                { value: "relevance", label: "Relevance" },
+                { value: "newest", label: "Newest" },
+                { value: "mostviewed", label: "Most Viewed" },
+            ],
+            default: "relevance",
+        },
+        {
+            key: "period",
+            display_name: "Period",
+            allowed_values: [
+                { value: "alltime", label: "All Time" },
+                { value: "weekly", label: "This Week" },
+                { value: "monthly", label: "This Month" },
+            ],
+            default: "alltime",
+        },
+    ],
+
+    search_content: (args) => {
+        const page = (args.page as number) ?? 1;
+        if (page === 1) {
+            return {
+                results: [
+                    {
+                        video_url: "https://example.com/video/1",
+                        title: "Test Video One",
+                        thumbnail_url: "https://example.com/thumb1.jpg",
+                        duration: 300,
+                        view_count: 12345,
+                        upload_date: "2024-01-15",
+                    },
+                    {
+                        video_url: "https://example.com/video/2",
+                        title: "Test Video Two",
+                        thumbnail_url: "https://example.com/thumb2.jpg",
+                        duration: 600,
+                        view_count: 67890,
+                        upload_date: "2024-02-20",
+                    },
+                ],
+                page: 1,
+                has_more: true,
+                total_estimate: 42,
+            };
+        }
+        return {
+            results: [
+                {
+                    video_url: "https://example.com/video/3",
+                    title: "Test Video Three",
+                    thumbnail_url: null,
+                    duration: 120,
+                    view_count: 999,
+                    upload_date: "2024-03-10",
+                },
+            ],
+            page: 2,
+            has_more: false,
+            total_estimate: 42,
+        };
+    },
+
+    get_settings: () => ({
+        output_dir: "/home/user/Downloads",
+        default_remux: null,
+        default_extract_audio: null,
+        default_subtitle_format: null,
+        default_subtitle_langs: [],
+        embed_thumbnail: true,
+        embed_metadata: true,
+        verbose: false,
+        default_search_provider: null,
+    }),
+
+    update_settings: () => null,
+
+    pick_directory: () => "/home/user/Videos",
+
+    get_formats: () => ({
+        title: "Test Video",
+        formats: [
+            {
+                format_id: "137",
+                ext: "mp4",
+                format_note: "1080p",
+                width: 1920,
+                height: 1080,
+                fps: 30.0,
+                tbr: 4000.0,
+                vcodec: "avc1",
+                acodec: null,
+                filesize: 524288000,
+                vbr: 4000.0,
+                abr: null,
+                asr: null,
+                protocol: "https",
+                has_video: true,
+                has_audio: false,
+            },
+        ],
+        subtitles: [],
+        thumbnail_url: "https://example.com/thumb.jpg",
+        duration: 600,
+    }),
+
+    start_download: () => "job-test-123",
+
+    get_queue: () => [],
+
+    get_history: () => [],
+};
+
+// ---------------------------------------------------------------------------
+// Mock setup function — injects __TAURI_INTERNALS__ and
+// __TAURI_EVENT_PLUGIN_INTERNALS__ on a window object.
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up the full Tauri IPC mock on a window.
+ * Called from `onBeforeLoad` for every `cy.visit()`.
+ */
+function setupTauriMock(
+    win: Window,
+    overrides: Record<string, InvokeHandler> = {},
+) {
+    const handlers: Record<string, InvokeHandler> = {
+        ...defaultHandlers,
+        ...overrides,
+    };
+
+    let nextEventId = 1;
+
+    // Mock __TAURI_EVENT_PLUGIN_INTERNALS__ so the event module's
+    // _unlisten() can call unregisterListener without crashing.
+    (win as Window & { __TAURI_EVENT_PLUGIN_INTERNALS__?: unknown })
+        .__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+            unregisterListener(_event: string, _eventId: number) {
+                // no-op in test
+            },
+        };
+
+    // Mock the __TAURI_INTERNALS__ object that @tauri-apps/api/core reads
+    // to dispatch invoke() calls. The real Tauri runtime sets this up;
+    // in Cypress we provide a stub that resolves immediately.
+    (win as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {
+        invoke(command: string, args: Record<string, unknown> = {}): Promise<unknown> {
+            // Handle Tauri event plugin commands
+            if (command === "plugin:event|listen") {
+                return Promise.resolve(nextEventId++);
+            }
+            if (command === "plugin:event|unlisten") {
+                return Promise.resolve();
+            }
+
+            const handler = handlers[command];
+            if (handler) {
+                try {
+                    const result = handler(args);
+                    return Promise.resolve(result);
+                } catch (err) {
+                    return Promise.reject(err);
+                }
+            }
+            // Unhandled commands resolve to null to prevent test hangs
+            cy.log(`[Tauri mock] Unhandled command: ${command}`);
+            return Promise.resolve(null);
+        },
+        // Additional internals stubs that Tauri plugins may read
+        transformCallback(callback: (data: unknown) => void, once?: boolean): number {
+            const id = Math.floor(Math.random() * 1000000);
+            (win as unknown as Record<string, unknown>)[`_${id}`] = once
+                ? (data: unknown) => {
+                      delete (win as unknown as Record<string, unknown>)[`_${id}`];
+                      callback(data);
+                  }
+                : callback;
+            return id;
+        },
+        convertFileSrc(src: string): string {
+            return src;
+        },
+        metadata: {
+            version: "2.0.0",
+            tauriVersion: "2.0.0",
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Inject Tauri mock before each test
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+    cy.visit("/", {
+        onBeforeLoad(win) {
+            setupTauriMock(win);
+        },
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Export for use in tests that need to re-visit with custom handlers
+// ---------------------------------------------------------------------------
+
+export { setupTauriMock, defaultHandlers };
+export type { InvokeHandler };

--- a/crates/rdlp-desktop/cypress/tsconfig.json
+++ b/crates/rdlp-desktop/cypress/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "lib": ["ES2020", "DOM"],
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "strict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "skipLibCheck": true,
+        "types": ["cypress"]
+    },
+    "include": ["./**/*.ts"]
+}

--- a/crates/rdlp-desktop/package.json
+++ b/crates/rdlp-desktop/package.json
@@ -7,7 +7,12 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "cypress run",
+    "cypress:open": "cypress open"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.0",
@@ -30,10 +35,17 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "cypress": "^15.10.0",
+    "jsdom": "^28.1.0",
     "typescript": "^5.4.5",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/crates/rdlp-desktop/src/components/CommandBar.test.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, act, createTestQueryClient } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { CommandBar } from "./CommandBar";
+import { searchParamsAtom, resetSearchParams } from "../stores/searchParamsStore";
+import { queryKeys } from "../query/queryKeys";
+import { createRef } from "react";
+import type { SearchSiteInfo } from "../types";
+
+const mockProviders: SearchSiteInfo[] = [
+    { name: "redtube", display_name: "RedTube" },
+    { name: "xhamster", display_name: "xHamster" },
+];
+
+/** Render CommandBar with query cache pre-populated so useQuery resolves
+ *  synchronously during render — no async microtask chain, no act() warnings. */
+function renderCommandBar(props?: {
+    activeTab?: string;
+    isFetching?: boolean;
+    onSearch?: () => void;
+}) {
+    const inputRef = createRef<HTMLInputElement>();
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(queryKeys.providers(), mockProviders);
+    return render(
+        <CommandBar
+            inputRef={inputRef as React.RefObject<HTMLInputElement>}
+            activeTab={props?.activeTab ?? "search"}
+            isFetching={props?.isFetching ?? false}
+            onSearch={props?.onSearch ?? vi.fn()}
+        />,
+        { queryClient },
+    );
+}
+
+beforeEach(() => {
+    resetSearchParams();
+});
+
+afterEach(() => {
+    act(() => resetSearchParams());
+});
+
+describe("CommandBar", () => {
+    it("renders the search input", () => {
+        renderCommandBar();
+        expect(screen.getByPlaceholderText("Search videos...")).toBeInTheDocument();
+    });
+
+    it("renders the site selector trigger", () => {
+        renderCommandBar();
+        expect(screen.getByRole("combobox", { name: /search site/i })).toBeInTheDocument();
+    });
+
+    it("renders the submit button", () => {
+        renderCommandBar();
+        expect(screen.getByRole("button", { name: /^search$/i })).toBeInTheDocument();
+    });
+
+    it("submit button is disabled when query is empty and no category filter", () => {
+        renderCommandBar();
+        const btn = screen.getByRole("button", { name: /^search$/i });
+        expect(btn).toBeDisabled();
+    });
+
+    it("submit button is enabled after typing a query", async () => {
+        renderCommandBar();
+        const input = screen.getByPlaceholderText("Search videos...");
+        await userEvent.type(input, "test");
+        expect(screen.getByRole("button", { name: /^search$/i })).not.toBeDisabled();
+    });
+
+    it("calls onSearch when form is submitted with non-empty query", async () => {
+        const onSearch = vi.fn();
+        renderCommandBar({ onSearch });
+        const input = screen.getByPlaceholderText("Search videos...");
+        await userEvent.type(input, "cats");
+        await userEvent.click(screen.getByRole("button", { name: /^search$/i }));
+        expect(onSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows clear button when query has text", async () => {
+        renderCommandBar();
+        const input = screen.getByPlaceholderText("Search videos...");
+        await userEvent.type(input, "dogs");
+        expect(screen.getByRole("button", { name: /clear search/i })).toBeInTheDocument();
+    });
+
+    it("clears the query when clear button is clicked", async () => {
+        renderCommandBar();
+        const input = screen.getByPlaceholderText("Search videos...");
+        await userEvent.type(input, "dogs");
+        await userEvent.click(screen.getByRole("button", { name: /clear search/i }));
+        expect(input).toHaveValue("");
+    });
+
+    it("disables input and submit button while fetching", () => {
+        renderCommandBar({ isFetching: true });
+        expect(screen.getByPlaceholderText("Search videos...")).toBeDisabled();
+        expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
+    });
+
+    it("updates store query on input change", async () => {
+        renderCommandBar();
+        const input = screen.getByPlaceholderText("Search videos...");
+        await userEvent.type(input, "hello");
+        expect(searchParamsAtom.state.query).toBe("hello");
+    });
+});

--- a/crates/rdlp-desktop/src/components/FilterBar.test.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, act, createTestQueryClient } from "@/test/test-utils";
+import { FilterBar } from "./FilterBar";
+import { resetSearchParams, setSearchParam, searchParamsAtom } from "../stores/searchParamsStore";
+import { queryKeys } from "../query/queryKeys";
+import type { SearchFilterDescriptor } from "../types";
+
+const mockFilters: SearchFilterDescriptor[] = [
+    {
+        key: "ordering",
+        display_name: "Sort",
+        default: "relevance",
+        allowed_values: [
+            { value: "relevance", label: "Relevance" },
+            { value: "newest", label: "Newest" },
+            { value: "mostviewed", label: "Most Viewed" },
+        ],
+    },
+    {
+        key: "period",
+        display_name: "Period",
+        default: "alltime",
+        allowed_values: [
+            { value: "alltime", label: "All Time" },
+            { value: "weekly", label: "Weekly" },
+        ],
+    },
+];
+
+/** Render FilterBar with query cache pre-populated so useQuery resolves
+ *  synchronously during render — no async microtask chain, no act() warnings. */
+function renderFilterBar(
+    props?: {
+        isFetching?: boolean;
+        hasSearchData?: boolean;
+        onSearch?: () => void;
+    },
+    filters: SearchFilterDescriptor[] = mockFilters,
+) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(queryKeys.filters("redtube"), filters);
+    return render(
+        <FilterBar
+            isFetching={props?.isFetching ?? false}
+            hasSearchData={props?.hasSearchData ?? false}
+            onSearch={props?.onSearch ?? vi.fn()}
+        />,
+        { queryClient },
+    );
+}
+
+beforeEach(() => {
+    resetSearchParams();
+    setSearchParam("site", "redtube");
+});
+
+afterEach(() => {
+    act(() => resetSearchParams());
+});
+
+describe("FilterBar", () => {
+    it("renders null when no filter descriptors are available", () => {
+        const { container } = renderFilterBar({}, []);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it("renders filter selects once descriptors load", () => {
+        renderFilterBar();
+        expect(screen.getByRole("combobox", { name: /sort/i })).toBeInTheDocument();
+    });
+
+    it("renders all default filter chips", () => {
+        renderFilterBar();
+        expect(screen.getByRole("combobox", { name: /sort/i })).toBeInTheDocument();
+        expect(screen.getByRole("combobox", { name: /period/i })).toBeInTheDocument();
+    });
+
+    it("shows reset button when a filter differs from its default", () => {
+        renderFilterBar({ hasSearchData: true });
+
+        // Manually set a non-default filter on the atom to simulate a change.
+        // Wrap in act() because the atom mutation triggers useStore re-render.
+        act(() => {
+            searchParamsAtom.setState((prev) => ({
+                ...prev,
+                filters: [{ key: "ordering", value: "newest" }],
+                hasUserFilters: true,
+            }));
+        });
+
+        expect(screen.getByRole("button", { name: /reset all filters/i })).toBeInTheDocument();
+    });
+
+    it("does not show reset button when all filters are at defaults", () => {
+        renderFilterBar();
+        expect(screen.queryByRole("button", { name: /reset all filters/i })).not.toBeInTheDocument();
+    });
+
+    it("disables filter selects while fetching", () => {
+        renderFilterBar({ isFetching: true });
+        const selects = screen.getAllByRole("combobox");
+        for (const s of selects) {
+            expect(s).toBeDisabled();
+        }
+    });
+});

--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { JobCard } from "./JobCard";
+import type { DownloadJob } from "../types";
+
+function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
+    return {
+        id: "job-1",
+        url: "https://example.com/video",
+        title: "Test Video",
+        status: "pending",
+        progress: null,
+        speed: null,
+        eta: null,
+        error: null,
+        retryable: false,
+        started_at: null,
+        completed_at: null,
+        output_path: null,
+        statusMessage: null,
+        ...overrides,
+    };
+}
+
+describe("JobCard", () => {
+    it("renders job title when provided", () => {
+        render(
+            <JobCard
+                job={makeJob({ title: "My Video" })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("My Video")).toBeInTheDocument();
+    });
+
+    it("falls back to URL when title is null", () => {
+        render(
+            <JobCard
+                job={makeJob({ title: null, url: "https://example.com/fallback" })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("https://example.com/fallback")).toBeInTheDocument();
+    });
+
+    it("renders status badge", () => {
+        render(
+            <JobCard
+                job={makeJob({ status: "running" })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("running")).toBeInTheDocument();
+    });
+
+    it("shows Cancel button while running", () => {
+        render(
+            <JobCard
+                job={makeJob({ status: "running", progress: 0.5 })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    it("calls onCancel with job id when Cancel is clicked", async () => {
+        const onCancel = vi.fn();
+        render(
+            <JobCard
+                job={makeJob({ status: "running", progress: 0.3 })}
+                onCancel={onCancel}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+        expect(onCancel).toHaveBeenCalledWith("job-1");
+    });
+
+    it("shows progress percentage while running", () => {
+        render(
+            <JobCard
+                job={makeJob({ status: "running", progress: 0.75 })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("75.0%")).toBeInTheDocument();
+    });
+
+    it("shows Remove button for terminal statuses", async () => {
+        const onRemove = vi.fn();
+        render(
+            <JobCard
+                job={makeJob({ status: "completed" })}
+                onCancel={vi.fn()}
+                onRemove={onRemove}
+                onRetry={vi.fn()}
+            />,
+        );
+        const removeBtn = screen.getByRole("button", { name: /remove/i });
+        await userEvent.click(removeBtn);
+        expect(onRemove).toHaveBeenCalledWith("job-1");
+    });
+
+    it("shows Retry button for retryable failed jobs", async () => {
+        const onRetry = vi.fn();
+        render(
+            <JobCard
+                job={makeJob({ status: "failed", retryable: true, error: "Network error" })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={onRetry}
+            />,
+        );
+        await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+        expect(onRetry).toHaveBeenCalledWith("https://example.com/video");
+    });
+
+    it("displays error message for failed jobs", () => {
+        render(
+            <JobCard
+                job={makeJob({ status: "failed", error: "Download timed out" })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("Download timed out")).toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/components/ResultCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/ResultCard.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
+import { ResultCard } from "./ResultCard";
+import type { SearchResultPreview } from "../types";
+
+const baseResult: SearchResultPreview = {
+    video_url: "https://example.com/video.mp4",
+    title: "Sample Video Title",
+    thumbnail_url: "https://example.com/thumb.jpg",
+    duration: 185,
+    view_count: 12500,
+    upload_date: null,
+};
+
+beforeEach(() => {
+    setInvokeHandler("get_settings", () => null);
+});
+
+afterEach(() => {
+    clearInvokeHandlers();
+});
+
+describe("ResultCard", () => {
+    it("renders the video title", () => {
+        render(
+            <ResultCard
+                result={baseResult}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        expect(screen.getByRole("heading", { name: "Sample Video Title" })).toBeInTheDocument();
+    });
+
+    it("renders thumbnail image with alt text", () => {
+        render(
+            <ResultCard
+                result={baseResult}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        const img = screen.getByRole("img", { name: "Sample Video Title" });
+        expect(img).toHaveAttribute("src", "https://example.com/thumb.jpg");
+    });
+
+    it("shows 'No thumbnail' placeholder when thumbnail_url is null", () => {
+        render(
+            <ResultCard
+                result={{ ...baseResult, thumbnail_url: null }}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        expect(screen.getByText(/no thumbnail/i)).toBeInTheDocument();
+    });
+
+    it("displays formatted duration", () => {
+        render(
+            <ResultCard
+                result={baseResult}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        // 185s = 3:05
+        expect(screen.getByText("3:05")).toBeInTheDocument();
+    });
+
+    it("displays formatted view count", () => {
+        render(
+            <ResultCard
+                result={baseResult}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("12.5K views")).toBeInTheDocument();
+    });
+
+    it("calls onDownload with video_url and title when Download button is clicked", async () => {
+        const onDownload = vi.fn();
+        render(
+            <ResultCard
+                result={baseResult}
+                onDownload={onDownload}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        await userEvent.click(screen.getByRole("button", { name: /^download$/i }));
+        expect(onDownload).toHaveBeenCalledWith(
+            "https://example.com/video.mp4",
+            "Sample Video Title",
+        );
+    });
+
+    it("calls onOpenFormatDialog when Choose Format is clicked", async () => {
+        const onOpenFormatDialog = vi.fn();
+        render(
+            <ResultCard
+                result={baseResult}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={onOpenFormatDialog}
+            />,
+        );
+        await userEvent.click(screen.getByRole("button", { name: /choose format/i }));
+        expect(onOpenFormatDialog).toHaveBeenCalledWith("https://example.com/video.mp4");
+    });
+
+    it("does not display view count when view_count is null", () => {
+        render(
+            <ResultCard
+                result={{ ...baseResult, view_count: null }}
+                onDownload={vi.fn()}
+                onDownloadWithOptions={vi.fn()}
+                onOpenFormatDialog={vi.fn()}
+            />,
+        );
+        expect(screen.queryByText(/views/i)).not.toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/components/StatusBar.test.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBar.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, act } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
+import { StatusBar } from "./StatusBar";
+import { resetSearchParams } from "../stores/searchParamsStore";
+
+beforeEach(() => {
+    resetSearchParams();
+    setInvokeHandler("get_search_providers", () => []);
+    setInvokeHandler("get_queue", () => []);
+});
+
+afterEach(() => {
+    clearInvokeHandlers();
+    act(() => resetSearchParams());
+});
+
+function renderStatusBar(props?: {
+    viewMode?: "list" | "grid";
+    onViewModeChange?: (mode: "list" | "grid") => void;
+    onSwitchToQueue?: () => void;
+}) {
+    return render(
+        <StatusBar
+            viewMode={props?.viewMode ?? "list"}
+            onViewModeChange={props?.onViewModeChange ?? vi.fn()}
+            onSwitchToQueue={props?.onSwitchToQueue ?? vi.fn()}
+        />,
+    );
+}
+
+describe("StatusBar", () => {
+    it("renders 'Ready' in idle state", () => {
+        renderStatusBar();
+        expect(screen.getByText("Ready")).toBeInTheDocument();
+    });
+
+    it("renders List view button", () => {
+        renderStatusBar();
+        expect(screen.getByRole("button", { name: /list view/i })).toBeInTheDocument();
+    });
+
+    it("renders Grid view button", () => {
+        renderStatusBar();
+        expect(screen.getByRole("button", { name: /grid view/i })).toBeInTheDocument();
+    });
+
+    it("calls onViewModeChange with 'grid' when Grid view is clicked", async () => {
+        const onViewModeChange = vi.fn();
+        renderStatusBar({ onViewModeChange });
+        await userEvent.click(screen.getByRole("button", { name: /grid view/i }));
+        expect(onViewModeChange).toHaveBeenCalledWith("grid");
+    });
+
+    it("calls onViewModeChange with 'list' when List view is clicked", async () => {
+        const onViewModeChange = vi.fn();
+        renderStatusBar({ viewMode: "grid", onViewModeChange });
+        await userEvent.click(screen.getByRole("button", { name: /list view/i }));
+        expect(onViewModeChange).toHaveBeenCalledWith("list");
+    });
+
+    it("does not render a queue link when no active downloads", () => {
+        renderStatusBar();
+        // The center text button linking to the queue only appears with active jobs
+        expect(screen.queryByTitle(/switch to queue/i)).not.toBeInTheDocument();
+    });
+
+    it("calls onSwitchToQueue when active download link is clicked", async () => {
+        const onSwitchToQueue = vi.fn();
+
+        // Return an active job so the center button appears
+        setInvokeHandler("get_queue", () => [
+            {
+                id: "job-1",
+                url: "https://example.com/video",
+                title: "Video",
+                status: "running",
+                progress: 0.5,
+                speed: "2 MB/s",
+                eta: "5s",
+                error: null,
+                retryable: false,
+                started_at: null,
+                completed_at: null,
+                output_path: null,
+                statusMessage: null,
+            },
+        ]);
+
+        renderStatusBar({ onSwitchToQueue });
+
+        // Wait for queue to load and the center button to appear
+        const link = await screen.findByTitle(/switch to queue/i);
+        await userEvent.click(link);
+        expect(onSwitchToQueue).toHaveBeenCalledTimes(1);
+    });
+});

--- a/crates/rdlp-desktop/src/components/utils/formatUtils.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/formatUtils.test.ts
@@ -1,0 +1,165 @@
+// Unit tests for formatUtils.ts — formatBrief, formatSize, formatBitrate,
+// formatResolution, formatType.
+
+import { describe, test, expect } from "vitest";
+import type { FormatInfo } from "../../types";
+import { formatBrief, formatSize, formatBitrate, formatResolution, formatType } from "./formatUtils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormat(overrides: Partial<FormatInfo> = {}): FormatInfo {
+    return {
+        format_id: "123",
+        ext: "mp4",
+        format_note: null,
+        width: null,
+        height: null,
+        fps: null,
+        tbr: null,
+        vcodec: null,
+        acodec: null,
+        filesize: null,
+        vbr: null,
+        abr: null,
+        asr: null,
+        protocol: "https",
+        has_video: true,
+        has_audio: true,
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// formatBrief
+// ---------------------------------------------------------------------------
+
+describe("formatBrief", () => {
+    test("uses height when present", () => {
+        expect(formatBrief(makeFormat({ height: 1080 }))).toBe("1080p mp4");
+    });
+
+    test("falls back to format_note when no height", () => {
+        expect(formatBrief(makeFormat({ format_note: "HQ", height: null }))).toBe("HQ mp4");
+    });
+
+    test("returns just ext when neither height nor note", () => {
+        expect(formatBrief(makeFormat({ height: null, format_note: null }))).toBe("mp4");
+    });
+
+    test("prefers height over format_note", () => {
+        expect(formatBrief(makeFormat({ height: 720, format_note: "HD" }))).toBe("720p mp4");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatSize
+// ---------------------------------------------------------------------------
+
+describe("formatSize", () => {
+    test("returns em-dash for null", () => {
+        expect(formatSize(null)).toBe("\u2014");
+    });
+
+    test("formats bytes below 1024 as B", () => {
+        expect(formatSize(512)).toBe("512 B");
+    });
+
+    test("formats kilobytes", () => {
+        expect(formatSize(2048)).toBe("2 KB");
+    });
+
+    test("formats megabytes", () => {
+        expect(formatSize(1_048_576)).toBe("1.0 MB");
+    });
+
+    test("formats gigabytes", () => {
+        expect(formatSize(1_073_741_824)).toBe("1.0 GB");
+    });
+
+    test("formats 0 bytes", () => {
+        expect(formatSize(0)).toBe("0 B");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatBitrate
+// ---------------------------------------------------------------------------
+
+describe("formatBitrate", () => {
+    test("returns em-dash for null", () => {
+        expect(formatBitrate(null)).toBe("\u2014");
+    });
+
+    test("formats sub-1000 kbps as kbps", () => {
+        expect(formatBitrate(500)).toBe("500 kbps");
+    });
+
+    test("formats >= 1000 kbps as Mbps", () => {
+        expect(formatBitrate(2500)).toBe("2.5 Mbps");
+    });
+
+    test("formats exactly 1000 kbps as Mbps", () => {
+        expect(formatBitrate(1000)).toBe("1.0 Mbps");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatResolution
+// ---------------------------------------------------------------------------
+
+describe("formatResolution", () => {
+    test("returns WxH when both width and height present", () => {
+        expect(formatResolution(makeFormat({ width: 1920, height: 1080 }))).toBe("1920\u00d71080");
+    });
+
+    test("returns height-only when width missing", () => {
+        expect(formatResolution(makeFormat({ width: null, height: 720 }))).toBe("720p");
+    });
+
+    test("returns format_note when neither dimension is present", () => {
+        expect(formatResolution(makeFormat({ width: null, height: null, format_note: "audio only" }))).toBe("audio only");
+    });
+
+    test("returns em-dash when no dimension and no note", () => {
+        expect(formatResolution(makeFormat({ width: null, height: null, format_note: null }))).toBe("\u2014");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatType
+// ---------------------------------------------------------------------------
+
+describe("formatType", () => {
+    test("returns HLS label for m3u8 protocol", () => {
+        const result = formatType(makeFormat({ protocol: "m3u8" }));
+        expect(result.label).toBe("HLS");
+    });
+
+    test("returns V+A label for video+audio stream", () => {
+        const result = formatType(makeFormat({ protocol: "https", has_video: true, has_audio: true }));
+        expect(result.label).toBe("V+A");
+    });
+
+    test("returns Video label for video-only stream", () => {
+        const result = formatType(makeFormat({ protocol: "https", has_video: true, has_audio: false }));
+        expect(result.label).toBe("Video");
+    });
+
+    test("returns Audio label for audio-only stream", () => {
+        const result = formatType(makeFormat({ protocol: "https", has_video: false, has_audio: false }));
+        expect(result.label).toBe("Audio");
+    });
+
+    test("HLS check takes priority over stream flags", () => {
+        const result = formatType(makeFormat({ protocol: "m3u8_native", has_video: true, has_audio: true }));
+        expect(result.label).toBe("HLS");
+    });
+
+    test("returns className strings", () => {
+        const result = formatType(makeFormat({ protocol: "https", has_video: true, has_audio: true }));
+        expect(typeof result.className).toBe("string");
+        expect(result.className.length).toBeGreaterThan(0);
+    });
+});

--- a/crates/rdlp-desktop/src/components/utils/searchUtils.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/searchUtils.test.ts
@@ -1,0 +1,103 @@
+// Unit tests for searchUtils.ts — formatDuration, formatCompactDate, formatViews.
+
+import { describe, test, expect } from "vitest";
+import { formatDuration, formatViews, formatCompactDate } from "./searchUtils";
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+    test("returns em-dash for null", () => {
+        expect(formatDuration(null)).toBe("\u2014");
+    });
+
+    test("formats 0 seconds as 0:00", () => {
+        expect(formatDuration(0)).toBe("0:00");
+    });
+
+    test("pads seconds below 10", () => {
+        expect(formatDuration(65)).toBe("1:05");
+    });
+
+    test("formats exactly 1 minute", () => {
+        expect(formatDuration(60)).toBe("1:00");
+    });
+
+    test("formats multi-digit minutes correctly", () => {
+        expect(formatDuration(3661)).toBe("61:01");
+    });
+
+    test("truncates fractional seconds", () => {
+        expect(formatDuration(90.9)).toBe("1:30");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatViews
+// ---------------------------------------------------------------------------
+
+describe("formatViews", () => {
+    test("returns empty string for null", () => {
+        expect(formatViews(null)).toBe("");
+    });
+
+    test("formats sub-thousand count as plain number", () => {
+        expect(formatViews(999)).toBe("999 views");
+    });
+
+    test("formats thousands with K suffix", () => {
+        expect(formatViews(1500)).toBe("1.5K views");
+    });
+
+    test("formats millions with M suffix", () => {
+        expect(formatViews(2_500_000)).toBe("2.5M views");
+    });
+
+    test("formats exactly 1000 as K", () => {
+        expect(formatViews(1000)).toBe("1.0K views");
+    });
+
+    test("formats exactly 1 million as M", () => {
+        expect(formatViews(1_000_000)).toBe("1.0M views");
+    });
+
+    test("formats zero", () => {
+        expect(formatViews(0)).toBe("0 views");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatCompactDate
+// ---------------------------------------------------------------------------
+
+describe("formatCompactDate", () => {
+    test("returns empty string for null", () => {
+        expect(formatCompactDate(null)).toBe("");
+    });
+
+    test("returns empty string for unrecognised timestamp", () => {
+        expect(formatCompactDate("not-a-date")).toBe("");
+    });
+
+    test("returns a non-empty string for a valid recent Unix timestamp", () => {
+        // A timestamp roughly 1 year in the past
+        const oneYearAgo = Math.floor(Date.now() / 1000) - 365 * 24 * 60 * 60;
+        const result = formatCompactDate(String(oneYearAgo));
+        expect(result).not.toBe("");
+        // Should contain digits
+        expect(result).toMatch(/\d/);
+    });
+
+    test("returns a compact suffix (no full words like 'days' or 'hours')", () => {
+        const threeDaysAgo = Math.floor(Date.now() / 1000) - 3 * 24 * 60 * 60;
+        const result = formatCompactDate(String(threeDaysAgo));
+        // Should not include the word 'days'
+        expect(result).not.toContain("days");
+        expect(result).not.toContain("day");
+    });
+
+    test("returns empty string for empty string input", () => {
+        expect(formatCompactDate("")).toBe("");
+    });
+});

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -1,0 +1,142 @@
+// Unit tests for tableHelpers.ts — groupRows and optionsSummary.
+
+import { describe, test, expect } from "vitest";
+import type { Row } from "@tanstack/react-table";
+import type { FormatInfo, DownloadOptions } from "../../types";
+import { groupRows, optionsSummary } from "./tableHelpers";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal Row<FormatInfo> stub — only `original` is needed by groupRows. */
+function makeRow(overrides: Partial<FormatInfo>): Row<FormatInfo> {
+    const format: FormatInfo = {
+        format_id: "id",
+        ext: "mp4",
+        format_note: null,
+        width: null,
+        height: null,
+        fps: null,
+        tbr: null,
+        vcodec: null,
+        acodec: null,
+        filesize: null,
+        vbr: null,
+        abr: null,
+        asr: null,
+        protocol: "https",
+        has_video: true,
+        has_audio: true,
+        ...overrides,
+    };
+    return { original: format, id: format.format_id } as unknown as Row<FormatInfo>;
+}
+
+function makeOptions(overrides: Partial<DownloadOptions> = {}): DownloadOptions {
+    return {
+        format: null,
+        outputDir: null,
+        subtitles: false,
+        subtitleLangs: [],
+        remux: null,
+        extractAudio: null,
+        embedThumbnail: false,
+        audioMultistreams: false,
+        recodeVideo: null,
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// groupRows
+// ---------------------------------------------------------------------------
+
+describe("groupRows", () => {
+    test("returns empty array for empty input", () => {
+        expect(groupRows([])).toEqual([]);
+    });
+
+    test("places video+audio rows in first group", () => {
+        const rows = [makeRow({ has_video: true, has_audio: true })];
+        const groups = groupRows(rows);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].label).toBe("Video + Audio");
+        expect(groups[0].rows).toHaveLength(1);
+    });
+
+    test("places video-only rows in second group", () => {
+        const rows = [makeRow({ has_video: true, has_audio: false })];
+        const groups = groupRows(rows);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].label).toBe("Video Only");
+    });
+
+    test("places audio-only rows in third group", () => {
+        const rows = [makeRow({ has_video: false, has_audio: false })];
+        const groups = groupRows(rows);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].label).toBe("Audio Only");
+    });
+
+    test("produces correct group ordering with all three types", () => {
+        const rows = [
+            makeRow({ has_video: false, has_audio: false }),
+            makeRow({ has_video: true, has_audio: false }),
+            makeRow({ has_video: true, has_audio: true }),
+        ];
+        const groups = groupRows(rows);
+        expect(groups).toHaveLength(3);
+        expect(groups[0].label).toBe("Video + Audio");
+        expect(groups[1].label).toBe("Video Only");
+        expect(groups[2].label).toBe("Audio Only");
+    });
+
+    test("omits empty groups", () => {
+        const rows = [makeRow({ has_video: true, has_audio: true })];
+        const groups = groupRows(rows);
+        // Only V+A group should exist — no Video Only or Audio Only
+        expect(groups.every((g) => g.label !== "Video Only")).toBe(true);
+        expect(groups.every((g) => g.label !== "Audio Only")).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// optionsSummary
+// ---------------------------------------------------------------------------
+
+describe("optionsSummary", () => {
+    test("returns 'Default settings' when no options are set", () => {
+        expect(optionsSummary(makeOptions())).toBe("Default settings");
+    });
+
+    test("includes remux format in uppercase", () => {
+        const result = optionsSummary(makeOptions({ remux: "mp4" }));
+        expect(result).toContain("MP4 remux");
+    });
+
+    test("includes audio format in uppercase", () => {
+        const result = optionsSummary(makeOptions({ extractAudio: "mp3" }));
+        expect(result).toContain("MP3 audio");
+    });
+
+    test("includes subtitle languages when subtitles enabled", () => {
+        const result = optionsSummary(makeOptions({ subtitles: true, subtitleLangs: ["en", "fr"] }));
+        expect(result).toContain("Subs: en, fr");
+    });
+
+    test("does not include subtitle entry when langs array is empty", () => {
+        const result = optionsSummary(makeOptions({ subtitles: true, subtitleLangs: [] }));
+        expect(result).not.toContain("Subs");
+    });
+
+    test("includes 'Thumbnail' when embedThumbnail is true", () => {
+        const result = optionsSummary(makeOptions({ embedThumbnail: true }));
+        expect(result).toContain("Thumbnail");
+    });
+
+    test("joins multiple options with middle-dot separator", () => {
+        const result = optionsSummary(makeOptions({ remux: "mkv", embedThumbnail: true }));
+        expect(result).toContain("\u00b7");
+    });
+});

--- a/crates/rdlp-desktop/src/lib/utils.test.ts
+++ b/crates/rdlp-desktop/src/lib/utils.test.ts
@@ -1,0 +1,94 @@
+// Unit tests for lib/utils.ts — cn() and parseUploadTimestamp().
+
+import { describe, test, expect } from "vitest";
+import { cn, parseUploadTimestamp } from "./utils";
+
+// ---------------------------------------------------------------------------
+// cn()
+// ---------------------------------------------------------------------------
+
+describe("cn", () => {
+    test("joins class strings", () => {
+        expect(cn("foo", "bar")).toBe("foo bar");
+    });
+
+    test("handles conditional falsy values", () => {
+        expect(cn("foo", false && "bar", undefined, null, "baz")).toBe("foo baz");
+    });
+
+    test("merges conflicting tailwind classes (last wins)", () => {
+        // twMerge behaviour: later class overrides earlier same-utility class
+        expect(cn("p-2", "p-4")).toBe("p-4");
+    });
+
+    test("handles an empty call", () => {
+        expect(cn()).toBe("");
+    });
+
+    test("handles object syntax", () => {
+        expect(cn({ "text-red-500": true, "text-blue-500": false })).toBe("text-red-500");
+    });
+
+    test("handles array syntax", () => {
+        expect(cn(["foo", "bar"])).toBe("foo bar");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseUploadTimestamp()
+// ---------------------------------------------------------------------------
+
+describe("parseUploadTimestamp", () => {
+    test("returns null for empty string", () => {
+        expect(parseUploadTimestamp("")).toBeNull();
+    });
+
+    test("returns null for whitespace-only string", () => {
+        expect(parseUploadTimestamp("   ")).toBeNull();
+    });
+
+    test("parses Unix timestamp (10 digits)", () => {
+        const d = parseUploadTimestamp("1700000000");
+        expect(d).not.toBeNull();
+        expect(d!.getTime()).toBe(1700000000 * 1000);
+    });
+
+    test("parses Unix timestamp (9 digits)", () => {
+        const d = parseUploadTimestamp("946684800");
+        expect(d).not.toBeNull();
+        expect(d!.getTime()).toBe(946684800 * 1000);
+    });
+
+    test("parses YYYYMMDD compact date", () => {
+        const d = parseUploadTimestamp("20230101");
+        expect(d).not.toBeNull();
+        expect(d!.getFullYear()).toBe(2023);
+        expect(d!.getMonth()).toBe(0); // January
+        expect(d!.getDate()).toBe(1);
+    });
+
+    test("parses YYYY-MM-DD ISO date", () => {
+        const d = parseUploadTimestamp("2024-06-15");
+        expect(d).not.toBeNull();
+        expect(d!.getFullYear()).toBe(2024);
+        expect(d!.getMonth()).toBe(5); // June
+        expect(d!.getDate()).toBe(15);
+    });
+
+    test("parses YYYY-MM-DD HH:MM:SS datetime", () => {
+        const d = parseUploadTimestamp("2024-06-15 10:30:00");
+        expect(d).not.toBeNull();
+        expect(d!.getFullYear()).toBe(2024);
+    });
+
+    test("returns null for unrecognized formats", () => {
+        expect(parseUploadTimestamp("June 15, 2024")).toBeNull();
+        expect(parseUploadTimestamp("not-a-date")).toBeNull();
+    });
+
+    test("trims surrounding whitespace before parsing", () => {
+        const d = parseUploadTimestamp("  20230101  ");
+        expect(d).not.toBeNull();
+        expect(d!.getFullYear()).toBe(2023);
+    });
+});

--- a/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
+import { SettingsPage } from "./SettingsPage";
+import type { AppSettings } from "../types";
+
+const defaultSettings: AppSettings = {
+    output_dir: "/home/user/Videos",
+    default_remux: null,
+    default_extract_audio: null,
+    default_subtitle_format: null,
+    default_subtitle_langs: [],
+    embed_thumbnail: true,
+    embed_metadata: true,
+    verbose: false,
+    default_search_provider: null,
+};
+
+beforeEach(() => {
+    setInvokeHandler("get_settings", () => defaultSettings);
+    setInvokeHandler("get_search_providers", () => [
+        { name: "redtube", display_name: "RedTube" },
+    ]);
+    setInvokeHandler("update_settings", () => undefined);
+});
+
+afterEach(() => {
+    clearInvokeHandlers();
+});
+
+describe("SettingsPage", () => {
+    it("shows loading state initially", () => {
+        render(<SettingsPage />);
+        expect(screen.getByText(/loading settings/i)).toBeInTheDocument();
+    });
+
+    it("renders the settings form after loading", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => {
+            expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
+        });
+    });
+
+    it("displays the output directory value", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => {
+            expect(screen.getByDisplayValue("/home/user/Videos")).toBeInTheDocument();
+        });
+    });
+
+    it("renders the Save Settings button", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /save settings/i })).toBeInTheDocument();
+        });
+    });
+
+    it("calls update_settings invoke when Save is clicked", async () => {
+        const updateHandler = vi.fn(() => undefined);
+        setInvokeHandler("update_settings", updateHandler);
+
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+
+        expect(updateHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows error message when save fails", async () => {
+        // invokeTyped wraps errors into { code, message, details }.
+        // SettingsPage.handleSave calls String(err) on non-Error rejects,
+        // so throw an AppError-shaped object whose message invokeClient can extract.
+        setInvokeHandler("update_settings", () => {
+            throw { kind: "SaveFailed", data: { message: "Backend error" } };
+        });
+
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+
+        await waitFor(() => {
+            // invokeTyped extracts the message from the AppError data, but handleSave
+            // then calls String() on the InvokeError object → check the error is visible
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+        });
+    });
+
+    it("embed thumbnails checkbox reflects current setting", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("heading", { name: /settings/i }));
+
+        // embed_thumbnail is true in defaultSettings → checkbox should be checked
+        const checkboxes = screen.getAllByRole("checkbox");
+        const thumbnailCheckbox = checkboxes[0];
+        expect(thumbnailCheckbox).toBeChecked();
+    });
+
+    it("verbose logging checkbox unchecked by default", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("heading", { name: /settings/i }));
+
+        // verbose is false in defaultSettings
+        const verboseLabel = screen.getByText(/verbose logging/i);
+        const checkbox = verboseLabel.closest("div")?.querySelector('button[role="checkbox"]');
+        expect(checkbox).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("renders Browse button for output directory", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /browse/i })).toBeInTheDocument();
+        });
+    });
+});

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -45,7 +45,12 @@ export function SettingsPage() {
             setSaveError(null);
             await updateSettings(draft);
         } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err);
+            const msg =
+                err instanceof Error
+                    ? err.message
+                    : typeof err === "object" && err !== null && "message" in err && typeof (err as Record<string, unknown>).message === "string"
+                      ? (err as Record<string, string>).message
+                      : String(err);
             setSaveError(msg);
         }
     };

--- a/crates/rdlp-desktop/src/query/queryKeys.test.ts
+++ b/crates/rdlp-desktop/src/query/queryKeys.test.ts
@@ -1,0 +1,101 @@
+// Unit tests for queryKeys.ts — deterministic key generation.
+
+import { describe, test, expect } from "vitest";
+import { queryKeys } from "./queryKeys";
+import type { SearchFilter } from "../types";
+
+describe("queryKeys.providers", () => {
+    test("returns ['providers']", () => {
+        expect(queryKeys.providers()).toEqual(["providers"]);
+    });
+});
+
+describe("queryKeys.filters", () => {
+    test("includes the site name", () => {
+        expect(queryKeys.filters("xhamster")).toEqual(["filters", "xhamster"]);
+    });
+});
+
+describe("queryKeys.search.all", () => {
+    test("returns ['search']", () => {
+        expect(queryKeys.search.all()).toEqual(["search"]);
+    });
+});
+
+describe("queryKeys.search.site", () => {
+    test("returns ['search', site]", () => {
+        expect(queryKeys.search.site("redtube")).toEqual(["search", "redtube"]);
+    });
+});
+
+describe("queryKeys.search.params", () => {
+    test("returns a 4-element tuple", () => {
+        const key = queryKeys.search.params("cats", "tnaflix", []);
+        expect(key).toHaveLength(4);
+        expect(key[0]).toBe("search");
+        expect(key[1]).toBe("tnaflix");
+        expect(key[2]).toBe("cats");
+    });
+
+    test("serializes empty filters as empty string", () => {
+        const key = queryKeys.search.params("dogs", "redtube", []);
+        expect(key[3]).toBe("");
+    });
+
+    test("serializes single filter as key=value", () => {
+        const filters: SearchFilter[] = [{ key: "ordering", value: "newest" }];
+        const key = queryKeys.search.params("cats", "redtube", filters);
+        expect(key[3]).toBe("ordering=newest");
+    });
+
+    test("serializes multiple filters sorted alphabetically", () => {
+        const filters: SearchFilter[] = [
+            { key: "period", value: "weekly" },
+            { key: "ordering", value: "newest" },
+        ];
+        const key = queryKeys.search.params("cats", "redtube", filters);
+        // sorted: ordering before period
+        expect(key[3]).toBe("ordering=newest&period=weekly");
+    });
+
+    test("is deterministic regardless of filter insertion order", () => {
+        const filtersA: SearchFilter[] = [
+            { key: "ordering", value: "newest" },
+            { key: "period", value: "weekly" },
+        ];
+        const filtersB: SearchFilter[] = [
+            { key: "period", value: "weekly" },
+            { key: "ordering", value: "newest" },
+        ];
+        const keyA = queryKeys.search.params("q", "redtube", filtersA);
+        const keyB = queryKeys.search.params("q", "redtube", filtersB);
+        expect(keyA[3]).toBe(keyB[3]);
+    });
+
+    test("different filter values produce different keys", () => {
+        const a = queryKeys.search.params("q", "redtube", [{ key: "ordering", value: "newest" }]);
+        const b = queryKeys.search.params("q", "redtube", [{ key: "ordering", value: "rating" }]);
+        expect(a[3]).not.toBe(b[3]);
+    });
+});
+
+describe("queryKeys.downloads.list", () => {
+    test("returns ['downloads']", () => {
+        expect(queryKeys.downloads.list()).toEqual(["downloads"]);
+    });
+});
+
+describe("queryKeys.formats", () => {
+    test("includes the url", () => {
+        expect(queryKeys.formats("https://example.com/video")).toEqual([
+            "formats",
+            "https://example.com/video",
+        ]);
+    });
+});
+
+describe("queryKeys.settings", () => {
+    test("returns ['settings']", () => {
+        expect(queryKeys.settings()).toEqual(["settings"]);
+    });
+});

--- a/crates/rdlp-desktop/src/stores/searchParamsStore.test.ts
+++ b/crates/rdlp-desktop/src/stores/searchParamsStore.test.ts
@@ -1,0 +1,93 @@
+// Unit tests for searchParamsStore.ts — state transitions via setSearchParam
+// and resetSearchParams.
+
+import { describe, test, expect, beforeEach } from "vitest";
+import { searchParamsAtom, setSearchParam, resetSearchParams } from "./searchParamsStore";
+
+// Reset to initial state before each test to prevent cross-test pollution.
+beforeEach(() => {
+    resetSearchParams();
+});
+
+describe("searchParamsAtom — initial state", () => {
+    test("starts with empty query", () => {
+        expect(searchParamsAtom.state.query).toBe("");
+    });
+
+    test("starts with empty site", () => {
+        expect(searchParamsAtom.state.site).toBe("");
+    });
+
+    test("starts with empty filters array", () => {
+        expect(searchParamsAtom.state.filters).toEqual([]);
+    });
+
+    test("starts with hasUserFilters false", () => {
+        expect(searchParamsAtom.state.hasUserFilters).toBe(false);
+    });
+});
+
+describe("setSearchParam", () => {
+    test("sets query", () => {
+        setSearchParam("query", "cats");
+        expect(searchParamsAtom.state.query).toBe("cats");
+    });
+
+    test("sets site", () => {
+        setSearchParam("site", "xhamster");
+        expect(searchParamsAtom.state.site).toBe("xhamster");
+    });
+
+    test("sets filters array", () => {
+        const filters = [{ key: "ordering", value: "newest" }];
+        setSearchParam("filters", filters);
+        expect(searchParamsAtom.state.filters).toEqual(filters);
+    });
+
+    test("sets hasUserFilters", () => {
+        setSearchParam("hasUserFilters", true);
+        expect(searchParamsAtom.state.hasUserFilters).toBe(true);
+    });
+
+    test("preserves other fields when setting one field", () => {
+        setSearchParam("query", "dogs");
+        setSearchParam("site", "redtube");
+        // Both should be set; filters and hasUserFilters unchanged
+        expect(searchParamsAtom.state.query).toBe("dogs");
+        expect(searchParamsAtom.state.site).toBe("redtube");
+        expect(searchParamsAtom.state.filters).toEqual([]);
+        expect(searchParamsAtom.state.hasUserFilters).toBe(false);
+    });
+
+    test("overwrites previous value for the same key", () => {
+        setSearchParam("query", "first");
+        setSearchParam("query", "second");
+        expect(searchParamsAtom.state.query).toBe("second");
+    });
+});
+
+describe("resetSearchParams", () => {
+    test("resets query to empty string", () => {
+        setSearchParam("query", "something");
+        resetSearchParams();
+        expect(searchParamsAtom.state.query).toBe("");
+    });
+
+    test("resets site to empty string", () => {
+        setSearchParam("site", "tnaflix");
+        resetSearchParams();
+        expect(searchParamsAtom.state.site).toBe("");
+    });
+
+    test("resets filters to empty array", () => {
+        setSearchParam("filters", [{ key: "ordering", value: "newest" }]);
+        resetSearchParams();
+        expect(searchParamsAtom.state.filters).toEqual([]);
+    });
+
+    test("resets hasUserFilters to false", () => {
+        setSearchParam("hasUserFilters", true);
+        resetSearchParams();
+        expect(searchParamsAtom.state.hasUserFilters).toBe(false);
+    });
+});

--- a/crates/rdlp-desktop/src/test/setup.ts
+++ b/crates/rdlp-desktop/src/test/setup.ts
@@ -1,0 +1,15 @@
+// Global test setup: jest-dom matchers + Tauri IPC mocks.
+
+import "@testing-library/jest-dom";
+import { mockInvoke, mockListen, mockEmit } from "./tauri-mock";
+
+// Mock @tauri-apps/api/core so tests never hit the real Tauri IPC bridge.
+vi.mock("@tauri-apps/api/core", () => ({
+    invoke: mockInvoke,
+}));
+
+// Mock @tauri-apps/api/event so event listeners are captured in tests.
+vi.mock("@tauri-apps/api/event", () => ({
+    listen: mockListen,
+    emit: mockEmit,
+}));

--- a/crates/rdlp-desktop/src/test/smoke.test.ts
+++ b/crates/rdlp-desktop/src/test/smoke.test.ts
@@ -1,0 +1,45 @@
+// Smoke test — verifies Vitest + Testing Library infrastructure is wired up.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { clearInvokeHandlers, setInvokeHandler, mockInvoke } from "./tauri-mock";
+import { clearEventListeners, mockListen, mockEmit } from "./tauri-mock";
+
+describe("Vitest infrastructure", () => {
+    afterEach(() => {
+        clearInvokeHandlers();
+        clearEventListeners();
+    });
+
+    it("runs a basic assertion", () => {
+        expect(1 + 1).toBe(2);
+    });
+
+    it("jest-dom matchers are available", () => {
+        const el = document.createElement("div");
+        el.textContent = "hello";
+        document.body.appendChild(el);
+        expect(el).toBeInTheDocument();
+        document.body.removeChild(el);
+    });
+
+    it("mockInvoke returns undefined for unregistered commands", async () => {
+        const result = await mockInvoke("unknown_command");
+        expect(result).toBeUndefined();
+    });
+
+    it("mockInvoke routes to registered handler", async () => {
+        setInvokeHandler("get_queue", () => []);
+        const result = await mockInvoke<unknown[]>("get_queue");
+        expect(result).toEqual([]);
+    });
+
+    it("mockListen + mockEmit delivers payloads to listeners", async () => {
+        const received: unknown[] = [];
+        await mockListen("download-progress", (event) => {
+            received.push(event.payload);
+        });
+        await mockEmit("download-progress", { percent: 42 });
+        expect(received).toHaveLength(1);
+        expect(received[0]).toEqual({ percent: 42 });
+    });
+});

--- a/crates/rdlp-desktop/src/test/tauri-mock.ts
+++ b/crates/rdlp-desktop/src/test/tauri-mock.ts
@@ -1,0 +1,65 @@
+// Typed Tauri invoke mock with fixture routing.
+//
+// Use `setInvokeHandler` in tests to register command handlers that
+// return fixture data. Unregistered commands resolve to undefined by default.
+
+type InvokeHandler = (args?: Record<string, unknown>) => unknown;
+
+const handlers: Map<string, InvokeHandler> = new Map();
+
+/** Register a handler for a specific Tauri command name. */
+export function setInvokeHandler(command: string, handler: InvokeHandler): void {
+    handlers.set(command, handler);
+}
+
+/** Remove all registered handlers (call in afterEach). */
+export function clearInvokeHandlers(): void {
+    handlers.clear();
+}
+
+/** The mock invoke function installed as `@tauri-apps/api/core` invoke. */
+export async function mockInvoke<T = unknown>(
+    command: string,
+    args?: Record<string, unknown>,
+): Promise<T> {
+    const handler = handlers.get(command);
+    if (handler) {
+        return handler(args) as T;
+    }
+    return undefined as T;
+}
+
+type ListenHandler = (payload: unknown) => void;
+type UnlistenFn = () => void;
+
+const eventListeners: Map<string, ListenHandler[]> = new Map();
+
+/** The mock listen function installed as `@tauri-apps/api/event` listen. */
+export async function mockListen<T = unknown>(
+    event: string,
+    handler: (event: { payload: T }) => void,
+): Promise<UnlistenFn> {
+    const wrapped = (payload: unknown) => handler({ payload: payload as T });
+    const listeners = eventListeners.get(event) ?? [];
+    listeners.push(wrapped);
+    eventListeners.set(event, listeners);
+
+    return () => {
+        const current = eventListeners.get(event) ?? [];
+        const idx = current.indexOf(wrapped);
+        if (idx !== -1) current.splice(idx, 1);
+    };
+}
+
+/** The mock emit function installed as `@tauri-apps/api/event` emit. */
+export async function mockEmit(event: string, payload?: unknown): Promise<void> {
+    const listeners = eventListeners.get(event) ?? [];
+    for (const handler of listeners) {
+        handler(payload);
+    }
+}
+
+/** Remove all registered event listeners (call in afterEach). */
+export function clearEventListeners(): void {
+    eventListeners.clear();
+}

--- a/crates/rdlp-desktop/src/test/test-utils.tsx
+++ b/crates/rdlp-desktop/src/test/test-utils.tsx
@@ -1,0 +1,57 @@
+// Custom render wrapping QueryClientProvider with a fresh client per test.
+
+import React from "react";
+import { render, type RenderOptions } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+
+/** Create a test QueryClient with retries disabled and data treated as fresh
+ *  so pre-populated queries (via setQueryData) don't trigger background refetches. */
+export function createTestQueryClient(): QueryClient {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+                gcTime: 0,
+                staleTime: Infinity,
+            },
+            mutations: {
+                retry: false,
+            },
+        },
+    });
+}
+
+interface WrapperProps {
+    children: React.ReactNode;
+}
+
+interface RenderWithProvidersOptions extends Omit<RenderOptions, "wrapper"> {
+    /** Supply a pre-configured QueryClient (e.g. with setQueryData). */
+    queryClient?: QueryClient;
+}
+
+/** Render with a fresh QueryClientProvider per test. */
+export function renderWithProviders(
+    ui: ReactElement,
+    { queryClient: passedClient, ...renderOptions }: RenderWithProvidersOptions = {},
+) {
+    const queryClient = passedClient ?? createTestQueryClient();
+
+    function Wrapper({ children }: WrapperProps) {
+        return (
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        );
+    }
+
+    return {
+        queryClient,
+        ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    };
+}
+
+// Re-export everything from Testing Library for convenience.
+export * from "@testing-library/react";
+export { renderWithProviders as render };

--- a/crates/rdlp-desktop/tsconfig.json
+++ b/crates/rdlp-desktop/tsconfig.json
@@ -22,7 +22,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["vitest/globals", "vitest/jsdom"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/crates/rdlp-desktop/vitest.config.ts
+++ b/crates/rdlp-desktop/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+    plugins: [react()],
+    resolve: {
+        alias: {
+            "@": path.resolve(__dirname, "./src"),
+        },
+    },
+    test: {
+        globals: true,
+        environment: "jsdom",
+        setupFiles: ["./src/test/setup.ts"],
+        include: ["src/**/*.{test,spec}.{ts,tsx}"],
+        coverage: {
+            provider: "v8",
+            reporter: ["text", "json", "html"],
+        },
+    },
+});


### PR DESCRIPTION
## Summary

- Add **151 Vitest unit/component tests** covering stores, query keys, utilities, and all major components (CommandBar, FilterBar, StatusBar, JobCard, ResultCard, SettingsPage)
- Add **23 Cypress e2e tests** covering search flow (query, pagination, clear, empty results) and settings page (load, toggle, save, browse, error handling)
- Tauri IPC mocked in both test environments: Vitest uses `vi.mock` in `setup.ts`; Cypress injects `__TAURI_INTERNALS__` + `__TAURI_EVENT_PLUGIN_INTERNALS__` via `onBeforeLoad`, matching the official `@tauri-apps/api/mocks` surface
- TanStack Store atom mutations wrapped in `act()` during test cleanup to prevent React warnings (root cause: `useStore` subscriptions trigger re-renders when atoms are mutated while components are still mounted)
- Pre-populated TanStack Query cache (`setQueryData` + `staleTime: Infinity`) eliminates async microtask chains during component render
- Fix `SettingsPage` error handler to extract `.message` from `InvokeError` objects thrown by `invokeTyped()`

## Test plan

- [x] `npm run test` — 151/151 Vitest tests pass, zero act() warnings
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [x] `npx cypress run` — 23/23 e2e tests pass (10 search + 13 settings)
- [x] `cargo check -p rdlp-desktop` — zero errors
- [x] `cargo clippy -p rdlp-desktop` — zero warnings
- [x] `cargo test -p rdlp-desktop` — 46/46 Rust tests pass