### PR TITLE
fix(extractor): infer muxed AAC audio for HLS AV1 variants

### DIFF
--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -79,4 +79,127 @@ mod tests {
 
     // Note: Integration tests with real URLs are in the redtube extractor tests
     // because they require network access and are marked with #[ignore]
+
+    use super::variants::infer_muxed_audio;
+
+    #[test]
+    fn test_infer_muxed_audio_video_only_no_audio_group() {
+        // AV1 with no declared audio and no separate audio rendition
+        // → should infer muxed AAC
+        assert_eq!(
+            infer_muxed_audio(Some("av1"), None, false),
+            Some("aac"),
+        );
+    }
+
+    #[test]
+    fn test_infer_muxed_audio_declared_audio_preserved() {
+        // h264+aac declared → should keep declared aac
+        assert_eq!(
+            infer_muxed_audio(Some("h264"), Some("aac"), false),
+            Some("aac"),
+        );
+    }
+
+    #[test]
+    fn test_infer_muxed_audio_opus_preserved() {
+        // AV1+opus declared → should keep declared opus
+        assert_eq!(
+            infer_muxed_audio(Some("av1"), Some("opus"), false),
+            Some("opus"),
+        );
+    }
+
+    #[test]
+    fn test_infer_muxed_audio_separate_audio_group() {
+        // Video only with separate AUDIO rendition → should NOT infer
+        assert_eq!(
+            infer_muxed_audio(Some("av1"), None, true),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_infer_muxed_audio_no_video() {
+        // Audio-only stream (no video) → should NOT infer
+        assert_eq!(
+            infer_muxed_audio(None, Some("aac"), false),
+            Some("aac"),
+        );
+    }
+
+    #[test]
+    fn test_infer_muxed_audio_no_codecs() {
+        // No codecs declared at all → should NOT infer
+        assert_eq!(
+            infer_muxed_audio(None, None, false),
+            None,
+        );
+    }
+
+    /// End-to-end: parse a master playlist with AV1-only CODECS and verify
+    /// the variant expansion infers muxed AAC.
+    #[test]
+    fn test_infer_muxed_audio_from_m3u8_parse() {
+        let master_m3u8 = "\
+            #EXTM3U\n\
+            #EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080,\
+            CODECS=\"av01.0.08M.08\"\n\
+            media_1080.m3u8\n\
+            #EXT-X-STREAM-INF:BANDWIDTH=3000000,RESOLUTION=1280x720,\
+            CODECS=\"avc1.640028,mp4a.40.2\"\n\
+            media_720.m3u8\n";
+
+        let playlist = m3u8_rs::parse_playlist_res(master_m3u8.as_bytes()).unwrap();
+        let master = match playlist {
+            m3u8_rs::Playlist::MasterPlaylist(m) => m,
+            _ => panic!("Expected master playlist"),
+        };
+
+        assert_eq!(master.variants.len(), 2);
+
+        // AV1 variant: video only in CODECS, no AUDIO attribute
+        let av1 = &master.variants[0];
+        let (v, a) = rdlp_core::parse_hls_codecs(av1.codecs.as_deref().unwrap());
+        let inferred = infer_muxed_audio(v, a, av1.audio.is_some());
+        assert_eq!(v, Some("av1"));
+        assert_eq!(a, None, "Raw CODECS should have no audio");
+        assert_eq!(inferred, Some("aac"), "Should infer muxed AAC");
+
+        // h264+aac variant: both declared
+        let h264 = &master.variants[1];
+        let (v2, a2) = rdlp_core::parse_hls_codecs(h264.codecs.as_deref().unwrap());
+        let inferred2 = infer_muxed_audio(v2, a2, h264.audio.is_some());
+        assert_eq!(v2, Some("h264"));
+        assert_eq!(a2, Some("aac"));
+        assert_eq!(inferred2, Some("aac"), "Declared audio preserved");
+    }
+
+    /// Parse a master playlist with separate AUDIO group and verify no inference.
+    #[test]
+    fn test_no_inference_with_audio_rendition() {
+        let master_m3u8 = "\
+            #EXTM3U\n\
+            #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"audio\",NAME=\"AAC\",\
+            DEFAULT=YES,URI=\"audio.m3u8\"\n\
+            #EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080,\
+            CODECS=\"av01.0.08M.08\",AUDIO=\"audio\"\n\
+            video_1080.m3u8\n";
+
+        let playlist = m3u8_rs::parse_playlist_res(master_m3u8.as_bytes()).unwrap();
+        let master = match playlist {
+            m3u8_rs::Playlist::MasterPlaylist(m) => m,
+            _ => panic!("Expected master playlist"),
+        };
+
+        let variant = &master.variants[0];
+        let (v, a) = rdlp_core::parse_hls_codecs(variant.codecs.as_deref().unwrap());
+        let inferred = infer_muxed_audio(v, a, variant.audio.is_some());
+        assert_eq!(v, Some("av1"));
+        assert!(variant.audio.is_some(), "AUDIO attribute should be present");
+        assert_eq!(
+            inferred, None,
+            "Should NOT infer audio when AUDIO group referenced"
+        );
+    }
 }

--- a/crates/rdlp-extractor/src/hls/variants.rs
+++ b/crates/rdlp-extractor/src/hls/variants.rs
@@ -9,6 +9,28 @@ use crate::base::common::BaseExtractor;
 use log::debug;
 use rdlp_core::{RdlpError, Result};
 
+/// Infer muxed audio codec for HLS variants.
+///
+/// Per the HLS spec, when a variant stream has a video codec declared in
+/// `CODECS` but no audio codec, and doesn't reference a separate audio
+/// rendition via the `AUDIO` attribute, audio is muxed in the transport
+/// stream segments. Default to "aac" — the universal HLS muxed audio codec.
+///
+/// Returns the audio codec to use: either the declared one or the inferred one.
+pub(crate) fn infer_muxed_audio<'a>(
+    video_codec: Option<&'a str>,
+    audio_codec: Option<&'a str>,
+    has_separate_audio_group: bool,
+) -> Option<&'a str> {
+    audio_codec.or(
+        if video_codec.is_some() && !has_separate_audio_group {
+            Some("aac")
+        } else {
+            None
+        },
+    )
+}
+
 impl HlsSizeDetector {
     /// Detect comprehensive HLS metadata from an M3U8 playlist
     ///
@@ -75,6 +97,8 @@ impl HlsSizeDetector {
                     .as_deref()
                     .map(rdlp_core::parse_hls_codecs)
                     .unwrap_or((None, None));
+                let audio_codec =
+                    infer_muxed_audio(video_codec, audio_codec, variant.audio.is_some());
                 let frame_rate = variant.frame_rate;
                 let bandwidth = Some(variant.bandwidth);
                 let average_bandwidth = variant.average_bandwidth;
@@ -229,6 +253,8 @@ impl HlsSizeDetector {
                 .as_deref()
                 .map(rdlp_core::parse_hls_codecs)
                 .unwrap_or((None, None));
+            let audio_codec =
+                infer_muxed_audio(video_codec, audio_codec, variant.audio.is_some());
 
             variants.push(HlsVariantInfo {
                 media_playlist_url: media_url,


### PR DESCRIPTION
## Summary
- XHamster AV1 HLS variants declare `CODECS="av01.0.08M.08"` (video only) without the audio codec, even though AAC audio is muxed in the transport stream segments
- Per HLS spec, when a variant doesn't reference a separate `AUDIO` rendition group, audio is muxed in the main segments — now defaults to "aac" in this case
- Fixes the desktop format dialog incorrectly grouping AV1 formats as "VIDEO ONLY" when they actually contain audio

## Test Plan
- [x] 8 new unit tests for `infer_muxed_audio()` covering all cases (video-only, declared audio, separate rendition, no codecs, end-to-end m3u8 parsing)
- [x] 1,217 workspace tests pass, clippy clean
- [ ] Verify XHamster AV1 formats show under "VIDEO + AUDIO" in the desktop format dialog