### PR TITLE
chore: demote verbose log levels across 12 workspace crates

### DIFF
--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -4,7 +4,7 @@
 //! previously duplicated between `state.rs` and `playlist.rs`.
 
 use super::{Orchestrator, errors::*};
-use log::{info, warn};
+use log::{debug, info, warn};
 use rdlp_core::{DownloadStats, Format, RdlpError};
 use rdlp_security::validate_url_security;
 use std::path::Path;
@@ -122,9 +122,8 @@ impl Orchestrator {
         }
         let stats = stats.expect("stats is Some when no error occurred");
 
-        info!("Downloaded successfully!");
-        info!("   File: {}", output_path.display());
-        info!("   Stats: {stats:?}");
+        debug!("Downloaded successfully: {}", output_path.display());
+        debug!("   Stats: {stats:?}");
 
         Ok(Some(DownloadOutcome { stats, is_hls }))
     }
@@ -193,7 +192,7 @@ impl Orchestrator {
             .await
         {
             Ok(Some(stats)) => {
-                info!("Stdout download completed: {stats:?}");
+                debug!("Stdout download completed: {stats:?}");
                 Ok(Some(stats))
             }
             Ok(None) => Ok(None),

--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -3,7 +3,7 @@
 use super::{Orchestrator, errors::*};
 use crate::events::Event;
 use crate::handle::DownloadId;
-use log::info;
+use log::{debug, info};
 use rdlp_core::{DownloadProgress, DownloadStats, Downloader, ProgressCallback};
 use std::path::Path;
 use std::sync::Arc;
@@ -74,7 +74,7 @@ impl Orchestrator {
             EventProgressCallback::new(self.event_tx.clone(), self.download_id),
         ));
 
-        info!("Starting download (cancel via CancellationToken)");
+        debug!("Starting download (cancel via CancellationToken)");
 
         let download_future = if resume_from > 0 {
             downloader.download_with_resume(url, output_path, resume_from, progress_callback)
@@ -88,7 +88,7 @@ impl Orchestrator {
                 result.map_err(OrchestratorError::DownloadFailed)?
             }
             () = self.cancel_token.cancelled() => {
-                info!("Download interrupted by cancellation");
+                debug!("Download interrupted by cancellation");
                 info!("Progress saved. Run the same command again to resume.");
                 return Ok(None);
             }
@@ -125,7 +125,7 @@ impl Orchestrator {
             EventProgressCallback::new(self.event_tx.clone(), self.download_id),
         ));
 
-        info!("Starting stdout download (cancel via CancellationToken)");
+        debug!("Starting stdout download (cancel via CancellationToken)");
 
         let download_future = downloader.download_to_writer(url, writer, progress_callback);
 
@@ -134,7 +134,7 @@ impl Orchestrator {
                 result.map_err(OrchestratorError::DownloadFailed)?
             }
             () = self.cancel_token.cancelled() => {
-                info!("Download to stdout interrupted by cancellation");
+                debug!("Download to stdout interrupted by cancellation");
                 return Ok(None);
             }
         };

--- a/crates/rdlp-api/src/orchestrator/extraction.rs
+++ b/crates/rdlp-api/src/orchestrator/extraction.rs
@@ -1,7 +1,7 @@
 //! Video information extraction
 
 use super::{Orchestrator, errors::*};
-use log::info;
+use log::{debug, info};
 use rdlp_core::{SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchResultPreview};
 use tracing::instrument;
 
