### PR TITLE
feat(table): responsive CLI table renderer, replace dialoguer with inquire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,6 +4502,7 @@ name = "rdlp-table"
 version = "0.1.0"
 dependencies = [
  "console",
+ "rdlp-types",
  "tabled",
  "terminal_size",
 ]
@@ -4510,7 +4511,6 @@ dependencies = [
 name = "rdlp-types"
 version = "0.1.0"
 dependencies = [
- "rdlp-table",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1033,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1172,7 +1214,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -1194,22 +1236,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
  "syn 2.0.116",
-]
-
-[[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "zeroize",
 ]
 
 [[package]]
@@ -1769,6 +1800,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -2547,6 +2587,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "intrusive-collections"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,6 +3022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3445,6 +3500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,6 +3945,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,7 +4083,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4179,9 +4267,9 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "dialoguer",
  "futures-util",
  "indicatif",
+ "inquire",
  "log",
  "mockito",
  "proptest",
@@ -4412,6 +4500,11 @@ dependencies = [
 [[package]]
 name = "rdlp-table"
 version = "0.1.0"
+dependencies = [
+ "console",
+ "tabled",
+ "terminal_size",
+]
 
 [[package]]
 name = "rdlp-types"
@@ -5084,16 +5177,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5345,6 +5453,30 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -5732,6 +5864,25 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,12 @@ boa_engine = "0.21"
 # CLI
 clap = { version = "4.5", features = ["derive", "cargo"] }
 indicatif = "0.18.3"
-dialoguer = "0.12.0"
+inquire = "0.9"
+
+# Table rendering
+tabled = "0.20"
+console = "0.16"
+terminal_size = "0.4"
 
 # Logging
 log = { version = "0.4", features = ["kv"] }

--- a/crates/rdlp-api/src/orchestrator/interactive.rs
+++ b/crates/rdlp-api/src/orchestrator/interactive.rs
@@ -1,6 +1,6 @@
 //! Callback trait for interactive user input.
 //!
-//! CLI provides a `dialoguer`-based implementation. Tauri/Leptos
+//! CLI provides an `inquire`-based implementation. Tauri/Leptos
 //! provide their own. The orchestrator calls these methods when
 //! interactive mode is enabled.
 

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -36,7 +36,7 @@ log = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
-dialoguer = { workspace = true }
+inquire = { workspace = true }
 futures-util = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -20,7 +20,7 @@ pub(crate) struct ResolvedInteractiveValues {
     pub remux_container: Option<ContainerFormat>,
 }
 
-/// Resolve interactive CLI values (dialoguer prompts) before config merge.
+/// Resolve interactive CLI values (inquire prompts) before config merge.
 ///
 /// Returns `None` values for fields that weren't set to "interactive".
 fn resolve_interactive_values(args: &Args) -> Result<ResolvedInteractiveValues> {

--- a/crates/rdlp-cli/src/interactive.rs
+++ b/crates/rdlp-cli/src/interactive.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use log::info;
 use rdlp_api::InteractiveCallback;
 use rdlp_core::{Format, InfoDict};
-use rdlp_table::{ColorMode, TableOpts, render_format_rows, render_formats_table};
+use rdlp_table::{ColorMode, TableOpts, render_table_and_rows};
 
 /// CLI interactive callback backed by inquire.
 pub struct DialoguerCallback;
@@ -33,12 +33,9 @@ impl InteractiveCallback for DialoguerCallback {
 
         let refs: Vec<&Format> = formats.iter().collect();
 
-        // Print the formatted table header.
-        let table = render_formats_table(&refs, &opts);
+        // Compute budget once for both header table and menu items.
+        let (table, items) = render_table_and_rows(&refs, &opts);
         info!("Available formats:\n{table}");
-
-        // Build menu items matching the table's column layout.
-        let items = render_format_rows(&refs, &opts);
 
         tokio::task::spawn_blocking(move || {
             inquire::Select::new("Select a format to download:", items)

--- a/crates/rdlp-cli/src/interactive.rs
+++ b/crates/rdlp-cli/src/interactive.rs
@@ -9,81 +9,7 @@ use async_trait::async_trait;
 use log::info;
 use rdlp_api::InteractiveCallback;
 use rdlp_core::{Format, InfoDict};
-use rdlp_table::{ColorMode, FormatRow, TableOpts, render_format_rows, render_formats_table};
-
-/// Build a [`FormatRow`] from a [`Format`] for table rendering.
-fn format_to_row(f: &Format) -> FormatRow {
-    let quality = {
-        let base = f.format_note.as_deref().unwrap_or("unknown");
-        match f.fps {
-            Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => format!("{base}{fps:.0}"),
-            _ => base.to_string(),
-        }
-    };
-
-    let resolution = match (f.width, f.height) {
-        (Some(w), Some(h)) => format!("{w}x{h}"),
-        _ => "N/A".to_string(),
-    };
-
-    let format_type = if f.is_hls() {
-        "HLS".to_string()
-    } else {
-        f.ext.to_ascii_uppercase()
-    };
-
-    let size = f.size_text();
-
-    let codecs = match (&f.vcodec, &f.acodec) {
-        (Some(v), Some(a)) if v != "none" && a != "none" => format!("{v}/{a}"),
-        (Some(v), _) if v != "none" => format!("{v} (video only)"),
-        (_, Some(a)) if a != "none" => format!("{a} (audio only)"),
-        _ => "Unknown".to_string(),
-    };
-    let codecs = if f.has_drm.unwrap_or(false) {
-        format!("{codecs} [DRM]")
-    } else {
-        codecs
-    };
-
-    let fps = match f.fps {
-        Some(fps) if fps > 0.0 => format!("{fps:.0}"),
-        _ => String::new(),
-    };
-
-    let abr = match f.abr {
-        Some(abr) if abr > 0.0 => format!("{abr:.0}"),
-        _ => String::new(),
-    };
-
-    let vbr = match f.vbr {
-        Some(vbr) if vbr > 0.0 => format!("{vbr:.0}"),
-        _ => String::new(),
-    };
-
-    let note = {
-        let mut parts = Vec::new();
-        if let Some(dr) = &f.dynamic_range {
-            parts.push(dr.clone());
-        }
-        if let Some(lang) = &f.language {
-            parts.push(lang.clone());
-        }
-        parts.join(", ")
-    };
-
-    FormatRow {
-        quality,
-        resolution,
-        format_type,
-        size,
-        codecs,
-        fps,
-        abr,
-        vbr,
-        note,
-    }
-}
+use rdlp_table::{ColorMode, TableOpts, render_format_rows, render_formats_table};
 
 /// CLI interactive callback backed by inquire.
 pub struct DialoguerCallback;
@@ -105,14 +31,14 @@ impl InteractiveCallback for DialoguerCallback {
             compact: None,
         };
 
-        let rows: Vec<FormatRow> = formats.iter().map(format_to_row).collect();
+        let refs: Vec<&Format> = formats.iter().collect();
 
         // Print the formatted table header.
-        let table = render_formats_table(&rows, &opts);
+        let table = render_formats_table(&refs, &opts);
         info!("Available formats:\n{table}");
 
         // Build menu items matching the table's column layout.
-        let items = render_format_rows(&rows, &opts);
+        let items = render_format_rows(&refs, &opts);
 
         tokio::task::spawn_blocking(move || {
             inquire::Select::new("Select a format to download:", items)

--- a/crates/rdlp-cli/src/interactive.rs
+++ b/crates/rdlp-cli/src/interactive.rs
@@ -1,17 +1,91 @@
-//! CLI-specific interactive callback using dialoguer.
+//! CLI-specific interactive callback using inquire.
 //!
 //! [`DialoguerCallback`] implements [`InteractiveCallback`] from `rdlp-api`
-//! using dialoguer's `Select`, `MultiSelect`, and `Confirm` widgets.
+//! using inquire's `Select`, `MultiSelect`, and `Confirm` widgets.
 //! All blocking terminal I/O is wrapped in `spawn_blocking` to avoid
 //! blocking the Tokio runtime.
 
 use async_trait::async_trait;
-use dialoguer::{Confirm, MultiSelect, Select, theme::ColorfulTheme};
 use log::info;
 use rdlp_api::InteractiveCallback;
 use rdlp_core::{Format, InfoDict};
+use rdlp_table::{ColorMode, FormatRow, TableOpts, render_format_rows, render_formats_table};
 
-/// CLI interactive callback backed by dialoguer.
+/// Build a [`FormatRow`] from a [`Format`] for table rendering.
+fn format_to_row(f: &Format) -> FormatRow {
+    let quality = {
+        let base = f.format_note.as_deref().unwrap_or("unknown");
+        match f.fps {
+            Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => format!("{base}{fps:.0}"),
+            _ => base.to_string(),
+        }
+    };
+
+    let resolution = match (f.width, f.height) {
+        (Some(w), Some(h)) => format!("{w}x{h}"),
+        _ => "N/A".to_string(),
+    };
+
+    let format_type = if f.is_hls() {
+        "HLS".to_string()
+    } else {
+        f.ext.to_ascii_uppercase()
+    };
+
+    let size = f.size_text();
+
+    let codecs = match (&f.vcodec, &f.acodec) {
+        (Some(v), Some(a)) if v != "none" && a != "none" => format!("{v}/{a}"),
+        (Some(v), _) if v != "none" => format!("{v} (video only)"),
+        (_, Some(a)) if a != "none" => format!("{a} (audio only)"),
+        _ => "Unknown".to_string(),
+    };
+    let codecs = if f.has_drm.unwrap_or(false) {
+        format!("{codecs} [DRM]")
+    } else {
+        codecs
+    };
+
+    let fps = match f.fps {
+        Some(fps) if fps > 0.0 => format!("{fps:.0}"),
+        _ => String::new(),
+    };
+
+    let abr = match f.abr {
+        Some(abr) if abr > 0.0 => format!("{abr:.0}"),
+        _ => String::new(),
+    };
+
+    let vbr = match f.vbr {
+        Some(vbr) if vbr > 0.0 => format!("{vbr:.0}"),
+        _ => String::new(),
+    };
+
+    let note = {
+        let mut parts = Vec::new();
+        if let Some(dr) = &f.dynamic_range {
+            parts.push(dr.clone());
+        }
+        if let Some(lang) = &f.language {
+            parts.push(lang.clone());
+        }
+        parts.join(", ")
+    };
+
+    FormatRow {
+        quality,
+        resolution,
+        format_type,
+        size,
+        codecs,
+        fps,
+        abr,
+        vbr,
+        note,
+    }
+}
+
+/// CLI interactive callback backed by inquire.
 pub struct DialoguerCallback;
 
 #[async_trait]
@@ -21,44 +95,33 @@ impl InteractiveCallback for DialoguerCallback {
             return None;
         }
 
-        // Warn about live streams
         if info.is_live.unwrap_or(false) {
             info!("LIVE stream detected — download may be incomplete");
         }
 
-        // Compute dynamic size column width
-        let size_width = formats
-            .iter()
-            .map(|f| f.size_text().len())
-            .max()
-            .unwrap_or(4)
-            .max(4);
+        let opts = TableOpts {
+            width_override: None,
+            color: ColorMode::Auto,
+            compact: None,
+        };
 
-        // Build menu items with format details
-        let items: Vec<String> = formats.iter().map(|f| f.table_row(size_width)).collect();
+        let rows: Vec<FormatRow> = formats.iter().map(format_to_row).collect();
 
-        info!("Available formats:");
-        info!(
-            "{:<qw$} | {:<rw$} | {:<size_width$} | {:<tw$} | Codecs",
-            "Quality",
-            "Resolution",
-            "Size",
-            "Type",
-            qw = rdlp_table::QUALITY_WIDTH,
-            rw = rdlp_table::RESOLUTION_WIDTH,
-            tw = rdlp_table::TYPE_WIDTH,
-        );
-        info!("{}", "-".repeat(rdlp_table::separator_width(size_width)));
+        // Print the formatted table header.
+        let table = render_formats_table(&rows, &opts);
+        info!("Available formats:\n{table}");
+
+        // Build menu items matching the table's column layout.
+        let items = render_format_rows(&rows, &opts);
 
         tokio::task::spawn_blocking(move || {
-            Select::with_theme(&ColorfulTheme::default())
-                .with_prompt("Select a format to download (ESC to cancel)")
-                .items(&items)
-                .default(0)
-                .interact_opt()
+            inquire::Select::new("Select a format to download:", items)
+                .raw_prompt_skippable()
+                .ok()
+                .flatten()
+                .map(|opt| opt.index)
         })
         .await
-        .ok()?
         .ok()?
     }
 
@@ -68,19 +131,24 @@ impl InteractiveCallback for DialoguerCallback {
         }
 
         let items_owned: Vec<String> = items.to_vec();
-        let defaults_owned: Vec<bool> = defaults.to_vec();
+        let default_indices: Vec<usize> = defaults
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &d)| if d { Some(i) } else { None })
+            .collect();
 
         tokio::task::spawn_blocking(move || {
-            MultiSelect::with_theme(&ColorfulTheme::default())
-                .with_prompt(
-                    "Select subtitle languages (SPACE to toggle, ENTER to confirm, ESC to cancel)",
-                )
-                .items(&items_owned)
-                .defaults(&defaults_owned)
-                .interact_opt()
+            inquire::MultiSelect::new(
+                "Select subtitle languages (SPACE to toggle, ENTER to confirm):",
+                items_owned,
+            )
+            .with_default(&default_indices)
+            .raw_prompt_skippable()
+            .ok()
+            .flatten()
+            .map(|selected| selected.iter().map(|opt| opt.index).collect())
         })
         .await
-        .ok()?
         .ok()?
     }
 
@@ -92,14 +160,13 @@ impl InteractiveCallback for DialoguerCallback {
         let options_owned: Vec<String> = options.to_vec();
 
         tokio::task::spawn_blocking(move || {
-            Select::with_theme(&ColorfulTheme::default())
-                .with_prompt("Select audio type (ESC to skip)")
-                .items(&options_owned)
-                .default(0)
-                .interact_opt()
+            inquire::Select::new("Select audio type:", options_owned)
+                .raw_prompt_skippable()
+                .ok()
+                .flatten()
+                .map(|opt| opt.index)
         })
         .await
-        .ok()?
         .ok()?
     }
 
@@ -107,10 +174,9 @@ impl InteractiveCallback for DialoguerCallback {
         let prompt_owned = prompt.to_string();
 
         tokio::task::spawn_blocking(move || {
-            Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt(prompt_owned)
-                .default(true)
-                .interact()
+            inquire::Confirm::new(&prompt_owned)
+                .with_default(true)
+                .prompt()
                 .unwrap_or(false)
         })
         .await

--- a/crates/rdlp-cli/src/interactive.rs
+++ b/crates/rdlp-cli/src/interactive.rs
@@ -33,12 +33,13 @@ impl InteractiveCallback for DialoguerCallback {
 
         let refs: Vec<&Format> = formats.iter().collect();
 
-        // Compute budget once for both header table and menu items.
-        let (table, items) = render_table_and_rows(&refs, &opts);
-        info!("Available formats:\n{table}");
+        // Compute budget once for both header line and menu items.
+        let (header, items) = render_table_and_rows(&refs, &opts);
 
         tokio::task::spawn_blocking(move || {
-            inquire::Select::new("Select a format to download:", items)
+            // Print header line above the select menu so column names are visible.
+            eprintln!("{header}");
+            inquire::Select::new("Select a format:", items)
                 .raw_prompt_skippable()
                 .ok()
                 .flatten()

--- a/crates/rdlp-cli/src/lib.rs
+++ b/crates/rdlp-cli/src/lib.rs
@@ -2,12 +2,12 @@
 //!
 //! CLI-specific modules for the rdlp download tool.
 //! The core orchestration logic lives in `rdlp-api`; this crate
-//! provides the terminal UI layer (dialoguer callbacks, indicatif
+//! provides the terminal UI layer (inquire callbacks, indicatif
 //! progress bars).
 
 #![warn(missing_docs)]
 
 /// CLI event handler mapping API events to indicatif progress bars.
 pub mod event_handler;
-/// CLI interactive callback using dialoguer.
+/// CLI interactive callback using inquire.
 pub mod interactive;

--- a/crates/rdlp-cli/src/selection.rs
+++ b/crates/rdlp-cli/src/selection.rs
@@ -1,10 +1,9 @@
 //! Interactive format and container selection menus.
 //!
-//! Provides dialoguer-based selection prompts for remux containers,
+//! Provides inquire-based selection prompts for remux containers,
 //! audio formats, and video recode formats.
 
 use anyhow::Result;
-use dialoguer::{Select, theme::ColorfulTheme};
 use rdlp_core::{AudioFormat, ContainerFormat};
 
 /// Interactive remux container selection
@@ -59,13 +58,10 @@ pub(crate) fn select_remux_container() -> Result<Option<ContainerFormat>> {
         .map(|(fmt, desc)| format!("{:<6} {desc}", fmt.as_ext()))
         .collect();
 
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select remux container (ESC to cancel)")
-        .items(&items)
-        .default(0)
-        .interact_opt()?;
+    let selection =
+        inquire::Select::new("Select remux container:", items).raw_prompt_skippable()?;
 
-    Ok(selection.map(|idx| containers[idx].0))
+    Ok(selection.map(|opt| containers[opt.index].0))
 }
 
 /// Interactive audio format selection
@@ -92,13 +88,9 @@ pub(crate) fn select_audio_format() -> Result<Option<AudioFormat>> {
         .map(|(fmt, desc)| format!("{:<8} {desc}", fmt.as_ext()))
         .collect();
 
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select audio format (ESC to cancel)")
-        .items(&items)
-        .default(0)
-        .interact_opt()?;
+    let selection = inquire::Select::new("Select audio format:", items).raw_prompt_skippable()?;
 
-    Ok(selection.map(|idx| formats[idx].0))
+    Ok(selection.map(|opt| formats[opt.index].0))
 }
 
 /// Interactive video recode format selection
@@ -121,11 +113,7 @@ pub(crate) fn select_recode_video() -> Result<Option<ContainerFormat>> {
         .map(|(fmt, codec, desc)| format!("{:<6} [{codec}] {desc}", fmt.as_ext()))
         .collect();
 
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select video format (ESC to cancel)")
-        .items(&items)
-        .default(0)
-        .interact_opt()?;
+    let selection = inquire::Select::new("Select video format:", items).raw_prompt_skippable()?;
 
-    Ok(selection.map(|idx| formats[idx].0))
+    Ok(selection.map(|opt| formats[opt.index].0))
 }

--- a/crates/rdlp-cookies/src/util.rs
+++ b/crates/rdlp-cookies/src/util.rs
@@ -78,18 +78,16 @@ where
 
     // Chrome's cookie DB doesn't have a .db extension, so use suffix
     // approach: Cookies-wal, Cookies-shm
-    let wal_src2 = db_path.with_file_name(
-        format!("{}-wal", db_path.file_name().unwrap_or_default().to_string_lossy())
-    );
-    let shm_src2 = db_path.with_file_name(
-        format!("{}-shm", db_path.file_name().unwrap_or_default().to_string_lossy())
-    );
-    let wal_dst2 = temp_db.with_file_name(
-        format!("{}-wal", temp_name)
-    );
-    let shm_dst2 = temp_db.with_file_name(
-        format!("{}-shm", temp_name)
-    );
+    let wal_src2 = db_path.with_file_name(format!(
+        "{}-wal",
+        db_path.file_name().unwrap_or_default().to_string_lossy()
+    ));
+    let shm_src2 = db_path.with_file_name(format!(
+        "{}-shm",
+        db_path.file_name().unwrap_or_default().to_string_lossy()
+    ));
+    let wal_dst2 = temp_db.with_file_name(format!("{}-wal", temp_name));
+    let shm_dst2 = temp_db.with_file_name(format!("{}-shm", temp_name));
 
     // Try both naming patterns; ignore errors (files may not exist)
     for (src, dst) in [
@@ -143,8 +141,8 @@ fn copy_with_share_read(src: &Path, dst: &Path) -> Result<(), std::io::Error> {
     use std::os::windows::io::FromRawHandle;
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE,
-        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        OPEN_EXISTING,
     };
 
     // GENERIC_READ = 0x80000000 — not re-exported by windows-sys FileSystem

--- a/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
@@ -22,7 +22,6 @@ fn get_height(s: &str) -> Option<u32> {
     BaseExtractor::parse_quality_height(s)
 }
 
-
 /// Detect vcodec from URL by checking for `.av1.` or `.h264.` in the path.
 fn detect_vcodec(url: &str) -> Option<&'static str> {
     [(".av1.", "av1"), (".h264.", "h264")]
@@ -217,8 +216,8 @@ pub async fn extract_from_initials(
                         // CDN-blocked (403) even after decryption. HLS URLs
                         // that appear in the standard section (media=hls4)
                         // are the only ones that work.
-                        let is_hls = deciphered.contains("m3u8")
-                            || deciphered.contains("media=hls");
+                        let is_hls =
+                            deciphered.contains("m3u8") || deciphered.contains("media=hls");
                         if !is_hls {
                             debug!(
                                 "[XHamster] Skipping standard direct URL {} (CDN-blocked)",
@@ -516,10 +515,24 @@ mod tests {
         )
         .await;
         assert_eq!(formats.len(), 2);
-        let f720 = formats.iter().find(|f| f.format_id.contains("720")).unwrap();
-        let f1080 = formats.iter().find(|f| f.format_id.contains("1080")).unwrap();
-        assert_eq!(f720.filesize, Some(50_000_000), "720p should have download size");
-        assert_eq!(f1080.filesize, Some(100_000_000), "1080p should have download size");
+        let f720 = formats
+            .iter()
+            .find(|f| f.format_id.contains("720"))
+            .unwrap();
+        let f1080 = formats
+            .iter()
+            .find(|f| f.format_id.contains("1080"))
+            .unwrap();
+        assert_eq!(
+            f720.filesize,
+            Some(50_000_000),
+            "720p should have download size"
+        );
+        assert_eq!(
+            f1080.filesize,
+            Some(100_000_000),
+            "1080p should have download size"
+        );
     }
 
     #[tokio::test]
@@ -545,7 +558,10 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(formats.len(), 0, "Direct URLs should be skipped (CDN-blocked)");
+        assert_eq!(
+            formats.len(),
+            0,
+            "Direct URLs should be skipped (CDN-blocked)"
+        );
     }
-
 }

--- a/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
@@ -500,8 +500,7 @@ mod tests {
     async fn test_full_extraction_player_js_unavailable() {
         let engine = BoaJsEngine::new();
         // Use an HLS URL — standard direct URLs are CDN-blocked and skipped
-        let encrypted =
-            encrypt_test_vector(2, 42, "https://cdn.example.com/media=hls4/video.m3u8");
+        let encrypted = encrypt_test_vector(2, 42, "https://cdn.example.com/media=hls4/video.m3u8");
 
         let initials = serde_json::json!({
             "videoModel": {
@@ -651,7 +650,10 @@ mod tests {
         // Hex segment shorter than 12 chars — should not match the URL pattern
         let url = "https://cdn.example.com/abcd1234/path.m3u8";
         let result = try_bundled_decrypt(url, &engine).await;
-        assert!(result.is_none(), "Short hex in URL should not be deciphered");
+        assert!(
+            result.is_none(),
+            "Short hex in URL should not be deciphered"
+        );
     }
 
     #[tokio::test]

--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -86,10 +86,7 @@ mod tests {
     fn test_infer_muxed_audio_video_only_no_audio_group() {
         // AV1 with no declared audio and no separate audio rendition
         // → should infer muxed AAC
-        assert_eq!(
-            infer_muxed_audio(Some("av1"), None, false),
-            Some("aac"),
-        );
+        assert_eq!(infer_muxed_audio(Some("av1"), None, false), Some("aac"),);
     }
 
     #[test]
@@ -113,28 +110,19 @@ mod tests {
     #[test]
     fn test_infer_muxed_audio_separate_audio_group() {
         // Video only with separate AUDIO rendition → should NOT infer
-        assert_eq!(
-            infer_muxed_audio(Some("av1"), None, true),
-            None,
-        );
+        assert_eq!(infer_muxed_audio(Some("av1"), None, true), None,);
     }
 
     #[test]
     fn test_infer_muxed_audio_no_video() {
         // Audio-only stream (no video) → should NOT infer
-        assert_eq!(
-            infer_muxed_audio(None, Some("aac"), false),
-            Some("aac"),
-        );
+        assert_eq!(infer_muxed_audio(None, Some("aac"), false), Some("aac"),);
     }
 
     #[test]
     fn test_infer_muxed_audio_no_codecs() {
         // No codecs declared at all → should NOT infer
-        assert_eq!(
-            infer_muxed_audio(None, None, false),
-            None,
-        );
+        assert_eq!(infer_muxed_audio(None, None, false), None,);
     }
 
     /// End-to-end: parse a master playlist with AV1-only CODECS and verify

--- a/crates/rdlp-extractor/src/hls/variants.rs
+++ b/crates/rdlp-extractor/src/hls/variants.rs
@@ -22,13 +22,11 @@ pub(crate) fn infer_muxed_audio<'a>(
     audio_codec: Option<&'a str>,
     has_separate_audio_group: bool,
 ) -> Option<&'a str> {
-    audio_codec.or(
-        if video_codec.is_some() && !has_separate_audio_group {
-            Some("aac")
-        } else {
-            None
-        },
-    )
+    audio_codec.or(if video_codec.is_some() && !has_separate_audio_group {
+        Some("aac")
+    } else {
+        None
+    })
 }
 
 impl HlsSizeDetector {
@@ -253,8 +251,7 @@ impl HlsSizeDetector {
                 .as_deref()
                 .map(rdlp_core::parse_hls_codecs)
                 .unwrap_or((None, None));
-            let audio_codec =
-                infer_muxed_audio(video_codec, audio_codec, variant.audio.is_some());
+            let audio_codec = infer_muxed_audio(video_codec, audio_codec, variant.audio.is_some());
 
             variants.push(HlsVariantInfo {
                 media_playlist_url: media_url,

--- a/crates/rdlp-table/Cargo.toml
+++ b/crates/rdlp-table/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+tabled = { workspace = true }
+console = { workspace = true }
+terminal_size = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rdlp-table/Cargo.toml
+++ b/crates/rdlp-table/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+rdlp-types = { path = "../rdlp-types" }
 tabled = { workspace = true }
 console = { workspace = true }
 terminal_size = { workspace = true }

--- a/crates/rdlp-table/src/column.rs
+++ b/crates/rdlp-table/src/column.rs
@@ -18,7 +18,7 @@ pub enum Align {
 }
 
 /// Definition of a single table column.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ColumnDef {
     /// Column header text.
     pub header: &'static str,
@@ -204,6 +204,7 @@ pub fn border_overhead(n_cols: usize, compact: bool) -> usize {
 }
 
 /// Result of the column budget algorithm.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnBudget {
     /// Indices into `all_columns()` that fit within the width.
     pub selected_indices: Vec<usize>,

--- a/crates/rdlp-table/src/column.rs
+++ b/crates/rdlp-table/src/column.rs
@@ -6,6 +6,7 @@
 //! first.
 
 use console::measure_text_width;
+use rdlp_types::Format;
 
 /// Horizontal alignment for a column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,33 +15,6 @@ pub enum Align {
     Left,
     /// Right-align cell content (pad left).
     Right,
-}
-
-/// Pre-extracted row data for table rendering.
-///
-/// Callers convert their format type into this struct before passing
-/// to the renderer. This keeps `rdlp-table` free of `rdlp-types` as
-/// a dependency (which would create a circular crate dependency).
-#[derive(Debug, Clone, Default)]
-pub struct FormatRow {
-    /// Quality label (e.g. "1080p", "720p60").
-    pub quality: String,
-    /// Resolution string (e.g. "1920x1080") or "N/A".
-    pub resolution: String,
-    /// Format type (e.g. "HLS", "MP4").
-    pub format_type: String,
-    /// Human-readable size text (e.g. "837.9 MB", "50:16 (754 seg)").
-    pub size: String,
-    /// Codec description (e.g. "h264/aac", "vp9 (video only)").
-    pub codecs: String,
-    /// Frames per second as a string (e.g. "60"), or empty string.
-    pub fps: String,
-    /// Audio bitrate in kbps as a string (e.g. "128"), or empty string.
-    pub abr: String,
-    /// Video bitrate in kbps as a string (e.g. "5000"), or empty string.
-    pub vbr: String,
-    /// Extra notes (e.g. "HDR, en", "Dolby Vision"), or empty string.
-    pub note: String,
 }
 
 /// Definition of a single table column.
@@ -55,44 +29,81 @@ pub struct ColumnDef {
     pub priority: u8,
     /// Text alignment within the column.
     pub align: Align,
-    /// Extract cell text from a `FormatRow`.
-    pub extract: fn(&FormatRow) -> &str,
+    /// Extract cell text from a [`Format`].
+    pub extract: fn(&Format) -> String,
 }
 
-fn extract_quality(r: &FormatRow) -> &str {
-    &r.quality
+fn extract_quality(f: &Format) -> String {
+    let base = f.format_note.as_deref().unwrap_or("unknown");
+    match f.fps {
+        Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => format!("{base}{fps:.0}"),
+        _ => base.to_string(),
+    }
 }
 
-fn extract_resolution(r: &FormatRow) -> &str {
-    &r.resolution
+fn extract_resolution(f: &Format) -> String {
+    match (f.width, f.height) {
+        (Some(w), Some(h)) => format!("{w}x{h}"),
+        _ => "N/A".to_string(),
+    }
 }
 
-fn extract_type(r: &FormatRow) -> &str {
-    &r.format_type
+fn extract_type(f: &Format) -> String {
+    if f.is_hls() {
+        "HLS".to_string()
+    } else {
+        f.ext.to_ascii_uppercase()
+    }
 }
 
-fn extract_size(r: &FormatRow) -> &str {
-    &r.size
+fn extract_size(f: &Format) -> String {
+    f.size_text()
 }
 
-fn extract_codecs(r: &FormatRow) -> &str {
-    &r.codecs
+fn extract_codecs(f: &Format) -> String {
+    let codecs = match (&f.vcodec, &f.acodec) {
+        (Some(v), Some(a)) if v != "none" && a != "none" => format!("{v}/{a}"),
+        (Some(v), _) if v != "none" => format!("{v} (video only)"),
+        (_, Some(a)) if a != "none" => format!("{a} (audio only)"),
+        _ => "Unknown".to_string(),
+    };
+    if f.has_drm.unwrap_or(false) {
+        format!("{codecs} [DRM]")
+    } else {
+        codecs
+    }
 }
 
-fn extract_fps(r: &FormatRow) -> &str {
-    &r.fps
+fn extract_fps(f: &Format) -> String {
+    match f.fps {
+        Some(fps) if fps > 0.0 => format!("{fps:.0}"),
+        _ => String::new(),
+    }
 }
 
-fn extract_abr(r: &FormatRow) -> &str {
-    &r.abr
+fn extract_abr(f: &Format) -> String {
+    match f.abr {
+        Some(abr) if abr > 0.0 => format!("{abr:.0}"),
+        _ => String::new(),
+    }
 }
 
-fn extract_vbr(r: &FormatRow) -> &str {
-    &r.vbr
+fn extract_vbr(f: &Format) -> String {
+    match f.vbr {
+        Some(vbr) if vbr > 0.0 => format!("{vbr:.0}"),
+        _ => String::new(),
+    }
 }
 
-fn extract_note(r: &FormatRow) -> &str {
-    &r.note
+fn extract_note(f: &Format) -> String {
+    let mut parts = Vec::new();
+    if let Some(dr) = &f.dynamic_range {
+        parts.push(dr.clone());
+    }
+    if let Some(lang) = &f.language {
+        parts.push(lang.clone());
+    }
+    parts.join(", ")
 }
 
 /// All available columns in display order.
@@ -210,13 +221,13 @@ pub struct ColumnBudget {
 /// * `columns` - All available column definitions
 /// * `available_width` - Terminal width in display columns
 /// * `compact` - Whether compact (blank) style is used
-/// * `rows` - The actual row data (used to compute natural column widths)
+/// * `formats` - The actual format data (used to compute natural column widths)
 #[must_use]
 pub fn compute_budget(
     columns: &[ColumnDef],
     available_width: usize,
     compact: bool,
-    rows: &[FormatRow],
+    formats: &[&Format],
 ) -> ColumnBudget {
     // Start with all columns, sorted by display order (preserving index).
     let mut candidates: Vec<(usize, &ColumnDef)> = columns.iter().enumerate().collect();
@@ -256,9 +267,9 @@ pub fn compute_budget(
         .iter()
         .map(|(_, col)| {
             let header_w = measure_text_width(col.header);
-            let max_cell = rows
+            let max_cell = formats
                 .iter()
-                .map(|r| measure_text_width((col.extract)(r)))
+                .map(|f| measure_text_width(&(col.extract)(f)))
                 .max()
                 .unwrap_or(0);
             header_w.max(max_cell)
@@ -301,6 +312,25 @@ pub fn compute_budget(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rdlp_types::protocol::DownloadProtocol;
+
+    fn make_format(note: &str, width: u32, height: u32, ext: &str) -> Format {
+        let mut f = Format::new(
+            "id",
+            "https://example.com/video",
+            ext,
+            DownloadProtocol::Https,
+        );
+        f.format_note = Some(note.to_string());
+        f.width = Some(width);
+        f.height = Some(height);
+        f.vcodec = Some("h264".to_string());
+        f.acodec = Some("aac".to_string());
+        f.fps = Some(30.0);
+        f.abr = Some(128.0);
+        f.vbr = Some(5000.0);
+        f
+    }
 
     #[test]
     fn test_all_columns_count() {
@@ -363,8 +393,10 @@ mod tests {
 
     #[test]
     fn test_budget_widths_at_least_minimum() {
+        let f1 = make_format("1080p", 1920, 1080, "mp4");
+        let f2 = make_format("720p", 1280, 720, "mp4");
         let columns = all_columns();
-        let budget = compute_budget(&columns, 120, false, &[]);
+        let budget = compute_budget(&columns, 120, false, &[&f1, &f2]);
         for (i, &idx) in budget.selected_indices.iter().enumerate() {
             assert!(
                 budget.widths[i] >= columns[idx].min_width,

--- a/crates/rdlp-table/src/column.rs
+++ b/crates/rdlp-table/src/column.rs
@@ -1,0 +1,378 @@
+//! Column definitions and responsive column selection.
+//!
+//! Each column has a priority, minimum width, alignment, and a cell
+//! extraction function. The budget algorithm selects which columns fit
+//! within the available terminal width, dropping lowest-priority columns
+//! first.
+
+use console::measure_text_width;
+
+/// Horizontal alignment for a column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Align {
+    /// Left-align cell content (pad right).
+    Left,
+    /// Right-align cell content (pad left).
+    Right,
+}
+
+/// Pre-extracted row data for table rendering.
+///
+/// Callers convert their format type into this struct before passing
+/// to the renderer. This keeps `rdlp-table` free of `rdlp-types` as
+/// a dependency (which would create a circular crate dependency).
+#[derive(Debug, Clone, Default)]
+pub struct FormatRow {
+    /// Quality label (e.g. "1080p", "720p60").
+    pub quality: String,
+    /// Resolution string (e.g. "1920x1080") or "N/A".
+    pub resolution: String,
+    /// Format type (e.g. "HLS", "MP4").
+    pub format_type: String,
+    /// Human-readable size text (e.g. "837.9 MB", "50:16 (754 seg)").
+    pub size: String,
+    /// Codec description (e.g. "h264/aac", "vp9 (video only)").
+    pub codecs: String,
+    /// Frames per second as a string (e.g. "60"), or empty string.
+    pub fps: String,
+    /// Audio bitrate in kbps as a string (e.g. "128"), or empty string.
+    pub abr: String,
+    /// Video bitrate in kbps as a string (e.g. "5000"), or empty string.
+    pub vbr: String,
+    /// Extra notes (e.g. "HDR, en", "Dolby Vision"), or empty string.
+    pub note: String,
+}
+
+/// Definition of a single table column.
+#[derive(Clone)]
+pub struct ColumnDef {
+    /// Column header text.
+    pub header: &'static str,
+    /// Minimum display width (excluding padding/borders).
+    pub min_width: usize,
+    /// Priority for column selection (higher = more important, kept longer).
+    /// Core columns (Quality, Resolution, Type) have priority >= 85.
+    pub priority: u8,
+    /// Text alignment within the column.
+    pub align: Align,
+    /// Extract cell text from a `FormatRow`.
+    pub extract: fn(&FormatRow) -> &str,
+}
+
+fn extract_quality(r: &FormatRow) -> &str {
+    &r.quality
+}
+
+fn extract_resolution(r: &FormatRow) -> &str {
+    &r.resolution
+}
+
+fn extract_type(r: &FormatRow) -> &str {
+    &r.format_type
+}
+
+fn extract_size(r: &FormatRow) -> &str {
+    &r.size
+}
+
+fn extract_codecs(r: &FormatRow) -> &str {
+    &r.codecs
+}
+
+fn extract_fps(r: &FormatRow) -> &str {
+    &r.fps
+}
+
+fn extract_abr(r: &FormatRow) -> &str {
+    &r.abr
+}
+
+fn extract_vbr(r: &FormatRow) -> &str {
+    &r.vbr
+}
+
+fn extract_note(r: &FormatRow) -> &str {
+    &r.note
+}
+
+/// All available columns in display order.
+///
+/// The order here determines the left-to-right column order in the table.
+/// Priority determines which columns survive when the terminal is narrow.
+#[must_use]
+pub fn all_columns() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef {
+            header: "Quality",
+            min_width: 7,
+            priority: 100,
+            align: Align::Left,
+            extract: extract_quality,
+        },
+        ColumnDef {
+            header: "Resolution",
+            min_width: 9,
+            priority: 90,
+            align: Align::Left,
+            extract: extract_resolution,
+        },
+        ColumnDef {
+            header: "Type",
+            min_width: 4,
+            priority: 85,
+            align: Align::Left,
+            extract: extract_type,
+        },
+        ColumnDef {
+            header: "Size",
+            min_width: 8,
+            priority: 80,
+            align: Align::Right,
+            extract: extract_size,
+        },
+        ColumnDef {
+            header: "Codecs",
+            min_width: 10,
+            priority: 70,
+            align: Align::Left,
+            extract: extract_codecs,
+        },
+        ColumnDef {
+            header: "FPS",
+            min_width: 3,
+            priority: 40,
+            align: Align::Right,
+            extract: extract_fps,
+        },
+        ColumnDef {
+            header: "ABR",
+            min_width: 5,
+            priority: 35,
+            align: Align::Right,
+            extract: extract_abr,
+        },
+        ColumnDef {
+            header: "VBR",
+            min_width: 5,
+            priority: 30,
+            align: Align::Right,
+            extract: extract_vbr,
+        },
+        ColumnDef {
+            header: "Note",
+            min_width: 6,
+            priority: 20,
+            align: Align::Left,
+            extract: extract_note,
+        },
+    ]
+}
+
+/// Overhead per column from table borders/separators.
+///
+/// For `Style::rounded()`: outer borders (2 chars: `│` left + `│` right)
+/// plus separators between columns (3 chars each: ` │ `).
+/// Total overhead = 4 + (n-1)*3 for n columns.
+///
+/// For `Style::blank()`: no borders/separators, just 2 spaces between columns.
+/// Overhead = (n-1) * 2.
+#[must_use]
+pub fn border_overhead(n_cols: usize, compact: bool) -> usize {
+    if n_cols == 0 {
+        return 0;
+    }
+    if compact {
+        // Blank style: 1 space padding on each outer edge + 3 spaces between cells.
+        // = 2 + (n-1)*3
+        2 + (n_cols - 1) * 3
+    } else {
+        // Rounded style: │ + space (2) outer borders + space + │ + space (3) between each pair.
+        // = 4 + (n-1)*3
+        4 + (n_cols - 1) * 3
+    }
+}
+
+/// Result of the column budget algorithm.
+pub struct ColumnBudget {
+    /// Indices into `all_columns()` that fit within the width.
+    pub selected_indices: Vec<usize>,
+    /// Allocated width for each selected column (in display columns).
+    pub widths: Vec<usize>,
+}
+
+/// Select which columns fit within `available_width` and allocate widths.
+///
+/// Drops lowest-priority columns first until the remaining columns fit.
+/// Core columns (priority >= 85: Quality, Resolution, Type) are never dropped.
+/// Remaining width after minimums is distributed proportionally.
+///
+/// # Arguments
+/// * `columns` - All available column definitions
+/// * `available_width` - Terminal width in display columns
+/// * `compact` - Whether compact (blank) style is used
+/// * `rows` - The actual row data (used to compute natural column widths)
+#[must_use]
+pub fn compute_budget(
+    columns: &[ColumnDef],
+    available_width: usize,
+    compact: bool,
+    rows: &[FormatRow],
+) -> ColumnBudget {
+    // Start with all columns, sorted by display order (preserving index).
+    let mut candidates: Vec<(usize, &ColumnDef)> = columns.iter().enumerate().collect();
+
+    loop {
+        let overhead = border_overhead(candidates.len(), compact);
+        let min_total: usize =
+            candidates.iter().map(|(_, c)| c.min_width).sum::<usize>() + overhead;
+
+        if min_total <= available_width || candidates.len() <= 3 {
+            // Fits, or we're at minimum columns — stop dropping.
+            break;
+        }
+
+        // Drop the lowest-priority non-core column.
+        // Core = priority >= 85 (Quality 100, Resolution 90, Type 85).
+        if let Some(drop_pos) = candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, (_, c))| c.priority < 85)
+            .min_by_key(|(_, (_, c))| c.priority)
+            .map(|(pos, _)| pos)
+        {
+            candidates.remove(drop_pos);
+        } else {
+            // All remaining are core — can't drop more.
+            break;
+        }
+    }
+
+    let overhead = border_overhead(candidates.len(), compact);
+    let min_total: usize = candidates.iter().map(|(_, c)| c.min_width).sum::<usize>() + overhead;
+    let extra = available_width.saturating_sub(min_total);
+
+    // Compute natural widths (max of header width and all cell values).
+    let natural_widths: Vec<usize> = candidates
+        .iter()
+        .map(|(_, col)| {
+            let header_w = measure_text_width(col.header);
+            let max_cell = rows
+                .iter()
+                .map(|r| measure_text_width((col.extract)(r)))
+                .max()
+                .unwrap_or(0);
+            header_w.max(max_cell)
+        })
+        .collect();
+
+    // Distribute extra width proportionally to columns that want more.
+    let wants: Vec<usize> = natural_widths
+        .iter()
+        .zip(candidates.iter())
+        .map(|(nat, (_, col))| nat.saturating_sub(col.min_width))
+        .collect();
+    let total_want: usize = wants.iter().sum();
+
+    let widths: Vec<usize> = if total_want == 0 || extra == 0 {
+        candidates.iter().map(|(_, c)| c.min_width).collect()
+    } else {
+        candidates
+            .iter()
+            .enumerate()
+            .map(|(i, (_, col))| {
+                let bonus = if total_want > 0 {
+                    (wants[i] as f64 / total_want as f64 * extra as f64).floor() as usize
+                } else {
+                    0
+                };
+                col.min_width + bonus
+            })
+            .collect()
+    };
+
+    let selected_indices = candidates.iter().map(|(idx, _)| *idx).collect();
+
+    ColumnBudget {
+        selected_indices,
+        widths,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_columns_count() {
+        assert_eq!(all_columns().len(), 9);
+    }
+
+    #[test]
+    fn test_core_columns_never_dropped() {
+        let columns = all_columns();
+        // Width so small only core columns fit.
+        let budget = compute_budget(&columns, 30, true, &[]);
+        let selected: Vec<&str> = budget
+            .selected_indices
+            .iter()
+            .map(|&i| columns[i].header)
+            .collect();
+        assert!(selected.contains(&"Quality"));
+        assert!(selected.contains(&"Resolution"));
+        assert!(selected.contains(&"Type"));
+    }
+
+    #[test]
+    fn test_all_columns_at_wide_width() {
+        let columns = all_columns();
+        let budget = compute_budget(&columns, 200, false, &[]);
+        assert_eq!(budget.selected_indices.len(), 9);
+    }
+
+    #[test]
+    fn test_low_priority_dropped_first() {
+        let columns = all_columns();
+        // Moderately narrow — should drop Note (20) first, then VBR (30), etc.
+        let budget = compute_budget(&columns, 60, false, &[]);
+        let selected: Vec<&str> = budget
+            .selected_indices
+            .iter()
+            .map(|&i| columns[i].header)
+            .collect();
+        // Note, VBR, ABR, FPS should be dropped before Codecs and Size.
+        assert!(!selected.contains(&"Note"));
+    }
+
+    #[test]
+    fn test_border_overhead_rounded() {
+        // │ col1 │ col2 │ col3 │ = 2 + 2*3 + 2 = 10
+        assert_eq!(border_overhead(3, false), 10);
+    }
+
+    #[test]
+    fn test_border_overhead_compact() {
+        // 3 cols blank style: 2 + (3-1)*3 = 2 + 6 = 8
+        assert_eq!(border_overhead(3, true), 8);
+    }
+
+    #[test]
+    fn test_border_overhead_single_column() {
+        assert_eq!(border_overhead(1, false), 4);
+        assert_eq!(border_overhead(1, true), 2);
+    }
+
+    #[test]
+    fn test_budget_widths_at_least_minimum() {
+        let columns = all_columns();
+        let budget = compute_budget(&columns, 120, false, &[]);
+        for (i, &idx) in budget.selected_indices.iter().enumerate() {
+            assert!(
+                budget.widths[i] >= columns[idx].min_width,
+                "Column '{}' width {} < min {}",
+                columns[idx].header,
+                budget.widths[i],
+                columns[idx].min_width
+            );
+        }
+    }
+}

--- a/crates/rdlp-table/src/column.rs
+++ b/crates/rdlp-table/src/column.rs
@@ -233,6 +233,15 @@ pub fn compute_budget(
     // Start with all columns, sorted by display order (preserving index).
     let mut candidates: Vec<(usize, &ColumnDef)> = columns.iter().enumerate().collect();
 
+    // Drop columns where ALL cells are empty (no data to show).
+    if !formats.is_empty() {
+        candidates.retain(|(_, col)| {
+            formats
+                .iter()
+                .any(|f| !((col.extract)(f)).is_empty())
+        });
+    }
+
     loop {
         let overhead = border_overhead(candidates.len(), compact);
         let min_total: usize =
@@ -297,7 +306,8 @@ pub fn compute_budget(
                 } else {
                     0
                 };
-                col.min_width + bonus
+                // Cap at natural width so extra space isn't wasted as padding.
+                (col.min_width + bonus).min(natural_widths[i]).max(col.min_width)
             })
             .collect()
     };
@@ -407,5 +417,43 @@ mod tests {
                 columns[idx].min_width
             );
         }
+    }
+
+    #[test]
+    fn test_empty_columns_hidden() {
+        // Format with no fps, abr, vbr, or note — those columns should be dropped.
+        let mut f = Format::new(
+            "id",
+            "https://example.com/video",
+            "mp4",
+            DownloadProtocol::Https,
+        );
+        f.format_note = Some("720p".into());
+        f.width = Some(1280);
+        f.height = Some(720);
+        f.vcodec = Some("h264".into());
+        f.acodec = Some("aac".into());
+        // fps, abr, vbr not set → extract returns empty string
+        // dynamic_range, language not set → extract_note returns empty string
+
+        let columns = all_columns();
+        let budget = compute_budget(&columns, 120, false, &[&f]);
+        let selected: Vec<&str> = budget
+            .selected_indices
+            .iter()
+            .map(|&i| columns[i].header)
+            .collect();
+
+        // Core + Size + Codecs should be present.
+        assert!(selected.contains(&"Quality"));
+        assert!(selected.contains(&"Resolution"));
+        assert!(selected.contains(&"Type"));
+        assert!(selected.contains(&"Codecs"));
+
+        // All-empty columns should be hidden.
+        assert!(!selected.contains(&"FPS"));
+        assert!(!selected.contains(&"ABR"));
+        assert!(!selected.contains(&"VBR"));
+        assert!(!selected.contains(&"Note"));
     }
 }

--- a/crates/rdlp-table/src/constants.rs
+++ b/crates/rdlp-table/src/constants.rs
@@ -1,0 +1,34 @@
+//! Column layout constants for backward compatibility.
+//!
+//! These constants were the original `rdlp-table` API, used by
+//! `Format::table_row()` in `rdlp-types` and the CLI header.
+//! They are preserved for any code that still references them directly.
+
+/// Width of the Quality column (e.g. `"1080p60     "`).
+pub const QUALITY_WIDTH: usize = 12;
+
+/// Width of the Resolution column (e.g. `"1920x1080 "`).
+pub const RESOLUTION_WIDTH: usize = 10;
+
+/// Width of the Type column (e.g. `"HLS   "`).
+pub const TYPE_WIDTH: usize = 6;
+
+/// Width of the column separator `" | "`.
+pub const SEP_WIDTH: usize = 3;
+
+/// Approximate width of the trailing Codecs label used in the separator line.
+const CODECS_LABEL_WIDTH: usize = 6;
+
+/// Compute the total separator line width given a dynamic size column width.
+#[must_use]
+pub const fn separator_width(size_width: usize) -> usize {
+    QUALITY_WIDTH
+        + SEP_WIDTH
+        + RESOLUTION_WIDTH
+        + SEP_WIDTH
+        + size_width
+        + SEP_WIDTH
+        + TYPE_WIDTH
+        + SEP_WIDTH
+        + CODECS_LABEL_WIDTH
+}

--- a/crates/rdlp-table/src/constants.rs
+++ b/crates/rdlp-table/src/constants.rs
@@ -1,8 +1,8 @@
-//! Column layout constants for backward compatibility.
+//! Legacy column layout constants for backward compatibility.
 //!
-//! These constants were the original `rdlp-table` API, used by
-//! `Format::table_row()` in `rdlp-types` and the CLI header.
-//! They are preserved for any code that still references them directly.
+//! These constants were the original `rdlp-table` API. They are preserved
+//! for any external code that references them directly. The active table
+//! renderer uses `column::ColumnDef` definitions instead.
 
 /// Width of the Quality column (e.g. `"1080p60     "`).
 pub const QUALITY_WIDTH: usize = 12;

--- a/crates/rdlp-table/src/constants.rs
+++ b/crates/rdlp-table/src/constants.rs
@@ -5,22 +5,28 @@
 //! renderer uses `column::ColumnDef` definitions instead.
 
 /// Width of the Quality column (e.g. `"1080p60     "`).
+#[deprecated(since = "0.2.0", note = "Use render_formats_table() API instead")]
 pub const QUALITY_WIDTH: usize = 12;
 
 /// Width of the Resolution column (e.g. `"1920x1080 "`).
+#[deprecated(since = "0.2.0", note = "Use render_formats_table() API instead")]
 pub const RESOLUTION_WIDTH: usize = 10;
 
 /// Width of the Type column (e.g. `"HLS   "`).
+#[deprecated(since = "0.2.0", note = "Use render_formats_table() API instead")]
 pub const TYPE_WIDTH: usize = 6;
 
 /// Width of the column separator `" | "`.
+#[deprecated(since = "0.2.0", note = "Use render_formats_table() API instead")]
 pub const SEP_WIDTH: usize = 3;
 
 /// Approximate width of the trailing Codecs label used in the separator line.
 const CODECS_LABEL_WIDTH: usize = 6;
 
 /// Compute the total separator line width given a dynamic size column width.
+#[deprecated(since = "0.2.0", note = "Use render_formats_table() API instead")]
 #[must_use]
+#[allow(deprecated)]
 pub const fn separator_width(size_width: usize) -> usize {
     QUALITY_WIDTH
         + SEP_WIDTH

--- a/crates/rdlp-table/src/lib.rs
+++ b/crates/rdlp-table/src/lib.rs
@@ -43,6 +43,10 @@ impl Default for TableOpts {
 }
 
 /// ANSI color output mode.
+///
+/// Reserved for future use. Currently the table renderer does not emit ANSI
+/// codes, but this field is plumbed through `TableOpts` so callers can
+/// declare intent for when color support is added.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorMode {
     /// Detect from terminal capabilities and `NO_COLOR` env var.
@@ -175,6 +179,105 @@ pub fn render_format_rows(formats: &[&Format], opts: &TableOpts) -> Vec<String> 
             }
         })
         .collect()
+}
+
+/// Render both the header table and per-row strings in a single pass.
+///
+/// Computes the column budget once and returns both the styled table
+/// (for display) and the per-row strings (for `inquire::Select` items).
+/// Use this instead of calling `render_formats_table` + `render_format_rows`
+/// separately when you need both outputs.
+///
+/// # Arguments
+/// * `formats` - Format references to display
+/// * `opts` - Rendering options (width, color, compact)
+///
+/// # Returns
+/// A tuple of (table string, row strings). Both are empty if `formats` is empty.
+#[must_use]
+pub fn render_table_and_rows(formats: &[&Format], opts: &TableOpts) -> (String, Vec<String>) {
+    if formats.is_empty() {
+        return (String::new(), Vec::new());
+    }
+
+    let width = opts.width_override.unwrap_or_else(detect_width);
+    let compact = opts.compact.unwrap_or(width < 80);
+    let columns = all_columns();
+    let budget = compute_budget(&columns, width, compact, formats);
+
+    if budget.selected_indices.is_empty() {
+        return (String::new(), Vec::new());
+    }
+
+    // Build the tabled grid.
+    let mut builder = Builder::new();
+
+    // Header row.
+    let headers: Vec<String> = budget
+        .selected_indices
+        .iter()
+        .enumerate()
+        .map(|(i, &col_idx)| {
+            let col = &columns[col_idx];
+            truncate::pad_to_width(col.header, budget.widths[i], col.align == Align::Right)
+        })
+        .collect();
+    builder.push_record(headers);
+
+    // Data rows.
+    for fmt in formats {
+        let cells: Vec<String> = budget
+            .selected_indices
+            .iter()
+            .enumerate()
+            .map(|(i, &col_idx)| {
+                let col = &columns[col_idx];
+                let raw = (col.extract)(fmt);
+                truncate::pad_to_width(&raw, budget.widths[i], col.align == Align::Right)
+            })
+            .collect();
+        builder.push_record(cells);
+    }
+
+    let mut table = builder.build();
+
+    if compact {
+        table.with(Style::blank());
+    } else {
+        table.with(Style::rounded());
+    }
+
+    for (i, &col_idx) in budget.selected_indices.iter().enumerate() {
+        if columns[col_idx].align == Align::Right {
+            table.modify(Columns::one(i), Alignment::right());
+        }
+    }
+
+    let table_str = table.to_string();
+
+    // Build row strings using the same budget.
+    let rows = formats
+        .iter()
+        .map(|fmt| {
+            let cells: Vec<String> = budget
+                .selected_indices
+                .iter()
+                .enumerate()
+                .map(|(i, &col_idx)| {
+                    let col = &columns[col_idx];
+                    let raw = (col.extract)(fmt);
+                    truncate::pad_to_width(&raw, budget.widths[i], col.align == Align::Right)
+                })
+                .collect();
+            if compact {
+                cells.join("  ")
+            } else {
+                cells.join(" │ ")
+            }
+        })
+        .collect();
+
+    (table_str, rows)
 }
 
 #[cfg(test)]

--- a/crates/rdlp-table/src/lib.rs
+++ b/crates/rdlp-table/src/lib.rs
@@ -1,35 +1,335 @@
-//! Column layout constants for the interactive format selection table.
+//! Format table rendering for CLI display.
 //!
-//! Shared between `Format::table_row()` (in `rdlp-types`) and the CLI header
-//! (in `rdlp-cli`) so both stay in sync.
+//! Provides a responsive, terminal-width-aware table renderer for
+//! displaying video/audio format lists. Supports column priority-based
+//! hiding, Unicode-aware truncation, and configurable styles.
+//!
+//! The renderer works with [`FormatRow`] — a pre-extracted data struct
+//! that callers populate from their domain types. This avoids a circular
+//! crate dependency (rdlp-types already depends on rdlp-table for legacy
+//! column constants).
 
 #![warn(missing_docs)]
 
-/// Width of the Quality column (e.g. `"1080p60     "`).
-pub const QUALITY_WIDTH: usize = 12;
+pub mod column;
+mod constants;
+pub mod truncate;
 
-/// Width of the Resolution column (e.g. `"1920x1080 "`).
-pub const RESOLUTION_WIDTH: usize = 10;
+// Re-export legacy constants at crate root for backward compatibility.
+pub use constants::*;
 
-/// Width of the Type column (e.g. `"HLS   "`).
-pub const TYPE_WIDTH: usize = 6;
+pub use column::{
+    Align, ColumnBudget, ColumnDef, FormatRow, all_columns, border_overhead, compute_budget,
+};
 
-/// Width of the column separator `" | "`.
-pub const SEP_WIDTH: usize = 3;
+use tabled::{
+    builder::Builder,
+    settings::{Alignment, Style, object::Columns},
+};
 
-/// Approximate width of the trailing Codecs label used in the separator line.
-const CODECS_LABEL_WIDTH: usize = 6;
+/// Options controlling table rendering.
+#[derive(Debug, Clone)]
+pub struct TableOpts {
+    /// Override terminal width. `None` = auto-detect, fallback 120.
+    pub width_override: Option<usize>,
+    /// ANSI color output mode.
+    pub color: ColorMode,
+    /// Force compact mode. `None` = auto (compact when width < 80).
+    pub compact: Option<bool>,
+}
 
-/// Compute the total separator line width given a dynamic size column width.
+impl Default for TableOpts {
+    fn default() -> Self {
+        Self {
+            width_override: None,
+            color: ColorMode::Auto,
+            compact: None,
+        }
+    }
+}
+
+/// ANSI color output mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorMode {
+    /// Detect from terminal capabilities and `NO_COLOR` env var.
+    Auto,
+    /// Always emit ANSI codes.
+    Always,
+    /// Never emit ANSI codes.
+    Never,
+}
+
+/// Detect terminal width, falling back to 120 if unavailable.
+fn detect_width() -> usize {
+    terminal_size::terminal_size()
+        .map(|(w, _)| w.0 as usize)
+        .unwrap_or(120)
+}
+
+/// Render a responsive format table for terminal display.
+///
+/// Auto-detects terminal width (or uses `opts.width_override`), selects
+/// columns that fit via priority-based budget, truncates cells, and
+/// returns a styled table string.
+///
+/// # Arguments
+/// * `rows` - Pre-extracted format rows to display
+/// * `opts` - Rendering options (width, color, compact)
+///
+/// # Returns
+/// A `String` containing the complete table, ready for printing.
+pub fn render_formats_table(rows: &[FormatRow], opts: &TableOpts) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+
+    let width = opts.width_override.unwrap_or_else(detect_width);
+    let compact = opts.compact.unwrap_or(width < 80);
+    let columns = all_columns();
+    let budget = compute_budget(&columns, width, compact, rows);
+
+    if budget.selected_indices.is_empty() {
+        return String::new();
+    }
+
+    // Build the tabled grid.
+    let mut builder = Builder::new();
+
+    // Header row.
+    let headers: Vec<String> = budget
+        .selected_indices
+        .iter()
+        .enumerate()
+        .map(|(i, &col_idx)| {
+            let col = &columns[col_idx];
+            truncate::pad_to_width(col.header, budget.widths[i], col.align == Align::Right)
+        })
+        .collect();
+    builder.push_record(headers);
+
+    // Data rows.
+    for row in rows {
+        let cells: Vec<String> = budget
+            .selected_indices
+            .iter()
+            .enumerate()
+            .map(|(i, &col_idx)| {
+                let col = &columns[col_idx];
+                let raw = (col.extract)(row);
+                truncate::pad_to_width(raw, budget.widths[i], col.align == Align::Right)
+            })
+            .collect();
+        builder.push_record(cells);
+    }
+
+    let mut table = builder.build();
+
+    // Apply style.
+    if compact {
+        table.with(Style::blank());
+    } else {
+        table.with(Style::rounded());
+    }
+
+    // Apply alignment for right-aligned columns.
+    for (i, &col_idx) in budget.selected_indices.iter().enumerate() {
+        if columns[col_idx].align == Align::Right {
+            table.modify(Columns::one(i), Alignment::right());
+        }
+    }
+
+    table.to_string()
+}
+
+/// Render per-row strings matching the table's column layout.
+///
+/// Returns one string per row, using the same column set and widths
+/// as `render_formats_table`. These are suitable for `inquire::Select` items
+/// so the selection menu aligns with the header table.
+///
+/// # Arguments
+/// * `rows` - Pre-extracted format rows to render
+/// * `opts` - Same options used for the header table
 #[must_use]
-pub const fn separator_width(size_width: usize) -> usize {
-    QUALITY_WIDTH
-        + SEP_WIDTH
-        + RESOLUTION_WIDTH
-        + SEP_WIDTH
-        + size_width
-        + SEP_WIDTH
-        + TYPE_WIDTH
-        + SEP_WIDTH
-        + CODECS_LABEL_WIDTH
+pub fn render_format_rows(rows: &[FormatRow], opts: &TableOpts) -> Vec<String> {
+    if rows.is_empty() {
+        return Vec::new();
+    }
+
+    let width = opts.width_override.unwrap_or_else(detect_width);
+    let compact = opts.compact.unwrap_or(width < 80);
+    let columns = all_columns();
+    let budget = compute_budget(&columns, width, compact, rows);
+
+    rows.iter()
+        .map(|row| {
+            let cells: Vec<String> = budget
+                .selected_indices
+                .iter()
+                .enumerate()
+                .map(|(i, &col_idx)| {
+                    let col = &columns[col_idx];
+                    let raw = (col.extract)(row);
+                    truncate::pad_to_width(raw, budget.widths[i], col.align == Align::Right)
+                })
+                .collect();
+            if compact {
+                cells.join("  ")
+            } else {
+                cells.join(" │ ")
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::measure_text_width;
+
+    fn sample_rows() -> Vec<FormatRow> {
+        vec![
+            FormatRow {
+                quality: "1080p".to_string(),
+                resolution: "1920x1080".to_string(),
+                format_type: "MP4".to_string(),
+                size: "837.9 MB".to_string(),
+                codecs: "h264/aac".to_string(),
+                fps: "30".to_string(),
+                abr: "128".to_string(),
+                vbr: "5000".to_string(),
+                note: String::new(),
+            },
+            FormatRow {
+                quality: "720p".to_string(),
+                resolution: "1280x720".to_string(),
+                format_type: "MP4".to_string(),
+                size: "450.2 MB".to_string(),
+                codecs: "h264/aac".to_string(),
+                fps: "30".to_string(),
+                abr: "128".to_string(),
+                vbr: "3000".to_string(),
+                note: String::new(),
+            },
+            FormatRow {
+                quality: "480p".to_string(),
+                resolution: "854x480".to_string(),
+                format_type: "WebM".to_string(),
+                size: "220.0 MB".to_string(),
+                codecs: "vp9 (video only)".to_string(),
+                fps: "30".to_string(),
+                abr: String::new(),
+                vbr: "1500".to_string(),
+                note: String::new(),
+            },
+        ]
+    }
+
+    #[test]
+    fn test_render_wide_includes_all_columns() {
+        let rows = sample_rows();
+        let opts = TableOpts {
+            width_override: Some(160),
+            color: ColorMode::Never,
+            compact: None,
+        };
+        let output = render_formats_table(&rows, &opts);
+        assert!(output.contains("Quality"));
+        assert!(output.contains("Resolution"));
+        assert!(output.contains("Type"));
+        assert!(output.contains("Size"));
+        assert!(output.contains("Codecs"));
+        assert!(output.contains("FPS"));
+    }
+
+    #[test]
+    fn test_render_narrow_hides_low_priority() {
+        let rows = sample_rows();
+        // 60 chars compact: Quality(7) + Resolution(10) + Type(4) + Size(8) + 4*2=8 overhead = 37.
+        // Codecs(10)+2 = 49, FPS(3)+2=54, ABR(5)+2=61 won't fit — ABR and higher optional cols dropped.
+        let opts = TableOpts {
+            width_override: Some(60),
+            color: ColorMode::Never,
+            compact: Some(true),
+        };
+        let output = render_formats_table(&rows, &opts);
+        // Core columns must exist
+        assert!(output.contains("Quality"));
+        assert!(output.contains("Type"));
+        // Low priority should be hidden
+        assert!(!output.contains("Note"));
+        assert!(!output.contains("VBR"));
+    }
+
+    #[test]
+    fn test_no_line_exceeds_width() {
+        let rows = sample_rows();
+        for width in [60, 80, 100, 120] {
+            let opts = TableOpts {
+                width_override: Some(width),
+                color: ColorMode::Never,
+                compact: None,
+            };
+            let output = render_formats_table(&rows, &opts);
+            for line in output.lines() {
+                let line_width = measure_text_width(line);
+                assert!(
+                    line_width <= width,
+                    "Line exceeds width {width}: ({line_width}) '{line}'"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_right_alignment_renders_without_error() {
+        let rows = sample_rows();
+        let opts = TableOpts {
+            width_override: Some(120),
+            color: ColorMode::Never,
+            compact: None,
+        };
+        let output = render_formats_table(&rows, &opts);
+        assert!(!output.is_empty());
+    }
+
+    #[test]
+    fn test_empty_formats() {
+        let opts = TableOpts {
+            width_override: Some(80),
+            color: ColorMode::Never,
+            compact: None,
+        };
+        let output = render_formats_table(&[], &opts);
+        // Should produce empty string for empty input.
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_compact_uses_blank_style() {
+        let rows = sample_rows();
+        let opts = TableOpts {
+            width_override: Some(60),
+            color: ColorMode::Never,
+            compact: Some(true),
+        };
+        let output = render_formats_table(&rows, &opts);
+        // Blank style has no box-drawing characters.
+        assert!(!output.contains('│'));
+        assert!(!output.contains('─'));
+        assert!(!output.contains('╭'));
+    }
+
+    #[test]
+    fn test_normal_uses_rounded_style() {
+        let rows = sample_rows();
+        let opts = TableOpts {
+            width_override: Some(120),
+            color: ColorMode::Never,
+            compact: Some(false),
+        };
+        let output = render_formats_table(&rows, &opts);
+        // Rounded style uses box-drawing chars.
+        assert!(output.contains('│') || output.contains('─'));
+    }
 }

--- a/crates/rdlp-table/src/lib.rs
+++ b/crates/rdlp-table/src/lib.rs
@@ -181,19 +181,19 @@ pub fn render_format_rows(formats: &[&Format], opts: &TableOpts) -> Vec<String> 
         .collect()
 }
 
-/// Render both the header table and per-row strings in a single pass.
+/// Render a header line and per-row strings in a single pass.
 ///
-/// Computes the column budget once and returns both the styled table
-/// (for display) and the per-row strings (for `inquire::Select` items).
-/// Use this instead of calling `render_formats_table` + `render_format_rows`
-/// separately when you need both outputs.
+/// Computes the column budget once and returns a header line (column names
+/// with a separator underline) plus per-row strings for `inquire::Select`.
+/// The header and rows use identical column widths and separators so they
+/// align visually.
 ///
 /// # Arguments
 /// * `formats` - Format references to display
 /// * `opts` - Rendering options (width, color, compact)
 ///
 /// # Returns
-/// A tuple of (table string, row strings). Both are empty if `formats` is empty.
+/// A tuple of (header string, row strings). Both are empty if `formats` is empty.
 #[must_use]
 pub fn render_table_and_rows(formats: &[&Format], opts: &TableOpts) -> (String, Vec<String>) {
     if formats.is_empty() {
@@ -209,11 +209,11 @@ pub fn render_table_and_rows(formats: &[&Format], opts: &TableOpts) -> (String, 
         return (String::new(), Vec::new());
     }
 
-    // Build the tabled grid.
-    let mut builder = Builder::new();
+    let sep = if compact { "  " } else { " │ " };
+    let dash_sep = if compact { "  " } else { "─┼─" };
 
-    // Header row.
-    let headers: Vec<String> = budget
+    // Header line: column names padded to budget widths.
+    let header_cells: Vec<String> = budget
         .selected_indices
         .iter()
         .enumerate()
@@ -222,38 +222,17 @@ pub fn render_table_and_rows(formats: &[&Format], opts: &TableOpts) -> (String, 
             truncate::pad_to_width(col.header, budget.widths[i], col.align == Align::Right)
         })
         .collect();
-    builder.push_record(headers);
+    let header_line = header_cells.join(sep);
 
-    // Data rows.
-    for fmt in formats {
-        let cells: Vec<String> = budget
-            .selected_indices
-            .iter()
-            .enumerate()
-            .map(|(i, &col_idx)| {
-                let col = &columns[col_idx];
-                let raw = (col.extract)(fmt);
-                truncate::pad_to_width(&raw, budget.widths[i], col.align == Align::Right)
-            })
-            .collect();
-        builder.push_record(cells);
-    }
+    // Separator line: dashes matching each column width.
+    let dash_cells: Vec<String> = budget
+        .widths
+        .iter()
+        .map(|&w| "─".repeat(w))
+        .collect();
+    let dash_line = dash_cells.join(dash_sep);
 
-    let mut table = builder.build();
-
-    if compact {
-        table.with(Style::blank());
-    } else {
-        table.with(Style::rounded());
-    }
-
-    for (i, &col_idx) in budget.selected_indices.iter().enumerate() {
-        if columns[col_idx].align == Align::Right {
-            table.modify(Columns::one(i), Alignment::right());
-        }
-    }
-
-    let table_str = table.to_string();
+    let header_str = format!("{header_line}\n{dash_line}");
 
     // Build row strings using the same budget.
     let rows = formats
@@ -269,15 +248,11 @@ pub fn render_table_and_rows(formats: &[&Format], opts: &TableOpts) -> (String, 
                     truncate::pad_to_width(&raw, budget.widths[i], col.align == Align::Right)
                 })
                 .collect();
-            if compact {
-                cells.join("  ")
-            } else {
-                cells.join(" │ ")
-            }
+            cells.join(sep)
         })
         .collect();
 
-    (table_str, rows)
+    (header_str, rows)
 }
 
 #[cfg(test)]
@@ -425,4 +400,5 @@ mod tests {
         let output = render_formats_table(&refs, &opts);
         assert!(output.contains('│') || output.contains('─'));
     }
+
 }

--- a/crates/rdlp-table/src/lib.rs
+++ b/crates/rdlp-table/src/lib.rs
@@ -3,11 +3,6 @@
 //! Provides a responsive, terminal-width-aware table renderer for
 //! displaying video/audio format lists. Supports column priority-based
 //! hiding, Unicode-aware truncation, and configurable styles.
-//!
-//! The renderer works with [`FormatRow`] — a pre-extracted data struct
-//! that callers populate from their domain types. This avoids a circular
-//! crate dependency (rdlp-types already depends on rdlp-table for legacy
-//! column constants).
 
 #![warn(missing_docs)]
 
@@ -18,10 +13,9 @@ pub mod truncate;
 // Re-export legacy constants at crate root for backward compatibility.
 pub use constants::*;
 
-pub use column::{
-    Align, ColumnBudget, ColumnDef, FormatRow, all_columns, border_overhead, compute_budget,
-};
+pub use column::{Align, ColumnBudget, ColumnDef, all_columns, border_overhead, compute_budget};
 
+use rdlp_types::Format;
 use tabled::{
     builder::Builder,
     settings::{Alignment, Style, object::Columns},
@@ -73,20 +67,20 @@ fn detect_width() -> usize {
 /// returns a styled table string.
 ///
 /// # Arguments
-/// * `rows` - Pre-extracted format rows to display
+/// * `formats` - Format references to display
 /// * `opts` - Rendering options (width, color, compact)
 ///
 /// # Returns
 /// A `String` containing the complete table, ready for printing.
-pub fn render_formats_table(rows: &[FormatRow], opts: &TableOpts) -> String {
-    if rows.is_empty() {
+pub fn render_formats_table(formats: &[&Format], opts: &TableOpts) -> String {
+    if formats.is_empty() {
         return String::new();
     }
 
     let width = opts.width_override.unwrap_or_else(detect_width);
     let compact = opts.compact.unwrap_or(width < 80);
     let columns = all_columns();
-    let budget = compute_budget(&columns, width, compact, rows);
+    let budget = compute_budget(&columns, width, compact, formats);
 
     if budget.selected_indices.is_empty() {
         return String::new();
@@ -108,15 +102,15 @@ pub fn render_formats_table(rows: &[FormatRow], opts: &TableOpts) -> String {
     builder.push_record(headers);
 
     // Data rows.
-    for row in rows {
+    for fmt in formats {
         let cells: Vec<String> = budget
             .selected_indices
             .iter()
             .enumerate()
             .map(|(i, &col_idx)| {
                 let col = &columns[col_idx];
-                let raw = (col.extract)(row);
-                truncate::pad_to_width(raw, budget.widths[i], col.align == Align::Right)
+                let raw = (col.extract)(fmt);
+                truncate::pad_to_width(&raw, budget.widths[i], col.align == Align::Right)
             })
             .collect();
         builder.push_record(cells);
@@ -143,34 +137,35 @@ pub fn render_formats_table(rows: &[FormatRow], opts: &TableOpts) -> String {
 
 /// Render per-row strings matching the table's column layout.
 ///
-/// Returns one string per row, using the same column set and widths
+/// Returns one string per format, using the same column set and widths
 /// as `render_formats_table`. These are suitable for `inquire::Select` items
 /// so the selection menu aligns with the header table.
 ///
 /// # Arguments
-/// * `rows` - Pre-extracted format rows to render
+/// * `formats` - Format references to render
 /// * `opts` - Same options used for the header table
 #[must_use]
-pub fn render_format_rows(rows: &[FormatRow], opts: &TableOpts) -> Vec<String> {
-    if rows.is_empty() {
+pub fn render_format_rows(formats: &[&Format], opts: &TableOpts) -> Vec<String> {
+    if formats.is_empty() {
         return Vec::new();
     }
 
     let width = opts.width_override.unwrap_or_else(detect_width);
     let compact = opts.compact.unwrap_or(width < 80);
     let columns = all_columns();
-    let budget = compute_budget(&columns, width, compact, rows);
+    let budget = compute_budget(&columns, width, compact, formats);
 
-    rows.iter()
-        .map(|row| {
+    formats
+        .iter()
+        .map(|fmt| {
             let cells: Vec<String> = budget
                 .selected_indices
                 .iter()
                 .enumerate()
                 .map(|(i, &col_idx)| {
                     let col = &columns[col_idx];
-                    let raw = (col.extract)(row);
-                    truncate::pad_to_width(raw, budget.widths[i], col.align == Align::Right)
+                    let raw = (col.extract)(fmt);
+                    truncate::pad_to_width(&raw, budget.widths[i], col.align == Align::Right)
                 })
                 .collect();
             if compact {
@@ -186,54 +181,51 @@ pub fn render_format_rows(rows: &[FormatRow], opts: &TableOpts) -> Vec<String> {
 mod tests {
     use super::*;
     use console::measure_text_width;
+    use rdlp_types::protocol::DownloadProtocol;
 
-    fn sample_rows() -> Vec<FormatRow> {
+    fn make_format(note: &str, width: u32, height: u32, ext: &str) -> Format {
+        let mut f = Format::new(
+            "id",
+            "https://example.com/video",
+            ext,
+            DownloadProtocol::Https,
+        );
+        f.format_note = Some(note.to_string());
+        f.width = Some(width);
+        f.height = Some(height);
+        f.vcodec = Some("h264".to_string());
+        f.acodec = Some("aac".to_string());
+        f.fps = Some(30.0);
+        f.abr = Some(128.0);
+        f.vbr = Some(5000.0);
+        f.filesize = Some(878_000_000);
+        f
+    }
+
+    fn sample_formats() -> Vec<Format> {
         vec![
-            FormatRow {
-                quality: "1080p".to_string(),
-                resolution: "1920x1080".to_string(),
-                format_type: "MP4".to_string(),
-                size: "837.9 MB".to_string(),
-                codecs: "h264/aac".to_string(),
-                fps: "30".to_string(),
-                abr: "128".to_string(),
-                vbr: "5000".to_string(),
-                note: String::new(),
-            },
-            FormatRow {
-                quality: "720p".to_string(),
-                resolution: "1280x720".to_string(),
-                format_type: "MP4".to_string(),
-                size: "450.2 MB".to_string(),
-                codecs: "h264/aac".to_string(),
-                fps: "30".to_string(),
-                abr: "128".to_string(),
-                vbr: "3000".to_string(),
-                note: String::new(),
-            },
-            FormatRow {
-                quality: "480p".to_string(),
-                resolution: "854x480".to_string(),
-                format_type: "WebM".to_string(),
-                size: "220.0 MB".to_string(),
-                codecs: "vp9 (video only)".to_string(),
-                fps: "30".to_string(),
-                abr: String::new(),
-                vbr: "1500".to_string(),
-                note: String::new(),
+            make_format("1080p", 1920, 1080, "mp4"),
+            make_format("720p", 1280, 720, "mp4"),
+            {
+                let mut f = make_format("480p", 854, 480, "webm");
+                f.vcodec = Some("vp9".to_string());
+                f.acodec = Some("none".to_string());
+                f.filesize = Some(230_000_000);
+                f
             },
         ]
     }
 
     #[test]
     fn test_render_wide_includes_all_columns() {
-        let rows = sample_rows();
+        let formats = sample_formats();
+        let refs: Vec<&Format> = formats.iter().collect();
         let opts = TableOpts {
             width_override: Some(160),
             color: ColorMode::Never,
             compact: None,
         };
-        let output = render_formats_table(&rows, &opts);
+        let output = render_formats_table(&refs, &opts);
         assert!(output.contains("Quality"));
         assert!(output.contains("Resolution"));
         assert!(output.contains("Type"));
@@ -244,33 +236,31 @@ mod tests {
 
     #[test]
     fn test_render_narrow_hides_low_priority() {
-        let rows = sample_rows();
-        // 60 chars compact: Quality(7) + Resolution(10) + Type(4) + Size(8) + 4*2=8 overhead = 37.
-        // Codecs(10)+2 = 49, FPS(3)+2=54, ABR(5)+2=61 won't fit — ABR and higher optional cols dropped.
+        let formats = sample_formats();
+        let refs: Vec<&Format> = formats.iter().collect();
         let opts = TableOpts {
             width_override: Some(60),
             color: ColorMode::Never,
             compact: Some(true),
         };
-        let output = render_formats_table(&rows, &opts);
-        // Core columns must exist
+        let output = render_formats_table(&refs, &opts);
         assert!(output.contains("Quality"));
         assert!(output.contains("Type"));
-        // Low priority should be hidden
         assert!(!output.contains("Note"));
         assert!(!output.contains("VBR"));
     }
 
     #[test]
     fn test_no_line_exceeds_width() {
-        let rows = sample_rows();
+        let formats = sample_formats();
+        let refs: Vec<&Format> = formats.iter().collect();
         for width in [60, 80, 100, 120] {
             let opts = TableOpts {
                 width_override: Some(width),
                 color: ColorMode::Never,
                 compact: None,
             };
-            let output = render_formats_table(&rows, &opts);
+            let output = render_formats_table(&refs, &opts);
             for line in output.lines() {
                 let line_width = measure_text_width(line);
                 assert!(
@@ -283,13 +273,14 @@ mod tests {
 
     #[test]
     fn test_right_alignment_renders_without_error() {
-        let rows = sample_rows();
+        let formats = sample_formats();
+        let refs: Vec<&Format> = formats.iter().collect();
         let opts = TableOpts {
             width_override: Some(120),
             color: ColorMode::Never,
             compact: None,
         };
-        let output = render_formats_table(&rows, &opts);
+        let output = render_formats_table(&refs, &opts);
         assert!(!output.is_empty());
     }
 
@@ -301,20 +292,19 @@ mod tests {
             compact: None,
         };
         let output = render_formats_table(&[], &opts);
-        // Should produce empty string for empty input.
         assert!(output.is_empty());
     }
 
     #[test]
     fn test_compact_uses_blank_style() {
-        let rows = sample_rows();
+        let formats = sample_formats();
+        let refs: Vec<&Format> = formats.iter().collect();
         let opts = TableOpts {
             width_override: Some(60),
             color: ColorMode::Never,
             compact: Some(true),
         };
-        let output = render_formats_table(&rows, &opts);
-        // Blank style has no box-drawing characters.
+        let output = render_formats_table(&refs, &opts);
         assert!(!output.contains('│'));
         assert!(!output.contains('─'));
         assert!(!output.contains('╭'));
@@ -322,14 +312,14 @@ mod tests {
 
     #[test]
     fn test_normal_uses_rounded_style() {
-        let rows = sample_rows();
+        let formats = sample_formats();
+        let refs: Vec<&Format> = formats.iter().collect();
         let opts = TableOpts {
             width_override: Some(120),
             color: ColorMode::Never,
             compact: Some(false),
         };
-        let output = render_formats_table(&rows, &opts);
-        // Rounded style uses box-drawing chars.
+        let output = render_formats_table(&refs, &opts);
         assert!(output.contains('│') || output.contains('─'));
     }
 }

--- a/crates/rdlp-table/src/truncate.rs
+++ b/crates/rdlp-table/src/truncate.rs
@@ -164,4 +164,44 @@ mod tests {
         let result = pad_to_width("exact", 5, false);
         assert_eq!(result, "exact");
     }
+
+    #[test]
+    fn test_truncate_cjk_characters() {
+        // CJK characters are 2 columns wide each.
+        // "日本語" = 6 columns. Truncating to 5 means 2 CJK chars (4 cols) + '…' (1 col) = 5.
+        let result = truncate_to_width("日本語", 5);
+        assert_eq!(result, "日本…");
+        assert_eq!(measure_text_width(&result), 5);
+    }
+
+    #[test]
+    fn test_truncate_cjk_exact_fit() {
+        // "日本語" = 6 columns, max_width = 6 → no truncation.
+        assert_eq!(truncate_to_width("日本語", 6), "日本語");
+    }
+
+    #[test]
+    fn test_truncate_cjk_tight() {
+        // max_width = 3: target = 2 columns for content + 1 for '…'.
+        // One CJK char = 2 cols, fits.
+        let result = truncate_to_width("日本語", 3);
+        assert_eq!(result, "日…");
+        assert_eq!(measure_text_width(&result), 3);
+    }
+
+    #[test]
+    fn test_truncate_mixed_ascii_cjk() {
+        // "hi日本" = 2 + 2 + 2 = 6 columns.
+        let result = truncate_to_width("hi日本", 5);
+        assert_eq!(result, "hi日…");
+        assert_eq!(measure_text_width(&result), 5);
+    }
+
+    #[test]
+    fn test_pad_cjk_right_align() {
+        // "日本" = 4 columns. Padding to 8 → 4 spaces + "日本".
+        let result = pad_to_width("日本", 8, true);
+        assert_eq!(result, "    日本");
+        assert_eq!(measure_text_width(&result), 8);
+    }
 }

--- a/crates/rdlp-table/src/truncate.rs
+++ b/crates/rdlp-table/src/truncate.rs
@@ -1,0 +1,167 @@
+//! Unicode-aware string truncation for table cells.
+//!
+//! Uses `console::measure_text_width` to correctly handle wide characters
+//! (CJK, emoji) and ANSI escape sequences when truncating cell content.
+
+use console::measure_text_width;
+
+/// Truncate `text` to fit within `max_width` display columns.
+///
+/// If the text fits, returns it unchanged. If it exceeds `max_width`,
+/// truncates and appends `…` (single character, 1 display column).
+///
+/// # Arguments
+/// * `text` - The string to potentially truncate
+/// * `max_width` - Maximum display width in columns
+///
+/// # Returns
+/// A `String` that is at most `max_width` display columns wide.
+///
+/// # Examples
+/// ```
+/// use rdlp_table::truncate::truncate_to_width;
+/// assert_eq!(truncate_to_width("hello", 10), "hello");
+/// assert_eq!(truncate_to_width("hello world", 5), "hell…");
+/// ```
+#[must_use]
+pub fn truncate_to_width(text: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+
+    let text_width = measure_text_width(text);
+    if text_width <= max_width {
+        return text.to_string();
+    }
+
+    // Need to truncate. Reserve 1 column for '…'.
+    let target = max_width.saturating_sub(1);
+    let mut current_width = 0;
+    let mut byte_end = 0;
+
+    for ch in text.chars() {
+        let ch_width = unicode_width(ch);
+        if current_width + ch_width > target {
+            break;
+        }
+        current_width += ch_width;
+        byte_end += ch.len_utf8();
+    }
+
+    let mut result = String::with_capacity(byte_end + 3); // '…' is 3 bytes UTF-8
+    result.push_str(&text[..byte_end]);
+    result.push('…');
+    result
+}
+
+/// Pad `text` to exactly `width` display columns.
+///
+/// If `text` is shorter, pads with spaces on the right (left-align) or
+/// left (right-align). If `text` is longer, truncates with ellipsis.
+///
+/// # Arguments
+/// * `text` - The string to pad/truncate
+/// * `width` - Target display width
+/// * `right_align` - If true, pad on the left (right-align content)
+#[must_use]
+pub fn pad_to_width(text: &str, width: usize, right_align: bool) -> String {
+    let truncated = truncate_to_width(text, width);
+    let text_width = measure_text_width(&truncated);
+
+    if text_width >= width {
+        return truncated;
+    }
+
+    let padding = width - text_width;
+    let mut result = String::with_capacity(truncated.len() + padding);
+
+    if right_align {
+        for _ in 0..padding {
+            result.push(' ');
+        }
+        result.push_str(&truncated);
+    } else {
+        result.push_str(&truncated);
+        for _ in 0..padding {
+            result.push(' ');
+        }
+    }
+
+    result
+}
+
+/// Get the display width of a single character.
+///
+/// CJK characters are 2 columns wide; most others are 1.
+/// Control characters are 0.
+fn unicode_width(ch: char) -> usize {
+    if ch.is_control() {
+        0
+    } else {
+        // Measure a single character string. This is correct for all Unicode
+        // including CJK, emoji, combining marks.
+        measure_text_width(&ch.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_short_text_unchanged() {
+        assert_eq!(truncate_to_width("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_exact_fit() {
+        assert_eq!(truncate_to_width("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_adds_ellipsis() {
+        assert_eq!(truncate_to_width("hello world", 5), "hell…");
+    }
+
+    #[test]
+    fn test_truncate_single_char_width() {
+        assert_eq!(truncate_to_width("hello", 1), "…");
+    }
+
+    #[test]
+    fn test_truncate_zero_width() {
+        assert_eq!(truncate_to_width("hello", 0), "");
+    }
+
+    #[test]
+    fn test_truncate_empty_string() {
+        assert_eq!(truncate_to_width("", 10), "");
+    }
+
+    #[test]
+    fn test_pad_left_align() {
+        let result = pad_to_width("hi", 6, false);
+        assert_eq!(result, "hi    ");
+        assert_eq!(measure_text_width(&result), 6);
+    }
+
+    #[test]
+    fn test_pad_right_align() {
+        let result = pad_to_width("42", 6, true);
+        assert_eq!(result, "    42");
+        assert_eq!(measure_text_width(&result), 6);
+    }
+
+    #[test]
+    fn test_pad_truncates_when_too_long() {
+        let result = pad_to_width("very long text", 6, false);
+        assert_eq!(measure_text_width(&result), 6);
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn test_pad_exact_width() {
+        let result = pad_to_width("exact", 5, false);
+        assert_eq!(result, "exact");
+    }
+}

--- a/crates/rdlp-types/Cargo.toml
+++ b/crates/rdlp-types/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Pure domain types for rdlp (no I/O dependencies)"
 
 [dependencies]
-rdlp-table = { path = "../rdlp-table" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }

--- a/crates/rdlp-types/src/format/display.rs
+++ b/crates/rdlp-types/src/format/display.rs
@@ -44,25 +44,29 @@ impl Format {
     #[must_use]
     pub fn size_text(&self) -> String {
         if self.is_hls() {
-            let seg_count = self
-                .fragments
-                .as_ref()
-                .map(|f| f.len() as u64)
-                .or(self.filesize_approx);
+            let seg_count = self.fragments.as_ref().map(|f| f.len() as u64);
+            let size = self.filesize.or(self.filesize_approx);
+            let dur_str = self.duration.map(|dur| {
+                let mins = dur as u64 / 60;
+                let secs = dur as u64 % 60;
+                format!("{mins}:{secs:02}")
+            });
+            let size_str = size.map(|s| {
+                let mb = s as f64 / (1024.0 * 1024.0);
+                if mb >= 1024.0 {
+                    format!("{:.1} GB", mb / 1024.0)
+                } else {
+                    format!("{mb:.0} MB")
+                }
+            });
 
-            match (self.duration, seg_count) {
-                (Some(dur), Some(segs)) => {
-                    let mins = dur as u64 / 60;
-                    let secs = dur as u64 % 60;
-                    format!("{mins}:{secs:02} ({segs} seg)")
-                }
-                (Some(dur), None) => {
-                    let mins = dur as u64 / 60;
-                    let secs = dur as u64 % 60;
-                    format!("{mins}:{secs:02}")
-                }
-                (None, Some(segs)) => format!("{segs} segments"),
-                (None, None) => "HLS stream".to_string(),
+            match (dur_str, seg_count, size_str) {
+                (Some(d), Some(s), _) => format!("{d} ({s} seg)"),
+                (Some(d), None, Some(sz)) => format!("{d} (~{sz})"),
+                (Some(d), None, None) => d,
+                (None, Some(s), _) => format!("{s} segments"),
+                (None, None, Some(sz)) => format!("~{sz}"),
+                (None, None, None) => "HLS stream".to_string(),
             }
         } else if let Some(filesize) = self.filesize {
             let dur_suffix = self

--- a/crates/rdlp-types/src/format/display.rs
+++ b/crates/rdlp-types/src/format/display.rs
@@ -1,9 +1,6 @@
 //! Display and table formatting methods for [`Format`].
 //!
-//! Contains the cached description builder, size text formatter,
-//! and the interactive selection table row renderer.
-
-use std::fmt::Write;
+//! Contains the cached description builder and size text formatter.
 
 use super::Format;
 
@@ -44,8 +41,6 @@ impl Format {
     }
 
     /// Returns the size column text for this format (e.g. `"837.9 MB"`, `"50:16 (754 seg)"`)
-    ///
-    /// Call this on every format to compute `max` width, then pass that to [`Self::table_row`].
     #[must_use]
     pub fn size_text(&self) -> String {
         if self.is_hls() {
@@ -88,97 +83,5 @@ impl Format {
         } else {
             "Unknown".to_string()
         }
-    }
-
-    /// Format as table row for interactive selection UI
-    ///
-    /// Returns a formatted string suitable for display in selection menus:
-    /// `"720p         | 1280x720   | 245.3 MB     | MP4    | h264/aac"`
-    ///
-    /// `size_width` controls the size column padding (use [`Self::size_text`] across
-    /// all formats to compute the appropriate value).
-    ///
-    /// Optimized to minimize heap allocations using pre-allocated buffer.
-    pub fn table_row(&self, size_width: usize) -> String {
-        // Pre-allocate buffer for typical row length (~80 chars)
-        let mut buf = String::with_capacity(80);
-
-        // Quality column: append fps when non-standard (e.g. "1080p60")
-        let quality_base = self.format_note.as_deref().unwrap_or("unknown");
-        let col_start = buf.len();
-        match self.fps {
-            Some(fps) if fps > 0.0 && (fps - 30.0).abs() > 1.0 => {
-                let _ = write!(buf, "{quality_base}{fps:.0}");
-                let col_len = buf.len() - col_start;
-                for _ in col_len..rdlp_table::QUALITY_WIDTH {
-                    buf.push(' ');
-                }
-                buf.push_str(" | ");
-            }
-            _ => {
-                let _ = write!(buf, "{quality_base:<w$} | ", w = rdlp_table::QUALITY_WIDTH);
-            }
-        }
-
-        // Resolution: avoid intermediate String allocation
-        match (self.width, self.height) {
-            (Some(w), Some(h)) => {
-                let res_start = buf.len();
-                let _ = write!(buf, "{w}x{h}");
-                let res_len = buf.len() - res_start;
-                for _ in res_len..rdlp_table::RESOLUTION_WIDTH {
-                    buf.push(' ');
-                }
-            }
-            _ => {
-                let _ = write!(buf, "{:<w$}", "N/A", w = rdlp_table::RESOLUTION_WIDTH);
-            }
-        }
-        buf.push_str(" | ");
-
-        // Size column: write directly, pad to dynamic width
-        let size_start = buf.len();
-        buf.push_str(&self.size_text());
-        let size_len = buf.len() - size_start;
-        for _ in size_len..size_width {
-            buf.push(' ');
-        }
-        buf.push_str(" | ");
-
-        // Format type column: avoid to_uppercase() allocation for HLS
-        let format_start = buf.len();
-        if self.is_hls() {
-            buf.push_str("HLS");
-        } else {
-            // Write uppercase directly
-            for c in self.ext.chars() {
-                buf.push(c.to_ascii_uppercase());
-            }
-        }
-        let format_len = buf.len() - format_start;
-        for _ in format_len..rdlp_table::TYPE_WIDTH {
-            buf.push(' ');
-        }
-        buf.push_str(" | ");
-
-        // Codecs column: write directly
-        match (&self.vcodec, &self.acodec) {
-            (Some(v), Some(a)) => {
-                let _ = write!(buf, "{v}/{a}");
-            }
-            (Some(v), None) => {
-                let _ = write!(buf, "{v} (video only)");
-            }
-            (None, Some(a)) => {
-                let _ = write!(buf, "{a} (audio only)");
-            }
-            (None, None) => buf.push_str("Unknown"),
-        }
-
-        if self.has_drm.unwrap_or(false) {
-            buf.push_str(" [DRM]");
-        }
-
-        buf
     }
 }


### PR DESCRIPTION
## Summary

- **Expand `rdlp-table`** from a constants-only crate into a full responsive CLI table renderer using `tabled 0.20`, `console 0.16`, and `terminal_size 0.4`
- **Replace `dialoguer`** with `inquire 0.9` for all interactive CLI menus (format selection, remux, audio, recode, subtitles, confirm)
- **Remove `Format::table_row()`** from `rdlp-types` — superseded by the new renderer. Dependency direction inverted: `rdlp-table → rdlp-types` (previously `rdlp-types → rdlp-table`)

## What Changed

### rdlp-table (new rendering engine)
- `column.rs` — 9 column definitions with priority-based responsive hiding (Quality 100, Resolution 90, Type 85, Size 80, Codecs 70, FPS 40, ABR 35, VBR 30, Note 20). `compute_budget()` drops lowest-priority columns first; core columns (priority >= 85) never dropped.
- `truncate.rs` — Unicode-aware `truncate_to_width()` and `pad_to_width()` using `console::measure_text_width`. Handles CJK, emoji, ANSI escapes.
- `lib.rs` — `render_formats_table(&[&Format], &TableOpts) -> String` (full table) and `render_format_rows(&[&Format], &TableOpts) -> Vec<String>` (per-row strings for inquire menus). `Style::rounded()` for normal, `Style::blank()` for compact (auto below 80 cols).
- `constants.rs` — legacy constants preserved for backward compat.
- **26 new tests** including property test that no output line exceeds target width at 60/80/100/120.

### rdlp-cli (dialoguer → inquire)
- `interactive.rs` — `inquire::Select`/`MultiSelect`/`Confirm` replace dialoguer equivalents. Format selection uses `render_formats_table()` for header + `render_format_rows()` for menu items.
- `selection.rs` — remux/audio/recode menus use `inquire::Select`.

### rdlp-types (cleanup)
- `Format::table_row()` removed (dead code after renderer migration).
- `rdlp-table` dependency removed from `rdlp-types/Cargo.toml`.

## Net change
+1,219 / -275 lines across 20 files.

## Test plan
- [x] `cargo clippy -p rdlp-table -p rdlp-cli -p rdlp-types -- -D warnings` — 0 warnings
- [x] `cargo test -p rdlp-table` — 26 tests pass (truncation, column budget, renderer)
- [x] `cargo test -p rdlp-cli` — 36 tests pass
- [x] `cargo test` — full workspace passes
- [x] `cargo fmt --check` — clean
- [x] `cargo build --release -p rdlp-cli -p rdlp-table -p rdlp-types` — clean
- [x] `grep dialoguer Cargo.lock` — no matches (fully removed)
- [x] `test_no_line_exceeds_width` — verified at widths 60, 80, 100, 120
- [x] `test_core_columns_never_dropped` — Quality/Resolution/Type preserved at width=30