### PR TITLE
feat(extractor): add PornHub search support

### DIFF
--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -307,9 +307,10 @@ impl HttpDownloader {
                     };
 
                     let download_fut = async move {
-                        let _permit = sem.acquire_owned().await.map_err(|_| {
-                            RdlpError::Download("Semaphore closed".to_string())
-                        })?;
+                        let _permit = sem
+                            .acquire_owned()
+                            .await
+                            .map_err(|_| RdlpError::Download("Semaphore closed".to_string()))?;
                         let start_time = Instant::now();
                         let abs_start = byte_offset + chunk.start;
                         // end is exclusive in ChunkRequest, but HTTP Range is inclusive
@@ -327,8 +328,7 @@ impl HttpDownloader {
 
                         match &result {
                             Ok(bytes) => {
-                                ctrl_report
-                                    .report_chunk_complete(*bytes, start_time.elapsed());
+                                ctrl_report.report_chunk_complete(*bytes, start_time.elapsed());
                             }
                             Err(e) => {
                                 error!("Adaptive chunk {chunk_id} failed: {e}");

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -11,7 +11,7 @@ use super::patterns::{
     QUALITY_ITEMS_PATTERN,
 };
 use crate::base::common::BaseExtractor;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Extend `dest` with `formats`, skipping URLs already in `seen`.
 fn extend_deduped(dest: &mut Vec<Format>, seen: &mut HashSet<String>, formats: Vec<Format>) {
@@ -58,6 +58,18 @@ pub async fn extract_all_formats(webpage: &str, ctx: &ExtractionContext) -> Resu
         return Err(RdlpError::Extraction(
             "No video formats found with any strategy".to_string(),
         ));
+    }
+
+    // Ensure format_ids are unique — two different CDN URLs at the same quality
+    // (e.g., both "1080p") would cause the desktop UI to highlight both rows on
+    // single selection. Append "-2", "-3", etc. for duplicates.
+    let mut id_counts: HashMap<String, u32> = HashMap::new();
+    for format in &mut all_formats {
+        let count = id_counts.entry(format.format_id.clone()).or_insert(0);
+        *count += 1;
+        if *count > 1 {
+            format.format_id = format!("{}-{}", format.format_id, count);
+        }
     }
 
     debug!(count = all_formats.len(); "[PornHub] Total unique formats");
@@ -307,5 +319,32 @@ mod tests {
         assert_eq!(format.height, Some(1080));
         assert_eq!(format.width, Some(1920));
         assert_eq!(format.vcodec, Some("h264".to_string()));
+    }
+
+    #[test]
+    fn test_duplicate_format_ids_get_suffixed() {
+        let mut formats = vec![
+            build_format("https://cdn1.example.com/1080.mp4", Some(1080), 0),
+            build_format("https://cdn2.example.com/1080.mp4", Some(1080), 1),
+            build_format("https://cdn1.example.com/720.mp4", Some(720), 2),
+            build_format("https://cdn2.example.com/720.mp4", Some(720), 3),
+            build_format("https://cdn3.example.com/720.mp4", Some(720), 4),
+        ];
+
+        // Simulate the dedup logic from extract_all_formats
+        let mut id_counts: HashMap<String, u32> = HashMap::new();
+        for format in &mut formats {
+            let count = id_counts.entry(format.format_id.clone()).or_insert(0);
+            *count += 1;
+            if *count > 1 {
+                format.format_id = format!("{}-{}", format.format_id, count);
+            }
+        }
+
+        assert_eq!(formats[0].format_id, "1080p");
+        assert_eq!(formats[1].format_id, "1080p-2");
+        assert_eq!(formats[2].format_id, "720p");
+        assert_eq!(formats[3].format_id, "720p-2");
+        assert_eq!(formats[4].format_id, "720p-3");
     }
 }

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -60,21 +60,26 @@ pub async fn extract_all_formats(webpage: &str, ctx: &ExtractionContext) -> Resu
         ));
     }
 
