### PR TITLE
fix(ffmpeg): pick compatible sample rate for encoder codec

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -60,6 +60,51 @@ impl FFmpegRunner {
         }
     }
 
+    /// Pick a sample rate supported by the encoder codec.
+    ///
+    /// If the codec accepts any rate (`supported_samplerates` is NULL), returns
+    /// `preferred` unchanged.  Otherwise returns `preferred` if it appears in
+    /// the supported list, or the nearest supported rate (preferring higher
+    /// rates on ties, which naturally selects 48 kHz for a 44.1 kHz source on
+    /// libopus).
+    pub(crate) fn pick_audio_sample_rate(
+        codec: &ffmpeg_the_third::Codec,
+        preferred: u32,
+    ) -> u32 {
+        // SAFETY: `codec.as_ptr()` returns a valid AVCodec pointer.
+        // `supported_samplerates` is a NULL-terminated i32 array (or NULL if
+        // the codec accepts any rate).
+        unsafe {
+            let ptr = codec.as_ptr();
+            let rates = (*ptr).supported_samplerates;
+            if rates.is_null() {
+                return preferred;
+            }
+
+            let mut i = 0;
+            let mut best: Option<u32> = None;
+            let mut best_dist = u32::MAX;
+            loop {
+                let rate = *rates.offset(i);
+                if rate == 0 {
+                    break;
+                }
+                let rate_u = rate as u32;
+                if rate_u == preferred {
+                    return preferred;
+                }
+                let dist = rate_u.abs_diff(preferred);
+                if dist < best_dist || (dist == best_dist && rate_u > best.unwrap_or(0)) {
+                    best = Some(rate_u);
+                    best_dist = dist;
+                }
+                i += 1;
+            }
+
+            best.unwrap_or(preferred)
+        }
+    }
+
     /// Enable VBR (variable bitrate) quality mode on an encoder.
     pub(crate) fn set_vbr_quality(
         encoder_ptr: *mut ffmpeg_the_third::ffi::AVCodecContext,
@@ -280,5 +325,32 @@ mod tests {
         let mut frame = ffmpeg_the_third::frame::Video::empty();
         frame_unref_video(&mut frame);
         frame_unref_video(&mut frame);
+    }
+
+    #[test]
+    fn pick_sample_rate_opus_rejects_44100() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let codec = ffmpeg_the_third::encoder::find_by_name("libopus").unwrap();
+        // 44100 is not a supported libopus rate; should pick 48000 (nearest).
+        let rate = FFmpegRunner::pick_audio_sample_rate(&codec, 44100);
+        assert_eq!(rate, 48000, "libopus should resample 44100→48000");
+    }
+
+    #[test]
+    fn pick_sample_rate_opus_accepts_48000() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let codec = ffmpeg_the_third::encoder::find_by_name("libopus").unwrap();
+        let rate = FFmpegRunner::pick_audio_sample_rate(&codec, 48000);
+        assert_eq!(rate, 48000);
+    }
+
+    #[test]
+    fn pick_sample_rate_aac_accepts_44100() {
+        crate::ffmpeg::ensure_init().unwrap();
+        if let Some(codec) = ffmpeg_the_third::encoder::find_by_name("aac") {
+            // AAC supports 44100; should return it unchanged.
+            let rate = FFmpegRunner::pick_audio_sample_rate(&codec, 44100);
+            assert_eq!(rate, 44100);
+        }
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -121,8 +121,16 @@ impl FFmpegRunner {
         let mut audio_encoder = audio_enc_context.encoder().audio()?;
         let target_format = Self::pick_audio_sample_format(&enc_codec, audio_decoder.format());
         audio_encoder.set_format(target_format);
-        audio_encoder.set_rate(audio_decoder.rate() as i32);
-        let enc_time_base = ffmpeg_the_third::Rational(1, audio_decoder.rate() as i32);
+        let target_rate = Self::pick_audio_sample_rate(&enc_codec, audio_decoder.rate());
+        if target_rate != audio_decoder.rate() {
+            debug!(
+                "[{label}] resampling {}→{} Hz (encoder does not support source rate)",
+                audio_decoder.rate(),
+                target_rate,
+            );
+        }
+        audio_encoder.set_rate(target_rate as i32);
+        let enc_time_base = ffmpeg_the_third::Rational(1, target_rate as i32);
         audio_encoder.set_time_base(enc_time_base);
 
         let channels = audio_decoder.ch_layout().channels();
@@ -250,10 +258,11 @@ impl FFmpegRunner {
         // starting mid-stream), this ensures the normalized audio output
         // preserves the same temporal offset, preventing audio/video desync
         // in the subsequent merge step.
+        let enc_rate = audio_encoder.rate();
         let start_samples = if format_start_time_us > 0
             && format_start_time_us != ffmpeg_the_third::ffi::AV_NOPTS_VALUE
         {
-            format_start_time_us * i64::from(audio_decoder.rate()) / 1_000_000
+            format_start_time_us * i64::from(enc_rate) / 1_000_000
         } else {
             0
         };
@@ -266,7 +275,7 @@ impl FFmpegRunner {
         let mut timing = MuxTimingState {
             encoder_frame_size: audio_encoder.frame_size(),
             expected_duration,
-            sample_rate: audio_decoder.rate(),
+            sample_rate: enc_rate,
             use_sample_clock: true,
             samples_written: start_samples,
             ..Default::default()

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -231,8 +231,16 @@ impl FFmpegRunner {
 
         let target_format = Self::pick_audio_sample_format(&enc_codec, decoder.format());
         audio_encoder.set_format(target_format);
-        audio_encoder.set_rate(decoder.rate() as i32);
-        let enc_time_base = ffmpeg_the_third::Rational(1, decoder.rate() as i32);
+        let target_rate = Self::pick_audio_sample_rate(&enc_codec, decoder.rate());
+        if target_rate != decoder.rate() {
+            debug!(
+                "Resampling {}→{} Hz (encoder does not support source rate)",
+                decoder.rate(),
+                target_rate,
+            );
+        }
+        audio_encoder.set_rate(target_rate as i32);
+        let enc_time_base = ffmpeg_the_third::Rational(1, target_rate as i32);
         audio_encoder.set_time_base(enc_time_base);
 
         // Set channel layout from decoder (default layout matching channel count)


### PR DESCRIPTION
## Summary
- libopus rejects 44100 Hz (only supports 48000/24000/16000/12000/8000). Remuxing to MKV with `--loudnorm` failed with "failed to open audio encoder: Invalid argument" because the normalization pipeline blindly copied the decoder's sample rate to the encoder.
- Add `pick_audio_sample_rate()` helper that queries `AVCodec.supported_samplerates` and selects the nearest compatible rate (e.g. 44100→48000 for libopus). The existing filter graph handles resampling transparently.
- Applied to both the normalization encode path and the audio extraction path.

## Test plan
- [x] 3 new unit tests: opus rejects 44100, opus accepts 48000, aac accepts 44100
- [x] All 77 rdlp-ffmpeg tests pass
- [x] Zero clippy warnings
- [x] Manual test: `--remux --loudnorm --loudnorm-preset=loud -i` on xhamster HLS content with 44100 Hz AAC source → normalization completes successfully with opus output in MKV