### PR TITLE
feat(extractor): add HQPorner extractor with search support

### DIFF
--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -92,6 +92,7 @@ impl Orchestrator {
             loudnorm_precompress: self.config.loudnorm_precompress,
             normalize_boost: self.config.normalize_boost,
             normalize_boost_db: self.config.normalize_boost_db,
+            verbose: self.config.verbose,
         }
     }
 

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -35,12 +35,19 @@ impl PostProcessCallback for PostProcessBridge {
 /// given download.
 ///
 /// The factory is called once per post-processing stage with the stage name,
-/// returning a fresh bridge for that stage.
+/// returning a fresh bridge for that stage. It also emits an
+/// [`Event::PostProcessing`] when each stage starts so the frontend can
+/// display stage names in the log panel.
 fn make_callback_factory(
     event_tx: mpsc::Sender<Event>,
     download_id: DownloadId,
 ) -> PostProcessCallbackFactory {
     Arc::new(move |stage_name: &str| -> Arc<dyn PostProcessCallback> {
+        // Notify the frontend that a new post-processing stage has started.
+        let _ = event_tx.try_send(Event::PostProcessing {
+            id: download_id,
+            stage: stage_name.to_string(),
+        });
         Arc::new(PostProcessBridge {
             event_tx: event_tx.clone(),
             download_id,
@@ -161,6 +168,10 @@ impl Orchestrator {
         // Run FFmpeg remux to fix container (faststart, timestamps)
         // Applied to both HLS and HTTP downloads for consistent output
         let result_files = if !self.config.extract_audio {
+            self.emit(Event::PostProcessing {
+                id: self.download_id,
+                stage: "Remuxing container".into(),
+            });
             self.ffmpeg_remux(&files).await.unwrap_or(files.clone())
         } else {
             files.clone()

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -29,6 +29,13 @@ impl PostProcessCallback for PostProcessBridge {
             progress,
         });
     }
+
+    fn on_log(&self, message: &str) {
+        let _ = self.event_tx.try_send(Event::Debug {
+            id: self.download_id,
+            message: message.to_string(),
+        });
+    }
 }
 
 /// Build a [`PostProcessCallbackFactory`] that emits progress events for the

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -200,4 +200,7 @@ pub struct PostProcessConfig {
 
     /// Gain in dB for limiter-boost fallback (default 12.0 when None)
     pub normalize_boost_db: Option<f64>,
+
+    /// Enable verbose FFmpeg logging (forward muxer trace to callback).
+    pub verbose: bool,
 }

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -29,6 +29,12 @@ use crate::{AudioFormat, ContainerFormat, InfoDict, Result};
 pub trait PostProcessCallback: Send + Sync {
     /// Report progress as a fraction in \[0.0, 1.0\].
     fn on_progress(&self, progress: f64);
+
+    /// Forward a log message from the post-processing stage.
+    ///
+    /// Used to surface FFmpeg C-level log output (e.g. matroska muxer trace)
+    /// to the frontend when verbose/trace mode is enabled. Default is a no-op.
+    fn on_log(&self, _message: &str) {}
 }
 
 /// Post-processing operations on downloaded files

--- a/crates/rdlp-desktop/src/components/FormatDialogHeader.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialogHeader.tsx
@@ -21,6 +21,7 @@ export function FormatDialogHeader({ title, thumbnailUrl }: FormatDialogHeaderPr
                         src={thumbnailUrl}
                         alt=""
                         className="w-12 h-[27px] object-cover rounded-sm shrink-0 bg-muted"
+                        referrerPolicy="no-referrer"
                     />
                 )}
                 <div className="min-w-0 flex-1">

--- a/crates/rdlp-desktop/src/components/ResultCard.tsx
+++ b/crates/rdlp-desktop/src/components/ResultCard.tsx
@@ -83,6 +83,7 @@ export function ResultCard({
                         src={result.thumbnail_url}
                         alt={result.title}
                         decoding="async"
+                        referrerPolicy="no-referrer"
                     />
                 ) : (
                     <div className="flex items-center justify-center h-full text-muted-foreground text-xs uppercase tracking-wider">

--- a/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
+++ b/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
@@ -84,6 +84,7 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
                             className="w-full h-full object-cover"
                             src={row.original.thumbnail_url}
                             alt=""
+                            referrerPolicy="no-referrer"
                         />
                     ) : (
                         <div className="w-full h-full bg-muted" />

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -46,9 +46,10 @@ pub use patterns::HQPORNER_VIDEO_PATTERN;
 /// Rate limit between listing/search page fetches (milliseconds).
 const PAGE_RATE_LIMIT_MS: u64 = 500;
 
-/// Pattern to extract duration from text like "26m 52s" or "1h 6m 39s".
-static DURATION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?:(\d+)h\s*)?(\d+)m\s*(\d+)s").expect("Valid duration pattern"));
+/// Pattern to extract duration from text like "26m 52s", "1h 6m 39s", or "45s".
+static DURATION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:(?:(\d+)h\s*)?(?:(\d+)m\s*))?(\d+)s").expect("Valid duration pattern")
+});
 
 /// HQPorner extractor.
 ///
@@ -269,7 +270,7 @@ impl InfoExtractor for HQPornerExtractor {
             }
 
             // Check for "Next" pagination link
-            if !webpage.contains("pagi-btn\">Next") {
+            if !search::has_next_page(&webpage) {
                 break;
             }
 
@@ -398,6 +399,11 @@ mod tests {
     #[test]
     fn test_parse_duration_hours_minutes_seconds() {
         assert_eq!(parse_duration("1h 6m 39s"), Some(3999.0));
+    }
+
+    #[test]
+    fn test_parse_duration_seconds_only() {
+        assert_eq!(parse_duration("45s"), Some(45.0));
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -29,8 +29,11 @@ mod search_patterns;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use log::warn;
-use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result};
+use log::{debug, warn};
+use rdlp_core::{
+    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
+    SearchPageResponse, SearchQuery, SearchResultPreview,
+};
 use regex::Regex;
 use scraper::Html;
 use std::sync::LazyLock;
@@ -291,6 +294,82 @@ impl InfoExtractor for HQPornerExtractor {
     }
 }
 
+#[async_trait]
+impl SearchExtractor for HQPornerExtractor {
+    fn name(&self) -> &str {
+        "HQPorner"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_core::SearchFilterDescriptor> {
+        // HQPorner search has no sort/filter options
+        vec![]
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
+        let mut all_results = Vec::new();
+        let mut page = 1_u32;
+
+        loop {
+            let page_url = search_patterns::build_search_url(&query.query, page);
+            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
+            debug!("[HQPorner] Fetching search page {page}: {sanitized}");
+
+            let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+            let page_results = search::parse_search_results(&webpage);
+
+            if page_results.is_empty() {
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if !search::has_next_page(&webpage) {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        debug!(
+            "[HQPorner] Search complete: {} results across {page} pages",
+            all_results.len()
+        );
+        Ok(all_results)
+    }
+
+    async fn search_page(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        let page = query.page.unwrap_or(1);
+        let page_url = search_patterns::build_search_url(&query.query, page);
+
+        let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+        let page_results = search::parse_search_results(&webpage);
+        let has_more = search::has_next_page(&webpage);
+        let total_estimate = search::extract_total_count(&webpage);
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page,
+            has_more,
+            total_estimate,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,5 +448,17 @@ full body massage</h1></body></html>"#;
     #[test]
     fn test_extract_iframe_url_missing() {
         assert_eq!(extract_iframe_url("<html>no iframe here</html>"), None);
+    }
+
+    #[test]
+    fn test_hqporner_implements_search_extractor() {
+        let extractor = HQPornerExtractor::new();
+        let filters =
+            <HQPornerExtractor as rdlp_core::SearchExtractor>::supported_filters(&extractor);
+        assert!(filters.is_empty(), "HQPorner has no search filters");
+        assert_eq!(
+            <HQPornerExtractor as rdlp_core::SearchExtractor>::name(&extractor),
+            "HQPorner"
+        );
     }
 }

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -99,9 +99,30 @@ pub(super) fn parse_duration(text: &str) -> Option<f64> {
     })
 }
 
+// --- Lazy selectors for metadata extraction ---
+
+static TITLE_SELECTOR: LazyLock<scraper::Selector> =
+    LazyLock::new(|| scraper::Selector::parse("h1.main-h1").expect("Valid title selector"));
+
+static DURATION_SELECTOR: LazyLock<scraper::Selector> = LazyLock::new(|| {
+    scraper::Selector::parse("li.icon.fa-clock-o").expect("Valid duration selector")
+});
+
+static ACTRESS_SELECTOR: LazyLock<scraper::Selector> = LazyLock::new(|| {
+    scraper::Selector::parse("a[href^='/actress/']").expect("Valid actress selector")
+});
+
+static CATEGORY_SELECTOR: LazyLock<scraper::Selector> = LazyLock::new(|| {
+    scraper::Selector::parse("a.tag-link[href^='/category/']").expect("Valid category selector")
+});
+
+static DESCRIPTION_SELECTOR: LazyLock<scraper::Selector> = LazyLock::new(|| {
+    scraper::Selector::parse("meta[name='description']").expect("Valid description selector")
+});
+
 /// Extract the video title from an HQPorner page.
 fn extract_title(html: &Html) -> String {
-    html.select(&scraper::Selector::parse("h1.main-h1").expect("Valid selector"))
+    html.select(&TITLE_SELECTOR)
         .next()
         .map(|el| el.text().collect::<String>().trim().to_string())
         .unwrap_or_default()
@@ -109,24 +130,22 @@ fn extract_title(html: &Html) -> String {
 
 /// Extract the video duration from an HQPorner page.
 fn extract_duration_from_html(html: &Html) -> Option<f64> {
-    html.select(&scraper::Selector::parse("li.icon.fa-clock-o").expect("Valid selector"))
-        .next()
-        .and_then(|el| {
-            let text = el.text().collect::<String>();
-            parse_duration(&text)
-        })
+    html.select(&DURATION_SELECTOR).next().and_then(|el| {
+        let text = el.text().collect::<String>();
+        parse_duration(&text)
+    })
 }
 
 /// Extract the actress name from an HQPorner page.
 fn extract_actress(html: &Html) -> Option<String> {
-    html.select(&scraper::Selector::parse("a[href^='/actress/']").expect("Valid selector"))
+    html.select(&ACTRESS_SELECTOR)
         .next()
         .map(|el| el.text().collect::<String>().trim().to_string())
 }
 
 /// Extract the actress profile URL from an HQPorner page.
 fn extract_actress_url(html: &Html) -> Option<String> {
-    html.select(&scraper::Selector::parse("a[href^='/actress/']").expect("Valid selector"))
+    html.select(&ACTRESS_SELECTOR)
         .next()
         .and_then(|el| el.value().attr("href"))
         .map(|href| format!("https://hqporner.com{href}"))
@@ -134,18 +153,15 @@ fn extract_actress_url(html: &Html) -> Option<String> {
 
 /// Extract category tags from an HQPorner page.
 fn extract_categories(html: &Html) -> Vec<String> {
-    html.select(
-        &scraper::Selector::parse("a.tag-link[href^='/category/']").expect("Valid selector"),
-    )
-    .map(|el| el.text().collect::<String>().trim().to_string())
-    .filter(|s| !s.is_empty())
-    .collect()
+    html.select(&CATEGORY_SELECTOR)
+        .map(|el| el.text().collect::<String>().trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
-/// Extract the meta description from the raw HTML.
-fn extract_description(webpage: &str) -> Option<String> {
-    let html = Html::parse_document(webpage);
-    html.select(&scraper::Selector::parse("meta[name='description']").expect("Valid selector"))
+/// Extract the meta description from an HQPorner page.
+fn extract_description(html: &Html) -> Option<String> {
+    html.select(&DESCRIPTION_SELECTOR)
         .next()
         .and_then(|el| el.value().attr("content"))
         .map(|s| s.to_string())
@@ -175,15 +191,13 @@ impl InfoExtractor for HQPornerExtractor {
 
         let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 
-        // Extract iframe URL before parsing HTML (avoids borrow issues)
+        // Extract iframe URL from raw HTML (regex, before DOM parse)
         let iframe_url = extract_iframe_url(&webpage).ok_or_else(|| {
             RdlpError::Extraction("No mydaddy.cc iframe found on page".to_string())
         })?;
 
-        let description = extract_description(&webpage);
-
-        // Parse HTML for metadata
-        let (title, duration, actress, actress_url, categories) = {
+        // Parse HTML once for all metadata extraction
+        let (title, duration, actress, actress_url, categories, description) = {
             let html = Html::parse_document(&webpage);
             (
                 extract_title(&html),
@@ -191,6 +205,7 @@ impl InfoExtractor for HQPornerExtractor {
                 extract_actress(&html),
                 extract_actress_url(&html),
                 extract_categories(&html),
+                extract_description(&html),
             )
         };
 
@@ -275,7 +290,7 @@ impl InfoExtractor for HQPornerExtractor {
             }
 
             // Build next page URL
-            page_url = search_patterns::next_listing_page_url(url, &webpage);
+            page_url = search_patterns::next_listing_page_url(&webpage);
             if page_url.is_empty() {
                 break;
             }

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -1,0 +1,373 @@
+//! HQPorner extractor module.
+//!
+//! This module provides extraction support for HQPorner videos, categories,
+//! actress listings, and keyword search.
+//!
+//! # Architecture
+//!
+//! HQPorner is a two-layer iframe-based site:
+//! - `patterns` - URL patterns and regex definitions
+//! - `mydaddy` - mydaddy.cc embed resolver (iframe → direct MP4 URLs)
+//! - `search` - Search result HTML parsing
+//! - `search_patterns` - Search URL builders
+//!
+//! The extractor fetches the HQPorner page for metadata, extracts the
+//! mydaddy.cc iframe URL, then resolves it to direct bigcdn.cc MP4 URLs.
+//!
+//! # Supported URLs
+//!
+//! - Videos: `https://hqporner.com/hdporn/81203-full_body_massage.html`
+//! - Categories: `https://hqporner.com/category/amateur`
+//! - Actresses: `https://hqporner.com/actress/emily-bloom`
+//! - Search: `https://hqporner.com/?q=massage`
+
+mod mydaddy;
+mod patterns;
+mod search;
+mod search_patterns;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use log::warn;
+use rdlp_core::{ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result};
+use regex::Regex;
+use scraper::Html;
+use std::sync::LazyLock;
+
+use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
+use crate::hls::detect_format_sizes;
+
+pub use patterns::HQPORNER_VIDEO_PATTERN;
+
+/// Rate limit between listing/search page fetches (milliseconds).
+const PAGE_RATE_LIMIT_MS: u64 = 500;
+
+/// Pattern to extract duration from text like "26m 52s" or "1h 6m 39s".
+static DURATION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:(\d+)h\s*)?(\d+)m\s*(\d+)s").expect("Valid duration pattern"));
+
+/// HQPorner extractor.
+///
+/// Supports single videos, category listings, actress listings, and search.
+///
+/// # Example
+///
+/// ```no_run
+/// use rdlp_extractor::HQPornerExtractor;
+/// use rdlp_core::InfoExtractor;
+///
+/// let extractor = HQPornerExtractor::new();
+/// assert!(extractor.suitable("https://hqporner.com/hdporn/81203-full_body_massage.html"));
+/// ```
+pub struct HQPornerExtractor;
+
+impl HQPornerExtractor {
+    /// Create a new HQPorner extractor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HQPornerExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse a duration string like "26m 52s" or "1h 6m 39s" into total seconds.
+pub(super) fn parse_duration(text: &str) -> Option<f64> {
+    DURATION_PATTERN.captures(text).map(|caps| {
+        let hours: f64 = caps
+            .get(1)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0.0);
+        let minutes: f64 = caps
+            .get(2)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0.0);
+        let seconds: f64 = caps
+            .get(3)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0.0);
+        hours * 3600.0 + minutes * 60.0 + seconds
+    })
+}
+
+/// Extract the video title from an HQPorner page.
+fn extract_title(html: &Html) -> String {
+    html.select(&scraper::Selector::parse("h1.main-h1").expect("Valid selector"))
+        .next()
+        .map(|el| el.text().collect::<String>().trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Extract the video duration from an HQPorner page.
+fn extract_duration_from_html(html: &Html) -> Option<f64> {
+    html.select(&scraper::Selector::parse("li.icon.fa-clock-o").expect("Valid selector"))
+        .next()
+        .and_then(|el| {
+            let text = el.text().collect::<String>();
+            parse_duration(&text)
+        })
+}
+
+/// Extract the actress name from an HQPorner page.
+fn extract_actress(html: &Html) -> Option<String> {
+    html.select(&scraper::Selector::parse("a[href^='/actress/']").expect("Valid selector"))
+        .next()
+        .map(|el| el.text().collect::<String>().trim().to_string())
+}
+
+/// Extract the actress profile URL from an HQPorner page.
+fn extract_actress_url(html: &Html) -> Option<String> {
+    html.select(&scraper::Selector::parse("a[href^='/actress/']").expect("Valid selector"))
+        .next()
+        .and_then(|el| el.value().attr("href"))
+        .map(|href| format!("https://hqporner.com{href}"))
+}
+
+/// Extract category tags from an HQPorner page.
+fn extract_categories(html: &Html) -> Vec<String> {
+    html.select(
+        &scraper::Selector::parse("a.tag-link[href^='/category/']").expect("Valid selector"),
+    )
+    .map(|el| el.text().collect::<String>().trim().to_string())
+    .filter(|s| !s.is_empty())
+    .collect()
+}
+
+/// Extract the meta description from the raw HTML.
+fn extract_description(webpage: &str) -> Option<String> {
+    let html = Html::parse_document(webpage);
+    html.select(&scraper::Selector::parse("meta[name='description']").expect("Valid selector"))
+        .next()
+        .and_then(|el| el.value().attr("content"))
+        .map(|s| s.to_string())
+}
+
+/// Extract the mydaddy.cc iframe URL from the raw HTML.
+fn extract_iframe_url(webpage: &str) -> Option<String> {
+    patterns::IFRAME_PATTERN
+        .captures(webpage)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+#[async_trait]
+impl InfoExtractor for HQPornerExtractor {
+    fn name(&self) -> &str {
+        "HQPorner"
+    }
+
+    fn valid_url(&self) -> &Regex {
+        &HQPORNER_VIDEO_PATTERN
+    }
+
+    async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
+        let video_id = patterns::extract_video_id(url)
+            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
+
+        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
+
+        // Extract iframe URL before parsing HTML (avoids borrow issues)
+        let iframe_url = extract_iframe_url(&webpage).ok_or_else(|| {
+            RdlpError::Extraction("No mydaddy.cc iframe found on page".to_string())
+        })?;
+
+        let description = extract_description(&webpage);
+
+        // Parse HTML for metadata
+        let (title, duration, actress, actress_url, categories) = {
+            let html = Html::parse_document(&webpage);
+            (
+                extract_title(&html),
+                extract_duration_from_html(&html),
+                extract_actress(&html),
+                extract_actress_url(&html),
+                extract_categories(&html),
+            )
+        };
+
+        // Resolve formats from mydaddy.cc embed
+        let mydaddy_result = mydaddy::resolve_formats(&iframe_url, ctx).await?;
+
+        if mydaddy_result.formats.is_empty() {
+            return Err(RdlpError::Extraction(format!(
+                "No video formats found for URL: {url}"
+            )));
+        }
+
+        // Detect file sizes
+        let extractor_name = InfoExtractor::name(self);
+        let (formats_with_size, hls_flags) =
+            detect_format_sizes(mydaddy_result.formats, ctx, extractor_name).await;
+
+        let mut info = InfoDict::new(&video_id, &title, extractor_name, url);
+        info.description = description;
+        info.thumbnail = mydaddy_result.thumbnail;
+        info.uploader = actress;
+        info.uploader_url = actress_url;
+        info.duration = duration;
+        info.age_limit = Some(18);
+        info.formats = formats_with_size;
+        info.tags = if categories.is_empty() {
+            None
+        } else {
+            Some(categories)
+        };
+        info.propagate_duration();
+
+        if hls_flags.is_live {
+            info.is_live = Some(true);
+        }
+
+        Ok(info)
+    }
+
+    async fn extract_playlist(&self, url: &str, ctx: &ExtractionContext) -> Result<Vec<InfoDict>> {
+        if !patterns::is_category_url(url) && !patterns::is_actress_url(url) {
+            return Ok(vec![self.extract(url, ctx).await?]);
+        }
+
+        // Extract listing pages
+        let mut all_results = Vec::new();
+        let mut page_url = url.to_string();
+
+        loop {
+            let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+
+            let video_urls: Vec<String> = patterns::VIDEO_LINK_PATTERN
+                .captures_iter(&webpage)
+                .filter_map(|c| c.get(1))
+                .map(|m| format!("https://hqporner.com{}", m.as_str()))
+                .collect();
+
+            if video_urls.is_empty() {
+                break;
+            }
+
+            for video_url in &video_urls {
+                match self.extract(video_url, ctx).await {
+                    Ok(info) => all_results.push(info),
+                    Err(e) => {
+                        warn!("[HQPorner] Failed to extract {video_url}: {e}");
+                    }
+                }
+
+                if all_results.len() >= MAX_PLAYLIST_SIZE {
+                    break;
+                }
+            }
+
+            if all_results.len() >= MAX_PLAYLIST_SIZE {
+                break;
+            }
+
+            // Check for "Next" pagination link
+            if !webpage.contains("pagi-btn\">Next") {
+                break;
+            }
+
+            // Build next page URL
+            page_url = search_patterns::next_listing_page_url(url, &webpage);
+            if page_url.is_empty() {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        Ok(all_results)
+    }
+
+    fn suitable(&self, url: &str) -> bool {
+        patterns::is_suitable(url)
+    }
+
+    fn priority(&self) -> i32 {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extractor_creation() {
+        let extractor = HQPornerExtractor::new();
+        assert_eq!(InfoExtractor::name(&extractor), "HQPorner");
+    }
+
+    #[test]
+    fn test_suitable_urls() {
+        let extractor = HQPornerExtractor::new();
+        assert!(extractor.suitable("https://hqporner.com/hdporn/81203-full_body_massage.html"));
+        assert!(extractor.suitable("https://hqporner.com/category/amateur"));
+        assert!(extractor.suitable("https://hqporner.com/actress/emily-bloom"));
+        assert!(extractor.suitable("https://hqporner.com/?q=test"));
+        assert!(!extractor.suitable("https://youtube.com/watch?v=test"));
+    }
+
+    #[test]
+    fn test_parse_duration_minutes_seconds() {
+        assert_eq!(parse_duration("26m 52s"), Some(1612.0));
+    }
+
+    #[test]
+    fn test_parse_duration_hours_minutes_seconds() {
+        assert_eq!(parse_duration("1h 6m 39s"), Some(3999.0));
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert_eq!(parse_duration("invalid"), None);
+        assert_eq!(parse_duration(""), None);
+    }
+
+    #[test]
+    fn test_extract_title_from_fixture() {
+        let html_str = r#"<html><body><h1 class="main-h1" style="line-height: 1em;">
+full body massage</h1></body></html>"#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(extract_title(&html), "full body massage");
+    }
+
+    #[test]
+    fn test_extract_duration_from_fixture() {
+        let html_str = r#"<html><body><li class="icon fa-clock-o">26m 52s</li></body></html>"#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(extract_duration_from_html(&html), Some(1612.0));
+    }
+
+    #[test]
+    fn test_extract_actress_from_fixture() {
+        let html_str = r#"<html><body><a href="/actress/emily-bloom" title="See all Emily Bloom videos" class="click-trigger">Emily Bloom</a></body></html>"#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(extract_actress(&html), Some("Emily Bloom".to_string()));
+    }
+
+    #[test]
+    fn test_extract_categories_from_fixture() {
+        let html_str = r#"<html><body><a href="/category/1080p-porn" class="tag-link click-trigger">1080p</a><a href="/category/fingering" class="tag-link click-trigger">fingering</a><a href="/category/porn-massage" class="tag-link click-trigger">massage</a></body></html>"#;
+        let html = Html::parse_document(html_str);
+        let cats = extract_categories(&html);
+        assert_eq!(cats, vec!["1080p", "fingering", "massage"]);
+    }
+
+    #[test]
+    fn test_extract_iframe_url() {
+        let html = r#"<iframe width="560" height="350" src="//mydaddy.cc/video/97d0145823aeb8edca/" frameborder="0" allowfullscreen></iframe>"#;
+        assert_eq!(
+            extract_iframe_url(html),
+            Some("//mydaddy.cc/video/97d0145823aeb8edca/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_iframe_url_missing() {
+        assert_eq!(extract_iframe_url("<html>no iframe here</html>"), None);
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
@@ -1,0 +1,241 @@
+//! mydaddy.cc embed resolver.
+//!
+//! Fetches the mydaddy.cc embed page (with Referer header) and extracts
+//! direct MP4 URLs from the inline JavaScript. No JS execution needed —
+//! URLs are static string literals in the HTML.
+
+use log::debug;
+use rdlp_core::{ExtractionContext, Format, RdlpError, Result};
+use regex::Regex;
+use std::sync::LazyLock;
+
+use crate::base::common::BaseExtractor;
+
+/// Pattern to extract MP4 source URLs from the embed page.
+///
+/// Matches: `//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/1080.mp4`
+static CDN_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(//s\d+\.bigcdn\.cc/pubs/[^"'\\]+\.mp4)"#).expect("Valid CDN URL pattern")
+});
+
+/// Pattern to extract the poster/thumbnail URL.
+static POSTER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(//s\d+\.bigcdn\.cc/pubs/[^"'\\]+/main\.jpg)"#).expect("Valid poster URL pattern")
+});
+
+/// Pattern to extract quality from CDN filename (e.g., "1080" from "/1080.mp4").
+static QUALITY_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"/(\d+)\.mp4$").expect("Valid quality pattern"));
+
+/// Resolved formats and metadata from a mydaddy.cc embed.
+pub(crate) struct MyDaddyResult {
+    pub formats: Vec<Format>,
+    pub thumbnail: Option<String>,
+}
+
+/// Resolve a mydaddy.cc embed URL to direct video format URLs.
+///
+/// Fetches the embed page with a `Referer: hqporner.com` header and parses
+/// the inline JS for bigcdn.cc MP4 URLs.
+///
+/// # Arguments
+/// * `embed_url` - The mydaddy.cc iframe URL (e.g., `//mydaddy.cc/video/{hash}/`)
+/// * `ctx` - Extraction context with HTTP client
+///
+/// # Returns
+/// Resolved formats and optional thumbnail URL.
+pub(crate) async fn resolve_formats(
+    embed_url: &str,
+    ctx: &ExtractionContext,
+) -> Result<MyDaddyResult> {
+    let full_url = if embed_url.starts_with("//") {
+        format!("https:{embed_url}")
+    } else {
+        embed_url.to_string()
+    };
+
+    let sanitized = rdlp_security::sanitize_for_logging(&full_url);
+    debug!("[HQPorner] Resolving mydaddy.cc embed: {sanitized}");
+
+    let html = fetch_embed(&full_url, ctx).await?;
+
+    // Check for blocked response
+    if html.contains("This domain has been blocked") {
+        return Err(RdlpError::Extraction(
+            "mydaddy.cc embed blocked — Referer header may not have been accepted".to_string(),
+        ));
+    }
+
+    let formats = parse_formats(&html);
+
+    if formats.is_empty() {
+        // Try alt player fallback
+        let alt_url = if full_url.ends_with('/') {
+            format!("{full_url}&alt")
+        } else {
+            format!("{full_url}/&alt")
+        };
+        debug!(
+            "[HQPorner] No formats found, trying alt player: {}",
+            rdlp_security::sanitize_for_logging(&alt_url)
+        );
+
+        let alt_html = fetch_embed(&alt_url, ctx).await?;
+        let alt_formats = parse_formats(&alt_html);
+
+        if alt_formats.is_empty() {
+            return Err(RdlpError::Extraction(
+                "No video formats found in mydaddy.cc embed or alt player".to_string(),
+            ));
+        }
+
+        let thumbnail = extract_thumbnail(&alt_html);
+        return Ok(MyDaddyResult {
+            formats: alt_formats,
+            thumbnail,
+        });
+    }
+
+    let thumbnail = extract_thumbnail(&html);
+
+    Ok(MyDaddyResult { formats, thumbnail })
+}
+
+/// Fetch the embed page with the required Referer header.
+async fn fetch_embed(url: &str, ctx: &ExtractionContext) -> Result<String> {
+    let response = ctx
+        .http_client
+        .get(url)
+        .header("Referer", "https://hqporner.com/")
+        .send()
+        .await
+        .map_err(|e| RdlpError::Network(format!("Failed to fetch mydaddy.cc embed: {e}")))?;
+
+    rdlp_core::check_http_response(&response)?;
+
+    response
+        .text()
+        .await
+        .map_err(|e| RdlpError::Network(format!("Failed to read mydaddy.cc response: {e}")))
+}
+
+/// Parse MP4 format URLs from the embed HTML.
+fn parse_formats(html: &str) -> Vec<Format> {
+    let mut seen = std::collections::HashSet::new();
+    let mut formats = Vec::new();
+
+    for caps in CDN_URL_PATTERN.captures_iter(html) {
+        let url = caps.get(1).unwrap().as_str();
+        if !seen.insert(url.to_string()) {
+            continue;
+        }
+
+        let full_url = format!("https:{url}");
+        let quality = QUALITY_PATTERN
+            .captures(url)
+            .and_then(|c| c.get(1))
+            .and_then(|m| m.as_str().parse::<u32>().ok());
+
+        let format_id = quality
+            .map(|q| format!("{q}p"))
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let format = BaseExtractor::build_format(format_id, full_url, "mp4", quality);
+
+        formats.push(format);
+    }
+
+    // Sort by quality ascending (360, 720, 1080)
+    formats.sort_by_key(|f| f.height.unwrap_or(0));
+
+    formats
+}
+
+/// Extract the poster thumbnail URL from embed HTML.
+fn extract_thumbnail(html: &str) -> Option<String> {
+    POSTER_PATTERN
+        .captures(html)
+        .and_then(|c| c.get(1))
+        .map(|m| format!("https:{}", m.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sample mydaddy.cc embed HTML (non-adblock path, 3 qualities).
+    fn sample_embed_html() -> &'static str {
+        r##"<script>function do_pl(){ console.log("ab:"+hasAdblock);if(!oldIE&&hasMP4Video){if(hasAdblock){$("#jw").html("<video id=\"flvv\" preload=\"none\" poster=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/main.jpg\" controls style=\"width:100%; height:100%;\" src=\"\"><source src=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/360.mp4\" title=\"360p\" type=\"video/mp4\" /></video>"); }else{ $("#jw").html("<video id=\"flvv\" preload=\"none\" poster=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/main.jpg\" controls style=\"width:100%; height:100%;\" src=\"\"><source src=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/360.mp4\" title=\"360p\" type=\"video/mp4\" /><source src=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/720.mp4\" title=\"720p HD\" type=\"video/mp4\" /><source src=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/1080.mp4\" title=\"1080p Full HD\" type=\"video/mp4\" /></video>");} }}</script>"##
+    }
+
+    /// Sample mydaddy.cc embed HTML (adblock path, 360p only).
+    fn sample_embed_adblock_html() -> &'static str {
+        r##"<script>function do_pl(){ if(hasAdblock){$("#jw").html("<video id=\"flvv\" poster=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/main.jpg\" src=\"\"><source src=\"//s57.bigcdn.cc/pubs/69af3debebaf77.86372927/360.mp4\" title=\"360p\" type=\"video/mp4\" /></video>"); }}</script>"##
+    }
+
+    #[test]
+    fn test_parse_formats_three_qualities() {
+        let formats = parse_formats(sample_embed_html());
+        assert_eq!(formats.len(), 3);
+        assert_eq!(formats[0].format_id, "360p");
+        assert_eq!(formats[0].height, Some(360));
+        assert!(formats[0].url.contains("360.mp4"));
+        assert_eq!(formats[1].format_id, "720p");
+        assert_eq!(formats[1].height, Some(720));
+        assert_eq!(formats[2].format_id, "1080p");
+        assert_eq!(formats[2].height, Some(1080));
+    }
+
+    #[test]
+    fn test_parse_formats_adblock_single_quality() {
+        let formats = parse_formats(sample_embed_adblock_html());
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].format_id, "360p");
+    }
+
+    #[test]
+    fn test_parse_formats_deduplicates() {
+        // The embed HTML contains each URL twice (adblock + non-adblock branch)
+        let formats = parse_formats(sample_embed_html());
+        assert_eq!(formats.len(), 3); // Not 6
+    }
+
+    #[test]
+    fn test_parse_formats_empty_html() {
+        let formats = parse_formats("<html></html>");
+        assert!(formats.is_empty());
+    }
+
+    #[test]
+    fn test_extract_thumbnail() {
+        let thumb = extract_thumbnail(sample_embed_html());
+        assert_eq!(
+            thumb,
+            Some("https://s57.bigcdn.cc/pubs/69af3debebaf77.86372927/main.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_thumbnail_missing() {
+        assert_eq!(extract_thumbnail("<html></html>"), None);
+    }
+
+    #[test]
+    fn test_formats_urls_are_https() {
+        let formats = parse_formats(sample_embed_html());
+        for f in &formats {
+            assert!(
+                f.url.starts_with("https://"),
+                "URL should be https: {}",
+                f.url
+            );
+        }
+    }
+
+    #[test]
+    fn test_formats_sorted_by_quality() {
+        let formats = parse_formats(sample_embed_html());
+        let heights: Vec<u32> = formats.iter().filter_map(|f| f.height).collect();
+        assert_eq!(heights, vec![360, 720, 1080]);
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
@@ -57,7 +57,24 @@ pub(crate) async fn resolve_formats(
     let sanitized = rdlp_security::sanitize_for_logging(&full_url);
     debug!("[HQPorner] Resolving mydaddy.cc embed: {sanitized}");
 
-    let html = fetch_embed(&full_url, ctx).await?;
+    // Build alt URL upfront for fallback on both fetch failure and empty formats
+    let alt_url = if full_url.ends_with('/') {
+        format!("{full_url}&alt")
+    } else {
+        format!("{full_url}/&alt")
+    };
+
+    // Try primary embed, fall back to alt on fetch failure
+    let html = match fetch_embed(&full_url, ctx).await {
+        Ok(h) => h,
+        Err(e) => {
+            debug!(
+                "[HQPorner] Primary embed fetch failed ({e}), trying alt player: {}",
+                rdlp_security::sanitize_for_logging(&alt_url)
+            );
+            return resolve_from_html(&fetch_embed(&alt_url, ctx).await?);
+        }
+    };
 
     // Check for blocked response
     if html.contains("This domain has been blocked") {
@@ -69,35 +86,31 @@ pub(crate) async fn resolve_formats(
     let formats = parse_formats(&html);
 
     if formats.is_empty() {
-        // Try alt player fallback
-        let alt_url = if full_url.ends_with('/') {
-            format!("{full_url}&alt")
-        } else {
-            format!("{full_url}/&alt")
-        };
         debug!(
             "[HQPorner] No formats found, trying alt player: {}",
             rdlp_security::sanitize_for_logging(&alt_url)
         );
 
         let alt_html = fetch_embed(&alt_url, ctx).await?;
-        let alt_formats = parse_formats(&alt_html);
-
-        if alt_formats.is_empty() {
-            return Err(RdlpError::Extraction(
-                "No video formats found in mydaddy.cc embed or alt player".to_string(),
-            ));
-        }
-
-        let thumbnail = extract_thumbnail(&alt_html);
-        return Ok(MyDaddyResult {
-            formats: alt_formats,
-            thumbnail,
-        });
+        return resolve_from_html(&alt_html);
     }
 
     let thumbnail = extract_thumbnail(&html);
 
+    Ok(MyDaddyResult { formats, thumbnail })
+}
+
+/// Parse formats and thumbnail from already-fetched embed HTML.
+fn resolve_from_html(html: &str) -> Result<MyDaddyResult> {
+    let formats = parse_formats(html);
+
+    if formats.is_empty() {
+        return Err(RdlpError::Extraction(
+            "No video formats found in mydaddy.cc embed or alt player".to_string(),
+        ));
+    }
+
+    let thumbnail = extract_thumbnail(html);
     Ok(MyDaddyResult { formats, thumbnail })
 }
 

--- a/crates/rdlp-extractor/src/extractors/hqporner/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/patterns.rs
@@ -1,0 +1,205 @@
+//! URL patterns for HQPorner extractor.
+//!
+//! Contains regex patterns for matching video, category, actress, and search URLs.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// URL pattern for HQPorner video pages.
+///
+/// Matches:
+/// - `https://hqporner.com/hdporn/81203-full_body_massage.html`
+/// - `https://www.hqporner.com/hdporn/81203-slug.html`
+/// - `https://m.hqporner.com/hdporn/81203-slug.html`
+///
+/// The slug is ignored by the server — only the numeric ID matters.
+pub static HQPORNER_VIDEO_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)
+        https?://
+        (?:(?:www|m)\.)?
+        hqporner\.com
+        /hdporn/(?P<id>\d+)-[\w-]+\.html
+        ",
+    )
+    .expect("Valid HQPorner video URL pattern")
+});
+
+/// URL pattern for HQPorner category pages.
+///
+/// Matches:
+/// - `https://hqporner.com/category/amateur`
+/// - `https://hqporner.com/category/1080p-porn/3`
+pub static HQPORNER_CATEGORY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)
+        https?://
+        (?:(?:www|m)\.)?
+        hqporner\.com
+        /category/(?P<name>[\w-]+)
+        (?:/(?P<page>\d+))?
+        ",
+    )
+    .expect("Valid HQPorner category URL pattern")
+});
+
+/// URL pattern for HQPorner actress pages.
+///
+/// Matches:
+/// - `https://hqporner.com/actress/emily-bloom`
+/// - `https://hqporner.com/actress/emily-bloom/2`
+pub static HQPORNER_ACTRESS_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)
+        https?://
+        (?:(?:www|m)\.)?
+        hqporner\.com
+        /actress/(?P<name>[\w-]+)
+        (?:/(?P<page>\d+))?
+        ",
+    )
+    .expect("Valid HQPorner actress URL pattern")
+});
+
+/// URL pattern for HQPorner search pages.
+///
+/// Matches:
+/// - `https://hqporner.com/?q=massage`
+/// - `https://hqporner.com/?q=massage&p=2`
+pub static HQPORNER_SEARCH_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)
+        https?://
+        (?:(?:www|m)\.)?
+        hqporner\.com
+        /\?q=
+        ",
+    )
+    .expect("Valid HQPorner search URL pattern")
+});
+
+/// Pattern to extract the mydaddy.cc iframe embed URL from a video page.
+pub static IFRAME_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"iframe[^>]+src="(//mydaddy\.cc/video/[^"]+)""#).expect("Valid iframe pattern")
+});
+
+/// Pattern to extract video links from listing pages.
+pub static VIDEO_LINK_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"href="(/hdporn/\d+-[\w-]+\.html)""#).expect("Valid video link pattern")
+});
+
+/// Extract the numeric video ID from a video URL.
+pub fn extract_video_id(url: &str) -> Option<String> {
+    HQPORNER_VIDEO_PATTERN
+        .captures(url)
+        .and_then(|c| c.name("id"))
+        .map(|m| m.as_str().to_string())
+}
+
+/// Check whether a URL matches any HQPorner URL type.
+pub fn is_suitable(url: &str) -> bool {
+    HQPORNER_VIDEO_PATTERN.is_match(url)
+        || HQPORNER_CATEGORY_PATTERN.is_match(url)
+        || HQPORNER_ACTRESS_PATTERN.is_match(url)
+        || HQPORNER_SEARCH_PATTERN.is_match(url)
+}
+
+/// Check whether a URL is a category page.
+pub fn is_category_url(url: &str) -> bool {
+    HQPORNER_CATEGORY_PATTERN.is_match(url)
+}
+
+/// Check whether a URL is an actress page.
+pub fn is_actress_url(url: &str) -> bool {
+    HQPORNER_ACTRESS_PATTERN.is_match(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_video_pattern_standard() {
+        assert!(
+            HQPORNER_VIDEO_PATTERN
+                .is_match("https://hqporner.com/hdporn/81203-full_body_massage.html")
+        );
+    }
+
+    #[test]
+    fn test_video_pattern_www() {
+        assert!(
+            HQPORNER_VIDEO_PATTERN
+                .is_match("https://www.hqporner.com/hdporn/81203-full_body_massage.html")
+        );
+    }
+
+    #[test]
+    fn test_video_pattern_mobile() {
+        assert!(
+            HQPORNER_VIDEO_PATTERN
+                .is_match("https://m.hqporner.com/hdporn/81203-full_body_massage.html")
+        );
+    }
+
+    #[test]
+    fn test_video_pattern_rejects_category() {
+        assert!(!HQPORNER_VIDEO_PATTERN.is_match("https://hqporner.com/category/amateur"));
+    }
+
+    #[test]
+    fn test_extract_video_id() {
+        assert_eq!(
+            extract_video_id("https://hqporner.com/hdporn/81203-full_body_massage.html"),
+            Some("81203".to_string())
+        );
+    }
+
+    #[test]
+    fn test_category_pattern() {
+        assert!(HQPORNER_CATEGORY_PATTERN.is_match("https://hqporner.com/category/1080p-porn"));
+        assert!(HQPORNER_CATEGORY_PATTERN.is_match("https://hqporner.com/category/1080p-porn/3"));
+    }
+
+    #[test]
+    fn test_actress_pattern() {
+        assert!(HQPORNER_ACTRESS_PATTERN.is_match("https://hqporner.com/actress/emily-bloom"));
+        assert!(HQPORNER_ACTRESS_PATTERN.is_match("https://hqporner.com/actress/emily-bloom/2"));
+    }
+
+    #[test]
+    fn test_search_pattern() {
+        assert!(HQPORNER_SEARCH_PATTERN.is_match("https://hqporner.com/?q=massage"));
+        assert!(HQPORNER_SEARCH_PATTERN.is_match("https://hqporner.com/?q=massage&p=2"));
+    }
+
+    #[test]
+    fn test_is_suitable_all_types() {
+        assert!(is_suitable("https://hqporner.com/hdporn/81203-slug.html"));
+        assert!(is_suitable("https://hqporner.com/category/amateur"));
+        assert!(is_suitable("https://hqporner.com/actress/emily-bloom"));
+        assert!(is_suitable("https://hqporner.com/?q=test"));
+        assert!(!is_suitable("https://youtube.com/watch?v=test"));
+    }
+
+    #[test]
+    fn test_iframe_pattern() {
+        let html = r#"<iframe width="560" height="350" src="//mydaddy.cc/video/97d0145823aeb8edca/" frameborder="0"></iframe>"#;
+        let caps = IFRAME_PATTERN.captures(html).unwrap();
+        assert_eq!(
+            caps.get(1).unwrap().as_str(),
+            "//mydaddy.cc/video/97d0145823aeb8edca/"
+        );
+    }
+
+    #[test]
+    fn test_video_link_pattern() {
+        let html =
+            r#"<a href="/hdporn/81203-full_body_massage.html" class="click-trigger">test</a>"#;
+        let caps = VIDEO_LINK_PATTERN.captures(html).unwrap();
+        assert_eq!(
+            caps.get(1).unwrap().as_str(),
+            "/hdporn/81203-full_body_massage.html"
+        );
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -57,13 +57,18 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
         let video_url = format!("https://hqporner.com{href}");
 
         let thumbnail_url = thumbs.get(i).and_then(|el| {
-            el.value().attr("src").map(|s| {
-                if s.starts_with("//") {
-                    format!("https:{s}")
-                } else {
-                    s.to_string()
-                }
-            })
+            el.value()
+                .attr("data-src")
+                .filter(|s| !s.is_empty())
+                .or_else(|| el.value().attr("src"))
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    if s.starts_with("//") {
+                        format!("https:{s}")
+                    } else {
+                        s.to_string()
+                    }
+                })
         });
 
         let duration = durations.get(i).and_then(|el| {
@@ -201,5 +206,51 @@ mod tests {
     #[test]
     fn test_has_next_page_false() {
         assert!(!has_next_page(sample_last_page_html()));
+    }
+
+    #[test]
+    fn test_parse_thumbnail_data_src_lazy_loaded() {
+        let html = r#"<html><body>
+<div class="4u">
+    <section class="box feature">
+        <a href="/hdporn/999-lazy.html" class="image featured atfib">
+            <div><img data-src="//fastporndelivery.hqporner.com/imgs/lazy/main.jpg" src="" /></div>
+        </a>
+        <div id="span-case">
+            <h3 class="meta-data-title"><a href="/hdporn/999-lazy.html" class="click-trigger">lazy loaded video</a></h3>
+            <span class="icon fa-clock-o meta-data">10m 00s</span>
+        </div>
+    </section>
+</div>
+</body></html>"#;
+        let results = parse_search_results(html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].thumbnail_url.as_deref(),
+            Some("https://fastporndelivery.hqporner.com/imgs/lazy/main.jpg")
+        );
+    }
+
+    #[test]
+    fn test_parse_thumbnail_src_fallback() {
+        let html = r#"<html><body>
+<div class="4u">
+    <section class="box feature">
+        <a href="/hdporn/888-srconly.html" class="image featured atfib">
+            <div><img src="//fastporndelivery.hqporner.com/imgs/src/main.jpg" /></div>
+        </a>
+        <div id="span-case">
+            <h3 class="meta-data-title"><a href="/hdporn/888-srconly.html" class="click-trigger">src only video</a></h3>
+            <span class="icon fa-clock-o meta-data">5m 00s</span>
+        </div>
+    </section>
+</div>
+</body></html>"#;
+        let results = parse_search_results(html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].thumbnail_url.as_deref(),
+            Some("https://fastporndelivery.hqporner.com/imgs/src/main.jpg")
+        );
     }
 }

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -1,0 +1,1 @@
+//! Search result parsing for HQPorner.

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -14,6 +14,19 @@ use super::parse_duration;
 static TOTAL_COUNT_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(\d+)\s+HD movies").expect("Valid total count pattern"));
 
+/// Selector for search result title links.
+static LINK_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("h3.meta-data-title a").expect("Valid link selector"));
+
+/// Selector for search result thumbnail images.
+static THUMB_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a.image img, a.atfib img").expect("Valid thumb selector"));
+
+/// Selector for search result duration spans.
+static DURATION_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("span.fa-clock-o.meta-data").expect("Valid duration selector")
+});
+
 /// Parse search/listing page HTML into search result previews.
 ///
 /// # Arguments
@@ -24,13 +37,9 @@ static TOTAL_COUNT_PATTERN: LazyLock<Regex> =
 pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
     let document = Html::parse_document(html);
 
-    let link_sel = Selector::parse("h3.meta-data-title a").unwrap();
-    let thumb_sel = Selector::parse("a.image img, a.atfib img").unwrap();
-    let duration_sel = Selector::parse("span.fa-clock-o.meta-data").unwrap();
-
-    let titles: Vec<_> = document.select(&link_sel).collect();
-    let thumbs: Vec<_> = document.select(&thumb_sel).collect();
-    let durations: Vec<_> = document.select(&duration_sel).collect();
+    let titles: Vec<_> = document.select(&LINK_SELECTOR).collect();
+    let thumbs: Vec<_> = document.select(&THUMB_SELECTOR).collect();
+    let durations: Vec<_> = document.select(&DURATION_SELECTOR).collect();
 
     let mut results = Vec::new();
 

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -3,10 +3,6 @@
 //! Parses search result HTML into `SearchResultPreview` items.
 //! Each result card contains a title, video URL, thumbnail, and duration.
 
-// Functions are pub(crate) but not yet called from the SearchExtractor impl
-// (wired in a later task). Allow dead_code until then.
-#![allow(dead_code)]
-
 use rdlp_core::SearchResultPreview;
 use regex::Regex;
 use scraper::{Html, Selector};

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -1,1 +1,200 @@
 //! Search result parsing for HQPorner.
+//!
+//! Parses search result HTML into `SearchResultPreview` items.
+//! Each result card contains a title, video URL, thumbnail, and duration.
+
+// Functions are pub(crate) but not yet called from the SearchExtractor impl
+// (wired in a later task). Allow dead_code until then.
+#![allow(dead_code)]
+
+use rdlp_core::SearchResultPreview;
+use regex::Regex;
+use scraper::{Html, Selector};
+use std::sync::LazyLock;
+
+use super::parse_duration;
+
+/// Pattern to extract total result count from "1850 HD movies" text.
+static TOTAL_COUNT_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\d+)\s+HD movies").expect("Valid total count pattern"));
+
+/// Parse search/listing page HTML into search result previews.
+///
+/// # Arguments
+/// * `html` - Raw HTML of the search/listing page.
+///
+/// # Returns
+/// Vector of search result previews extracted from the page.
+pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
+    let document = Html::parse_document(html);
+
+    let link_sel = Selector::parse("h3.meta-data-title a").unwrap();
+    let thumb_sel = Selector::parse("a.image img, a.atfib img").unwrap();
+    let duration_sel = Selector::parse("span.fa-clock-o.meta-data").unwrap();
+
+    let titles: Vec<_> = document.select(&link_sel).collect();
+    let thumbs: Vec<_> = document.select(&thumb_sel).collect();
+    let durations: Vec<_> = document.select(&duration_sel).collect();
+
+    let mut results = Vec::new();
+
+    for (i, title_el) in titles.iter().enumerate() {
+        let href = match title_el.value().attr("href") {
+            Some(h) if h.starts_with("/hdporn/") => h,
+            _ => continue,
+        };
+
+        let title = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let video_url = format!("https://hqporner.com{href}");
+
+        let thumbnail_url = thumbs.get(i).and_then(|el| {
+            el.value().attr("src").map(|s| {
+                if s.starts_with("//") {
+                    format!("https:{s}")
+                } else {
+                    s.to_string()
+                }
+            })
+        });
+
+        let duration = durations.get(i).and_then(|el| {
+            let text = el.text().collect::<String>();
+            parse_duration(&text)
+        });
+
+        results.push(SearchResultPreview {
+            video_url,
+            title,
+            thumbnail_url,
+            duration,
+            view_count: None,
+            upload_date: None,
+        });
+    }
+
+    results
+}
+
+/// Extract the total result count from "N HD movies" text on the page.
+pub(crate) fn extract_total_count(html: &str) -> Option<u64> {
+    TOTAL_COUNT_PATTERN
+        .captures(html)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}
+
+/// Check whether the page has a "Next" pagination link.
+pub(crate) fn has_next_page(html: &str) -> bool {
+    html.contains(">Next<")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_search_html() -> &'static str {
+        r#"<html><body>
+<li class="icon fa-clock-o">1850 HD movies</li>
+<div class="4u">
+    <section class="box feature">
+        <a href="/hdporn/81203-full_body_massage.html" class="image featured atfib">
+            <div><img id="cover_81203" src="//fastporndelivery.hqporner.com/imgs/ab/cd/main.jpg" alt="full body massage" /></div>
+        </a>
+        <div id="span-case">
+            <h3 class="meta-data-title"><a href="/hdporn/81203-full_body_massage.html" class="click-trigger">full body massage</a></h3>
+            <span class="icon fa-clock-o meta-data">26m 52s</span>
+        </div>
+    </section>
+</div>
+<div class="4u">
+    <section class="box feature">
+        <a href="/hdporn/81221-same_sex_oral_massage.html" class="image featured atfib">
+            <div><img id="cover_81221" src="//fastporndelivery.hqporner.com/imgs/ef/gh/main.jpg" alt="same sex oral massage" /></div>
+        </a>
+        <div id="span-case">
+            <h3 class="meta-data-title"><a href="/hdporn/81221-same_sex_oral_massage.html" class="click-trigger">same sex oral massage</a></h3>
+            <span class="icon fa-clock-o meta-data">18m 28s</span>
+        </div>
+    </section>
+</div>
+<ul class="actions pagination">
+<li><span class="pagi-btn-alt">1</span></li>
+<li><a href="/?q=massage&p=2" class="pagi-btn">2</a></li>
+<li><a href="/?q=massage&p=2" class="pagi-btn">Next</a></li>
+</ul>
+</body></html>"#
+    }
+
+    fn sample_last_page_html() -> &'static str {
+        r#"<html><body>
+<li class="icon fa-clock-o">50 HD movies</li>
+<div class="4u">
+    <section class="box feature">
+        <a href="/hdporn/123-test.html" class="image featured atfib">
+            <div><img src="//fastporndelivery.hqporner.com/imgs/xx/yy/main.jpg" /></div>
+        </a>
+        <div id="span-case">
+            <h3 class="meta-data-title"><a href="/hdporn/123-test.html" class="click-trigger">test video</a></h3>
+            <span class="icon fa-clock-o meta-data">5m 30s</span>
+        </div>
+    </section>
+</div>
+<ul class="actions pagination">
+<li><a href="/?q=test&p=1" class="pagi-btn">Prev</a></li>
+<li><span class="pagi-btn-alt">2</span></li>
+</ul>
+</body></html>"#
+    }
+
+    #[test]
+    fn test_parse_search_results() {
+        let results = parse_search_results(sample_search_html());
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "full body massage");
+        assert_eq!(
+            results[0].video_url,
+            "https://hqporner.com/hdporn/81203-full_body_massage.html"
+        );
+        assert_eq!(results[0].duration, Some(1612.0));
+        assert!(
+            results[0]
+                .thumbnail_url
+                .as_ref()
+                .unwrap()
+                .starts_with("https://")
+        );
+    }
+
+    #[test]
+    fn test_parse_search_results_second_item() {
+        let results = parse_search_results(sample_search_html());
+        assert_eq!(results[1].title, "same sex oral massage");
+        assert_eq!(results[1].duration, Some(1108.0));
+    }
+
+    #[test]
+    fn test_parse_search_results_empty() {
+        let results = parse_search_results("<html><body></body></html>");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_extract_total_count() {
+        assert_eq!(extract_total_count("1850 HD movies"), Some(1850));
+        assert_eq!(extract_total_count("no count here"), None);
+    }
+
+    #[test]
+    fn test_has_next_page_true() {
+        assert!(has_next_page(sample_search_html()));
+    }
+
+    #[test]
+    fn test_has_next_page_false() {
+        assert!(!has_next_page(sample_last_page_html()));
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/hqporner/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search_patterns.rs
@@ -1,0 +1,17 @@
+//! URL builders for HQPorner search and listing pages.
+
+/// Build the next listing page URL from the current URL and page HTML.
+///
+/// Parses the pagination links to find the "Next" page URL.
+///
+/// # Arguments
+/// * `current_url` - The current listing page URL
+/// * `_webpage` - The current page HTML (used for pagination link extraction)
+///
+/// # Returns
+/// The next page URL, or an empty string if no next page exists.
+pub(crate) fn next_listing_page_url(current_url: &str, _webpage: &str) -> String {
+    // Placeholder — implemented in Task 5
+    let _ = current_url;
+    String::new()
+}

--- a/crates/rdlp-extractor/src/extractors/hqporner/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search_patterns.rs
@@ -27,11 +27,10 @@ pub(crate) fn build_search_url(query: &str, page: u32) -> String {
     }
 }
 
-/// Build the next listing page URL from the current URL and page HTML.
+/// Extract the next listing page URL from pagination HTML.
 ///
 /// Parses the pagination links to find the "Next" page href.
-pub(crate) fn next_listing_page_url(current_url: &str, webpage: &str) -> String {
-    let _ = current_url;
+pub(crate) fn next_listing_page_url(webpage: &str) -> String {
     NEXT_PAGE_PATTERN
         .captures(webpage)
         .and_then(|c| c.get(1))
@@ -71,21 +70,21 @@ mod tests {
     #[test]
     fn test_next_listing_page_url() {
         let html = r#"<a href="/?q=massage&p=3" class="button mobile-pagi pagi-btn">Next</a>"#;
-        let next = next_listing_page_url("https://hqporner.com/?q=massage&p=2", html);
+        let next = next_listing_page_url(html);
         assert_eq!(next, "https://hqporner.com/?q=massage&p=3");
     }
 
     #[test]
     fn test_next_listing_page_url_category() {
         let html = r#"<a href="/category/amateur/3" class="button mobile-hide pagi-btn">Next</a>"#;
-        let next = next_listing_page_url("https://hqporner.com/category/amateur/2", html);
+        let next = next_listing_page_url(html);
         assert_eq!(next, "https://hqporner.com/category/amateur/3");
     }
 
     #[test]
     fn test_next_listing_page_url_no_next() {
         let html = r#"<span class="pagi-btn-alt">5</span>"#;
-        let next = next_listing_page_url("https://hqporner.com/?q=test", html);
+        let next = next_listing_page_url(html);
         assert!(next.is_empty());
     }
 }

--- a/crates/rdlp-extractor/src/extractors/hqporner/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search_patterns.rs
@@ -1,17 +1,91 @@
 //! URL builders for HQPorner search and listing pages.
 
-/// Build the next listing page URL from the current URL and page HTML.
-///
-/// Parses the pagination links to find the "Next" page URL.
+use regex::Regex;
+use std::sync::LazyLock;
+use url::form_urlencoded;
+
+/// HQPorner search base URL.
+const SEARCH_BASE: &str = "https://hqporner.com/";
+
+/// Pattern to extract the "Next" page URL from pagination.
+static NEXT_PAGE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"href="([^"]+)"[^>]*class="[^"]*pagi-btn[^"]*">Next"#)
+        .expect("Valid next page pattern")
+});
+
+/// Build a search URL.
 ///
 /// # Arguments
-/// * `current_url` - The current listing page URL
-/// * `_webpage` - The current page HTML (used for pagination link extraction)
+/// * `query` - Search keyword string.
+/// * `page` - 1-based page number.
+pub(crate) fn build_search_url(query: &str, page: u32) -> String {
+    let encoded: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();
+    if page <= 1 {
+        format!("{SEARCH_BASE}?q={encoded}")
+    } else {
+        format!("{SEARCH_BASE}?q={encoded}&p={page}")
+    }
+}
+
+/// Build the next listing page URL from the current URL and page HTML.
 ///
-/// # Returns
-/// The next page URL, or an empty string if no next page exists.
-pub(crate) fn next_listing_page_url(current_url: &str, _webpage: &str) -> String {
-    // Placeholder — implemented in Task 5
+/// Parses the pagination links to find the "Next" page href.
+pub(crate) fn next_listing_page_url(current_url: &str, webpage: &str) -> String {
     let _ = current_url;
-    String::new()
+    NEXT_PAGE_PATTERN
+        .captures(webpage)
+        .and_then(|c| c.get(1))
+        .map(|m| {
+            let href = m.as_str();
+            if href.starts_with("http") {
+                href.to_string()
+            } else {
+                format!("https://hqporner.com{href}")
+            }
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_search_url_page_1() {
+        let url = build_search_url("massage", 1);
+        assert_eq!(url, "https://hqporner.com/?q=massage");
+    }
+
+    #[test]
+    fn test_build_search_url_page_2() {
+        let url = build_search_url("massage", 2);
+        assert_eq!(url, "https://hqporner.com/?q=massage&p=2");
+    }
+
+    #[test]
+    fn test_build_search_url_encodes_spaces() {
+        let url = build_search_url("big tits", 1);
+        assert!(url.contains("big+tits") || url.contains("big%20tits"));
+    }
+
+    #[test]
+    fn test_next_listing_page_url() {
+        let html = r#"<a href="/?q=massage&p=3" class="button mobile-pagi pagi-btn">Next</a>"#;
+        let next = next_listing_page_url("https://hqporner.com/?q=massage&p=2", html);
+        assert_eq!(next, "https://hqporner.com/?q=massage&p=3");
+    }
+
+    #[test]
+    fn test_next_listing_page_url_category() {
+        let html = r#"<a href="/category/amateur/3" class="button mobile-hide pagi-btn">Next</a>"#;
+        let next = next_listing_page_url("https://hqporner.com/category/amateur/2", html);
+        assert_eq!(next, "https://hqporner.com/category/amateur/3");
+    }
+
+    #[test]
+    fn test_next_listing_page_url_no_next() {
+        let html = r#"<span class="pagi-btn-alt">5</span>"#;
+        let next = next_listing_page_url("https://hqporner.com/?q=test", html);
+        assert!(next.is_empty());
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/mod.rs
@@ -4,6 +4,7 @@
 //! particular website. Re-exports provide convenient access to the top-level
 //! extractor types.
 
+pub mod hqporner;
 pub mod nine_anime;
 pub mod pornhub;
 pub mod redtube;
@@ -11,6 +12,7 @@ pub mod tnaflix;
 pub mod xhamster;
 pub mod xtits;
 
+pub use hqporner::HQPornerExtractor;
 pub use nine_anime::NineAnimeExtractor;
 pub use pornhub::PornHubExtractor;
 pub use redtube::RedTubeExtractor;

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -238,6 +238,7 @@ mod tests {
         assert!(extractors.contains(&"XTits"));
         assert!(extractors.contains(&"XHamster"));
         assert!(extractors.contains(&"9anime"));
+        assert!(extractors.contains(&"HQPorner"));
     }
 
     #[test]
@@ -317,7 +318,20 @@ mod tests {
         assert!(nine_anime.is_some());
         assert_eq!(nine_anime.unwrap().name(), "9anime");
 
+        let hqporner =
+            registry.find_extractor("https://hqporner.com/hdporn/81203-full_body_massage.html");
+        assert!(hqporner.is_some());
+        assert_eq!(hqporner.unwrap().name(), "HQPorner");
+
         let unknown = registry.find_extractor("https://youtube.com/watch?v=test");
         assert!(unknown.is_none());
+    }
+
+    #[test]
+    fn test_find_search_extractor_hqporner() {
+        let registry = ExtractorRegistry::new();
+        let extractor = registry.find_search_extractor("hqporner");
+        assert!(extractor.is_some());
+        assert_eq!(extractor.unwrap().name(), "HQPorner");
     }
 }

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -121,6 +121,9 @@ impl ExtractorRegistry {
         registry
             .search_extractors
             .push(Arc::new(PornHubExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(HQPornerExtractor::new()));
 
         registry
     }

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -40,7 +40,7 @@ pub mod utils;
 
 // Re-export extractors
 pub use extractors::{
-    NineAnimeExtractor, PornHubExtractor, RedTubeExtractor, TNAFlixExtractor,
+    HQPornerExtractor, NineAnimeExtractor, PornHubExtractor, RedTubeExtractor, TNAFlixExtractor,
     TNAFlixSearchExtractor, XHamsterExtractor, XTitsExtractor,
 };
 
@@ -104,6 +104,9 @@ impl ExtractorRegistry {
 
         // Register 9anime extractor
         registry.register(Arc::new(NineAnimeExtractor::new()));
+
+        // Register HQPorner extractor
+        registry.register(Arc::new(HQPornerExtractor::new()));
 
         // Register search extractors
         registry

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -45,6 +45,9 @@ impl FFmpegRunner {
     ) -> Result<()> {
         ensure_init()?;
 
+        // Suppress FFmpeg's internal muxer trace/debug spam
+        let _log_suppress = super::log_capture::LogSuppressGuard::error_level();
+
         let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
             PostProcessError::FFmpegLibraryError {
                 message: format!("failed to open input {}: {e}", input.display()),

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -2,8 +2,10 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use log::debug;
+use rdlp_core::PostProcessCallback;
 
 use crate::error::{PostProcessError, Result};
 
@@ -15,19 +17,24 @@ impl FFmpegRunner {
     /// Copies all streams without re-encoding, sets format-level metadata via
     /// `Dictionary`, and adds chapters via `add_chapter()`. No temporary
     /// FFMETADATA1 file is needed.
+    ///
+    /// When `callback` is provided, FFmpeg C-level log messages are captured
+    /// and forwarded via [`PostProcessCallback::on_log`] instead of being
+    /// suppressed. When `None`, muxer trace is silently suppressed.
     pub async fn embed_metadata(
         &self,
         input: impl AsRef<Path>,
         output: impl AsRef<Path>,
         metadata: &HashMap<String, String>,
         chapters: &[ChapterEntry],
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let metadata = metadata.clone();
         let chapters = chapters.to_vec();
         Self::spawn_blocking("embed_metadata", move || {
-            Self::embed_metadata_sync(&input, &output, &metadata, &chapters)
+            Self::embed_metadata_sync(&input, &output, &metadata, &chapters, callback.as_deref())
         })
         .await
     }
@@ -42,11 +49,22 @@ impl FFmpegRunner {
         output: &Path,
         metadata: &HashMap<String, String>,
         chapters: &[ChapterEntry],
+        callback: Option<&dyn PostProcessCallback>,
     ) -> Result<()> {
         ensure_init()?;
 
-        // Suppress FFmpeg's internal muxer trace/debug spam
-        let _log_suppress = super::log_capture::LogSuppressGuard::error_level();
+        // When a callback is provided, capture FFmpeg logs and forward them;
+        // otherwise suppress muxer trace/debug spam.
+        let capture = if callback.is_some() {
+            Some(super::log_capture::LogCaptureGuard::begin()?)
+        } else {
+            None
+        };
+        let _suppress = if callback.is_none() {
+            Some(super::log_capture::LogSuppressGuard::error_level())
+        } else {
+            None
+        };
 
         let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
             PostProcessError::FFmpegLibraryError {
@@ -169,6 +187,18 @@ impl FFmpegRunner {
             .map_err(|e| PostProcessError::FFmpegLibraryError {
                 message: format!("failed to write output trailer: {e}"),
             })?;
+
+        // Forward captured FFmpeg logs to the callback
+        if let (Some(guard), Some(cb)) = (&capture, callback)
+            && let Ok(logs) = guard.take_captured()
+        {
+            for line in logs {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    cb.on_log(trimmed);
+                }
+            }
+        }
 
         Ok(())
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -40,13 +40,7 @@ impl FFmpegRunner {
         let output = output.as_ref().to_path_buf();
         let container = container.to_string();
         Self::spawn_blocking("embed_thumbnail", move || {
-            Self::embed_thumbnail_sync(
-                &media,
-                &thumbnail,
-                &output,
-                &container,
-                callback.as_deref(),
-            )
+            Self::embed_thumbnail_sync(&media, &thumbnail, &output, &container, callback.as_deref())
         })
         .await
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -9,6 +9,9 @@
 mod mkv_raw_ffi;
 
 use std::path::Path;
+use std::sync::Arc;
+
+use rdlp_core::PostProcessCallback;
 
 use crate::error::{PostProcessError, Result};
 
@@ -20,19 +23,30 @@ impl FFmpegRunner {
     /// Opens both the media file and thumbnail image, copies all media streams,
     /// and adds the thumbnail as a video stream with `ATTACHED_PIC` disposition.
     /// Container-specific handling for MKV (attachment) and MP3 (ID3v2).
+    ///
+    /// When `callback` is provided, FFmpeg C-level log messages are captured
+    /// and forwarded via [`PostProcessCallback::on_log`] instead of being
+    /// suppressed. When `None`, muxer trace is silently suppressed.
     pub async fn embed_thumbnail(
         &self,
         media: impl AsRef<Path>,
         thumbnail: impl AsRef<Path>,
         output: impl AsRef<Path>,
         container: &str,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<()> {
         let media = media.as_ref().to_path_buf();
         let thumbnail = thumbnail.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let container = container.to_string();
         Self::spawn_blocking("embed_thumbnail", move || {
-            Self::embed_thumbnail_sync(&media, &thumbnail, &output, &container)
+            Self::embed_thumbnail_sync(
+                &media,
+                &thumbnail,
+                &output,
+                &container,
+                callback.as_deref(),
+            )
         })
         .await
     }
@@ -49,16 +63,30 @@ impl FFmpegRunner {
         thumbnail: &Path,
         output: &Path,
         container: &str,
+        callback: Option<&dyn PostProcessCallback>,
     ) -> Result<()> {
         ensure_init()?;
 
-        // Suppress FFmpeg's internal muxer trace/debug spam (e.g. matroska "Writing block")
-        let _log_suppress = super::log_capture::LogSuppressGuard::error_level();
+        // When a callback is provided, capture FFmpeg logs and forward them;
+        // otherwise suppress muxer trace/debug spam.
+        let capture = if callback.is_some() {
+            Some(super::log_capture::LogCaptureGuard::begin()?)
+        } else {
+            None
+        };
+        let _suppress = if callback.is_none() {
+            Some(super::log_capture::LogSuppressGuard::error_level())
+        } else {
+            None
+        };
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility
         let is_mkv = container.eq_ignore_ascii_case("mkv") || container.eq_ignore_ascii_case("mka");
         if is_mkv {
-            return Self::embed_thumbnail_mkv_raw_ffi(media, thumbnail, output);
+            let result = Self::embed_thumbnail_mkv_raw_ffi(media, thumbnail, output);
+            // Forward captured logs before returning
+            Self::forward_captured_logs(&capture, callback);
+            return result;
         }
 
         // Open media input
@@ -236,6 +264,26 @@ impl FFmpegRunner {
                 message: format!("failed to write output trailer: {e}"),
             })?;
 
+        // Forward captured FFmpeg logs to the callback
+        Self::forward_captured_logs(&capture, callback);
+
         Ok(())
+    }
+
+    /// Drain captured FFmpeg C-level log messages and forward via callback.
+    fn forward_captured_logs(
+        capture: &Option<super::log_capture::LogCaptureGuard>,
+        callback: Option<&dyn PostProcessCallback>,
+    ) {
+        if let (Some(guard), Some(cb)) = (capture, callback)
+            && let Ok(logs) = guard.take_captured()
+        {
+            for line in logs {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    cb.on_log(trimmed);
+                }
+            }
+        }
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -52,6 +52,9 @@ impl FFmpegRunner {
     ) -> Result<()> {
         ensure_init()?;
 
+        // Suppress FFmpeg's internal muxer trace/debug spam (e.g. matroska "Writing block")
+        let _log_suppress = super::log_capture::LogSuppressGuard::error_level();
+
         // MKV: use raw FFI with proper stream property copying for VLC compatibility
         let is_mkv = container.eq_ignore_ascii_case("mkv") || container.eq_ignore_ascii_case("mka");
         if is_mkv {

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -230,7 +230,13 @@ impl PostProcessor for EmbedThumbnail {
         let log_callback = if config.verbose { callback } else { None };
         match self
             .ffmpeg
-            .embed_thumbnail(&media_file, &thumbnail_file, &temp_output, &extension, log_callback)
+            .embed_thumbnail(
+                &media_file,
+                &thumbnail_file,
+                &temp_output,
+                &extension,
+                log_callback,
+            )
             .await
         {
             Ok(()) => {

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -225,10 +225,12 @@ impl PostProcessor for EmbedThumbnail {
         // Create temp output file
         let temp_output = media_file.with_extension(format!("thumb.{extension}"));
 
-        // Embed via library bindings
+        // Embed via library bindings.
+        // Only forward FFmpeg C-level logs when verbose mode is enabled.
+        let log_callback = if config.verbose { callback } else { None };
         match self
             .ffmpeg
-            .embed_thumbnail(&media_file, &thumbnail_file, &temp_output, &extension, callback)
+            .embed_thumbnail(&media_file, &thumbnail_file, &temp_output, &extension, log_callback)
             .await
         {
             Ok(()) => {

--- a/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
+++ b/crates/rdlp-postprocess/src/processors/embed_thumbnail.rs
@@ -160,7 +160,7 @@ impl PostProcessor for EmbedThumbnail {
         info: &InfoDict,
         files: Vec<PathBuf>,
         config: &PostProcessConfig,
-        _callback: Option<Arc<dyn PostProcessCallback>>,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -228,7 +228,7 @@ impl PostProcessor for EmbedThumbnail {
         // Embed via library bindings
         match self
             .ffmpeg
-            .embed_thumbnail(&media_file, &thumbnail_file, &temp_output, &extension)
+            .embed_thumbnail(&media_file, &thumbnail_file, &temp_output, &extension, callback)
             .await
         {
             Ok(()) => {

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -136,7 +136,7 @@ impl PostProcessor for FFmpegMetadata {
         &self,
         info: &InfoDict,
         files: Vec<PathBuf>,
-        _config: &PostProcessConfig,
+        config: &PostProcessConfig,
         callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
@@ -164,9 +164,11 @@ impl PostProcessor for FFmpegMetadata {
         let metadata = Self::build_metadata(info);
         let chapters = Self::build_chapters(info);
 
-        // Embed via library bindings (stream copy + metadata + chapters)
+        // Embed via library bindings (stream copy + metadata + chapters).
+        // Only forward FFmpeg C-level logs when verbose mode is enabled.
+        let log_callback = if config.verbose { callback } else { None };
         self.ffmpeg
-            .embed_metadata(input_file, &temp_output, &metadata, &chapters, callback)
+            .embed_metadata(input_file, &temp_output, &metadata, &chapters, log_callback)
             .await?;
 
         // Replace original with temp

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_metadata.rs
@@ -137,7 +137,7 @@ impl PostProcessor for FFmpegMetadata {
         info: &InfoDict,
         files: Vec<PathBuf>,
         _config: &PostProcessConfig,
-        _callback: Option<Arc<dyn PostProcessCallback>>,
+        callback: Option<Arc<dyn PostProcessCallback>>,
     ) -> Result<PostProcessResult> {
         if files.is_empty() {
             return Ok(PostProcessResult::new(info.clone(), files));
@@ -166,7 +166,7 @@ impl PostProcessor for FFmpegMetadata {
 
         // Embed via library bindings (stream copy + metadata + chapters)
         self.ffmpeg
-            .embed_metadata(input_file, &temp_output, &metadata, &chapters)
+            .embed_metadata(input_file, &temp_output, &metadata, &chapters, callback)
             .await?;
 
         // Replace original with temp


### PR DESCRIPTION
## Summary
- Add HQPorner video extractor with two-layer iframe resolution (HQPorner → mydaddy.cc embed → bigcdn.cc CDN MP4)
- Implement `SearchExtractor` trait with pagination, total count estimation, and `has_next_page` detection
- Add alt player fallback when primary mydaddy.cc embed fails or returns empty formats
- Suppress FFmpeg muxer trace spam in metadata and thumbnail embedding paths

## Details
- 5 new source files under `crates/rdlp-extractor/src/extractors/hqporner/`
- 45 unit tests covering URL patterns, mydaddy resolver, search parsing, and pagination
- Registered in `ExtractorRegistry` (both extractor and search_extractor lists)
- Supports video pages, category listings, actress pages, and keyword search
- `LogSuppressGuard::error_level()` added to `embed_metadata_sync()` and `embed_thumbnail_sync()`

## Test plan
- [x] `cargo test -p rdlp-extractor` — 45 HQPorner tests pass
- [x] `cargo test -p rdlp-ffmpeg` — 77 tests pass
- [x] `cargo clippy -p rdlp-ffmpeg -- -D warnings` — clean
- [x] Live test: downloaded video from HQPorner with thumbnail embedding, metadata, and MKV remux