### PR TITLE
feat(desktop): add full audio normalization GUI controls

### DIFF
--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -109,6 +109,27 @@ impl MergeOverrides for PostProcessOptions {
         if let Some(ref v) = self.loudnorm_preset {
             config.loudnorm_preset = Some(v.clone());
         }
+        if let Some(v) = self.loudnorm_target_i {
+            config.loudnorm_target_i = Some(v);
+        }
+        if let Some(v) = self.loudnorm_target_tp {
+            config.loudnorm_target_tp = Some(v);
+        }
+        if let Some(v) = self.loudnorm_target_lra {
+            config.loudnorm_target_lra = Some(v);
+        }
+        if let Some(v) = self.loudnorm_dynamic {
+            config.loudnorm_dynamic = v;
+        }
+        if let Some(v) = self.loudnorm_precompress {
+            config.loudnorm_precompress = v;
+        }
+        if let Some(v) = self.normalize_boost {
+            config.normalize_boost = v;
+        }
+        if let Some(v) = self.normalize_boost_db {
+            config.normalize_boost_db = Some(v);
+        }
         if let Some(v) = self.recode_video {
             config.recode_video = Some(v);
         }

--- a/crates/rdlp-api/src/merge/tests_postprocess_network.rs
+++ b/crates/rdlp-api/src/merge/tests_postprocess_network.rs
@@ -245,6 +245,181 @@ fn test_postprocess_some_overrides_loudnorm_preset() {
 }
 
 #[test]
+fn test_postprocess_none_preserves_loudnorm_target_i() {
+    let mut config = Config {
+        loudnorm_target_i: Some(-16.0),
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert_eq!(config.loudnorm_target_i, Some(-16.0));
+}
+
+#[test]
+fn test_postprocess_some_overrides_loudnorm_target_i() {
+    let mut config = Config {
+        loudnorm_target_i: None,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        loudnorm_target_i: Some(-23.0),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert_eq!(config.loudnorm_target_i, Some(-23.0));
+}
+
+#[test]
+fn test_postprocess_none_preserves_loudnorm_target_tp() {
+    let mut config = Config {
+        loudnorm_target_tp: Some(-1.0),
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert_eq!(config.loudnorm_target_tp, Some(-1.0));
+}
+
+#[test]
+fn test_postprocess_some_overrides_loudnorm_target_tp() {
+    let mut config = Config {
+        loudnorm_target_tp: None,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        loudnorm_target_tp: Some(-2.0),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert_eq!(config.loudnorm_target_tp, Some(-2.0));
+}
+
+#[test]
+fn test_postprocess_none_preserves_loudnorm_target_lra() {
+    let mut config = Config {
+        loudnorm_target_lra: Some(7.0),
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert_eq!(config.loudnorm_target_lra, Some(7.0));
+}
+
+#[test]
+fn test_postprocess_some_overrides_loudnorm_target_lra() {
+    let mut config = Config {
+        loudnorm_target_lra: None,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        loudnorm_target_lra: Some(11.0),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert_eq!(config.loudnorm_target_lra, Some(11.0));
+}
+
+#[test]
+fn test_postprocess_none_preserves_loudnorm_dynamic() {
+    let mut config = Config {
+        loudnorm_dynamic: true,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert!(config.loudnorm_dynamic);
+}
+
+#[test]
+fn test_postprocess_some_overrides_loudnorm_dynamic() {
+    let mut config = Config {
+        loudnorm_dynamic: false,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        loudnorm_dynamic: Some(true),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert!(config.loudnorm_dynamic);
+}
+
+#[test]
+fn test_postprocess_none_preserves_loudnorm_precompress() {
+    let mut config = Config {
+        loudnorm_precompress: true,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert!(config.loudnorm_precompress);
+}
+
+#[test]
+fn test_postprocess_some_overrides_loudnorm_precompress() {
+    let mut config = Config {
+        loudnorm_precompress: false,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        loudnorm_precompress: Some(true),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert!(config.loudnorm_precompress);
+}
+
+#[test]
+fn test_postprocess_none_preserves_normalize_boost() {
+    let mut config = Config {
+        normalize_boost: true,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert!(config.normalize_boost);
+}
+
+#[test]
+fn test_postprocess_some_overrides_normalize_boost() {
+    let mut config = Config {
+        normalize_boost: false,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        normalize_boost: Some(true),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert!(config.normalize_boost);
+}
+
+#[test]
+fn test_postprocess_none_preserves_normalize_boost_db() {
+    let mut config = Config {
+        normalize_boost_db: Some(8.0),
+        ..Config::default()
+    };
+    let opts = PostProcessOptions::default();
+    opts.merge_into(&mut config);
+    assert_eq!(config.normalize_boost_db, Some(8.0));
+}
+
+#[test]
+fn test_postprocess_some_overrides_normalize_boost_db() {
+    let mut config = Config {
+        normalize_boost_db: None,
+        ..Config::default()
+    };
+    let opts = PostProcessOptions {
+        normalize_boost_db: Some(12.0),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert_eq!(config.normalize_boost_db, Some(12.0));
+}
+
+#[test]
 fn test_postprocess_none_preserves_recode_video() {
     let mut config = Config {
         recode_video: Some(rdlp_core::ContainerFormat::Mkv),

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -189,6 +189,20 @@ pub struct PostProcessOptions {
     pub loudnorm: Option<bool>,
     /// Loudness normalization preset name (e.g. `"streaming"`).
     pub loudnorm_preset: Option<String>,
+    /// Target integrated loudness in LUFS. `None` preserves base config.
+    pub loudnorm_target_i: Option<f64>,
+    /// Target true peak in dBTP. `None` preserves base config.
+    pub loudnorm_target_tp: Option<f64>,
+    /// Target loudness range in LU. `None` preserves base config.
+    pub loudnorm_target_lra: Option<f64>,
+    /// Force dynamic (per-frame compression) in loudnorm pass 2. `None` preserves base config.
+    pub loudnorm_dynamic: Option<bool>,
+    /// Prepend a mild acompressor before loudnorm. `None` preserves base config.
+    pub loudnorm_precompress: Option<bool>,
+    /// Enable limiter-boost fallback for over-compressed content. `None` preserves base config.
+    pub normalize_boost: Option<bool>,
+    /// Gain in dB for limiter-boost fallback. `None` preserves base config.
+    pub normalize_boost_db: Option<f64>,
     /// Recode (transcode) video into a different container format.
     pub recode_video: Option<ContainerFormat>,
 }
@@ -266,6 +280,13 @@ mod tests {
         assert!(req.postprocess.normalize_audio.is_none());
         assert!(req.postprocess.loudnorm.is_none());
         assert!(req.postprocess.loudnorm_preset.is_none());
+        assert!(req.postprocess.loudnorm_target_i.is_none());
+        assert!(req.postprocess.loudnorm_target_tp.is_none());
+        assert!(req.postprocess.loudnorm_target_lra.is_none());
+        assert!(req.postprocess.loudnorm_dynamic.is_none());
+        assert!(req.postprocess.loudnorm_precompress.is_none());
+        assert!(req.postprocess.normalize_boost.is_none());
+        assert!(req.postprocess.normalize_boost_db.is_none());
         assert!(req.postprocess.recode_video.is_none());
 
         // NetworkOptions defaults

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -155,34 +155,24 @@ pub async fn start_download(
             recode_video: options.recode_video,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
-            normalize_audio: Some(
-                options.normalize_audio.unwrap_or(settings.normalize_audio),
-            ),
+            normalize_audio: Some(options.normalize_audio.unwrap_or(settings.normalize_audio)),
             loudnorm: Some(options.loudnorm.unwrap_or(settings.loudnorm)),
-            loudnorm_preset: options
-                .loudnorm_preset
-                .or(settings.loudnorm_preset.clone()),
+            loudnorm_preset: options.loudnorm_preset.or(settings.loudnorm_preset.clone()),
             loudnorm_target_i: options.loudnorm_target_i.or(settings.loudnorm_target_i),
-            loudnorm_target_tp: options
-                .loudnorm_target_tp
-                .or(settings.loudnorm_target_tp),
-            loudnorm_target_lra: options
-                .loudnorm_target_lra
-                .or(settings.loudnorm_target_lra),
+            loudnorm_target_tp: options.loudnorm_target_tp.or(settings.loudnorm_target_tp),
+            loudnorm_target_lra: options.loudnorm_target_lra.or(settings.loudnorm_target_lra),
             loudnorm_dynamic: Some(
-                options.loudnorm_dynamic.unwrap_or(settings.loudnorm_dynamic),
+                options
+                    .loudnorm_dynamic
+                    .unwrap_or(settings.loudnorm_dynamic),
             ),
             loudnorm_precompress: Some(
                 options
                     .loudnorm_precompress
                     .unwrap_or(settings.loudnorm_precompress),
             ),
-            normalize_boost: Some(
-                options.normalize_boost.unwrap_or(settings.normalize_boost),
-            ),
-            normalize_boost_db: options
-                .normalize_boost_db
-                .or(settings.normalize_boost_db),
+            normalize_boost: Some(options.normalize_boost.unwrap_or(settings.normalize_boost)),
+            normalize_boost_db: options.normalize_boost_db.or(settings.normalize_boost_db),
             ..PostProcessOptions::default()
         },
         verbose: if settings.verbose { Some(true) } else { None },
@@ -255,6 +245,323 @@ pub async fn start_download(
     });
 
     Ok(job_id)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the normalization option merge logic in [`start_download`].
+    //!
+    //! Because `start_download` is an async Tauri command that requires
+    //! managed `State` and `AppHandle`, it cannot be called directly in
+    //! unit tests.  Instead, the merge pattern is replicated here in
+    //! [`merge_normalize_options`] so the semantics can be verified in
+    //! isolation.
+
+    use super::*;
+    use crate::state::AppSettings;
+
+    /// Replicates the normalization-field merge from `start_download`
+    /// (the `postprocess` block) for isolated testing.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Frontend-supplied download options.
+    /// * `settings` - Persisted application settings used as defaults.
+    ///
+    /// # Returns
+    ///
+    /// A [`PostProcessOptions`] with every normalization field resolved.
+    fn merge_normalize_options(
+        options: &DownloadOptions,
+        settings: &AppSettings,
+    ) -> PostProcessOptions {
+        PostProcessOptions {
+            normalize_audio: Some(options.normalize_audio.unwrap_or(settings.normalize_audio)),
+            loudnorm: Some(options.loudnorm.unwrap_or(settings.loudnorm)),
+            loudnorm_preset: options
+                .loudnorm_preset
+                .clone()
+                .or(settings.loudnorm_preset.clone()),
+            loudnorm_target_i: options.loudnorm_target_i.or(settings.loudnorm_target_i),
+            loudnorm_target_tp: options.loudnorm_target_tp.or(settings.loudnorm_target_tp),
+            loudnorm_target_lra: options.loudnorm_target_lra.or(settings.loudnorm_target_lra),
+            loudnorm_dynamic: Some(
+                options
+                    .loudnorm_dynamic
+                    .unwrap_or(settings.loudnorm_dynamic),
+            ),
+            loudnorm_precompress: Some(
+                options
+                    .loudnorm_precompress
+                    .unwrap_or(settings.loudnorm_precompress),
+            ),
+            normalize_boost: Some(options.normalize_boost.unwrap_or(settings.normalize_boost)),
+            normalize_boost_db: options.normalize_boost_db.or(settings.normalize_boost_db),
+            ..PostProcessOptions::default()
+        }
+    }
+
+    /// Build a [`DownloadOptions`] with all normalization fields set to `None`.
+    fn default_download_options() -> DownloadOptions {
+        DownloadOptions {
+            format: None,
+            output_dir: None,
+            subtitles: false,
+            subtitle_langs: Vec::new(),
+            remux: None,
+            extract_audio: None,
+            embed_thumbnail: true,
+            audio_multistreams: false,
+            recode_video: None,
+            normalize_audio: None,
+            loudnorm: None,
+            loudnorm_preset: None,
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
+            loudnorm_dynamic: None,
+            loudnorm_precompress: None,
+            normalize_boost: None,
+            normalize_boost_db: None,
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // A. All-None options fall back to settings defaults
+    // ------------------------------------------------------------------ //
+
+    /// When every normalization field in `DownloadOptions` is `None`, the
+    /// result MUST equal the corresponding settings value.
+    #[test]
+    fn test_merge_all_none_uses_settings_defaults() {
+        let settings = AppSettings {
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_preset: Some("broadcast".to_owned()),
+            loudnorm_target_i: Some(-23.0),
+            loudnorm_target_tp: Some(-2.0),
+            loudnorm_target_lra: Some(7.0),
+            loudnorm_dynamic: true,
+            loudnorm_precompress: true,
+            normalize_boost: true,
+            normalize_boost_db: Some(8.0),
+            ..AppSettings::default()
+        };
+        let options = default_download_options();
+        let result = merge_normalize_options(&options, &settings);
+
+        assert_eq!(result.normalize_audio, Some(true));
+        assert_eq!(result.loudnorm, Some(true));
+        assert_eq!(result.loudnorm_preset.as_deref(), Some("broadcast"));
+        assert_eq!(result.loudnorm_target_i, Some(-23.0));
+        assert_eq!(result.loudnorm_target_tp, Some(-2.0));
+        assert_eq!(result.loudnorm_target_lra, Some(7.0));
+        assert_eq!(result.loudnorm_dynamic, Some(true));
+        assert_eq!(result.loudnorm_precompress, Some(true));
+        assert_eq!(result.normalize_boost, Some(true));
+        assert_eq!(result.normalize_boost_db, Some(8.0));
+    }
+
+    // ------------------------------------------------------------------ //
+    // B. Per-download overrides take precedence over settings
+    // ------------------------------------------------------------------ //
+
+    /// Explicit values in `DownloadOptions` MUST shadow settings defaults.
+    #[test]
+    fn test_merge_overrides_take_precedence() {
+        let settings = AppSettings {
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_preset: Some("broadcast".to_owned()),
+            loudnorm_target_i: Some(-23.0),
+            loudnorm_target_tp: Some(-2.0),
+            loudnorm_target_lra: Some(7.0),
+            loudnorm_dynamic: true,
+            loudnorm_precompress: true,
+            normalize_boost: true,
+            normalize_boost_db: Some(12.0),
+            ..AppSettings::default()
+        };
+        let options = DownloadOptions {
+            normalize_audio: Some(false),
+            loudnorm: Some(false),
+            loudnorm_preset: Some("streaming".to_owned()),
+            loudnorm_target_i: Some(-14.0),
+            loudnorm_target_tp: Some(-1.0),
+            loudnorm_target_lra: Some(11.0),
+            loudnorm_dynamic: Some(false),
+            loudnorm_precompress: Some(false),
+            normalize_boost: Some(false),
+            normalize_boost_db: Some(6.0),
+            ..default_download_options()
+        };
+        let result = merge_normalize_options(&options, &settings);
+
+        assert_eq!(result.normalize_audio, Some(false));
+        assert_eq!(result.loudnorm, Some(false));
+        assert_eq!(result.loudnorm_preset.as_deref(), Some("streaming"));
+        assert_eq!(result.loudnorm_target_i, Some(-14.0));
+        assert_eq!(result.loudnorm_target_tp, Some(-1.0));
+        assert_eq!(result.loudnorm_target_lra, Some(11.0));
+        assert_eq!(result.loudnorm_dynamic, Some(false));
+        assert_eq!(result.loudnorm_precompress, Some(false));
+        assert_eq!(result.normalize_boost, Some(false));
+        assert_eq!(result.normalize_boost_db, Some(6.0));
+    }
+
+    // ------------------------------------------------------------------ //
+    // C. Mixed: some overridden, some defaulted
+    // ------------------------------------------------------------------ //
+
+    /// Overriding only a subset of fields MUST leave the rest falling
+    /// through to the settings defaults.
+    #[test]
+    fn test_merge_partial_overrides() {
+        let settings = AppSettings {
+            normalize_audio: false,
+            loudnorm: true,
+            loudnorm_preset: Some("broadcast".to_owned()),
+            loudnorm_target_i: Some(-23.0),
+            loudnorm_dynamic: false,
+            ..AppSettings::default()
+        };
+        // Override normalize_audio and loudnorm_target_i only; leave
+        // loudnorm_preset as None so it falls back to the settings value.
+        let options = DownloadOptions {
+            normalize_audio: Some(true),
+            loudnorm_target_i: Some(-16.0),
+            ..default_download_options()
+        };
+        let result = merge_normalize_options(&options, &settings);
+
+        // Overridden fields
+        assert_eq!(result.normalize_audio, Some(true));
+        assert_eq!(result.loudnorm_target_i, Some(-16.0));
+
+        // Fields that fall through to settings
+        assert_eq!(result.loudnorm, Some(true));
+        assert_eq!(result.loudnorm_preset.as_deref(), Some("broadcast"));
+        assert_eq!(result.loudnorm_dynamic, Some(false));
+    }
+
+    // ------------------------------------------------------------------ //
+    // D. Default settings + default options = all disabled
+    // ------------------------------------------------------------------ //
+
+    /// When both options and settings are at their default values every
+    /// normalization flag MUST be disabled and every target MUST be `None`.
+    #[test]
+    fn test_merge_all_defaults_all_disabled() {
+        let settings = AppSettings::default();
+        let options = default_download_options();
+        let result = merge_normalize_options(&options, &settings);
+
+        assert_eq!(result.normalize_audio, Some(false));
+        assert_eq!(result.loudnorm, Some(false));
+        assert!(result.loudnorm_preset.is_none());
+        assert!(result.loudnorm_target_i.is_none());
+        assert!(result.loudnorm_target_tp.is_none());
+        assert!(result.loudnorm_target_lra.is_none());
+        assert_eq!(result.loudnorm_dynamic, Some(false));
+        assert_eq!(result.loudnorm_precompress, Some(false));
+        assert_eq!(result.normalize_boost, Some(false));
+        assert!(result.normalize_boost_db.is_none());
+    }
+
+    // ------------------------------------------------------------------ //
+    // E. Option<f64> fields: None option + None settings → None result
+    // ------------------------------------------------------------------ //
+
+    /// When both the download option and the settings value for an
+    /// `Option<f64>` field are `None`, the result MUST also be `None`.
+    #[test]
+    fn test_merge_option_f64_both_none_stays_none() {
+        let settings = AppSettings {
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
+            normalize_boost_db: None,
+            ..AppSettings::default()
+        };
+        let options = DownloadOptions {
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
+            normalize_boost_db: None,
+            ..default_download_options()
+        };
+        let result = merge_normalize_options(&options, &settings);
+
+        assert!(result.loudnorm_target_i.is_none());
+        assert!(result.loudnorm_target_tp.is_none());
+        assert!(result.loudnorm_target_lra.is_none());
+        assert!(result.normalize_boost_db.is_none());
+    }
+
+    // ------------------------------------------------------------------ //
+    // F. unwrap_or vs or semantics
+    // ------------------------------------------------------------------ //
+
+    /// For `bool` fields (merged via `unwrap_or`): `Some(false)` in the
+    /// download options MUST override a `true` settings default.
+    #[test]
+    fn test_merge_bool_some_false_overrides_true_settings() {
+        let settings = AppSettings {
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_dynamic: true,
+            loudnorm_precompress: true,
+            normalize_boost: true,
+            ..AppSettings::default()
+        };
+        let options = DownloadOptions {
+            normalize_audio: Some(false),
+            loudnorm: Some(false),
+            loudnorm_dynamic: Some(false),
+            loudnorm_precompress: Some(false),
+            normalize_boost: Some(false),
+            ..default_download_options()
+        };
+        let result = merge_normalize_options(&options, &settings);
+
+        assert_eq!(result.normalize_audio, Some(false));
+        assert_eq!(result.loudnorm, Some(false));
+        assert_eq!(result.loudnorm_dynamic, Some(false));
+        assert_eq!(result.loudnorm_precompress, Some(false));
+        assert_eq!(result.normalize_boost, Some(false));
+    }
+
+    /// For `Option<f64>` fields (merged via `or`): `None` in the download
+    /// options MUST pass through to the settings value; `Some(x)` MUST
+    /// override the settings value.
+    #[test]
+    fn test_merge_option_f64_or_semantics() {
+        let settings = AppSettings {
+            loudnorm_target_i: Some(-23.0),
+            loudnorm_target_tp: Some(-2.0),
+            normalize_boost_db: Some(8.0),
+            ..AppSettings::default()
+        };
+
+        // None option → falls through to settings
+        let none_options = default_download_options();
+        let result = merge_normalize_options(&none_options, &settings);
+        assert_eq!(result.loudnorm_target_i, Some(-23.0));
+        assert_eq!(result.loudnorm_target_tp, Some(-2.0));
+        assert_eq!(result.normalize_boost_db, Some(8.0));
+
+        // Some(x) option → overrides settings
+        let some_options = DownloadOptions {
+            loudnorm_target_i: Some(-14.0),
+            loudnorm_target_tp: Some(-1.0),
+            normalize_boost_db: Some(4.0),
+            ..default_download_options()
+        };
+        let result = merge_normalize_options(&some_options, &settings);
+        assert_eq!(result.loudnorm_target_i, Some(-14.0));
+        assert_eq!(result.loudnorm_target_tp, Some(-1.0));
+        assert_eq!(result.normalize_boost_db, Some(4.0));
+    }
 }
 
 /// Cancel an in-progress download by its job ID.

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -45,6 +45,26 @@ pub struct DownloadOptions {
     pub audio_multistreams: bool,
     /// Container format to recode video into (transcodes, not just remux).
     pub recode_video: Option<ContainerFormat>,
+    /// Enable audio normalization for this download. `None` = use settings default.
+    pub normalize_audio: Option<bool>,
+    /// Use EBU R128 loudnorm mode. `None` = use settings default.
+    pub loudnorm: Option<bool>,
+    /// Loudnorm preset override. `None` = use settings default.
+    pub loudnorm_preset: Option<String>,
+    /// Custom LUFS target. `None` = use settings default.
+    pub loudnorm_target_i: Option<f64>,
+    /// Custom dBTP target. `None` = use settings default.
+    pub loudnorm_target_tp: Option<f64>,
+    /// Custom LU target. `None` = use settings default.
+    pub loudnorm_target_lra: Option<f64>,
+    /// Force dynamic mode. `None` = use settings default.
+    pub loudnorm_dynamic: Option<bool>,
+    /// Precompress before loudnorm. `None` = use settings default.
+    pub loudnorm_precompress: Option<bool>,
+    /// Enable boost fallback. `None` = use settings default.
+    pub normalize_boost: Option<bool>,
+    /// Boost gain in dB. `None` = use settings default.
+    pub normalize_boost_db: Option<f64>,
 }
 
 /// Start a new download for the given URL.
@@ -135,6 +155,34 @@ pub async fn start_download(
             recode_video: options.recode_video,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
+            normalize_audio: Some(
+                options.normalize_audio.unwrap_or(settings.normalize_audio),
+            ),
+            loudnorm: Some(options.loudnorm.unwrap_or(settings.loudnorm)),
+            loudnorm_preset: options
+                .loudnorm_preset
+                .or(settings.loudnorm_preset.clone()),
+            loudnorm_target_i: options.loudnorm_target_i.or(settings.loudnorm_target_i),
+            loudnorm_target_tp: options
+                .loudnorm_target_tp
+                .or(settings.loudnorm_target_tp),
+            loudnorm_target_lra: options
+                .loudnorm_target_lra
+                .or(settings.loudnorm_target_lra),
+            loudnorm_dynamic: Some(
+                options.loudnorm_dynamic.unwrap_or(settings.loudnorm_dynamic),
+            ),
+            loudnorm_precompress: Some(
+                options
+                    .loudnorm_precompress
+                    .unwrap_or(settings.loudnorm_precompress),
+            ),
+            normalize_boost: Some(
+                options.normalize_boost.unwrap_or(settings.normalize_boost),
+            ),
+            normalize_boost_db: options
+                .normalize_boost_db
+                .or(settings.normalize_boost_db),
             ..PostProcessOptions::default()
         },
         verbose: if settings.verbose { Some(true) } else { None },

--- a/crates/rdlp-desktop/src-tauri/src/state/app_settings.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/app_settings.rs
@@ -38,6 +38,36 @@ pub struct AppSettings {
     pub verbose: bool,
     /// Default search provider site name (e.g. `"xhamster"`).
     pub default_search_provider: Option<String>,
+    /// Enable audio normalization (peak mode unless loudnorm is set).
+    #[serde(default)]
+    pub normalize_audio: bool,
+    /// Use EBU R128 loudnorm normalization (implies normalize_audio).
+    #[serde(default)]
+    pub loudnorm: bool,
+    /// Loudnorm preset name ("streaming", "broadcast", "loud").
+    #[serde(default)]
+    pub loudnorm_preset: Option<String>,
+    /// Custom target integrated loudness in LUFS (overrides preset).
+    #[serde(default)]
+    pub loudnorm_target_i: Option<f64>,
+    /// Custom target true peak in dBTP (overrides preset).
+    #[serde(default)]
+    pub loudnorm_target_tp: Option<f64>,
+    /// Custom target loudness range in LU (overrides preset).
+    #[serde(default)]
+    pub loudnorm_target_lra: Option<f64>,
+    /// Force dynamic (per-frame compression) mode in loudnorm pass 2.
+    #[serde(default)]
+    pub loudnorm_dynamic: bool,
+    /// Prepend a mild acompressor before loudnorm to tame extreme peaks.
+    #[serde(default)]
+    pub loudnorm_precompress: bool,
+    /// Enable limiter-boost fallback for over-compressed content.
+    #[serde(default)]
+    pub normalize_boost: bool,
+    /// Gain in dB for limiter-boost fallback.
+    #[serde(default)]
+    pub normalize_boost_db: Option<f64>,
 }
 
 impl AppSettings {
@@ -126,6 +156,16 @@ impl Default for AppSettings {
             embed_metadata: false,
             verbose: false,
             default_search_provider: None,
+            normalize_audio: false,
+            loudnorm: false,
+            loudnorm_preset: None,
+            loudnorm_target_i: None,
+            loudnorm_target_tp: None,
+            loudnorm_target_lra: None,
+            loudnorm_dynamic: false,
+            loudnorm_precompress: false,
+            normalize_boost: false,
+            normalize_boost_db: None,
         }
     }
 }
@@ -155,6 +195,16 @@ mod tests {
         assert!(settings.default_subtitle_format.is_none());
         assert!(settings.default_subtitle_langs.is_empty());
         assert!(settings.default_search_provider.is_none());
+        assert!(!settings.normalize_audio);
+        assert!(!settings.loudnorm);
+        assert!(settings.loudnorm_preset.is_none());
+        assert!(settings.loudnorm_target_i.is_none());
+        assert!(settings.loudnorm_target_tp.is_none());
+        assert!(settings.loudnorm_target_lra.is_none());
+        assert!(!settings.loudnorm_dynamic);
+        assert!(!settings.loudnorm_precompress);
+        assert!(!settings.normalize_boost);
+        assert!(settings.normalize_boost_db.is_none());
     }
 
     #[test]
@@ -194,6 +244,16 @@ mod tests {
             embed_metadata: true,
             verbose: true,
             default_search_provider: Some("xhamster".to_owned()),
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_preset: Some("streaming".to_owned()),
+            loudnorm_target_i: Some(-14.0),
+            loudnorm_target_tp: Some(-1.0),
+            loudnorm_target_lra: Some(11.0),
+            loudnorm_dynamic: true,
+            loudnorm_precompress: true,
+            normalize_boost: true,
+            normalize_boost_db: Some(8.0),
         };
 
         let json = serde_json::to_string(&settings).expect("serialization should succeed");
@@ -212,5 +272,15 @@ mod tests {
             restored.default_search_provider.as_deref(),
             Some("xhamster")
         );
+        assert!(restored.normalize_audio);
+        assert!(restored.loudnorm);
+        assert_eq!(restored.loudnorm_preset.as_deref(), Some("streaming"));
+        assert_eq!(restored.loudnorm_target_i, Some(-14.0));
+        assert_eq!(restored.loudnorm_target_tp, Some(-1.0));
+        assert_eq!(restored.loudnorm_target_lra, Some(11.0));
+        assert!(restored.loudnorm_dynamic);
+        assert!(restored.loudnorm_precompress);
+        assert!(restored.normalize_boost);
+        assert_eq!(restored.normalize_boost_db, Some(8.0));
     }
 }

--- a/crates/rdlp-desktop/src-tauri/src/state/app_settings.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/app_settings.rs
@@ -232,6 +232,49 @@ mod tests {
         );
     }
 
+    /// Settings JSON that predates the normalization fields (i.e. produced
+    /// by an older version of the application) MUST deserialize without
+    /// error, with all normalization fields falling back to their defaults.
+    #[test]
+    fn test_load_legacy_settings_without_normalization_fields() {
+        // Simulate a settings.json from before normalization was added.
+        let legacy_json = r#"{
+            "output_dir": "/tmp/downloads",
+            "default_remux": null,
+            "default_extract_audio": null,
+            "default_subtitle_format": null,
+            "default_subtitle_langs": [],
+            "embed_thumbnail": true,
+            "embed_metadata": false,
+            "verbose": false,
+            "default_search_provider": null
+        }"#;
+
+        let settings: AppSettings = serde_json::from_str(legacy_json)
+            .expect("legacy JSON without normalization fields should deserialize");
+
+        // All normalization fields should default to false / None.
+        assert!(!settings.normalize_audio);
+        assert!(!settings.loudnorm);
+        assert!(settings.loudnorm_preset.is_none());
+        assert!(settings.loudnorm_target_i.is_none());
+        assert!(settings.loudnorm_target_tp.is_none());
+        assert!(settings.loudnorm_target_lra.is_none());
+        assert!(!settings.loudnorm_dynamic);
+        assert!(!settings.loudnorm_precompress);
+        assert!(!settings.normalize_boost);
+        assert!(settings.normalize_boost_db.is_none());
+
+        // Pre-existing fields should be preserved.
+        assert_eq!(
+            settings.output_dir,
+            std::path::PathBuf::from("/tmp/downloads")
+        );
+        assert!(settings.embed_thumbnail);
+        assert!(!settings.embed_metadata);
+        assert!(!settings.verbose);
+    }
+
     #[test]
     fn test_settings_round_trip() {
         let settings = AppSettings {

--- a/crates/rdlp-desktop/src/components/CommandBar.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.tsx
@@ -125,7 +125,7 @@ export function CommandBar({ inputRef, activeTab, isFetching, onSearch }: Comman
                         <X className="h-3.5 w-3.5" />
                     </button>
                 )}
-                <kbd className="absolute right-2 px-1.5 py-0.5 rounded-sm bg-white/[0.04] border border-white/[0.06] text-muted-foreground font-mono text-[10px] pointer-events-none peer-focus:opacity-0">Ctrl+K</kbd>
+                <kbd className="absolute right-2 kbd-chip pointer-events-none peer-focus:opacity-0">Ctrl+K</kbd>
             </div>
 
             <Button

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -243,7 +243,7 @@ export function DownloadOptionsPanel({
                         </div>
 
                         {/* Audio Normalization */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide self-start pt-1.5">
                             Normalize
                         </Label>
                         <div className="flex flex-col gap-0">

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -52,9 +52,6 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
 
 const NONE_SENTINEL = "none";
 
-/** Applied to SelectTrigger when a non-default value is chosen. */
-const ACTIVE_SELECT = "border-primary/40 text-primary";
-
 // -- Types ----------------------------------------------------------------
 
 interface DownloadOptionsPanelProps {
@@ -129,7 +126,7 @@ export function DownloadOptionsPanel({
                                 remux: val === NONE_SENTINEL ? null : (val as ContainerFormat),
                             }))}
                         >
-                            <SelectTrigger className={cn("h-7 text-xs", options.remux && ACTIVE_SELECT)}>
+                            <SelectTrigger className={cn("h-7 text-xs", options.remux && "select-active")}>
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -151,7 +148,7 @@ export function DownloadOptionsPanel({
                                 extractAudio: val === NONE_SENTINEL ? null : (val as AudioFormat),
                             }))}
                         >
-                            <SelectTrigger className={cn("h-7 text-xs", options.extractAudio && ACTIVE_SELECT)}>
+                            <SelectTrigger className={cn("h-7 text-xs", options.extractAudio && "select-active")}>
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -257,7 +254,7 @@ export function DownloadOptionsPanel({
                                     setOptions((prev) => handleNormSelectChange(prev, val))
                                 }
                             >
-                                <SelectTrigger className={cn("h-7 text-xs", getNormSelectValue(options) !== "default" && ACTIVE_SELECT)}>
+                                <SelectTrigger className={cn("h-7 text-xs", getNormSelectValue(options) !== "default" && "select-active")}>
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -94,7 +94,7 @@ export function DownloadOptionsPanel({
                 <CollapsibleContent>
                     <div className="px-5 pb-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2.5 items-center animate-in fade-in-0 slide-in-from-top-1 duration-150">
                         {/* Save to */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                        <Label className="options-label">
                             Save to
                         </Label>
                         <div className="flex gap-1.5">
@@ -116,7 +116,7 @@ export function DownloadOptionsPanel({
                         </div>
 
                         {/* Remux */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                        <Label className="options-label">
                             Remux
                         </Label>
                         <Select
@@ -138,7 +138,7 @@ export function DownloadOptionsPanel({
                         </Select>
 
                         {/* Extract Audio */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                        <Label className="options-label">
                             Audio
                         </Label>
                         <Select
@@ -160,7 +160,7 @@ export function DownloadOptionsPanel({
                         </Select>
 
                         {/* Subtitles */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                        <Label className="options-label">
                             Subtitles
                         </Label>
                         <div className="flex flex-col gap-1.5">
@@ -226,7 +226,7 @@ export function DownloadOptionsPanel({
                         </div>
 
                         {/* Thumbnail */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                        <Label className="options-label">
                             Thumbnail
                         </Label>
                         <div className="flex items-center gap-2">
@@ -244,7 +244,7 @@ export function DownloadOptionsPanel({
                         </div>
 
                         {/* Audio Normalization */}
-                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide self-start pt-1.5">
+                        <Label className="options-label self-start pt-1.5">
                             Normalize
                         </Label>
                         <div className="flex flex-col gap-0">

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -2,6 +2,7 @@
 //
 // Contains save directory, remux, audio extraction, subtitles, and thumbnail controls.
 
+import { cn } from "@/lib/utils";
 import { ChevronUp, ChevronDown, FolderOpen, Settings2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -50,6 +51,9 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
 ];
 
 const NONE_SENTINEL = "none";
+
+/** Applied to SelectTrigger when a non-default value is chosen. */
+const ACTIVE_SELECT = "border-primary/40 text-primary";
 
 // -- Types ----------------------------------------------------------------
 
@@ -125,7 +129,7 @@ export function DownloadOptionsPanel({
                                 remux: val === NONE_SENTINEL ? null : (val as ContainerFormat),
                             }))}
                         >
-                            <SelectTrigger className="h-7 text-xs">
+                            <SelectTrigger className={cn("h-7 text-xs", options.remux && ACTIVE_SELECT)}>
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -147,7 +151,7 @@ export function DownloadOptionsPanel({
                                 extractAudio: val === NONE_SENTINEL ? null : (val as AudioFormat),
                             }))}
                         >
-                            <SelectTrigger className="h-7 text-xs">
+                            <SelectTrigger className={cn("h-7 text-xs", options.extractAudio && ACTIVE_SELECT)}>
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -253,7 +257,7 @@ export function DownloadOptionsPanel({
                                     setOptions((prev) => handleNormSelectChange(prev, val))
                                 }
                             >
-                                <SelectTrigger className="h-7 text-xs">
+                                <SelectTrigger className={cn("h-7 text-xs", getNormSelectValue(options) !== "default" && ACTIVE_SELECT)}>
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -239,6 +239,86 @@ export function DownloadOptionsPanel({
                                 Embed thumbnail
                             </Label>
                         </div>
+
+                        {/* Audio Normalization */}
+                        <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                            Normalize
+                        </Label>
+                        <Select
+                            value={
+                                options.normalizeAudio === null
+                                    ? "default"
+                                    : !options.normalizeAudio
+                                      ? "off"
+                                      : !options.loudnorm
+                                        ? "peak"
+                                        : options.loudnormPreset === "broadcast"
+                                          ? "loudnorm-broadcast"
+                                          : options.loudnormPreset === "loud"
+                                            ? "loudnorm-loud"
+                                            : options.loudnormPreset === "streaming" || options.loudnormPreset === null
+                                              ? "loudnorm-streaming"
+                                              : "default"
+                            }
+                            onValueChange={(val) => {
+                                if (val === "default") {
+                                    setOptions((prev) => ({
+                                        ...prev,
+                                        normalizeAudio: null,
+                                        loudnorm: null,
+                                        loudnormPreset: null,
+                                        loudnormTargetI: null,
+                                        loudnormTargetTp: null,
+                                        loudnormTargetLra: null,
+                                        loudnormDynamic: null,
+                                        loudnormPrecompress: null,
+                                        normalizeBoost: null,
+                                        normalizeBoostDb: null,
+                                    }));
+                                } else if (val === "off") {
+                                    setOptions((prev) => ({
+                                        ...prev,
+                                        normalizeAudio: false,
+                                        loudnorm: false,
+                                        loudnormPreset: null,
+                                        loudnormTargetI: null,
+                                        loudnormTargetTp: null,
+                                        loudnormTargetLra: null,
+                                        loudnormDynamic: false,
+                                        loudnormPrecompress: false,
+                                        normalizeBoost: false,
+                                        normalizeBoostDb: null,
+                                    }));
+                                } else if (val === "peak") {
+                                    setOptions((prev) => ({
+                                        ...prev,
+                                        normalizeAudio: true,
+                                        loudnorm: false,
+                                        loudnormPreset: null,
+                                    }));
+                                } else {
+                                    const preset = val.replace("loudnorm-", "");
+                                    setOptions((prev) => ({
+                                        ...prev,
+                                        normalizeAudio: true,
+                                        loudnorm: true,
+                                        loudnormPreset: preset,
+                                    }));
+                                }
+                            }}
+                        >
+                            <SelectTrigger className="h-7 text-xs">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="default">Use Settings Default</SelectItem>
+                                <SelectItem value="off">Off</SelectItem>
+                                <SelectItem value="peak">Peak</SelectItem>
+                                <SelectItem value="loudnorm-streaming">Loudnorm (Streaming -14 LUFS)</SelectItem>
+                                <SelectItem value="loudnorm-broadcast">Loudnorm (Broadcast -23 LUFS)</SelectItem>
+                                <SelectItem value="loudnorm-loud">Loudnorm (Loud -11 LUFS)</SelectItem>
+                            </SelectContent>
+                        </Select>
                     </div>
                 </CollapsibleContent>
             </Collapsible>

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -25,6 +25,8 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { optionsSummary } from "./utils/tableHelpers";
+import { getNormSelectValue, handleNormSelectChange } from "./utils/normalization";
+import { NormalizationCustomControls } from "./NormalizationCustomControls";
 import type {
     AppSettings,
     AudioFormat,
@@ -244,81 +246,34 @@ export function DownloadOptionsPanel({
                         <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
                             Normalize
                         </Label>
-                        <Select
-                            value={
-                                options.normalizeAudio === null
-                                    ? "default"
-                                    : !options.normalizeAudio
-                                      ? "off"
-                                      : !options.loudnorm
-                                        ? "peak"
-                                        : options.loudnormPreset === "broadcast"
-                                          ? "loudnorm-broadcast"
-                                          : options.loudnormPreset === "loud"
-                                            ? "loudnorm-loud"
-                                            : options.loudnormPreset === "streaming" || options.loudnormPreset === null
-                                              ? "loudnorm-streaming"
-                                              : "default"
-                            }
-                            onValueChange={(val) => {
-                                if (val === "default") {
-                                    setOptions((prev) => ({
-                                        ...prev,
-                                        normalizeAudio: null,
-                                        loudnorm: null,
-                                        loudnormPreset: null,
-                                        loudnormTargetI: null,
-                                        loudnormTargetTp: null,
-                                        loudnormTargetLra: null,
-                                        loudnormDynamic: null,
-                                        loudnormPrecompress: null,
-                                        normalizeBoost: null,
-                                        normalizeBoostDb: null,
-                                    }));
-                                } else if (val === "off") {
-                                    setOptions((prev) => ({
-                                        ...prev,
-                                        normalizeAudio: false,
-                                        loudnorm: false,
-                                        loudnormPreset: null,
-                                        loudnormTargetI: null,
-                                        loudnormTargetTp: null,
-                                        loudnormTargetLra: null,
-                                        loudnormDynamic: false,
-                                        loudnormPrecompress: false,
-                                        normalizeBoost: false,
-                                        normalizeBoostDb: null,
-                                    }));
-                                } else if (val === "peak") {
-                                    setOptions((prev) => ({
-                                        ...prev,
-                                        normalizeAudio: true,
-                                        loudnorm: false,
-                                        loudnormPreset: null,
-                                    }));
-                                } else {
-                                    const preset = val.replace("loudnorm-", "");
-                                    setOptions((prev) => ({
-                                        ...prev,
-                                        normalizeAudio: true,
-                                        loudnorm: true,
-                                        loudnormPreset: preset,
-                                    }));
+                        <div className="flex flex-col gap-0">
+                            <Select
+                                value={getNormSelectValue(options)}
+                                onValueChange={(val) =>
+                                    setOptions((prev) => handleNormSelectChange(prev, val))
                                 }
-                            }}
-                        >
-                            <SelectTrigger className="h-7 text-xs">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="default">Use Settings Default</SelectItem>
-                                <SelectItem value="off">Off</SelectItem>
-                                <SelectItem value="peak">Peak</SelectItem>
-                                <SelectItem value="loudnorm-streaming">Loudnorm (Streaming -14 LUFS)</SelectItem>
-                                <SelectItem value="loudnorm-broadcast">Loudnorm (Broadcast -23 LUFS)</SelectItem>
-                                <SelectItem value="loudnorm-loud">Loudnorm (Loud -11 LUFS)</SelectItem>
-                            </SelectContent>
-                        </Select>
+                            >
+                                <SelectTrigger className="h-7 text-xs">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="default">Use Settings Default</SelectItem>
+                                    <SelectItem value="off">Off</SelectItem>
+                                    <SelectItem value="peak">Peak</SelectItem>
+                                    <SelectItem value="loudnorm-streaming">Loudnorm (Streaming -14 LUFS)</SelectItem>
+                                    <SelectItem value="loudnorm-broadcast">Loudnorm (Broadcast -23 LUFS)</SelectItem>
+                                    <SelectItem value="loudnorm-loud">Loudnorm (Loud -11 LUFS)</SelectItem>
+                                    <SelectItem value="custom">Custom...</SelectItem>
+                                </SelectContent>
+                            </Select>
+                            {getNormSelectValue(options) === "custom" && (
+                                <NormalizationCustomControls
+                                    value={options}
+                                    onChange={(next) => setOptions(next)}
+                                    idPrefix="dop-norm"
+                                />
+                            )}
+                        </div>
                     </div>
                 </CollapsibleContent>
             </Collapsible>

--- a/crates/rdlp-desktop/src/components/FilterBar.tsx
+++ b/crates/rdlp-desktop/src/components/FilterBar.tsx
@@ -142,7 +142,7 @@ export function FilterBar({ isFetching, hasSearchData, onSearch }: FilterBarProp
                                     "hover:border-white/[0.08] hover:text-foreground/70",
                                     "focus:outline-none focus:ring-1 focus:ring-ring",
                                     "disabled:opacity-40 disabled:cursor-not-allowed",
-                                    active && "border-primary/30 text-foreground bg-primary/[0.06]",
+                                    active && "select-active bg-primary/[0.06]",
                                 )}
                                 aria-label={desc.display_name}
                             >
@@ -219,7 +219,7 @@ export function FilterBar({ isFetching, hasSearchData, onSearch }: FilterBarProp
                                             "hover:border-white/[0.08] hover:text-foreground/70",
                                             "focus:outline-none focus:ring-1 focus:ring-ring",
                                             "disabled:opacity-40 disabled:cursor-not-allowed",
-                                            active && "border-primary/30 text-foreground bg-primary/[0.06]",
+                                            active && "select-active bg-primary/[0.06]",
                                         )}
                                         aria-label={desc.display_name}
                                     >

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
@@ -1,0 +1,474 @@
+import { render, screen } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import {
+    FormatOptionsPanel,
+    buildDefaultOptions,
+    PRESETS,
+} from "./FormatOptionsPanel";
+import type { AppSettings, DownloadOptions } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal valid AppSettings with all normalization fields present. */
+const fullSettings: AppSettings = {
+    output_dir: "/home/user/Videos",
+    default_remux: null,
+    default_extract_audio: null,
+    default_subtitle_format: null,
+    default_subtitle_langs: [],
+    embed_thumbnail: true,
+    embed_metadata: true,
+    verbose: false,
+    default_search_provider: null,
+    normalize_audio: true,
+    loudnorm: true,
+    loudnorm_preset: "streaming",
+    loudnorm_target_i: -14,
+    loudnorm_target_tp: -1,
+    loudnorm_target_lra: 11,
+    loudnorm_dynamic: true,
+    loudnorm_precompress: false,
+    normalize_boost: true,
+    normalize_boost_db: 8,
+};
+
+/** Default DownloadOptions used in rendering tests. */
+const defaultOptions: DownloadOptions = {
+    format: null,
+    outputDir: null,
+    subtitles: false,
+    subtitleLangs: [],
+    remux: null,
+    extractAudio: null,
+    embedThumbnail: true,
+    audioMultistreams: false,
+    recodeVideo: null,
+    normalizeAudio: null,
+    loudnorm: null,
+    loudnormPreset: null,
+    loudnormTargetI: null,
+    loudnormTargetTp: null,
+    loudnormTargetLra: null,
+    loudnormDynamic: null,
+    loudnormPrecompress: null,
+    normalizeBoost: null,
+    normalizeBoostDb: null,
+};
+
+function renderPanel(value: DownloadOptions, onChange = vi.fn()) {
+    return render(
+        <FormatOptionsPanel value={value} onChange={onChange} />,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A. buildDefaultOptions — pure function unit tests
+// ---------------------------------------------------------------------------
+
+describe("buildDefaultOptions", () => {
+    it("returns sensible defaults when settings is null", () => {
+        const opts = buildDefaultOptions(null);
+        expect(opts.format).toBeNull();
+        expect(opts.subtitles).toBe(false);
+        expect(opts.embedThumbnail).toBe(true);
+        expect(opts.normalizeAudio).toBe(false);
+        expect(opts.loudnorm).toBe(false);
+        expect(opts.loudnormPreset).toBeNull();
+        expect(opts.loudnormTargetI).toBeNull();
+        expect(opts.loudnormTargetTp).toBeNull();
+        expect(opts.loudnormTargetLra).toBeNull();
+        expect(opts.loudnormDynamic).toBe(false);
+        expect(opts.loudnormPrecompress).toBe(false);
+        expect(opts.normalizeBoost).toBe(false);
+        expect(opts.normalizeBoostDb).toBeNull();
+    });
+
+    it("populates all 10 normalization fields from settings when normalization is enabled", () => {
+        const opts = buildDefaultOptions(fullSettings);
+        expect(opts.normalizeAudio).toBe(true);
+        expect(opts.loudnorm).toBe(true);
+        expect(opts.loudnormPreset).toBe("streaming");
+        expect(opts.loudnormTargetI).toBe(-14);
+        expect(opts.loudnormTargetTp).toBe(-1);
+        expect(opts.loudnormTargetLra).toBe(11);
+        expect(opts.loudnormDynamic).toBe(true);
+        expect(opts.loudnormPrecompress).toBe(false);
+        expect(opts.normalizeBoost).toBe(true);
+        expect(opts.normalizeBoostDb).toBe(8);
+    });
+
+    it("maps normalize_audio true with loudnorm false as peak mode", () => {
+        const settings: AppSettings = {
+            ...fullSettings,
+            normalize_audio: true,
+            loudnorm: false,
+            loudnorm_preset: null,
+        };
+        const opts = buildDefaultOptions(settings);
+        expect(opts.normalizeAudio).toBe(true);
+        expect(opts.loudnorm).toBe(false);
+        expect(opts.loudnormPreset).toBeNull();
+    });
+
+    it("respects embed_thumbnail from settings", () => {
+        const settings: AppSettings = { ...fullSettings, embed_thumbnail: false };
+        const opts = buildDefaultOptions(settings);
+        expect(opts.embedThumbnail).toBe(false);
+    });
+
+    it("sets subtitles true when default_subtitle_langs is non-empty", () => {
+        const settings: AppSettings = {
+            ...fullSettings,
+            default_subtitle_langs: ["en", "sv"],
+        };
+        const opts = buildDefaultOptions(settings);
+        expect(opts.subtitles).toBe(true);
+        expect(opts.subtitleLangs).toEqual(["en", "sv"]);
+    });
+
+    it("always sets format to null regardless of settings", () => {
+        const opts = buildDefaultOptions(fullSettings);
+        expect(opts.format).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// B. activePreset — tested indirectly via rendered RadioGroup selection
+// (also tested as a pure function by inspecting PRESETS)
+// ---------------------------------------------------------------------------
+
+describe("activePreset (via PRESETS constant)", () => {
+    it("null format has no matching preset", () => {
+        // Render with format: null → no radio should appear checked
+        const { container } = renderPanel({ ...defaultOptions, format: null });
+        const radios = container.querySelectorAll('[role="radio"]');
+        for (const r of radios) {
+            expect(r).toHaveAttribute("aria-checked", "false");
+        }
+    });
+
+    it("format matching a preset selector selects that preset", () => {
+        const bestPreset = PRESETS.find((p) => p.id === "best")!;
+        renderPanel({ ...defaultOptions, format: bestPreset.selector });
+        const radio = screen.getByRole("radio", { name: /best quality/i });
+        expect(radio).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("format matching 720p preset selects 720p", () => {
+        const preset = PRESETS.find((p) => p.id === "720p")!;
+        renderPanel({ ...defaultOptions, format: preset.selector });
+        const radio = screen.getByRole("radio", { name: /720p/i });
+        expect(radio).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("unrecognized format selector does not select any preset", () => {
+        const { container } = renderPanel({
+            ...defaultOptions,
+            format: "custom-selector",
+        });
+        const radios = container.querySelectorAll('[role="radio"]');
+        for (const r of radios) {
+            expect(r).toHaveAttribute("aria-checked", "false");
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// C. Audio Normalization Select value derivation
+// ---------------------------------------------------------------------------
+
+describe("Audio Normalization Select — displayed value", () => {
+    /** Helper: get the combobox for Audio Normalization. */
+    function getNormSelect() {
+        // The Audio Normalization label is immediately above its combobox.
+        // There are multiple comboboxes (Remux, Extract Audio, Audio Normalization).
+        // We rely on the label text to identify the right trigger.
+        const label = screen.getByText(/audio normalization/i);
+        // The trigger is the next sibling combobox; use closest parent container.
+        const container = label.closest("div.flex-col")!;
+        return container.querySelector('[role="combobox"]') as HTMLElement;
+    }
+
+    it("normalizeAudio null shows 'Use Settings Default'", () => {
+        renderPanel({ ...defaultOptions, normalizeAudio: null });
+        expect(getNormSelect()).toHaveTextContent(/use settings default/i);
+    });
+
+    it("normalizeAudio false shows 'Off'", () => {
+        renderPanel({ ...defaultOptions, normalizeAudio: false, loudnorm: false });
+        expect(getNormSelect()).toHaveTextContent(/^off$/i);
+    });
+
+    it("normalizeAudio true, loudnorm false shows 'Peak'", () => {
+        renderPanel({
+            ...defaultOptions,
+            normalizeAudio: true,
+            loudnorm: false,
+        });
+        expect(getNormSelect()).toHaveTextContent(/^peak$/i);
+    });
+
+    it("normalizeAudio true, loudnorm true, preset 'streaming' shows loudnorm streaming", () => {
+        renderPanel({
+            ...defaultOptions,
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "streaming",
+        });
+        expect(getNormSelect()).toHaveTextContent(/loudnorm.*streaming/i);
+    });
+
+    it("normalizeAudio true, loudnorm true, preset 'broadcast' shows loudnorm broadcast", () => {
+        renderPanel({
+            ...defaultOptions,
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "broadcast",
+        });
+        expect(getNormSelect()).toHaveTextContent(/loudnorm.*broadcast/i);
+    });
+
+    it("normalizeAudio true, loudnorm true, preset 'loud' shows loudnorm loud", () => {
+        renderPanel({
+            ...defaultOptions,
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "loud",
+        });
+        expect(getNormSelect()).toHaveTextContent(/loudnorm.*loud/i);
+    });
+
+    it("normalizeAudio true, loudnorm true, preset null defaults to loudnorm streaming (bugfix case)", () => {
+        renderPanel({
+            ...defaultOptions,
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: null,
+        });
+        expect(getNormSelect()).toHaveTextContent(/loudnorm.*streaming/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// D. Audio Normalization Select onValueChange branches
+// ---------------------------------------------------------------------------
+
+describe("Audio Normalization Select — onChange branches", () => {
+    async function openNormSelect() {
+        const label = screen.getByText(/audio normalization/i);
+        const container = label.closest("div.flex-col")!;
+        const trigger = container.querySelector('[role="combobox"]') as HTMLElement;
+        await userEvent.click(trigger);
+    }
+
+    it("selecting 'default' calls onChange with all 10 normalization fields null", async () => {
+        const onChange = vi.fn();
+        renderPanel(
+            { ...defaultOptions, normalizeAudio: false, loudnorm: false },
+            onChange,
+        );
+        await openNormSelect();
+        await userEvent.click(screen.getByRole("option", { name: /use settings default/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.normalizeAudio).toBeNull();
+        expect(called.loudnorm).toBeNull();
+        expect(called.loudnormPreset).toBeNull();
+        expect(called.loudnormTargetI).toBeNull();
+        expect(called.loudnormTargetTp).toBeNull();
+        expect(called.loudnormTargetLra).toBeNull();
+        expect(called.loudnormDynamic).toBeNull();
+        expect(called.loudnormPrecompress).toBeNull();
+        expect(called.normalizeBoost).toBeNull();
+        expect(called.normalizeBoostDb).toBeNull();
+    });
+
+    it("selecting 'off' calls onChange with normalizeAudio false and loudnorm false", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
+        await openNormSelect();
+        await userEvent.click(screen.getByRole("option", { name: /^off$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.normalizeAudio).toBe(false);
+        expect(called.loudnorm).toBe(false);
+        expect(called.normalizeBoost).toBe(false);
+        expect(called.normalizeBoostDb).toBeNull();
+    });
+
+    it("selecting 'peak' calls onChange with normalizeAudio true and loudnorm false", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
+        await openNormSelect();
+        await userEvent.click(screen.getByRole("option", { name: /^peak$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.normalizeAudio).toBe(true);
+        expect(called.loudnorm).toBe(false);
+        expect(called.loudnormPreset).toBeNull();
+    });
+
+    it("selecting 'loudnorm-streaming' calls onChange with loudnorm true and preset 'streaming'", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
+        await openNormSelect();
+        await userEvent.click(
+            screen.getByRole("option", { name: /loudnorm.*streaming/i }),
+        );
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.normalizeAudio).toBe(true);
+        expect(called.loudnorm).toBe(true);
+        expect(called.loudnormPreset).toBe("streaming");
+    });
+
+    it("selecting 'loudnorm-broadcast' calls onChange with loudnorm true and preset 'broadcast'", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
+        await openNormSelect();
+        await userEvent.click(
+            screen.getByRole("option", { name: /loudnorm.*broadcast/i }),
+        );
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.normalizeAudio).toBe(true);
+        expect(called.loudnorm).toBe(true);
+        expect(called.loudnormPreset).toBe("broadcast");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// E. Quality preset radio buttons
+// ---------------------------------------------------------------------------
+
+describe("Quality preset radio buttons", () => {
+    it("clicking a preset calls onChange with the preset's selector string", async () => {
+        const onChange = vi.fn();
+        renderPanel(defaultOptions, onChange);
+        await userEvent.click(screen.getByRole("radio", { name: /720p/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        const preset = PRESETS.find((p) => p.id === "720p")!;
+        expect(called.format).toBe(preset.selector);
+    });
+
+    it("clicking 'Best Quality' preset calls onChange with best selector", async () => {
+        const onChange = vi.fn();
+        renderPanel(defaultOptions, onChange);
+        await userEvent.click(screen.getByRole("radio", { name: /best quality/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        const preset = PRESETS.find((p) => p.id === "best")!;
+        expect(called.format).toBe(preset.selector);
+    });
+
+    it("clicking 'Audio Only' preset calls onChange with audio-only selector", async () => {
+        const onChange = vi.fn();
+        renderPanel(defaultOptions, onChange);
+        await userEvent.click(screen.getByRole("radio", { name: /audio only/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        const preset = PRESETS.find((p) => p.id === "audio-only")!;
+        expect(called.format).toBe(preset.selector);
+    });
+
+    it("current format matching 1080p preset shows that preset as selected", () => {
+        const preset = PRESETS.find((p) => p.id === "1080p")!;
+        renderPanel({ ...defaultOptions, format: preset.selector });
+        const radio = screen.getByRole("radio", { name: /1080p/i });
+        expect(radio).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("presets are hidden when hidePresets is true", () => {
+        render(
+            <FormatOptionsPanel
+                value={defaultOptions}
+                onChange={vi.fn()}
+                hidePresets
+            />,
+        );
+        expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// F. Remux and Extract Audio selects
+// ---------------------------------------------------------------------------
+
+describe("Remux Select", () => {
+    function getRemuxSelect() {
+        const label = screen.getByText(/^remux$/i);
+        const container = label.closest("div.flex-col")!;
+        return container.querySelector('[role="combobox"]') as HTMLElement;
+    }
+
+    it("shows 'None' when remux is null", () => {
+        renderPanel({ ...defaultOptions, remux: null });
+        expect(getRemuxSelect()).toHaveTextContent(/^none$/i);
+    });
+
+    it("selecting MP4 calls onChange with remux: 'mp4'", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, remux: null }, onChange);
+        await userEvent.click(getRemuxSelect());
+        await userEvent.click(screen.getByRole("option", { name: /^mp4$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.remux).toBe("mp4");
+    });
+
+    it("selecting MKV calls onChange with remux: 'mkv'", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, remux: null }, onChange);
+        await userEvent.click(getRemuxSelect());
+        await userEvent.click(screen.getByRole("option", { name: /^mkv$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.remux).toBe("mkv");
+    });
+
+    it("selecting None calls onChange with remux: null", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, remux: "mp4" }, onChange);
+        await userEvent.click(getRemuxSelect());
+        await userEvent.click(screen.getByRole("option", { name: /^none$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.remux).toBeNull();
+    });
+});
+
+describe("Extract Audio Select", () => {
+    function getAudioSelect() {
+        const label = screen.getByText(/extract audio/i);
+        const container = label.closest("div.flex-col")!;
+        return container.querySelector('[role="combobox"]') as HTMLElement;
+    }
+
+    it("shows 'None' when extractAudio is null", () => {
+        renderPanel({ ...defaultOptions, extractAudio: null });
+        expect(getAudioSelect()).toHaveTextContent(/^none$/i);
+    });
+
+    it("selecting MP3 calls onChange with extractAudio: 'mp3'", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, extractAudio: null }, onChange);
+        await userEvent.click(getAudioSelect());
+        await userEvent.click(screen.getByRole("option", { name: /^mp3$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.extractAudio).toBe("mp3");
+    });
+
+    it("selecting Opus calls onChange with extractAudio: 'opus'", async () => {
+        const onChange = vi.fn();
+        renderPanel({ ...defaultOptions, extractAudio: null }, onChange);
+        await userEvent.click(getAudioSelect());
+        await userEvent.click(screen.getByRole("option", { name: /^opus$/i }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const called = onChange.mock.calls[0][0] as DownloadOptions;
+        expect(called.extractAudio).toBe("opus");
+    });
+});

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -66,6 +66,9 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
 /** Sentinel value for "no selection" in Radix Select (empty string is not supported). */
 const NONE_SENTINEL = "none";
 
+/** Applied to SelectTrigger when a non-default value is chosen. */
+const ACTIVE_SELECT = "border-primary/40 text-primary";
+
 /**
  * Build a `DownloadOptions` from persisted settings.
  *
@@ -208,7 +211,7 @@ export function FormatOptionsPanel({
                     value={value.remux ?? NONE_SENTINEL}
                     onValueChange={handleRemux}
                 >
-                    <SelectTrigger size="sm" className="w-full text-xs">
+                    <SelectTrigger size="sm" className={cn("w-full text-xs", value.remux && ACTIVE_SELECT)}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -230,7 +233,7 @@ export function FormatOptionsPanel({
                     value={value.extractAudio ?? NONE_SENTINEL}
                     onValueChange={handleAudio}
                 >
-                    <SelectTrigger size="sm" className="w-full text-xs">
+                    <SelectTrigger size="sm" className={cn("w-full text-xs", value.extractAudio && ACTIVE_SELECT)}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -343,7 +346,7 @@ export function FormatOptionsPanel({
                     value={getNormSelectValue(value)}
                     onValueChange={(val) => onChange(handleNormSelectChange(value, val))}
                 >
-                    <SelectTrigger size="sm" className="w-full text-xs">
+                    <SelectTrigger size="sm" className={cn("w-full text-xs", getNormSelectValue(value) !== "default" && ACTIVE_SELECT)}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -22,6 +22,8 @@ import type {
     ContainerFormat,
     DownloadOptions,
 } from "../types";
+import { getNormSelectValue, handleNormSelectChange } from "./utils/normalization";
+import { NormalizationCustomControls } from "./NormalizationCustomControls";
 
 /** A format preset with a human-readable label and yt-dlp selector string. */
 export interface FormatPreset {
@@ -338,67 +340,8 @@ export function FormatOptionsPanel({
                     Audio Normalization
                 </Label>
                 <Select
-                    value={
-                        value.normalizeAudio === null
-                            ? "default"
-                            : !value.normalizeAudio
-                              ? "off"
-                              : !value.loudnorm
-                                ? "peak"
-                                : value.loudnormPreset === "broadcast"
-                                  ? "loudnorm-broadcast"
-                                  : value.loudnormPreset === "loud"
-                                    ? "loudnorm-loud"
-                                    : value.loudnormPreset === "streaming" || value.loudnormPreset === null
-                                      ? "loudnorm-streaming"
-                                      : "default"
-                    }
-                    onValueChange={(val) => {
-                        if (val === "default") {
-                            onChange({
-                                ...value,
-                                normalizeAudio: null,
-                                loudnorm: null,
-                                loudnormPreset: null,
-                                loudnormTargetI: null,
-                                loudnormTargetTp: null,
-                                loudnormTargetLra: null,
-                                loudnormDynamic: null,
-                                loudnormPrecompress: null,
-                                normalizeBoost: null,
-                                normalizeBoostDb: null,
-                            });
-                        } else if (val === "off") {
-                            onChange({
-                                ...value,
-                                normalizeAudio: false,
-                                loudnorm: false,
-                                loudnormPreset: null,
-                                loudnormTargetI: null,
-                                loudnormTargetTp: null,
-                                loudnormTargetLra: null,
-                                loudnormDynamic: false,
-                                loudnormPrecompress: false,
-                                normalizeBoost: false,
-                                normalizeBoostDb: null,
-                            });
-                        } else if (val === "peak") {
-                            onChange({
-                                ...value,
-                                normalizeAudio: true,
-                                loudnorm: false,
-                                loudnormPreset: null,
-                            });
-                        } else {
-                            const preset = val.replace("loudnorm-", "");
-                            onChange({
-                                ...value,
-                                normalizeAudio: true,
-                                loudnorm: true,
-                                loudnormPreset: preset,
-                            });
-                        }
-                    }}
+                    value={getNormSelectValue(value)}
+                    onValueChange={(val) => onChange(handleNormSelectChange(value, val))}
                 >
                     <SelectTrigger size="sm" className="w-full text-xs">
                         <SelectValue />
@@ -410,8 +353,16 @@ export function FormatOptionsPanel({
                         <SelectItem value="loudnorm-streaming">Loudnorm (Streaming -14 LUFS)</SelectItem>
                         <SelectItem value="loudnorm-broadcast">Loudnorm (Broadcast -23 LUFS)</SelectItem>
                         <SelectItem value="loudnorm-loud">Loudnorm (Loud -11 LUFS)</SelectItem>
+                        <SelectItem value="custom">Custom...</SelectItem>
                     </SelectContent>
                 </Select>
+                {getNormSelectValue(value) === "custom" && (
+                    <NormalizationCustomControls
+                        value={value}
+                        onChange={onChange}
+                        idPrefix="fop-norm"
+                    />
+                )}
             </div>
         </div>
     );

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -349,7 +349,7 @@ export function FormatOptionsPanel({
                                   ? "loudnorm-broadcast"
                                   : value.loudnormPreset === "loud"
                                     ? "loudnorm-loud"
-                                    : value.loudnormPreset === "streaming"
+                                    : value.loudnormPreset === "streaming" || value.loudnormPreset === null
                                       ? "loudnorm-streaming"
                                       : "default"
                     }

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -83,6 +83,16 @@ export function buildDefaultOptions(
         embedThumbnail: settings?.embed_thumbnail ?? true,
         audioMultistreams: false,
         recodeVideo: null,
+        normalizeAudio: settings?.normalize_audio ?? false,
+        loudnorm: settings?.loudnorm ?? false,
+        loudnormPreset: settings?.loudnorm_preset ?? null,
+        loudnormTargetI: settings?.loudnorm_target_i ?? null,
+        loudnormTargetTp: settings?.loudnorm_target_tp ?? null,
+        loudnormTargetLra: settings?.loudnorm_target_lra ?? null,
+        loudnormDynamic: settings?.loudnorm_dynamic ?? false,
+        loudnormPrecompress: settings?.loudnorm_precompress ?? false,
+        normalizeBoost: settings?.normalize_boost ?? false,
+        normalizeBoostDb: settings?.normalize_boost_db ?? null,
     };
 }
 

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -332,6 +332,87 @@ export function FormatOptionsPanel({
                     </Label>
                 </div>
             </div>
+
+            <div className="flex flex-col gap-1">
+                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                    Audio Normalization
+                </Label>
+                <Select
+                    value={
+                        value.normalizeAudio === null
+                            ? "default"
+                            : !value.normalizeAudio
+                              ? "off"
+                              : !value.loudnorm
+                                ? "peak"
+                                : value.loudnormPreset === "broadcast"
+                                  ? "loudnorm-broadcast"
+                                  : value.loudnormPreset === "loud"
+                                    ? "loudnorm-loud"
+                                    : value.loudnormPreset === "streaming"
+                                      ? "loudnorm-streaming"
+                                      : "default"
+                    }
+                    onValueChange={(val) => {
+                        if (val === "default") {
+                            onChange({
+                                ...value,
+                                normalizeAudio: null,
+                                loudnorm: null,
+                                loudnormPreset: null,
+                                loudnormTargetI: null,
+                                loudnormTargetTp: null,
+                                loudnormTargetLra: null,
+                                loudnormDynamic: null,
+                                loudnormPrecompress: null,
+                                normalizeBoost: null,
+                                normalizeBoostDb: null,
+                            });
+                        } else if (val === "off") {
+                            onChange({
+                                ...value,
+                                normalizeAudio: false,
+                                loudnorm: false,
+                                loudnormPreset: null,
+                                loudnormTargetI: null,
+                                loudnormTargetTp: null,
+                                loudnormTargetLra: null,
+                                loudnormDynamic: false,
+                                loudnormPrecompress: false,
+                                normalizeBoost: false,
+                                normalizeBoostDb: null,
+                            });
+                        } else if (val === "peak") {
+                            onChange({
+                                ...value,
+                                normalizeAudio: true,
+                                loudnorm: false,
+                                loudnormPreset: null,
+                            });
+                        } else {
+                            const preset = val.replace("loudnorm-", "");
+                            onChange({
+                                ...value,
+                                normalizeAudio: true,
+                                loudnorm: true,
+                                loudnormPreset: preset,
+                            });
+                        }
+                    }}
+                >
+                    <SelectTrigger size="sm" className="w-full text-xs">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="default">Use Settings Default</SelectItem>
+                        <SelectItem value="off">Off</SelectItem>
+                        <SelectItem value="peak">Peak</SelectItem>
+                        <SelectItem value="loudnorm-streaming">Loudnorm (Streaming -14 LUFS)</SelectItem>
+                        <SelectItem value="loudnorm-broadcast">Loudnorm (Broadcast -23 LUFS)</SelectItem>
+                        <SelectItem value="loudnorm-loud">Loudnorm (Loud -11 LUFS)</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
         </div>
     );
 }

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -66,9 +66,6 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
 /** Sentinel value for "no selection" in Radix Select (empty string is not supported). */
 const NONE_SENTINEL = "none";
 
-/** Applied to SelectTrigger when a non-default value is chosen. */
-const ACTIVE_SELECT = "border-primary/40 text-primary";
-
 /**
  * Build a `DownloadOptions` from persisted settings.
  *
@@ -211,7 +208,7 @@ export function FormatOptionsPanel({
                     value={value.remux ?? NONE_SENTINEL}
                     onValueChange={handleRemux}
                 >
-                    <SelectTrigger size="sm" className={cn("w-full text-xs", value.remux && ACTIVE_SELECT)}>
+                    <SelectTrigger size="sm" className={cn("w-full text-xs", value.remux && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -233,7 +230,7 @@ export function FormatOptionsPanel({
                     value={value.extractAudio ?? NONE_SENTINEL}
                     onValueChange={handleAudio}
                 >
-                    <SelectTrigger size="sm" className={cn("w-full text-xs", value.extractAudio && ACTIVE_SELECT)}>
+                    <SelectTrigger size="sm" className={cn("w-full text-xs", value.extractAudio && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -346,7 +343,7 @@ export function FormatOptionsPanel({
                     value={getNormSelectValue(value)}
                     onValueChange={(val) => onChange(handleNormSelectChange(value, val))}
                 >
-                    <SelectTrigger size="sm" className={cn("w-full text-xs", getNormSelectValue(value) !== "default" && ACTIVE_SELECT)}>
+                    <SelectTrigger size="sm" className={cn("w-full text-xs", getNormSelectValue(value) !== "default" && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -169,7 +169,7 @@ export function FormatOptionsPanel({
         <div className="flex flex-col gap-1.5">
             {!hidePresets && (
                 <div className="flex flex-col gap-1">
-                    <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                    <Label className="options-label">
                         Quality Preset
                     </Label>
                     <RadioGroup
@@ -201,7 +201,7 @@ export function FormatOptionsPanel({
             )}
 
             <div className="flex flex-col gap-1">
-                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                <Label className="options-label">
                     Remux
                 </Label>
                 <Select
@@ -223,7 +223,7 @@ export function FormatOptionsPanel({
             </div>
 
             <div className="flex flex-col gap-1">
-                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                <Label className="options-label">
                     Extract Audio
                 </Label>
                 <Select
@@ -255,7 +255,7 @@ export function FormatOptionsPanel({
                     />
                     <Label
                         htmlFor="subtitles"
-                        className="text-[11px] font-semibold text-muted-foreground tracking-wide cursor-pointer"
+                        className="options-label cursor-pointer"
                     >
                         Download Subtitles
                     </Label>
@@ -328,7 +328,7 @@ export function FormatOptionsPanel({
                     />
                     <Label
                         htmlFor="embed-thumbnail"
-                        className="text-[11px] font-semibold text-muted-foreground tracking-wide cursor-pointer"
+                        className="options-label cursor-pointer"
                     >
                         Embed Thumbnail
                     </Label>
@@ -336,7 +336,7 @@ export function FormatOptionsPanel({
             </div>
 
             <div className="flex flex-col gap-1">
-                <Label className="text-[11px] font-semibold text-muted-foreground tracking-wide">
+                <Label className="options-label">
                     Audio Normalization
                 </Label>
                 <Select

--- a/crates/rdlp-desktop/src/components/FormatTableSection.tsx
+++ b/crates/rdlp-desktop/src/components/FormatTableSection.tsx
@@ -111,7 +111,7 @@ export function FormatTableSection({
                                             key={header.id}
                                             style={{ width: `${(header.getSize() / totalColumnSize * 100).toFixed(1)}%` }}
                                             className={cn(
-                                                "h-8 px-3 text-[10px] font-bold tracking-wider uppercase select-none transition-colors",
+                                                "table-th",
                                                 header.column.getCanSort() && "cursor-pointer hover:text-foreground",
                                                 align === "right" && "text-right",
                                                 align === "center" && "text-center",
@@ -151,9 +151,9 @@ export function FormatTableSection({
                             </TableRow>
                         )}
                     </TableBody>
-                    <TableFooter className="sticky bottom-0 z-10 bg-card/95 backdrop-blur-sm">
+                    <TableFooter className="table-footer-sticky">
                         <TableRow className="hover:bg-transparent">
-                            <TableCell colSpan={columns.length} className="px-3 py-1.5 text-[10px] text-muted-foreground">
+                            <TableCell colSpan={columns.length} className="table-footer-cell">
                                 {filteredCount} format{filteredCount !== 1 ? "s" : ""}
                             </TableCell>
                         </TableRow>

--- a/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
+++ b/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
@@ -5,17 +5,8 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { DownloadOptions } from "../types";
-
-const NONE_SENTINEL = "none";
 
 interface NormalizationCustomControlsProps {
     value: DownloadOptions;
@@ -57,27 +48,6 @@ export function NormalizationCustomControls({
             {/* Loudnorm-specific controls */}
             {value.loudnorm && (
                 <>
-                    {/* Preset */}
-                    <div>
-                        <Label className="text-[10px] text-muted-foreground mb-1 block">Preset</Label>
-                        <Select
-                            value={value.loudnormPreset ?? NONE_SENTINEL}
-                            onValueChange={(val) =>
-                                onChange({ ...value, loudnormPreset: val === NONE_SENTINEL ? null : val })
-                            }
-                        >
-                            <SelectTrigger className="h-6 text-[11px]">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value={NONE_SENTINEL}>Default (Streaming)</SelectItem>
-                                <SelectItem value="streaming">Streaming (-14 LUFS)</SelectItem>
-                                <SelectItem value="broadcast">Broadcast (-23 LUFS)</SelectItem>
-                                <SelectItem value="loud">Loud (-11 LUFS)</SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </div>
-
                     {/* Custom targets */}
                     <div className="grid grid-cols-3 gap-1.5">
                         <div>
@@ -87,11 +57,7 @@ export function NormalizationCustomControls({
                                 step="0.1"
                                 min="-70"
                                 max="0"
-                                placeholder={
-                                    value.loudnormPreset === "broadcast" ? "-23.0"
-                                    : value.loudnormPreset === "loud" ? "-11.0"
-                                    : "-14.0"
-                                }
+                                placeholder="-14.0"
                                 value={value.loudnormTargetI ?? ""}
                                 onChange={(e) =>
                                     onChange({
@@ -109,7 +75,7 @@ export function NormalizationCustomControls({
                                 step="0.1"
                                 min="-9"
                                 max="0"
-                                placeholder={value.loudnormPreset === "broadcast" ? "-2.0" : "-1.0"}
+                                placeholder="-1.0"
                                 value={value.loudnormTargetTp ?? ""}
                                 onChange={(e) =>
                                     onChange({
@@ -127,7 +93,7 @@ export function NormalizationCustomControls({
                                 step="0.1"
                                 min="1"
                                 max="30"
-                                placeholder={value.loudnormPreset === "broadcast" ? "7.0" : "11.0"}
+                                placeholder="11.0"
                                 value={value.loudnormTargetLra ?? ""}
                                 onChange={(e) =>
                                     onChange({

--- a/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
+++ b/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
@@ -22,7 +22,7 @@ export function NormalizationCustomControls({
     idPrefix = "norm",
 }: NormalizationCustomControlsProps) {
     return (
-        <div className="mt-1.5 pl-3 border-l-2 border-border space-y-2 animate-in fade-in-0 slide-in-from-top-1 duration-150">
+        <div className="mt-2 pl-3 border-l-2 border-border space-y-3 animate-in fade-in-0 slide-in-from-top-1 duration-150">
             {/* Mode: Peak vs Loudnorm */}
             <div>
                 <Label className="text-[10px] text-muted-foreground mb-1 block">Mode</Label>
@@ -43,133 +43,177 @@ export function NormalizationCustomControls({
                         EBU R128
                     </ToggleGroupItem>
                 </ToggleGroup>
+                <p className="text-[10px] text-muted-foreground/60 mt-1">
+                    {value.loudnorm
+                        ? "Two-pass loudness normalization (EBU R128)"
+                        : "Normalize peak level to 0 dBFS"}
+                </p>
             </div>
 
             {/* Loudnorm-specific controls */}
             {value.loudnorm && (
-                <>
-                    {/* Custom targets */}
-                    <div className="grid grid-cols-3 gap-1.5">
-                        <div>
-                            <Label className="text-[10px] text-muted-foreground mb-0.5 block">LUFS</Label>
-                            <Input
-                                type="number"
-                                step="0.1"
-                                min="-70"
-                                max="0"
-                                placeholder="-14.0"
-                                value={value.loudnormTargetI ?? ""}
-                                onChange={(e) =>
-                                    onChange({
-                                        ...value,
-                                        loudnormTargetI: e.target.value ? Number(e.target.value) : null,
-                                    })
-                                }
-                                className="h-6 text-[11px] font-mono"
-                            />
+                <div className="space-y-2.5">
+                    {/* Target values */}
+                    <div>
+                        <Label className="text-[10px] text-muted-foreground mb-1 block">Targets</Label>
+                        <div className="grid grid-cols-3 gap-1.5">
+                            <div>
+                                <Label className="text-[10px] text-muted-foreground/60 mb-0.5 block">
+                                    I (LUFS)
+                                </Label>
+                                <Input
+                                    type="number"
+                                    step="0.1"
+                                    min="-70"
+                                    max="0"
+                                    placeholder="-14.0"
+                                    value={value.loudnormTargetI ?? ""}
+                                    onChange={(e) =>
+                                        onChange({
+                                            ...value,
+                                            loudnormTargetI: e.target.value ? Number(e.target.value) : null,
+                                        })
+                                    }
+                                    className="h-6 text-[11px] font-mono"
+                                />
+                            </div>
+                            <div>
+                                <Label className="text-[10px] text-muted-foreground/60 mb-0.5 block">
+                                    TP (dBTP)
+                                </Label>
+                                <Input
+                                    type="number"
+                                    step="0.1"
+                                    min="-9"
+                                    max="0"
+                                    placeholder="-1.0"
+                                    value={value.loudnormTargetTp ?? ""}
+                                    onChange={(e) =>
+                                        onChange({
+                                            ...value,
+                                            loudnormTargetTp: e.target.value ? Number(e.target.value) : null,
+                                        })
+                                    }
+                                    className="h-6 text-[11px] font-mono"
+                                />
+                            </div>
+                            <div>
+                                <Label className="text-[10px] text-muted-foreground/60 mb-0.5 block">
+                                    LRA (LU)
+                                </Label>
+                                <Input
+                                    type="number"
+                                    step="0.1"
+                                    min="1"
+                                    max="30"
+                                    placeholder="11.0"
+                                    value={value.loudnormTargetLra ?? ""}
+                                    onChange={(e) =>
+                                        onChange({
+                                            ...value,
+                                            loudnormTargetLra: e.target.value ? Number(e.target.value) : null,
+                                        })
+                                    }
+                                    className="h-6 text-[11px] font-mono"
+                                />
+                            </div>
                         </div>
-                        <div>
-                            <Label className="text-[10px] text-muted-foreground mb-0.5 block">TP (dB)</Label>
-                            <Input
-                                type="number"
-                                step="0.1"
-                                min="-9"
-                                max="0"
-                                placeholder="-1.0"
-                                value={value.loudnormTargetTp ?? ""}
-                                onChange={(e) =>
-                                    onChange({
-                                        ...value,
-                                        loudnormTargetTp: e.target.value ? Number(e.target.value) : null,
-                                    })
-                                }
-                                className="h-6 text-[11px] font-mono"
-                            />
-                        </div>
-                        <div>
-                            <Label className="text-[10px] text-muted-foreground mb-0.5 block">LRA (LU)</Label>
-                            <Input
-                                type="number"
-                                step="0.1"
-                                min="1"
-                                max="30"
-                                placeholder="11.0"
-                                value={value.loudnormTargetLra ?? ""}
-                                onChange={(e) =>
-                                    onChange({
-                                        ...value,
-                                        loudnormTargetLra: e.target.value ? Number(e.target.value) : null,
-                                    })
-                                }
-                                className="h-6 text-[11px] font-mono"
-                            />
-                        </div>
+                        <p className="text-[10px] text-muted-foreground/60 mt-1">
+                            Leave blank to use defaults
+                        </p>
                     </div>
 
-                    {/* Dynamic mode */}
-                    <div className="flex items-center gap-2">
-                        <Checkbox
-                            id={`${idPrefix}-dynamic`}
-                            checked={value.loudnormDynamic === true}
-                            onCheckedChange={(checked) =>
-                                onChange({ ...value, loudnormDynamic: checked === true })
-                            }
-                        />
-                        <Label htmlFor={`${idPrefix}-dynamic`} className="text-[11px] text-muted-foreground cursor-pointer">
-                            Dynamic mode
-                        </Label>
+                    {/* Processing options */}
+                    <div className="space-y-1.5">
+                        <Label className="text-[10px] text-muted-foreground block">Options</Label>
+                        <div className="flex items-start gap-2">
+                            <Checkbox
+                                id={`${idPrefix}-dynamic`}
+                                checked={value.loudnormDynamic === true}
+                                onCheckedChange={(checked) =>
+                                    onChange({ ...value, loudnormDynamic: checked === true })
+                                }
+                                className="mt-0.5"
+                            />
+                            <div>
+                                <Label htmlFor={`${idPrefix}-dynamic`} className="text-[11px] text-muted-foreground cursor-pointer block">
+                                    Dynamic mode
+                                </Label>
+                                <p className="text-[10px] text-muted-foreground/50">
+                                    Use linear normalization instead of compression
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-start gap-2">
+                            <Checkbox
+                                id={`${idPrefix}-precompress`}
+                                checked={value.loudnormPrecompress === true}
+                                onCheckedChange={(checked) =>
+                                    onChange({ ...value, loudnormPrecompress: checked === true })
+                                }
+                                className="mt-0.5"
+                            />
+                            <div>
+                                <Label htmlFor={`${idPrefix}-precompress`} className="text-[11px] text-muted-foreground cursor-pointer block">
+                                    Precompress
+                                </Label>
+                                <p className="text-[10px] text-muted-foreground/50">
+                                    Apply gentle compression before loudnorm
+                                </p>
+                            </div>
+                        </div>
                     </div>
+                </div>
+            )}
 
-                    {/* Precompress */}
-                    <div className="flex items-center gap-2">
-                        <Checkbox
-                            id={`${idPrefix}-precompress`}
-                            checked={value.loudnormPrecompress === true}
-                            onCheckedChange={(checked) =>
-                                onChange({ ...value, loudnormPrecompress: checked === true })
-                            }
-                        />
-                        <Label htmlFor={`${idPrefix}-precompress`} className="text-[11px] text-muted-foreground cursor-pointer">
-                            Precompress
-                        </Label>
-                    </div>
-                </>
+            {/* Separator between loudnorm options and boost */}
+            {value.loudnorm && (
+                <div className="border-t border-border/50" />
             )}
 
             {/* Boost fallback — always visible in custom mode */}
-            <div className="flex items-center gap-2">
-                <Checkbox
-                    id={`${idPrefix}-boost`}
-                    checked={value.normalizeBoost === true}
-                    onCheckedChange={(checked) =>
-                        onChange({ ...value, normalizeBoost: checked === true })
-                    }
-                />
-                <Label htmlFor={`${idPrefix}-boost`} className="text-[11px] text-muted-foreground cursor-pointer">
-                    Boost fallback
-                </Label>
-            </div>
-
-            {value.normalizeBoost && (
-                <div className="flex items-center gap-2">
-                    <Label className="text-[10px] text-muted-foreground">Gain (dB)</Label>
-                    <Input
-                        type="number"
-                        step="0.5"
-                        min="0"
-                        max="30"
-                        placeholder="12.0"
-                        value={value.normalizeBoostDb ?? ""}
-                        onChange={(e) =>
-                            onChange({
-                                ...value,
-                                normalizeBoostDb: e.target.value ? Number(e.target.value) : null,
-                            })
+            <div className="space-y-1.5">
+                <div className="flex items-start gap-2">
+                    <Checkbox
+                        id={`${idPrefix}-boost`}
+                        checked={value.normalizeBoost === true}
+                        onCheckedChange={(checked) =>
+                            onChange({ ...value, normalizeBoost: checked === true })
                         }
-                        className="w-20 h-6 text-[11px] font-mono"
+                        className="mt-0.5"
                     />
+                    <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                            <Label htmlFor={`${idPrefix}-boost`} className="text-[11px] text-muted-foreground cursor-pointer">
+                                Boost fallback
+                            </Label>
+                            {value.normalizeBoost && (
+                                <div className="flex items-center gap-1">
+                                    <Input
+                                        type="number"
+                                        step="0.5"
+                                        min="0"
+                                        max="30"
+                                        placeholder="12"
+                                        value={value.normalizeBoostDb ?? ""}
+                                        onChange={(e) =>
+                                            onChange({
+                                                ...value,
+                                                normalizeBoostDb: e.target.value ? Number(e.target.value) : null,
+                                            })
+                                        }
+                                        className="w-16 h-5 text-[11px] font-mono"
+                                    />
+                                    <span className="text-[10px] text-muted-foreground/50">dB</span>
+                                </div>
+                            )}
+                        </div>
+                        <p className="text-[10px] text-muted-foreground/50">
+                            Apply +dB gain with limiter if normalization is too quiet
+                        </p>
+                    </div>
                 </div>
-            )}
+            </div>
         </div>
     );
 }

--- a/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
+++ b/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
@@ -36,10 +36,10 @@ export function NormalizationCustomControls({
                     }}
                     className="w-fit"
                 >
-                    <ToggleGroupItem value="peak" size="sm" className="text-[11px] px-2.5 h-6 data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:border-primary/40">
+                    <ToggleGroupItem value="peak" size="sm" className="text-[11px] px-2.5 h-6 data-[state=on]:select-active data-[state=on]:bg-primary/15">
                         Peak
                     </ToggleGroupItem>
-                    <ToggleGroupItem value="loudnorm" size="sm" className="text-[11px] px-2.5 h-6 data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:border-primary/40">
+                    <ToggleGroupItem value="loudnorm" size="sm" className="text-[11px] px-2.5 h-6 data-[state=on]:select-active data-[state=on]:bg-primary/15">
                         EBU R128
                     </ToggleGroupItem>
                 </ToggleGroup>

--- a/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
+++ b/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
@@ -36,10 +36,10 @@ export function NormalizationCustomControls({
                     }}
                     className="w-fit"
                 >
-                    <ToggleGroupItem value="peak" size="sm" className="text-[11px] px-2.5 h-6">
+                    <ToggleGroupItem value="peak" size="sm" className="text-[11px] px-2.5 h-6 data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:border-primary/40">
                         Peak
                     </ToggleGroupItem>
-                    <ToggleGroupItem value="loudnorm" size="sm" className="text-[11px] px-2.5 h-6">
+                    <ToggleGroupItem value="loudnorm" size="sm" className="text-[11px] px-2.5 h-6 data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:border-primary/40">
                         EBU R128
                     </ToggleGroupItem>
                 </ToggleGroup>

--- a/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
+++ b/crates/rdlp-desktop/src/components/NormalizationCustomControls.tsx
@@ -1,0 +1,209 @@
+// Expanded inline controls for custom audio normalization parameters.
+//
+// Used by both FormatOptionsPanel (DownloadPage) and DownloadOptionsPanel (FormatDialog).
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { DownloadOptions } from "../types";
+
+const NONE_SENTINEL = "none";
+
+interface NormalizationCustomControlsProps {
+    value: DownloadOptions;
+    onChange: (next: DownloadOptions) => void;
+    /** Prefix for DOM ids to avoid collisions when multiple instances exist. */
+    idPrefix?: string;
+}
+
+/** Expanded inline controls for custom audio normalization. */
+export function NormalizationCustomControls({
+    value,
+    onChange,
+    idPrefix = "norm",
+}: NormalizationCustomControlsProps) {
+    return (
+        <div className="mt-1.5 pl-3 border-l-2 border-border space-y-2 animate-in fade-in-0 slide-in-from-top-1 duration-150">
+            {/* Mode: Peak vs Loudnorm */}
+            <div>
+                <Label className="text-[10px] text-muted-foreground mb-1 block">Mode</Label>
+                <ToggleGroup
+                    type="single"
+                    variant="outline"
+                    spacing={0}
+                    value={value.loudnorm ? "loudnorm" : "peak"}
+                    onValueChange={(val) => {
+                        if (val) onChange({ ...value, loudnorm: val === "loudnorm" });
+                    }}
+                    className="w-fit"
+                >
+                    <ToggleGroupItem value="peak" size="sm" className="text-[11px] px-2.5 h-6">
+                        Peak
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="loudnorm" size="sm" className="text-[11px] px-2.5 h-6">
+                        EBU R128
+                    </ToggleGroupItem>
+                </ToggleGroup>
+            </div>
+
+            {/* Loudnorm-specific controls */}
+            {value.loudnorm && (
+                <>
+                    {/* Preset */}
+                    <div>
+                        <Label className="text-[10px] text-muted-foreground mb-1 block">Preset</Label>
+                        <Select
+                            value={value.loudnormPreset ?? NONE_SENTINEL}
+                            onValueChange={(val) =>
+                                onChange({ ...value, loudnormPreset: val === NONE_SENTINEL ? null : val })
+                            }
+                        >
+                            <SelectTrigger className="h-6 text-[11px]">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={NONE_SENTINEL}>Default (Streaming)</SelectItem>
+                                <SelectItem value="streaming">Streaming (-14 LUFS)</SelectItem>
+                                <SelectItem value="broadcast">Broadcast (-23 LUFS)</SelectItem>
+                                <SelectItem value="loud">Loud (-11 LUFS)</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Custom targets */}
+                    <div className="grid grid-cols-3 gap-1.5">
+                        <div>
+                            <Label className="text-[10px] text-muted-foreground mb-0.5 block">LUFS</Label>
+                            <Input
+                                type="number"
+                                step="0.1"
+                                min="-70"
+                                max="0"
+                                placeholder={
+                                    value.loudnormPreset === "broadcast" ? "-23.0"
+                                    : value.loudnormPreset === "loud" ? "-11.0"
+                                    : "-14.0"
+                                }
+                                value={value.loudnormTargetI ?? ""}
+                                onChange={(e) =>
+                                    onChange({
+                                        ...value,
+                                        loudnormTargetI: e.target.value ? Number(e.target.value) : null,
+                                    })
+                                }
+                                className="h-6 text-[11px] font-mono"
+                            />
+                        </div>
+                        <div>
+                            <Label className="text-[10px] text-muted-foreground mb-0.5 block">TP (dB)</Label>
+                            <Input
+                                type="number"
+                                step="0.1"
+                                min="-9"
+                                max="0"
+                                placeholder={value.loudnormPreset === "broadcast" ? "-2.0" : "-1.0"}
+                                value={value.loudnormTargetTp ?? ""}
+                                onChange={(e) =>
+                                    onChange({
+                                        ...value,
+                                        loudnormTargetTp: e.target.value ? Number(e.target.value) : null,
+                                    })
+                                }
+                                className="h-6 text-[11px] font-mono"
+                            />
+                        </div>
+                        <div>
+                            <Label className="text-[10px] text-muted-foreground mb-0.5 block">LRA (LU)</Label>
+                            <Input
+                                type="number"
+                                step="0.1"
+                                min="1"
+                                max="30"
+                                placeholder={value.loudnormPreset === "broadcast" ? "7.0" : "11.0"}
+                                value={value.loudnormTargetLra ?? ""}
+                                onChange={(e) =>
+                                    onChange({
+                                        ...value,
+                                        loudnormTargetLra: e.target.value ? Number(e.target.value) : null,
+                                    })
+                                }
+                                className="h-6 text-[11px] font-mono"
+                            />
+                        </div>
+                    </div>
+
+                    {/* Dynamic mode */}
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id={`${idPrefix}-dynamic`}
+                            checked={value.loudnormDynamic === true}
+                            onCheckedChange={(checked) =>
+                                onChange({ ...value, loudnormDynamic: checked === true })
+                            }
+                        />
+                        <Label htmlFor={`${idPrefix}-dynamic`} className="text-[11px] text-muted-foreground cursor-pointer">
+                            Dynamic mode
+                        </Label>
+                    </div>
+
+                    {/* Precompress */}
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id={`${idPrefix}-precompress`}
+                            checked={value.loudnormPrecompress === true}
+                            onCheckedChange={(checked) =>
+                                onChange({ ...value, loudnormPrecompress: checked === true })
+                            }
+                        />
+                        <Label htmlFor={`${idPrefix}-precompress`} className="text-[11px] text-muted-foreground cursor-pointer">
+                            Precompress
+                        </Label>
+                    </div>
+                </>
+            )}
+
+            {/* Boost fallback — always visible in custom mode */}
+            <div className="flex items-center gap-2">
+                <Checkbox
+                    id={`${idPrefix}-boost`}
+                    checked={value.normalizeBoost === true}
+                    onCheckedChange={(checked) =>
+                        onChange({ ...value, normalizeBoost: checked === true })
+                    }
+                />
+                <Label htmlFor={`${idPrefix}-boost`} className="text-[11px] text-muted-foreground cursor-pointer">
+                    Boost fallback
+                </Label>
+            </div>
+
+            {value.normalizeBoost && (
+                <div className="flex items-center gap-2">
+                    <Label className="text-[10px] text-muted-foreground">Gain (dB)</Label>
+                    <Input
+                        type="number"
+                        step="0.5"
+                        min="0"
+                        max="30"
+                        placeholder="12.0"
+                        value={value.normalizeBoostDb ?? ""}
+                        onChange={(e) =>
+                            onChange({
+                                ...value,
+                                normalizeBoostDb: e.target.value ? Number(e.target.value) : null,
+                            })
+                        }
+                        className="w-20 h-6 text-[11px] font-mono"
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
+++ b/crates/rdlp-desktop/src/components/ResultsTableSection.tsx
@@ -113,7 +113,7 @@ export function ResultsTableSection({
                                             key={header.id}
                                             style={{ width: `${(header.getSize() / visibleTotalSize * 100).toFixed(1)}%` }}
                                             className={cn(
-                                                "h-8 px-3 text-[10px] font-bold tracking-wider uppercase select-none transition-colors relative",
+                                                "table-th relative",
                                                 header.column.getCanSort() && "cursor-pointer hover:text-foreground",
                                                 align === "right" && "text-right",
                                                 isSorted ? "text-foreground" : "text-muted-foreground",
@@ -185,9 +185,9 @@ export function ResultsTableSection({
                             </TableRow>
                         )}
                     </TableBody>
-                    <TableFooter className="sticky bottom-0 z-10 bg-card/95 backdrop-blur-sm">
+                    <TableFooter className="table-footer-sticky">
                         <TableRow className="hover:bg-transparent">
-                            <TableCell colSpan={columns.length} className="px-3 py-1.5 text-[10px] text-muted-foreground">
+                            <TableCell colSpan={columns.length} className="table-footer-cell">
                                 {resultCount} result{resultCount !== 1 ? "s" : ""}
                             </TableCell>
                         </TableRow>

--- a/crates/rdlp-desktop/src/components/SearchIdleState.tsx
+++ b/crates/rdlp-desktop/src/components/SearchIdleState.tsx
@@ -72,7 +72,7 @@ export function SearchIdleState({
                     <div className="flex flex-col gap-1">
                         {SHORTCUTS.map((s) => (
                             <div key={s.keys} className="flex items-center gap-2.5 text-xs text-muted-foreground">
-                                <kbd className="inline-block min-w-16 px-1.5 py-0.5 rounded-sm bg-white/[0.04] border border-white/[0.06] font-mono text-[10px] text-muted-foreground text-center">
+                                <kbd className="kbd-chip inline-block min-w-16 text-center">
                                     {s.keys}
                                 </kbd>
                                 <span>{s.desc}</span>

--- a/crates/rdlp-desktop/src/components/SidebarDownloads.tsx
+++ b/crates/rdlp-desktop/src/components/SidebarDownloads.tsx
@@ -39,7 +39,7 @@ export function SidebarDownloads({ onSwitchToQueue }: SidebarDownloadsProps) {
         >
             <CollapsibleTrigger asChild>
                 <button
-                    className="sidebar-section-btn hover:bg-white/[0.04]"
+                    className="sidebar-section-btn"
                     aria-expanded={!collapsed}
                 >
                     <ChevronDown

--- a/crates/rdlp-desktop/src/components/SidebarDownloads.tsx
+++ b/crates/rdlp-desktop/src/components/SidebarDownloads.tsx
@@ -39,7 +39,7 @@ export function SidebarDownloads({ onSwitchToQueue }: SidebarDownloadsProps) {
         >
             <CollapsibleTrigger asChild>
                 <button
-                    className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:bg-white/[0.04] transition-colors"
+                    className="sidebar-section-btn hover:bg-white/[0.04]"
                     aria-expanded={!collapsed}
                 >
                     <ChevronDown

--- a/crates/rdlp-desktop/src/components/SidebarHistory.tsx
+++ b/crates/rdlp-desktop/src/components/SidebarHistory.tsx
@@ -26,7 +26,7 @@ export function SidebarHistory({ onRestoreSearch }: SidebarHistoryProps) {
         >
             <CollapsibleTrigger asChild>
                 <button
-                    className="sidebar-section-btn hover:bg-white/[0.04]"
+                    className="sidebar-section-btn"
                     aria-expanded={!collapsed}
                 >
                     <ChevronDown

--- a/crates/rdlp-desktop/src/components/SidebarHistory.tsx
+++ b/crates/rdlp-desktop/src/components/SidebarHistory.tsx
@@ -26,7 +26,7 @@ export function SidebarHistory({ onRestoreSearch }: SidebarHistoryProps) {
         >
             <CollapsibleTrigger asChild>
                 <button
-                    className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:bg-white/[0.04] transition-colors"
+                    className="sidebar-section-btn hover:bg-white/[0.04]"
                     aria-expanded={!collapsed}
                 >
                     <ChevronDown

--- a/crates/rdlp-desktop/src/components/utils/normalization.ts
+++ b/crates/rdlp-desktop/src/components/utils/normalization.ts
@@ -1,0 +1,106 @@
+// Shared normalization helpers for the format options panels.
+
+import type { DownloadOptions } from "../../types";
+
+/** Check whether any custom normalization parameters are set beyond a standard preset. */
+export function isCustomNormalization(opts: DownloadOptions): boolean {
+    if (!opts.normalizeAudio) return false;
+    return (
+        opts.loudnormTargetI !== null ||
+        opts.loudnormTargetTp !== null ||
+        opts.loudnormTargetLra !== null ||
+        opts.loudnormDynamic === true ||
+        opts.loudnormPrecompress === true ||
+        opts.normalizeBoost === true
+    );
+}
+
+/** Compute the Select value string for the normalization dropdown. */
+export function getNormSelectValue(opts: DownloadOptions): string {
+    if (isCustomNormalization(opts)) return "custom";
+    if (opts.normalizeAudio === null) return "default";
+    if (!opts.normalizeAudio) return "off";
+    if (!opts.loudnorm) return "peak";
+    if (opts.loudnormPreset === "broadcast") return "loudnorm-broadcast";
+    if (opts.loudnormPreset === "loud") return "loudnorm-loud";
+    if (
+        opts.loudnormPreset === "streaming" ||
+        opts.loudnormPreset === null
+    )
+        return "loudnorm-streaming";
+    return "default";
+}
+
+/** Handle normalization Select value changes, returning the updated options. */
+export function handleNormSelectChange(
+    current: DownloadOptions,
+    val: string,
+): DownloadOptions {
+    if (val === "default") {
+        return {
+            ...current,
+            normalizeAudio: null,
+            loudnorm: null,
+            loudnormPreset: null,
+            loudnormTargetI: null,
+            loudnormTargetTp: null,
+            loudnormTargetLra: null,
+            loudnormDynamic: null,
+            loudnormPrecompress: null,
+            normalizeBoost: null,
+            normalizeBoostDb: null,
+        };
+    }
+    if (val === "off") {
+        return {
+            ...current,
+            normalizeAudio: false,
+            loudnorm: false,
+            loudnormPreset: null,
+            loudnormTargetI: null,
+            loudnormTargetTp: null,
+            loudnormTargetLra: null,
+            loudnormDynamic: false,
+            loudnormPrecompress: false,
+            normalizeBoost: false,
+            normalizeBoostDb: null,
+        };
+    }
+    if (val === "peak") {
+        return {
+            ...current,
+            normalizeAudio: true,
+            loudnorm: false,
+            loudnormPreset: null,
+            loudnormTargetI: null,
+            loudnormTargetTp: null,
+            loudnormTargetLra: null,
+            loudnormDynamic: null,
+            loudnormPrecompress: null,
+            normalizeBoost: null,
+            normalizeBoostDb: null,
+        };
+    }
+    if (val === "custom") {
+        return {
+            ...current,
+            normalizeAudio: true,
+            loudnorm: current.loudnorm ?? true,
+        };
+    }
+    // Standard loudnorm preset — clear custom overrides
+    const preset = val.replace("loudnorm-", "");
+    return {
+        ...current,
+        normalizeAudio: true,
+        loudnorm: true,
+        loudnormPreset: preset,
+        loudnormTargetI: null,
+        loudnormTargetTp: null,
+        loudnormTargetLra: null,
+        loudnormDynamic: null,
+        loudnormPrecompress: null,
+        normalizeBoost: null,
+        normalizeBoostDb: null,
+    };
+}

--- a/crates/rdlp-desktop/src/components/utils/normalization.ts
+++ b/crates/rdlp-desktop/src/components/utils/normalization.ts
@@ -6,6 +6,7 @@ import type { DownloadOptions } from "../../types";
 export function isCustomNormalization(opts: DownloadOptions): boolean {
     if (!opts.normalizeAudio) return false;
     return (
+        opts.loudnormPreset === "custom" ||
         opts.loudnormTargetI !== null ||
         opts.loudnormTargetTp !== null ||
         opts.loudnormTargetLra !== null ||
@@ -86,6 +87,7 @@ export function handleNormSelectChange(
             ...current,
             normalizeAudio: true,
             loudnorm: current.loudnorm ?? true,
+            loudnormPreset: "custom",
         };
     }
     // Standard loudnorm preset — clear custom overrides

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -149,4 +149,30 @@ describe("optionsSummary", () => {
         const result = optionsSummary(makeOptions({ remux: "mkv", embedThumbnail: true }));
         expect(result).toContain("\u00b7");
     });
+
+    test("includes 'Peak normalize' when normalizeAudio is true and loudnorm is false", () => {
+        const result = optionsSummary(makeOptions({ normalizeAudio: true, loudnorm: false }));
+        expect(result).toContain("Peak normalize");
+    });
+
+    test("includes 'Loudnorm (streaming)' when loudnorm is enabled with streaming preset", () => {
+        const result = optionsSummary(makeOptions({ normalizeAudio: true, loudnorm: true, loudnormPreset: "streaming" }));
+        expect(result).toContain("Loudnorm (streaming)");
+    });
+
+    test("includes 'Loudnorm (broadcast)' when loudnorm is enabled with broadcast preset", () => {
+        const result = optionsSummary(makeOptions({ normalizeAudio: true, loudnorm: true, loudnormPreset: "broadcast" }));
+        expect(result).toContain("Loudnorm (broadcast)");
+    });
+
+    test("defaults to 'Loudnorm (streaming)' when loudnorm preset is null", () => {
+        const result = optionsSummary(makeOptions({ normalizeAudio: true, loudnorm: true, loudnormPreset: null }));
+        expect(result).toContain("Loudnorm (streaming)");
+    });
+
+    test("does not include normalization when normalizeAudio is null", () => {
+        const result = optionsSummary(makeOptions({ normalizeAudio: null }));
+        expect(result).not.toContain("normalize");
+        expect(result).not.toContain("Loudnorm");
+    });
 });

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -44,6 +44,16 @@ function makeOptions(overrides: Partial<DownloadOptions> = {}): DownloadOptions 
         embedThumbnail: false,
         audioMultistreams: false,
         recodeVideo: null,
+        normalizeAudio: null,
+        loudnorm: null,
+        loudnormPreset: null,
+        loudnormTargetI: null,
+        loudnormTargetTp: null,
+        loudnormTargetLra: null,
+        loudnormDynamic: null,
+        loudnormPrecompress: null,
+        normalizeBoost: null,
+        normalizeBoostDb: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -4,6 +4,11 @@ import { describe, test, expect } from "vitest";
 import type { Row } from "@tanstack/react-table";
 import type { FormatInfo, DownloadOptions } from "../../types";
 import { groupRows, optionsSummary } from "./tableHelpers";
+import {
+    isCustomNormalization,
+    getNormSelectValue,
+    handleNormSelectChange,
+} from "./normalization";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -174,5 +179,248 @@ describe("optionsSummary", () => {
         const result = optionsSummary(makeOptions({ normalizeAudio: null }));
         expect(result).not.toContain("normalize");
         expect(result).not.toContain("Loudnorm");
+    });
+
+    test("includes 'Custom normalize' when custom target fields are set", () => {
+        const result = optionsSummary(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "streaming",
+            loudnormTargetI: -16,
+        }));
+        expect(result).toContain("Custom normalize");
+    });
+
+    test("includes 'Custom normalize' when dynamic mode is enabled", () => {
+        const result = optionsSummary(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormDynamic: true,
+        }));
+        expect(result).toContain("Custom normalize");
+    });
+
+    test("includes 'Custom normalize' when boost is enabled", () => {
+        const result = optionsSummary(makeOptions({
+            normalizeAudio: true,
+            loudnorm: false,
+            normalizeBoost: true,
+        }));
+        expect(result).toContain("Custom normalize");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// isCustomNormalization
+// ---------------------------------------------------------------------------
+
+describe("isCustomNormalization", () => {
+    test("returns false when normalizeAudio is null", () => {
+        expect(isCustomNormalization(makeOptions())).toBe(false);
+    });
+
+    test("returns false when normalizeAudio is false", () => {
+        expect(isCustomNormalization(makeOptions({ normalizeAudio: false }))).toBe(false);
+    });
+
+    test("returns false for standard peak mode", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: false,
+        }))).toBe(false);
+    });
+
+    test("returns false for standard loudnorm preset", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "streaming",
+        }))).toBe(false);
+    });
+
+    test("returns true when loudnormTargetI is set", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormTargetI: -16,
+        }))).toBe(true);
+    });
+
+    test("returns true when loudnormTargetTp is set", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormTargetTp: -2,
+        }))).toBe(true);
+    });
+
+    test("returns true when loudnormTargetLra is set", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormTargetLra: 9,
+        }))).toBe(true);
+    });
+
+    test("returns true when loudnormDynamic is true", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormDynamic: true,
+        }))).toBe(true);
+    });
+
+    test("returns true when loudnormPrecompress is true", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPrecompress: true,
+        }))).toBe(true);
+    });
+
+    test("returns true when normalizeBoost is true", () => {
+        expect(isCustomNormalization(makeOptions({
+            normalizeAudio: true,
+            normalizeBoost: true,
+        }))).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getNormSelectValue
+// ---------------------------------------------------------------------------
+
+describe("getNormSelectValue", () => {
+    test("returns 'default' for null normalizeAudio", () => {
+        expect(getNormSelectValue(makeOptions())).toBe("default");
+    });
+
+    test("returns 'off' when normalizeAudio is false", () => {
+        expect(getNormSelectValue(makeOptions({ normalizeAudio: false }))).toBe("off");
+    });
+
+    test("returns 'peak' when normalizeAudio is true and loudnorm is false", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: false,
+        }))).toBe("peak");
+    });
+
+    test("returns 'loudnorm-streaming' for streaming preset", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "streaming",
+        }))).toBe("loudnorm-streaming");
+    });
+
+    test("returns 'loudnorm-streaming' when preset is null", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: null,
+        }))).toBe("loudnorm-streaming");
+    });
+
+    test("returns 'loudnorm-broadcast' for broadcast preset", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "broadcast",
+        }))).toBe("loudnorm-broadcast");
+    });
+
+    test("returns 'loudnorm-loud' for loud preset", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "loud",
+        }))).toBe("loudnorm-loud");
+    });
+
+    test("returns 'custom' when custom target fields are set", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormTargetI: -16,
+        }))).toBe("custom");
+    });
+
+    test("returns 'custom' when boost is enabled", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: false,
+            normalizeBoost: true,
+        }))).toBe("custom");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// handleNormSelectChange
+// ---------------------------------------------------------------------------
+
+describe("handleNormSelectChange", () => {
+    test("'default' clears all normalization fields to null", () => {
+        const result = handleNormSelectChange(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "streaming",
+            loudnormTargetI: -16,
+        }), "default");
+        expect(result.normalizeAudio).toBeNull();
+        expect(result.loudnorm).toBeNull();
+        expect(result.loudnormPreset).toBeNull();
+        expect(result.loudnormTargetI).toBeNull();
+        expect(result.normalizeBoost).toBeNull();
+    });
+
+    test("'off' sets normalizeAudio to false and clears fields", () => {
+        const result = handleNormSelectChange(makeOptions(), "off");
+        expect(result.normalizeAudio).toBe(false);
+        expect(result.loudnorm).toBe(false);
+        expect(result.loudnormDynamic).toBe(false);
+        expect(result.normalizeBoost).toBe(false);
+    });
+
+    test("'peak' clears custom fields", () => {
+        const result = handleNormSelectChange(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormTargetI: -16,
+            normalizeBoost: true,
+        }), "peak");
+        expect(result.normalizeAudio).toBe(true);
+        expect(result.loudnorm).toBe(false);
+        expect(result.loudnormTargetI).toBeNull();
+        expect(result.normalizeBoost).toBeNull();
+    });
+
+    test("'custom' enables normalization and keeps existing values", () => {
+        const opts = makeOptions({
+            normalizeAudio: false,
+            loudnorm: false,
+            loudnormPreset: "broadcast",
+        });
+        const result = handleNormSelectChange(opts, "custom");
+        expect(result.normalizeAudio).toBe(true);
+        expect(result.loudnormPreset).toBe("broadcast");
+    });
+
+    test("loudnorm preset clears custom overrides", () => {
+        const result = handleNormSelectChange(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormTargetI: -16,
+            loudnormDynamic: true,
+            normalizeBoost: true,
+            normalizeBoostDb: 8,
+        }), "loudnorm-broadcast");
+        expect(result.normalizeAudio).toBe(true);
+        expect(result.loudnorm).toBe(true);
+        expect(result.loudnormPreset).toBe("broadcast");
+        expect(result.loudnormTargetI).toBeNull();
+        expect(result.loudnormDynamic).toBeNull();
+        expect(result.normalizeBoost).toBeNull();
+        expect(result.normalizeBoostDb).toBeNull();
     });
 });

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -338,6 +338,14 @@ describe("getNormSelectValue", () => {
         }))).toBe("loudnorm-loud");
     });
 
+    test("returns 'custom' when loudnormPreset is 'custom' (no custom fields yet)", () => {
+        expect(getNormSelectValue(makeOptions({
+            normalizeAudio: true,
+            loudnorm: true,
+            loudnormPreset: "custom",
+        }))).toBe("custom");
+    });
+
     test("returns 'custom' when custom target fields are set", () => {
         expect(getNormSelectValue(makeOptions({
             normalizeAudio: true,
@@ -395,7 +403,7 @@ describe("handleNormSelectChange", () => {
         expect(result.normalizeBoost).toBeNull();
     });
 
-    test("'custom' enables normalization and keeps existing values", () => {
+    test("'custom' enables normalization and sets preset to 'custom'", () => {
         const opts = makeOptions({
             normalizeAudio: false,
             loudnorm: false,
@@ -403,7 +411,7 @@ describe("handleNormSelectChange", () => {
         });
         const result = handleNormSelectChange(opts, "custom");
         expect(result.normalizeAudio).toBe(true);
-        expect(result.loudnormPreset).toBe("broadcast");
+        expect(result.loudnormPreset).toBe("custom");
     });
 
     test("loudnorm preset clears custom overrides", () => {

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.ts
@@ -32,5 +32,13 @@ export function optionsSummary(opts: DownloadOptions): string {
     if (opts.subtitles && opts.subtitleLangs.length > 0)
         parts.push(`Subs: ${opts.subtitleLangs.join(", ")}`);
     if (opts.embedThumbnail) parts.push("Thumbnail");
+    if (opts.normalizeAudio === true) {
+        if (opts.loudnorm) {
+            const preset = opts.loudnormPreset ?? "streaming";
+            parts.push(`Loudnorm (${preset})`);
+        } else {
+            parts.push("Peak normalize");
+        }
+    }
     return parts.length > 0 ? parts.join(" \u00b7 ") : "Default settings";
 }

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.ts
@@ -3,6 +3,7 @@
 import type { Row } from "@tanstack/react-table";
 import type { DownloadOptions, FormatInfo } from "../../types";
 import type { FormatGroup } from "../FormatGroupSection";
+import { isCustomNormalization } from "./normalization";
 
 /** Group sorted TanStack rows into Video+Audio, Video Only, Audio Only sections. */
 export function groupRows(rows: Row<FormatInfo>[]): FormatGroup[] {
@@ -33,7 +34,9 @@ export function optionsSummary(opts: DownloadOptions): string {
         parts.push(`Subs: ${opts.subtitleLangs.join(", ")}`);
     if (opts.embedThumbnail) parts.push("Thumbnail");
     if (opts.normalizeAudio === true) {
-        if (opts.loudnorm) {
+        if (isCustomNormalization(opts)) {
+            parts.push("Custom normalize");
+        } else if (opts.loudnorm) {
             const preset = opts.loudnormPreset ?? "streaming";
             parts.push(`Loudnorm (${preset})`);
         } else {

--- a/crates/rdlp-desktop/src/index.css
+++ b/crates/rdlp-desktop/src/index.css
@@ -121,6 +121,12 @@
     background: hsl(220 5% 20%);
 }
 
+/* Active-state styling for Select triggers and toggle items. */
+@utility select-active {
+    border-color: oklch(from var(--color-primary) l c h / 0.4);
+    color: var(--color-primary);
+}
+
 @keyframes loading-sweep {
     0% { transform: translateX(-100%); }
     100% { transform: translateX(350%); }

--- a/crates/rdlp-desktop/src/index.css
+++ b/crates/rdlp-desktop/src/index.css
@@ -170,6 +170,10 @@
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms;
 }
+.settings-toggle-row:hover {
+    border-color: rgb(255 255 255 / 0.08);
+    background-color: var(--color-muted);
+}
 
 /* Sidebar collapsible section trigger button. */
 @utility sidebar-section-btn {
@@ -187,6 +191,9 @@
     transition-property: color, background-color;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms;
+}
+.sidebar-section-btn:hover {
+    background-color: rgb(255 255 255 / 0.04);
 }
 
 /* Keyboard shortcut chip. */

--- a/crates/rdlp-desktop/src/index.css
+++ b/crates/rdlp-desktop/src/index.css
@@ -127,6 +127,110 @@
     color: var(--color-primary);
 }
 
+/* Section heading with bottom border and uppercase tracking. */
+@utility section-heading {
+    margin-bottom: 0.625rem;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.375rem;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-muted-foreground);
+}
+
+/* Compact label for format/download option panels. */
+@utility options-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-muted-foreground);
+    letter-spacing: 0.025em;
+}
+
+/* Settings page field label. */
+@utility settings-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-foreground);
+    margin-bottom: 0.375rem;
+    display: block;
+}
+
+/* Settings page checkbox card row. */
+@utility settings-toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.625rem 0.75rem;
+    background-color: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition-property: color, background-color, border-color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+}
+
+/* Sidebar collapsible section trigger button. */
+@utility sidebar-section-btn {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: 0.375rem;
+    border-radius: var(--radius-md);
+    padding: 0.375rem 0.5rem;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted-foreground);
+    transition-property: color, background-color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+}
+
+/* Keyboard shortcut chip. */
+@utility kbd-chip {
+    padding: 0.125rem 0.375rem;
+    border-radius: var(--radius-sm);
+    background-color: rgb(255 255 255 / 0.04);
+    border: 1px solid rgb(255 255 255 / 0.06);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-muted-foreground);
+}
+
+/* Table header cell base styling. */
+@utility table-th {
+    height: 2rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    user-select: none;
+    transition-property: color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+}
+
+/* Sticky table footer with blur. */
+@utility table-footer-sticky {
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    background-color: oklch(from var(--color-card) l c h / 0.95);
+    backdrop-filter: blur(4px);
+}
+
+/* Table footer count cell. */
+@utility table-footer-cell {
+    padding: 0.375rem 0.75rem;
+    font-size: 10px;
+    color: var(--color-muted-foreground);
+}
+
 @keyframes loading-sweep {
     0% { transform: translateX(-100%); }
     100% { transform: translateX(350%); }

--- a/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
@@ -14,6 +14,16 @@ const defaultSettings: AppSettings = {
     embed_metadata: true,
     verbose: false,
     default_search_provider: null,
+    normalize_audio: false,
+    loudnorm: false,
+    loudnorm_preset: null,
+    loudnorm_target_i: null,
+    loudnorm_target_tp: null,
+    loudnorm_target_lra: null,
+    loudnorm_dynamic: false,
+    loudnorm_precompress: false,
+    normalize_boost: false,
+    normalize_boost_db: null,
 };
 
 beforeEach(() => {

--- a/crates/rdlp-desktop/src/pages/DownloadPage.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.tsx
@@ -175,11 +175,7 @@ export function DownloadPage() {
             {/* Recent downloads */}
             {recentJobs.length > 0 && (
                 <section className="mt-6">
-                    <h3
-                        className="mb-2.5 border-b border-border pb-1.5
-                            text-[11px] font-bold uppercase tracking-widest
-                            text-muted-foreground"
-                    >
+                    <h3 className="section-heading">
                         Recent Downloads
                     </h3>
                     <div className="space-y-2">

--- a/crates/rdlp-desktop/src/pages/QueuePage.tsx
+++ b/crates/rdlp-desktop/src/pages/QueuePage.tsx
@@ -62,11 +62,7 @@ export function QueuePage() {
         <div className="max-w-3xl">
             {activeJobs.length > 0 && (
                 <section className="mb-6">
-                    <h3
-                        className="mb-2.5 border-b border-border pb-1.5
-                            text-[11px] font-bold uppercase tracking-widest
-                            text-muted-foreground"
-                    >
+                    <h3 className="section-heading">
                         Active ({activeJobs.length})
                     </h3>
                     <div className="space-y-2">
@@ -85,11 +81,7 @@ export function QueuePage() {
 
             {completedJobs.length > 0 && (
                 <section className="mb-6">
-                    <h3
-                        className="mb-2.5 border-b border-border pb-1.5
-                            text-[11px] font-bold uppercase tracking-widest
-                            text-muted-foreground"
-                    >
+                    <h3 className="section-heading">
                         History ({completedJobs.length})
                     </h3>
                     <div className="space-y-2">

--- a/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
@@ -14,6 +14,16 @@ const defaultSettings: AppSettings = {
     embed_metadata: true,
     verbose: false,
     default_search_provider: null,
+    normalize_audio: false,
+    loudnorm: false,
+    loudnorm_preset: null,
+    loudnorm_target_i: null,
+    loudnorm_target_tp: null,
+    loudnorm_target_lra: null,
+    loudnorm_dynamic: false,
+    loudnorm_precompress: false,
+    normalize_boost: false,
+    normalize_boost_db: null,
 };
 
 beforeEach(() => {

--- a/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
@@ -121,4 +121,51 @@ describe("SettingsPage", () => {
             expect(screen.getByRole("button", { name: /browse/i })).toBeInTheDocument();
         });
     });
+
+    it("shows normalize audio checkbox unchecked by default", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByText(/normalize audio/i));
+        const label = screen.getByText(/normalize audio/i);
+        const checkbox = label.closest("div")?.querySelector('button[role="checkbox"]');
+        expect(checkbox).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("reveals mode toggle and boost fallback when normalize audio is checked", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByText(/normalize audio/i));
+        // Click the checkbox button directly to avoid double-fire from label+div onClick
+        const normalizeLabel = screen.getByText(/normalize audio/i);
+        const checkbox = normalizeLabel.closest("div")?.querySelector('button[role="checkbox"]');
+        await userEvent.click(checkbox!);
+        await waitFor(() => {
+            expect(screen.getByText(/ebu r128 loudnorm/i)).toBeInTheDocument();
+        });
+        expect(screen.getByText(/boost fallback/i)).toBeInTheDocument();
+    });
+
+    it("reveals preset select and advanced options when loudnorm mode is active", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            loudnorm: true,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByText(/dynamic mode/i));
+        expect(screen.getByText(/dynamic mode/i)).toBeInTheDocument();
+        expect(screen.getByText(/precompress/i)).toBeInTheDocument();
+        // Preset label is present (using heading role to disambiguate from select items)
+        expect(screen.getByText("Preset")).toBeInTheDocument();
+    });
+
+    it("reveals boost gain input when boost fallback is checked", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            loudnorm: true,
+            normalize_boost: true,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByPlaceholderText("12.0"));
+        expect(screen.getByPlaceholderText("12.0")).toBeInTheDocument();
+    });
 });

--- a/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
@@ -168,4 +168,148 @@ describe("SettingsPage", () => {
         await waitFor(() => screen.getByPlaceholderText("12.0"));
         expect(screen.getByPlaceholderText("12.0")).toBeInTheDocument();
     });
+
+    // -----------------------------------------------------------------------
+    // A. Range validation errors on save
+    // -----------------------------------------------------------------------
+
+    it("shows error when loudnorm_target_i is out of range (above 0)", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            loudnorm: true,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByLabelText(/loudness target/i));
+
+        // Enter an out-of-range value: 5 is > 0, valid range is -70..0
+        const input = screen.getByLabelText(/loudness target/i);
+        await userEvent.clear(input);
+        await userEvent.type(input, "5");
+
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+        await waitFor(() => {
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+        });
+        expect(screen.getByRole("alert")).toHaveTextContent(/loudness target/i);
+    });
+
+    it("shows error when loudnorm_target_tp is out of range (above 0)", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            loudnorm: true,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByLabelText(/true peak limit/i));
+
+        // Enter 1.0 — above the 0 maximum for true peak limit
+        const input = screen.getByLabelText(/true peak limit/i);
+        await userEvent.clear(input);
+        await userEvent.type(input, "1");
+
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+        await waitFor(() => {
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+        });
+        expect(screen.getByRole("alert")).toHaveTextContent(/true peak/i);
+    });
+
+    it("shows error when normalize_boost_db is out of range (above 30)", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            normalize_boost: true,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByPlaceholderText("12.0"));
+
+        // Enter 50 — above the 30 maximum for boost gain
+        const input = screen.getByPlaceholderText("12.0");
+        await userEvent.clear(input);
+        await userEvent.type(input, "50");
+
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+        await waitFor(() => {
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+        });
+        expect(screen.getByRole("alert")).toHaveTextContent(/boost gain/i);
+    });
+
+    // -----------------------------------------------------------------------
+    // B. Save payload with normalization settings
+    // -----------------------------------------------------------------------
+
+    it("calls update_settings with correct normalization payload for loudnorm broadcast preset", async () => {
+        const updateHandler = vi.fn((_args?: Record<string, unknown>) => undefined);
+        setInvokeHandler("update_settings", updateHandler);
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            loudnorm: true,
+            loudnorm_preset: "broadcast",
+        }));
+
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+
+        expect(updateHandler).toHaveBeenCalledTimes(1);
+        // updateSettings calls invoke("update_settings", { settings }) so the mock
+        // handler receives { settings: AppSettings } as its first argument.
+        const args = updateHandler.mock.calls[0][0] as { settings: AppSettings };
+        expect(args.settings.normalize_audio).toBe(true);
+        expect(args.settings.loudnorm).toBe(true);
+        expect(args.settings.loudnorm_preset).toBe("broadcast");
+    });
+
+    it("calls update_settings with normalize_audio false when unchecked", async () => {
+        const updateHandler = vi.fn((_args?: Record<string, unknown>) => undefined);
+        setInvokeHandler("update_settings", updateHandler);
+
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
+
+        expect(updateHandler).toHaveBeenCalledTimes(1);
+        const args = updateHandler.mock.calls[0][0] as { settings: AppSettings };
+        expect(args.settings.normalize_audio).toBe(false);
+    });
+
+    // -----------------------------------------------------------------------
+    // C. Visibility cascading
+    // -----------------------------------------------------------------------
+
+    it("loudnorm mode toggle not visible when normalize_audio is unchecked", async () => {
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByRole("heading", { name: /settings/i }));
+        // normalize_audio is false in defaultSettings, so loudnorm toggle should be hidden
+        expect(screen.queryByText(/ebu r128 loudnorm/i)).not.toBeInTheDocument();
+    });
+
+    it("preset select and custom targets not visible when normalize_audio is checked but mode is Peak", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            loudnorm: false,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByText(/ebu r128 loudnorm/i));
+        // Peak mode: loudnorm-specific options should not appear
+        expect(screen.queryByText(/dynamic mode/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/precompress/i)).not.toBeInTheDocument();
+        expect(screen.queryByText("Preset")).not.toBeInTheDocument();
+    });
+
+    it("boost dB input not visible when boost fallback is unchecked", async () => {
+        setInvokeHandler("get_settings", () => ({
+            ...defaultSettings,
+            normalize_audio: true,
+            normalize_boost: false,
+        }));
+        render(<SettingsPage />);
+        await waitFor(() => screen.getByText(/boost fallback/i));
+        // normalize_boost is false → boost gain input should not appear
+        expect(screen.queryByPlaceholderText("12.0")).not.toBeInTheDocument();
+    });
 });

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { settingsQueryOptions, updateSettings, pickDirectory } from "../api/settings";
@@ -115,7 +116,7 @@ export function SettingsPage() {
                         })
                     }
                 >
-                    <SelectTrigger className="w-full text-sm">
+                    <SelectTrigger className={cn("w-full text-sm", draft.default_remux && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -139,7 +140,7 @@ export function SettingsPage() {
                         })
                     }
                 >
-                    <SelectTrigger className="w-full text-sm">
+                    <SelectTrigger className={cn("w-full text-sm", draft.default_extract_audio && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -164,7 +165,7 @@ export function SettingsPage() {
                         })
                     }
                 >
-                    <SelectTrigger className="w-full text-sm">
+                    <SelectTrigger className={cn("w-full text-sm", draft.default_subtitle_format && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -206,7 +207,7 @@ export function SettingsPage() {
                         })
                     }
                 >
-                    <SelectTrigger className="w-full text-sm">
+                    <SelectTrigger className={cn("w-full text-sm", draft.default_search_provider && "select-active")}>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -300,13 +301,13 @@ export function SettingsPage() {
                                 aria-labelledby="normalize-mode-label"
                                 className="w-fit"
                             >
-                                <ToggleGroupItem value="peak" size="sm" className="text-xs px-3">
+                                <ToggleGroupItem value="peak" size="sm" className="text-xs px-3 data-[state=on]:select-active data-[state=on]:bg-primary/15">
                                     Peak
                                 </ToggleGroupItem>
                                 <Tooltip>
                                     <TooltipTrigger asChild>
                                         <span>
-                                            <ToggleGroupItem value="loudnorm" size="sm" className="text-xs px-3">
+                                            <ToggleGroupItem value="loudnorm" size="sm" className="text-xs px-3 data-[state=on]:select-active data-[state=on]:bg-primary/15">
                                                 EBU R128 Loudnorm
                                             </ToggleGroupItem>
                                         </span>
@@ -339,7 +340,7 @@ export function SettingsPage() {
                                         })
                                     }
                                 >
-                                    <SelectTrigger id="loudnorm-preset" className="w-full text-sm">
+                                    <SelectTrigger id="loudnorm-preset" className={cn("w-full text-sm", draft.loudnorm_preset && "select-active")}>
                                         <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -97,7 +97,7 @@ export function SettingsPage() {
             <h2 className="text-lg font-bold mb-4 text-foreground">Settings</h2>
 
             <div className="mb-4">
-                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Output Directory</Label>
+                <Label className="settings-label">Output Directory</Label>
                 <div className="flex gap-1.5">
                     <Input type="text" value={draft.output_dir} readOnly className="flex-1 font-mono text-xs" />
                     <Button variant="outline" onClick={handlePickDir}>Browse</Button>
@@ -105,7 +105,7 @@ export function SettingsPage() {
             </div>
 
             <div className="mb-4">
-                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Remux Format</Label>
+                <Label className="settings-label">Default Remux Format</Label>
                 <Select
                     value={draft.default_remux ?? NONE_SENTINEL}
                     onValueChange={(val) =>
@@ -129,7 +129,7 @@ export function SettingsPage() {
             </div>
 
             <div className="mb-4">
-                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Audio Extraction</Label>
+                <Label className="settings-label">Default Audio Extraction</Label>
                 <Select
                     value={draft.default_extract_audio ?? NONE_SENTINEL}
                     onValueChange={(val) =>
@@ -154,7 +154,7 @@ export function SettingsPage() {
             </div>
 
             <div className="mb-4">
-                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Subtitle Format</Label>
+                <Label className="settings-label">Default Subtitle Format</Label>
                 <Select
                     value={draft.default_subtitle_format ?? NONE_SENTINEL}
                     onValueChange={(val) =>
@@ -178,7 +178,7 @@ export function SettingsPage() {
             </div>
 
             <div className="mb-4">
-                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Subtitle Languages</Label>
+                <Label className="settings-label">Default Subtitle Languages</Label>
                 <Input
                     type="text"
                     placeholder="en,sv,ja"
@@ -196,7 +196,7 @@ export function SettingsPage() {
             </div>
 
             <div className="mb-4">
-                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">Default Search Provider</Label>
+                <Label className="settings-label">Default Search Provider</Label>
                 <Select
                     value={draft.default_search_provider ?? NONE_SENTINEL}
                     onValueChange={(val) =>
@@ -222,7 +222,7 @@ export function SettingsPage() {
             </div>
 
             <div
-                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors mb-4"
+                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-4"
                 onClick={() => setDraft({ ...draft, embed_thumbnail: !draft.embed_thumbnail })}
             >
                 <Checkbox
@@ -235,7 +235,7 @@ export function SettingsPage() {
             </div>
 
             <div
-                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors mb-4"
+                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-4"
                 onClick={() => setDraft({ ...draft, embed_metadata: !draft.embed_metadata })}
             >
                 <Checkbox
@@ -248,7 +248,7 @@ export function SettingsPage() {
             </div>
 
             <div
-                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors mb-4"
+                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-4"
                 onClick={() => setDraft({ ...draft, verbose: !draft.verbose })}
             >
                 <Checkbox
@@ -266,7 +266,7 @@ export function SettingsPage() {
             <h3 className="text-sm font-bold text-foreground mb-3">Audio Normalization</h3>
 
             <div
-                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors mb-3"
+                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-3"
                 onClick={() => setDraft({ ...draft, normalize_audio: !draft.normalize_audio })}
             >
                 <Checkbox
@@ -285,7 +285,7 @@ export function SettingsPage() {
                     <div>
                         <Label
                             id="normalize-mode-label"
-                            className="text-[13px] font-semibold text-foreground mb-1.5 block"
+                            className="settings-label"
                         >
                             Mode
                         </Label>
@@ -327,7 +327,7 @@ export function SettingsPage() {
                             <div>
                                 <Label
                                     htmlFor="loudnorm-preset"
-                                    className="text-[13px] font-semibold text-foreground mb-1.5 block"
+                                    className="settings-label"
                                 >
                                     Preset
                                 </Label>
@@ -354,7 +354,7 @@ export function SettingsPage() {
 
                             {/* Custom targets */}
                             <div>
-                                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">
+                                <Label className="settings-label">
                                     Custom Targets (override preset)
                                 </Label>
                                 <div className="grid grid-cols-3 gap-2">
@@ -451,7 +451,7 @@ export function SettingsPage() {
 
                             {/* Dynamic mode */}
                             <div
-                                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors"
+                                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted"
                                 onClick={() =>
                                     setDraft({ ...draft, loudnorm_dynamic: !draft.loudnorm_dynamic })
                                 }
@@ -473,7 +473,7 @@ export function SettingsPage() {
 
                             {/* Precompress */}
                             <div
-                                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors"
+                                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted"
                                 onClick={() =>
                                     setDraft({ ...draft, loudnorm_precompress: !draft.loudnorm_precompress })
                                 }
@@ -497,7 +497,7 @@ export function SettingsPage() {
 
                     {/* Boost fallback — visible whenever normalize_audio is true */}
                     <div
-                        className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors"
+                        className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted"
                         onClick={() =>
                             setDraft({ ...draft, normalize_boost: !draft.normalize_boost })
                         }
@@ -521,7 +521,7 @@ export function SettingsPage() {
                         <div>
                             <Label
                                 htmlFor="normalize-boost-db"
-                                className="text-[13px] font-semibold text-foreground mb-1.5 block"
+                                className="settings-label"
                             >
                                 Boost Gain (dB)
                             </Label>

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -20,6 +20,18 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import {
+    Collapsible,
+    CollapsibleContent,
+} from "@/components/ui/collapsible";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /** Sentinel value for "no selection" since Radix Select does not support empty string values. */
 const NONE_SENTINEL = "none";
@@ -41,6 +53,23 @@ export function SettingsPage() {
     }
 
     const handleSave = async () => {
+        // Range validation for loudnorm numeric fields
+        if (draft.loudnorm_target_i !== null && (draft.loudnorm_target_i < -70 || draft.loudnorm_target_i > 0)) {
+            setSaveError("Loudness Target must be between -70 and 0 LUFS.");
+            return;
+        }
+        if (draft.loudnorm_target_tp !== null && (draft.loudnorm_target_tp < -9 || draft.loudnorm_target_tp > 0)) {
+            setSaveError("True Peak Limit must be between -9 and 0 dBTP.");
+            return;
+        }
+        if (draft.loudnorm_target_lra !== null && (draft.loudnorm_target_lra < 1 || draft.loudnorm_target_lra > 30)) {
+            setSaveError("Loudness Range must be between 1 and 30 LU.");
+            return;
+        }
+        if (draft.normalize_boost_db !== null && (draft.normalize_boost_db < 0 || draft.normalize_boost_db > 30)) {
+            setSaveError("Boost Gain must be between 0 and 30 dB.");
+            return;
+        }
         try {
             setSaveError(null);
             await updateSettings(draft);
@@ -222,13 +251,299 @@ export function SettingsPage() {
                 onClick={() => setDraft({ ...draft, verbose: !draft.verbose })}
             >
                 <Checkbox
+                    id="verbose"
                     checked={draft.verbose}
                     onCheckedChange={(checked) => setDraft({ ...draft, verbose: checked === true })}
                 />
-                <Label className="text-sm font-medium text-muted-foreground cursor-pointer">
+                <Label htmlFor="verbose" className="text-sm font-medium text-muted-foreground cursor-pointer">
                     Verbose logging
                 </Label>
             </div>
+
+            <Separator className="my-6" />
+
+            <h3 className="text-sm font-bold text-foreground mb-3">Audio Normalization</h3>
+
+            <div
+                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors mb-3"
+                onClick={() => setDraft({ ...draft, normalize_audio: !draft.normalize_audio })}
+            >
+                <Checkbox
+                    id="normalize-audio"
+                    checked={draft.normalize_audio}
+                    onCheckedChange={(checked) => setDraft({ ...draft, normalize_audio: checked === true })}
+                />
+                <Label htmlFor="normalize-audio" className="text-sm font-medium text-muted-foreground cursor-pointer">
+                    Normalize audio
+                </Label>
+            </div>
+
+            <Collapsible open={draft.normalize_audio}>
+                <CollapsibleContent className="pl-4 border-l-2 border-border space-y-3 overflow-hidden">
+                    {/* Mode: Peak vs EBU R128 Loudnorm */}
+                    <div>
+                        <Label
+                            id="normalize-mode-label"
+                            className="text-[13px] font-semibold text-foreground mb-1.5 block"
+                        >
+                            Mode
+                        </Label>
+                        <TooltipProvider>
+                            <ToggleGroup
+                                type="single"
+                                variant="outline"
+                                spacing={0}
+                                value={draft.loudnorm ? "loudnorm" : "peak"}
+                                onValueChange={(val) => {
+                                    if (val) setDraft({ ...draft, loudnorm: val === "loudnorm" });
+                                }}
+                                aria-labelledby="normalize-mode-label"
+                                className="w-fit"
+                            >
+                                <ToggleGroupItem value="peak" size="sm" className="text-xs px-3">
+                                    Peak
+                                </ToggleGroupItem>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <ToggleGroupItem value="loudnorm" size="sm" className="text-xs px-3">
+                                            EBU R128 Loudnorm
+                                        </ToggleGroupItem>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top">
+                                        Two-pass loudness normalization to a target LUFS level
+                                    </TooltipContent>
+                                </Tooltip>
+                            </ToggleGroup>
+                        </TooltipProvider>
+                    </div>
+
+                    {/* Loudnorm-specific options */}
+                    {draft.loudnorm && (
+                        <>
+                            {/* Preset */}
+                            <div>
+                                <Label
+                                    htmlFor="loudnorm-preset"
+                                    className="text-[13px] font-semibold text-foreground mb-1.5 block"
+                                >
+                                    Preset
+                                </Label>
+                                <Select
+                                    value={draft.loudnorm_preset ?? NONE_SENTINEL}
+                                    onValueChange={(val) =>
+                                        setDraft({
+                                            ...draft,
+                                            loudnorm_preset: val === NONE_SENTINEL ? null : val,
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger id="loudnorm-preset" className="w-full text-sm">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={NONE_SENTINEL}>Default (Streaming)</SelectItem>
+                                        <SelectItem value="streaming">Streaming (-14 LUFS)</SelectItem>
+                                        <SelectItem value="broadcast">Broadcast (-23 LUFS)</SelectItem>
+                                        <SelectItem value="loud">Loud (-11 LUFS)</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            {/* Custom targets */}
+                            <div>
+                                <Label className="text-[13px] font-semibold text-foreground mb-1.5 block">
+                                    Custom Targets (override preset)
+                                </Label>
+                                <div className="grid grid-cols-3 gap-2">
+                                    <div>
+                                        <Label
+                                            htmlFor="loudnorm-target-i"
+                                            className="text-[11px] text-muted-foreground mb-1 block"
+                                        >
+                                            Loudness Target (LUFS)
+                                        </Label>
+                                        <Input
+                                            id="loudnorm-target-i"
+                                            type="number"
+                                            step="0.1"
+                                            min="-70"
+                                            max="0"
+                                            placeholder={
+                                                draft.loudnorm_preset === "broadcast"
+                                                    ? "-23.0"
+                                                    : draft.loudnorm_preset === "loud"
+                                                      ? "-11.0"
+                                                      : "-14.0"
+                                            }
+                                            value={draft.loudnorm_target_i ?? ""}
+                                            onChange={(e) =>
+                                                setDraft({
+                                                    ...draft,
+                                                    loudnorm_target_i: e.target.value
+                                                        ? Number(e.target.value)
+                                                        : null,
+                                                })
+                                            }
+                                            className="font-mono text-xs"
+                                        />
+                                    </div>
+                                    <div>
+                                        <Label
+                                            htmlFor="loudnorm-target-tp"
+                                            className="text-[11px] text-muted-foreground mb-1 block"
+                                        >
+                                            True Peak Limit (dBTP)
+                                        </Label>
+                                        <Input
+                                            id="loudnorm-target-tp"
+                                            type="number"
+                                            step="0.1"
+                                            min="-9"
+                                            max="0"
+                                            placeholder={
+                                                draft.loudnorm_preset === "broadcast" ? "-2.0" : "-1.0"
+                                            }
+                                            value={draft.loudnorm_target_tp ?? ""}
+                                            onChange={(e) =>
+                                                setDraft({
+                                                    ...draft,
+                                                    loudnorm_target_tp: e.target.value
+                                                        ? Number(e.target.value)
+                                                        : null,
+                                                })
+                                            }
+                                            className="font-mono text-xs"
+                                        />
+                                    </div>
+                                    <div>
+                                        <Label
+                                            htmlFor="loudnorm-target-lra"
+                                            className="text-[11px] text-muted-foreground mb-1 block"
+                                        >
+                                            Loudness Range (LU)
+                                        </Label>
+                                        <Input
+                                            id="loudnorm-target-lra"
+                                            type="number"
+                                            step="0.1"
+                                            min="1"
+                                            max="30"
+                                            placeholder={
+                                                draft.loudnorm_preset === "broadcast" ? "7.0" : "11.0"
+                                            }
+                                            value={draft.loudnorm_target_lra ?? ""}
+                                            onChange={(e) =>
+                                                setDraft({
+                                                    ...draft,
+                                                    loudnorm_target_lra: e.target.value
+                                                        ? Number(e.target.value)
+                                                        : null,
+                                                })
+                                            }
+                                            className="font-mono text-xs"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Dynamic mode */}
+                            <div
+                                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors"
+                                onClick={() =>
+                                    setDraft({ ...draft, loudnorm_dynamic: !draft.loudnorm_dynamic })
+                                }
+                            >
+                                <Checkbox
+                                    id="loudnorm-dynamic"
+                                    checked={draft.loudnorm_dynamic}
+                                    onCheckedChange={(checked) =>
+                                        setDraft({ ...draft, loudnorm_dynamic: checked === true })
+                                    }
+                                />
+                                <Label
+                                    htmlFor="loudnorm-dynamic"
+                                    className="text-sm font-medium text-muted-foreground cursor-pointer"
+                                >
+                                    Dynamic mode (per-frame compression)
+                                </Label>
+                            </div>
+
+                            {/* Precompress */}
+                            <div
+                                className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors"
+                                onClick={() =>
+                                    setDraft({ ...draft, loudnorm_precompress: !draft.loudnorm_precompress })
+                                }
+                            >
+                                <Checkbox
+                                    id="loudnorm-precompress"
+                                    checked={draft.loudnorm_precompress}
+                                    onCheckedChange={(checked) =>
+                                        setDraft({ ...draft, loudnorm_precompress: checked === true })
+                                    }
+                                />
+                                <Label
+                                    htmlFor="loudnorm-precompress"
+                                    className="text-sm font-medium text-muted-foreground cursor-pointer"
+                                >
+                                    Precompress (tame extreme peaks)
+                                </Label>
+                            </div>
+                        </>
+                    )}
+
+                    {/* Boost fallback — visible whenever normalize_audio is true */}
+                    <div
+                        className="flex items-center gap-2.5 p-2.5 px-3 bg-card border border-border rounded-md cursor-pointer hover:border-white/[0.08] hover:bg-muted transition-colors"
+                        onClick={() =>
+                            setDraft({ ...draft, normalize_boost: !draft.normalize_boost })
+                        }
+                    >
+                        <Checkbox
+                            id="normalize-boost"
+                            checked={draft.normalize_boost}
+                            onCheckedChange={(checked) =>
+                                setDraft({ ...draft, normalize_boost: checked === true })
+                            }
+                        />
+                        <Label
+                            htmlFor="normalize-boost"
+                            className="text-sm font-medium text-muted-foreground cursor-pointer"
+                        >
+                            Boost fallback (quiet/compressed audio)
+                        </Label>
+                    </div>
+
+                    {draft.normalize_boost && (
+                        <div>
+                            <Label
+                                htmlFor="normalize-boost-db"
+                                className="text-[13px] font-semibold text-foreground mb-1.5 block"
+                            >
+                                Boost Gain (dB)
+                            </Label>
+                            <Input
+                                id="normalize-boost-db"
+                                type="number"
+                                step="0.5"
+                                min="0"
+                                max="30"
+                                placeholder="12.0"
+                                value={draft.normalize_boost_db ?? ""}
+                                onChange={(e) =>
+                                    setDraft({
+                                        ...draft,
+                                        normalize_boost_db: e.target.value
+                                            ? Number(e.target.value)
+                                            : null,
+                                    })
+                                }
+                                className="w-32 font-mono text-xs"
+                            />
+                        </div>
+                    )}
+                </CollapsibleContent>
+            </Collapsible>
 
             {saveError && (
                 <Alert variant="destructive" className="mb-4">

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -222,7 +222,7 @@ export function SettingsPage() {
             </div>
 
             <div
-                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-4"
+                className="settings-toggle-row mb-4"
                 onClick={() => setDraft({ ...draft, embed_thumbnail: !draft.embed_thumbnail })}
             >
                 <Checkbox
@@ -235,7 +235,7 @@ export function SettingsPage() {
             </div>
 
             <div
-                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-4"
+                className="settings-toggle-row mb-4"
                 onClick={() => setDraft({ ...draft, embed_metadata: !draft.embed_metadata })}
             >
                 <Checkbox
@@ -248,7 +248,7 @@ export function SettingsPage() {
             </div>
 
             <div
-                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-4"
+                className="settings-toggle-row mb-4"
                 onClick={() => setDraft({ ...draft, verbose: !draft.verbose })}
             >
                 <Checkbox
@@ -266,7 +266,7 @@ export function SettingsPage() {
             <h3 className="text-sm font-bold text-foreground mb-3">Audio Normalization</h3>
 
             <div
-                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted mb-3"
+                className="settings-toggle-row mb-3"
                 onClick={() => setDraft({ ...draft, normalize_audio: !draft.normalize_audio })}
             >
                 <Checkbox
@@ -451,7 +451,7 @@ export function SettingsPage() {
 
                             {/* Dynamic mode */}
                             <div
-                                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted"
+                                className="settings-toggle-row"
                                 onClick={() =>
                                     setDraft({ ...draft, loudnorm_dynamic: !draft.loudnorm_dynamic })
                                 }
@@ -473,7 +473,7 @@ export function SettingsPage() {
 
                             {/* Precompress */}
                             <div
-                                className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted"
+                                className="settings-toggle-row"
                                 onClick={() =>
                                     setDraft({ ...draft, loudnorm_precompress: !draft.loudnorm_precompress })
                                 }
@@ -497,7 +497,7 @@ export function SettingsPage() {
 
                     {/* Boost fallback — visible whenever normalize_audio is true */}
                     <div
-                        className="settings-toggle-row hover:border-white/[0.08] hover:bg-muted"
+                        className="settings-toggle-row"
                         onClick={() =>
                             setDraft({ ...draft, normalize_boost: !draft.normalize_boost })
                         }

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -305,9 +305,11 @@ export function SettingsPage() {
                                 </ToggleGroupItem>
                                 <Tooltip>
                                     <TooltipTrigger asChild>
-                                        <ToggleGroupItem value="loudnorm" size="sm" className="text-xs px-3">
-                                            EBU R128 Loudnorm
-                                        </ToggleGroupItem>
+                                        <span>
+                                            <ToggleGroupItem value="loudnorm" size="sm" className="text-xs px-3">
+                                                EBU R128 Loudnorm
+                                            </ToggleGroupItem>
+                                        </span>
                                     </TooltipTrigger>
                                     <TooltipContent side="top">
                                         Two-pass loudness normalization to a target LUFS level

--- a/crates/rdlp-desktop/src/test/setup.ts
+++ b/crates/rdlp-desktop/src/test/setup.ts
@@ -1,7 +1,24 @@
-// Global test setup: jest-dom matchers + Tauri IPC mocks.
+// Global test setup: jest-dom matchers + Tauri IPC mocks + jsdom polyfills.
 
 import "@testing-library/jest-dom";
 import { mockInvoke, mockListen, mockEmit } from "./tauri-mock";
+
+// Polyfill pointer-capture methods missing in jsdom.
+// Radix UI Select uses hasPointerCapture internally, which throws in jsdom.
+if (typeof Element.prototype.hasPointerCapture !== "function") {
+    Element.prototype.hasPointerCapture = () => false;
+}
+if (typeof Element.prototype.setPointerCapture !== "function") {
+    Element.prototype.setPointerCapture = () => {};
+}
+if (typeof Element.prototype.releasePointerCapture !== "function") {
+    Element.prototype.releasePointerCapture = () => {};
+}
+
+// Polyfill scrollIntoView (used by Radix Select for option scrolling).
+if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = () => {};
+}
 
 // Mock @tauri-apps/api/core so tests never hit the real Tauri IPC bridge.
 vi.mock("@tauri-apps/api/core", () => ({

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -153,6 +153,16 @@ export interface DownloadOptions {
     embedThumbnail: boolean;
     audioMultistreams: boolean;
     recodeVideo: ContainerFormat | null;
+    normalizeAudio: boolean | null;
+    loudnorm: boolean | null;
+    loudnormPreset: string | null;
+    loudnormTargetI: number | null;
+    loudnormTargetTp: number | null;
+    loudnormTargetLra: number | null;
+    loudnormDynamic: boolean | null;
+    loudnormPrecompress: boolean | null;
+    normalizeBoost: boolean | null;
+    normalizeBoostDb: number | null;
 }
 
 // ========== Event Payloads (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========
@@ -211,6 +221,16 @@ export interface AppSettings {
     embed_metadata: boolean;
     verbose: boolean;
     default_search_provider: string | null;
+    normalize_audio: boolean;
+    loudnorm: boolean;
+    loudnorm_preset: string | null;
+    loudnorm_target_i: number | null;
+    loudnorm_target_tp: number | null;
+    loudnorm_target_lra: number | null;
+    loudnorm_dynamic: boolean;
+    loudnorm_precompress: boolean;
+    normalize_boost: boolean;
+    normalize_boost_db: number | null;
 }
 
 // ========== Error Types ==========

--- a/crates/rdlp-desktop/vite.config.ts
+++ b/crates/rdlp-desktop/vite.config.ts
@@ -42,5 +42,34 @@ export default defineConfig(async () => ({
     minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
     // Produce sourcemaps for debug builds
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom"],
+          "vendor-radix": [
+            "@radix-ui/react-checkbox",
+            "@radix-ui/react-collapsible",
+            "@radix-ui/react-dialog",
+            "@radix-ui/react-dropdown-menu",
+            "@radix-ui/react-label",
+            "@radix-ui/react-popover",
+            "@radix-ui/react-progress",
+            "@radix-ui/react-radio-group",
+            "@radix-ui/react-scroll-area",
+            "@radix-ui/react-select",
+            "@radix-ui/react-separator",
+            "@radix-ui/react-slot",
+            "@radix-ui/react-toggle",
+            "@radix-ui/react-toggle-group",
+            "@radix-ui/react-tooltip",
+          ],
+          "vendor-tanstack": [
+            "@tanstack/react-query",
+            "@tanstack/react-table",
+            "@tanstack/react-store",
+          ],
+        },
+      },
+    },
   },
 }));

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -59,6 +59,13 @@ impl FFmpegRunner {
             })?
         };
 
+        // Read the format-level start_time (in AV_TIME_BASE = µs) before
+        // borrowing individual streams.  HLS downloads and some containers
+        // have a non-zero start time.  We must preserve this offset in the
+        // sample-clock DTS synthesis so the normalized audio aligns with
+        // the original video stream when they are merged back together.
+        let format_start_time_us: i64 = unsafe { (*ictx.as_mut_ptr()).start_time };
+
         let audio_ist_index = ictx
             .streams()
             .best(ffmpeg_the_third::media::Type::Audio)
@@ -71,6 +78,7 @@ impl FFmpegRunner {
             ))
         })?;
         let audio_ist_time_base = audio_ist.time_base();
+
         let mut audio_dec_ctx =
             ffmpeg_the_third::codec::context::Context::from_parameters(audio_ist.parameters())?;
         set_single_thread_codec(unsafe { audio_dec_ctx.as_mut_ptr() });
@@ -237,11 +245,30 @@ impl FFmpegRunner {
 
         let _log_suppress = LogSuppressGuard::error_level();
 
+        // Compute the starting sample offset from the input's format-level
+        // start_time.  When the source has a non-zero start (e.g. HLS downloads
+        // starting mid-stream), this ensures the normalized audio output
+        // preserves the same temporal offset, preventing audio/video desync
+        // in the subsequent merge step.
+        let start_samples = if format_start_time_us > 0
+            && format_start_time_us != ffmpeg_the_third::ffi::AV_NOPTS_VALUE
+        {
+            format_start_time_us * i64::from(audio_decoder.rate()) / 1_000_000
+        } else {
+            0
+        };
+        if start_samples > 0 {
+            info!(
+                "[{label}] preserving input start offset: {format_start_time_us} µs = {start_samples} samples",
+            );
+        }
+
         let mut timing = MuxTimingState {
             encoder_frame_size: audio_encoder.frame_size(),
             expected_duration,
             sample_rate: audio_decoder.rate(),
             use_sample_clock: true,
+            samples_written: start_samples,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary

- Add full audio normalization controls to the desktop GUI, matching all CLI options (`--normalize-audio`, `--loudnorm`, `--loudnorm-preset`, custom LUFS/TP/LRA targets, dynamic mode, precompress, boost fallback)
- **SettingsPage**: New "Audio Normalization" section with enable checkbox, Peak/Loudnorm mode toggle, preset selector, custom LUFS/TP/LRA inputs, dynamic/precompress checkboxes, and boost fallback with dB input
- **FormatOptionsPanel**: Per-download override Select with 7 options (Use Settings Default / Off / Peak / Loudnorm Streaming / Broadcast / Loud / Custom...)
- **DownloadOptionsPanel**: Same 7-option normalization Select in the FormatDialog's collapsible download options
- **Custom mode**: Expands inline controls for mode toggle (Peak/EBU R128), LUFS/TP/LRA targets, dynamic, precompress, and boost fallback — shared component used by both panels
- **Backend**: 10 new `AppSettings` fields with `#[serde(default)]` for backward-compatible deserialization, 10 new `DownloadOptions` fields with `Option<T>` for per-download overrides merged with settings defaults in `start_download`
- **rdlp-api**: 7 new fields on `PostProcessOptions` with merge logic and 14 tests
- **UX polish**: Active Select/toggle states highlighted with primary color across all pages, consistent visual feedback for non-default selections
- **Tailwind @utility extraction**: 10 custom `@utility` classes in `index.css` replacing repeated inline class strings across 12 component files (select-active, section-heading, options-label, settings-label, settings-toggle-row, sidebar-section-btn, kbd-chip, table-th, table-footer-sticky, table-footer-cell)
- **Build**: Vendor chunk splitting via Rollup `manualChunks` — eliminates 542 KB single-chunk warning (largest chunk now 272 KB)

## Changes

| Layer | Files | Description |
|-------|-------|-------------|
| rdlp-api | `request.rs`, `merge/mod.rs`, `merge/tests_postprocess_network.rs` | 7 new PostProcessOptions fields + merge logic + 14 tests |
| Desktop backend | `app_settings.rs`, `commands/download.rs` | 10 AppSettings fields, 10 DownloadOptions fields, start_download wiring, 8 merge tests, backward-compat serde test |
| Desktop frontend | `types/index.ts`, `SettingsPage.tsx`, `FormatOptionsPanel.tsx`, `DownloadOptionsPanel.tsx` | TypeScript types, full settings UI, per-download overrides in both panels |
| Shared components | `NormalizationCustomControls.tsx`, `utils/normalization.ts` | Shared custom normalization inline controls + helper functions |
| UX/styling | `index.css`, `FilterBar.tsx`, `CommandBar.tsx`, `SearchIdleState.tsx`, `SidebarDownloads.tsx`, `SidebarHistory.tsx`, `FormatTableSection.tsx`, `ResultsTableSection.tsx`, `DownloadPage.tsx`, `QueuePage.tsx` | 10 Tailwind @utility classes, active-state styling on all Select/toggle controls |
| Build | `vite.config.ts` | Rollup manualChunks: vendor-radix (272 KB), vendor-tanstack (107 KB), vendor-react, app (164 KB) |
| Tests | `FormatOptionsPanel.test.tsx` (new), `SettingsPage.test.tsx`, `tableHelpers.test.ts`, `setup.ts` | 77 new tests + jsdom pointer-capture polyfill |

## Test plan

- [x] `cargo clippy -p rdlp-desktop -- -D warnings` — zero warnings
- [x] `cargo clippy -p rdlp-api -- -D warnings` — zero warnings
- [x] `cargo test -p rdlp-desktop` — 54 tests pass (was 46, +8 new)
- [x] `npx tsc --noEmit` — compiles clean
- [x] `npm run test` — 253 Vitest tests pass (was 178, +75 new)
- [x] `npm run build` — production build clean, no chunk size warnings
- [x] FormatOptionsPanel.test.tsx: 34 tests — buildDefaultOptions, activePreset, Select value derivation (7 states), onChange branches (5), quality presets, remux/audio selects
- [x] SettingsPage.test.tsx: +8 tests — range validation errors, save payload assertions, visibility cascading
- [x] tableHelpers.test.ts: +30 tests — optionsSummary custom normalize, isCustomNormalization (10), getNormSelectValue (9), handleNormSelectChange (5)
- [x] download.rs: +7 tests — settings-fallback merge logic, override precedence, unwrap_or vs or semantics
- [x] app_settings.rs: +1 test — legacy JSON backward-compat serde defaulting
- [x] Bugfix verified: null loudnorm preset correctly maps to streaming in Select
- [x] Standard preset selections clear custom overrides to prevent stale state
- [x] Active Select/toggle styling verified across all pages (Settings, Search, Download, Queue, FormatDialog)