### PR TITLE
feat(desktop): add single URL download tab

### DIFF
--- a/crates/rdlp-desktop/src/App.tsx
+++ b/crates/rdlp-desktop/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
-import { Search, Download, Link, Settings } from "lucide-react";
+import { Search, Download, ArrowDownToLine, Settings } from "lucide-react";
 import { SearchPage } from "./pages/SearchPage";
 import { QueuePage } from "./pages/QueuePage";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -26,7 +26,7 @@ const SIDEBAR_KEY = "rdlp-sidebar-collapsed";
 const TAB_CONFIG = [
     { id: "search" as const, label: "Search", icon: Search },
     { id: "queue" as const, label: "Queue", icon: Download },
-    { id: "download" as const, label: "Download", icon: Link },
+    { id: "download" as const, label: "Download", icon: ArrowDownToLine },
     { id: "settings" as const, label: "Settings", icon: Settings },
 ] as const;
 

--- a/crates/rdlp-desktop/src/App.tsx
+++ b/crates/rdlp-desktop/src/App.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
-import { Search, Download, Settings } from "lucide-react";
+import { Search, Download, Link, Settings } from "lucide-react";
 import { SearchPage } from "./pages/SearchPage";
 import { QueuePage } from "./pages/QueuePage";
 import { SettingsPage } from "./pages/SettingsPage";
+import { DownloadPage } from "./pages/DownloadPage";
 import { Sidebar } from "./components/Sidebar";
 import { StatusBar } from "./components/StatusBar";
 import { queryClient } from "./query/queryClient";
@@ -17,7 +18,7 @@ import { downloadsQueryOptions } from "./api/downloads";
 import { cn } from "@/lib/utils";
 import type { SearchFilter, ViewMode } from "./types";
 
-type Tab = "search" | "queue" | "settings";
+type Tab = "search" | "queue" | "download" | "settings";
 
 const VIEW_MODE_KEY = "rdlp-view-mode";
 const SIDEBAR_KEY = "rdlp-sidebar-collapsed";
@@ -25,6 +26,7 @@ const SIDEBAR_KEY = "rdlp-sidebar-collapsed";
 const TAB_CONFIG = [
     { id: "search" as const, label: "Search", icon: Search },
     { id: "queue" as const, label: "Queue", icon: Download },
+    { id: "download" as const, label: "Download", icon: Link },
     { id: "settings" as const, label: "Settings", icon: Settings },
 ] as const;
 
@@ -119,7 +121,16 @@ function AppContent() {
             }
             if ((e.ctrlKey || e.metaKey) && e.key === "3") {
                 e.preventDefault();
+                setActiveTab("download");
+            }
+            if ((e.ctrlKey || e.metaKey) && e.key === "4") {
+                e.preventDefault();
                 setActiveTab("settings");
+            }
+            if ((e.ctrlKey || e.metaKey) && e.key === "d") {
+                e.preventDefault();
+                setActiveTab("download");
+                window.dispatchEvent(new CustomEvent("rdlp-focus-url"));
             }
         };
         document.addEventListener("keydown", handler);
@@ -169,6 +180,7 @@ function AppContent() {
                         <SearchPage activeTab={activeTab} viewMode={viewMode} />
                     )}
                     {activeTab === "queue" && <QueuePage />}
+                    {activeTab === "download" && <DownloadPage />}
                     {activeTab === "settings" && <SettingsPage />}
                 </main>
             </div>

--- a/crates/rdlp-desktop/src/components/ui/input.tsx
+++ b/crates/rdlp-desktop/src/components/ui/input.tsx
@@ -2,20 +2,24 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        data-slot="input"
+        ref={ref}
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
 
 export { Input }