@@ -17,7 +17,7 @@ impl Orchestrator {
     /// - Extraction fails
     #[instrument(skip(self), fields(url = %url))]
     pub(super) async fn extract_video_info(&self, url: &str) -> Result<rdlp_core::InfoDict> {
-        info!("Finding extractor for URL...");
+        debug!("Finding extractor for URL...");
 
         let extractor = self.extractor_registry.find_extractor(url).ok_or_else(|| {
             OrchestratorError::NoExtractor {
@@ -25,8 +25,8 @@ impl Orchestrator {
             }
         })?;
 
-        info!("Using extractor: {}", extractor.name());
-        info!("Extracting video information...");
+        debug!("Using extractor: {}", extractor.name());
+        debug!("Extracting video information...");
 
         let mut info = extractor
             .extract(url, &self.extraction_context)
@@ -34,32 +34,32 @@ impl Orchestrator {
             .map_err(OrchestratorError::ExtractionFailed)?;
 
         // Log extracted metadata
-        info!("Title: {}", info.title);
+        debug!("Title: {}", info.title);
 
         if let Some(ref uploader) = info.uploader {
-            info!("Uploader: {uploader}");
+            debug!("Uploader: {uploader}");
         }
         if let Some(ref channel) = info.channel {
-            info!("Channel: {channel}");
+            debug!("Channel: {channel}");
         }
         if let Some(duration) = info.duration {
             let mins = (duration / 60.0) as u32;
             let secs = (duration % 60.0) as u32;
-            info!("Duration: {mins}:{secs:02}");
+            debug!("Duration: {mins}:{secs:02}");
         }
         if let Some(views) = info.view_count {
-            info!("Views: {views}");
+            debug!("Views: {views}");
         }
         if let Some(rating) = info.average_rating {
-            info!("Rating: {rating:.0}%");
+            debug!("Rating: {rating:.0}%");
         }
         if let Some(ref tags) = info.tags
             && !tags.is_empty()
         {
-            info!("Tags: {}", tags.len());
+            debug!("Tags: {}", tags.len());
         }
 
-        info!("Found {} formats", info.formats.len());
+        debug!("Found {} formats", info.formats.len());
 
         // Auto-set Referer header on all formats that don't already have one.
         // Many CDNs (PornHub, XHamster, etc.) require a Referer to serve content.
@@ -95,7 +95,7 @@ impl Orchestrator {
             .await
             .map_err(OrchestratorError::ExtractionFailed)?;
 
-        info!(formats = info.formats.len(); "Lazily resolved formats");
+        debug!(formats = info.formats.len(); "Lazily resolved formats");
 
         // Auto-set Referer header on all formats
         if !info.webpage_url.is_empty() {
@@ -131,7 +131,7 @@ impl Orchestrator {
         &self,
         url: &str,
     ) -> Result<Vec<rdlp_core::InfoDict>> {
-        info!("Finding extractor for URL...");
+        debug!("Finding extractor for URL...");
 
         let extractor = self.extractor_registry.find_extractor(url).ok_or_else(|| {
             OrchestratorError::NoExtractor {
@@ -139,8 +139,8 @@ impl Orchestrator {
             }
         })?;
 
-        info!("Using extractor: {}", extractor.name());
-        info!("Extracting playlist information...");
+        debug!("Using extractor: {}", extractor.name());
+        debug!("Extracting playlist information...");
 
         let infos = extractor
             .extract_playlist(url, &self.extraction_context)
@@ -148,14 +148,14 @@ impl Orchestrator {
             .map_err(OrchestratorError::ExtractionFailed)?;
 
         if infos.len() == 1 {
-            info!("Single video: {}", infos[0].title);
+            debug!("Single video: {}", infos[0].title);
         } else {
             let playlist_title = infos[0]
                 .playlist_title
                 .as_deref()
                 .unwrap_or("Unnamed Playlist");
             info!("Playlist: {playlist_title}");
-            info!("Found {} videos", infos.len());
+            debug!("Found {} videos", infos.len());
         }
 
         Ok(infos)

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -234,7 +234,7 @@ impl Orchestrator {
                     path.display()
                 ))
             })?;
-            info!(count, file = path.display().to_string().as_str(); "Loaded cookies from file");
+            debug!(count, file = path.display().to_string().as_str(); "Loaded cookies from file");
         }
 
         if let Some(browser) = self.config.cookies_from_browser {
@@ -243,7 +243,7 @@ impl Orchestrator {
                     "Failed to load cookies from {browser}: {e}"
                 ))
             })?;
-            info!(count, browser = browser.to_string().as_str(); "Loaded cookies from browser");
+            debug!(count, browser = browser.to_string().as_str(); "Loaded cookies from browser");
         }
 
         Ok(())

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -82,7 +82,7 @@ impl Orchestrator {
             let tokens_stale =
                 attempt == 0 && batch_resolved_at.is_some_and(|t| t.elapsed() > TOKEN_MAX_AGE);
             if tokens_stale {
-                info!(
+                debug!(
                     "Batch-resolved tokens stale (>{} min), forcing re-extraction",
                     TOKEN_MAX_AGE.as_secs() / 60
                 );
@@ -90,7 +90,7 @@ impl Orchestrator {
             let info_ref = if (attempt > 0 || info.formats.is_empty() || tokens_stale)
                 && !info.webpage_url.is_empty()
             {
-                info!(title:? = info.title; "Lazily resolving episode formats");
+                debug!(title:? = info.title; "Lazily resolving episode formats");
                 let mut resolved = match self.extract_lazy_formats(&info.webpage_url).await {
                     Ok(r) => r,
                     Err(e) if attempt < MAX_EXTRACT_RETRIES => {
@@ -165,7 +165,7 @@ impl Orchestrator {
                         self.cleanup_leftover_segments(output_dir, &sanitized_title)
                             .await;
 
-                        info!(path:? = path.display(); "Downloading to");
+                        debug!(path:? = path.display(); "Downloading to");
                         output_path = Some(path);
                     }
 
@@ -178,7 +178,7 @@ impl Orchestrator {
                     if let Some(expected_size) = format.filesize
                         && resume_offset == expected_size
                     {
-                        info!("File already complete, skipping");
+                        debug!("File already complete, skipping");
                         return Ok(Some(path.clone()));
                     }
 
@@ -246,7 +246,7 @@ impl Orchestrator {
                         self.cleanup_leftover_segments(output_dir, &sanitized_title)
                             .await;
 
-                        info!(path:? = path.display(); "Downloading merge to");
+                        debug!(path:? = path.display(); "Downloading merge to");
                         output_path = Some(path);
                     }
 

--- a/crates/rdlp-api/src/orchestrator/playlist/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/execution.rs
@@ -65,7 +65,7 @@ impl Orchestrator {
             let sub_langs = selected_sub_langs.to_vec();
             let audio = selected_audio.clone();
             async move {
-                info!("{}", "\u{2500}".repeat(60));
+                debug!("{}", "\u{2500}".repeat(60));
                 info!(position, total, title:? = info_owned.title; "Downloading");
                 let result = self
                     .download_from_info_to_dir(
@@ -91,7 +91,7 @@ impl Orchestrator {
                         Some((position, info_owned, result)) => {
                             match result {
                                 Ok(Some(path)) => {
-                                    info!(position, total, path:? = path.display(); "Saved");
+                                    debug!(position, total, path:? = path.display(); "Saved");
                                     downloaded.push(path);
                                     self.record_in_archive(
                                         &info_owned.extractor,
@@ -99,7 +99,7 @@ impl Orchestrator {
                                     );
                                 }
                                 Ok(None) => {
-                                    info!(position, total; "Skipped by user");
+                                    debug!(position, total; "Skipped by user");
                                 }
                                 Err(e) => {
                                     error!(position, total; "Failed: {e}");
@@ -223,7 +223,7 @@ impl Orchestrator {
                             Some((pos, title, result)) => {
                                 match result {
                                     Ok(Some(path)) => {
-                                        info!(
+                                        debug!(
                                             wave = wave + 1,
                                             pos, total,
                                             path:? = path.display();
@@ -238,7 +238,7 @@ impl Orchestrator {
                                         retried_ok += 1;
                                     }
                                     Ok(None) => {
-                                        info!(
+                                        debug!(
                                             pos, total;
                                             "Skipped on retry"
                                         );

--- a/crates/rdlp-api/src/orchestrator/playlist/helpers.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/helpers.rs
@@ -2,7 +2,7 @@
 
 use super::super::{Orchestrator, Result};
 use futures_util::StreamExt;
-use log::{info, warn};
+use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -85,7 +85,7 @@ impl Orchestrator {
 
         // Resolve with buffer_unordered
         let futs = to_resolve.into_iter().map(|(i, url, title)| async move {
-            info!(position = i + 1, title:? = title; "Resolving episode");
+            debug!(position = i + 1, title:? = title; "Resolving episode");
             (i, self.extract_lazy_formats(&url).await)
         });
 
@@ -130,7 +130,7 @@ impl Orchestrator {
         }
 
         let batch_resolved_at = Instant::now();
-        info!("Batch resolution complete ({resolve_count} episodes)");
+        debug!("Batch resolution complete ({resolve_count} episodes)");
         batch_resolved_at
     }
 }

--- a/crates/rdlp-api/src/orchestrator/playlist/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/mod.rs
@@ -222,11 +222,11 @@ impl Orchestrator {
 
             // Apply audio filter from saved state
             if let Some(ref lang) = selected_audio {
-                info!(audio:% = lang; "Restoring audio type from saved state");
+                debug!(audio:% = lang; "Restoring audio type from saved state");
                 filter_formats_by_language(&mut infos, lang);
             }
             if !selected_sub_langs.is_empty() {
-                info!(
+                debug!(
                     subs:% = selected_sub_langs.join(", ");
                     "Restoring subtitle selection from saved state"
                 );
@@ -248,7 +248,7 @@ impl Orchestrator {
                     && idx < type_count
                 {
                     let selected = &audio_types[idx];
-                    info!(audio:% = selected; "Filtering to selected audio type");
+                    debug!(audio:% = selected; "Filtering to selected audio type");
                     selected_audio = Some(selected.clone());
                     filter_formats_by_language(&mut infos, selected);
                 }
@@ -290,7 +290,7 @@ impl Orchestrator {
                 };
 
                 if !callback.confirm(&prompt).await {
-                    info!("Cancelled by user");
+                    debug!("Cancelled by user");
                     return Ok(None);
                 }
             }
@@ -321,7 +321,7 @@ impl Orchestrator {
                         playlist_dir.display()
                     ))
                 })?;
-            info!(path:? = playlist_dir.display(); "Created folder");
+            debug!(path:? = playlist_dir.display(); "Created folder");
         }
 
         // Download episodes with bounded parallelism (2 concurrent).

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -4,7 +4,7 @@
 
 use super::{Orchestrator, Result};
 use crate::events::Event;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use rdlp_core::PostProcessConfig;
 use std::path::PathBuf;
 
@@ -105,7 +105,7 @@ impl Orchestrator {
             pp_config.merge_output_format = Some(resolved.format);
         }
 
-        info!("Running post-processing pipeline...");
+        debug!("Running post-processing pipeline...");
 
         if self.config.verbose {
             let processors = registry.list_processors();
@@ -132,7 +132,7 @@ impl Orchestrator {
         {
             Ok(result) => {
                 if result.files != files {
-                    info!("Post-processing complete");
+                    debug!("Post-processing complete");
                     if self.config.verbose {
                         for file in &result.files {
                             let msg = format!("Output: {}", file.display());
@@ -176,7 +176,7 @@ impl Orchestrator {
                 .extension()
                 .and_then(|e| e.to_str())
                 .unwrap_or_else(|| {
-                    info!(file:? = file.display(); "No file extension detected, defaulting to mp4");
+                    debug!(file:? = file.display(); "No file extension detected, defaulting to mp4");
                     "mp4"
                 });
 
@@ -205,7 +205,7 @@ impl Orchestrator {
                         warn!("Could not rename fixed file: {e}");
                         output_files.push(temp_path);
                     } else {
-                        info!("Post-processed: faststart enabled, container fixed");
+                        debug!("Post-processed: faststart enabled, container fixed");
                         output_files.push(final_path);
                     }
                 }
@@ -260,7 +260,7 @@ impl Orchestrator {
         }
 
         if deleted > 0 {
-            info!(deleted; "Cleaned up leftover segment files");
+            debug!(deleted; "Cleaned up leftover segment files");
         }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/resume.rs
@@ -1,7 +1,7 @@
 //! Resume detection and chunk merging functionality
 
 use super::{Orchestrator, errors::*};
-use log::{info, warn};
+use log::{debug, warn};
 use std::path::{Path, PathBuf};
 use tracing::instrument;
 
@@ -109,7 +109,7 @@ pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo
         None => "old-style".to_string(),
     };
 
-    info!(chunk_count, chunk_type:?; "Merging chunks");
+    debug!(chunk_count, chunk_type:?; "Merging chunks");
 
     // Create output file
     let file = File::create(output_path)
@@ -139,7 +139,7 @@ pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo
 
         // Progress update every 100 chunks
         if (idx + 1) % 100 == 0 || idx == chunk_count - 1 {
-            info!(merged = idx + 1, total = chunk_count; "   Merge progress");
+            debug!(merged = idx + 1, total = chunk_count; "   Merge progress");
         }
 
         // Delete chunk file after successful merge
@@ -153,7 +153,7 @@ pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo
         .await
         .map_err(OrchestratorError::ChunkMergeFailed)?;
 
-    info!(chunk_count; "Cleaned up chunk files");
+    debug!(chunk_count; "Cleaned up chunk files");
 
     Ok(total_size)
 }
@@ -175,7 +175,7 @@ async fn cleanup_old_chunks(output_path: &Path) {
     }
 
     if deleted > 0 {
-        info!(deleted; "Cleaned up old-style chunk files");
+        debug!(deleted; "Cleaned up old-style chunk files");
     }
 }
 
@@ -207,7 +207,7 @@ impl Orchestrator {
                 // Check if file is already complete
                 if let Some(expected) = expected_size {
                     if size == expected {
-                        info!(
+                        debug!(
                             "File already downloaded ({:.1} MB), skipping...",
                             size as f64 / (1024.0 * 1024.0)
                         );
@@ -225,7 +225,7 @@ impl Orchestrator {
                         return Ok(0);
                     }
                 }
-                info!(
+                debug!(
                     "Found partial download ({:.1} MB), resuming...",
                     size as f64 / (1024.0 * 1024.0)
                 );
@@ -243,7 +243,7 @@ impl Orchestrator {
                 "old-style".to_string()
             };
 
-            info!(
+            debug!(
                 "Found {} interrupted {} chunk files ({:.1} MB), merging and resuming...",
                 chunk_info.chunk_paths.len(),
                 chunk_type,
@@ -259,7 +259,7 @@ impl Orchestrator {
             match merge_chunk_files(output_path, &chunk_info).await {
                 Ok(size) => {
                     let mb = size as f64 / (1024.0 * 1024.0);
-                    info!(
+                    debug!(
                         chunks = chunk_info.chunk_paths.len(),
                         mb:?;
                         "Merged chunks into main file"

--- a/crates/rdlp-api/src/orchestrator/session_state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/session_state/mod.rs
@@ -6,7 +6,7 @@
 //! the downloader crate.
 
 use chrono::{DateTime, Utc};
-use log::{debug, warn};
+use log::debug;
 use rdlp_security::extract_url_path;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -203,7 +203,7 @@ impl SessionState {
         let json = match serde_json::to_string_pretty(self) {
             Ok(j) => j,
             Err(e) => {
-                warn!("Failed to serialize session state: {e}");
+                debug!("Failed to serialize session state: {e}");
                 return;
             }
         };
@@ -215,17 +215,17 @@ impl SessionState {
             && !parent.exists()
             && let Err(e) = tokio::fs::create_dir_all(parent).await
         {
-            warn!("Failed to create directory for session state: {e}");
+            debug!("Failed to create directory for session state: {e}");
             return;
         }
 
         if let Err(e) = tokio::fs::write(&temp_path, json.as_bytes()).await {
-            warn!("Failed to write session state temp file: {e}");
+            debug!("Failed to write session state temp file: {e}");
             return;
         }
 
         if let Err(e) = tokio::fs::rename(&temp_path, path).await {
-            warn!("Failed to rename session state file: {e}");
+            debug!("Failed to rename session state file: {e}");
             // Clean up temp file on rename failure
             let _ = tokio::fs::remove_file(&temp_path).await;
             return;
@@ -252,7 +252,7 @@ impl SessionState {
                 // Already gone — nothing to do
             }
             Err(e) => {
-                warn!("Failed to delete session state at {}: {e}", path.display());
+                debug!("Failed to delete session state at {}: {e}", path.display());
             }
         }
     }

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -8,7 +8,7 @@ use super::DownloadPlan;
 use super::session_state::{self, SessionState, SingleVideoState};
 use super::{Orchestrator, errors::*};
 use crate::events::Event;
-use log::{info, warn};
+use log::{debug, warn};
 use rdlp_core::Format;
 use std::fmt;
 use std::path::PathBuf;
@@ -176,7 +176,7 @@ impl DownloadPhase {
                         .find(|f| f.format_id == saved.format_id)
                         .cloned()
                     {
-                        info!(
+                        debug!(
                             format_id = saved.format_id.as_str();
                             "Resuming with saved selections"
                         );
@@ -191,7 +191,7 @@ impl DownloadPhase {
                                 .find(|f| f.format_id == *audio_id)
                                 .cloned()
                             {
-                                info!(
+                                debug!(
                                     audio_id = audio_id.as_str();
                                     "Resuming merge plan with saved audio format"
                                 );
@@ -321,7 +321,7 @@ impl DownloadPhase {
                                 .to_string(),
                         ));
                     }
-                    info!("Downloading to stdout");
+                    debug!("Downloading to stdout");
                     return Ok(Self::Downloading {
                         info,
                         output_path: PathBuf::from("-"),
@@ -333,7 +333,7 @@ impl DownloadPhase {
                 }
 
                 let output_path = orchestrator.generate_output_path(&info, &format)?;
-                info!(path:? = output_path.display(); "Downloading to");
+                debug!(path:? = output_path.display(); "Downloading to");
 
                 // Resume detection only applies to Single downloads.
                 // Merge downloads create separate stream files (video + audio)

--- a/crates/rdlp-api/src/orchestrator/subtitle/download.rs
+++ b/crates/rdlp-api/src/orchestrator/subtitle/download.rs
@@ -1,7 +1,7 @@
 //! Subtitle download execution — HTTP fetching and pipeline integration
 
 use super::{Orchestrator, Result};
-use log::{debug, info, warn};
+use log::{debug, warn};
 use rdlp_core::InfoDict;
 use std::path::{Path, PathBuf};
 
@@ -69,11 +69,11 @@ impl Orchestrator {
                 continue;
             }
 
-            info!("Downloading subtitle: lang={lang}, url={}", sub.url);
+            debug!("Downloading subtitle: lang={lang}, url={}", sub.url);
 
             match self.download_subtitle_file(&sub.url, &sub_path).await {
                 Ok(()) => {
-                    info!("Subtitle downloaded: {}", sub_path.display());
+                    debug!("Subtitle downloaded: {}", sub_path.display());
                     downloaded.push((lang.clone(), sub_path));
                 }
                 Err(e) => {
@@ -105,7 +105,7 @@ impl Orchestrator {
         };
 
         if selected.is_empty() {
-            info!("No subtitles selected");
+            debug!("No subtitles selected");
             return Ok(Some(Vec::new()));
         }
 
@@ -186,7 +186,7 @@ impl Orchestrator {
                 continue;
             }
 
-            info!(
+            debug!(
                 lang:% = track.language,
                 ext:% = track.ext;
                 "Downloading subtitle"
@@ -194,7 +194,7 @@ impl Orchestrator {
 
             match self.download_subtitle_file(&track.url, &sub_path).await {
                 Ok(()) => {
-                    info!("Subtitle downloaded: {}", sub_path.display());
+                    debug!("Subtitle downloaded: {}", sub_path.display());
                     downloaded.push((track.language.clone(), sub_path));
                 }
                 Err(e) => {

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -14,7 +14,7 @@ use rdlp_api::{RdlpApiError, RdlpClient};
 use rdlp_cli::event_handler::CliEventHandler;
 use rdlp_cli::interactive::DialoguerCallback;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -95,7 +95,7 @@ async fn async_main() -> Result<()> {
     }
 
     if let Some(rate) = config.rate_limit {
-        info!("Rate limit: {rate} bytes/s");
+        debug!("Rate limit: {rate} bytes/s");
     }
 
     if config.verify_sub_urls && !config.strict_subs {
@@ -118,17 +118,17 @@ async fn async_main() -> Result<()> {
 
     // List extractors if requested
     if args.list_extractors {
-        info!("Available extractors:");
+        debug!("Available extractors:");
         for extractor in client.list_extractors() {
-            info!("  - {extractor}");
+            debug!("  - {extractor}");
         }
         return Ok(());
     }
 
     if args.list_downloaders {
-        info!("Available download protocols:");
+        debug!("Available download protocols:");
         for downloader in client.list_downloaders() {
-            info!("  - {downloader}");
+            debug!("  - {downloader}");
         }
         return Ok(());
     }
@@ -221,7 +221,7 @@ async fn async_main() -> Result<()> {
             match client.download_subtitles_only(info).await {
                 Ok(Some(paths)) => {
                     if paths.is_empty() {
-                        info!("No subtitles downloaded");
+                        debug!("No subtitles downloaded");
                     } else {
                         for path in &paths {
                             info!("Subtitle saved: {}", path.display());
@@ -229,7 +229,7 @@ async fn async_main() -> Result<()> {
                     }
                 }
                 Ok(None) => {
-                    info!("Subtitle selection cancelled");
+                    debug!("Subtitle selection cancelled");
                 }
                 Err(e) => fail_with(e, verbose),
             }
@@ -260,7 +260,7 @@ async fn async_main() -> Result<()> {
 
         if args.simulate && !args.dump_json && args.print.is_none() {
             for info in &infos {
-                info!(
+                debug!(
                     "[Simulate] {} | id={} | extractor={} | {} format(s)",
                     info.title,
                     info.id,

--- a/crates/rdlp-cookies/src/chrome.rs
+++ b/crates/rdlp-cookies/src/chrome.rs
@@ -9,7 +9,7 @@ use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use log::{debug, warn};
+use log::debug;
 use reqwest::cookie::CookieStore;
 
 use crate::util;
@@ -277,7 +277,7 @@ fn read_cookies_from_db(
             match row {
                 Ok(r) => r,
                 Err(e) => {
-                    warn!("Failed to read cookie row: {e}");
+                    debug!("Failed to read cookie row: {e}");
                     continue;
                 }
             };

--- a/crates/rdlp-cookies/src/firefox.rs
+++ b/crates/rdlp-cookies/src/firefox.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use log::{debug, warn};
+use log::debug;
 use reqwest::cookie::CookieStore;
 
 use crate::util;
@@ -209,7 +209,7 @@ fn read_cookies_from_db(db_path: &Path, jar: &impl CookieStore) -> Result<usize,
         let (host, name, value, path, is_secure, is_httponly) = match row {
             Ok(r) => r,
             Err(e) => {
-                warn!("Failed to read Firefox cookie row: {e}");
+                debug!("Failed to read Firefox cookie row: {e}");
                 continue;
             }
         };

--- a/crates/rdlp-cookies/src/lib.rs
+++ b/crates/rdlp-cookies/src/lib.rs
@@ -15,7 +15,7 @@ mod netscape;
 mod util;
 
 use async_trait::async_trait;
-use log::{debug, warn};
+use log::debug;
 use rdlp_core::{BrowserType, CookieJar, Result};
 use reqwest::cookie::CookieStore;
 use std::path::Path;
@@ -73,7 +73,7 @@ impl CookieJar for SimpleCookieJar {
         let parsed = match Url::parse(url) {
             Ok(u) => u,
             Err(e) => {
-                warn!("Invalid URL for cookie: {e}");
+                debug!("Invalid URL for cookie: {e}");
                 return Ok(());
             }
         };

--- a/crates/rdlp-cookies/src/netscape.rs
+++ b/crates/rdlp-cookies/src/netscape.rs
@@ -7,7 +7,7 @@
 
 use std::path::Path;
 
-use log::debug;
+use log::trace;
 use reqwest::cookie::CookieStore;
 
 use crate::util;
@@ -60,7 +60,7 @@ fn load_cookie_string(content: &str, jar: &impl CookieStore) -> usize {
         };
 
         let Some(cookie) = parse_cookie_line(line) else {
-            debug!("Skipping malformed cookie line: {line}");
+            trace!("Skipping malformed cookie line: {line}");
             continue;
         };
         if insert_cookie(&cookie, jar) {

--- a/crates/rdlp-cookies/src/util.rs
+++ b/crates/rdlp-cookies/src/util.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use log::warn;
+use log::debug;
 use reqwest::cookie::CookieStore;
 use reqwest::header::HeaderValue;
 use url::Url;
@@ -24,7 +24,7 @@ pub(crate) fn insert_cookie_into_jar(
     let url_str = format!("{scheme}://{host}{path}");
 
     let Ok(url) = Url::parse(&url_str) else {
-        warn!("Invalid URL from cookie domain: {url_str}");
+        debug!("Invalid URL from cookie domain: {url_str}");
         return false;
     };
 
@@ -42,7 +42,7 @@ pub(crate) fn insert_cookie_into_jar(
             true
         }
         Err(e) => {
-            warn!("Invalid cookie header value for {name}: {e}");
+            debug!("Invalid cookie header value for {name}: {e}");
             false
         }
     }

--- a/crates/rdlp-crypto/src/xhamster.rs
+++ b/crates/rdlp-crypto/src/xhamster.rs
@@ -32,7 +32,7 @@
 //! }
 //! ```
 
-use log::{debug, warn};
+use log::{debug, trace};
 use regex::Regex;
 use std::sync::LazyLock;
 use url::Url;
@@ -127,7 +127,7 @@ fn decipher_bare_hex(hex_str: &str) -> Option<String> {
 fn decipher_hex_bytes(hex_str: &str) -> Option<String> {
     let byte_data = hex::decode(hex_str).ok()?;
     if byte_data.len() < 6 {
-        debug!("[XHamster] Hex data too short: {} bytes", byte_data.len());
+        trace!("[XHamster] Hex data too short: {} bytes", byte_data.len());
         return None;
     }
 
@@ -136,7 +136,7 @@ fn decipher_hex_bytes(hex_str: &str) -> Option<String> {
     let seed = i32::from_le_bytes([byte_data[1], byte_data[2], byte_data[3], byte_data[4]]);
 
     let Some(mut rng) = ByteGenerator::new(algo_id, seed) else {
-        warn!("[XHamster] Unknown algorithm ID: {algo_id}");
+        debug!("[XHamster] Unknown algorithm ID: {algo_id}");
         return None;
     };
 

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -5,7 +5,7 @@
 //! events. The frontend listens for these events via Tauri's IPC
 //! event system to update the download queue UI in real time.
 
-use log::warn;
+use log::debug;
 use rdlp_api::Event;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -139,7 +139,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-progress", &payload) {
-                warn!("Failed to emit download-progress for job {job_id}: {e}");
+                debug!("Failed to emit download-progress for job {job_id}: {e}");
             }
         }
 
@@ -156,7 +156,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-complete", &payload) {
-                warn!("Failed to emit download-complete for job {job_id}: {e}");
+                debug!("Failed to emit download-complete for job {job_id}: {e}");
             }
         }
 
@@ -168,7 +168,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-error", &payload) {
-                warn!("Failed to emit download-error for job {job_id}: {e}");
+                debug!("Failed to emit download-error for job {job_id}: {e}");
             }
         }
 
@@ -180,7 +180,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-log", &payload) {
-                warn!("Failed to emit download-log (metadata-ready) for job {job_id}: {e}");
+                debug!("Failed to emit download-log (metadata-ready) for job {job_id}: {e}");
             }
         }
 
@@ -192,7 +192,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-log", &payload) {
-                warn!("Failed to emit download-log (post-processing) for job {job_id}: {e}");
+                debug!("Failed to emit download-log (post-processing) for job {job_id}: {e}");
             }
         }
 
@@ -204,7 +204,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-log", &payload) {
-                warn!("Failed to emit download-log (warning) for job {job_id}: {e}");
+                debug!("Failed to emit download-log (warning) for job {job_id}: {e}");
             }
         }
 
@@ -221,7 +221,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-log", &payload) {
-                warn!("Failed to emit download-log (retrying) for job {job_id}: {e}");
+                debug!("Failed to emit download-log (retrying) for job {job_id}: {e}");
             }
         }
 
@@ -234,7 +234,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 quality: quality.clone(),
             };
             if let Err(e) = app.emit("format-selected", &payload) {
-                warn!("Failed to emit format-selected for job {job_id}: {e}");
+                debug!("Failed to emit format-selected for job {job_id}: {e}");
             }
 
             // Also emit as a log message for the status bar
@@ -244,7 +244,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 message: format!("Format selected: {quality} ({format_id})"),
             };
             if let Err(e) = app.emit("download-log", &log) {
-                warn!("Failed to emit download-log (format-selected) for job {job_id}: {e}");
+                debug!("Failed to emit download-log (format-selected) for job {job_id}: {e}");
             }
         }
 
@@ -256,7 +256,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             };
 
             if let Err(e) = app.emit("download-log", &payload) {
-                warn!("Failed to emit download-log (debug) for job {job_id}: {e}");
+                debug!("Failed to emit download-log (debug) for job {job_id}: {e}");
             }
         }
 

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
-use log::{debug, info, warn};
+use log::{debug, warn};
 use rdlp_core::{RdlpError, Result, RetryConfig};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
@@ -119,9 +119,9 @@ pub(crate) async fn download_segments_with_resume(
     let remaining = to_download.len();
 
     if remaining == 0 {
-        info!(total = total_segments; "All segments already downloaded, skipping to merge");
+        debug!(total = total_segments; "All segments already downloaded, skipping to merge");
     } else {
-        info!(
+        debug!(
             remaining,
             completed = already_downloaded,
             concurrent = concurrent_segments;
@@ -282,7 +282,7 @@ pub(crate) async fn download_segments_with_resume(
         .map(|(_, path)| path)
         .collect();
 
-    info!(total = total_segments; "All segments ready for merge");
+    debug!(total = total_segments; "All segments ready for merge");
     Ok(segment_paths)
 }
 
@@ -304,7 +304,7 @@ pub(crate) async fn merge_segments(
 ) -> Result<u64> {
     tokio::time::timeout(merge_timeout, async {
         let has_init = segment_init_paths.iter().any(|p| p.is_some());
-        info!(
+        debug!(
             segments = segment_paths.len(),
             fmp4 = has_init;
             "Merging segments into final file"
@@ -350,7 +350,7 @@ pub(crate) async fn merge_segments(
         }
 
         writer.flush().await.map_err(RdlpError::Io)?;
-        info!(mb = total_bytes / (1024 * 1024); "Merge complete");
+        debug!(mb = total_bytes / (1024 * 1024); "Merge complete");
 
         Ok(total_bytes)
     })

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use log::{info, warn};
+use log::{debug, info, warn};
 use rdlp_core::{DownloadStats, Downloader, ProgressCallback, RdlpError, Result, RetryConfig};
 use tokio::sync::Mutex;
 use tracing::instrument;
@@ -204,7 +204,7 @@ impl Downloader for HlsDownloader {
             let has_init = segments.iter().any(|s| s.init_segment.is_some());
             let total_segments = segments.len();
             let total_duration: f64 = segments.iter().map(|s| s.duration).sum();
-            info!(
+            debug!(
                 segments = total_segments,
                 duration_secs = total_duration,
                 fmp4 = has_init;
@@ -225,7 +225,7 @@ impl Downloader for HlsDownloader {
                     Arc::new(Mutex::new(existing_state))
                 }
                 None => {
-                    info!("Starting fresh HLS download");
+                    debug!("Starting fresh HLS download");
                     Arc::new(Mutex::new(HlsDownloadState::new(
                         url.to_string(),
                         total_segments,
@@ -303,7 +303,7 @@ impl Downloader for HlsDownloader {
                 HashMap::with_capacity(unique_inits.len());
             for (i, init) in unique_inits.into_iter().enumerate() {
                 let init_path = temp_dir.join(format!("{base_filename}.init{i}"));
-                info!(index = i; "Downloading fMP4 init segment (EXT-X-MAP): {}", init.url);
+                debug!(index = i; "Downloading fMP4 init segment (EXT-X-MAP): {}", init.url);
                 download_init_segment(&self.http_downloader, &self.retry_config, &init, &init_path)
                     .await?;
                 init_file_map.insert(init, init_path);

--- a/crates/rdlp-downloader/src/hls_state.rs
+++ b/crates/rdlp-downloader/src/hls_state.rs
@@ -21,7 +21,7 @@
 //! ```
 
 use chrono::{DateTime, Utc};
-use log::{debug, info, warn};
+use log::{debug, info};
 use rdlp_security::extract_url_path;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -111,28 +111,28 @@ impl HlsDownloadState {
         let mut file = match File::open(&state_path).await {
             Ok(file) => file,
             Err(e) => {
-                warn!("Failed to open HLS state file: {e}");
+                debug!("Failed to open HLS state file: {e}");
                 return None;
             }
         };
 
         let mut contents = String::new();
         if let Err(e) = file.read_to_string(&mut contents).await {
-            warn!("Failed to read HLS state file: {e}");
+            debug!("Failed to read HLS state file: {e}");
             return None;
         }
 
         let state: Self = match serde_json::from_str(&contents) {
             Ok(state) => state,
             Err(e) => {
-                warn!("Failed to parse HLS state file: {e}");
+                debug!("Failed to parse HLS state file: {e}");
                 return None;
             }
         };
 
         // Validate state
         if state.version != STATE_VERSION {
-            warn!(
+            debug!(
                 "HLS state version mismatch (expected {}, got {}), starting fresh",
                 STATE_VERSION, state.version
             );
@@ -142,12 +142,12 @@ impl HlsDownloadState {
         // Compare normalized URLs to handle dynamic tokens
         let normalized_url = extract_url_path(playlist_url);
         if state.playlist_url != normalized_url {
-            warn!(old:? = state.playlist_url, new:? = normalized_url; "Playlist URL changed, starting fresh");
+            debug!(old:? = state.playlist_url, new:? = normalized_url; "Playlist URL changed, starting fresh");
             return None;
         }
 
         if state.segment_count != segment_count {
-            warn!(
+            debug!(
                 "Segment count changed ({} -> {}), starting fresh",
                 state.segment_count, segment_count
             );

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -52,7 +52,7 @@ async fn cleanup_chunk_files(
     download_id: u64,
     total_chunks: usize,
 ) {
-    info!(chunks = total_chunks; "Cleaning up partial chunk files");
+    debug!(chunks = total_chunks; "Cleaning up partial chunk files");
     let mut deleted = 0;
     for chunk_id in 0..total_chunks {
         let chunk_path = temp_dir.join(format!("{filename}.{download_id}.part{chunk_id}"));
@@ -101,7 +101,7 @@ impl HttpDownloader {
             ProgressReporterConfig::http(start_time, total_size, 0),
         );
 
-        info!(
+        debug!(
             "Starting parallel download with {} concurrent connections",
             self.config.concurrent_fragments
         );
@@ -152,7 +152,7 @@ impl HttpDownloader {
         };
 
         let total_downloaded: u64 = chunk_results.iter().sum();
-        info!(
+        debug!(
             "All {} chunks completed ({} MB total)",
             total_chunks,
             total_downloaded / 1024 / 1024
@@ -221,7 +221,7 @@ impl HttpDownloader {
             ProgressReporterConfig::http(start_time, total_size, resume_from),
         );
 
-        info!(
+        debug!(
             "Starting parallel download with {} concurrent connections",
             self.config.concurrent_fragments
         );
@@ -273,7 +273,7 @@ impl HttpDownloader {
         };
 
         let newly_downloaded: u64 = chunk_results.iter().sum();
-        info!(
+        debug!(
             "All {} chunks completed ({} MB new data)",
             total_chunks,
             newly_downloaded / 1024 / 1024
@@ -334,7 +334,7 @@ async fn merge_chunks_with_mode(
         };
         let mut writer = BufWriter::with_capacity(config.buffer_size, file);
 
-        info!(chunks = total_chunks; "{action} chunks into file");
+        debug!(chunks = total_chunks; "{action} chunks into file");
         let mut deleted_chunks = 0;
         for chunk_id in 0..total_chunks {
             let chunk_path = temp_dir.join(format!("{filename}.{download_id}.{suffix}{chunk_id}"));

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use log::{debug, info, warn};
+use log::debug;
 use rdlp_core::{
     DownloadProgress, DownloadStats, Downloader, ProgressCallback, RdlpError, Result,
     check_http_response,
@@ -90,7 +90,7 @@ impl Downloader for HttpDownloader {
             };
 
             if use_parallel {
-                info!(
+                debug!(
                     "Using parallel download mode ({} connections)",
                     self.config.concurrent_fragments
                 );
@@ -106,7 +106,7 @@ impl Downloader for HttpDownloader {
                 Some(_) if !supports_ranges => "server doesn't support ranges",
                 Some(_) => "unknown reason",
             };
-            warn!(
+            debug!(
                 "Using sequential download - reason: {reason} (size: {:?} MB, fragments: {}, ranges: {supports_ranges})",
                 size.map(|s| s / 1024 / 1024),
                 self.config.concurrent_fragments
@@ -341,7 +341,7 @@ impl Downloader for HttpDownloader {
                     && supports_ranges;
 
                 if can_parallel {
-                    info!(
+                    debug!(
                         "Using parallel resume mode ({} connections), keeping {} MB, parallelizing {} MB",
                         self.config.concurrent_fragments,
                         resume_from / 1024 / 1024,
@@ -354,7 +354,7 @@ impl Downloader for HttpDownloader {
                         .await;
                 }
 
-                warn!(
+                debug!(
                     "Parallel resume not available (remaining: {} MB, concurrent: {}, ranges: {}), using sequential",
                     remaining_size / 1024 / 1024,
                     self.config.concurrent_fragments,

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
@@ -19,7 +19,7 @@
 pub mod cipher;
 mod client_key;
 
-use log::{debug, info, warn};
+use log::debug;
 use rdlp_core::{ExtractionContext, RdlpError, Result};
 use regex::Regex;
 use std::sync::LazyLock;
@@ -109,7 +109,7 @@ pub async fn extract_sources(embed_url: &str, ctx: &ExtractionContext) -> Result
         match fetch_get_sources(&url, embed_url, ctx).await {
             Ok(json) => match parse_sources_response(&json, None, None) {
                 Ok(sources) if !sources.sources.is_empty() => {
-                    info!("Resolved sources via same-domain getSources");
+                    debug!("Resolved sources via same-domain getSources");
                     return Ok(sources);
                 }
                 Ok(_) => debug!("Same-domain getSources returned empty sources"),
@@ -123,7 +123,7 @@ pub async fn extract_sources(embed_url: &str, ctx: &ExtractionContext) -> Result
     match try_extract_v3(&source_id, embed_url, ctx).await {
         Ok(sources) => return Ok(sources),
         Err(e) => {
-            warn!("v3 extraction failed: {e}");
+            debug!("v3 extraction failed: {e}");
         }
     }
 
@@ -265,7 +265,7 @@ fn parse_sources_response(
 
         match (client_key, megacloud_key) {
             (Some(ck), Some(mk)) => {
-                info!("Decrypting sources with custom cipher");
+                debug!("Decrypting sources with custom cipher");
                 let decrypted = cipher::decrypt_src(encrypted_str, ck, mk)?;
                 let arr: Vec<serde_json::Value> =
                     serde_json::from_str(&decrypted).map_err(|e| {

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -96,7 +96,7 @@ pub(crate) async fn resolve_episode_formats(
 
     api::sort_by_preference(&mut servers);
 
-    info!(
+    debug!(
         servers = servers.len();
         "Found streaming servers, attempting extraction"
     );
@@ -132,7 +132,7 @@ pub(crate) async fn resolve_episode_formats(
         // Extract video sources from Megacloud embed
         match megacloud::extract_sources(&source.embed_url, ctx).await {
             Ok(mega_sources) => {
-                info!(
+                debug!(
                     server:% = server.server_name,
                     sources = mega_sources.sources.len(),
                     tracks = mega_sources.tracks.len();
@@ -375,7 +375,7 @@ impl InfoExtractor for NineAnimeExtractor {
             ))
         })?;
 
-        info!(episode_id:%; "Lazily resolving 9anime episode formats");
+        debug!(episode_id:%; "Lazily resolving 9anime episode formats");
 
         let (formats, hls_flags, subtitle_tracks) =
             resolve_episode_formats(&episode_id, ctx).await?;

--- a/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
@@ -13,7 +13,7 @@
 //! - Each episode resolves formats just before download (~3-5s per episode)
 
 use crate::base::common::MAX_PLAYLIST_SIZE;
-use log::{debug, info, warn};
+use log::{debug, info};
 use rdlp_core::{ExtractionContext, InfoDict, RdlpError, Result};
 use scraper::Html;
 
@@ -52,7 +52,7 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
     };
 
     let anime_title = anime_metadata.title.clone();
-    info!(title:% = anime_title; "Anime metadata resolved");
+    debug!(title:% = anime_title; "Anime metadata resolved");
 
     // Fetch full episode list
     let episodes = episodes::fetch_all_episodes(&anime_id, ctx).await?;
@@ -64,7 +64,7 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
     }
 
     let total = episodes.len();
-    info!(total; "Found episodes in anime");
+    debug!(total; "Found episodes in anime");
 
     // Security: limit playlist size
     if total > MAX_PLAYLIST_SIZE {
@@ -91,7 +91,7 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
 
         match resolve_episode_formats(&ep.data_id, ctx).await {
             Ok((formats, hls_flags, subtitle_tracks)) if !formats.is_empty() => {
-                info!(
+                debug!(
                     episode:% = label,
                     formats = formats.len();
                     "Episode resolved successfully for type detection"
@@ -101,10 +101,10 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
                 break;
             }
             Ok(_) => {
-                warn!(episode:% = label; "No formats resolved, trying next episode");
+                debug!(episode:% = label; "No formats resolved, trying next episode");
             }
             Err(e) => {
-                warn!(episode:% = label; "Failed to resolve episode: {e}");
+                debug!(episode:% = label; "Failed to resolve episode: {e}");
             }
         }
     }

--- a/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
@@ -10,7 +10,7 @@
 
 use crate::base::common::MAX_PLAYLIST_SIZE;
 use futures::stream::{self, StreamExt};
-use log::{debug, info, warn};
+use log::{debug, info};
 use rdlp_core::{
     ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, check_http_response,
 };
@@ -115,7 +115,7 @@ pub async fn extract_playlist(
                     all_video_urls.extend(page_videos);
                 }
                 Err(e) => {
-                    warn!(page = page_num; "Failed to fetch page: {e}");
+                    debug!(page = page_num; "Failed to fetch page: {e}");
                     break;
                 }
             }
@@ -126,7 +126,7 @@ pub async fn extract_playlist(
     }
 
     let total = all_video_urls.len();
-    info!(total; "[PornHub] Found videos in playlist");
+    debug!(total; "[PornHub] Found videos in playlist");
 
     // Security check: limit playlist size to prevent memory exhaustion
     if total > MAX_PLAYLIST_SIZE {
@@ -169,14 +169,14 @@ pub async fn extract_playlist(
                         Some((position, info))
                     }
                     Ok(Err(e)) => {
-                        warn!(
+                        debug!(
                             position, total, title:? = video_title_hint;
                             "Failed to extract video: {e}"
                         );
                         None
                     }
                     Err(_) => {
-                        warn!(position, total, title:? = video_title_hint; "Timed out extracting video");
+                        debug!(position, total, title:? = video_title_hint; "Timed out extracting video");
                         None
                     }
                 }

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -3,7 +3,7 @@
 //! Extracts video formats from JavaScript sources, mediaDefinition arrays,
 //! and the `getVideoById` JSON API response.
 
-use log::{debug, warn};
+use log::debug;
 use rdlp_core::{ExtractionContext, Format, RdlpError, Result, Thumbnail};
 use regex::Regex;
 use serde::Deserialize;
@@ -399,11 +399,11 @@ async fn fetch_formats_from_endpoint(
         Ok(r) => r,
         Err(e) => {
             if e.is_timeout() {
-                warn!(url:? = absolute_url; "[RedTube] Request timed out");
+                debug!(url:? = absolute_url; "[RedTube] Request timed out");
             } else if e.is_connect() {
-                warn!(url:? = absolute_url; "[RedTube] Connection failed: {e}");
+                debug!(url:? = absolute_url; "[RedTube] Connection failed: {e}");
             } else {
-                warn!("[RedTube] Request failed: {e}");
+                debug!("[RedTube] Request failed: {e}");
             }
             return None;
         }

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -21,7 +21,7 @@ mod patterns;
 mod search;
 
 use async_trait::async_trait;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use rdlp_core::{
     ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
     SearchPageResponse,
@@ -307,7 +307,7 @@ impl RedTubeExtractor {
                 Err(e) => {
                     if page == 1 {
                         // First page failed, try HTML fallback
-                        warn!("[RedTube] API search failed, falling back to HTML: {e}");
+                        debug!("[RedTube] API search failed, falling back to HTML: {e}");
                         let html_url = patterns::build_html_search_url(&query.query);
                         match self.fetch_html_search_page(&html_url, ctx).await {
                             Ok(results) => results,
@@ -317,7 +317,7 @@ impl RedTubeExtractor {
                             }
                         }
                     } else {
-                        warn!(
+                        debug!(
                             page;
                             "[RedTube] Failed to fetch search page, returning partial results: {e}"
                         );
@@ -350,7 +350,7 @@ impl RedTubeExtractor {
             tokio::time::sleep(Duration::from_millis(SEARCH_RATE_LIMIT_MS)).await;
         }
 
-        info!(
+        debug!(
             count = all_results.len(), pages = page;
             "[RedTube] Search complete"
         );
@@ -431,7 +431,7 @@ impl SearchExtractor for RedTubeExtractor {
             Ok(result) => result,
             Err(e) => {
                 if page == 1 {
-                    warn!("[RedTube] API search failed, falling back to HTML: {e}");
+                    debug!("[RedTube] API search failed, falling back to HTML: {e}");
                     let html_url = patterns::build_html_search_url(&query.query);
                     let results = self.fetch_html_search_page(&html_url, ctx).await?;
                     (results, None)

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -3,7 +3,7 @@
 //! Provides serde structs for the RedTube JSON API response, conversion to
 //! `SearchResultPreview`, HTML fallback scraping, and filter validation.
 
-use log::warn;
+use log::debug;
 use rdlp_core::{RdlpError, Result, SearchFilter, SearchFilterDescriptor, SearchResultPreview};
 use serde::{Deserialize, Deserializer};
 
@@ -109,7 +109,7 @@ pub(crate) fn parse_api_search_results(
 /// Returns `None` if essential fields (url) are empty, logging a warning.
 fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
     if video.url.is_empty() {
-        warn!(
+        debug!(
             "[RedTube] Search result missing URL for video_id={}, skipping",
             video.video_id
         );

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -18,7 +18,7 @@ mod search;
 mod search_patterns;
 
 use async_trait::async_trait;
-use log::{debug, info, warn};
+use log::debug;
 use rdlp_core::{
     ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
     SearchPageResponse,
@@ -275,7 +275,7 @@ impl TNAFlixSearchExtractor {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    warn!(page; "[TNAFlix] Failed to fetch search page, returning partial results: {e}");
+                    debug!(page; "[TNAFlix] Failed to fetch search page, returning partial results: {e}");
                     break;
                 }
             };
@@ -300,7 +300,7 @@ impl TNAFlixSearchExtractor {
             tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
         }
 
-        info!(count = all_results.len(), pages = page; "[TNAFlix] Search complete");
+        debug!(count = all_results.len(), pages = page; "[TNAFlix] Search complete");
 
         Ok(all_results)
     }

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -26,7 +26,7 @@ mod search_patterns;
 mod utils;
 
 use async_trait::async_trait;
-use log::{debug, info, warn};
+use log::debug;
 use rdlp_core::{
     ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
     SearchPageResponse,
@@ -232,7 +232,7 @@ impl XHamsterExtractor {
             {
                 Ok(result) => result,
                 Err(e) => {
-                    warn!(page; "[XHamster] Failed to fetch search page, returning partial results: {e}");
+                    debug!(page; "[XHamster] Failed to fetch search page, returning partial results: {e}");
                     break;
                 }
             };
@@ -257,7 +257,7 @@ impl XHamsterExtractor {
             tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
         }
 
-        info!(count = all_results.len(), pages = page; "[XHamster] Search complete");
+        debug!(count = all_results.len(), pages = page; "[XHamster] Search complete");
 
         Ok(all_results)
     }

--- a/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
@@ -6,7 +6,7 @@ use super::XHamsterExtractor;
 use super::patterns;
 use crate::base::common::MAX_PLAYLIST_SIZE;
 use futures::stream::{self, StreamExt};
-use log::{debug, info, warn};
+use log::{debug, info};
 use rdlp_core::{ExtractionContext, InfoDict, RdlpError, Result, check_http_response};
 use regex::Regex;
 use std::collections::HashSet;
@@ -83,7 +83,7 @@ impl XHamsterExtractor {
         }
 
         let total = all_video_urls.len();
-        info!(total; "[XHamster] Found videos in user playlist");
+        debug!(total; "[XHamster] Found videos in user playlist");
 
         if total == 0 {
             return Err(RdlpError::Extraction(format!(
@@ -130,11 +130,11 @@ impl XHamsterExtractor {
                                 Some((position, info))
                             }
                             Ok(Err(e)) => {
-                                warn!(position, total; "Failed to extract video: {e}");
+                                debug!(position, total; "Failed to extract video: {e}");
                                 None
                             }
                             Err(_) => {
-                                warn!(position, total; "Timed out extracting video");
+                                debug!(position, total; "Timed out extracting video");
                                 None
                             }
                         }

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -1,6 +1,6 @@
 //! XHamster search result parsing and filter validation.
 
-use log::warn;
+use log::debug;
 use rdlp_core::{RdlpError, Result, SearchFilter, SearchResultPreview};
 use serde_json::Value;
 
@@ -38,7 +38,7 @@ pub fn parse_search_results_json(initials: &Value) -> Result<Vec<SearchResultPre
         let video_url = match item.get("pageURL").and_then(|v| v.as_str()) {
             Some(url) => url.to_string(),
             None => {
-                warn!("[XHamster] Search result missing pageURL, skipping");
+                debug!("[XHamster] Search result missing pageURL, skipping");
                 continue;
             }
         };

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
@@ -7,7 +7,7 @@
 use std::ffi::CStr;
 use std::path::Path;
 
-use log::{debug, info, warn};
+use log::{debug, warn};
 
 use crate::error::{PostProcessError, Result};
 
@@ -327,10 +327,10 @@ impl FFmpegRunner {
     /// levels against targets. Warns on significant deviations but does
     /// not fail — the output is already written.
     pub(super) fn verify_loudness_sync(output: &Path, opts: &NormalizeOptions) -> Result<()> {
-        info!("Loudness verification: analyzing output...");
+        debug!("Loudness verification: analyzing output...");
         match Self::loudnorm_pass1_sync(output, opts) {
             Ok(measured) => {
-                info!(
+                debug!(
                     "Loudness verification: I={:.1} LUFS, TP={:.1} dBTP, LRA={:.1} LU",
                     measured.input_i, measured.input_tp, measured.input_lra
                 );

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use log::{debug, info, warn};
+use log::{debug, warn};
 
 use crate::error::{PostProcessError, Result};
 
@@ -49,7 +49,7 @@ impl FFmpegRunner {
         crate::ffmpeg::ensure_init()?;
 
         let mut ictx = if resilient {
-            info!("[{label}] opening input with resilient flags (discardcorrupt+genpts)");
+            debug!("[{label}] opening input with resilient flags (discardcorrupt+genpts)");
             open_input_resilient(input)?
         } else {
             ffmpeg_the_third::format::input(input).map_err(|e| {
@@ -189,15 +189,15 @@ impl FFmpegRunner {
             audio_encoder.rate(),
             &enc_ch_layout_desc,
         );
-        info!("[{label}] filter_spec={filter_spec}");
+        debug!("[{label}] filter_spec={filter_spec}");
 
-        info!(
+        debug!(
             "[{label}] decoder: sample_rate={}, format={}, ch_layout={}",
             audio_decoder.rate(),
             audio_decoder.format().name(),
             audio_decoder.ch_layout().description(),
         );
-        info!(
+        debug!(
             "[{label}] encoder: sample_rate={}, format={}, ch_layout={}",
             audio_encoder.rate(),
             audio_encoder.format().name(),
@@ -233,7 +233,7 @@ impl FFmpegRunner {
         } else {
             0
         };
-        info!(
+        debug!(
             "Expected audio packet duration: {} (frame_size={}, enc_tb={}/{}, ost_tb={}/{})",
             expected_duration,
             audio_encoder.frame_size(),
@@ -258,7 +258,7 @@ impl FFmpegRunner {
             0
         };
         if start_samples > 0 {
-            info!(
+            debug!(
                 "[{label}] preserving input start offset: {format_start_time_us} µs = {start_samples} samples",
             );
         }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use log::{info, warn};
+use log::{debug, warn};
 
 use crate::error::{PostProcessError, Result};
 
@@ -68,7 +68,7 @@ pub(super) fn build_loudnorm_pass2_filter(
     let shortfall = measurements.linear_shortfall(opts.target_i, opts.target_tp);
     let predicted_gain = measurements.predict_linear_gain(opts.target_i, opts.target_tp);
 
-    info!(
+    debug!(
         "Loudnorm analysis: desired_gain={:.1} dB, predicted_linear_gain={:.1} dB, \
          shortfall={:.1} LU",
         opts.target_i - measurements.input_i,
@@ -77,10 +77,10 @@ pub(super) fn build_loudnorm_pass2_filter(
     );
 
     let linear_mode = if opts.force_dynamic {
-        info!("Strategy: dynamic (forced via --loudnorm-dynamic)");
+        debug!("Strategy: dynamic (forced via --loudnorm-dynamic)");
         "false"
     } else {
-        info!(
+        debug!(
             "Strategy: linear (shortfall={shortfall:.1} LU, \
              loudnorm handles internal fallback to dynamic if needed)"
         );
@@ -103,7 +103,7 @@ pub(super) fn build_loudnorm_pass2_filter(
     );
 
     if opts.precompress {
-        info!("Precompress enabled: prepending acompressor (threshold=-18dB, ratio=3:1)");
+        debug!("Precompress enabled: prepending acompressor (threshold=-18dB, ratio=3:1)");
         format!(
             "acompressor=threshold=0.125893:ratio=3:attack=20:release=200:makeup=2:knee=6,\
              {loudnorm}"
@@ -330,7 +330,7 @@ where
             let result = encode_fn(&salvaged, false);
             if result.is_ok() {
                 if keep_salvage {
-                    info!(
+                    debug!(
                         "RDLP_KEEP_SALVAGE=1: keeping salvage temp {}",
                         salvaged.display()
                     );
@@ -344,7 +344,7 @@ where
                 result.as_ref().unwrap_err()
             );
             if !keep_salvage {
-                info!(
+                debug!(
                     "Keeping salvage temp for post-mortem: {}",
                     salvaged.display()
                 );
@@ -363,7 +363,7 @@ where
     }
 
     // Tier 3: library encode with resilient input (discardcorrupt+genpts)
-    info!("Attempting resilient encode (discardcorrupt+genpts)...");
+    debug!("Attempting resilient encode (discardcorrupt+genpts)...");
     encode_fn(input, true)
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
@@ -18,7 +18,7 @@ mod tests;
 
 use std::path::Path;
 
-use log::{info, warn};
+use log::{debug, info, warn};
 
 use crate::error::{PostProcessError, Result};
 
@@ -73,14 +73,14 @@ impl FFmpegRunner {
     fn normalize_peak_sync(input: &Path, output: &Path, opts: &NormalizeOptions) -> Result<()> {
         let analysis = Self::analyze_peak_sync(input, opts.target_peak_db)?;
 
-        info!(
+        debug!(
             "Peak analysis: peak={:.1} dBFS, RMS={:.1} dBFS, gain={:.1} dB",
             analysis.peak_db, analysis.rms_db, analysis.gain_db
         );
 
         // Skip if gain adjustment is negligible
         if analysis.gain_db.abs() < 0.5 {
-            info!("Audio already near target peak, skipping normalization");
+            debug!("Audio already near target peak, skipping normalization");
             std::fs::copy(input, output).map_err(|e| PostProcessError::IoError {
                 message: format!("failed to copy file: {e}"),
                 source: e,
@@ -96,7 +96,7 @@ impl FFmpegRunner {
         info!("Loudnorm pass 1: analyzing EBU R128 levels...");
         let measurements = Self::loudnorm_pass1_sync(input, opts)?;
 
-        info!(
+        debug!(
             "Loudnorm measurements: I={:.1} LUFS, TP={:.1} dBTP, LRA={:.1} LU",
             measurements.input_i, measurements.input_tp, measurements.input_lra
         );
@@ -113,7 +113,7 @@ impl FFmpegRunner {
         let shortfall = measurements.linear_shortfall(opts.target_i, opts.target_tp);
         if opts.boost_enabled {
             if shortfall > LIMITER_BOOST_SHORTFALL_THRESHOLD {
-                info!(
+                debug!(
                     "LimiterBoost: shortfall={shortfall:.1} LU, \
                      gain={:.1} dB — using fixed gain + limiter",
                     opts.boost_gain_db
@@ -122,7 +122,7 @@ impl FFmpegRunner {
                 Self::verify_loudness_sync(output, opts)?;
                 return Ok(());
             }
-            info!(
+            debug!(
                 "LimiterBoost: enabled but shortfall={shortfall:.1} LU <= \
                  {LIMITER_BOOST_SHORTFALL_THRESHOLD:.1} threshold — using standard loudnorm",
             );
@@ -149,7 +149,7 @@ impl FFmpegRunner {
     ) -> Result<()> {
         let ceiling_db = opts.target_tp - ALIMITER_TP_HEADROOM_DB;
         let limit_linear = 10f64.powf(ceiling_db / 20.0);
-        info!(
+        debug!(
             "LimiterBoost: gain_db={:.1}, ceiling_db={:.1} (TP={:.1} - headroom={:.1}), \
              limit_linear={:.6}",
             opts.boost_gain_db, ceiling_db, opts.target_tp, ALIMITER_TP_HEADROOM_DB, limit_linear,

--- a/crates/rdlp-http/src/client.rs
+++ b/crates/rdlp-http/src/client.rs
@@ -82,7 +82,7 @@ impl HttpClientFactory {
         if let Some(proxy_url) = &self.config.proxy {
             match reqwest::Proxy::all(proxy_url) {
                 Ok(proxy) => builder = builder.proxy(proxy),
-                Err(e) => tracing::warn!("Invalid proxy URL '{}': {}", proxy_url, e),
+                Err(e) => tracing::debug!("Invalid proxy URL '{}': {}", proxy_url, e),
             }
         }
 

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -131,7 +131,7 @@ impl EmbedThumbnail {
         .await;
 
         match result {
-            Ok(Ok(())) => info!("MP4 covr atom written for Windows Explorer"),
+            Ok(Ok(())) => debug!("MP4 covr atom written for Windows Explorer"),
             Ok(Err(e)) => warn!("Failed to write MP4 covr atom: {e}"),
             Err(e) => warn!("covr atom task panicked: {e}"),
         }
@@ -172,7 +172,7 @@ impl PostProcessor for EmbedThumbnail {
         let mut temp_files: Vec<PathBuf> = Vec::new();
         let (media_file, extension, output_files) = if !Self::supports_thumbnail(extension) {
             let remuxed_path = media_file.with_extension("mp4");
-            info!(
+            debug!(
                 from:? = media_file.display(),
                 to:? = remuxed_path.display();
                 "Auto-remuxing unsupported container to MP4 for thumbnail embedding"
@@ -226,7 +226,7 @@ impl PostProcessor for EmbedThumbnail {
             Ok(()) => {
                 // Replace original with temp
                 tokio::fs::rename(&temp_output, &media_file).await?;
-                info!(file:? = media_file.display(); "Thumbnail embedded via FFmpeg");
+                debug!(file:? = media_file.display(); "Thumbnail embedded via FFmpeg");
 
                 // For MP4-family: write covr atom so Windows Explorer shows the thumbnail
                 if Self::is_mp4_family(&extension) {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -101,7 +101,7 @@ impl PostProcessor for FFmpegExtractAudio {
         let target_format = match config.audio_format {
             Some(f) => f.codec_name(),
             None => {
-                info!("No audio format configured; defaulting to MP3");
+                debug!("No audio format configured; defaulting to MP3");
                 "mp3"
             }
         };
@@ -111,7 +111,7 @@ impl PostProcessor for FFmpegExtractAudio {
                 operation: "audio extraction".to_string(),
             })?;
 
-        info!(
+        debug!(
             "Extracting audio from {} to {} format",
             input_file.display(),
             target_format

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -46,7 +46,7 @@ impl FFmpegMerger {
 
             // Default to MP4 for most content (h264/h265 + aac)
             _ => {
-                info!("No merge output format configured; defaulting to MP4");
+                debug!("No merge output format configured; defaulting to MP4");
                 "mp4"
             }
         }
@@ -131,7 +131,7 @@ impl PostProcessor for FFmpegMerger {
             .merge(video_file, audio_file, &output_path, &opts)
             .await?;
 
-        info!(output:? = output_path.display(); "Merged output");
+        debug!(output:? = output_path.display(); "Merged output");
 
         // Return result with merged file and original files as temp
         Ok(PostProcessResult {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use log::info;
+use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::ChapterEntry;
@@ -144,7 +144,7 @@ impl PostProcessor for FFmpegMetadata {
             .extension()
             .and_then(|e| e.to_str())
             .unwrap_or_else(|| {
-                info!(
+                debug!(
                     file:? = input_file.display();
                     "No file extension detected, defaulting to mp4"
                 );

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use log::info;
+use log::{debug, info};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::{AudioNormMode, LoudnormPreset, NormalizeOptions, PostProcessError};
@@ -108,7 +108,7 @@ impl PostProcessor for FFmpegNormalizeAudio {
             .extension()
             .and_then(|e| e.to_str())
             .unwrap_or_else(|| {
-                info!(
+                debug!(
                     file:? = input_file.display();
                     "No file extension detected, defaulting to mp4"
                 );

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -108,7 +108,7 @@ impl PostProcessor for FFmpegRemuxer {
         // Perform remux via library bindings
         self.ffmpeg.remux(input_file, &output_path, &opts).await?;
 
-        info!(
+        debug!(
             output:? = output_path.display();
             "Remuxed successfully"
         );

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -174,7 +174,7 @@ impl PostProcessor for FFmpegVideoConvertor {
         let target_format = match config.recode_video {
             Some(c) => c.as_ext(),
             None => {
-                info!("No recode target configured; defaulting to MP4");
+                debug!("No recode target configured; defaulting to MP4");
                 "mp4"
             }
         };

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -37,7 +37,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, info, warn};
+use log::{debug, info, trace, warn};
 use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor};
 
 use crate::processors::*;
@@ -173,7 +173,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
 
         for processor in &processors {
             if !processor.should_run(&current_info, config) {
-                debug!(name:? = processor.name(); "Skipping post-processor (should_run returned false)");
+                trace!(name:? = processor.name(); "Skipping post-processor (should_run returned false)");
                 continue;
             }
 
@@ -211,7 +211,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
         for temp_file in &all_temp_files {
             if temp_file.exists() {
                 if let Err(e) = tokio::fs::remove_file(temp_file).await {
-                    warn!(path:? = temp_file.display(); "Failed to remove temp file: {e}");
+                    debug!(path:? = temp_file.display(); "Failed to remove temp file: {e}");
                 } else {
                     debug!(path:? = temp_file.display(); "Removed temp file");
                 }


### PR DESCRIPTION
## Summary

- Demote implementation details from `info!`/`warn!` to `debug!`/`trace!` across 50 files in 12 crates
- Only user-visible lifecycle events remain at `info!` (download started/completed, format selected, major post-process steps)
- No functional changes — pure log level refactoring

### Log distribution before/after

| Level | Before | After | Change |
|-------|--------|-------|--------|
| `error!` | 11 | 12 | +1 |
| `warn!` | 150 | 102 | -32% |
| `info!` | 248 | 111 | -55% |
| `debug!` | 206 | 377 | +83% |
| `trace!` | 13 | 16 | +23% |

### Crates affected
rdlp-api, rdlp-cli, rdlp-cookies, rdlp-crypto, rdlp-desktop, rdlp-downloader, rdlp-extractor, rdlp-ffmpeg, rdlp-http, rdlp-postprocess

### Key demotion patterns
- Session state save/delete errors: `warn!` → `debug!` (best-effort, non-blocking)
- HLS state validation mismatches: `warn!` → `debug!` (expected fallback to fresh download)
- Desktop IPC emission failures: `warn!` → `debug!` (non-critical for downloads)
- CLI list/simulate output: `info!` → `debug!`
- Cookie per-row parse errors: `warn!` → `debug!` (per-item silent skip)
- Post-processor defaults/skips: `info!`/`debug!` → `debug!`/`trace!`
- FFmpeg normalize internals (filter_spec, codec details): `info!` → `debug!`
- Extractor intermediate steps (URL resolution, cipher details): `info!` → `debug!`

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass