### PR TITLE
fix(extractor): XHamster file size propagation and hex-segment tests

### DIFF
--- a/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
@@ -247,6 +247,21 @@ pub async fn extract_from_initials(
         debug!("[XHamster] No xplayerSettings.sources found");
     }
 
+    // Propagate file sizes from sources.download to extracted formats.
+    // Match by quality label in the format_id (e.g., "720" matches "720p").
+    if !format_sizes.is_empty() {
+        for format in &mut formats {
+            for (quality, &size) in &format_sizes {
+                // Strip trailing 'p'/'P' from quality for numeric comparison
+                let q = quality.trim_end_matches(['p', 'P']);
+                if format.format_id.contains(q) {
+                    format.filesize = Some(size as u64);
+                    break;
+                }
+            }
+        }
+    }
+
     debug!("[XHamster] Total formats extracted: {}", formats.len());
     fixup_formats(&mut formats);
     formats
@@ -463,6 +478,48 @@ mod tests {
         .await;
         // Same URL should be deduped
         assert_eq!(formats.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_extract_from_initials_filesize_propagation() {
+        use rdlp_jsinterp::BoaJsEngine;
+        let engine = BoaJsEngine::new();
+        // HLS URLs with download sizes that should be propagated
+        let enc_720 = encrypt_url("https://example.com/media=hls4/720.m3u8");
+        let enc_1080 = encrypt_url("https://example.com/media=hls4/1080.m3u8");
+        let initials = serde_json::json!({
+            "videoModel": {
+                "sources": {
+                    "download": {
+                        "720p": {"size": 50_000_000.0},
+                        "1080p": {"size": 100_000_000.0}
+                    }
+                }
+            },
+            "xplayerSettings": {
+                "sources": {
+                    "standard": {
+                        "h264": [
+                            { "quality": "720", "url": enc_720 },
+                            { "quality": "1080", "url": enc_1080 }
+                        ]
+                    }
+                }
+            }
+        });
+
+        let formats = extract_from_initials(
+            &initials,
+            "https://xhamster.com/videos/test-123",
+            &engine,
+            None,
+        )
+        .await;
+        assert_eq!(formats.len(), 2);
+        let f720 = formats.iter().find(|f| f.format_id.contains("720")).unwrap();
+        let f1080 = formats.iter().find(|f| f.format_id.contains("1080")).unwrap();
+        assert_eq!(f720.filesize, Some(50_000_000), "720p should have download size");
+        assert_eq!(f1080.filesize, Some(100_000_000), "1080p should have download size");
     }
 
     #[tokio::test]

--- a/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
@@ -620,6 +620,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_decipher_url_with_hex_segment() {
+        let engine = BoaJsEngine::new();
+        // Encrypt a path segment, then embed it in a full URL with remainder.
+        // This tests the URL-with-hex-segment path in decipherFormatUrl.
+        let plaintext = "decrypted-path-segment";
+        let hex_segment = encrypt_test_vector(1, 42, plaintext);
+        let url_with_hex = format!("https://cdn.example.com/{hex_segment}/rest/of/path.m3u8");
+
+        let result = try_bundled_decrypt(&url_with_hex, &engine).await;
+        assert!(result.is_some(), "Should handle URL-with-hex-segment");
+        let decrypted = result.unwrap();
+        assert!(
+            decrypted.contains(plaintext),
+            "Decrypted URL should contain plaintext segment: {decrypted}"
+        );
+        assert!(
+            decrypted.contains("/rest/of/path.m3u8"),
+            "Remainder should be preserved: {decrypted}"
+        );
+        assert!(
+            decrypted.starts_with("https://cdn.example.com/"),
+            "Host should be preserved: {decrypted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decipher_url_with_short_hex_not_matched() {
+        let engine = BoaJsEngine::new();
+        // Hex segment shorter than 12 chars — should not match the URL pattern
+        let url = "https://cdn.example.com/abcd1234/path.m3u8";
+        let result = try_bundled_decrypt(url, &engine).await;
+        assert!(result.is_none(), "Short hex in URL should not be deciphered");
+    }
+
+    #[tokio::test]
     async fn test_boa_very_large_initials() {
         let engine = BoaJsEngine::new();
         // Generate a large but valid initials object


### PR DESCRIPTION
## Summary

- Propagate `videoModel.sources.download` file sizes to extracted HLS format objects (previously collected but never attached after direct MP4 removal)
- Add tests confirming hex-segment URL decryption already works via bundled `decrypt.js`

Closes #102

## Test plan

- [x] 367 extractor tests pass (3 new)
- [x] 1,209 total workspace tests pass
- [x] Clippy clean