--- a/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
+import { DownloadPage } from "./DownloadPage";
+import type { AppSettings } from "../types";
+
+const defaultSettings: AppSettings = {
+    output_dir: "/home/user/Videos",
+    default_remux: null,
+    default_extract_audio: null,
+    default_subtitle_format: null,
+    default_subtitle_langs: [],
+    embed_thumbnail: true,
+    embed_metadata: true,
+    verbose: false,
+    default_search_provider: null,
+};
+
+beforeEach(() => {
+    setInvokeHandler("get_settings", () => defaultSettings);
+    setInvokeHandler("get_queue", () => []);
+});
+
+afterEach(() => {
+    clearInvokeHandlers();
+});
+
+describe("DownloadPage", () => {
+    it("renders the URL input and Go button", async () => {
+        render(<DownloadPage />);
+        expect(screen.getByPlaceholderText(/paste a video url/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /go/i })).toBeInTheDocument();
+    });
+
+    it("renders the Choose Format button", () => {
+        render(<DownloadPage />);
+        expect(screen.getByRole("button", { name: /choose format/i })).toBeInTheDocument();
+    });
+
+    it("shows validation error for non-URL input", async () => {
+        const user = userEvent.setup();
+        render(<DownloadPage />);
+        const input = screen.getByPlaceholderText(/paste a video url/i);
+        await user.type(input, "not a url");
+        await user.click(screen.getByRole("button", { name: /go/i }));
+        await waitFor(() => {
+            expect(screen.getByText(/enter a valid url/i)).toBeInTheDocument();
+        });
+    });
+
+    it("calls start_download with a valid URL", async () => {
+        const startHandler = vi.fn(() => "job-123");
+        setInvokeHandler("start_download", startHandler);
+        const user = userEvent.setup();
+        render(<DownloadPage />);
+        const input = screen.getByPlaceholderText(/paste a video url/i);
+        await user.type(input, "https://example.com/video");
+        await user.click(screen.getByRole("button", { name: /go/i }));
+        await waitFor(() => {
+            expect(startHandler).toHaveBeenCalled();
+        });
+    });
+
+    it("clears the input after successful download start", async () => {
+        setInvokeHandler("start_download", () => "job-123");
+        const user = userEvent.setup();
+        render(<DownloadPage />);
+        const input = screen.getByPlaceholderText(/paste a video url/i);
+        await user.type(input, "https://example.com/video");
+        await user.click(screen.getByRole("button", { name: /go/i }));
+        await waitFor(() => {
+            expect(input).toHaveValue("");
+        });
+    });
+
+    it("shows error message when start_download fails", async () => {
+        setInvokeHandler("start_download", () => {
+            throw { kind: "InvalidInput", data: { message: "URL blocked by security policy" } };
+        });
+        const user = userEvent.setup();
+        render(<DownloadPage />);
+        const input = screen.getByPlaceholderText(/paste a video url/i);
+        await user.type(input, "https://evil.local/video");
+        await user.click(screen.getByRole("button", { name: /go/i }));
+        await waitFor(() => {
+            expect(screen.getByText(/failed to start download/i)).toBeInTheDocument();
+        });
+    });
+
+    it("disables Go button when input is empty", () => {
+        render(<DownloadPage />);
+        expect(screen.getByRole("button", { name: /go/i })).toBeDisabled();
+    });
+});

