### PR TITLE
feat(downloader): adaptive AIMD chunk sizing and connection tuning

### DIFF
--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -45,6 +45,13 @@ impl ProgressCallback for EventProgressCallback {
             message: format!("Download error: {error}"),
         });
     }
+
+    fn on_log(&self, message: &str) {
+        let _ = self.event_tx.try_send(Event::Debug {
+            id: self.download_id,
+            message: message.to_string(),
+        });
+    }
 }
 
 impl Orchestrator {

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -136,6 +136,12 @@ pub trait ProgressCallback: Send + Sync {
 
     /// Called when download fails
     fn on_error(&self, error: &str);
+
+    /// Called when a log message is produced during download.
+    ///
+    /// Used by the adaptive controller to report AIMD decisions.
+    /// Default is a no-op; GUI implementations forward to the event system.
+    fn on_log(&self, _message: &str) {}
 }
 
 /// Current download progress information

--- a/crates/rdlp-desktop/src/components/CommandBar.test.tsx
+++ b/crates/rdlp-desktop/src/components/CommandBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, createTestQueryClient } from "@/test/test-utils";
+import { render, screen, act, fireEvent, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import { CommandBar } from "./CommandBar";
 import { searchParamsAtom, resetSearchParams } from "../stores/searchParamsStore";
@@ -62,10 +62,10 @@ describe("CommandBar", () => {
         expect(btn).toBeDisabled();
     });
 
-    it("submit button is enabled after typing a query", async () => {
+    it("submit button is enabled after typing a query", () => {
         renderCommandBar();
         const input = screen.getByPlaceholderText("Search videos...");
-        await userEvent.type(input, "test");
+        fireEvent.change(input, { target: { value: "test" } });
         expect(screen.getByRole("button", { name: /^search$/i })).not.toBeDisabled();
     });
 
@@ -73,22 +73,22 @@ describe("CommandBar", () => {
         const onSearch = vi.fn();
         renderCommandBar({ onSearch });
         const input = screen.getByPlaceholderText("Search videos...");
-        await userEvent.type(input, "cats");
+        fireEvent.change(input, { target: { value: "cats" } });
         await userEvent.click(screen.getByRole("button", { name: /^search$/i }));
         expect(onSearch).toHaveBeenCalledTimes(1);
     });
 
-    it("shows clear button when query has text", async () => {
+    it("shows clear button when query has text", () => {
         renderCommandBar();
         const input = screen.getByPlaceholderText("Search videos...");
-        await userEvent.type(input, "dogs");
+        fireEvent.change(input, { target: { value: "dogs" } });
         expect(screen.getByRole("button", { name: /clear search/i })).toBeInTheDocument();
     });
 
     it("clears the query when clear button is clicked", async () => {
         renderCommandBar();
         const input = screen.getByPlaceholderText("Search videos...");
-        await userEvent.type(input, "dogs");
+        fireEvent.change(input, { target: { value: "dogs" } });
         await userEvent.click(screen.getByRole("button", { name: /clear search/i }));
         expect(input).toHaveValue("");
     });
@@ -99,10 +99,10 @@ describe("CommandBar", () => {
         expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
     });
 
-    it("updates store query on input change", async () => {
+    it("updates store query on input change", () => {
         renderCommandBar();
         const input = screen.getByPlaceholderText("Search videos...");
-        await userEvent.type(input, "hello");
+        fireEvent.change(input, { target: { value: "hello" } });
         expect(searchParamsAtom.state.query).toBe("hello");
     });
 });

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@/test/test-utils";
+import { render, screen, fireEvent } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import {
     FormatOptionsPanel,
@@ -265,21 +265,21 @@ describe("Audio Normalization Select — displayed value", () => {
 // ---------------------------------------------------------------------------
 
 describe("Audio Normalization Select — onChange branches", () => {
-    async function openNormSelect() {
+    function openNormSelect() {
         const label = screen.getByText(/audio normalization/i);
         const container = label.closest("div.flex-col")!;
         const trigger = container.querySelector('[role="combobox"]') as HTMLElement;
-        await userEvent.click(trigger);
+        fireEvent.pointerDown(trigger, { button: 0, pointerType: "mouse" });
     }
 
-    it("selecting 'default' calls onChange with all 10 normalization fields null", async () => {
+    it("selecting 'default' calls onChange with all 10 normalization fields null", () => {
         const onChange = vi.fn();
         renderPanel(
             { ...defaultOptions, normalizeAudio: false, loudnorm: false },
             onChange,
         );
-        await openNormSelect();
-        await userEvent.click(screen.getByRole("option", { name: /use settings default/i }));
+        openNormSelect();
+        fireEvent.click(screen.getByRole("option", { name: /use settings default/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.normalizeAudio).toBeNull();
@@ -294,11 +294,11 @@ describe("Audio Normalization Select — onChange branches", () => {
         expect(called.normalizeBoostDb).toBeNull();
     });
 
-    it("selecting 'off' calls onChange with normalizeAudio false and loudnorm false", async () => {
+    it("selecting 'off' calls onChange with normalizeAudio false and loudnorm false", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
-        await openNormSelect();
-        await userEvent.click(screen.getByRole("option", { name: /^off$/i }));
+        openNormSelect();
+        fireEvent.click(screen.getByRole("option", { name: /^off$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.normalizeAudio).toBe(false);
@@ -307,11 +307,11 @@ describe("Audio Normalization Select — onChange branches", () => {
         expect(called.normalizeBoostDb).toBeNull();
     });
 
-    it("selecting 'peak' calls onChange with normalizeAudio true and loudnorm false", async () => {
+    it("selecting 'peak' calls onChange with normalizeAudio true and loudnorm false", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
-        await openNormSelect();
-        await userEvent.click(screen.getByRole("option", { name: /^peak$/i }));
+        openNormSelect();
+        fireEvent.click(screen.getByRole("option", { name: /^peak$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.normalizeAudio).toBe(true);
@@ -319,11 +319,11 @@ describe("Audio Normalization Select — onChange branches", () => {
         expect(called.loudnormPreset).toBeNull();
     });
 
-    it("selecting 'loudnorm-streaming' calls onChange with loudnorm true and preset 'streaming'", async () => {
+    it("selecting 'loudnorm-streaming' calls onChange with loudnorm true and preset 'streaming'", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
-        await openNormSelect();
-        await userEvent.click(
+        openNormSelect();
+        fireEvent.click(
             screen.getByRole("option", { name: /loudnorm.*streaming/i }),
         );
         expect(onChange).toHaveBeenCalledTimes(1);
@@ -333,11 +333,11 @@ describe("Audio Normalization Select — onChange branches", () => {
         expect(called.loudnormPreset).toBe("streaming");
     });
 
-    it("selecting 'loudnorm-broadcast' calls onChange with loudnorm true and preset 'broadcast'", async () => {
+    it("selecting 'loudnorm-broadcast' calls onChange with loudnorm true and preset 'broadcast'", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, normalizeAudio: null }, onChange);
-        await openNormSelect();
-        await userEvent.click(
+        openNormSelect();
+        fireEvent.click(
             screen.getByRole("option", { name: /loudnorm.*broadcast/i }),
         );
         expect(onChange).toHaveBeenCalledTimes(1);
@@ -418,31 +418,31 @@ describe("Remux Select", () => {
         expect(getRemuxSelect()).toHaveTextContent(/^none$/i);
     });
 
-    it("selecting MP4 calls onChange with remux: 'mp4'", async () => {
+    it("selecting MP4 calls onChange with remux: 'mp4'", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, remux: null }, onChange);
-        await userEvent.click(getRemuxSelect());
-        await userEvent.click(screen.getByRole("option", { name: /^mp4$/i }));
+        fireEvent.pointerDown(getRemuxSelect(), { button: 0, pointerType: "mouse" });
+        fireEvent.click(screen.getByRole("option", { name: /^mp4$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.remux).toBe("mp4");
     });
 
-    it("selecting MKV calls onChange with remux: 'mkv'", async () => {
+    it("selecting MKV calls onChange with remux: 'mkv'", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, remux: null }, onChange);
-        await userEvent.click(getRemuxSelect());
-        await userEvent.click(screen.getByRole("option", { name: /^mkv$/i }));
+        fireEvent.pointerDown(getRemuxSelect(), { button: 0, pointerType: "mouse" });
+        fireEvent.click(screen.getByRole("option", { name: /^mkv$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.remux).toBe("mkv");
     });
 
-    it("selecting None calls onChange with remux: null", async () => {
+    it("selecting None calls onChange with remux: null", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, remux: "mp4" }, onChange);
-        await userEvent.click(getRemuxSelect());
-        await userEvent.click(screen.getByRole("option", { name: /^none$/i }));
+        fireEvent.pointerDown(getRemuxSelect(), { button: 0, pointerType: "mouse" });
+        fireEvent.click(screen.getByRole("option", { name: /^none$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.remux).toBeNull();
@@ -461,21 +461,21 @@ describe("Extract Audio Select", () => {
         expect(getAudioSelect()).toHaveTextContent(/^none$/i);
     });
 
-    it("selecting MP3 calls onChange with extractAudio: 'mp3'", async () => {
+    it("selecting MP3 calls onChange with extractAudio: 'mp3'", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, extractAudio: null }, onChange);
-        await userEvent.click(getAudioSelect());
-        await userEvent.click(screen.getByRole("option", { name: /^mp3$/i }));
+        fireEvent.pointerDown(getAudioSelect(), { button: 0, pointerType: "mouse" });
+        fireEvent.click(screen.getByRole("option", { name: /^mp3$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.extractAudio).toBe("mp3");
     });
 
-    it("selecting Opus calls onChange with extractAudio: 'opus'", async () => {
+    it("selecting Opus calls onChange with extractAudio: 'opus'", () => {
         const onChange = vi.fn();
         renderPanel({ ...defaultOptions, extractAudio: null }, onChange);
-        await userEvent.click(getAudioSelect());
-        await userEvent.click(screen.getByRole("option", { name: /^opus$/i }));
+        fireEvent.pointerDown(getAudioSelect(), { button: 0, pointerType: "mouse" });
+        fireEvent.click(screen.getByRole("option", { name: /^opus$/i }));
         expect(onChange).toHaveBeenCalledTimes(1);
         const called = onChange.mock.calls[0][0] as DownloadOptions;
         expect(called.extractAudio).toBe("opus");

--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -20,6 +20,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         output_path: null,
         options: null,
         statusMessage: null,
+        logMessages: undefined,
         ...overrides,
     };
 }
@@ -196,5 +197,59 @@ describe("JobCard", () => {
             expect(screen.getByText(/could not reveal file/i)).toBeInTheDocument();
         });
         clearInvokeHandlers();
+    });
+
+    it("does not render log panel when logMessages is undefined", () => {
+        render(
+            <JobCard
+                job={makeJob({ logMessages: undefined })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.queryByText(/^logs/i)).not.toBeInTheDocument();
+    });
+
+    it("does not render log panel when logMessages is empty", () => {
+        render(
+            <JobCard
+                job={makeJob({ logMessages: [] })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.queryByText(/^logs/i)).not.toBeInTheDocument();
+    });
+
+    it("renders log panel summary with message count", () => {
+        render(
+            <JobCard
+                job={makeJob({ logMessages: ["Starting download", "Fetching metadata"] })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("Logs (2)")).toBeInTheDocument();
+    });
+
+    it("renders all log messages in the panel", async () => {
+        render(
+            <JobCard
+                job={makeJob({
+                    logMessages: ["First message", "Second message", "Third message"],
+                })}
+                onCancel={vi.fn()}
+                onRemove={vi.fn()}
+                onRetry={vi.fn()}
+            />,
+        );
+        // Open the details element
+        await userEvent.click(screen.getByText("Logs (3)"));
+        expect(screen.getByText("First message")).toBeInTheDocument();
+        expect(screen.getByText("Second message")).toBeInTheDocument();
+        expect(screen.getByText("Third message")).toBeInTheDocument();
     });
 });

--- a/crates/rdlp-desktop/src/components/JobCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.tsx
@@ -100,6 +100,26 @@ export function JobCard({ job, onCancel, onRemove, onRetry }: JobCardProps) {
                     </div>
                 )}
 
+                {job.logMessages && job.logMessages.length > 0 && (
+                    <div className="border-t border-border pt-2">
+                        <details>
+                            <summary className="cursor-pointer select-none text-xs text-muted-foreground">
+                                Logs ({job.logMessages.length})
+                            </summary>
+                            <div className="mt-1.5 max-h-[120px] overflow-y-auto">
+                                {job.logMessages.map((msg, i) => (
+                                    <p
+                                        key={i}
+                                        className="font-mono text-xs text-muted-foreground"
+                                    >
+                                        {msg}
+                                    </p>
+                                ))}
+                            </div>
+                        </details>
+                    </div>
+                )}
+
                 {isFailed && job.error && (
                     <Alert variant="destructive" className="py-2">
                         <AlertDescription className="text-xs">

--- a/crates/rdlp-desktop/src/components/ResultCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/ResultCard.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@/test/test-utils";
+import { render, screen, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
-import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
 import { ResultCard } from "./ResultCard";
+import { queryKeys } from "../query/queryKeys";
 import type { SearchResultPreview } from "../types";
 
 const baseResult: SearchResultPreview = {
@@ -13,13 +13,12 @@ const baseResult: SearchResultPreview = {
     upload_date: null,
 };
 
-beforeEach(() => {
-    setInvokeHandler("get_settings", () => null);
-});
-
-afterEach(() => {
-    clearInvokeHandlers();
-});
+/** Pre-seed settings so ResultCard renders synchronously. */
+function seededClient() {
+    const qc = createTestQueryClient();
+    qc.setQueryData(queryKeys.settings(), null);
+    return qc;
+}
 
 describe("ResultCard", () => {
     it("renders the video title", () => {
@@ -30,6 +29,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         expect(screen.getByRole("heading", { name: "Sample Video Title" })).toBeInTheDocument();
     });
@@ -42,6 +42,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         const img = screen.getByRole("img", { name: "Sample Video Title" });
         expect(img).toHaveAttribute("src", "https://example.com/thumb.jpg");
@@ -55,6 +56,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         expect(screen.getByText(/no thumbnail/i)).toBeInTheDocument();
     });
@@ -67,6 +69,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         // 185s = 3:05
         expect(screen.getByText("3:05")).toBeInTheDocument();
@@ -80,6 +83,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         expect(screen.getByText("12.5K views")).toBeInTheDocument();
     });
@@ -93,6 +97,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         await userEvent.click(screen.getByRole("button", { name: /^download$/i }));
         expect(onDownload).toHaveBeenCalledWith(
@@ -110,6 +115,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={onOpenFormatDialog}
             />,
+            { queryClient: seededClient() },
         );
         await userEvent.click(screen.getByRole("button", { name: /choose format/i }));
         expect(onOpenFormatDialog).toHaveBeenCalledWith("https://example.com/video.mp4");
@@ -123,6 +129,7 @@ describe("ResultCard", () => {
                 onDownloadWithOptions={vi.fn()}
                 onOpenFormatDialog={vi.fn()}
             />,
+            { queryClient: seededClient() },
         );
         expect(screen.queryByText(/views/i)).not.toBeInTheDocument();
     });

--- a/crates/rdlp-desktop/src/components/StatusBar.test.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBar.test.tsx
@@ -1,8 +1,18 @@
-import { render, screen, act } from "@/test/test-utils";
+import { render, screen, act, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
 import { StatusBar } from "./StatusBar";
 import { resetSearchParams } from "../stores/searchParamsStore";
+import { queryKeys } from "../query/queryKeys";
+import type { DownloadJob } from "../types";
+
+/** Pre-seed the query cache so StatusBar renders synchronously. */
+function seededClient(jobs: DownloadJob[] = []) {
+    const qc = createTestQueryClient();
+    qc.setQueryData(queryKeys.providers(), []);
+    qc.setQueryData(queryKeys.downloads.list(), jobs);
+    return qc;
+}
 
 beforeEach(() => {
     resetSearchParams();
@@ -15,17 +25,21 @@ afterEach(() => {
     act(() => resetSearchParams());
 });
 
-function renderStatusBar(props?: {
-    viewMode?: "list" | "grid";
-    onViewModeChange?: (mode: "list" | "grid") => void;
-    onSwitchToQueue?: () => void;
-}) {
+function renderStatusBar(
+    props?: {
+        viewMode?: "list" | "grid";
+        onViewModeChange?: (mode: "list" | "grid") => void;
+        onSwitchToQueue?: () => void;
+    },
+    jobs: DownloadJob[] = [],
+) {
     return render(
         <StatusBar
             viewMode={props?.viewMode ?? "list"}
             onViewModeChange={props?.onViewModeChange ?? vi.fn()}
             onSwitchToQueue={props?.onSwitchToQueue ?? vi.fn()}
         />,
+        { queryClient: seededClient(jobs) },
     );
 }
 
@@ -67,30 +81,24 @@ describe("StatusBar", () => {
 
     it("calls onSwitchToQueue when active download link is clicked", async () => {
         const onSwitchToQueue = vi.fn();
-
-        // Return an active job so the center button appears
-        setInvokeHandler("get_queue", () => [
-            {
-                id: "job-1",
-                url: "https://example.com/video",
-                title: "Video",
-                status: "running",
-                progress: 0.5,
-                speed: "2 MB/s",
-                eta: "5s",
-                error: null,
-                retryable: false,
-                started_at: null,
-                completed_at: null,
-                output_path: null,
-                statusMessage: null,
-            },
-        ]);
-
-        renderStatusBar({ onSwitchToQueue });
-
-        // Wait for queue to load and the center button to appear
-        const link = await screen.findByTitle(/switch to queue/i);
+        const activeJob: DownloadJob = {
+            id: "job-1",
+            url: "https://example.com/video",
+            title: "Video",
+            status: "running",
+            progress: 0.5,
+            speed: "2 MB/s",
+            eta: "5s",
+            error: null,
+            retryable: false,
+            started_at: null,
+            completed_at: null,
+            output_path: null,
+            options: null,
+            statusMessage: null,
+        };
+        renderStatusBar({ onSwitchToQueue }, [activeJob]);
+        const link = screen.getByTitle(/switch to queue/i);
         await userEvent.click(link);
         expect(onSwitchToQueue).toHaveBeenCalledTimes(1);
     });

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -1,0 +1,129 @@
+// Tests for registerDownloadEvents — verifying cache mutations per event type.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { mockEmit, clearEventListeners } from "@/test/tauri-mock";
+import { queryKeys } from "../query/queryKeys";
+import { registerDownloadEvents } from "./registerDownloadEvents";
+import type { DownloadJob } from "../types";
+
+function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
+    return {
+        id: "job-1",
+        url: "https://example.com/video",
+        title: "Test Video",
+        status: "running",
+        progress: 0,
+        speed: null,
+        eta: null,
+        error: null,
+        retryable: false,
+        started_at: null,
+        completed_at: null,
+        output_path: null,
+        options: null,
+        statusMessage: null,
+        logMessages: undefined,
+        ...overrides,
+    };
+}
+
+describe("registerDownloadEvents", () => {
+    let qc: QueryClient;
+    let cleanup: () => void;
+
+    beforeEach(() => {
+        qc = new QueryClient({
+            defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+        });
+        cleanup = registerDownloadEvents(qc);
+    });
+
+    afterEach(() => {
+        cleanup();
+        clearEventListeners();
+        qc.clear();
+    });
+
+    it("appends a log message to logMessages on download-log event", async () => {
+        const job = makeJob({ id: "job-42" });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("download-log", {
+            jobId: "job-42",
+            level: "info",
+            message: "Fetching metadata",
+        });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0].logMessages).toEqual(["Fetching metadata"]);
+    });
+
+    it("accumulates multiple log messages in order", async () => {
+        const job = makeJob({ id: "job-42" });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("download-log", {
+            jobId: "job-42",
+            level: "info",
+            message: "First",
+        });
+        await mockEmit("download-log", {
+            jobId: "job-42",
+            level: "info",
+            message: "Second",
+        });
+        await mockEmit("download-log", {
+            jobId: "job-42",
+            level: "warn",
+            message: "Third",
+        });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0].logMessages).toEqual(["First", "Second", "Third"]);
+    });
+
+    it("also updates statusMessage on download-log event", async () => {
+        const job = makeJob({ id: "job-42" });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("download-log", {
+            jobId: "job-42",
+            level: "info",
+            message: "Merging streams",
+        });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0].statusMessage).toBe("Merging streams");
+    });
+
+    it("does not affect other jobs when a log event arrives", async () => {
+        const job1 = makeJob({ id: "job-1" });
+        const job2 = makeJob({ id: "job-2", title: "Other Video" });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job1, job2]);
+
+        await mockEmit("download-log", {
+            jobId: "job-1",
+            level: "info",
+            message: "Only for job-1",
+        });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0].logMessages).toEqual(["Only for job-1"]);
+        expect(jobs[1].logMessages).toBeUndefined();
+    });
+
+    it("appends to existing logMessages when already populated", async () => {
+        const job = makeJob({ id: "job-42", logMessages: ["Previous message"] });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("download-log", {
+            jobId: "job-42",
+            level: "info",
+            message: "New message",
+        });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0].logMessages).toEqual(["Previous message", "New message"]);
+    });
+});

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -128,7 +128,11 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                 (old) =>
                     old?.map((job) =>
                         job.id === p.jobId
-                            ? { ...job, statusMessage: p.message }
+                            ? {
+                                  ...job,
+                                  statusMessage: p.message,
+                                  logMessages: [...(job.logMessages || []), p.message],
+                              }
                             : job,
                     ),
             );

--- a/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from "@/test/test-utils";
+import { render, screen, waitFor, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
 import { DownloadPage } from "./DownloadPage";
+import { queryKeys } from "../query/queryKeys";
 import type { AppSettings } from "../types";
 
 const defaultSettings: AppSettings = {
@@ -34,6 +35,14 @@ const defaultSettings: AppSettings = {
     embed_subtitles: false,
 };
 
+/** Pre-seed the query cache so components render synchronously. */
+function seededClient() {
+    const qc = createTestQueryClient();
+    qc.setQueryData(queryKeys.settings(), defaultSettings);
+    qc.setQueryData(queryKeys.downloads.list(), []);
+    return qc;
+}
+
 beforeEach(() => {
     setInvokeHandler("get_settings", () => defaultSettings);
     setInvokeHandler("get_queue", () => []);
@@ -44,34 +53,32 @@ afterEach(() => {
 });
 
 describe("DownloadPage", () => {
-    it("renders the URL input and Download button", async () => {
-        render(<DownloadPage />);
+    it("renders the URL input and Download button", () => {
+        render(<DownloadPage />, { queryClient: seededClient() });
         expect(screen.getByPlaceholderText(/paste a video url/i)).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
     });
 
     it("renders the Choose Format button", () => {
-        render(<DownloadPage />);
+        render(<DownloadPage />, { queryClient: seededClient() });
         expect(screen.getByRole("button", { name: /choose format/i })).toBeInTheDocument();
     });
 
     it("shows validation error for non-URL input", async () => {
         const user = userEvent.setup();
-        render(<DownloadPage />);
+        render(<DownloadPage />, { queryClient: seededClient() });
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.click(input);
         await user.paste("not a url");
         await user.click(screen.getByRole("button", { name: /download/i }));
-        await waitFor(() => {
-            expect(screen.getByText(/enter a valid url/i)).toBeInTheDocument();
-        });
+        expect(screen.getByText(/enter a valid url/i)).toBeInTheDocument();
     });
 
     it("calls start_download with a valid URL", async () => {
         const startHandler = vi.fn(() => "job-123");
         setInvokeHandler("start_download", startHandler);
         const user = userEvent.setup();
-        render(<DownloadPage />);
+        render(<DownloadPage />, { queryClient: seededClient() });
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.click(input);
         await user.paste("https://example.com/video");
@@ -84,7 +91,7 @@ describe("DownloadPage", () => {
     it("clears the input after successful download start", async () => {
         setInvokeHandler("start_download", () => "job-123");
         const user = userEvent.setup();
-        render(<DownloadPage />);
+        render(<DownloadPage />, { queryClient: seededClient() });
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.click(input);
         await user.paste("https://example.com/video");
@@ -99,7 +106,7 @@ describe("DownloadPage", () => {
             throw { kind: "InvalidInput", data: { message: "URL blocked by security policy" } };
         });
         const user = userEvent.setup();
-        render(<DownloadPage />);
+        render(<DownloadPage />, { queryClient: seededClient() });
         const input = screen.getByPlaceholderText(/paste a video url/i);
         await user.click(input);
         await user.paste("https://evil.local/video");
@@ -110,7 +117,7 @@ describe("DownloadPage", () => {
     });
 
     it("disables Download button when input is empty", () => {
-        render(<DownloadPage />);
+        render(<DownloadPage />, { queryClient: seededClient() });
         expect(screen.getByRole("button", { name: /download/i })).toBeDisabled();
     });
 });

--- a/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/DownloadPage.test.tsx
@@ -59,7 +59,8 @@ describe("DownloadPage", () => {
         const user = userEvent.setup();
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
-        await user.type(input, "not a url");
+        await user.click(input);
+        await user.paste("not a url");
         await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(screen.getByText(/enter a valid url/i)).toBeInTheDocument();
@@ -72,7 +73,8 @@ describe("DownloadPage", () => {
         const user = userEvent.setup();
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
-        await user.type(input, "https://example.com/video");
+        await user.click(input);
+        await user.paste("https://example.com/video");
         await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(startHandler).toHaveBeenCalled();
@@ -84,7 +86,8 @@ describe("DownloadPage", () => {
         const user = userEvent.setup();
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
-        await user.type(input, "https://example.com/video");
+        await user.click(input);
+        await user.paste("https://example.com/video");
         await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(input).toHaveValue("");
@@ -98,7 +101,8 @@ describe("DownloadPage", () => {
         const user = userEvent.setup();
         render(<DownloadPage />);
         const input = screen.getByPlaceholderText(/paste a video url/i);
-        await user.type(input, "https://evil.local/video");
+        await user.click(input);
+        await user.paste("https://evil.local/video");
         await user.click(screen.getByRole("button", { name: /download/i }));
         await waitFor(() => {
             expect(screen.getByText(/failed to start download/i)).toBeInTheDocument();

--- a/crates/rdlp-desktop/src/pages/QueuePage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/QueuePage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from "@/test/test-utils";
+import { render, screen, waitFor, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
 import { QueuePage } from "./QueuePage";
+import { queryKeys } from "../query/queryKeys";
 import type { AppSettings, DownloadJob } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -58,6 +59,14 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
     };
 }
 
+/** Pre-seed the query cache so QueuePage renders synchronously. */
+function seededClient(jobs: DownloadJob[] = []) {
+    const qc = createTestQueryClient();
+    qc.setQueryData(queryKeys.settings(), defaultSettings);
+    qc.setQueryData(queryKeys.downloads.list(), jobs);
+    return qc;
+}
+
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
@@ -80,16 +89,14 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("QueuePage — empty state", () => {
-    it("shows empty state when there are no jobs", async () => {
-        render(<QueuePage />);
-        await waitFor(() => {
-            expect(screen.getByText(/no downloads yet/i)).toBeInTheDocument();
-        });
+    it("shows empty state when there are no jobs", () => {
+        render(<QueuePage />, { queryClient: seededClient() });
+        expect(screen.getByText(/no downloads yet/i)).toBeInTheDocument();
     });
 
-    it("does not render Active or History headings when queue is empty", async () => {
-        render(<QueuePage />);
-        await waitFor(() => screen.getByText(/no downloads yet/i));
+    it("does not render Active or History headings when queue is empty", () => {
+        render(<QueuePage />, { queryClient: seededClient() });
+        expect(screen.getByText(/no downloads yet/i)).toBeInTheDocument();
         expect(screen.queryByText(/^active/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/^history/i)).not.toBeInTheDocument();
     });
@@ -100,60 +107,54 @@ describe("QueuePage — empty state", () => {
 // ---------------------------------------------------------------------------
 
 describe("QueuePage — active/history split", () => {
-    it("renders Active section for pending and running jobs", async () => {
-        setInvokeHandler("get_queue", () => [
+    it("renders Active section for pending and running jobs", () => {
+        const jobs = [
             makeJob({ id: "j1", status: "pending" }),
             makeJob({ id: "j2", status: "running", progress: 0.5 }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => {
-            expect(screen.getByText(/^active \(2\)/i)).toBeInTheDocument();
-        });
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^active \(2\)/i)).toBeInTheDocument();
         expect(screen.queryByText(/^history/i)).not.toBeInTheDocument();
     });
 
-    it("renders History section for completed, failed, and cancelled jobs", async () => {
-        setInvokeHandler("get_queue", () => [
+    it("renders History section for completed, failed, and cancelled jobs", () => {
+        const jobs = [
             makeJob({ id: "j1", status: "completed" }),
             makeJob({ id: "j2", status: "failed", error: "timeout" }),
             makeJob({ id: "j3", status: "cancelled" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => {
-            expect(screen.getByText(/^history \(3\)/i)).toBeInTheDocument();
-        });
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^history \(3\)/i)).toBeInTheDocument();
         expect(screen.queryByText(/^active/i)).not.toBeInTheDocument();
     });
 
-    it("renders both Active and History sections when both exist", async () => {
-        setInvokeHandler("get_queue", () => [
+    it("renders both Active and History sections when both exist", () => {
+        const jobs = [
             makeJob({ id: "j1", status: "running", progress: 0.2 }),
             makeJob({ id: "j2", status: "completed" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => {
-            expect(screen.getByText(/^active \(1\)/i)).toBeInTheDocument();
-        });
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^active \(1\)/i)).toBeInTheDocument();
         expect(screen.getByText(/^history \(1\)/i)).toBeInTheDocument();
     });
 
-    it("renders a Cancel button only for active jobs", async () => {
-        setInvokeHandler("get_queue", () => [
+    it("renders a Cancel button only for active jobs", () => {
+        const jobs = [
             makeJob({ id: "j1", status: "running", progress: 0.3 }),
             makeJob({ id: "j2", status: "completed" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByText(/^active \(1\)/i));
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^active \(1\)/i)).toBeInTheDocument();
         expect(screen.getAllByRole("button", { name: /cancel/i })).toHaveLength(1);
     });
 
-    it("renders a Remove button for each terminal job", async () => {
-        setInvokeHandler("get_queue", () => [
+    it("renders a Remove button for each terminal job", () => {
+        const jobs = [
             makeJob({ id: "j1", status: "completed" }),
             makeJob({ id: "j2", status: "cancelled" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByText(/^history \(2\)/i));
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^history \(2\)/i)).toBeInTheDocument();
         expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(2);
     });
 });
@@ -166,11 +167,8 @@ describe("QueuePage — cancel", () => {
     it("calls cancel_download with the correct job id", async () => {
         const cancelHandler = vi.fn((_args?: Record<string, unknown>) => undefined);
         setInvokeHandler("cancel_download", cancelHandler);
-        setInvokeHandler("get_queue", () => [
-            makeJob({ id: "job-abc", status: "running", progress: 0.5 }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByRole("button", { name: /cancel/i }));
+        const jobs = [makeJob({ id: "job-abc", status: "running", progress: 0.5 })];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
         await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
         await waitFor(() => expect(cancelHandler).toHaveBeenCalled());
         const args = cancelHandler.mock.calls[0][0] as { jobId: string };
@@ -186,11 +184,8 @@ describe("QueuePage — remove", () => {
     it("calls remove_job with the correct job id", async () => {
         const removeHandler = vi.fn((_args?: Record<string, unknown>) => undefined);
         setInvokeHandler("remove_job", removeHandler);
-        setInvokeHandler("get_queue", () => [
-            makeJob({ id: "job-xyz", status: "completed" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByRole("button", { name: /remove/i }));
+        const jobs = [makeJob({ id: "job-xyz", status: "completed" })];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
         await userEvent.click(screen.getByRole("button", { name: /remove/i }));
         await waitFor(() => expect(removeHandler).toHaveBeenCalled());
         const args = removeHandler.mock.calls[0][0] as { jobId: string };
@@ -203,29 +198,23 @@ describe("QueuePage — remove", () => {
 // ---------------------------------------------------------------------------
 
 describe("QueuePage — retry", () => {
-    it("shows Retry button for retryable failed jobs", async () => {
-        setInvokeHandler("get_queue", () => [
-            makeJob({ status: "failed", retryable: true, error: "Network error" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() =>
-            expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument(),
-        );
+    it("shows Retry button for retryable failed jobs", () => {
+        const jobs = [makeJob({ status: "failed", retryable: true, error: "Network error" })];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
     });
 
-    it("does not show Retry button for non-retryable failed jobs", async () => {
-        setInvokeHandler("get_queue", () => [
-            makeJob({ status: "failed", retryable: false, error: "Fatal error" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByText(/^history/i));
+    it("does not show Retry button for non-retryable failed jobs", () => {
+        const jobs = [makeJob({ status: "failed", retryable: false, error: "Fatal error" })];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^history/i)).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
     });
 
     it("calls start_download when Retry is clicked", async () => {
         const startHandler = vi.fn(() => "new-job-id");
         setInvokeHandler("start_download", startHandler);
-        setInvokeHandler("get_queue", () => [
+        const jobs = [
             makeJob({
                 id: "j1",
                 url: "https://example.com/retry-me",
@@ -233,9 +222,8 @@ describe("QueuePage — retry", () => {
                 retryable: true,
                 error: "Timeout",
             }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByRole("button", { name: /retry/i }));
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
         await userEvent.click(screen.getByRole("button", { name: /retry/i }));
         await waitFor(() => expect(startHandler).toHaveBeenCalled());
     });
@@ -246,33 +234,28 @@ describe("QueuePage — retry", () => {
 // ---------------------------------------------------------------------------
 
 describe("QueuePage — Clear All", () => {
-    it("shows Clear All button in the History section", async () => {
-        setInvokeHandler("get_queue", () => [
-            makeJob({ id: "j1", status: "completed" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByText(/^history/i));
+    it("shows Clear All button in the History section", () => {
+        const jobs = [makeJob({ id: "j1", status: "completed" })];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^history/i)).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /clear all/i })).toBeInTheDocument();
     });
 
-    it("does not show Clear All button when history is empty", async () => {
-        setInvokeHandler("get_queue", () => [
-            makeJob({ id: "j1", status: "running", progress: 0.1 }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByText(/^active/i));
+    it("does not show Clear All button when history is empty", () => {
+        const jobs = [makeJob({ id: "j1", status: "running", progress: 0.1 })];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
+        expect(screen.getByText(/^active/i)).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: /clear all/i })).not.toBeInTheDocument();
     });
 
     it("calls clear_completed_jobs when Clear All is clicked", async () => {
         const clearHandler = vi.fn(() => undefined);
         setInvokeHandler("clear_completed_jobs", clearHandler);
-        setInvokeHandler("get_queue", () => [
+        const jobs = [
             makeJob({ id: "j1", status: "completed" }),
             makeJob({ id: "j2", status: "failed", error: "Error" }),
-        ]);
-        render(<QueuePage />);
-        await waitFor(() => screen.getByRole("button", { name: /clear all/i }));
+        ];
+        render(<QueuePage />, { queryClient: seededClient(jobs) });
         await userEvent.click(screen.getByRole("button", { name: /clear all/i }));
         await waitFor(() => expect(clearHandler).toHaveBeenCalled());
     });

--- a/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, createTestQueryClient } from "@/test/test-utils";
+import { render, screen, waitFor, fireEvent, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
 import { SettingsPage } from "./SettingsPage";
@@ -159,10 +159,7 @@ describe("SettingsPage", () => {
         const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true };
         render(<SettingsPage />, { queryClient: seededClient(settings) });
 
-        const input = screen.getByLabelText(/loudness target/i);
-        await userEvent.clear(input);
-        await userEvent.type(input, "5");
-
+        fireEvent.change(screen.getByLabelText(/loudness target/i), { target: { value: "5" } });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
         await waitFor(() => {
             expect(screen.getByRole("alert")).toBeInTheDocument();
@@ -174,10 +171,7 @@ describe("SettingsPage", () => {
         const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true };
         render(<SettingsPage />, { queryClient: seededClient(settings) });
 
-        const input = screen.getByLabelText(/true peak limit/i);
-        await userEvent.clear(input);
-        await userEvent.type(input, "1");
-
+        fireEvent.change(screen.getByLabelText(/true peak limit/i), { target: { value: "1" } });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
         await waitFor(() => {
             expect(screen.getByRole("alert")).toBeInTheDocument();
@@ -189,10 +183,7 @@ describe("SettingsPage", () => {
         const settings = { ...defaultSettings, normalize_audio: true, normalize_boost: true };
         render(<SettingsPage />, { queryClient: seededClient(settings) });
 
-        const input = screen.getByPlaceholderText("12.0");
-        await userEvent.clear(input);
-        await userEvent.type(input, "50");
-
+        fireEvent.change(screen.getByPlaceholderText("12.0"), { target: { value: "50" } });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
         await waitFor(() => {
             expect(screen.getByRole("alert")).toBeInTheDocument();

--- a/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from "@/test/test-utils";
+import { render, screen, waitFor, createTestQueryClient } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
 import { setInvokeHandler, clearInvokeHandlers } from "@/test/tauri-mock";
 import { SettingsPage } from "./SettingsPage";
+import { queryKeys } from "../query/queryKeys";
 import type { AppSettings } from "../types";
 
 const defaultSettings: AppSettings = {
@@ -34,11 +35,19 @@ const defaultSettings: AppSettings = {
     embed_subtitles: false,
 };
 
+const mockProviders = [{ name: "redtube", display_name: "RedTube" }];
+
+/** Pre-seed the query cache so SettingsPage renders synchronously. */
+function seededClient(settings: AppSettings = defaultSettings) {
+    const qc = createTestQueryClient();
+    qc.setQueryData(queryKeys.settings(), settings);
+    qc.setQueryData(queryKeys.providers(), mockProviders);
+    return qc;
+}
+
 beforeEach(() => {
     setInvokeHandler("get_settings", () => defaultSettings);
-    setInvokeHandler("get_search_providers", () => [
-        { name: "redtube", display_name: "RedTube" },
-    ]);
+    setInvokeHandler("get_search_providers", () => mockProviders);
     setInvokeHandler("update_settings", () => undefined);
 });
 
@@ -48,100 +57,77 @@ afterEach(() => {
 
 describe("SettingsPage", () => {
     it("shows loading state initially", () => {
+        // Do NOT pre-seed — test the loading skeleton
         render(<SettingsPage />);
         expect(screen.getByText(/loading settings/i)).toBeInTheDocument();
     });
 
-    it("renders the settings form after loading", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => {
-            expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
-        });
+    it("renders the settings form after loading", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
+        expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
     });
 
-    it("displays the output directory value", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => {
-            expect(screen.getByDisplayValue("/home/user/Videos")).toBeInTheDocument();
-        });
+    it("displays the output directory value", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
+        expect(screen.getByDisplayValue("/home/user/Videos")).toBeInTheDocument();
     });
 
-    it("renders the Save Settings button", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => {
-            expect(screen.getByRole("button", { name: /save settings/i })).toBeInTheDocument();
-        });
+    it("renders the Save Settings button", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
+        expect(screen.getByRole("button", { name: /save settings/i })).toBeInTheDocument();
     });
 
     it("calls update_settings invoke when Save is clicked", async () => {
         const updateHandler = vi.fn(() => undefined);
         setInvokeHandler("update_settings", updateHandler);
 
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        render(<SettingsPage />, { queryClient: seededClient() });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
 
         expect(updateHandler).toHaveBeenCalledTimes(1);
     });
 
     it("shows error message when save fails", async () => {
-        // invokeTyped wraps errors into { code, message, details }.
-        // SettingsPage.handleSave calls String(err) on non-Error rejects,
-        // so throw an AppError-shaped object whose message invokeClient can extract.
         setInvokeHandler("update_settings", () => {
             throw { kind: "SaveFailed", data: { message: "Backend error" } };
         });
 
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        render(<SettingsPage />, { queryClient: seededClient() });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
 
         await waitFor(() => {
-            // invokeTyped extracts the message from the AppError data, but handleSave
-            // then calls String() on the InvokeError object → check the error is visible
             expect(screen.getByRole("alert")).toBeInTheDocument();
         });
     });
 
-    it("embed thumbnails checkbox reflects current setting", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("heading", { name: /settings/i }));
-
-        // embed_thumbnail is true in defaultSettings → checkbox should be checked
+    it("embed thumbnails checkbox reflects current setting", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
         const checkboxes = screen.getAllByRole("checkbox");
         const thumbnailCheckbox = checkboxes[0];
         expect(thumbnailCheckbox).toBeChecked();
     });
 
-    it("verbose logging checkbox unchecked by default", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("heading", { name: /settings/i }));
-
-        // verbose is false in defaultSettings
+    it("verbose logging checkbox unchecked by default", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
         const verboseLabel = screen.getByText(/verbose logging/i);
         const checkbox = verboseLabel.closest("div")?.querySelector('button[role="checkbox"]');
         expect(checkbox).toHaveAttribute("aria-checked", "false");
     });
 
-    it("renders Browse button for output directory", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => {
-            expect(screen.getByRole("button", { name: /browse/i })).toBeInTheDocument();
-        });
+    it("renders Browse button for output directory", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
+        expect(screen.getByRole("button", { name: /browse/i })).toBeInTheDocument();
     });
 
-    it("shows normalize audio checkbox unchecked by default", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByText(/normalize audio/i));
+    it("shows normalize audio checkbox unchecked by default", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
         const label = screen.getByText(/normalize audio/i);
         const checkbox = label.closest("div")?.querySelector('button[role="checkbox"]');
         expect(checkbox).toHaveAttribute("aria-checked", "false");
     });
 
     it("reveals mode toggle and boost fallback when normalize audio is checked", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByText(/normalize audio/i));
-        // Click the checkbox button directly to avoid double-fire from label+div onClick
+        render(<SettingsPage />, { queryClient: seededClient() });
         const normalizeLabel = screen.getByText(/normalize audio/i);
         const checkbox = normalizeLabel.closest("div")?.querySelector('button[role="checkbox"]');
         await userEvent.click(checkbox!);
@@ -151,29 +137,17 @@ describe("SettingsPage", () => {
         expect(screen.getByText(/boost fallback/i)).toBeInTheDocument();
     });
 
-    it("reveals preset select and advanced options when loudnorm mode is active", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            loudnorm: true,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByText(/dynamic mode/i));
+    it("reveals preset select and advanced options when loudnorm mode is active", () => {
+        const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
         expect(screen.getByText(/dynamic mode/i)).toBeInTheDocument();
         expect(screen.getByText(/precompress/i)).toBeInTheDocument();
-        // Preset label is present (using heading role to disambiguate from select items)
         expect(screen.getByText("Preset")).toBeInTheDocument();
     });
 
-    it("reveals boost gain input when boost fallback is checked", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            loudnorm: true,
-            normalize_boost: true,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByPlaceholderText("12.0"));
+    it("reveals boost gain input when boost fallback is checked", () => {
+        const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true, normalize_boost: true };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
         expect(screen.getByPlaceholderText("12.0")).toBeInTheDocument();
     });
 
@@ -182,15 +156,9 @@ describe("SettingsPage", () => {
     // -----------------------------------------------------------------------
 
     it("shows error when loudnorm_target_i is out of range (above 0)", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            loudnorm: true,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByLabelText(/loudness target/i));
+        const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
 
-        // Enter an out-of-range value: 5 is > 0, valid range is -70..0
         const input = screen.getByLabelText(/loudness target/i);
         await userEvent.clear(input);
         await userEvent.type(input, "5");
@@ -203,15 +171,9 @@ describe("SettingsPage", () => {
     });
 
     it("shows error when loudnorm_target_tp is out of range (above 0)", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            loudnorm: true,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByLabelText(/true peak limit/i));
+        const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
 
-        // Enter 1.0 — above the 0 maximum for true peak limit
         const input = screen.getByLabelText(/true peak limit/i);
         await userEvent.clear(input);
         await userEvent.type(input, "1");
@@ -224,15 +186,9 @@ describe("SettingsPage", () => {
     });
 
     it("shows error when normalize_boost_db is out of range (above 30)", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            normalize_boost: true,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByPlaceholderText("12.0"));
+        const settings = { ...defaultSettings, normalize_audio: true, normalize_boost: true };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
 
-        // Enter 50 — above the 30 maximum for boost gain
         const input = screen.getByPlaceholderText("12.0");
         await userEvent.clear(input);
         await userEvent.type(input, "50");
@@ -251,20 +207,12 @@ describe("SettingsPage", () => {
     it("calls update_settings with correct normalization payload for loudnorm broadcast preset", async () => {
         const updateHandler = vi.fn((_args?: Record<string, unknown>) => undefined);
         setInvokeHandler("update_settings", updateHandler);
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            loudnorm: true,
-            loudnorm_preset: "broadcast",
-        }));
+        const settings = { ...defaultSettings, normalize_audio: true, loudnorm: true, loudnorm_preset: "broadcast" };
 
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
 
         expect(updateHandler).toHaveBeenCalledTimes(1);
-        // updateSettings calls invoke("update_settings", { settings }) so the mock
-        // handler receives { settings: AppSettings } as its first argument.
         const args = updateHandler.mock.calls[0][0] as { settings: AppSettings };
         expect(args.settings.normalize_audio).toBe(true);
         expect(args.settings.loudnorm).toBe(true);
@@ -275,8 +223,7 @@ describe("SettingsPage", () => {
         const updateHandler = vi.fn((_args?: Record<string, unknown>) => undefined);
         setInvokeHandler("update_settings", updateHandler);
 
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("button", { name: /save settings/i }));
+        render(<SettingsPage />, { queryClient: seededClient() });
         await userEvent.click(screen.getByRole("button", { name: /save settings/i }));
 
         expect(updateHandler).toHaveBeenCalledTimes(1);
@@ -288,36 +235,22 @@ describe("SettingsPage", () => {
     // C. Visibility cascading
     // -----------------------------------------------------------------------
 
-    it("loudnorm mode toggle not visible when normalize_audio is unchecked", async () => {
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByRole("heading", { name: /settings/i }));
-        // normalize_audio is false in defaultSettings, so loudnorm toggle should be hidden
+    it("loudnorm mode toggle not visible when normalize_audio is unchecked", () => {
+        render(<SettingsPage />, { queryClient: seededClient() });
         expect(screen.queryByText(/ebu r128 loudnorm/i)).not.toBeInTheDocument();
     });
 
-    it("preset select and custom targets not visible when normalize_audio is checked but mode is Peak", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            loudnorm: false,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByText(/ebu r128 loudnorm/i));
-        // Peak mode: loudnorm-specific options should not appear
+    it("preset select and custom targets not visible when normalize_audio is checked but mode is Peak", () => {
+        const settings = { ...defaultSettings, normalize_audio: true, loudnorm: false };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
         expect(screen.queryByText(/dynamic mode/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/precompress/i)).not.toBeInTheDocument();
         expect(screen.queryByText("Preset")).not.toBeInTheDocument();
     });
 
-    it("boost dB input not visible when boost fallback is unchecked", async () => {
-        setInvokeHandler("get_settings", () => ({
-            ...defaultSettings,
-            normalize_audio: true,
-            normalize_boost: false,
-        }));
-        render(<SettingsPage />);
-        await waitFor(() => screen.getByText(/boost fallback/i));
-        // normalize_boost is false → boost gain input should not appear
+    it("boost dB input not visible when boost fallback is unchecked", () => {
+        const settings = { ...defaultSettings, normalize_audio: true, normalize_boost: false };
+        render(<SettingsPage />, { queryClient: seededClient(settings) });
         expect(screen.queryByPlaceholderText("12.0")).not.toBeInTheDocument();
     });
 });

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -117,6 +117,8 @@ export interface DownloadJob {
     options: DownloadOptions | null;
     /** Latest log message from the download-log event (frontend-only, not from Rust). */
     statusMessage: string | null;
+    /** Accumulated log messages from download-log events (frontend-only, not from Rust). */
+    logMessages?: string[];
 }
 
 /**

--- a/crates/rdlp-desktop/vitest.config.ts
+++ b/crates/rdlp-desktop/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         environment: "jsdom",
         setupFiles: ["./src/test/setup.ts"],
         include: ["src/**/*.{test,spec}.{ts,tsx}"],
+        pool: "threads",
         coverage: {
             provider: "v8",
             reporter: ["text", "json", "html"],

--- a/crates/rdlp-downloader/src/adaptive.rs
+++ b/crates/rdlp-downloader/src/adaptive.rs
@@ -18,6 +18,8 @@
 //! HLS mode skips chunk-level adjustments (segments have fixed server-determined
 //! sizes) and only tunes the connection count.
 
+use log::info;
+use rdlp_core::ProgressCallback;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -167,6 +169,7 @@ pub struct AdaptiveController {
     config: AdaptiveConfig,
     total_size: u64,
     mode: ControllerMode,
+    log_callback: Option<Arc<dyn ProgressCallback>>,
 }
 
 impl AdaptiveController {
@@ -176,18 +179,43 @@ impl AdaptiveController {
     /// * `total_size` - Total number of bytes to download.
     /// * `config` - Tuning parameters (connections, intervals, initial level).
     /// * `mode` - Whether this is an HTTP chunked or HLS segment download.
+    /// * `log_callback` - Optional progress callback for forwarding AIMD log messages.
     ///
     /// # Returns
     /// A new `AdaptiveController` ready to issue chunk requests.
-    pub fn new(total_size: u64, config: AdaptiveConfig, mode: ControllerMode) -> Self {
+    pub fn new(
+        total_size: u64,
+        config: AdaptiveConfig,
+        mode: ControllerMode,
+        log_callback: Option<Arc<dyn ProgressCallback>>,
+    ) -> Self {
+        let msg = format!(
+            "Adaptive controller: mode={mode:?}, size={:.1} MB, \
+             connections={}, chunk_level={} ({}KB)",
+            total_size as f64 / 1024.0 / 1024.0,
+            config.initial_connections,
+            config.initial_chunk_level,
+            CHUNK_LEVELS[config.initial_chunk_level as usize] / 1024,
+        );
+        info!("{msg}");
         let semaphore = Arc::new(Semaphore::new(config.initial_connections));
         let state = AdaptiveState::new(config.initial_connections, config.initial_chunk_level);
-        Self {
+        let ctrl = Self {
             state: Mutex::new(state),
             semaphore,
             config,
             total_size,
             mode,
+            log_callback,
+        };
+        ctrl.log(&msg);
+        ctrl
+    }
+
+    /// Forward a log message to the progress callback if one is set.
+    fn log(&self, message: &str) {
+        if let Some(ref cb) = self.log_callback {
+            cb.on_log(message);
         }
     }
 
@@ -322,6 +350,13 @@ impl AdaptiveController {
     ) {
         let Some(prev) = prev_ewma else {
             // No previous measurement — stay in SlowStart and ramp up.
+            let msg = format!(
+                "Adaptive [SlowStart]: initial ramp — chunk +2, +1 connection \
+                 (ewma={:.1} MB/s)",
+                current_ewma / 1024.0 / 1024.0,
+            );
+            info!("{msg}");
+            self.log(&msg);
             self.bump_chunk_level(state, 2);
             self.increase_connections(state);
             return;
@@ -329,11 +364,27 @@ impl AdaptiveController {
 
         if current_ewma > prev {
             // Throughput is increasing — stay aggressive.
+            let msg = format!(
+                "Adaptive [SlowStart]: throughput rising {:.1} → {:.1} MB/s — \
+                 chunk +2, +1 connection",
+                prev / 1024.0 / 1024.0,
+                current_ewma / 1024.0 / 1024.0,
+            );
+            info!("{msg}");
+            self.log(&msg);
             state.slow_start_plateaus = 0;
             self.bump_chunk_level(state, 2);
             self.increase_connections(state);
         } else if current_ewma < prev {
             // Throughput dropped — transition to Steady and apply one MD.
+            let msg = format!(
+                "Adaptive [SlowStart → Steady]: throughput drop {:.1} → {:.1} MB/s — \
+                 applying multiplicative decrease",
+                prev / 1024.0 / 1024.0,
+                current_ewma / 1024.0 / 1024.0,
+            );
+            info!("{msg}");
+            self.log(&msg);
             state.phase = Phase::Steady;
             state.slow_start_plateaus = 0;
             self.apply_md(state);
@@ -341,6 +392,14 @@ impl AdaptiveController {
             // Plateau: throughput unchanged.
             state.slow_start_plateaus += 1;
             if state.slow_start_plateaus >= SLOW_START_PLATEAU_LIMIT {
+                let msg = format!(
+                    "Adaptive [SlowStart → Steady]: {} consecutive plateaus at \
+                     {:.1} MB/s — transitioning",
+                    SLOW_START_PLATEAU_LIMIT,
+                    current_ewma / 1024.0 / 1024.0,
+                );
+                info!("{msg}");
+                self.log(&msg);
                 state.phase = Phase::Steady;
                 state.slow_start_plateaus = 0;
             }
@@ -364,20 +423,47 @@ impl AdaptiveController {
 
         if ratio > MD_THRESHOLD {
             // Throughput dropped > 30 % — multiplicative decrease.
+            let msg = format!(
+                "Adaptive [Steady]: throughput drop {:.0}% ({:.1} → {:.1} MB/s) — \
+                 multiplicative decrease",
+                ratio * 100.0,
+                prev / 1024.0 / 1024.0,
+                current_ewma / 1024.0 / 1024.0,
+            );
+            info!("{msg}");
+            self.log(&msg);
             self.apply_md(state);
         } else if ratio > NOISE_THRESHOLD {
             // 10–30 % drop — within noise, hold.
         } else {
             // Stable or improving — additive increase (+1 level).
+            let msg = format!(
+                "Adaptive [Steady]: stable at {:.1} MB/s — chunk +1",
+                current_ewma / 1024.0 / 1024.0,
+            );
+            info!("{msg}");
+            self.log(&msg);
             self.bump_chunk_level(state, 1);
         }
     }
 
     /// Apply multiplicative decrease: halve connections, chunk level −2.
     fn apply_md(&self, state: &mut AdaptiveState) {
+        let before_conns = state.current_connections;
+        let before_level = state.current_chunk_level;
         let target = (state.current_connections / 2).max(1);
         self.decrease_connections(state, target);
         self.bump_chunk_level(state, -(2i8));
+        let msg = format!(
+            "Adaptive MD: connections {} → {}, chunk level {} → {} ({}KB)",
+            before_conns,
+            state.current_connections,
+            before_level,
+            state.current_chunk_level,
+            CHUNK_LEVELS[state.current_chunk_level as usize] / 1024,
+        );
+        info!("{msg}");
+        self.log(&msg);
     }
 
     /// Increase the chunk level by `delta`, clamped to [0, 7].
@@ -387,8 +473,20 @@ impl AdaptiveController {
         if self.mode == ControllerMode::HlsSegments {
             return;
         }
-        let new_level = (state.current_chunk_level as i16 + delta as i16).clamp(0, 7) as u8;
+        let old_level = state.current_chunk_level;
+        let new_level = (old_level as i16 + delta as i16).clamp(0, 7) as u8;
         state.current_chunk_level = new_level;
+        if new_level != old_level {
+            let msg = format!(
+                "Adaptive: chunk level {} → {} ({}KB → {}KB)",
+                old_level,
+                new_level,
+                CHUNK_LEVELS[old_level as usize] / 1024,
+                CHUNK_LEVELS[new_level as usize] / 1024,
+            );
+            info!("{msg}");
+            self.log(&msg);
+        }
     }
 
     /// Increase connections by 1, up to `max_connections`.
@@ -398,6 +496,12 @@ impl AdaptiveController {
         if state.current_connections < self.config.max_connections {
             state.current_connections += 1;
             self.semaphore.add_permits(1);
+            let msg = format!(
+                "Adaptive: connections → {} (max {})",
+                state.current_connections, self.config.max_connections,
+            );
+            info!("{msg}");
+            self.log(&msg);
         }
     }
 
@@ -432,6 +536,7 @@ mod tests {
             total_size,
             AdaptiveConfig::default(),
             ControllerMode::HttpChunked,
+            None,
         )
     }
 
@@ -441,7 +546,7 @@ mod tests {
         config: AdaptiveConfig,
         mode: ControllerMode,
     ) -> AdaptiveController {
-        AdaptiveController::new(total_size, config, mode)
+        AdaptiveController::new(total_size, config, mode, None)
     }
 
     /// Drive the controller through `n` chunks and report each at `throughput` bytes/s.
@@ -819,6 +924,7 @@ mod tests {
             10 * 1024 * 1024,
             AdaptiveConfig::default(),
             ControllerMode::HlsSegments,
+            None,
         );
 
         // A 4-second segment downloaded in 1 second → ratio = 4.0.

--- a/crates/rdlp-downloader/src/adaptive.rs
+++ b/crates/rdlp-downloader/src/adaptive.rs
@@ -1,0 +1,837 @@
+//! Adaptive chunk sizing and connection tuning for downloads.
+//!
+//! This module implements an AIMD (Additive Increase / Multiplicative Decrease)
+//! controller that dynamically adjusts chunk sizes and parallel connection counts
+//! based on observed throughput. Both HTTP chunked downloads and HLS segment
+//! downloads are supported via the [`ControllerMode`] enum.
+//!
+//! # Algorithm Overview
+//!
+//! The controller operates in two phases:
+//!
+//! - **SlowStart**: Aggressively increases chunk level (+2) and adds a connection
+//!   each adjustment interval while throughput is growing. Exits to Steady on a
+//!   throughput drop or after 3 consecutive plateaus.
+//! - **Steady**: Uses classic AIMD — +1 level on stable throughput, halve
+//!   connections and −2 levels on a >30% drop, hold on 10–30% drops.
+//!
+//! HLS mode skips chunk-level adjustments (segments have fixed server-determined
+//! sizes) and only tunes the connection count.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+/// Power-of-two chunk size levels (bytes), from 64 KB to 8 MB.
+///
+/// The level index is an index into this array. Level 0 = 64 KB (minimum),
+/// level 7 = 8 MB (maximum).
+pub(crate) const CHUNK_LEVELS: [usize; 8] = [
+    64 * 1024,       // 64 KB
+    128 * 1024,      // 128 KB
+    256 * 1024,      // 256 KB
+    512 * 1024,      // 512 KB
+    1024 * 1024,     // 1 MB
+    2 * 1024 * 1024, // 2 MB
+    4 * 1024 * 1024, // 4 MB
+    8 * 1024 * 1024, // 8 MB
+];
+
+/// Maximum number of throughput samples retained in history.
+const MAX_HISTORY: usize = 8;
+
+/// EWMA smoothing factor: weight of the newest sample.
+const EWMA_ALPHA: f64 = 0.3;
+
+/// Threshold for "significant drop" (triggers multiplicative decrease).
+const MD_THRESHOLD: f64 = 0.30;
+
+/// Threshold for "mild noise" (within 10 %, hold steady).
+const NOISE_THRESHOLD: f64 = 0.10;
+
+/// Number of consecutive plateaus in SlowStart before transitioning to Steady.
+const SLOW_START_PLATEAU_LIMIT: usize = 3;
+
+// ─── Phase ────────────────────────────────────────────────────────────────────
+
+/// Congestion-control phase for the adaptive controller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    /// Aggressive ramp-up: chunk level grows by 2 each interval.
+    SlowStart,
+    /// AIMD steady state: +1 on stability, halve on congestion.
+    Steady,
+}
+
+// ─── ControllerMode ───────────────────────────────────────────────────────────
+
+/// Operating mode of the adaptive controller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerMode {
+    /// HTTP range-request chunked downloads. Both chunk level and connection
+    /// count are adjusted.
+    HttpChunked,
+    /// HLS segment downloads. Chunk-level adjustments are skipped because
+    /// segment sizes are determined by the server playlist.
+    HlsSegments,
+}
+
+// ─── ChunkRequest ─────────────────────────────────────────────────────────────
+
+/// A byte-range request produced by [`AdaptiveController::next_chunk`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkRequest {
+    /// Inclusive byte offset of the first byte.
+    pub start: u64,
+    /// Exclusive byte offset of the last byte (i.e. `end - start` == chunk length).
+    pub end: u64,
+}
+
+// ─── AdaptiveConfig ───────────────────────────────────────────────────────────
+
+/// Configuration for [`AdaptiveController`].
+#[derive(Debug, Clone)]
+pub struct AdaptiveConfig {
+    /// Maximum number of parallel connections permitted.
+    pub max_connections: usize,
+    /// How many completed chunks/segments to wait between AIMD adjustments.
+    pub decision_interval: usize,
+    /// Number of connections to start with.
+    pub initial_connections: usize,
+    /// Index into [`CHUNK_LEVELS`] to use at startup.
+    pub initial_chunk_level: u8,
+}
+
+impl Default for AdaptiveConfig {
+    fn default() -> Self {
+        Self {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 2,
+            initial_chunk_level: 0,
+        }
+    }
+}
+
+// ─── AdaptiveState ────────────────────────────────────────────────────────────
+
+/// Mutable runtime state guarded by [`AdaptiveController`]'s mutex.
+struct AdaptiveState {
+    current_chunk_level: u8,
+    current_connections: usize,
+    throughput_history: VecDeque<f64>,
+    chunks_since_last_adjust: usize,
+    bytes_assigned: u64,
+    phase: Phase,
+    /// Segment-to-realtime ratio (bytes/s / segment-bitrate).
+    realtime_ratio: Option<f64>,
+    /// Consecutive plateau count during SlowStart.
+    slow_start_plateaus: usize,
+    /// EWMA throughput from the previous adjustment, used to detect trend.
+    last_ewma: Option<f64>,
+}
+
+impl AdaptiveState {
+    fn new(initial_connections: usize, initial_chunk_level: u8) -> Self {
+        Self {
+            current_chunk_level: initial_chunk_level.min(7),
+            current_connections: initial_connections.max(1),
+            throughput_history: VecDeque::with_capacity(MAX_HISTORY),
+            chunks_since_last_adjust: 0,
+            bytes_assigned: 0,
+            phase: Phase::SlowStart,
+            realtime_ratio: None,
+            slow_start_plateaus: 0,
+            last_ewma: None,
+        }
+    }
+}
+
+// ─── AdaptiveController ───────────────────────────────────────────────────────
+
+/// AIMD-based adaptive controller for chunk sizes and connection counts.
+///
+/// Callers interact with this controller as follows:
+///
+/// 1. Call [`next_chunk`](Self::next_chunk) to obtain the next byte-range to
+///    download. Returns `None` when the file is fully assigned.
+/// 2. Acquire a permit from [`semaphore`](Self::semaphore) before starting each
+///    parallel worker (this gates concurrency).
+/// 3. After completing a chunk, call [`report_chunk_complete`](Self::report_chunk_complete)
+///    (HTTP) or [`report_segment_complete`](Self::report_segment_complete) (HLS)
+///    to record throughput and trigger potential AIMD adjustments.
+pub struct AdaptiveController {
+    state: Mutex<AdaptiveState>,
+    semaphore: Arc<Semaphore>,
+    config: AdaptiveConfig,
+    total_size: u64,
+    mode: ControllerMode,
+}
+
+impl AdaptiveController {
+    /// Create a new controller for a download of `total_size` bytes.
+    ///
+    /// # Arguments
+    /// * `total_size` - Total number of bytes to download.
+    /// * `config` - Tuning parameters (connections, intervals, initial level).
+    /// * `mode` - Whether this is an HTTP chunked or HLS segment download.
+    ///
+    /// # Returns
+    /// A new `AdaptiveController` ready to issue chunk requests.
+    pub fn new(total_size: u64, config: AdaptiveConfig, mode: ControllerMode) -> Self {
+        let semaphore = Arc::new(Semaphore::new(config.initial_connections));
+        let state = AdaptiveState::new(config.initial_connections, config.initial_chunk_level);
+        Self {
+            state: Mutex::new(state),
+            semaphore,
+            config,
+            total_size,
+            mode,
+        }
+    }
+
+    /// Returns a reference to the shared semaphore Arc.
+    ///
+    /// Callers should call [`Semaphore::acquire_owned`] on the returned value so
+    /// that the permit is automatically released when the worker future completes.
+    ///
+    /// # Returns
+    /// A reference to the `Arc<Semaphore>` controlling parallelism.
+    pub fn semaphore(&self) -> &Arc<Semaphore> {
+        &self.semaphore
+    }
+
+    /// Lazily generate the next chunk request based on the current chunk level.
+    ///
+    /// # Returns
+    /// `Some(ChunkRequest)` with the next byte range, or `None` when all bytes
+    /// have been assigned.
+    pub fn next_chunk(&self) -> Option<ChunkRequest> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        if state.bytes_assigned >= self.total_size {
+            return None;
+        }
+
+        let chunk_size = CHUNK_LEVELS[state.current_chunk_level as usize] as u64;
+        let start = state.bytes_assigned;
+        let end = (start + chunk_size).min(self.total_size);
+
+        state.bytes_assigned = end;
+        Some(ChunkRequest { start, end })
+    }
+
+    /// Record the completion of an HTTP chunk and potentially trigger AIMD.
+    ///
+    /// # Arguments
+    /// * `bytes` - Number of bytes downloaded in this chunk.
+    /// * `duration` - Wall-clock time taken to download the chunk.
+    pub fn report_chunk_complete(&self, bytes: u64, duration: Duration) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        self.record_sample(&mut state, bytes, duration);
+    }
+
+    /// Record the completion of an HLS segment and potentially trigger AIMD.
+    ///
+    /// # Arguments
+    /// * `bytes` - Number of bytes downloaded for this segment.
+    /// * `duration` - Wall-clock time taken to download the segment.
+    /// * `segment_duration_secs` - Declared playback duration of the segment (from
+    ///   the m3u8 playlist), used to compute the realtime ratio. `None` if unknown.
+    pub fn report_segment_complete(
+        &self,
+        bytes: u64,
+        duration: Duration,
+        segment_duration_secs: Option<f64>,
+    ) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Compute the realtime ratio if the segment's declared duration is known.
+        if let Some(seg_dur) = segment_duration_secs
+            && seg_dur > 0.0
+        {
+            let download_dur = duration.as_secs_f64();
+            if download_dur > 0.0 {
+                // ratio > 1.0 means we're downloading faster than realtime.
+                state.realtime_ratio = Some(seg_dur / download_dur);
+            }
+        }
+
+        self.record_sample(&mut state, bytes, duration);
+    }
+
+    // ─── Private helpers ──────────────────────────────────────────────────────
+
+    /// Record a throughput sample and trigger AIMD if the interval has elapsed.
+    fn record_sample(&self, state: &mut AdaptiveState, bytes: u64, duration: Duration) {
+        let secs = duration.as_secs_f64();
+        if secs > 0.0 {
+            let throughput = bytes as f64 / secs;
+            if state.throughput_history.len() >= MAX_HISTORY {
+                state.throughput_history.pop_front();
+            }
+            state.throughput_history.push_back(throughput);
+        }
+
+        state.chunks_since_last_adjust += 1;
+        if state.chunks_since_last_adjust >= self.config.decision_interval {
+            self.adjust(state);
+        }
+    }
+
+    /// Compute an EWMA over the throughput history.
+    ///
+    /// Returns `None` if the history is empty.
+    fn compute_ewma(history: &VecDeque<f64>) -> Option<f64> {
+        let mut iter = history.iter();
+        let first = iter.next()?;
+        let ewma = iter.fold(*first, |acc, &sample| {
+            EWMA_ALPHA * sample + (1.0 - EWMA_ALPHA) * acc
+        });
+        Some(ewma)
+    }
+
+    /// Core AIMD adjustment logic.
+    ///
+    /// Called after `decision_interval` chunks/segments have completed.
+    fn adjust(&self, state: &mut AdaptiveState) {
+        state.chunks_since_last_adjust = 0;
+
+        let current_ewma = match Self::compute_ewma(&state.throughput_history) {
+            Some(e) => e,
+            None => return,
+        };
+
+        let prev_ewma = state.last_ewma;
+        state.last_ewma = Some(current_ewma);
+
+        match state.phase {
+            Phase::SlowStart => self.adjust_slow_start(state, current_ewma, prev_ewma),
+            Phase::Steady => self.adjust_steady(state, current_ewma, prev_ewma),
+        }
+    }
+
+    /// SlowStart phase AIMD adjustments.
+    fn adjust_slow_start(
+        &self,
+        state: &mut AdaptiveState,
+        current_ewma: f64,
+        prev_ewma: Option<f64>,
+    ) {
+        let Some(prev) = prev_ewma else {
+            // No previous measurement — stay in SlowStart and ramp up.
+            self.bump_chunk_level(state, 2);
+            self.increase_connections(state);
+            return;
+        };
+
+        if current_ewma > prev {
+            // Throughput is increasing — stay aggressive.
+            state.slow_start_plateaus = 0;
+            self.bump_chunk_level(state, 2);
+            self.increase_connections(state);
+        } else if current_ewma < prev {
+            // Throughput dropped — transition to Steady and apply one MD.
+            state.phase = Phase::Steady;
+            state.slow_start_plateaus = 0;
+            self.apply_md(state);
+        } else {
+            // Plateau: throughput unchanged.
+            state.slow_start_plateaus += 1;
+            if state.slow_start_plateaus >= SLOW_START_PLATEAU_LIMIT {
+                state.phase = Phase::Steady;
+                state.slow_start_plateaus = 0;
+            }
+        }
+    }
+
+    /// Steady phase AIMD adjustments.
+    fn adjust_steady(&self, state: &mut AdaptiveState, current_ewma: f64, prev_ewma: Option<f64>) {
+        let Some(prev) = prev_ewma else {
+            // First measurement in Steady — apply additive increase.
+            self.bump_chunk_level(state, 1);
+            return;
+        };
+
+        if prev == 0.0 {
+            self.bump_chunk_level(state, 1);
+            return;
+        }
+
+        let ratio = (prev - current_ewma) / prev;
+
+        if ratio > MD_THRESHOLD {
+            // Throughput dropped > 30 % — multiplicative decrease.
+            self.apply_md(state);
+        } else if ratio > NOISE_THRESHOLD {
+            // 10–30 % drop — within noise, hold.
+        } else {
+            // Stable or improving — additive increase (+1 level).
+            self.bump_chunk_level(state, 1);
+        }
+    }
+
+    /// Apply multiplicative decrease: halve connections, chunk level −2.
+    fn apply_md(&self, state: &mut AdaptiveState) {
+        let target = (state.current_connections / 2).max(1);
+        self.decrease_connections(state, target);
+        self.bump_chunk_level(state, -(2i8));
+    }
+
+    /// Increase the chunk level by `delta`, clamped to [0, 7].
+    ///
+    /// In HLS mode the chunk level is not adjusted.
+    fn bump_chunk_level(&self, state: &mut AdaptiveState, delta: i8) {
+        if self.mode == ControllerMode::HlsSegments {
+            return;
+        }
+        let new_level = (state.current_chunk_level as i16 + delta as i16).clamp(0, 7) as u8;
+        state.current_chunk_level = new_level;
+    }
+
+    /// Increase connections by 1, up to `max_connections`.
+    ///
+    /// Adds a permit to the semaphore so an additional worker can be dispatched.
+    fn increase_connections(&self, state: &mut AdaptiveState) {
+        if state.current_connections < self.config.max_connections {
+            state.current_connections += 1;
+            self.semaphore.add_permits(1);
+        }
+    }
+
+    /// Reduce connections to `target` (minimum 1).
+    ///
+    /// For each permit to remove, attempts a `try_acquire` and forgets the
+    /// permit so it is permanently removed from the semaphore budget.
+    fn decrease_connections(&self, state: &mut AdaptiveState, target: usize) {
+        let target = target.max(1);
+        while state.current_connections > target {
+            // try_acquire is non-blocking; if no permit is immediately
+            // available the semaphore is already under pressure — stop.
+            if let Ok(permit) = self.semaphore.try_acquire() {
+                permit.forget();
+                state.current_connections -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a default controller for HTTP mode with given total_size.
+    fn make_controller(total_size: u64) -> AdaptiveController {
+        AdaptiveController::new(
+            total_size,
+            AdaptiveConfig::default(),
+            ControllerMode::HttpChunked,
+        )
+    }
+
+    /// Build a controller with explicit config.
+    fn make_controller_cfg(
+        total_size: u64,
+        config: AdaptiveConfig,
+        mode: ControllerMode,
+    ) -> AdaptiveController {
+        AdaptiveController::new(total_size, config, mode)
+    }
+
+    /// Drive the controller through `n` chunks and report each at `throughput` bytes/s.
+    fn drive(ctrl: &AdaptiveController, n: usize, throughput_bps: f64) {
+        for _ in 0..n {
+            let chunk = ctrl.next_chunk();
+            if let Some(req) = chunk {
+                let bytes = req.end - req.start;
+                let dur = Duration::from_secs_f64(bytes as f64 / throughput_bps);
+                ctrl.report_chunk_complete(bytes, dur);
+            }
+        }
+    }
+
+    // ── next_chunk tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_next_chunk_basic() {
+        let ctrl = make_controller(1024 * 1024); // 1 MB
+        let chunk = ctrl.next_chunk().unwrap();
+        // Level 0 = 64 KB
+        assert_eq!(chunk.start, 0);
+        assert_eq!(chunk.end, 64 * 1024);
+    }
+
+    #[test]
+    fn test_next_chunk_variable_sizes() {
+        let ctrl = make_controller(10 * 1024 * 1024);
+        let first = ctrl.next_chunk().unwrap();
+        assert_eq!(first.start, 0);
+        let first_size = first.end - first.start;
+
+        // Manually bump level via a state mutation.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            state.current_chunk_level = 3; // 512 KB
+        }
+
+        let second = ctrl.next_chunk().unwrap();
+        let second_size = second.end - second.start;
+        assert_ne!(
+            first_size, second_size,
+            "chunk sizes should differ after level change"
+        );
+        assert_eq!(second_size, 512 * 1024);
+    }
+
+    #[test]
+    fn test_next_chunk_exhaustion() {
+        let total = 200 * 1024; // 200 KB
+        let ctrl = make_controller(total as u64);
+
+        // Drain all chunks.
+        let mut total_bytes = 0u64;
+        while let Some(req) = ctrl.next_chunk() {
+            total_bytes += req.end - req.start;
+        }
+
+        assert_eq!(total_bytes, total as u64);
+        // Further calls return None.
+        assert!(ctrl.next_chunk().is_none());
+    }
+
+    // ── slow-start tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_slow_start_ramp_up() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 2,
+            initial_chunk_level: 0,
+        };
+        let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // First interval — no prev_ewma, so it bumps +2 and +1 connection.
+        drive(&ctrl, 4, 10_000_000.0);
+        let (level1, conns1) = {
+            let state = ctrl.state.lock().unwrap();
+            (state.current_chunk_level, state.current_connections)
+        };
+        assert_eq!(level1, 2, "chunk level should have increased by 2");
+        assert_eq!(conns1, 3, "connections should have increased by 1");
+
+        // Second interval — throughput still high (increasing) → another ramp.
+        drive(&ctrl, 4, 12_000_000.0);
+        let (level2, conns2) = {
+            let state = ctrl.state.lock().unwrap();
+            (state.current_chunk_level, state.current_connections)
+        };
+        assert!(level2 >= level1, "chunk level should not decrease");
+        assert!(conns2 >= conns1, "connections should not decrease");
+    }
+
+    #[test]
+    fn test_slow_start_to_steady_on_decrease() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 4,
+            initial_chunk_level: 4,
+        };
+        let ctrl = make_controller_cfg(200 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // First interval at high throughput.
+        drive(&ctrl, 4, 10_000_000.0);
+
+        // Second interval at drastically lower throughput — should trigger MD
+        // and transition to Steady.
+        drive(&ctrl, 4, 1_000_000.0);
+
+        let state = ctrl.state.lock().unwrap();
+        assert_eq!(
+            state.phase,
+            Phase::Steady,
+            "should have transitioned to Steady"
+        );
+    }
+
+    #[test]
+    fn test_slow_start_plateau_exit() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 2,
+            initial_chunk_level: 0,
+        };
+        let ctrl = make_controller_cfg(200 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Seed state so that current_ewma == prev_ewma every time adjust runs.
+        // Pre-fill history with a constant value so the EWMA converges exactly.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            for _ in 0..MAX_HISTORY {
+                state.throughput_history.push_back(5_000_000.0);
+            }
+            // Pre-set last_ewma to the same value so the first call is already
+            // a plateau (not a "no prev" ramp-up).
+            state.last_ewma = Some(5_000_000.0);
+        }
+
+        // Trigger SLOW_START_PLATEAU_LIMIT adjustment rounds, each with a
+        // plateau (current_ewma == prev_ewma == 5 MB/s).
+        for _ in 0..SLOW_START_PLATEAU_LIMIT {
+            let mut state = ctrl.state.lock().unwrap();
+            ctrl.adjust(&mut state);
+        }
+
+        let state = ctrl.state.lock().unwrap();
+        // After 3 plateaus the phase should be Steady.
+        assert_eq!(
+            state.phase,
+            Phase::Steady,
+            "should transition to Steady after 3 plateaus (got {} plateaus so far)",
+            state.slow_start_plateaus
+        );
+    }
+
+    // ── steady-state tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_steady_additive_increase() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 4,
+            initial_chunk_level: 2,
+        };
+        let ctrl = make_controller_cfg(500 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Force into Steady phase with a known last_ewma.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            state.phase = Phase::Steady;
+            state.last_ewma = Some(8_000_000.0);
+            for _ in 0..MAX_HISTORY {
+                state.throughput_history.push_back(8_000_000.0);
+            }
+        }
+
+        let initial_level = ctrl.state.lock().unwrap().current_chunk_level;
+
+        // Drive one interval at the same throughput — stable → AI.
+        drive(&ctrl, 4, 8_000_000.0);
+
+        let final_level = ctrl.state.lock().unwrap().current_chunk_level;
+        assert!(
+            final_level >= initial_level,
+            "AI: chunk level should not decrease in stable throughput"
+        );
+    }
+
+    #[test]
+    fn test_steady_multiplicative_decrease() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 6,
+            initial_chunk_level: 5,
+        };
+        let ctrl = make_controller_cfg(500 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Force into Steady with high prev_ewma.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            state.phase = Phase::Steady;
+            state.last_ewma = Some(10_000_000.0);
+            state.current_connections = 6;
+            state.current_chunk_level = 5;
+            for _ in 0..MAX_HISTORY {
+                state.throughput_history.push_back(10_000_000.0);
+            }
+        }
+
+        // Drive at very low throughput (>30 % drop from prev_ewma).
+        drive(&ctrl, 4, 1_000_000.0);
+
+        let state = ctrl.state.lock().unwrap();
+        // Connections should have halved (from 6 → 3).
+        assert!(
+            state.current_connections <= 4,
+            "MD: connections should have halved (was 6, now {})",
+            state.current_connections
+        );
+        // Chunk level should have dropped by 2.
+        assert!(
+            state.current_chunk_level <= 5,
+            "MD: chunk level should have decreased"
+        );
+    }
+
+    #[test]
+    fn test_steady_noise_tolerance() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 4,
+            initial_chunk_level: 3,
+        };
+        let ctrl = make_controller_cfg(500 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Force Steady with prev_ewma = 10 MB/s.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            state.phase = Phase::Steady;
+            state.last_ewma = Some(10_000_000.0);
+            state.current_chunk_level = 3;
+            state.current_connections = 4;
+            // Seed history with ~15% lower throughput to land in noise band.
+            for _ in 0..MAX_HISTORY {
+                state.throughput_history.push_back(8_500_000.0);
+            }
+        }
+
+        let level_before = ctrl.state.lock().unwrap().current_chunk_level;
+        let conns_before = ctrl.state.lock().unwrap().current_connections;
+
+        // Trigger one adjustment interval manually.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            state.chunks_since_last_adjust = ctrl.config.decision_interval;
+            ctrl.adjust(&mut state);
+        }
+
+        let state = ctrl.state.lock().unwrap();
+        // In the noise band: hold — level and connections unchanged.
+        assert_eq!(
+            state.current_chunk_level, level_before,
+            "noise: chunk level should be held"
+        );
+        assert_eq!(
+            state.current_connections, conns_before,
+            "noise: connections should be held"
+        );
+    }
+
+    // ── bounds tests ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_bounds_chunk_level() {
+        let cfg = AdaptiveConfig {
+            max_connections: 2,
+            decision_interval: 1,
+            initial_connections: 1,
+            initial_chunk_level: 0,
+        };
+        let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Repeatedly drive with increasing throughput to try to exceed level 7.
+        for i in 0..20 {
+            drive(&ctrl, 1, (i + 1) as f64 * 1_000_000.0);
+        }
+        let level = ctrl.state.lock().unwrap().current_chunk_level;
+        assert!(level <= 7, "chunk level must not exceed 7, got {level}");
+
+        // Now force into Steady and apply many MDs to try to go below 0.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            state.phase = Phase::Steady;
+            state.current_chunk_level = 0;
+            state.last_ewma = Some(10_000_000.0);
+            for _ in 0..MAX_HISTORY {
+                state.throughput_history.push_back(100.0);
+            }
+            state.chunks_since_last_adjust = ctrl.config.decision_interval;
+            ctrl.adjust(&mut state);
+        }
+        let level = ctrl.state.lock().unwrap().current_chunk_level;
+        assert_eq!(level, 0, "chunk level must not go below 0");
+    }
+
+    #[test]
+    fn test_bounds_connections() {
+        let cfg = AdaptiveConfig {
+            max_connections: 4,
+            decision_interval: 1,
+            initial_connections: 2,
+            initial_chunk_level: 0,
+        };
+        let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Try to exceed max_connections.
+        for _ in 0..10 {
+            let mut state = ctrl.state.lock().unwrap();
+            ctrl.increase_connections(&mut state);
+        }
+        let conns = ctrl.state.lock().unwrap().current_connections;
+        assert!(
+            conns <= 4,
+            "connections must not exceed max (4), got {conns}"
+        );
+
+        // Try to go below 1.
+        for _ in 0..10 {
+            let mut state = ctrl.state.lock().unwrap();
+            ctrl.decrease_connections(&mut state, 0);
+        }
+        let conns = ctrl.state.lock().unwrap().current_connections;
+        assert!(conns >= 1, "connections must be at least 1, got {conns}");
+    }
+
+    // ── HLS mode test ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_hls_mode_skips_chunk_level() {
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 4,
+            initial_connections: 2,
+            initial_chunk_level: 0,
+        };
+        let ctrl = make_controller_cfg(500 * 1024 * 1024, cfg, ControllerMode::HlsSegments);
+        let initial_level = ctrl.state.lock().unwrap().current_chunk_level;
+
+        // Drive many intervals to trigger multiple adjustments.
+        for i in 0..20 {
+            let bytes = 512u64 * 1024;
+            let throughput = (i + 1) as f64 * 500_000.0;
+            let dur = Duration::from_secs_f64(bytes as f64 / throughput);
+            ctrl.report_segment_complete(bytes, dur, Some(2.0));
+        }
+
+        let final_level = ctrl.state.lock().unwrap().current_chunk_level;
+        assert_eq!(
+            final_level, initial_level,
+            "HLS mode must not adjust chunk level"
+        );
+    }
+
+    // ── realtime ratio test ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_realtime_ratio_calculation() {
+        let ctrl = AdaptiveController::new(
+            10 * 1024 * 1024,
+            AdaptiveConfig::default(),
+            ControllerMode::HlsSegments,
+        );
+
+        // A 4-second segment downloaded in 1 second → ratio = 4.0.
+        let bytes = 512u64 * 1024;
+        let download_duration = Duration::from_secs(1);
+        ctrl.report_segment_complete(bytes, download_duration, Some(4.0));
+
+        let ratio = ctrl.state.lock().unwrap().realtime_ratio;
+        assert!(ratio.is_some(), "realtime_ratio should be set");
+        let ratio = ratio.unwrap();
+        assert!(
+            (ratio - 4.0).abs() < 1e-6,
+            "realtime_ratio should be 4.0, got {ratio}"
+        );
+    }
+}

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use log::{debug, warn};
-use rdlp_core::{RdlpError, Result, RetryConfig};
+use rdlp_core::{ProgressCallback, RdlpError, Result, RetryConfig};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::Mutex;
@@ -45,7 +45,7 @@ use crate::http::HttpDownloader;
 /// * `Ok(Vec<PathBuf>)` - Paths to ALL segment files (in order, including pre-existing)
 /// * `Err(_)` - Download error (network, I/O, etc.)
 #[allow(clippy::too_many_arguments)]
-#[instrument(skip(http_downloader, retry_config, segments, progress_counter, segments_counter, duration_counter, state), fields(segments = segments.len()))]
+#[instrument(skip(http_downloader, retry_config, segments, progress_counter, segments_counter, duration_counter, state, log_callback), fields(segments = segments.len()))]
 pub(crate) async fn download_segments_with_resume(
     http_downloader: &HttpDownloader,
     retry_config: Arc<RetryConfig>,
@@ -60,6 +60,7 @@ pub(crate) async fn download_segments_with_resume(
     duration_counter: Arc<AtomicU64>,
     state: Arc<Mutex<HlsDownloadState>>,
     output_path: &Path,
+    log_callback: Option<Arc<dyn ProgressCallback>>,
 ) -> Result<Vec<PathBuf>> {
     let total_segments = segments.len();
 
@@ -138,7 +139,7 @@ pub(crate) async fn download_segments_with_resume(
             ..AdaptiveConfig::default()
         },
         ControllerMode::HlsSegments,
-        None, // log_callback: HLS segment path does not thread a ProgressCallback here
+        log_callback,
     ));
     let sem = controller.semaphore().clone();
 

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -138,6 +138,7 @@ pub(crate) async fn download_segments_with_resume(
             ..AdaptiveConfig::default()
         },
         ControllerMode::HlsSegments,
+        None, // log_callback: HLS segment path does not thread a ProgressCallback here
     ));
     let sem = controller.semaphore().clone();
 

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use log::{debug, warn};
@@ -16,6 +16,7 @@ use tracing::instrument;
 
 use super::segment::download_segment_with_retry;
 use super::types::SegmentInfo;
+use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
 use crate::hls_state::HlsDownloadState;
 use crate::http::HttpDownloader;
 
@@ -129,7 +130,17 @@ pub(crate) async fn download_segments_with_resume(
         );
     }
 
-    // Download remaining segments using buffer_unordered with state tracking
+    // Download remaining segments using adaptive controller with semaphore-based concurrency.
+    let controller = Arc::new(AdaptiveController::new(
+        0, // total_size not meaningful for HLS (segment count drives iteration)
+        AdaptiveConfig {
+            max_connections: concurrent_segments,
+            ..AdaptiveConfig::default()
+        },
+        ControllerMode::HlsSegments,
+    ));
+    let sem = controller.semaphore().clone();
+
     let http_downloader = http_downloader.clone();
     let temp_dir_owned = temp_dir.to_path_buf();
     let base_filename_owned = base_filename.to_string();
@@ -147,6 +158,8 @@ pub(crate) async fn download_segments_with_resume(
             let output_path = output_path_owned.clone();
             let seg_duration = seg.duration;
             let seg_url = seg.url;
+            let sem = sem.clone();
+            let controller = controller.clone();
 
             async move {
                 // Check if segment file already exists and is non-empty (single async stat)
@@ -170,7 +183,16 @@ pub(crate) async fn download_segments_with_resume(
                     return Ok((idx, segment_path, bytes));
                 }
 
-                // Download segment with retry logic (now using backon)
+                // Acquire semaphore permit before starting the download so that
+                // the adaptive controller governs the actual concurrency level.
+                let _permit = sem
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| RdlpError::Download("Semaphore closed".to_string()))?;
+
+                let download_start = Instant::now();
+
+                // Download segment with retry logic
                 let result = download_segment_with_retry(
                     &http_downloader,
                     &retry_config,
@@ -184,6 +206,13 @@ pub(crate) async fn download_segments_with_resume(
 
                 match &result {
                     Ok((_, _, bytes)) => {
+                        // Report to adaptive controller (permit still held — released on drop)
+                        controller.report_segment_complete(
+                            *bytes,
+                            download_start.elapsed(),
+                            Some(seg_duration),
+                        );
+
                         // Update state on success; clone if periodic save needed
                         let snapshot = {
                             let mut guard = state.lock().await;
@@ -217,7 +246,7 @@ pub(crate) async fn download_segments_with_resume(
                 result
             }
         })
-        .buffer_unordered(concurrent_segments);
+        .buffer_unordered(concurrent_segments * 2);
 
     // Collect results, tolerating up to max_segment_failures errors
     let mut results: Vec<(usize, PathBuf, u64)> = Vec::new();

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -243,6 +243,9 @@ impl Downloader for HlsDownloader {
             let duration_completed = Arc::new(AtomicU64::new(0));
             let total_segments_u64 = total_segments as u64;
 
+            // Clone before reporter consumes it — merge needs it for adaptive log callback
+            let log_callback = progress.clone();
+
             // Spawn progress reporter task with duration-based progress
             let mut progress_guard = spawn_progress_reporter(
                 progress,
@@ -275,6 +278,7 @@ impl Downloader for HlsDownloader {
                 duration_completed.clone(),
                 state.clone(),
                 path,
+                log_callback,
             )
             .await
             {

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -194,6 +194,7 @@ impl Downloader for HlsDownloader {
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
+        let progress: Option<Arc<dyn ProgressCallback>> = progress.map(Arc::from);
         let timeout = self.download_timeout;
         tokio::time::timeout(timeout, async {
             let start_time = Instant::now();

--- a/crates/rdlp-downloader/src/http/config.rs
+++ b/crates/rdlp-downloader/src/http/config.rs
@@ -53,6 +53,9 @@ pub(crate) struct DownloaderConfig {
     pub download_timeout: Duration,
     /// Merge operation timeout (chunk/segment merge must complete within this)
     pub merge_timeout: Duration,
+    /// Enable adaptive chunk sizing and connection tuning via AIMD controller.
+    /// Forced to `false` when `chunk_strategy` is `Fixed`.
+    pub adaptive: bool,
 }
 
 impl Default for DownloaderConfig {
@@ -76,6 +79,7 @@ impl Default for DownloaderConfig {
             read_timeout: DEFAULT_READ_TIMEOUT,
             download_timeout: DEFAULT_DOWNLOAD_TIMEOUT,
             merge_timeout: DEFAULT_MERGE_TIMEOUT,
+            adaptive: true,
         }
     }
 }

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -122,10 +122,28 @@ impl HttpDownloader {
         self
     }
 
-    /// Set chunk size strategy
+    /// Set chunk size strategy.
+    ///
+    /// When `Fixed` or `Legacy` is used, adaptive mode is forced off because
+    /// the caller has explicitly chosen a predictable chunk sizing scheme.
     #[must_use = "builder methods consume self and return a new instance"]
     pub fn with_chunk_strategy(mut self, strategy: ChunkSizeStrategy) -> Self {
-        Arc::make_mut(&mut self.config).chunk_strategy = strategy;
+        let cfg = Arc::make_mut(&mut self.config);
+        if !matches!(strategy, ChunkSizeStrategy::Auto) {
+            cfg.adaptive = false;
+        }
+        cfg.chunk_strategy = strategy;
+        self
+    }
+
+    /// Enable or disable adaptive chunk sizing and connection tuning.
+    ///
+    /// When `false`, the downloader uses the static `chunk_strategy` with a
+    /// fixed connection count. Automatically forced to `false` when
+    /// `chunk_strategy` is not `Auto`.
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_adaptive(mut self, adaptive: bool) -> Self {
+        Arc::make_mut(&mut self.config).adaptive = adaptive;
         self
     }
 

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -290,6 +290,7 @@ impl HttpDownloader {
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
+        let progress: Option<Arc<dyn ProgressCallback>> = progress.map(Arc::from);
         let start_time = Instant::now();
         let client = self.client.clone();
         let url_string = url.to_string();

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -9,7 +9,7 @@ use crate::chunking::calculate_chunks;
 use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use log::{debug, error, info};
-use rdlp_core::{DownloadStats, RdlpError, Result};
+use rdlp_core::{DownloadStats, ProgressCallback, RdlpError, Result};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -80,8 +80,9 @@ impl HttpDownloader {
             .into_owned();
 
         let downloaded = Arc::new(AtomicU64::new(0));
+        let progress: Option<Arc<dyn rdlp_core::ProgressCallback>> = progress.map(Arc::from);
         let _progress_guard = spawn_progress_reporter(
-            progress,
+            progress.clone(),
             ProgressMetrics::bytes_only(downloaded.clone()),
             ProgressReporterConfig::http(start_time, total_size, 0),
         );
@@ -96,6 +97,7 @@ impl HttpDownloader {
                 downloaded.clone(),
                 0,
                 "part",
+                progress.clone(),
             )
             .await?
         } else {
@@ -164,8 +166,9 @@ impl HttpDownloader {
             .into_owned();
 
         let downloaded = Arc::new(AtomicU64::new(resume_from));
+        let progress: Option<Arc<dyn rdlp_core::ProgressCallback>> = progress.map(Arc::from);
         let mut progress_guard = spawn_progress_reporter(
-            progress,
+            progress.clone(),
             ProgressMetrics::bytes_only(downloaded.clone()),
             ProgressReporterConfig::http(start_time, total_size, resume_from),
         );
@@ -188,6 +191,7 @@ impl HttpDownloader {
                 downloaded.clone(),
                 resume_from,
                 "resume",
+                progress.clone(),
             )
             .await
         } else {
@@ -254,6 +258,7 @@ impl HttpDownloader {
         progress_counter: Arc<AtomicU64>,
         byte_offset: u64,
         suffix: &str,
+        log_callback: Option<Arc<dyn ProgressCallback>>,
     ) -> Result<(Vec<PathBuf>, u64)> {
         let controller = Arc::new(AdaptiveController::new(
             size_to_download,
@@ -262,6 +267,7 @@ impl HttpDownloader {
                 ..AdaptiveConfig::default()
             },
             ControllerMode::HttpChunked,
+            log_callback,
         ));
 
         let sem = controller.semaphore().clone();

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -2,20 +2,20 @@
 //!
 //! Provides parallel download using multiple range requests with fine-grained chunking.
 
+use super::HttpDownloader;
+use super::config::DownloaderConfig;
+use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
+use crate::chunking::calculate_chunks;
+use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use log::{debug, error, info};
 use rdlp_core::{DownloadStats, RdlpError, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
-
-use super::HttpDownloader;
-use super::config::DownloaderConfig;
-use crate::chunking::calculate_chunks;
-use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 
 /// Mode for chunk merging operations
 #[derive(Clone, Copy)]
@@ -27,13 +27,6 @@ enum MergeMode {
 }
 
 impl MergeMode {
-    fn chunk_suffix(self) -> &'static str {
-        match self {
-            MergeMode::Create => "part",
-            MergeMode::Append => "resume",
-        }
-    }
-
     fn log_action(self) -> &'static str {
         match self {
             MergeMode::Create => "Merging",
@@ -45,7 +38,7 @@ impl MergeMode {
 /// Global atomic counter for generating unique download IDs
 static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Cleanup chunk files on error
+/// Cleanup chunk files by index range (used when chunk list is not available)
 async fn cleanup_chunk_files(
     temp_dir: &Path,
     filename: &str,
@@ -64,7 +57,11 @@ async fn cleanup_chunk_files(
 }
 
 impl HttpDownloader {
-    /// Parallel download using multiple range requests with fine-grained chunking
+    /// Parallel download using multiple range requests with fine-grained chunking.
+    ///
+    /// When `config.adaptive` is `true`, chunk sizes and connection counts are
+    /// dynamically tuned by an AIMD controller. Otherwise the static
+    /// `chunk_strategy` is used with a fixed connection count.
     pub(super) async fn download_parallel(
         &self,
         url: &str,
@@ -74,17 +71,6 @@ impl HttpDownloader {
     ) -> Result<DownloadStats> {
         let start_time = Instant::now();
         let download_id = DOWNLOAD_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let (chunk_size, total_chunks) = calculate_chunks(total_size, self.config.chunk_strategy);
-
-        debug!(
-            download_id,
-            size_mb = total_size / 1024 / 1024,
-            chunk_kb = chunk_size / 1024,
-            chunks = total_chunks,
-            concurrent = self.config.concurrent_fragments,
-            batches = total_chunks.div_ceil(self.config.concurrent_fragments);
-            "Chunk analysis"
-        );
 
         let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let filename = path
@@ -94,76 +80,46 @@ impl HttpDownloader {
             .into_owned();
 
         let downloaded = Arc::new(AtomicU64::new(0));
-
         let _progress_guard = spawn_progress_reporter(
             progress,
             ProgressMetrics::bytes_only(downloaded.clone()),
             ProgressReporterConfig::http(start_time, total_size, 0),
         );
 
-        debug!(
-            "Starting parallel download with {} concurrent connections",
-            self.config.concurrent_fragments
-        );
-
-        let url_shared: Arc<str> = Arc::from(url);
-
-        let chunk_results: Vec<u64> = match stream::iter(0..total_chunks)
-            .map(|chunk_id| {
-                let start = chunk_id as u64 * chunk_size as u64;
-                let end = if chunk_id == total_chunks - 1 {
-                    total_size - 1
-                } else {
-                    start + chunk_size as u64 - 1
-                };
-
-                let chunk_path =
-                    temp_dir.join(format!("{}.{}.part{}", &filename, download_id, chunk_id));
-                let downloader = self.clone();
-                let url = Arc::clone(&url_shared);
-                let progress_counter = Some(downloaded.clone());
-
-                async move {
-                    let result = downloader
-                        .download_range_with_progress(
-                            &url,
-                            start,
-                            end,
-                            &chunk_path,
-                            progress_counter,
-                        )
-                        .await;
-                    if let Err(ref e) = result {
-                        error!("Chunk {chunk_id} failed: {e}");
-                    }
-                    result.map(|bytes| (chunk_id, bytes, chunk_path))
-                }
-            })
-            .buffer_unordered(self.config.concurrent_fragments)
-            .try_collect::<Vec<_>>()
-            .await
-        {
-            Ok(results) => results.into_iter().map(|(_, bytes, _)| bytes).collect(),
-            Err(e) => {
-                error!("Download failed: {e}");
-                cleanup_chunk_files(temp_dir, &filename, download_id, total_chunks).await;
-                return Err(e);
-            }
+        let (chunk_paths, total_downloaded) = if self.config.adaptive {
+            self.download_parallel_adaptive(
+                url,
+                total_size,
+                download_id,
+                temp_dir,
+                &filename,
+                downloaded.clone(),
+                0,
+                "part",
+            )
+            .await?
+        } else {
+            self.download_parallel_static(
+                url,
+                total_size,
+                download_id,
+                temp_dir,
+                &filename,
+                downloaded.clone(),
+                0,
+                "part",
+            )
+            .await?
         };
 
-        let total_downloaded: u64 = chunk_results.iter().sum();
-        debug!(
-            "All {} chunks completed ({} MB total)",
-            total_chunks,
-            total_downloaded / 1024 / 1024
-        );
+        let chunk_count = chunk_paths.len();
 
-        merge_chunks_with_mode(
+        merge_chunks_ordered(
             path,
             temp_dir,
             &filename,
             download_id,
-            total_chunks,
+            &chunk_paths,
             &self.config,
             MergeMode::Create,
         )
@@ -178,11 +134,16 @@ impl HttpDownloader {
             duration.as_secs_f64(),
             (total_downloaded as f64 / duration.as_secs_f64()) / 1024.0 / 1024.0
         );
+        debug!(
+            "All {} chunks completed ({} MB total)",
+            chunk_count,
+            total_downloaded / 1024 / 1024
+        );
 
         Ok(stats)
     }
 
-    /// Parallel resume: downloads remaining chunks in parallel
+    /// Parallel resume: downloads remaining chunks in parallel.
     pub(super) async fn download_parallel_resume(
         &self,
         url: &str,
@@ -194,17 +155,6 @@ impl HttpDownloader {
         let start_time = Instant::now();
         let remaining_size = total_size - resume_from;
         let download_id = DOWNLOAD_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let (chunk_size, total_chunks) =
-            calculate_chunks(remaining_size, self.config.chunk_strategy);
-
-        debug!(
-            "Parallel resume: download_id={download_id}, already={} MB ({:.1}%), remaining={} MB, chunk_size={} KB, chunks={total_chunks}, concurrent={}",
-            resume_from / 1024 / 1024,
-            (resume_from as f64 / total_size as f64) * 100.0,
-            remaining_size / 1024 / 1024,
-            chunk_size / 1024,
-            self.config.concurrent_fragments
-        );
 
         let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let filename = path
@@ -214,7 +164,6 @@ impl HttpDownloader {
             .into_owned();
 
         let downloaded = Arc::new(AtomicU64::new(resume_from));
-
         let mut progress_guard = spawn_progress_reporter(
             progress,
             ProgressMetrics::bytes_only(downloaded.clone()),
@@ -222,72 +171,54 @@ impl HttpDownloader {
         );
 
         debug!(
-            "Starting parallel download with {} concurrent connections",
+            "Parallel resume: download_id={download_id}, already={} MB ({:.1}%), remaining={} MB, concurrent={}",
+            resume_from / 1024 / 1024,
+            (resume_from as f64 / total_size as f64) * 100.0,
+            remaining_size / 1024 / 1024,
             self.config.concurrent_fragments
         );
 
-        let url_shared: Arc<str> = Arc::from(url);
-
-        let chunk_results: Vec<u64> = match stream::iter(0..total_chunks)
-            .map(|chunk_id| {
-                let start = resume_from + (chunk_id as u64 * chunk_size as u64);
-                let end = if chunk_id == total_chunks - 1 {
-                    total_size - 1
-                } else {
-                    start + chunk_size as u64 - 1
-                };
-
-                let chunk_path =
-                    temp_dir.join(format!("{}.{}.resume{}", &filename, download_id, chunk_id));
-                let downloader = self.clone();
-                let url = Arc::clone(&url_shared);
-                let progress_counter = Some(downloaded.clone());
-
-                async move {
-                    let result = downloader
-                        .download_range_with_progress(
-                            &url,
-                            start,
-                            end,
-                            &chunk_path,
-                            progress_counter,
-                        )
-                        .await;
-                    if let Err(ref e) = result {
-                        error!("Chunk {chunk_id} failed: {e}");
-                    }
-                    result.map(|bytes| (chunk_id, bytes, chunk_path))
-                }
-            })
-            .buffer_unordered(self.config.concurrent_fragments)
-            .try_collect::<Vec<_>>()
+        let result = if self.config.adaptive {
+            self.download_parallel_adaptive(
+                url,
+                remaining_size,
+                download_id,
+                temp_dir,
+                &filename,
+                downloaded.clone(),
+                resume_from,
+                "resume",
+            )
             .await
-        {
-            Ok(results) => results.into_iter().map(|(_, bytes, _)| bytes).collect(),
+        } else {
+            self.download_parallel_static(
+                url,
+                remaining_size,
+                download_id,
+                temp_dir,
+                &filename,
+                downloaded.clone(),
+                resume_from,
+                "resume",
+            )
+            .await
+        };
+
+        let (chunk_paths, newly_downloaded) = match result {
+            Ok(v) => v,
             Err(e) => {
                 error!("Resume failed: {e}");
                 progress_guard.abort();
-                cleanup_chunk_files(temp_dir, &filename, download_id, total_chunks).await;
                 return Err(e);
             }
         };
 
-        let newly_downloaded: u64 = chunk_results.iter().sum();
-        debug!(
-            "All {} chunks completed ({} MB new data)",
-            total_chunks,
-            newly_downloaded / 1024 / 1024
-        );
-
-        // Progress guard will be dropped and abort the task automatically
-
-        // Append chunks to existing file
-        merge_chunks_with_mode(
+        merge_chunks_ordered(
             path,
             temp_dir,
             &filename,
             download_id,
-            total_chunks,
+            &chunk_paths,
             &self.config,
             MergeMode::Append,
         )
@@ -307,20 +238,216 @@ impl HttpDownloader {
 
         Ok(stats)
     }
+
+    /// Adaptive download: uses `AdaptiveController` for dynamic chunk sizing and concurrency.
+    ///
+    /// Returns `(chunk_paths_in_order, total_bytes_downloaded)`.
+    /// `byte_offset` is added to every chunk's start position (for resume).
+    #[allow(clippy::too_many_arguments)]
+    async fn download_parallel_adaptive(
+        &self,
+        url: &str,
+        size_to_download: u64,
+        download_id: u64,
+        temp_dir: &Path,
+        filename: &str,
+        progress_counter: Arc<AtomicU64>,
+        byte_offset: u64,
+        suffix: &str,
+    ) -> Result<(Vec<PathBuf>, u64)> {
+        let controller = Arc::new(AdaptiveController::new(
+            size_to_download,
+            AdaptiveConfig {
+                max_connections: self.config.concurrent_fragments,
+                ..AdaptiveConfig::default()
+            },
+            ControllerMode::HttpChunked,
+        ));
+
+        let sem = controller.semaphore().clone();
+
+        // Chunk paths collected in assignment order; we re-sort by chunk_id before merge.
+        // Each entry is (chunk_id, PathBuf, bytes_downloaded).
+        let url_shared: Arc<str> = Arc::from(url);
+
+        // Generate tasks lazily using stream::unfold driven by controller.next_chunk().
+        // buffer_unordered with a generous buffer lets the semaphore control actual concurrency.
+        let buffer_factor = self.config.concurrent_fragments * 2;
+
+        let results: Vec<(u64, PathBuf, u64)> = {
+            let ctrl_clone = controller.clone();
+            let sem_clone = sem.clone();
+            let downloader = self.clone();
+            let url_arc = url_shared.clone();
+            let progress = progress_counter.clone();
+            let temp_dir_owned = temp_dir.to_path_buf();
+            let filename_owned = filename.to_string();
+            let suffix_owned = suffix.to_string();
+
+            stream::unfold((ctrl_clone, 0u64), move |(ctrl, chunk_id)| {
+                let ctrl2 = ctrl.clone();
+                async move {
+                    ctrl.next_chunk()
+                        .map(|chunk| ((chunk_id, chunk), (ctrl2, chunk_id + 1)))
+                }
+            })
+            .map(move |(chunk_id, chunk)| {
+                let permit_future = {
+                    let sem = sem_clone.clone();
+                    async move {
+                        sem.acquire_owned()
+                            .await
+                            .map_err(|_| RdlpError::Download("Semaphore closed".to_string()))
+                    }
+                };
+
+                let downloader = downloader.clone();
+                let url = url_arc.clone();
+                let progress = progress.clone();
+                let controller = controller.clone();
+                let chunk_path = temp_dir_owned.join(format!(
+                    "{}.{}.{}{}",
+                    filename_owned, download_id, suffix_owned, chunk_id
+                ));
+
+                async move {
+                    let _permit = permit_future.await?;
+                    let start_time = Instant::now();
+                    let abs_start = byte_offset + chunk.start;
+                    // end is exclusive in ChunkRequest, but HTTP Range is inclusive
+                    let abs_end = byte_offset + chunk.end - 1;
+
+                    let result = downloader
+                        .download_range_with_progress(
+                            &url,
+                            abs_start,
+                            abs_end,
+                            &chunk_path,
+                            Some(progress),
+                        )
+                        .await;
+
+                    match &result {
+                        Ok(bytes) => {
+                            controller.report_chunk_complete(*bytes, start_time.elapsed());
+                        }
+                        Err(e) => {
+                            error!("Adaptive chunk {chunk_id} failed: {e}");
+                        }
+                    }
+
+                    result.map(|bytes| (chunk_id, chunk_path, bytes))
+                }
+            })
+            .buffer_unordered(buffer_factor)
+            .try_collect()
+            .await
+            .map_err(|e: rdlp_core::RdlpError| e)?
+        };
+
+        // Sort by chunk_id to ensure correct merge order.
+        let mut sorted = results;
+        sorted.sort_by_key(|(id, _, _)| *id);
+
+        let total_bytes: u64 = sorted.iter().map(|(_, _, b)| b).sum();
+        let chunk_paths: Vec<PathBuf> = sorted.into_iter().map(|(_, path, _)| path).collect();
+
+        Ok((chunk_paths, total_bytes))
+    }
+
+    /// Static download: uses a fixed chunk size and connection count.
+    ///
+    /// Returns `(chunk_paths_in_order, total_bytes_downloaded)`.
+    #[allow(clippy::too_many_arguments)]
+    async fn download_parallel_static(
+        &self,
+        url: &str,
+        size_to_download: u64,
+        download_id: u64,
+        temp_dir: &Path,
+        filename: &str,
+        progress_counter: Arc<AtomicU64>,
+        byte_offset: u64,
+        suffix: &str,
+    ) -> Result<(Vec<PathBuf>, u64)> {
+        let (chunk_size, total_chunks) =
+            calculate_chunks(size_to_download, self.config.chunk_strategy);
+
+        debug!(
+            download_id,
+            size_mb = size_to_download / 1024 / 1024,
+            chunk_kb = chunk_size / 1024,
+            chunks = total_chunks,
+            concurrent = self.config.concurrent_fragments;
+            "Static chunk analysis"
+        );
+
+        let url_shared: Arc<str> = Arc::from(url);
+        let temp_dir_owned = temp_dir.to_path_buf();
+        let filename_owned = filename.to_string();
+        let suffix_owned = suffix.to_string();
+
+        let results: Vec<(usize, PathBuf, u64)> = match stream::iter(0..total_chunks)
+            .map(|chunk_id| {
+                let start = byte_offset + (chunk_id as u64 * chunk_size as u64);
+                let end = if chunk_id == total_chunks - 1 {
+                    byte_offset + size_to_download - 1
+                } else {
+                    start + chunk_size as u64 - 1
+                };
+
+                let chunk_path = temp_dir_owned.join(format!(
+                    "{}.{}.{}{}",
+                    filename_owned, download_id, suffix_owned, chunk_id
+                ));
+                let downloader = self.clone();
+                let url = Arc::clone(&url_shared);
+                let progress = Some(progress_counter.clone());
+
+                async move {
+                    let result = downloader
+                        .download_range_with_progress(&url, start, end, &chunk_path, progress)
+                        .await;
+                    if let Err(ref e) = result {
+                        error!("Chunk {chunk_id} failed: {e}");
+                    }
+                    result.map(|bytes| (chunk_id, chunk_path, bytes))
+                }
+            })
+            .buffer_unordered(self.config.concurrent_fragments)
+            .try_collect::<Vec<_>>()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Download failed: {e}");
+                cleanup_chunk_files(temp_dir, filename, download_id, total_chunks).await;
+                return Err(e);
+            }
+        };
+
+        let total_bytes: u64 = results.iter().map(|(_, _, b)| b).sum();
+
+        // Results arrive in completion order; sort by chunk_id for correct merge.
+        let mut sorted = results;
+        sorted.sort_by_key(|(id, _, _)| *id);
+        let chunk_paths: Vec<PathBuf> = sorted.into_iter().map(|(_, path, _)| path).collect();
+
+        Ok((chunk_paths, total_bytes))
+    }
 }
 
-/// Merge or append chunks to file
-async fn merge_chunks_with_mode(
+/// Merge or append chunks to file using an explicit ordered list of paths.
+async fn merge_chunks_ordered(
     path: &Path,
-    temp_dir: &Path,
-    filename: &str,
-    download_id: u64,
-    total_chunks: usize,
+    _temp_dir: &Path,
+    _filename: &str,
+    _download_id: u64,
+    chunk_paths: &[PathBuf],
     config: &DownloaderConfig,
     mode: MergeMode,
 ) -> Result<()> {
     let merge_timeout = config.merge_timeout;
-    let suffix = mode.chunk_suffix();
     let action = mode.log_action();
 
     tokio::time::timeout(merge_timeout, async {
@@ -334,21 +461,21 @@ async fn merge_chunks_with_mode(
         };
         let mut writer = BufWriter::with_capacity(config.buffer_size, file);
 
-        debug!(chunks = total_chunks; "{action} chunks into file");
+        debug!(chunks = chunk_paths.len(); "{action} chunks into file");
         let mut deleted_chunks = 0;
-        for chunk_id in 0..total_chunks {
-            let chunk_path = temp_dir.join(format!("{filename}.{download_id}.{suffix}{chunk_id}"));
-            let mut chunk_file = File::open(&chunk_path).await.map_err(RdlpError::Io)?;
+        let total = chunk_paths.len();
+        for (idx, chunk_path) in chunk_paths.iter().enumerate() {
+            let mut chunk_file = File::open(chunk_path).await.map_err(RdlpError::Io)?;
             tokio::io::copy(&mut chunk_file, &mut writer)
                 .await
                 .map_err(RdlpError::Io)?;
 
-            if tokio::fs::remove_file(&chunk_path).await.is_ok() {
+            if tokio::fs::remove_file(chunk_path).await.is_ok() {
                 deleted_chunks += 1;
             }
 
-            if (chunk_id + 1) % 100 == 0 || chunk_id == total_chunks - 1 {
-                debug!(processed = chunk_id + 1, total = total_chunks; "{action} progress");
+            if (idx + 1) % 100 == 0 || idx == total - 1 {
+                debug!(processed = idx + 1, total; "{action} progress");
             }
         }
         debug!(deleted = deleted_chunks; "Chunk cleanup complete");

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -238,6 +238,8 @@
 
 #![warn(missing_docs)]
 
+/// Adaptive chunk sizing and connection tuning (AIMD controller)
+pub(crate) mod adaptive;
 /// Intelligent chunk size calculation for optimal download performance
 pub mod chunking;
 /// HLS (HTTP Live Streaming) downloader with parallel segment downloads
@@ -323,7 +325,8 @@ impl DownloaderRegistry {
         let http_downloader = HttpDownloader::with_client(client.clone())
             .with_buffer_size(config.buffer_size)
             .with_concurrent_fragments(config.concurrent_fragments)
-            .with_rate_limiter(rate_limiter);
+            .with_rate_limiter(rate_limiter)
+            .with_adaptive(config.adaptive_downloads);
 
         // Create HLS downloader
         let hls_downloader = HlsDownloader::new()

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -128,7 +128,7 @@ impl ProgressReporterConfig {
 /// A `ProgressGuard` that manages the spawned task's lifecycle.
 #[must_use]
 pub fn spawn_progress_reporter(
-    callback: Option<Box<dyn ProgressCallback>>,
+    callback: Option<Arc<dyn ProgressCallback>>,
     metrics: ProgressMetrics,
     config: ProgressReporterConfig,
 ) -> ProgressGuard {

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -304,6 +304,17 @@ pub struct Config {
 
     /// Load dynamic plugins
     pub load_plugins: bool,
+
+    // === Download performance ===
+    /// Enable adaptive chunk sizing and connection tuning for downloads.
+    /// When true, the downloader adjusts chunk sizes and parallel connections
+    /// based on observed throughput using an AIMD algorithm.
+    #[serde(default = "default_true")]
+    pub adaptive_downloads: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for Config {
@@ -411,6 +422,9 @@ impl Default for Config {
             plugin_directories: Vec::new(),
             enabled_plugins: None,
             load_plugins: true,
+
+            // Download performance
+            adaptive_downloads: true,
         }
     }
 }


### PR DESCRIPTION
Closes #97

## Summary

- **AIMD adaptive controller** (`adaptive.rs`, 943 lines) — dynamically tunes chunk sizes (64KB–8MB power-of-two levels) and parallel connection count based on observed throughput. Two phases: SlowStart (aggressive ramp) and Steady (classic additive-increase / multiplicative-decrease). Supports both HTTP chunked downloads and HLS segment downloads via `ControllerMode`.
- **Desktop log panel** — adaptive decisions are surfaced in the UI via a new `ProgressCallback::on_log()` trait method, routed through `Event::Debug` to the frontend. `JobCard` shows a collapsible log panel with all AIMD messages.
- **HLS integration** — the log callback is threaded through the HLS download path so adaptive decisions during segment downloads appear in the UI alongside HTTP downloads.
- **Config integration** — new `adaptive_downloads` field in `Config` (default: true) controls whether the adaptive controller is used.
- **Test performance** — pre-seed TanStack Query caches, replace `userEvent` with `fireEvent` for Radix Select interactions, switch Vitest to `pool: "threads"`. CI test time reduced significantly across all component test files.

## Changes

| Crate | Files | What |
|-------|-------|------|
| `rdlp-downloader` | `adaptive.rs` (new), `http/parallel.rs`, `http/mod.rs`, `http/config.rs`, `hls/merge.rs`, `hls/mod.rs`, `progress.rs`, `lib.rs` | AIMD controller, parallel download integration, HLS threading |
| `rdlp-core` | `traits/downloader.rs` | `on_log()` default method on `ProgressCallback` |
| `rdlp-api` | `orchestrator/execution.rs` | `on_log` → `Event::Debug` in `EventProgressCallback` |
| `rdlp-types` | `config.rs` | `adaptive_downloads` config field |
| `rdlp-desktop` | `JobCard.tsx`, `registerDownloadEvents.ts`, `types/index.ts` + tests | Log accumulation, collapsible log panel, 18 new tests |
| `rdlp-desktop` | `vitest.config.ts`, 7 test files | Test perf: query pre-seeding, fireEvent for Radix, threads pool |

## Test performance (CI)

| File | Before | After |
|------|--------|-------|
| FormatOptionsPanel | 7.2s | 3.3s |
| SettingsPage | 5.1s | 2.6s |
| QueuePage | 2.1s | 721ms |
| CommandBar | 2.0s | 673ms |
| FormatGroupSection | 2.0s | 769ms |
| DownloadPage | 1.7s | 667ms |
| JobCard | 1.7s | 550ms |

## Test plan

- [x] `cargo clippy -p rdlp-downloader` — zero warnings
- [x] `cargo test -p rdlp-downloader` — 13 adaptive controller unit tests pass
- [x] `npm run test` (desktop) — 281 tests pass
- [x] CI green on Ubuntu, Windows, macOS
- [x] Manual: HTTP download shows AIMD decisions in log panel
- [x] Manual: HLS download shows AIMD decisions in log panel
- [ ] Verify adaptive mode can be disabled via `adaptive_downloads: false` in config