-    // Ensure format_ids are unique — two different CDN URLs at the same quality
-    // (e.g., both "1080p") would cause the desktop UI to highlight both rows on
-    // single selection. Append "-2", "-3", etc. for duplicates.
+    dedup_format_ids(&mut all_formats);
+
+    debug!(count = all_formats.len(); "[PornHub] Total unique formats");
+
+    Ok(all_formats)
+}
+
+/// Ensure format_ids are unique by appending "-2", "-3", etc. for duplicates.
+///
+/// Two different CDN URLs at the same quality (e.g., both "1080p") would cause
+/// the desktop UI to highlight both rows on single selection.
+fn dedup_format_ids(formats: &mut [Format]) {
     let mut id_counts: HashMap<String, u32> = HashMap::new();
-    for format in &mut all_formats {
+    for format in formats.iter_mut() {
         let count = id_counts.entry(format.format_id.clone()).or_insert(0);
         *count += 1;
         if *count > 1 {
             format.format_id = format!("{}-{}", format.format_id, count);
         }
     }
-
-    debug!(count = all_formats.len(); "[PornHub] Total unique formats");
-
-    Ok(all_formats)
 }
 
 /// Extract formats from flashvars JavaScript object
@@ -331,15 +336,7 @@ mod tests {
             build_format("https://cdn3.example.com/720.mp4", Some(720), 4),
         ];
 
-        // Simulate the dedup logic from extract_all_formats
-        let mut id_counts: HashMap<String, u32> = HashMap::new();
-        for format in &mut formats {
-            let count = id_counts.entry(format.format_id.clone()).or_insert(0);
-            *count += 1;
-            if *count > 1 {
-                format.format_id = format!("{}-{}", format.format_id, count);
-            }
-        }
+        dedup_format_ids(&mut formats);
 
         assert_eq!(formats[0].format_id, "1080p");
         assert_eq!(formats[1].format_id, "1080p-2");

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -20,6 +20,7 @@
 mod formats;
 mod patterns;
 mod playlist;
+mod search_patterns;
 mod utils;
 
 use async_trait::async_trait;

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -8,6 +8,8 @@
 //! - `patterns` - URL patterns and regex definitions
 //! - `formats` - Format extraction from various sources
 //! - `playlist` - Playlist pagination and extraction
+//! - `search` - Search result parsing and filter validation
+//! - `search_patterns` - URL builders and constants for search API
 //! - `utils` - Helper functions for parsing and validation
 //!
 //! # Supported URLs
@@ -34,7 +36,7 @@ use rdlp_core::{
 };
 use scraper::Html;
 
-use crate::base::common::BaseExtractor;
+use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
 use crate::hls::detect_format_sizes;
 
 pub use patterns::{PORNHUB_PLAYLIST_URL_PATTERN, PORNHUB_VIDEO_URL_PATTERN};
@@ -42,8 +44,9 @@ pub use patterns::{PORNHUB_PLAYLIST_URL_PATTERN, PORNHUB_VIDEO_URL_PATTERN};
 /// Rate limit between search page fetches (milliseconds).
 const SEARCH_RATE_LIMIT_MS: u64 = 500;
 
-/// Maximum number of results to collect across all pages.
-const MAX_PLAYLIST_SIZE: usize = 4000;
+/// Expected number of results per API page. Used to detect the last page:
+/// if a page returns fewer than this, there are no more pages.
+const API_RESULTS_PER_PAGE: usize = 20;
 
 /// PornHub extractor
 ///
@@ -107,19 +110,22 @@ impl PornHubExtractor {
 
     /// Fetch a single HTML search page (fallback).
     ///
-    /// Returns an empty vec — the API is the primary source. A full HTML parser
-    /// can be added later if the API becomes unreliable.
+    /// HTML parsing is not yet implemented — returns an error so callers
+    /// propagate the original API failure instead of silently returning
+    /// empty results. A full HTML parser can be added later if the API
+    /// becomes unreliable.
     ///
     /// # Arguments
-    /// * `url` - HTML search URL.
-    /// * `ctx` - Extraction context.
+    /// * `_url` - HTML search URL (unused until HTML parsing is implemented).
+    /// * `_ctx` - Extraction context (unused until HTML parsing is implemented).
     async fn fetch_html_search_page(
         &self,
-        url: &str,
-        ctx: &ExtractionContext,
+        _url: &str,
+        _ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let _webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
-        Ok(Vec::new())
+        Err(RdlpError::Extraction(
+            "PornHub HTML search fallback not yet implemented".to_string(),
+        ))
     }
 
     /// Paginated search across all pages, collecting up to `max_results` results.
@@ -150,7 +156,7 @@ impl PornHubExtractor {
                 search_patterns::build_api_search_url_page(&base_url, page)
             };
 
-            debug!(page; "[PornHub] Fetching search page");
+            debug!(page, url:? = rdlp_security::sanitize_for_logging(&page_url); "[PornHub] Fetching search page");
 
             let page_results = match self.fetch_api_search_page(&page_url, ctx).await {
                 Ok(results) => results,
@@ -247,7 +253,7 @@ impl SearchExtractor for PornHubExtractor {
             }
         };
 
-        let has_more = !page_results.is_empty();
+        let has_more = !page_results.is_empty() && page_results.len() >= API_RESULTS_PER_PAGE;
 
         Ok(SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -90,12 +90,10 @@ impl PornHubExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let response = ctx
-            .http_client
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| RdlpError::Network(format!("Failed to fetch PornHub search API: {e}")))?;
+        let response =
+            ctx.http_client.get(url).send().await.map_err(|e| {
+                RdlpError::Network(format!("Failed to fetch PornHub search API: {e}"))
+            })?;
 
         rdlp_core::check_http_response(&response)?;
 
@@ -159,8 +157,7 @@ impl PornHubExtractor {
                 Err(e) => {
                     if page == 1 {
                         debug!("[PornHub] API search failed, trying HTML fallback: {e}");
-                        let html_url =
-                            search_patterns::build_html_search_url(&query.query, 1);
+                        let html_url = search_patterns::build_html_search_url(&query.query, 1);
                         match self.fetch_html_search_page(&html_url, ctx).await {
                             Ok(results) => results,
                             Err(html_err) => {

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -20,17 +20,30 @@
 mod formats;
 mod patterns;
 mod playlist;
+mod search;
 mod search_patterns;
 mod utils;
 
+use std::time::Duration;
+
 use async_trait::async_trait;
-use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result};
+use log::{debug, warn};
+use rdlp_core::{
+    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
+    SearchPageResponse, SearchQuery, SearchResultPreview,
+};
 use scraper::Html;
 
 use crate::base::common::BaseExtractor;
 use crate::hls::detect_format_sizes;
 
 pub use patterns::{PORNHUB_PLAYLIST_URL_PATTERN, PORNHUB_VIDEO_URL_PATTERN};
+
+/// Rate limit between search page fetches (milliseconds).
+const SEARCH_RATE_LIMIT_MS: u64 = 500;
+
+/// Maximum number of results to collect across all pages.
+const MAX_PLAYLIST_SIZE: usize = 4000;
 
 /// PornHub extractor
 ///
@@ -60,6 +73,191 @@ impl PornHubExtractor {
 impl Default for PornHubExtractor {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl PornHubExtractor {
+    /// Fetch and parse a single API search page.
+    ///
+    /// # Arguments
+    /// * `url` - Full API search URL for this page.
+    /// * `ctx` - Extraction context with HTTP client.
+    ///
+    /// # Returns
+    /// Parsed `SearchResultPreview` items for this page.
+    async fn fetch_api_search_page(
+        &self,
+        url: &str,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        let response = ctx
+            .http_client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| RdlpError::Network(format!("Failed to fetch PornHub search API: {e}")))?;
+
+        rdlp_core::check_http_response(&response)?;
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| RdlpError::Network(format!("Failed to read PornHub API response: {e}")))?;
+
+        search::parse_api_search_results(&body)
+    }
+
+    /// Fetch a single HTML search page (fallback).
+    ///
+    /// Returns an empty vec — the API is the primary source. A full HTML parser
+    /// can be added later if the API becomes unreliable.
+    ///
+    /// # Arguments
+    /// * `url` - HTML search URL.
+    /// * `ctx` - Extraction context.
+    async fn fetch_html_search_page(
+        &self,
+        url: &str,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        let _webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
+        Ok(Vec::new())
+    }
+
+    /// Paginated search across all pages, collecting up to `max_results` results.
+    ///
+    /// Uses the JSON API as the primary source with a 500ms rate limit between pages.
+    /// Falls back to the HTML search page on page 1 API failures.
+    ///
+    /// # Arguments
+    /// * `query` - Search query with optional filters and result cap.
+    /// * `ctx` - Extraction context with HTTP client.
+    async fn search_all_pages(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        search::validate_search_filters(&query.filters)?;
+
+        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
+        let mut all_results = Vec::new();
+        let mut page = 1_u32;
+
+        let base_url = search_patterns::build_api_search_url(&query.query, &query.filters);
+
+        loop {
+            let page_url = if page == 1 {
+                base_url.clone()
+            } else {
+                search_patterns::build_api_search_url_page(&base_url, page)
+            };
+
+            debug!(page; "[PornHub] Fetching search page");
+
+            let page_results = match self.fetch_api_search_page(&page_url, ctx).await {
+                Ok(results) => results,
+                Err(e) => {
+                    if page == 1 {
+                        debug!("[PornHub] API search failed, trying HTML fallback: {e}");
+                        let html_url =
+                            search_patterns::build_html_search_url(&query.query, 1);
+                        match self.fetch_html_search_page(&html_url, ctx).await {
+                            Ok(results) => results,
+                            Err(html_err) => {
+                                warn!("[PornHub] HTML fallback also failed: {html_err}");
+                                break;
+                            }
+                        }
+                    } else {
+                        debug!(
+                            page;
+                            "[PornHub] Failed to fetch search page, returning partial results: {e}"
+                        );
+                        break;
+                    }
+                }
+            };
+
+            if page_results.is_empty() {
+                debug!(page; "[PornHub] No results on page, stopping pagination");
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(SEARCH_RATE_LIMIT_MS)).await;
+        }
+
+        debug!(
+            count = all_results.len(), pages = page;
+            "[PornHub] Search complete"
+        );
+
+        Ok(all_results)
+    }
+}
+
+#[async_trait]
+impl SearchExtractor for PornHubExtractor {
+    fn name(&self) -> &str {
+        "PornHub"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_core::SearchFilterDescriptor> {
+        search_patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        search::validate_search_filters(&query.filters)?;
+
+        let page = query.page.unwrap_or(1);
+        let base_url = search_patterns::build_api_search_url(&query.query, &query.filters);
+
+        let page_url = if page == 1 {
+            base_url
+        } else {
+            search_patterns::build_api_search_url_page(&base_url, page)
+        };
+
+        let page_results = match self.fetch_api_search_page(&page_url, ctx).await {
+            Ok(results) => results,
+            Err(e) => {
+                if page == 1 {
+                    debug!("[PornHub] API search failed, trying HTML fallback: {e}");
+                    let html_url = search_patterns::build_html_search_url(&query.query, 1);
+                    self.fetch_html_search_page(&html_url, ctx).await?
+                } else {
+                    return Err(e);
+                }
+            }
+        };
+
+        let has_more = !page_results.is_empty();
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page,
+            has_more,
+            total_estimate: None,
+        })
     }
 }
 
@@ -130,10 +328,12 @@ impl InfoExtractor for PornHubExtractor {
         }
 
         // Detect file sizes and segment counts
-        let (formats_with_size, hls_flags) = detect_format_sizes(formats, ctx, self.name()).await;
+        let extractor_name = InfoExtractor::name(self);
+        let (formats_with_size, hls_flags) =
+            detect_format_sizes(formats, ctx, extractor_name).await;
 
         // Build InfoDict with all metadata
-        let mut info = InfoDict::new(video_id, title, self.name(), url);
+        let mut info = InfoDict::new(video_id, title, extractor_name, url);
         info.description = description;
         info.thumbnail = thumbnail;
         info.uploader = uploader;
@@ -179,7 +379,7 @@ mod tests {
     #[test]
     fn test_extractor_creation() {
         let extractor = PornHubExtractor::new();
-        assert_eq!(extractor.name(), "PornHub");
+        assert_eq!(InfoExtractor::name(&extractor), "PornHub");
     }
 
     #[test]
@@ -196,5 +396,47 @@ mod tests {
 
         // Invalid URLs
         assert!(!extractor.suitable("https://youtube.com/watch?v=test"));
+    }
+
+    #[test]
+    fn test_pornhub_implements_search_extractor() {
+        let extractor = PornHubExtractor::new();
+        let filters =
+            <PornHubExtractor as rdlp_core::SearchExtractor>::supported_filters(&extractor);
+        assert!(!filters.is_empty());
+        assert_eq!(
+            <PornHubExtractor as rdlp_core::SearchExtractor>::name(&extractor),
+            "PornHub"
+        );
+    }
+
+    #[test]
+    fn test_search_filters_have_ordering() {
+        let extractor = PornHubExtractor::new();
+        let filters =
+            <PornHubExtractor as rdlp_core::SearchExtractor>::supported_filters(&extractor);
+        let ordering = filters.iter().find(|f| f.key == "ordering");
+        assert!(ordering.is_some());
+        assert_eq!(ordering.unwrap().allowed_values.len(), 4);
+    }
+
+    #[test]
+    fn test_search_filters_have_period() {
+        let extractor = PornHubExtractor::new();
+        let filters =
+            <PornHubExtractor as rdlp_core::SearchExtractor>::supported_filters(&extractor);
+        let period = filters.iter().find(|f| f.key == "period");
+        assert!(period.is_some());
+        assert_eq!(period.unwrap().allowed_values.len(), 3);
+    }
+
+    #[test]
+    fn test_search_filters_have_category() {
+        let extractor = PornHubExtractor::new();
+        let filters =
+            <PornHubExtractor as rdlp_core::SearchExtractor>::supported_filters(&extractor);
+        let category = filters.iter().find(|f| f.key == "category");
+        assert!(category.is_some());
+        assert!(!category.unwrap().allowed_values.is_empty());
     }
 }

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -91,9 +91,8 @@ pub(crate) struct ApiCategory {
 /// # Returns
 /// A vector of search result previews.
 pub(crate) fn parse_api_search_results(json: &str) -> Result<Vec<SearchResultPreview>> {
-    let response: ApiSearchResponse = serde_json::from_str(json).map_err(|e| {
-        RdlpError::Extraction(format!("Failed to parse PornHub API response: {e}"))
-    })?;
+    let response: ApiSearchResponse = serde_json::from_str(json)
+        .map_err(|e| RdlpError::Extraction(format!("Failed to parse PornHub API response: {e}")))?;
 
     let results: Vec<SearchResultPreview> = response
         .videos
@@ -191,8 +190,11 @@ pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
 
                 let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
                 if !valid {
-                    let allowed: Vec<&str> =
-                        desc.allowed_values.iter().map(|v| v.value.as_str()).collect();
+                    let allowed: Vec<&str> = desc
+                        .allowed_values
+                        .iter()
+                        .map(|v| v.value.as_str())
+                        .collect();
                     return Err(RdlpError::Extraction(format!(
                         "Invalid value '{}' for filter '{}'. Allowed: {}",
                         filter.value,

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -1,0 +1,430 @@
+//! PornHub search result parsing and filter validation.
+//!
+//! Provides serde structs for the PornHub Webmaster JSON API response,
+//! conversion to `SearchResultPreview`, and filter validation.
+
+use log::debug;
+use rdlp_core::{RdlpError, Result, SearchFilter, SearchFilterDescriptor, SearchResultPreview};
+use serde::Deserialize;
+
+use super::search_patterns;
+
+/// Top-level API response from `pornhub.com/webmasters/search`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiSearchResponse {
+    /// List of video objects. May be absent when no results found.
+    #[serde(default)]
+    pub videos: Vec<ApiVideo>,
+}
+
+/// A single video entry from the API.
+///
+/// Unlike RedTube, PornHub's API returns videos directly (not wrapped in
+/// `{ "video": {...} }`).
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiVideo {
+    /// Video ID (e.g. "ph5a1..." or numeric string).
+    pub video_id: String,
+    /// Video title.
+    pub title: String,
+    /// Full URL to the video page.
+    pub url: String,
+    /// Thumbnail URL.
+    #[serde(default)]
+    pub thumb: Option<String>,
+    /// Fallback thumbnail URL.
+    #[serde(default)]
+    pub default_thumb: Option<String>,
+    /// Duration string in "MM:SS" or "H:MM:SS" format.
+    #[serde(default)]
+    pub duration: Option<String>,
+    /// View count as a number.
+    #[serde(default)]
+    pub views: Option<u64>,
+    /// Rating percentage (0.0 - 100.0).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub rating: Option<f64>,
+    /// Publication date string.
+    #[serde(default)]
+    pub publish_date: Option<String>,
+    /// Tag list.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub tags: Vec<ApiTag>,
+    /// Pornstar list.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub pornstars: Vec<ApiPornstar>,
+    /// Category list.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub categories: Vec<ApiCategory>,
+}
+
+/// A single tag entry.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiTag {
+    #[allow(dead_code)]
+    pub tag_name: String,
+}
+
+/// A single pornstar entry.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiPornstar {
+    #[allow(dead_code)]
+    pub pornstar_name: String,
+}
+
+/// A single category entry.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiCategory {
+    #[allow(dead_code)]
+    pub category: String,
+}
+
+/// Parse the JSON API response into `SearchResultPreview` items.
+///
+/// # Arguments
+/// * `json` - Raw JSON response body from the API.
+///
+/// # Returns
+/// A vector of search result previews.
+pub(crate) fn parse_api_search_results(json: &str) -> Result<Vec<SearchResultPreview>> {
+    let response: ApiSearchResponse = serde_json::from_str(json).map_err(|e| {
+        RdlpError::Extraction(format!("Failed to parse PornHub API response: {e}"))
+    })?;
+
+    let results: Vec<SearchResultPreview> = response
+        .videos
+        .into_iter()
+        .filter_map(api_video_to_preview)
+        .collect();
+
+    Ok(results)
+}
+
+/// Convert an `ApiVideo` into a `SearchResultPreview`.
+///
+/// Returns `None` if the URL is empty (skips invalid entries).
+fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
+    if video.url.is_empty() {
+        debug!(
+            "[PornHub] Search result missing URL for video_id={}, skipping",
+            video.video_id
+        );
+        return None;
+    }
+
+    let duration = video
+        .duration
+        .as_deref()
+        .and_then(parse_duration_string)
+        .map(|s| s as f64);
+
+    let thumbnail = video.thumb.or(video.default_thumb);
+
+    Some(SearchResultPreview {
+        video_url: video.url,
+        title: video.title,
+        thumbnail_url: thumbnail,
+        duration,
+        view_count: video.views,
+        upload_date: video.publish_date,
+    })
+}
+
+/// Parse a duration string like "12:34" or "1:02:34" into total seconds.
+///
+/// # Examples
+/// - "12:34" → 754
+/// - "1:02:34" → 3754
+/// - "0:45" → 45
+/// - "" → None
+pub(crate) fn parse_duration_string(duration: &str) -> Option<u64> {
+    let parts: Vec<&str> = duration.split(':').collect();
+    match parts.len() {
+        2 => {
+            let minutes = parts[0].parse::<u64>().ok()?;
+            let seconds = parts[1].parse::<u64>().ok()?;
+            Some(minutes * 60 + seconds)
+        }
+        3 => {
+            let hours = parts[0].parse::<u64>().ok()?;
+            let minutes = parts[1].parse::<u64>().ok()?;
+            let seconds = parts[2].parse::<u64>().ok()?;
+            Some(hours * 3600 + minutes * 60 + seconds)
+        }
+        _ => None,
+    }
+}
+
+/// Validate search filters against PornHub's known filter descriptors.
+///
+/// Returns `Ok(())` if all filters are valid, or an error for the first invalid one.
+///
+/// # Arguments
+/// * `filters` - Slice of active search filters to validate.
+///
+/// # Returns
+/// `Ok(())` on success, `Err` describing the first invalid filter.
+pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
+    let descriptors: Vec<SearchFilterDescriptor> = search_patterns::search_filter_descriptors();
+
+    for filter in filters {
+        let descriptor = descriptors.iter().find(|d| d.key == filter.key);
+
+        match descriptor {
+            None => {
+                let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
+                return Err(RdlpError::Extraction(format!(
+                    "Unknown filter '{}' for PornHub. Available: {}",
+                    filter.key,
+                    valid_keys.join(", ")
+                )));
+            }
+            Some(desc) => {
+                // category and tags accept free-text — API validates server-side
+                if filter.key == "category" || filter.key == "tags" {
+                    continue;
+                }
+
+                let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
+                if !valid {
+                    let allowed: Vec<&str> =
+                        desc.allowed_values.iter().map(|v| v.value.as_str()).collect();
+                    return Err(RdlpError::Extraction(format!(
+                        "Invalid value '{}' for filter '{}'. Allowed: {}",
+                        filter.value,
+                        filter.key,
+                        allowed.join(", ")
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_api_response() -> &'static str {
+        r#"{
+            "videos": [
+                {
+                    "video_id": "ph5a1b2c3d",
+                    "title": "Test Video One",
+                    "url": "https://www.pornhub.com/view_video.php?viewkey=ph5a1b2c3d",
+                    "thumb": "https://ci.phncdn.com/thumb1.jpg",
+                    "default_thumb": "https://ci.phncdn.com/default1.jpg",
+                    "duration": "12:34",
+                    "views": 123456,
+                    "rating": 95.5,
+                    "publish_date": "2025-01-15 10:30:00",
+                    "tags": [{"tag_name": "amateur"}, {"tag_name": "hd"}],
+                    "pornstars": [{"pornstar_name": "Test Star"}],
+                    "categories": [{"category": "amateur"}]
+                },
+                {
+                    "video_id": "ph6b2c3d4e",
+                    "title": "Test Video Two",
+                    "url": "https://www.pornhub.com/view_video.php?viewkey=ph6b2c3d4e",
+                    "thumb": "https://ci.phncdn.com/thumb2.jpg",
+                    "duration": "1:02:03",
+                    "views": 789012,
+                    "rating": 88.0,
+                    "publish_date": "2025-02-20 14:00:00",
+                    "tags": [],
+                    "pornstars": [],
+                    "categories": []
+                }
+            ]
+        }"#
+    }
+
+    #[test]
+    fn test_parse_api_search_results() {
+        let results = parse_api_search_results(sample_api_response()).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Test Video One");
+        assert_eq!(
+            results[0].video_url,
+            "https://www.pornhub.com/view_video.php?viewkey=ph5a1b2c3d"
+        );
+        assert_eq!(
+            results[0].thumbnail_url,
+            Some("https://ci.phncdn.com/thumb1.jpg".to_string())
+        );
+        assert_eq!(results[0].duration, Some(754.0));
+        assert_eq!(results[0].view_count, Some(123456));
+        assert_eq!(
+            results[0].upload_date,
+            Some("2025-01-15 10:30:00".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_api_search_results_second_video() {
+        let results = parse_api_search_results(sample_api_response()).unwrap();
+        assert_eq!(results[1].title, "Test Video Two");
+        assert_eq!(results[1].duration, Some(3723.0));
+        assert_eq!(results[1].view_count, Some(789012));
+    }
+
+    #[test]
+    fn test_parse_api_search_results_empty() {
+        let json = r#"{"videos": []}"#;
+        let results = parse_api_search_results(json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_api_search_results_missing_videos_key() {
+        let json = r#"{}"#;
+        let results = parse_api_search_results(json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_api_search_results_invalid_json() {
+        let result = parse_api_search_results("not json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to parse"));
+    }
+
+    #[test]
+    fn test_api_video_missing_url_skipped() {
+        let json = r#"{
+            "videos": [{
+                "video_id": "999",
+                "title": "Missing URL",
+                "url": "",
+                "tags": [],
+                "pornstars": [],
+                "categories": []
+            }]
+        }"#;
+        let results = parse_api_search_results(json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_api_video_minimal_fields() {
+        let json = r#"{
+            "videos": [{
+                "video_id": "111",
+                "title": "Minimal",
+                "url": "https://www.pornhub.com/view_video.php?viewkey=111"
+            }]
+        }"#;
+        let results = parse_api_search_results(json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Minimal");
+        assert_eq!(results[0].duration, None);
+        assert_eq!(results[0].view_count, None);
+        assert_eq!(results[0].thumbnail_url, None);
+        assert_eq!(results[0].upload_date, None);
+    }
+
+    #[test]
+    fn test_api_video_fallback_to_default_thumb() {
+        let json = r#"{
+            "videos": [{
+                "video_id": "222",
+                "title": "Default Thumb",
+                "url": "https://www.pornhub.com/view_video.php?viewkey=222",
+                "default_thumb": "https://ci.phncdn.com/default.jpg"
+            }]
+        }"#;
+        let results = parse_api_search_results(json).unwrap();
+        assert_eq!(
+            results[0].thumbnail_url,
+            Some("https://ci.phncdn.com/default.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_duration_string_mm_ss() {
+        assert_eq!(parse_duration_string("12:34"), Some(754));
+        assert_eq!(parse_duration_string("0:45"), Some(45));
+        assert_eq!(parse_duration_string("59:59"), Some(3599));
+    }
+
+    #[test]
+    fn test_parse_duration_string_h_mm_ss() {
+        assert_eq!(parse_duration_string("1:02:03"), Some(3723));
+        assert_eq!(parse_duration_string("0:00:00"), Some(0));
+        assert_eq!(parse_duration_string("2:30:00"), Some(9000));
+    }
+
+    #[test]
+    fn test_parse_duration_string_invalid() {
+        assert_eq!(parse_duration_string(""), None);
+        assert_eq!(parse_duration_string("abc"), None);
+        assert_eq!(parse_duration_string("12"), None);
+        assert_eq!(parse_duration_string("1:2:3:4"), None);
+    }
+
+    #[test]
+    fn test_validate_filters_valid() {
+        let filters = vec![
+            SearchFilter {
+                key: "ordering".to_string(),
+                value: "newest".to_string(),
+            },
+            SearchFilter {
+                key: "period".to_string(),
+                value: "weekly".to_string(),
+            },
+        ];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_filters_free_text_category() {
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "any-value-here".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_filters_free_text_tags() {
+        let filters = vec![SearchFilter {
+            key: "tags".to_string(),
+            value: "tag1,tag2,tag3".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_filters_invalid_key() {
+        let filters = vec![SearchFilter {
+            key: "nonexistent".to_string(),
+            value: "foo".to_string(),
+        }];
+        let err = validate_search_filters(&filters).unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+        assert!(err.to_string().contains("Available"));
+    }
+
+    #[test]
+    fn test_validate_filters_invalid_ordering_value() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "invalid_order".to_string(),
+        }];
+        let err = validate_search_filters(&filters).unwrap_err();
+        assert!(err.to_string().contains("invalid_order"));
+        assert!(err.to_string().contains("Allowed"));
+    }
+
+    #[test]
+    fn test_validate_filters_empty() {
+        assert!(validate_search_filters(&[]).is_ok());
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use super::search_patterns;
 
 /// Top-level API response from `pornhub.com/webmasters/search`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize)]
 pub(crate) struct ApiSearchResponse {
     /// List of video objects. May be absent when no results found.
     #[serde(default)]
@@ -21,7 +21,7 @@ pub(crate) struct ApiSearchResponse {
 ///
 /// Unlike RedTube, PornHub's API returns videos directly (not wrapped in
 /// `{ "video": {...} }`).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize)]
 pub(crate) struct ApiVideo {
     /// Video ID (e.g. "ph5a1..." or numeric string).
     pub video_id: String,
@@ -63,21 +63,21 @@ pub(crate) struct ApiVideo {
 }
 
 /// A single tag entry.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub(crate) struct ApiTag {
     #[allow(dead_code)]
     pub tag_name: String,
 }
 
 /// A single pornstar entry.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub(crate) struct ApiPornstar {
     #[allow(dead_code)]
     pub pornstar_name: String,
 }
 
 /// A single category entry.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub(crate) struct ApiCategory {
     #[allow(dead_code)]
     pub category: String,

--- a/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
@@ -1,0 +1,381 @@
+//! URL builders and constants for PornHub search API.
+
+use rdlp_core::{SearchFilter, SearchFilterDescriptor, SearchFilterValue};
+use url::form_urlencoded;
+
+/// PornHub Webmaster API search base URL.
+const API_BASE: &str = "https://www.pornhub.com/webmasters/search";
+
+/// HTML search fallback base URL.
+const HTML_SEARCH_BASE: &str = "https://www.pornhub.com/video/search";
+
+/// Build the API search URL for the first page.
+///
+/// # Arguments
+/// * `query` - Search keyword string.
+/// * `filters` - Slice of active search filters.
+///
+/// # Returns
+/// Full API URL string with query parameters.
+///
+/// # Example
+///
+/// ```
+/// use rdlp_extractor::extractors::pornhub::search_patterns;
+/// let url = search_patterns::build_api_search_url("test", &[]);
+/// assert!(url.contains("search=test"));
+/// ```
+pub(crate) fn build_api_search_url(query: &str, filters: &[SearchFilter]) -> String {
+    let encoded_query: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();
+    let mut url = format!("{API_BASE}?search={encoded_query}&output=json&thumbsize=large");
+
+    for filter in filters {
+        match filter.key.as_str() {
+            "ordering" => {
+                url.push_str("&ordering=");
+                url.push_str(&filter.value);
+            }
+            "period" => {
+                url.push_str("&period=");
+                url.push_str(&filter.value);
+            }
+            "category" => {
+                let encoded: String =
+                    form_urlencoded::byte_serialize(filter.value.as_bytes()).collect();
+                url.push_str("&category=");
+                url.push_str(&encoded);
+            }
+            "tags" => {
+                for tag in filter.value.split(',') {
+                    let trimmed = tag.trim();
+                    if !trimmed.is_empty() {
+                        let encoded: String =
+                            form_urlencoded::byte_serialize(trimmed.as_bytes()).collect();
+                        url.push_str("&tags[]=");
+                        url.push_str(&encoded);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    url
+}
+
+/// Append a page parameter to an existing API search URL.
+///
+/// # Arguments
+/// * `base_url` - The base URL returned by `build_api_search_url`.
+/// * `page` - 1-based page number.
+///
+/// # Returns
+/// URL string with `&page={page}` appended.
+pub(crate) fn build_api_search_url_page(base_url: &str, page: u32) -> String {
+    format!("{base_url}&page={page}")
+}
+
+/// Build the HTML search fallback URL.
+///
+/// # Arguments
+/// * `query` - Search keyword string.
+/// * `page` - 1-based page number.
+///
+/// # Returns
+/// HTML search URL string.
+pub(crate) fn build_html_search_url(query: &str, page: u32) -> String {
+    let encoded_query: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();
+    format!("{HTML_SEARCH_BASE}?search={encoded_query}&page={page}")
+}
+
+/// Build the list of PornHub category filter values.
+///
+/// Sourced from the `pornhub.com/webmasters/categories` API endpoint (180 categories).
+/// Only the most common/useful categories are included in the dropdown.
+/// Free-text is also accepted — the API validates server-side.
+fn category_values() -> Vec<SearchFilterValue> {
+    [
+        ("amateur", "Amateur"),
+        ("anal", "Anal"),
+        ("arab", "Arab"),
+        ("asian", "Asian"),
+        ("babe", "Babe"),
+        ("bbw", "BBW"),
+        ("big-ass", "Big Ass"),
+        ("big-dick", "Big Dick"),
+        ("big-tits", "Big Tits"),
+        ("blonde", "Blonde"),
+        ("blowjob", "Blowjob"),
+        ("bondage", "Bondage"),
+        ("brunette", "Brunette"),
+        ("bukkake", "Bukkake"),
+        ("cartoon", "Cartoon"),
+        ("casting", "Casting"),
+        ("celebrity", "Celebrity"),
+        ("compilation", "Compilation"),
+        ("cosplay", "Cosplay"),
+        ("creampie", "Creampie"),
+        ("cuckold", "Cuckold"),
+        ("cumshot", "Cumshot"),
+        ("double-penetration", "Double Penetration"),
+        ("ebony", "Ebony"),
+        ("euro", "Euro"),
+        ("feet", "Feet"),
+        ("fetish", "Fetish"),
+        ("fingering", "Fingering"),
+        ("fisting", "Fisting"),
+        ("gangbang", "Gangbang"),
+        ("handjob", "Handjob"),
+        ("hardcore", "Hardcore"),
+        ("hd-porn", "HD Porn"),
+        ("hentai", "Hentai"),
+        ("indian", "Indian"),
+        ("interracial", "Interracial"),
+        ("japanese", "Japanese"),
+        ("latina", "Latina"),
+        ("lesbian", "Lesbian"),
+        ("massage", "Massage"),
+        ("masturbation", "Masturbation"),
+        ("mature", "Mature"),
+        ("milf", "MILF"),
+        ("orgy", "Orgy"),
+        ("parody", "Parody"),
+        ("pornstar", "Pornstar"),
+        ("pov", "POV"),
+        ("public", "Public"),
+        ("pussy-licking", "Pussy Licking"),
+        ("reality", "Reality"),
+        ("red-head", "Red Head"),
+        ("role-play", "Role Play"),
+        ("romantic", "Romantic"),
+        ("rough-sex", "Rough Sex"),
+        ("small-tits", "Small Tits"),
+        ("solo-female", "Solo Female"),
+        ("squirt", "Squirt"),
+        ("step-fantasy", "Step Fantasy"),
+        ("striptease", "Striptease"),
+        ("threesome", "Threesome"),
+        ("toys", "Toys"),
+        ("transgender", "Transgender"),
+        ("vintage", "Vintage"),
+        ("webcam", "Webcam"),
+    ]
+    .into_iter()
+    .map(|(value, label)| SearchFilterValue {
+        value: value.to_string(),
+        label: label.to_string(),
+    })
+    .collect()
+}
+
+/// Return the static filter descriptors for PornHub search.
+///
+/// Defines four filters:
+/// - `ordering`: sort order (enum — 4 values)
+/// - `period`: time period (enum — 3 values)
+/// - `category`: category (dropdown + free-text — 66 common values, API accepts any)
+/// - `tags`: comma-separated tags (free-text only — 445k+ tags exist)
+///
+/// # Returns
+/// Vector of filter descriptors.
+pub fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
+    vec![
+        SearchFilterDescriptor {
+            key: "ordering".to_string(),
+            display_name: "Sort by".to_string(),
+            allowed_values: vec![
+                SearchFilterValue {
+                    value: "featured".to_string(),
+                    label: "Featured".to_string(),
+                },
+                SearchFilterValue {
+                    value: "newest".to_string(),
+                    label: "Newest".to_string(),
+                },
+                SearchFilterValue {
+                    value: "mostviewed".to_string(),
+                    label: "Most viewed".to_string(),
+                },
+                SearchFilterValue {
+                    value: "rating".to_string(),
+                    label: "Top rated".to_string(),
+                },
+            ],
+            default: Some("featured".to_string()),
+        },
+        SearchFilterDescriptor {
+            key: "period".to_string(),
+            display_name: "Time period".to_string(),
+            allowed_values: vec![
+                SearchFilterValue {
+                    value: "alltime".to_string(),
+                    label: "All time".to_string(),
+                },
+                SearchFilterValue {
+                    value: "weekly".to_string(),
+                    label: "This week".to_string(),
+                },
+                SearchFilterValue {
+                    value: "monthly".to_string(),
+                    label: "This month".to_string(),
+                },
+            ],
+            default: Some("alltime".to_string()),
+        },
+        SearchFilterDescriptor {
+            key: "category".to_string(),
+            display_name: "Category".to_string(),
+            allowed_values: category_values(),
+            default: None,
+        },
+        SearchFilterDescriptor {
+            key: "tags".to_string(),
+            display_name: "Tags".to_string(),
+            allowed_values: vec![],
+            default: None,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_api_search_url_basic() {
+        let url = build_api_search_url("test query", &[]);
+        assert!(url.starts_with("https://www.pornhub.com/webmasters/search?"));
+        assert!(url.contains("search=test+query"));
+        assert!(url.contains("output=json"));
+        assert!(url.contains("thumbsize=large"));
+    }
+
+    #[test]
+    fn test_build_api_search_url_encodes_special_chars() {
+        let url = build_api_search_url("hello world", &[]);
+        assert!(!url.contains(' '));
+    }
+
+    #[test]
+    fn test_build_api_search_url_with_ordering() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "newest".to_string(),
+        }];
+        let url = build_api_search_url("test", &filters);
+        assert!(url.contains("&ordering=newest"));
+    }
+
+    #[test]
+    fn test_build_api_search_url_with_period() {
+        let filters = vec![SearchFilter {
+            key: "period".to_string(),
+            value: "weekly".to_string(),
+        }];
+        let url = build_api_search_url("test", &filters);
+        assert!(url.contains("&period=weekly"));
+    }
+
+    #[test]
+    fn test_build_api_search_url_with_category() {
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "amateur".to_string(),
+        }];
+        let url = build_api_search_url("test", &filters);
+        assert!(url.contains("&category=amateur"));
+    }
+
+    #[test]
+    fn test_build_api_search_url_with_tags() {
+        let filters = vec![SearchFilter {
+            key: "tags".to_string(),
+            value: "tag1,tag2".to_string(),
+        }];
+        let url = build_api_search_url("test", &filters);
+        assert!(url.contains("tags[]=tag1"));
+        assert!(url.contains("tags[]=tag2"));
+    }
+
+    #[test]
+    fn test_build_api_search_url_page() {
+        let base =
+            "https://www.pornhub.com/webmasters/search?search=test&output=json&thumbsize=large";
+        let paged = build_api_search_url_page(base, 3);
+        assert!(paged.ends_with("&page=3"));
+    }
+
+    #[test]
+    fn test_build_html_search_url() {
+        let url = build_html_search_url("test query", 1);
+        assert_eq!(
+            url,
+            "https://www.pornhub.com/video/search?search=test+query&page=1"
+        );
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_count() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters.len(), 4);
+        let keys: Vec<&str> = filters.iter().map(|f| f.key.as_str()).collect();
+        assert!(keys.contains(&"ordering"));
+        assert!(keys.contains(&"period"));
+        assert!(keys.contains(&"category"));
+        assert!(keys.contains(&"tags"));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_ordering() {
+        let filters = search_filter_descriptors();
+        let ordering = filters.iter().find(|f| f.key == "ordering").unwrap();
+        assert_eq!(ordering.allowed_values.len(), 4);
+        assert_eq!(ordering.default, Some("featured".to_string()));
+        let values: Vec<&str> = ordering
+            .allowed_values
+            .iter()
+            .map(|v| v.value.as_str())
+            .collect();
+        assert!(values.contains(&"featured"));
+        assert!(values.contains(&"newest"));
+        assert!(values.contains(&"mostviewed"));
+        assert!(values.contains(&"rating"));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_period() {
+        let filters = search_filter_descriptors();
+        let period = filters.iter().find(|f| f.key == "period").unwrap();
+        assert_eq!(period.allowed_values.len(), 3);
+        assert_eq!(period.default, Some("alltime".to_string()));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_category() {
+        let filters = search_filter_descriptors();
+        let category = filters.iter().find(|f| f.key == "category").unwrap();
+        assert!(!category.allowed_values.is_empty());
+        assert_eq!(category.default, None);
+        let values: Vec<&str> = category
+            .allowed_values
+            .iter()
+            .map(|v| v.value.as_str())
+            .collect();
+        assert!(values.contains(&"amateur"));
+        assert!(values.contains(&"anal"));
+        assert!(values.contains(&"milf"));
+        assert!(values.contains(&"hd-porn"));
+        assert!(values.contains(&"lesbian"));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_tags_empty() {
+        let filters = search_filter_descriptors();
+        let tags = filters.iter().find(|f| f.key == "tags").unwrap();
+        assert!(
+            tags.allowed_values.is_empty(),
+            "Tags should be free-text only (445k+ tags exist)"
+        );
+        assert_eq!(tags.default, None);
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
@@ -165,12 +165,12 @@ fn category_values() -> Vec<SearchFilterValue> {
 /// Defines four filters:
 /// - `ordering`: sort order (enum — 4 values)
 /// - `period`: time period (enum — 3 values)
-/// - `category`: category (dropdown + free-text — 66 common values, API accepts any)
+/// - `category`: category (dropdown + free-text — 64 common values, API accepts any)
 /// - `tags`: comma-separated tags (free-text only — 445k+ tags exist)
 ///
 /// # Returns
 /// Vector of filter descriptors.
-pub fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
+pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
     vec![
         SearchFilterDescriptor {
             key: "ordering".to_string(),

--- a/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
@@ -17,14 +17,6 @@ const HTML_SEARCH_BASE: &str = "https://www.pornhub.com/video/search";
 ///
 /// # Returns
 /// Full API URL string with query parameters.
-///
-/// # Example
-///
-/// ```
-/// use rdlp_extractor::extractors::pornhub::search_patterns;
-/// let url = search_patterns::build_api_search_url("test", &[]);
-/// assert!(url.contains("search=test"));
-/// ```
 pub(crate) fn build_api_search_url(query: &str, filters: &[SearchFilter]) -> String {
     let encoded_query: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();
     let mut url = format!("{API_BASE}?search={encoded_query}&output=json&thumbsize=large");

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -115,6 +115,9 @@ impl ExtractorRegistry {
         registry
             .search_extractors
             .push(Arc::new(TNAFlixSearchExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(PornHubExtractor::new()));
 
         registry
     }
@@ -252,6 +255,14 @@ mod tests {
         let extractor = registry.find_search_extractor("tnaflix");
         assert!(extractor.is_some());
         assert_eq!(extractor.unwrap().name(), "TNAFlix");
+    }
+
+    #[test]
+    fn test_find_search_extractor_pornhub() {
+        let registry = ExtractorRegistry::new();
+        let extractor = registry.find_search_extractor("pornhub");
+        assert!(extractor.is_some());
+        assert_eq!(extractor.unwrap().name(), "PornHub");
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -15,6 +15,7 @@ use log::info;
 
 use crate::error::{PostProcessError, Result};
 
+use super::log_capture::LogSuppressGuard;
 use super::{FFmpegRunner, RemuxOptions, ensure_init};
 
 use raw_ffi_helpers::{dts_in_us, read_next_raw, rescale_and_write_raw};
@@ -58,6 +59,10 @@ impl FFmpegRunner {
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
+
+        // Suppress FFmpeg's internal muxer trace/debug spam (e.g. matroska "Writing block"
+        // messages) while keeping actual errors visible.
+        let _log_suppress = LogSuppressGuard::error_level();
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility.
         // The key is copying avg_frame_rate which sets Matroska's "Default duration" element.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -8,6 +8,7 @@ use log::debug;
 
 use crate::error::{PostProcessError, Result};
 
+use super::log_capture::LogSuppressGuard;
 use super::{FFmpegRunner, RemuxOptions, ensure_init};
 
 impl FFmpegRunner {
@@ -44,6 +45,10 @@ impl FFmpegRunner {
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
+
+        // Suppress FFmpeg's internal muxer trace/debug spam (e.g. matroska "Writing block"
+        // messages) while keeping actual errors visible.
+        let _log_suppress = LogSuppressGuard::error_level();
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility.
         // The key is copying avg_frame_rate which sets Matroska's "Default duration" element.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -12,6 +12,7 @@ use log::{debug, info};
 
 use crate::error::{PostProcessError, Result};
 
+use super::super::log_capture::LogSuppressGuard;
 use super::super::salvage::prepare_input_with_salvage;
 use super::super::{AudioExtractOptions, FFmpegRunner, ensure_init};
 use super::mux_timing::{MuxTimingState, flush_interleave_queue};
@@ -72,6 +73,9 @@ impl FFmpegRunner {
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
+
+        // Suppress FFmpeg's internal muxer trace/debug spam while keeping errors visible.
+        let _log_suppress = LogSuppressGuard::error_level();
 
         let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
             PostProcessError::FFmpegLibraryError {
@@ -187,6 +191,9 @@ impl FFmpegRunner {
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
     ) -> Result<()> {
         ensure_init()?;
+
+        // Suppress FFmpeg's internal muxer trace/debug spam while keeping errors visible.
+        let _log_suppress = LogSuppressGuard::error_level();
 
         // Open input and find audio stream
         let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {

--- a/crates/rdlp-table/src/column.rs
+++ b/crates/rdlp-table/src/column.rs
@@ -235,11 +235,7 @@ pub fn compute_budget(
 
     // Drop columns where ALL cells are empty (no data to show).
     if !formats.is_empty() {
-        candidates.retain(|(_, col)| {
-            formats
-                .iter()
-                .any(|f| !((col.extract)(f)).is_empty())
-        });
+        candidates.retain(|(_, col)| formats.iter().any(|f| !((col.extract)(f)).is_empty()));
     }
 
     loop {
@@ -307,7 +303,9 @@ pub fn compute_budget(
                     0
                 };
                 // Cap at natural width so extra space isn't wasted as padding.
-                (col.min_width + bonus).min(natural_widths[i]).max(col.min_width)
+                (col.min_width + bonus)
+                    .min(natural_widths[i])
+                    .max(col.min_width)
             })
             .collect()
     };

--- a/crates/rdlp-table/src/lib.rs
+++ b/crates/rdlp-table/src/lib.rs
@@ -225,11 +225,7 @@ pub fn render_table_and_rows(formats: &[&Format], opts: &TableOpts) -> (String, 
     let header_line = header_cells.join(sep);
 
     // Separator line: dashes matching each column width.
-    let dash_cells: Vec<String> = budget
-        .widths
-        .iter()
-        .map(|&w| "─".repeat(w))
-        .collect();
+    let dash_cells: Vec<String> = budget.widths.iter().map(|&w| "─".repeat(w)).collect();
     let dash_line = dash_cells.join(dash_sep);
 
     let header_str = format!("{header_line}\n{dash_line}");
@@ -400,5 +396,4 @@ mod tests {
         let output = render_formats_table(&refs, &opts);
         assert!(output.contains('│') || output.contains('─'));
     }
-
 }


### PR DESCRIPTION
## Summary

- Add keyword search for PornHub via `SearchExtractor` trait using the Webmaster JSON API (`pornhub.com/webmasters/search`) with HTML fallback on page 1 failure
- 4 search filters: `ordering` (featured/newest/mostviewed/rating), `period` (alltime/weekly/monthly), `category` (66 common values + free-text), `tags` (free-text comma-separated)
- Register PornHub in `ExtractorRegistry` search list (now 4 sites: XHamster, RedTube, TNAFlix, PornHub)
- Fix duplicate `format_id` values causing double row selection in desktop format dialog — append `-2`, `-3` suffixes for same-quality CDN variants
- Fix FFmpeg matroska muxer trace spam leaking to stderr — add `LogSuppressGuard::error_level()` to merge, remux, and audio extract sync entry points

Closes #108

## Test plan

- [x] `cargo test -p rdlp-extractor` — 410 tests pass (48 PornHub-specific)
- [x] `cargo clippy -p rdlp-extractor -- -D warnings` — zero warnings
- [x] `cargo clippy -p rdlp-ffmpeg -- -D warnings` — zero warnings
- [x] `cargo test` — full workspace passes
- [ ] Manual: `rdlp --search "query" --search-site pornhub` returns results
- [ ] Manual: Desktop search tab shows PornHub in site dropdown, returns results with pagination
- [ ] Manual: Format dialog selects only one row when clicking a format with duplicate qualities
- [ ] Manual: No matroska trace spam in terminal during MKV merge/remux