--- a/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
@@ -26,10 +26,10 @@ afterEach(() => {
 });
 
 describe("DownloadPage", () => {
-    it("renders the URL input and Go button", async () => {
+    it("renders the URL input and Download button", async () => {
         render(<DownloadPage />);
         expect(screen.getByPlaceholderText(/paste a video url/i)).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: /go/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
     });
 
     it("renders the Choose Format button", () => {
@@ -42,7 +42,7 @@ describe("DownloadPage", () => {
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.type(input, "not a url");
-        await user.click(screen.getByRole("button", { name: /go/i }));
+        await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(screen.getByText(/enter a valid url/i)).toBeInTheDocument();
         });
@@ -55,7 +55,7 @@ describe("DownloadPage", () => {
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.type(input, "https://example.com/video");
-        await user.click(screen.getByRole("button", { name: /go/i }));
+        await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(startHandler).toHaveBeenCalled();
         });
@@ -67,7 +67,7 @@ describe("DownloadPage", () => {
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.type(input, "https://example.com/video");
-        await user.click(screen.getByRole("button", { name: /go/i }));
+        await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(input).toHaveValue("");
         });
@@ -81,14 +81,14 @@ describe("DownloadPage", () => {
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.type(input, "https://evil.local/video");
-        await user.click(screen.getByRole("button", { name: /go/i }));
+        await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(screen.getByText(/failed to start download/i)).toBeInTheDocument();
         });
     });
 
-    it("disables Go button when input is empty", () => {
+    it("disables Download button when input is empty", () => {
         render(<DownloadPage />);
-        expect(screen.getByRole("button", { name: /go/i })).toBeDisabled();
+        expect(screen.getByRole("button", { name: /download/i })).toBeDisabled();
     });
 });

--- a/crates/rdlp-desktop/src/pages/DownloadPage.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, ArrowDown, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { JobCard } from "../components/JobCard";
+import {
+    downloadsQueryOptions,
+    startDownload,
+    cancelDownload,
+    removeJob,
+    buildDefaultOptions,
+} from "../api/downloads";
+import { settingsQueryOptions } from "../api/settings";
+import { FormatDialog } from "../components/FormatDialog";
+import type { DownloadOptions } from "../types";
+
+const URL_PATTERN = /^https?:\/\/.+/i;
+
+/** Download tab: paste a URL to quick-download or choose format. */
+export function DownloadPage() {
+    const [url, setUrl] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [isStarting, setIsStarting] = useState(false);
+    const [formatDialogUrl, setFormatDialogUrl] = useState<string | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const { data: settings = null } = useQuery(settingsQueryOptions());
+    const { data: jobs = [] } = useQuery(downloadsQueryOptions());
+
+    // Listen for Ctrl+D focus event from App.tsx
+    useEffect(() => {
+        const handler = () => inputRef.current?.focus();
+        window.addEventListener("rdlp-focus-url", handler);
+        return () => window.removeEventListener("rdlp-focus-url", handler);
+    }, []);
+
+    const trimmedUrl = url.trim();
+    const isValidUrl = URL_PATTERN.test(trimmedUrl);
+
+    const handleQuickDownload = useCallback(async () => {
+        if (!trimmedUrl) return;
+        if (!isValidUrl) {
+            setError("Please enter a valid URL starting with http:// or https://");
+            return;
+        }
+        setError(null);
+        setIsStarting(true);
+        try {
+            const options = buildDefaultOptions(settings);
+            await startDownload(trimmedUrl, options);
+            setUrl("");
+        } catch (e) {
+            setError("Failed to start download. The URL may be invalid or unsupported.");
+        } finally {
+            setIsStarting(false);
+        }
+    }, [trimmedUrl, isValidUrl, settings]);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" && trimmedUrl && !isStarting) {
+                e.preventDefault();
+                void handleQuickDownload();
+            }
+        },
+        [handleQuickDownload, trimmedUrl, isStarting],
+    );
+
+    const handleChooseFormat = useCallback(() => {
+        if (!trimmedUrl) return;
+        if (!isValidUrl) {
+            setError("Please enter a valid URL starting with http:// or https://");
+            return;
+        }
+        setError(null);
+        setFormatDialogUrl(trimmedUrl);
+    }, [trimmedUrl, isValidUrl]);
+
+    const handleFormatConfirm = useCallback(
+        (options: DownloadOptions, title?: string) => {
+            if (!formatDialogUrl) return;
+            void startDownload(formatDialogUrl, options, title)
+                .then(() => {
+                    setUrl("");
+                    setFormatDialogUrl(null);
+                })
+                .catch(() => {
+                    setError("Failed to start download.");
+                });
+        },
+        [formatDialogUrl],
+    );
+
+    const handleCancel = (id: string) => {
+        cancelDownload(id).catch((e) => console.error("Failed to cancel", e));
+    };
+    const handleRemove = (id: string) => {
+        removeJob(id).catch((e) => console.error("Failed to remove", e));
+    };
+    const handleRetry = (retryUrl: string) => {
+        const options = buildDefaultOptions(settings);
+        startDownload(retryUrl, options).catch((e) =>
+            console.error("Failed to retry", e),
+        );
+    };
+
+    // Show last 5 jobs (most recent first)
+    const recentJobs = [...jobs]
+        .sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
+        .slice(0, 5);
+
+    return (
+        <div className="max-w-2xl mx-auto">
+            {/* Hero section */}
+            <div className="flex flex-col items-center gap-4 pt-8 pb-6">
+                <Link className="h-10 w-10 text-muted-foreground opacity-50" />
+                <h2 className="text-lg font-semibold text-foreground">
+                    Download a Video
+                </h2>
+            </div>
+
+            {/* URL input row */}
+            <div className="flex gap-2 mb-2">
+                <Input
+                    ref={inputRef}
+                    type="url"
+                    placeholder="Paste a video URL..."
+                    value={url}
+                    onChange={(e) => {
+                        setUrl(e.target.value);
+                        if (error) setError(null);
+                    }}
+                    onKeyDown={handleKeyDown}
+                    className="flex-1 font-mono text-sm"
+                    autoFocus
+                />
+                <Button
+                    onClick={() => void handleQuickDownload()}
+                    disabled={!trimmedUrl || isStarting}
+                    className="shrink-0"
+                    aria-label="Go"
+                >
+                    {isStarting ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                        <ArrowDown className="h-4 w-4" />
+                    )}
+                    <span className="ml-1.5">Go</span>
+                </Button>
+            </div>
+
+            {/* Choose Format button */}
+            <div className="flex justify-center mb-4">
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleChooseFormat}
+                    disabled={!trimmedUrl || isStarting}
+                    className="text-muted-foreground text-xs"
+                >
+                    Choose Format...
+                </Button>
+            </div>
+
+            {/* Error message */}
+            {error && (
+                <Alert variant="destructive" className="mb-4">
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+
+            {/* Recent downloads */}
+            {recentJobs.length > 0 && (
+                <section className="mt-6">
+                    <h3
+                        className="mb-2.5 border-b border-border pb-1.5
+                            text-[11px] font-bold uppercase tracking-widest
+                            text-muted-foreground"
+                    >
+                        Recent Downloads
+                    </h3>
+                    <div className="space-y-2">
+                        {recentJobs.map((job) => (
+                            <JobCard
+                                key={job.id}
+                                job={job}
+                                onCancel={handleCancel}
+                                onRemove={handleRemove}
+                                onRetry={handleRetry}
+                            />
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {/* Format dialog (reused from search flow) */}
+            {formatDialogUrl && (
+                <FormatDialog
+                    url={formatDialogUrl}
+                    onConfirm={handleFormatConfirm}
+                    onClose={() => setFormatDialogUrl(null)}
+                />
+            )}
+        </div>
+    );
+}

--- a/crates/rdlp-desktop/src/pages/DownloadPage.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link, ArrowDown, Loader2 } from "lucide-react";
+import { ArrowDownToLine, ArrowDown, Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -115,7 +115,7 @@ export function DownloadPage() {
         <div className="max-w-2xl mx-auto">
             {/* Hero section */}
             <div className="flex flex-col items-center gap-4 pt-8 pb-6">
-                <Link className="h-10 w-10 text-muted-foreground opacity-50" />
+                <ArrowDownToLine className="h-10 w-10 text-muted-foreground opacity-50" aria-hidden="true" />
                 <h2 className="text-lg font-semibold text-foreground">
                     Download a Video
                 </h2>
@@ -140,16 +140,23 @@ export function DownloadPage() {
                     onClick={() => void handleQuickDownload()}
                     disabled={!trimmedUrl || isStarting}
                     className="shrink-0"
-                    aria-label="Go"
+                    title={!trimmedUrl ? "Enter a URL first" : undefined}
                 >
                     {isStarting ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
                         <ArrowDown className="h-4 w-4" />
                     )}
-                    <span className="ml-1.5">Go</span>
+                    <span className="ml-1.5">Download</span>
                 </Button>
             </div>
+
+            {/* Error message */}
+            {error && (
+                <Alert variant="destructive" className="mb-2">
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
 
             {/* Choose Format button */}
             <div className="flex justify-center mb-4">
@@ -159,17 +166,11 @@ export function DownloadPage() {
                     onClick={handleChooseFormat}
                     disabled={!trimmedUrl || isStarting}
                     className="text-muted-foreground text-xs"
+                    title={!trimmedUrl ? "Enter a URL first" : undefined}
                 >
                     Choose Format...
                 </Button>
             </div>
-
-            {/* Error message */}
-            {error && (
-                <Alert variant="destructive" className="mb-4">
-                    <AlertDescription>{error}</AlertDescription>
-                </Alert>
-            )}
 
             {/* Recent downloads */}
             {recentJobs.length > 0 && (


### PR DESCRIPTION
## Summary

- Adds a 4th "Download" tab to the desktop app for pasting a video URL and downloading directly
- Quick download with Settings defaults via the Download button, or fine-grained format selection via "Choose Format" (reuses existing FormatDialog)
- Shows last 5 recent downloads on the page via existing JobCard component
- Keyboard shortcuts: Ctrl+3 (Download tab), Ctrl+4 (Settings tab, renumbered), Ctrl+D (focus URL input)
- Converts shadcn Input component to forwardRef for ref support
- 7 new Vitest tests for DownloadPage (158 total, all passing)

## Changes

| File | Change |
|------|--------|
| `App.tsx` | Add "download" tab type, config entry (ArrowDownToLine icon), keyboard shortcuts |
| `DownloadPage.tsx` | New page: URL input, quick download, format picker, recent jobs, error handling |
| `DownloadPage.test.tsx` | 7 Vitest tests covering render, validation, download, error, disabled states |
| `input.tsx` | Convert to forwardRef for ref forwarding |

## Backend changes

None — reuses existing `start_download` and `get_formats` Tauri commands.

## Test plan

- [x] 158 Vitest tests passing (14 test files)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] Rust check clean (`cargo check -p rdlp-desktop`)
- [x] Rust tests passing (`cargo test -p rdlp-desktop`)
- [x] Manual verification: Download tab renders, FormatDialog opens from "Choose Format"