### PR TITLE
feat: post-processing progress reporting

### DIFF
--- a/crates/rdlp-api/src/dto.rs
+++ b/crates/rdlp-api/src/dto.rs
@@ -84,6 +84,16 @@ impl From<&Event> for EventDto {
 
             Event::PostProcessing { stage, .. } => ("post_processing", json!({ "stage": stage })),
 
+            Event::PostProcessProgress {
+                stage, progress, ..
+            } => (
+                "postprocess_progress",
+                json!({
+                    "stage": stage,
+                    "progress": progress,
+                }),
+            ),
+
             Event::SubtitlesFound { langs, .. } => ("subtitles_found", json!({ "langs": langs })),
 
             Event::SubtitlesMissing { requested, .. } => {

--- a/crates/rdlp-api/src/events.rs
+++ b/crates/rdlp-api/src/events.rs
@@ -58,6 +58,16 @@ pub enum Event {
         stage: String,
     },
 
+    /// Post-processing progress update.
+    PostProcessProgress {
+        /// The download this event belongs to.
+        id: DownloadId,
+        /// Name of the post-processing stage (e.g. "remux", "normalize").
+        stage: String,
+        /// Progress as a fraction in \[0.0, 1.0\].
+        progress: f64,
+    },
+
     /// Subtitles were found for the requested languages.
     SubtitlesFound {
         /// The download this event belongs to.
@@ -159,6 +169,7 @@ impl Event {
             | Self::FormatSelected { id, .. }
             | Self::Progress { id, .. }
             | Self::PostProcessing { id, .. }
+            | Self::PostProcessProgress { id, .. }
             | Self::SubtitlesFound { id, .. }
             | Self::SubtitlesMissing { id, .. }
             | Self::Warning { id, .. }
@@ -210,6 +221,11 @@ mod tests {
             Event::PostProcessing {
                 id,
                 stage: "remux".into(),
+            },
+            Event::PostProcessProgress {
+                id,
+                stage: "remux".into(),
+                progress: 0.45,
             },
             Event::SubtitlesFound {
                 id,

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -4,9 +4,50 @@
 
 use super::{Orchestrator, Result};
 use crate::events::Event;
+use crate::handle::DownloadId;
 use log::{debug, warn};
-use rdlp_core::PostProcessConfig;
+use rdlp_core::{PostProcessCallback, PostProcessCallbackFactory, PostProcessConfig};
 use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// Bridges post-processor progress into [`Event::PostProcessProgress`] events.
+///
+/// One instance is created per post-processing stage. Progress values in
+/// `[0.0, 1.0]` are forwarded to the event channel via `try_send`.
+struct PostProcessBridge {
+    event_tx: mpsc::Sender<Event>,
+    download_id: DownloadId,
+    stage: String,
+}
+
+impl PostProcessCallback for PostProcessBridge {
+    fn on_progress(&self, progress: f64) {
+        let _ = self.event_tx.try_send(Event::PostProcessProgress {
+            id: self.download_id,
+            stage: self.stage.clone(),
+            progress,
+        });
+    }
+}
+
+/// Build a [`PostProcessCallbackFactory`] that emits progress events for the
+/// given download.
+///
+/// The factory is called once per post-processing stage with the stage name,
+/// returning a fresh bridge for that stage.
+fn make_callback_factory(
+    event_tx: mpsc::Sender<Event>,
+    download_id: DownloadId,
+) -> PostProcessCallbackFactory {
+    Arc::new(move |stage_name: &str| -> Arc<dyn PostProcessCallback> {
+        Arc::new(PostProcessBridge {
+            event_tx: event_tx.clone(),
+            download_id,
+            stage: stage_name.to_string(),
+        })
+    })
+}
 
 impl Orchestrator {
     /// Convert Config to PostProcessConfig
@@ -125,9 +166,15 @@ impl Orchestrator {
             files.clone()
         };
 
+        // Build a per-stage progress callback factory for the pipeline.
+        let callback_factory = Some(make_callback_factory(
+            self.event_tx.clone(),
+            self.download_id,
+        ));
+
         // Run the full post-processing pipeline
         match registry
-            .process(info, result_files.clone(), &pp_config, None)
+            .process(info, result_files.clone(), &pp_config, callback_factory)
             .await
         {
             Ok(result) => {

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -127,7 +127,7 @@ impl Orchestrator {
 
         // Run the full post-processing pipeline
         match registry
-            .process(info, result_files.clone(), &pp_config)
+            .process(info, result_files.clone(), &pp_config, None)
             .await
         {
             Ok(result) => {

--- a/crates/rdlp-api/tests/api_integration.rs
+++ b/crates/rdlp-api/tests/api_integration.rs
@@ -29,6 +29,7 @@ fn event_tag(event: &Event) -> &'static str {
         Event::FormatSelected { .. } => "format_selected",
         Event::Progress { .. } => "progress",
         Event::PostProcessing { .. } => "post_processing",
+        Event::PostProcessProgress { .. } => "post_process_progress",
         Event::SubtitlesFound { .. } => "subtitles_found",
         Event::SubtitlesMissing { .. } => "subtitles_missing",
         Event::Warning { .. } => "warning",

--- a/crates/rdlp-cli/src/event_handler.rs
+++ b/crates/rdlp-cli/src/event_handler.rs
@@ -61,7 +61,7 @@ impl CliEventHandler {
                     let pb = self.multi_progress.add(ProgressBar::new(1000));
                     pb.set_style(
                         ProgressStyle::with_template(
-                            "{wide_bar:.yellow/blue} {pos:.0}% | Post-processing: {msg}",
+                            "{wide_bar:.yellow/blue} {percent}% | Post-processing: {msg}",
                         )
                         .expect("valid progress template"),
                     );
@@ -81,7 +81,7 @@ impl CliEventHandler {
                     let pb = self.multi_progress.add(ProgressBar::new(1000));
                     pb.set_style(
                         ProgressStyle::with_template(
-                            "{wide_bar:.yellow/blue} {pos:.0}% | Post-processing: {msg}",
+                            "{wide_bar:.yellow/blue} {percent}% | Post-processing: {msg}",
                         )
                         .expect("valid progress template"),
                     );

--- a/crates/rdlp-cli/src/event_handler.rs
+++ b/crates/rdlp-cli/src/event_handler.rs
@@ -58,10 +58,36 @@ impl CliEventHandler {
             Event::PostProcessing { stage, .. } => {
                 self.finish_progress();
                 if !self.quiet {
-                    let spinner = self.multi_progress.add(ProgressBar::new_spinner());
-                    spinner.set_message(format!("Post-processing: {stage}..."));
-                    spinner.enable_steady_tick(Duration::from_millis(100));
-                    self.progress_bar = Some(spinner);
+                    let pb = self.multi_progress.add(ProgressBar::new(1000));
+                    pb.set_style(
+                        ProgressStyle::with_template(
+                            "{wide_bar:.yellow/blue} {pos:.0}% | Post-processing: {msg}",
+                        )
+                        .expect("valid progress template"),
+                    );
+                    pb.set_message(stage.clone());
+                    pb.set_position(0);
+                    self.progress_bar = Some(pb);
+                }
+            }
+            Event::PostProcessProgress {
+                stage, progress, ..
+            } => {
+                if let Some(ref pb) = self.progress_bar {
+                    let pct = (*progress * 1000.0) as u64;
+                    pb.set_position(pct);
+                    pb.set_message(stage.clone());
+                } else if !self.quiet {
+                    let pb = self.multi_progress.add(ProgressBar::new(1000));
+                    pb.set_style(
+                        ProgressStyle::with_template(
+                            "{wide_bar:.yellow/blue} {pos:.0}% | Post-processing: {msg}",
+                        )
+                        .expect("valid progress template"),
+                    );
+                    pb.set_message(stage.clone());
+                    pb.set_position((*progress * 1000.0) as u64);
+                    self.progress_bar = Some(pb);
                 }
             }
             Event::SubtitlesFound { langs, .. } => {

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -58,6 +58,6 @@ pub use retry::{ExponentialBuilder, RetryConfig, Retryable, is_retryable_error};
 // Re-export traits
 pub use traits::{
     CookieJar, DownloadProgress, DownloadStats, Downloader, ExtractionContext, InfoExtractor,
-    JsEngine, PostProcessConfig, PostProcessResult, PostProcessor, ProgressCallback,
-    SearchExtractor,
+    JsEngine, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor,
+    ProgressCallback, SearchExtractor,
 };

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -58,6 +58,6 @@ pub use retry::{ExponentialBuilder, RetryConfig, Retryable, is_retryable_error};
 // Re-export traits
 pub use traits::{
     CookieJar, DownloadProgress, DownloadStats, Downloader, ExtractionContext, InfoExtractor,
-    JsEngine, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor,
-    ProgressCallback, SearchExtractor,
+    JsEngine, PostProcessCallback, PostProcessCallbackFactory, PostProcessConfig,
+    PostProcessResult, PostProcessor, ProgressCallback, SearchExtractor,
 };

--- a/crates/rdlp-core/src/traits/mod.rs
+++ b/crates/rdlp-core/src/traits/mod.rs
@@ -14,4 +14,4 @@ pub mod postprocessor;
 
 pub use downloader::{DownloadProgress, DownloadStats, Downloader, ProgressCallback};
 pub use extractor::{CookieJar, ExtractionContext, InfoExtractor, JsEngine, SearchExtractor};
-pub use postprocessor::{PostProcessConfig, PostProcessResult, PostProcessor};
+pub use postprocessor::{PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor};

--- a/crates/rdlp-core/src/traits/mod.rs
+++ b/crates/rdlp-core/src/traits/mod.rs
@@ -14,4 +14,7 @@ pub mod postprocessor;
 
 pub use downloader::{DownloadProgress, DownloadStats, Downloader, ProgressCallback};
 pub use extractor::{CookieJar, ExtractionContext, InfoExtractor, JsEngine, SearchExtractor};
-pub use postprocessor::{PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor};
+pub use postprocessor::{
+    PostProcessCallback, PostProcessCallbackFactory, PostProcessConfig, PostProcessResult,
+    PostProcessor,
+};

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -1,7 +1,35 @@
 use async_trait::async_trait;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::{AudioFormat, ContainerFormat, InfoDict, Result};
+
+/// Callback for reporting post-processing progress.
+///
+/// Implementations receive progress updates (0.0–1.0) during FFmpeg
+/// post-processing stages. Used to bridge synchronous FFmpeg loops
+/// to the async event system.
+///
+/// # Arguments
+/// * `progress` - Progress fraction in \[0.0, 1.0\]
+///
+/// # Example
+///
+/// ```rust
+/// use rdlp_core::PostProcessCallback;
+/// use std::sync::Arc;
+///
+/// struct PrintProgress;
+/// impl PostProcessCallback for PrintProgress {
+///     fn on_progress(&self, progress: f64) {
+///         println!("Progress: {:.0}%", progress * 100.0);
+///     }
+/// }
+/// ```
+pub trait PostProcessCallback: Send + Sync {
+    /// Report progress as a fraction in \[0.0, 1.0\].
+    fn on_progress(&self, progress: f64);
+}
 
 /// Post-processing operations on downloaded files
 ///
@@ -18,6 +46,7 @@ pub trait PostProcessor: Send + Sync {
     /// * `info` - Video metadata
     /// * `files` - List of downloaded file paths to process
     /// * `config` - Post-processing configuration
+    /// * `callback` - Optional progress callback (0.0–1.0) for heavy operations
     ///
     /// # Returns
     /// Updated InfoDict and potentially new file paths after processing
@@ -26,6 +55,7 @@ pub trait PostProcessor: Send + Sync {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult>;
 
     /// Check if this post-processor should run based on config

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -77,6 +77,14 @@ pub trait PostProcessor: Send + Sync {
     }
 }
 
+/// Factory for creating per-stage post-processing callbacks.
+///
+/// Receives the processor/stage name and returns a fresh callback that
+/// will receive progress updates (0.0–1.0) for that specific stage.
+/// Used by the registry to create a callback for each processor run.
+pub type PostProcessCallbackFactory =
+    Arc<dyn Fn(&str) -> Arc<dyn PostProcessCallback> + Send + Sync>;
+
 /// Result of post-processing
 #[derive(Debug, Clone)]
 pub struct PostProcessResult {

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -80,6 +80,21 @@ pub struct FormatSelectedPayload {
     pub(crate) quality: String,
 }
 
+/// Post-processing progress payload emitted as `"postprocess-progress"`.
+///
+/// Sent for every [`Event::PostProcessProgress`] update. The `progress`
+/// field is a fraction in `[0.0, 1.0]`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostProcessProgressPayload {
+    /// The UUID of the download job.
+    pub(crate) job_id: String,
+    /// Name of the post-processing stage (e.g. `"remux"`, `"normalize"`).
+    pub(crate) stage: String,
+    /// Progress as a fraction in `[0.0, 1.0]`.
+    pub(crate) progress: f64,
+}
+
 /// Log message payload emitted as `"download-log"`.
 ///
 /// Used for informational events (metadata ready, post-processing
@@ -193,6 +208,19 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
 
             if let Err(e) = app.emit("download-log", &payload) {
                 debug!("Failed to emit download-log (post-processing) for job {job_id}: {e}");
+            }
+        }
+
+        Event::PostProcessProgress {
+            stage, progress, ..
+        } => {
+            let payload = PostProcessProgressPayload {
+                job_id: job_id.to_owned(),
+                stage: stage.clone(),
+                progress: *progress,
+            };
+            if let Err(e) = app.emit("postprocess-progress", &payload) {
+                debug!("Failed to emit postprocess-progress for job {job_id}: {e}");
             }
         }
 
@@ -354,5 +382,18 @@ mod tests {
         assert_eq!(json["jobId"], "abc-123");
         assert_eq!(json["level"], "warn");
         assert_eq!(json["message"], "low quality fallback");
+    }
+
+    #[test]
+    fn test_postprocess_progress_payload_serializes() {
+        let payload = PostProcessProgressPayload {
+            job_id: "abc-123".to_owned(),
+            stage: "remux".to_owned(),
+            progress: 0.45,
+        };
+        let json = serde_json::to_value(&payload).expect("serialization should succeed");
+        assert_eq!(json["jobId"], "abc-123");
+        assert_eq!(json["stage"], "remux");
+        assert_eq!(json["progress"], 0.45);
     }
 }

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -14,6 +14,7 @@ import {
     onDownloadError,
     onDownloadLog,
     onFormatSelected,
+    onPostProcessProgress,
 } from "../lib/tauri";
 import { queryKeys } from "../query/queryKeys";
 import type { DownloadJob } from "../types";
@@ -148,6 +149,25 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                     old?.map((job) =>
                         job.id === p.jobId
                             ? { ...job, statusMessage: `Format: ${p.quality}` }
+                            : job,
+                    ),
+            );
+        }),
+    );
+
+    unlisteners.push(
+        onPostProcessProgress((p) => {
+            if (!mounted) return;
+            const pct = Math.round(p.progress * 100);
+            qc.setQueryData<DownloadJob[]>(
+                queryKeys.downloads.list(),
+                (old) =>
+                    old?.map((job) =>
+                        job.id === p.jobId
+                            ? {
+                                  ...job,
+                                  statusMessage: `${p.stage}… ${pct}%`,
+                              }
                             : job,
                     ),
             );

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -15,6 +15,7 @@ import type {
     DownloadProgressPayload,
     FormatListResponse,
     FormatSelectedPayload,
+    PostProcessProgressPayload,
     SearchFilter,
     SearchFilterDescriptor,
     SearchPageResponse,
@@ -138,6 +139,15 @@ export function onFormatSelected(
     callback: (payload: FormatSelectedPayload) => void,
 ): Promise<UnlistenFn> {
     return listen<FormatSelectedPayload>("format-selected", (event) =>
+        callback(event.payload),
+    );
+}
+
+/** Subscribe to post-processing progress events. Returns an unlisten function. */
+export function onPostProcessProgress(
+    callback: (payload: PostProcessProgressPayload) => void,
+): Promise<UnlistenFn> {
+    return listen<PostProcessProgressPayload>("postprocess-progress", (event) =>
         callback(event.payload),
     );
 }

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -209,6 +209,13 @@ export interface DownloadLogPayload {
     message: string;
 }
 
+/** Post-processing progress payload emitted as "postprocess-progress". */
+export interface PostProcessProgressPayload {
+    jobId: string;
+    stage: string;
+    progress: number; // 0.0–1.0
+}
+
 // ========== Settings Types ==========
 
 /**

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -67,10 +67,7 @@ impl FFmpegRunner {
     /// the supported list, or the nearest supported rate (preferring higher
     /// rates on ties, which naturally selects 48 kHz for a 44.1 kHz source on
     /// libopus).
-    pub(crate) fn pick_audio_sample_rate(
-        codec: &ffmpeg_the_third::Codec,
-        preferred: u32,
-    ) -> u32 {
+    pub(crate) fn pick_audio_sample_rate(codec: &ffmpeg_the_third::Codec, preferred: u32) -> u32 {
         // SAFETY: `codec.as_ptr()` returns a valid AVCodec pointer.
         // `supported_samplerates` is a NULL-terminated i32 array (or NULL if
         // the codec accepts any rate).

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -5,6 +5,7 @@
 //! plus `cluster_time_limit=500` for VLC-compatible seeking.
 
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use log::{debug, info};
 
@@ -31,6 +32,7 @@ impl FFmpegRunner {
         video_input: &Path,
         audio_input: &Path,
         output: &Path,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         use ffmpeg_the_third::ffi;
         use std::ffi::CString;
@@ -328,6 +330,17 @@ impl FFmpegRunner {
 
             info!("Merge: video=stream#{video_out_idx}, audio=stream#{audio_out_idx} (DEFAULT)");
 
+            // Byte-based progress tracking
+            let total_input_bytes = std::fs::metadata(video_input)
+                .map(|m| m.len())
+                .unwrap_or(0)
+                + std::fs::metadata(audio_input)
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+            let mut bytes_written: u64 = 0;
+            let mut last_progress = Instant::now();
+            let throttle = Duration::from_millis(100);
+
             // 13. Two-way timestamp-interleaved merge
             //
             // Write packets from both inputs in DTS order to avoid ENOMEM
@@ -351,6 +364,7 @@ impl FFmpegRunner {
                     match (have_video, have_audio) {
                         (false, false) => break,
                         (true, false) => {
+                            bytes_written += vpkt.size as u64;
                             rescale_and_write_raw(
                                 &mut vpkt,
                                 in_video_stream,
@@ -361,6 +375,7 @@ impl FFmpegRunner {
                             have_video = read_next_raw(ifmt_video, video_stream_idx, &mut vpkt);
                         }
                         (false, true) => {
+                            bytes_written += apkt.size as u64;
                             rescale_and_write_raw(
                                 &mut apkt,
                                 in_audio_stream,
@@ -382,6 +397,7 @@ impl FFmpegRunner {
                             };
 
                             if write_video {
+                                bytes_written += vpkt.size as u64;
                                 rescale_and_write_raw(
                                     &mut vpkt,
                                     in_video_stream,
@@ -391,6 +407,7 @@ impl FFmpegRunner {
                                 ffi::av_packet_unref(&mut vpkt);
                                 have_video = read_next_raw(ifmt_video, video_stream_idx, &mut vpkt);
                             } else {
+                                bytes_written += apkt.size as u64;
                                 rescale_and_write_raw(
                                     &mut apkt,
                                     in_audio_stream,
@@ -402,10 +419,26 @@ impl FFmpegRunner {
                             }
                         }
                     }
+
+                    // Report byte-based progress (throttled to 10 updates/sec)
+                    if let Some(ref progress) = progress_fn {
+                        if total_input_bytes > 0 && last_progress.elapsed() >= throttle {
+                            let frac = (bytes_written as f64 / total_input_bytes as f64)
+                                .clamp(0.0, 1.0);
+                            progress(frac);
+                            last_progress = Instant::now();
+                        }
+                    }
                 }
 
                 ffi::av_packet_unref(&mut vpkt);
                 ffi::av_packet_unref(&mut apkt);
+
+                // Emit final 1.0 on completion
+                if let Some(ref progress) = progress_fn {
+                    progress(1.0);
+                }
+
                 Ok(())
             })();
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -331,12 +331,8 @@ impl FFmpegRunner {
             info!("Merge: video=stream#{video_out_idx}, audio=stream#{audio_out_idx} (DEFAULT)");
 
             // Byte-based progress tracking
-            let total_input_bytes = std::fs::metadata(video_input)
-                .map(|m| m.len())
-                .unwrap_or(0)
-                + std::fs::metadata(audio_input)
-                    .map(|m| m.len())
-                    .unwrap_or(0);
+            let total_input_bytes = std::fs::metadata(video_input).map(|m| m.len()).unwrap_or(0)
+                + std::fs::metadata(audio_input).map(|m| m.len()).unwrap_or(0);
             let mut bytes_written: u64 = 0;
             let mut last_progress = Instant::now();
             let throttle = Duration::from_millis(100);
@@ -421,13 +417,14 @@ impl FFmpegRunner {
                     }
 
                     // Report byte-based progress (throttled to 10 updates/sec)
-                    if let Some(ref progress) = progress_fn {
-                        if total_input_bytes > 0 && last_progress.elapsed() >= throttle {
-                            let frac = (bytes_written as f64 / total_input_bytes as f64)
-                                .clamp(0.0, 1.0);
-                            progress(frac);
-                            last_progress = Instant::now();
-                        }
+                    if let Some(ref progress) = progress_fn
+                        && total_input_bytes > 0
+                        && last_progress.elapsed() >= throttle
+                    {
+                        let frac =
+                            (bytes_written as f64 / total_input_bytes as f64).clamp(0.0, 1.0);
+                        progress(frac);
+                        last_progress = Instant::now();
                     }
                 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -161,12 +161,8 @@ impl FFmpegRunner {
         info!("Merge: video=stream#{video_ost_index}, audio=stream#{audio_ost_index} (DEFAULT)");
 
         // Byte-based progress: sum input file sizes before starting
-        let total_input_bytes = std::fs::metadata(video_input)
-            .map(|m| m.len())
-            .unwrap_or(0)
-            + std::fs::metadata(audio_input)
-                .map(|m| m.len())
-                .unwrap_or(0);
+        let total_input_bytes = std::fs::metadata(video_input).map(|m| m.len()).unwrap_or(0)
+            + std::fs::metadata(audio_input).map(|m| m.len()).unwrap_or(0);
         let mut bytes_written: u64 = 0;
         let mut last_progress = Instant::now();
         let throttle = Duration::from_millis(100);
@@ -265,13 +261,13 @@ impl FFmpegRunner {
                 }
 
                 // Report byte-based progress (throttled to 10 updates/sec)
-                if let Some(ref progress) = progress_fn {
-                    if total_input_bytes > 0 && last_progress.elapsed() >= throttle {
-                        let frac =
-                            (bytes_written as f64 / total_input_bytes as f64).clamp(0.0, 1.0);
-                        progress(frac);
-                        last_progress = Instant::now();
-                    }
+                if let Some(ref progress) = progress_fn
+                    && total_input_bytes > 0
+                    && last_progress.elapsed() >= throttle
+                {
+                    let frac = (bytes_written as f64 / total_input_bytes as f64).clamp(0.0, 1.0);
+                    progress(frac);
+                    last_progress = Instant::now();
                 }
             }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -8,6 +8,8 @@ mod mkv_raw_ffi;
 mod raw_ffi_helpers;
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use log::info;
 
@@ -29,13 +31,20 @@ impl FFmpegRunner {
         audio_input: impl AsRef<Path>,
         output: impl AsRef<Path>,
         opts: &RemuxOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
     ) -> Result<()> {
         let video_input = video_input.as_ref().to_path_buf();
         let audio_input = audio_input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
         Self::spawn_blocking("merge", move || {
-            Self::merge_sync(&video_input, &audio_input, &output, &opts)
+            Self::merge_sync(
+                &video_input,
+                &audio_input,
+                &output,
+                &opts,
+                progress_fn.as_deref(),
+            )
         })
         .await
     }
@@ -46,6 +55,7 @@ impl FFmpegRunner {
         audio_input: &Path,
         output: &Path,
         opts: &RemuxOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
 
@@ -55,7 +65,7 @@ impl FFmpegRunner {
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
         if is_mkv {
-            return Self::merge_mkv_raw_ffi(video_input, audio_input, output);
+            return Self::merge_mkv_raw_ffi(video_input, audio_input, output, progress_fn);
         }
 
         let mut ictx_video = ffmpeg_the_third::format::input(video_input).map_err(|e| {
@@ -150,6 +160,17 @@ impl FFmpegRunner {
 
         info!("Merge: video=stream#{video_ost_index}, audio=stream#{audio_ost_index} (DEFAULT)");
 
+        // Byte-based progress: sum input file sizes before starting
+        let total_input_bytes = std::fs::metadata(video_input)
+            .map(|m| m.len())
+            .unwrap_or(0)
+            + std::fs::metadata(audio_input)
+                .map(|m| m.len())
+                .unwrap_or(0);
+        let mut bytes_written: u64 = 0;
+        let mut last_progress = Instant::now();
+        let throttle = Duration::from_millis(100);
+
         // Two-way timestamp-interleaved merge: read packets from both inputs
         // and write them in DTS order to avoid ENOMEM from buffering an entire
         // stream while waiting for the other.
@@ -183,6 +204,7 @@ impl FFmpegRunner {
                 match (have_video, have_audio) {
                     (false, false) => break,
                     (true, false) => {
+                        bytes_written += vpkt.size as u64;
                         rescale_and_write_raw(
                             &mut vpkt,
                             in_video_stream,
@@ -193,6 +215,7 @@ impl FFmpegRunner {
                         have_video = read_next_raw(video_ctx, video_ist_index, &mut vpkt);
                     }
                     (false, true) => {
+                        bytes_written += apkt.size as u64;
                         rescale_and_write_raw(
                             &mut apkt,
                             in_audio_stream,
@@ -218,6 +241,7 @@ impl FFmpegRunner {
                         };
 
                         if write_video {
+                            bytes_written += vpkt.size as u64;
                             rescale_and_write_raw(
                                 &mut vpkt,
                                 in_video_stream,
@@ -227,6 +251,7 @@ impl FFmpegRunner {
                             ffi::av_packet_unref(&mut vpkt);
                             have_video = read_next_raw(video_ctx, video_ist_index, &mut vpkt);
                         } else {
+                            bytes_written += apkt.size as u64;
                             rescale_and_write_raw(
                                 &mut apkt,
                                 in_audio_stream,
@@ -238,11 +263,26 @@ impl FFmpegRunner {
                         }
                     }
                 }
+
+                // Report byte-based progress (throttled to 10 updates/sec)
+                if let Some(ref progress) = progress_fn {
+                    if total_input_bytes > 0 && last_progress.elapsed() >= throttle {
+                        let frac =
+                            (bytes_written as f64 / total_input_bytes as f64).clamp(0.0, 1.0);
+                        progress(frac);
+                        last_progress = Instant::now();
+                    }
+                }
             }
 
             // Clean up any unreleased packets
             ffi::av_packet_unref(&mut vpkt);
             ffi::av_packet_unref(&mut apkt);
+        }
+
+        // Emit final 1.0 on completion
+        if let Some(ref progress) = progress_fn {
+            progress(1.0);
         }
 
         octx.write_trailer()

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -21,10 +21,17 @@ impl FFmpegRunner {
         output: &Path,
         analysis: &PeakAnalysis,
         opts: &NormalizeOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
-        Self::dispatch_normalize_sync(input, output, opts.salvage, |inp, out, ext, resilient| {
-            Self::peak_encode_audio_only(inp, out, ext, analysis, opts, resilient)
-        })
+        Self::dispatch_normalize_sync(
+            input,
+            output,
+            opts.salvage,
+            progress_fn,
+            |inp, out, ext, resilient, pfn| {
+                Self::peak_encode_audio_only(inp, out, ext, analysis, opts, resilient, pfn)
+            },
+        )
     }
 
     /// Encode peak-normalized audio to an output file (video streams discarded).
@@ -35,6 +42,7 @@ impl FFmpegRunner {
         analysis: &PeakAnalysis,
         opts: &NormalizeOptions,
         resilient: bool,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         let gain_db = opts.target_peak_db - analysis.peak_db;
         let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
@@ -44,6 +52,7 @@ impl FFmpegRunner {
             final_output_ext,
             "peak encode",
             resilient,
+            progress_fn,
             |fmt, rate, ch_layout| {
                 let oversample_prefix = if gain_db >= TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD {
                     let rate_4x = rate * 4;
@@ -67,10 +76,17 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         measurements: &LoudnormMeasurements,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
-        Self::dispatch_normalize_sync(input, output, opts.salvage, |inp, out, ext, resilient| {
-            Self::loudnorm_encode_audio_only(inp, out, ext, opts, measurements, resilient)
-        })
+        Self::dispatch_normalize_sync(
+            input,
+            output,
+            opts.salvage,
+            progress_fn,
+            |inp, out, ext, resilient, pfn| {
+                Self::loudnorm_encode_audio_only(inp, out, ext, opts, measurements, resilient, pfn)
+            },
+        )
     }
 
     /// Encode loudnorm-normalized audio to an output file (video streams discarded).
@@ -81,6 +97,7 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
         measurements: &LoudnormMeasurements,
         resilient: bool,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
         let limiter = build_alimiter_spec(opts.target_tp);
@@ -90,6 +107,7 @@ impl FFmpegRunner {
             final_output_ext,
             "loudnorm pass 2",
             resilient,
+            progress_fn,
             |fmt, rate, ch_layout| {
                 format!(
                     "aformat=sample_fmts=dbl,{loudnorm_core},aresample,\
@@ -110,7 +128,8 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         salvage: bool,
-        encode_fn: impl Fn(&Path, &Path, &str, bool) -> Result<()>,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        encode_fn: impl Fn(&Path, &Path, &str, bool, Option<&(dyn Fn(f64) + Send + Sync)>) -> Result<()>,
     ) -> Result<()> {
         crate::ffmpeg::ensure_init()?;
 
@@ -139,25 +158,26 @@ impl FFmpegRunner {
 
             if salvage {
                 with_mux_retry(input, &temp_audio, |effective_input, resilient| {
-                    encode_fn(effective_input, &temp_audio, ext, resilient)
+                    encode_fn(effective_input, &temp_audio, ext, resilient, progress_fn)
                 })?;
             } else {
-                encode_fn(input, &temp_audio, ext, false)?;
+                encode_fn(input, &temp_audio, ext, false, progress_fn)?;
             }
             let merge_result = Self::merge_sync(
                 input,
                 &temp_audio,
                 output,
                 &super::super::RemuxOptions::default(),
+                None,
             );
             let _ = std::fs::remove_file(&temp_audio);
             merge_result
         } else if salvage {
             with_mux_retry(input, output, |effective_input, resilient| {
-                encode_fn(effective_input, output, ext, resilient)
+                encode_fn(effective_input, output, ext, resilient, progress_fn)
             })
         } else {
-            encode_fn(input, output, ext, false)
+            encode_fn(input, output, ext, false, progress_fn)
         }
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -4,6 +4,7 @@
 //! peak normalization and loudnorm pass 2.
 
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use log::{debug, warn};
 
@@ -40,6 +41,7 @@ impl FFmpegRunner {
         final_output_ext: &str,
         label: &str,
         resilient: bool,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
         build_filter: impl FnOnce(
             /*fmt:*/ &str,
             /*rate:*/ u32,
@@ -59,12 +61,13 @@ impl FFmpegRunner {
             })?
         };
 
-        // Read the format-level start_time (in AV_TIME_BASE = µs) before
+        // Read the format-level start_time and duration (in AV_TIME_BASE = µs) before
         // borrowing individual streams.  HLS downloads and some containers
         // have a non-zero start time.  We must preserve this offset in the
         // sample-clock DTS synthesis so the normalized audio aligns with
         // the original video stream when they are merged back together.
         let format_start_time_us: i64 = unsafe { (*ictx.as_mut_ptr()).start_time };
+        let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
         let audio_ist_index = ictx
             .streams()
@@ -284,12 +287,27 @@ impl FFmpegRunner {
         // Transcode loop (audio only)
         let mut packets_processed = 0u64;
         let mut packets_skipped = 0u64;
+        let mut last_progress = Instant::now();
+        let progress_throttle = Duration::from_millis(100);
         for result in ictx.packets() {
             let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to read packet: {e}"),
             })?;
             if stream.index() != audio_ist_index {
                 continue;
+            }
+            // PTS-based progress: rescale packet PTS to µs, compare against total duration
+            if let Some(ref progress) = progress_fn {
+                if input_duration_us > 0 && last_progress.elapsed() >= progress_throttle {
+                    if let Some(pts) = packet.pts() {
+                        let tb = audio_ist_time_base;
+                        let pts_us = pts * i64::from(tb.numerator()) * 1_000_000
+                            / i64::from(tb.denominator());
+                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                        progress(frac);
+                        last_progress = Instant::now();
+                    }
+                }
             }
             if let Err(e) = audio_decoder.send_packet(&packet) {
                 if packets_skipped == 0 {
@@ -336,6 +354,10 @@ impl FFmpegRunner {
                 &mut timing,
                 Some(output),
             )?;
+        }
+        // Emit final 1.0 on completion
+        if let Some(ref progress) = progress_fn {
+            progress(1.0);
         }
 
         if packets_skipped > 0 {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -297,17 +297,17 @@ impl FFmpegRunner {
                 continue;
             }
             // PTS-based progress: rescale packet PTS to µs, compare against total duration
-            if let Some(ref progress) = progress_fn {
-                if input_duration_us > 0 && last_progress.elapsed() >= progress_throttle {
-                    if let Some(pts) = packet.pts() {
-                        let tb = audio_ist_time_base;
-                        let pts_us = pts * i64::from(tb.numerator()) * 1_000_000
-                            / i64::from(tb.denominator());
-                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
-                        progress(frac);
-                        last_progress = Instant::now();
-                    }
-                }
+            if let Some(ref progress) = progress_fn
+                && input_duration_us > 0
+                && last_progress.elapsed() >= progress_throttle
+                && let Some(pts) = packet.pts()
+            {
+                let tb = audio_ist_time_base;
+                let pts_us =
+                    pts * i64::from(tb.numerator()) * 1_000_000 / i64::from(tb.denominator());
+                let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                progress(frac);
+                last_progress = Instant::now();
             }
             if let Err(e) = audio_decoder.send_packet(&packet) {
                 if packets_skipped == 0 {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
@@ -55,18 +55,12 @@ impl FFmpegRunner {
             let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, opts.salvage)?;
 
             let result = match opts.mode {
-                AudioNormMode::Peak => Self::normalize_peak_sync(
-                    &effective_input,
-                    &output,
-                    &opts,
-                    progress_fn.clone(),
-                ),
-                AudioNormMode::Loudnorm => Self::normalize_loudnorm_sync(
-                    &effective_input,
-                    &output,
-                    &opts,
-                    progress_fn,
-                ),
+                AudioNormMode::Peak => {
+                    Self::normalize_peak_sync(&effective_input, &output, &opts, progress_fn.clone())
+                }
+                AudioNormMode::Loudnorm => {
+                    Self::normalize_loudnorm_sync(&effective_input, &output, &opts, progress_fn)
+                }
             };
 
             // Clean up salvage temp file regardless of success/failure
@@ -112,13 +106,7 @@ impl FFmpegRunner {
             progress_fn.map(|p| -> Arc<dyn Fn(f64) + Send + Sync> {
                 Arc::new(move |frac: f64| p(0.3 + frac * 0.7))
             });
-        Self::apply_peak_gain_sync(
-            input,
-            output,
-            &analysis,
-            opts,
-            encode_progress.as_deref(),
-        )
+        Self::apply_peak_gain_sync(input, output, &analysis, opts, encode_progress.as_deref())
     }
 
     /// EBU R128 loudnorm two-pass normalization.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
@@ -17,6 +17,7 @@ mod io_diag;
 mod tests;
 
 use std::path::Path;
+use std::sync::Arc;
 
 use log::{debug, info, warn};
 
@@ -45,6 +46,7 @@ impl FFmpegRunner {
         input: impl AsRef<Path>,
         output: impl AsRef<Path>,
         opts: &NormalizeOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -53,10 +55,18 @@ impl FFmpegRunner {
             let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, opts.salvage)?;
 
             let result = match opts.mode {
-                AudioNormMode::Peak => Self::normalize_peak_sync(&effective_input, &output, &opts),
-                AudioNormMode::Loudnorm => {
-                    Self::normalize_loudnorm_sync(&effective_input, &output, &opts)
-                }
+                AudioNormMode::Peak => Self::normalize_peak_sync(
+                    &effective_input,
+                    &output,
+                    &opts,
+                    progress_fn.clone(),
+                ),
+                AudioNormMode::Loudnorm => Self::normalize_loudnorm_sync(
+                    &effective_input,
+                    &output,
+                    &opts,
+                    progress_fn,
+                ),
             };
 
             // Clean up salvage temp file regardless of success/failure
@@ -70,7 +80,12 @@ impl FFmpegRunner {
     }
 
     /// Peak normalization: analyze then apply gain + limiter.
-    fn normalize_peak_sync(input: &Path, output: &Path, opts: &NormalizeOptions) -> Result<()> {
+    fn normalize_peak_sync(
+        input: &Path,
+        output: &Path,
+        opts: &NormalizeOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+    ) -> Result<()> {
         let analysis = Self::analyze_peak_sync(input, opts.target_peak_db)?;
 
         debug!(
@@ -85,14 +100,34 @@ impl FFmpegRunner {
                 message: format!("failed to copy file: {e}"),
                 source: e,
             })?;
+            // Emit final 1.0 even when skipping
+            if let Some(ref progress) = progress_fn {
+                progress(1.0);
+            }
             return Ok(());
         }
 
-        Self::apply_peak_gain_sync(input, output, &analysis, opts)
+        // Peak: analysis (0.0–0.3) already done above; encode phase (0.3–1.0)
+        let encode_progress: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            progress_fn.map(|p| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac: f64| p(0.3 + frac * 0.7))
+            });
+        Self::apply_peak_gain_sync(
+            input,
+            output,
+            &analysis,
+            opts,
+            encode_progress.as_deref(),
+        )
     }
 
     /// EBU R128 loudnorm two-pass normalization.
-    fn normalize_loudnorm_sync(input: &Path, output: &Path, opts: &NormalizeOptions) -> Result<()> {
+    fn normalize_loudnorm_sync(
+        input: &Path,
+        output: &Path,
+        opts: &NormalizeOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+    ) -> Result<()> {
         info!("Loudnorm pass 1: analyzing EBU R128 levels...");
         let measurements = Self::loudnorm_pass1_sync(input, opts)?;
 
@@ -118,7 +153,8 @@ impl FFmpegRunner {
                      gain={:.1} dB — using fixed gain + limiter",
                     opts.boost_gain_db
                 );
-                Self::apply_limiter_boost_sync(input, output, opts)?;
+                // Boost maps to full range 0.0–1.0
+                Self::apply_limiter_boost_sync(input, output, opts, progress_fn.as_deref())?;
                 Self::verify_loudness_sync(output, opts)?;
                 return Ok(());
             }
@@ -129,7 +165,18 @@ impl FFmpegRunner {
         }
 
         info!("Loudnorm pass 2: applying normalization...");
-        Self::loudnorm_pass2_sync(input, output, opts, &measurements)?;
+        // Pass 2: progress maps to 0.5–1.0 (pass 1 covers 0.0–0.5 but is fast/no callback)
+        let pass2_progress: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            progress_fn.map(|p| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac: f64| p(0.5 + frac * 0.5))
+            });
+        Self::loudnorm_pass2_sync(
+            input,
+            output,
+            opts,
+            &measurements,
+            pass2_progress.as_deref(),
+        )?;
 
         // Verify output loudness against targets
         Self::verify_loudness_sync(output, opts)?;
@@ -146,6 +193,7 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         opts: &NormalizeOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         let ceiling_db = opts.target_tp - ALIMITER_TP_HEADROOM_DB;
         let limit_linear = 10f64.powf(ceiling_db / 20.0);
@@ -164,6 +212,6 @@ impl FFmpegRunner {
         let mut boost_opts = opts.clone();
         boost_opts.target_peak_db = ceiling_db;
 
-        Self::apply_peak_gain_sync(input, output, &synthetic_analysis, &boost_opts)
+        Self::apply_peak_gain_sync(input, output, &synthetic_analysis, &boost_opts, progress_fn)
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -161,22 +161,17 @@ impl FFmpegRunner {
             let ost_idx = ost_idx as usize;
 
             // Report PTS-based progress (throttled to 10 updates/sec)
-            if let Some(ref progress) = progress_fn {
-                if input_duration_us > 0 {
-                    if let Some(pts) = packet.pts() {
-                        if last_progress.elapsed() >= throttle {
-                            let ist_tb = ist_time_bases[ist_index];
-                            let pts_us = pts
-                                * i64::from(ist_tb.numerator())
-                                * 1_000_000
-                                / i64::from(ist_tb.denominator());
-                            let frac =
-                                (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
-                            progress(frac);
-                            last_progress = Instant::now();
-                        }
-                    }
-                }
+            if let Some(ref progress) = progress_fn
+                && input_duration_us > 0
+                && let Some(pts) = packet.pts()
+                && last_progress.elapsed() >= throttle
+            {
+                let ist_tb = ist_time_bases[ist_index];
+                let pts_us = pts * i64::from(ist_tb.numerator()) * 1_000_000
+                    / i64::from(ist_tb.denominator());
+                let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                progress(frac);
+                last_progress = Instant::now();
             }
 
             // Apply PTS offset to normalize timestamps to start at 0
@@ -478,17 +473,19 @@ impl FFmpegRunner {
                 let out_stream = *(*ofmt_ctx).streams.add(out_stream_idx as usize);
 
                 // Report PTS-based progress using AV_TIME_BASE (throttled)
-                if let Some(ref progress) = progress_fn {
-                    if input_duration_us > 0
-                        && pkt.pts != ffi::AV_NOPTS_VALUE
-                        && last_progress_mkv.elapsed() >= throttle_mkv
-                    {
-                        let av_time_base = ffi::AVRational { num: 1, den: 1_000_000 };
-                        let pts_us = ffi::av_rescale_q(pkt.pts, (*in_stream).time_base, av_time_base);
-                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
-                        progress(frac);
-                        last_progress_mkv = Instant::now();
-                    }
+                if let Some(ref progress) = progress_fn
+                    && input_duration_us > 0
+                    && pkt.pts != ffi::AV_NOPTS_VALUE
+                    && last_progress_mkv.elapsed() >= throttle_mkv
+                {
+                    let av_time_base = ffi::AVRational {
+                        num: 1,
+                        den: 1_000_000,
+                    };
+                    let pts_us = ffi::av_rescale_q(pkt.pts, (*in_stream).time_base, av_time_base);
+                    let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                    progress(frac);
+                    last_progress_mkv = Instant::now();
                 }
 
                 // Guard against AV_NOPTS_VALUE before rescaling

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -1,6 +1,8 @@
 //! Container remuxing (stream copy, no re-encoding).
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use log::debug;
 
@@ -20,18 +22,27 @@ impl FFmpegRunner {
         input: impl AsRef<Path>,
         output: impl AsRef<Path>,
         opts: &RemuxOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        Self::spawn_blocking("remux", move || Self::remux_sync(&input, &output, &opts)).await
+        Self::spawn_blocking("remux", move || {
+            Self::remux_sync(&input, &output, &opts, progress_fn.as_deref())
+        })
+        .await
     }
 
     /// Remux a single input file synchronously (stream copy).
     ///
     /// Normalizes PTS/DTS timestamps to start at 0 (fixes HLS streams with non-zero start times).
     /// For MKV output, uses raw FFI with proper stream property copying for VLC compatibility.
-    pub(crate) fn remux_sync(input: &Path, output: &Path, opts: &RemuxOptions) -> Result<()> {
+    pub(crate) fn remux_sync(
+        input: &Path,
+        output: &Path,
+        opts: &RemuxOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+    ) -> Result<()> {
         ensure_init()?;
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility.
@@ -40,7 +51,7 @@ impl FFmpegRunner {
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
         if is_mkv {
-            return Self::remux_mkv_raw_ffi(input, output);
+            return Self::remux_mkv_raw_ffi(input, output, progress_fn);
         }
 
         let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
@@ -131,6 +142,11 @@ impl FFmpegRunner {
                 message: format!("failed to write output header: {e}"),
             })?;
 
+        // Read input duration for progress reporting (AV_TIME_BASE microseconds)
+        let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
+        let mut last_progress = Instant::now();
+        let throttle = Duration::from_millis(100);
+
         // Copy packets with PTS normalization (shifts timestamps to start at 0)
         for result in ictx.packets() {
             let (stream, mut packet) =
@@ -143,6 +159,25 @@ impl FFmpegRunner {
                 continue;
             }
             let ost_idx = ost_idx as usize;
+
+            // Report PTS-based progress (throttled to 10 updates/sec)
+            if let Some(ref progress) = progress_fn {
+                if input_duration_us > 0 {
+                    if let Some(pts) = packet.pts() {
+                        if last_progress.elapsed() >= throttle {
+                            let ist_tb = ist_time_bases[ist_index];
+                            let pts_us = pts
+                                * i64::from(ist_tb.numerator())
+                                * 1_000_000
+                                / i64::from(ist_tb.denominator());
+                            let frac =
+                                (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                            progress(frac);
+                            last_progress = Instant::now();
+                        }
+                    }
+                }
+            }
 
             // Apply PTS offset to normalize timestamps to start at 0
             let offset = ist_pts_offsets[ist_index];
@@ -171,6 +206,11 @@ impl FFmpegRunner {
             })?;
         }
 
+        // Emit final 1.0 on completion
+        if let Some(ref progress) = progress_fn {
+            progress(1.0);
+        }
+
         octx.write_trailer()
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to write output trailer: {e}"),
@@ -191,7 +231,11 @@ impl FFmpegRunner {
     /// - `max_interleave_delta=0` — disables delta-based queue flushing (safe
     ///   for remux since packets arrive in muxer order from a single input)
     #[allow(clippy::too_many_lines, clippy::needless_range_loop)]
-    fn remux_mkv_raw_ffi(input: &Path, output: &Path) -> Result<()> {
+    fn remux_mkv_raw_ffi(
+        input: &Path,
+        output: &Path,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+    ) -> Result<()> {
         use ffmpeg_the_third::ffi;
         use std::ffi::CString;
         use std::ptr;
@@ -410,6 +454,10 @@ impl FFmpegRunner {
                 time_base: ffi::AVRational { num: 0, den: 1 },
             };
 
+            let input_duration_us: i64 = (*ifmt_ctx).duration;
+            let mut last_progress_mkv = Instant::now();
+            let throttle_mkv = Duration::from_millis(100);
+
             loop {
                 let ret = ffi::av_read_frame(ifmt_ctx, &mut pkt);
                 if ret < 0 {
@@ -428,6 +476,20 @@ impl FFmpegRunner {
                 // Rescale timestamps
                 let in_stream = *(*ifmt_ctx).streams.add(in_stream_idx);
                 let out_stream = *(*ofmt_ctx).streams.add(out_stream_idx as usize);
+
+                // Report PTS-based progress using AV_TIME_BASE (throttled)
+                if let Some(ref progress) = progress_fn {
+                    if input_duration_us > 0
+                        && pkt.pts != ffi::AV_NOPTS_VALUE
+                        && last_progress_mkv.elapsed() >= throttle_mkv
+                    {
+                        let av_time_base = ffi::AVRational { num: 1, den: 1_000_000 };
+                        let pts_us = ffi::av_rescale_q(pkt.pts, (*in_stream).time_base, av_time_base);
+                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                        progress(frac);
+                        last_progress_mkv = Instant::now();
+                    }
+                }
 
                 // Guard against AV_NOPTS_VALUE before rescaling
                 if pkt.pts != ffi::AV_NOPTS_VALUE {
@@ -462,6 +524,11 @@ impl FFmpegRunner {
                     log::error!("Error writing packet: {ret}");
                     break;
                 }
+            }
+
+            // Emit final 1.0 on completion
+            if let Some(ref progress) = progress_fn {
+                progress(1.0);
             }
 
             // 10. Write trailer and cleanup

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -5,6 +5,8 @@
 //! sample format/rate conversion.
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use log::{debug, info};
 
@@ -27,6 +29,7 @@ impl FFmpegRunner {
         input: impl AsRef<Path>,
         output: impl AsRef<Path>,
         opts: &AudioExtractOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -34,7 +37,8 @@ impl FFmpegRunner {
         Self::spawn_blocking("extract_audio", move || {
             let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, true)?;
 
-            let result = Self::extract_audio_sync(&effective_input, &output, &opts);
+            let result =
+                Self::extract_audio_sync(&effective_input, &output, &opts, progress_fn.as_deref());
 
             if let Some(ref temp) = salvage_temp {
                 let _ = std::fs::remove_file(temp);
@@ -46,18 +50,27 @@ impl FFmpegRunner {
     }
 
     /// Extract audio synchronously (dispatches to copy or transcode).
-    fn extract_audio_sync(input: &Path, output: &Path, opts: &AudioExtractOptions) -> Result<()> {
+    fn extract_audio_sync(
+        input: &Path,
+        output: &Path,
+        opts: &AudioExtractOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+    ) -> Result<()> {
         if opts.copy {
-            Self::extract_audio_copy_sync(input, output)
+            Self::extract_audio_copy_sync(input, output, progress_fn)
         } else {
-            Self::extract_audio_transcode_sync(input, output, opts)
+            Self::extract_audio_transcode_sync(input, output, opts, progress_fn)
         }
     }
 
     /// Extract audio by stream copy (no re-encoding).
     ///
     /// Maps only the best audio stream from input to output without transcoding.
-    fn extract_audio_copy_sync(input: &Path, output: &Path) -> Result<()> {
+    fn extract_audio_copy_sync(
+        input: &Path,
+        output: &Path,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+    ) -> Result<()> {
         ensure_init()?;
 
         let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
@@ -65,6 +78,8 @@ impl FFmpegRunner {
                 message: format!("failed to open input {}: {e}", input.display()),
             }
         })?;
+
+        let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
         let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
             PostProcessError::FFmpegLibraryError {
@@ -110,6 +125,9 @@ impl FFmpegRunner {
                 message: format!("failed to write output header: {e}"),
             })?;
 
+        let mut last_progress = Instant::now();
+        let throttle = Duration::from_millis(100);
+
         // Copy only audio packets
         for result in ictx.packets() {
             let (stream, mut packet) =
@@ -118,6 +136,18 @@ impl FFmpegRunner {
                 })?;
             if stream.index() != ist_index {
                 continue;
+            }
+            // PTS-based progress
+            if let Some(ref progress) = progress_fn {
+                if input_duration_us > 0 && last_progress.elapsed() >= throttle {
+                    if let Some(pts) = packet.pts() {
+                        let pts_us = pts * i64::from(ist_time_base.numerator()) * 1_000_000
+                            / i64::from(ist_time_base.denominator());
+                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                        progress(frac);
+                        last_progress = Instant::now();
+                    }
+                }
             }
             let ost_time_base = octx
                 .stream(0)
@@ -131,6 +161,10 @@ impl FFmpegRunner {
                     message: format!("failed to write packet: {e}"),
                 }
             })?;
+        }
+
+        if let Some(ref progress) = progress_fn {
+            progress(1.0);
         }
 
         octx.write_trailer()
@@ -150,6 +184,7 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         opts: &AudioExtractOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
 
@@ -159,6 +194,8 @@ impl FFmpegRunner {
                 message: format!("failed to open input {}: {e}", input.display()),
             }
         })?;
+
+        let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
         let ist_index = ictx
             .streams()
@@ -339,6 +376,9 @@ impl FFmpegRunner {
             ..Default::default()
         };
 
+        let mut last_progress = Instant::now();
+        let progress_throttle = Duration::from_millis(100);
+
         // Transcode loop: read -> decode -> filter -> encode -> write
         for result in ictx.packets() {
             let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
@@ -346,6 +386,18 @@ impl FFmpegRunner {
             })?;
             if stream.index() != ist_index {
                 continue;
+            }
+            // PTS-based progress
+            if let Some(ref progress) = progress_fn {
+                if input_duration_us > 0 && last_progress.elapsed() >= progress_throttle {
+                    if let Some(pts) = packet.pts() {
+                        let pts_us = pts * i64::from(ist_time_base.numerator()) * 1_000_000
+                            / i64::from(ist_time_base.denominator());
+                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                        progress(frac);
+                        last_progress = Instant::now();
+                    }
+                }
             }
             decoder.send_packet(&packet)?;
             Self::receive_and_process_audio(
@@ -357,6 +409,10 @@ impl FFmpegRunner {
                 enc_time_base,
                 &mut timing,
             )?;
+        }
+        // Emit final 1.0 on completion
+        if let Some(ref progress) = progress_fn {
+            progress(1.0);
         }
 
         // Flush decoder

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -138,16 +138,16 @@ impl FFmpegRunner {
                 continue;
             }
             // PTS-based progress
-            if let Some(ref progress) = progress_fn {
-                if input_duration_us > 0 && last_progress.elapsed() >= throttle {
-                    if let Some(pts) = packet.pts() {
-                        let pts_us = pts * i64::from(ist_time_base.numerator()) * 1_000_000
-                            / i64::from(ist_time_base.denominator());
-                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
-                        progress(frac);
-                        last_progress = Instant::now();
-                    }
-                }
+            if let Some(ref progress) = progress_fn
+                && input_duration_us > 0
+                && last_progress.elapsed() >= throttle
+                && let Some(pts) = packet.pts()
+            {
+                let pts_us = pts * i64::from(ist_time_base.numerator()) * 1_000_000
+                    / i64::from(ist_time_base.denominator());
+                let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                progress(frac);
+                last_progress = Instant::now();
             }
             let ost_time_base = octx
                 .stream(0)
@@ -388,16 +388,16 @@ impl FFmpegRunner {
                 continue;
             }
             // PTS-based progress
-            if let Some(ref progress) = progress_fn {
-                if input_duration_us > 0 && last_progress.elapsed() >= progress_throttle {
-                    if let Some(pts) = packet.pts() {
-                        let pts_us = pts * i64::from(ist_time_base.numerator()) * 1_000_000
-                            / i64::from(ist_time_base.denominator());
-                        let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
-                        progress(frac);
-                        last_progress = Instant::now();
-                    }
-                }
+            if let Some(ref progress) = progress_fn
+                && input_duration_us > 0
+                && last_progress.elapsed() >= progress_throttle
+                && let Some(pts) = packet.pts()
+            {
+                let pts_us = pts * i64::from(ist_time_base.numerator()) * 1_000_000
+                    / i64::from(ist_time_base.denominator());
+                let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                progress(frac);
+                last_progress = Instant::now();
             }
             decoder.send_packet(&packet)?;
             Self::receive_and_process_audio(

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -295,18 +295,17 @@ impl FFmpegRunner {
 
             if ist_index == video_ist_index {
                 // PTS-based progress from video stream
-                if let Some(ref progress) = progress_fn {
-                    if input_duration_us > 0 && last_progress.elapsed() >= progress_throttle {
-                        if let Some(pts) = packet.pts() {
-                            let tb = video_ist_time_base;
-                            let pts_us = pts * i64::from(tb.numerator()) * 1_000_000
-                                / i64::from(tb.denominator());
-                            let frac =
-                                (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
-                            progress(frac);
-                            last_progress = Instant::now();
-                        }
-                    }
+                if let Some(ref progress) = progress_fn
+                    && input_duration_us > 0
+                    && last_progress.elapsed() >= progress_throttle
+                    && let Some(pts) = packet.pts()
+                {
+                    let tb = video_ist_time_base;
+                    let pts_us =
+                        pts * i64::from(tb.numerator()) * 1_000_000 / i64::from(tb.denominator());
+                    let frac = (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                    progress(frac);
+                    last_progress = Instant::now();
                 }
                 // Video: decode -> filter -> encode -> write
                 video_decoder.send_packet(&packet)?;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -5,6 +5,8 @@
 //! encoder packet writing.
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use log::debug;
 
@@ -28,6 +30,7 @@ impl FFmpegRunner {
         input: impl AsRef<Path>,
         output: impl AsRef<Path>,
         opts: &VideoConvertOptions,
+        progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -35,7 +38,8 @@ impl FFmpegRunner {
         Self::spawn_blocking("convert_video", move || {
             let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, true)?;
 
-            let result = Self::convert_video_sync(&effective_input, &output, &opts);
+            let result =
+                Self::convert_video_sync(&effective_input, &output, &opts, progress_fn.as_deref());
 
             if let Some(ref temp) = salvage_temp {
                 let _ = std::fs::remove_file(temp);
@@ -47,7 +51,12 @@ impl FFmpegRunner {
     }
 
     /// Convert video synchronously (dispatches to remux or transcode).
-    fn convert_video_sync(input: &Path, output: &Path, opts: &VideoConvertOptions) -> Result<()> {
+    fn convert_video_sync(
+        input: &Path,
+        output: &Path,
+        opts: &VideoConvertOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+    ) -> Result<()> {
         if opts.remux_only {
             // Determine if output is MP4/MOV for faststart
             let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -55,9 +64,9 @@ impl FFmpegRunner {
                 faststart: ext.eq_ignore_ascii_case("mp4") || ext.eq_ignore_ascii_case("mov"),
                 ..Default::default()
             };
-            Self::remux_sync(input, output, &remux_opts)
+            Self::remux_sync(input, output, &remux_opts, progress_fn)
         } else {
-            Self::convert_video_transcode_sync(input, output, opts)
+            Self::convert_video_transcode_sync(input, output, opts, progress_fn)
         }
     }
 
@@ -71,6 +80,7 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         opts: &VideoConvertOptions,
+        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
 
@@ -80,6 +90,8 @@ impl FFmpegRunner {
                 message: format!("failed to open input {}: {e}", input.display()),
             }
         })?;
+
+        let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
         // Find video and audio stream indices
         let video_ist_index = ictx
@@ -270,6 +282,9 @@ impl FFmpegRunner {
         let mut filter_graph =
             Self::build_video_filter(&video_decoder, &video_encoder, video_ist_time_base)?;
 
+        let mut last_progress = Instant::now();
+        let progress_throttle = Duration::from_millis(100);
+
         // Process packets: video -> decode/filter/encode, audio -> copy
         for result in ictx.packets() {
             let (stream, mut packet) =
@@ -279,6 +294,20 @@ impl FFmpegRunner {
             let ist_index = stream.index();
 
             if ist_index == video_ist_index {
+                // PTS-based progress from video stream
+                if let Some(ref progress) = progress_fn {
+                    if input_duration_us > 0 && last_progress.elapsed() >= progress_throttle {
+                        if let Some(pts) = packet.pts() {
+                            let tb = video_ist_time_base;
+                            let pts_us = pts * i64::from(tb.numerator()) * 1_000_000
+                                / i64::from(tb.denominator());
+                            let frac =
+                                (pts_us as f64 / input_duration_us as f64).clamp(0.0, 1.0);
+                            progress(frac);
+                            last_progress = Instant::now();
+                        }
+                    }
+                }
                 // Video: decode -> filter -> encode -> write
                 video_decoder.send_packet(&packet)?;
                 Self::receive_and_process_video(
@@ -312,6 +341,10 @@ impl FFmpegRunner {
                     })?;
                 }
             }
+        }
+        // Emit final 1.0 on completion
+        if let Some(ref progress) = progress_fn {
+            progress(1.0);
         }
 
         // Flush video decoder

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! // Process files
 //! let files = vec![PathBuf::from("video.mp4")];
-//! let result = registry.process(&info, files, &config).await?;
+//! let result = registry.process(&info, files, &config, None).await?;
 //!
 //! println!("Output: {:?}", result.files);
 //! # Ok(())
@@ -57,8 +57,9 @@
 //!
 //! ```no_run
 //! use async_trait::async_trait;
-//! use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+//! use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 //! use std::path::PathBuf;
+//! use std::sync::Arc;
 //!
 //! struct MyProcessor;
 //!
@@ -73,7 +74,13 @@
 //!         true
 //!     }
 //!
-//!     async fn process(&self, info: &InfoDict, files: Vec<PathBuf>, _config: &PostProcessConfig) -> Result<PostProcessResult> {
+//!     async fn process(
+//!         &self,
+//!         info: &InfoDict,
+//!         files: Vec<PathBuf>,
+//!         _config: &PostProcessConfig,
+//!         _callback: Option<Arc<dyn PostProcessCallback>>,
+//!     ) -> Result<PostProcessResult> {
 //!         // Custom processing logic
 //!         Ok(PostProcessResult::new(info.clone(), files))
 //!     }

--- a/crates/rdlp-postprocess/src/processors/embed_subtitles.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_subtitles.rs
@@ -10,10 +10,11 @@
 //! `{stem}.{lang}.{ext}` where `ext` is one of: srt, vtt, ass, ssa, lrc.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 /// Subtitle file extensions to search for.
 const SUBTITLE_EXTENSIONS: &[&str] = &["srt", "vtt", "ass", "ssa", "lrc"];
@@ -178,6 +179,7 @@ impl PostProcessor for EmbedSubtitles {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        _callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));

--- a/crates/rdlp-postprocess/src/processors/embed_subtitles.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_subtitles.rs
@@ -14,7 +14,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 /// Subtitle file extensions to search for.
 const SUBTITLE_EXTENSIONS: &[&str] = &["srt", "vtt", "ass", "ssa", "lrc"];

--- a/crates/rdlp-postprocess/src/processors/embed_subtitles_tests.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_subtitles_tests.rs
@@ -266,7 +266,10 @@ async fn test_process_no_files_returns_unchanged() {
     let info = InfoDict::new("id", "title", "extractor", "https://example.com");
     let config = PostProcessConfig::default();
 
-    let result = processor.process(&info, vec![], &config).await.unwrap();
+    let result = processor
+        .process(&info, vec![], &config, None)
+        .await
+        .unwrap();
     assert!(result.files.is_empty());
     assert!(result.temp_files.is_empty());
 }
@@ -289,7 +292,7 @@ async fn test_process_unsupported_container() {
     fs::write(&video, b"fake").unwrap();
 
     let result = processor
-        .process(&info, vec![video.clone()], &config)
+        .process(&info, vec![video.clone()], &config, None)
         .await
         .unwrap();
     assert_eq!(result.files, vec![video]);
@@ -314,7 +317,7 @@ async fn test_process_no_subtitle_files() {
     fs::write(&video, b"fake").unwrap();
 
     let result = processor
-        .process(&info, vec![video.clone()], &config)
+        .process(&info, vec![video.clone()], &config, None)
         .await
         .unwrap();
     assert_eq!(result.files, vec![video]);
@@ -342,7 +345,7 @@ async fn test_process_marks_subs_as_temp_when_not_write() {
     fs::write(&sub, b"subtitle").unwrap();
 
     let result = processor
-        .process(&info, vec![video.clone()], &config)
+        .process(&info, vec![video.clone()], &config, None)
         .await
         .unwrap();
     assert_eq!(result.files, vec![video]);
@@ -372,7 +375,7 @@ async fn test_process_keeps_subs_when_write_subtitles() {
     fs::write(&sub, b"subtitle").unwrap();
 
     let result = processor
-        .process(&info, vec![video.clone()], &config)
+        .process(&info, vec![video.clone()], &config, None)
         .await
         .unwrap();
     assert_eq!(result.files, vec![video]);

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -13,10 +13,11 @@
 //! cover art from the `covr` atom, not from `attached_pic` streams.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 use rdlp_ffmpeg::RemuxOptions;
 
 /// Supported thumbnail formats.
@@ -157,6 +158,7 @@ impl PostProcessor for EmbedThumbnail {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        _callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -182,7 +184,7 @@ impl PostProcessor for EmbedThumbnail {
                 faststart: true,
                 ..Default::default()
             };
-            match self.ffmpeg.remux(media_file, &remuxed_path, &opts).await {
+            match self.ffmpeg.remux(media_file, &remuxed_path, &opts, None).await {
                 Ok(()) => {
                     // Track original file as temp for cleanup
                     temp_files.push(media_file.clone());

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 use rdlp_ffmpeg::RemuxOptions;
 
 /// Supported thumbnail formats.
@@ -184,7 +186,11 @@ impl PostProcessor for EmbedThumbnail {
                 faststart: true,
                 ..Default::default()
             };
-            match self.ffmpeg.remux(media_file, &remuxed_path, &opts, None).await {
+            match self
+                .ffmpeg
+                .remux(media_file, &remuxed_path, &opts, None)
+                .await
+            {
                 Ok(()) => {
                     // Track original file as temp for cleanup
                     temp_files.push(media_file.clone());

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -5,10 +5,11 @@
 //! Supports various output formats including MP3, AAC, Opus, FLAC, etc.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::PostProcessError;
 use rdlp_ffmpeg::ffmpeg::{AudioCodecConfig, AudioExtractOptions, get_audio_codec};
@@ -84,6 +85,7 @@ impl PostProcessor for FFmpegExtractAudio {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -135,8 +137,12 @@ impl PostProcessor for FFmpegExtractAudio {
             Self::build_extract_options(codec_config, can_copy, config.audio_quality.as_deref());
 
         // Extract audio via library bindings
+        let progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac| cb.on_progress(frac))
+            });
         self.ffmpeg
-            .extract_audio(input_file, &output_path, &opts)
+            .extract_audio(input_file, &output_path, &opts, progress_fn)
             .await?;
 
         info!(output:? = output_path.display(); "Audio extracted");

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_extract_audio.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 use rdlp_ffmpeg::PostProcessError;
 use rdlp_ffmpeg::ffmpeg::{AudioCodecConfig, AudioExtractOptions, get_audio_codec};

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -6,10 +6,11 @@
 //! video and audio separately (like HLS/DASH streams).
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::RemuxOptions;
 
@@ -77,6 +78,7 @@ impl PostProcessor for FFmpegMerger {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.len() < 2 {
             // Nothing to merge
@@ -127,8 +129,12 @@ impl PostProcessor for FFmpegMerger {
             faststart: matches!(output_format, "mp4" | "mov"),
             ..Default::default()
         };
+        let progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac| cb.on_progress(frac))
+            });
         self.ffmpeg
-            .merge(video_file, audio_file, &output_path, &opts)
+            .merge(video_file, audio_file, &output_path, &opts, progress_fn)
             .await?;
 
         debug!(output:? = output_path.display(); "Merged output");

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 use rdlp_ffmpeg::RemuxOptions;
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -6,10 +6,11 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::ChapterEntry;
 
@@ -134,6 +135,7 @@ impl PostProcessor for FFmpegMetadata {
         info: &InfoDict,
         files: Vec<PathBuf>,
         _config: &PostProcessConfig,
+        _callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 use rdlp_ffmpeg::ChapterEntry;
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 use rdlp_ffmpeg::{AudioNormMode, LoudnormPreset, NormalizeOptions, PostProcessError};
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_normalize_audio.rs
@@ -5,10 +5,11 @@
 //! Video streams are copied without re-encoding.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::{AudioNormMode, LoudnormPreset, NormalizeOptions, PostProcessError};
 
@@ -79,6 +80,7 @@ impl PostProcessor for FFmpegNormalizeAudio {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -120,8 +122,12 @@ impl PostProcessor for FFmpegNormalizeAudio {
             .unwrap_or("output");
         let output_path = input_file.with_file_name(format!("{stem}.norm.{ext}"));
 
+        let progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac| cb.on_progress(frac))
+            });
         self.ffmpeg
-            .normalize_audio(input_file, &output_path, &opts)
+            .normalize_audio(input_file, &output_path, &opts, progress_fn)
             .await?;
 
         info!("Audio normalization complete: {}", output_path.display());

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 use rdlp_ffmpeg::RemuxOptions;
 

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_remuxer.rs
@@ -5,10 +5,11 @@
 //! a centralized index.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::RemuxOptions;
 
@@ -57,6 +58,7 @@ impl PostProcessor for FFmpegRemuxer {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -106,7 +108,13 @@ impl PostProcessor for FFmpegRemuxer {
         };
 
         // Perform remux via library bindings
-        self.ffmpeg.remux(input_file, &output_path, &opts).await?;
+        let progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac| cb.on_progress(frac))
+            });
+        self.ffmpeg
+            .remux(input_file, &output_path, &opts, progress_fn)
+            .await?;
 
         debug!(
             output:? = output_path.display();

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -4,10 +4,11 @@
 //! containers using `ffmpeg-the-third` library bindings (no CLI process spawning).
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
 
 use rdlp_ffmpeg::PostProcessError;
 use rdlp_ffmpeg::VideoConvertOptions;
@@ -164,6 +165,7 @@ impl PostProcessor for FFmpegVideoConvertor {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -226,8 +228,12 @@ impl PostProcessor for FFmpegVideoConvertor {
         let opts = Self::build_convert_options(target_format, can_remux);
 
         // Convert via library bindings
+        let progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>> =
+            callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+                Arc::new(move |frac| cb.on_progress(frac))
+            });
         self.ffmpeg
-            .convert_video(input_file, &output_path, &opts)
+            .convert_video(input_file, &output_path, &opts, progress_fn)
             .await?;
 
         info!(output:? = output_path.display(); "Converted");

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result};
+use rdlp_core::{
+    InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
+};
 
 use rdlp_ffmpeg::PostProcessError;
 use rdlp_ffmpeg::VideoConvertOptions;

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -27,7 +27,7 @@
 //! let config = PostProcessConfig::default();
 //! let files = vec![PathBuf::from("video.mp4")];
 //!
-//! let result = registry.process(&info, files, &config).await?;
+//! let result = registry.process(&info, files, &config, None).await?;
 //! println!("Output files: {:?}", result.files);
 //! # Ok(())
 //! # }
@@ -38,7 +38,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, trace, warn};
-use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor};
+use rdlp_core::{
+    InfoDict, PostProcessCallbackFactory, PostProcessConfig, PostProcessResult, PostProcessor,
+};
 
 use crate::processors::*;
 use rdlp_ffmpeg::error::Result;
@@ -49,14 +51,16 @@ use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 pub trait PostProcessorRegistryTrait: Send + Sync {
     /// Process files through all applicable post-processors.
     ///
-    /// The `callback` is called by each processor with progress in `[0.0, 1.0]`.
-    /// It is reset per-processor (each starts at 0.0 and completes at 1.0).
+    /// The `callback_factory` is called once per processor stage with the
+    /// processor name, returning a fresh `PostProcessCallback` for that stage.
+    /// Each stage callback receives progress in `[0.0, 1.0]`, starting at 0.0
+    /// and reaching 1.0 when the stage completes.
     async fn process(
         &self,
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
-        callback: Option<Arc<dyn PostProcessCallback>>,
+        callback_factory: Option<PostProcessCallbackFactory>,
     ) -> anyhow::Result<PostProcessResult>;
 
     /// Remux a file with faststart enabled (stream copy, no re-encoding).
@@ -168,7 +172,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
-        callback: Option<Arc<dyn PostProcessCallback>>,
+        callback_factory: Option<PostProcessCallbackFactory>,
     ) -> anyhow::Result<PostProcessResult> {
         let mut current_info = info.clone();
         let mut current_files = files;
@@ -184,8 +188,13 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
 
             info!(name:? = processor.name(); "Running post-processor");
 
+            // Create a per-stage callback from the factory, if provided.
+            let stage_callback = callback_factory
+                .as_ref()
+                .map(|factory| factory(processor.name()));
+
             match processor
-                .process(&current_info, current_files.clone(), config, callback.clone())
+                .process(&current_info, current_files.clone(), config, stage_callback)
                 .await
             {
                 Ok(result) => {

--- a/crates/rdlp-postprocess/src/registry.rs
+++ b/crates/rdlp-postprocess/src/registry.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, info, trace, warn};
-use rdlp_core::{InfoDict, PostProcessConfig, PostProcessResult, PostProcessor};
+use rdlp_core::{InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor};
 
 use crate::processors::*;
 use rdlp_ffmpeg::error::Result;
@@ -48,11 +48,15 @@ use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 #[async_trait]
 pub trait PostProcessorRegistryTrait: Send + Sync {
     /// Process files through all applicable post-processors.
+    ///
+    /// The `callback` is called by each processor with progress in `[0.0, 1.0]`.
+    /// It is reset per-processor (each starts at 0.0 and completes at 1.0).
     async fn process(
         &self,
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> anyhow::Result<PostProcessResult>;
 
     /// Remux a file with faststart enabled (stream copy, no re-encoding).
@@ -164,6 +168,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> anyhow::Result<PostProcessResult> {
         let mut current_info = info.clone();
         let mut current_files = files;
@@ -180,7 +185,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
             info!(name:? = processor.name(); "Running post-processor");
 
             match processor
-                .process(&current_info, current_files.clone(), config)
+                .process(&current_info, current_files.clone(), config, callback.clone())
                 .await
             {
                 Ok(result) => {
@@ -230,7 +235,7 @@ impl PostProcessorRegistryTrait for PostProcessorRegistry {
             faststart: true,
             ..Default::default()
         };
-        self.ffmpeg.remux(input, output, &opts).await?;
+        self.ffmpeg.remux(input, output, &opts, None).await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Add real-time progress reporting (0.0–1.0) from FFmpeg post-processing stages across 6 crates
- Desktop GUI shows "Remuxing… 45%" in JobCard status; CLI shows a determinate progress bar replacing the old spinner
- PTS-based progress for remux/transcode/normalize/extract, byte-based for merge, two-pass split for loudnorm (0.0–0.5 / 0.5–1.0)

Closes #96

## Changes

### rdlp-core
- `PostProcessCallback` trait with `fn on_progress(&self, progress: f64)` for sync 0.0–1.0 reporting
- `PostProcessCallbackFactory` type alias for per-processor callback creation

### rdlp-api
- `Event::PostProcessProgress { id, stage, progress }` variant
- `PostProcessBridge` struct forwarding callbacks to events via `mpsc::try_send()`
- `make_callback_factory()` wired into orchestrator's `run_postprocessing()`

### rdlp-ffmpeg
- `progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>` added to remux, merge, normalize, extract_audio, video_convert
- 100ms throttling via `Instant::elapsed()` to prevent callback flood
- Two-pass split: loudnorm maps pass 1 → 0.0–0.5, pass 2 → 0.5–1.0

### rdlp-postprocess
- All 8 processors updated to accept `Option<Arc<dyn PostProcessCallback>>`
- Registry accepts `Option<PostProcessCallbackFactory>`, creates per-stage callbacks

### rdlp-desktop
- `PostProcessProgressPayload` struct + `"postprocess-progress"` Tauri event
- TypeScript `PostProcessProgressPayload` interface + `onPostProcessProgress()` listener
- `registerDownloadEvents.ts` updates `statusMessage` to `"${stage}… ${pct}%"`

### rdlp-cli
- Determinate `ProgressBar::new(1000)` with `{percent}%` replaces post-processing spinner

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 1,259 tests pass
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [x] `npm run test` — 281 Vitest tests pass