### PR TITLE
chore: workspace audit fixes (8 issues)

### DIFF
--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -230,6 +230,9 @@ impl From<OrchestratorError> for RdlpApiError {
                 message: io_err.to_string(),
             },
             OrchestratorError::Configuration(msg) => Self::InvalidInput { message: msg },
+            OrchestratorError::InteractiveNotConfigured => Self::InvalidInput {
+                message: "Interactive selection not configured".into(),
+            },
         }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/errors.rs
+++ b/crates/rdlp-api/src/orchestrator/errors.rs
@@ -84,6 +84,10 @@ pub enum OrchestratorError {
     /// with stdout").
     #[error("{0}")]
     Configuration(String),
+
+    /// Interactive callback not configured but interactive mode was requested
+    #[error("Interactive format selection requested but no interactive callback is configured")]
+    InteractiveNotConfigured,
 }
 
 /// Check if an error warrants re-extracting fresh URLs.

--- a/crates/rdlp-api/src/orchestrator/extraction.rs
+++ b/crates/rdlp-api/src/orchestrator/extraction.rs
@@ -188,10 +188,15 @@ impl Orchestrator {
 
         info!(site = extractor_name, query = query.query.as_str(); "Starting search");
 
-        let results = extractor
-            .search(query, &self.extraction_context)
-            .await
-            .map_err(OrchestratorError::ExtractionFailed)?;
+        let results = tokio::select! {
+            res = extractor.search(query, &self.extraction_context) => {
+                res.map_err(OrchestratorError::ExtractionFailed)?
+            }
+            () = self.cancel_token.cancelled() => {
+                debug!("Search cancelled by token");
+                return Err(OrchestratorError::UserCancelled);
+            }
+        };
 
         info!(site = extractor_name, count = results.len(); "Search complete");
 
@@ -218,10 +223,15 @@ impl Orchestrator {
 
         info!(site = extractor_name, query = query.query.as_str(); "Starting paginated search");
 
-        let response = extractor
-            .search_page(query, &self.extraction_context)
-            .await
-            .map_err(OrchestratorError::ExtractionFailed)?;
+        let response = tokio::select! {
+            res = extractor.search_page(query, &self.extraction_context) => {
+                res.map_err(OrchestratorError::ExtractionFailed)?
+            }
+            () = self.cancel_token.cancelled() => {
+                debug!("Paginated search cancelled by token");
+                return Err(OrchestratorError::UserCancelled);
+            }
+        };
 
         info!(site = extractor_name, count = response.results.len(), page = response.page; "Search page complete");
 

--- a/crates/rdlp-api/src/orchestrator/selection/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/selection/mod.rs
@@ -164,7 +164,7 @@ impl Orchestrator {
         let callback = self
             .interactive
             .as_ref()
-            .expect("interactive callback is set for interactive mode");
+            .ok_or(OrchestratorError::InteractiveNotConfigured)?;
         let grouped_owned: Vec<Format> = by_key.values().map(|f| (*f).clone()).collect();
 
         let selection = callback.select_format(&grouped_owned, info).await;

--- a/crates/rdlp-api/src/orchestrator/subtitle_pipeline/tests.rs
+++ b/crates/rdlp-api/src/orchestrator/subtitle_pipeline/tests.rs
@@ -177,40 +177,58 @@ fn test_strict_subs_passes_when_all_found() {
 
 // -- URL validation tests --
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_validate_urls_keeps_reachable() {
-    let mut server = mockito::Server::new_async().await;
+    let opts = mockito::ServerOpts {
+        host: "127.0.0.1",
+        ..Default::default()
+    };
+    let mut server = mockito::Server::new_with_opts_async(opts).await;
+    let base_url = server.url();
     let _mock = server
         .mock("HEAD", "/en.vtt")
         .with_status(200)
+        .expect(1)
         .create_async()
         .await;
 
     let mut t = track("en", "vtt", false);
-    t.url = server.url() + "/en.vtt";
+    t.url = base_url + "/en.vtt";
     let result = result_with(vec![t]);
 
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap();
     let validated = validate_subtitle_urls(result, &client).await;
 
     assert_eq!(validated.tracks.len(), 1);
     assert_eq!(validated.status, SubtitleStatus::Available);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_validate_urls_filters_unreachable() {
-    let mut server = mockito::Server::new_async().await;
+    let opts = mockito::ServerOpts {
+        host: "127.0.0.1",
+        ..Default::default()
+    };
+    let mut server = mockito::Server::new_with_opts_async(opts).await;
+    let base_url = server.url();
     let _mock = server
         .mock("HEAD", "/en.vtt")
         .with_status(404)
+        .expect(1)
         .create_async()
         .await;
 
     let mut t = track("en", "vtt", false);
-    t.url = server.url() + "/en.vtt";
+    t.url = base_url + "/en.vtt";
     let result = result_with(vec![t]);
 
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap();
     let validated = validate_subtitle_urls(result, &client).await;
 
     assert!(validated.tracks.is_empty());
@@ -222,20 +240,29 @@ async fn test_validate_urls_filters_unreachable() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_validate_urls_auth_reason_on_403() {
-    let mut server = mockito::Server::new_async().await;
+    let opts = mockito::ServerOpts {
+        host: "127.0.0.1",
+        ..Default::default()
+    };
+    let mut server = mockito::Server::new_with_opts_async(opts).await;
+    let base_url = server.url();
     let _mock = server
         .mock("HEAD", "/en.vtt")
         .with_status(403)
+        .expect(1)
         .create_async()
         .await;
 
     let mut t = track("en", "vtt", false);
-    t.url = server.url() + "/en.vtt";
+    t.url = base_url + "/en.vtt";
     let result = result_with(vec![t]);
 
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap();
     let validated = validate_subtitle_urls(result, &client).await;
 
     assert!(validated.tracks.is_empty());

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -180,21 +180,21 @@ async fn async_main() -> Result<()> {
         match client.search(site, &search_query).await {
             Ok(results) => {
                 if results.is_empty() {
-                    println!("No results found for '{query_text}'.");
+                    eprintln!("No results found for '{query_text}'.");
                 } else {
-                    println!("Found {} results:\n", results.len());
+                    eprintln!("Found {} results:\n", results.len());
                     for (i, r) in results.iter().enumerate() {
-                        println!("{:>3}. {}", i + 1, r.title);
-                        println!("     {}", r.video_url);
+                        eprintln!("{:>3}. {}", i + 1, r.title);
+                        eprintln!("     {}", r.video_url);
                         if let Some(d) = r.duration {
                             let mins = d as u32 / 60;
                             let secs = d as u32 % 60;
-                            print!("     Duration: {mins}:{secs:02}");
+                            eprint!("     Duration: {mins}:{secs:02}");
                         }
                         if let Some(views) = r.view_count {
-                            print!("  Views: {views}");
+                            eprint!("  Views: {views}");
                         }
-                        println!();
+                        eprintln!();
                     }
                 }
             }

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -215,26 +215,21 @@ pub(crate) async fn download_segments_with_resume(
                             Some(seg_duration),
                         );
 
-                        // Update state on success; serialize inside lock, write outside
-                        let save_bytes = {
+                        // Update state on success; clone if periodic save needed
+                        let snapshot = {
                             let mut guard = state.lock().await;
                             guard.mark_completed(idx, *bytes);
                             if guard.completed_segments.len() % 50 == 0 {
-                                guard.to_json_bytes().ok()
+                                Some(guard.clone())
                             } else {
                                 None
                             }
                         };
-                        // Write outside the lock to avoid holding it across I/O
-                        if let Some(bytes_to_write) = save_bytes {
-                            let state_path = HlsDownloadState::state_file_path(&output_path);
-                            let temp_path = state_path.with_extension("json.tmp");
-                            if let Err(e) = tokio::fs::write(&temp_path, &bytes_to_write)
-                                .await
-                                .and(tokio::fs::rename(&temp_path, &state_path).await)
-                            {
-                                warn!("Failed to save HLS state: {e}");
-                            }
+                        // Save outside the lock to avoid holding it across I/O
+                        if let Some(snapshot) = snapshot
+                            && let Err(e) = snapshot.save(&output_path).await
+                        {
+                            warn!("Failed to save HLS state: {e}");
                         }
 
                         segments.fetch_add(1, Ordering::Relaxed);
@@ -414,7 +409,7 @@ pub(crate) async fn cleanup_segments(segment_paths: &[PathBuf]) {
         match tokio::fs::remove_file(path).await {
             Ok(()) => deleted += 1,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => warn!(path:? = path; "Failed to clean up segment file: {e}"),
+            Err(e) => warn!(path:? = path; "Failed to delete segment file: {e}"),
         }
     }
 

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -215,21 +215,26 @@ pub(crate) async fn download_segments_with_resume(
                             Some(seg_duration),
                         );
 
-                        // Update state on success; clone if periodic save needed
-                        let snapshot = {
+                        // Update state on success; serialize inside lock, write outside
+                        let save_bytes = {
                             let mut guard = state.lock().await;
                             guard.mark_completed(idx, *bytes);
                             if guard.completed_segments.len() % 50 == 0 {
-                                Some(guard.clone())
+                                guard.to_json_bytes().ok()
                             } else {
                                 None
                             }
                         };
-                        // Save outside the lock to avoid holding it across I/O
-                        if let Some(snapshot) = snapshot
-                            && let Err(e) = snapshot.save(&output_path).await
-                        {
-                            warn!("Failed to save HLS state: {e}");
+                        // Write outside the lock to avoid holding it across I/O
+                        if let Some(bytes_to_write) = save_bytes {
+                            let state_path = HlsDownloadState::state_file_path(&output_path);
+                            let temp_path = state_path.with_extension("json.tmp");
+                            if let Err(e) = tokio::fs::write(&temp_path, &bytes_to_write)
+                                .await
+                                .and(tokio::fs::rename(&temp_path, &state_path).await)
+                            {
+                                warn!("Failed to save HLS state: {e}");
+                            }
                         }
 
                         segments.fetch_add(1, Ordering::Relaxed);
@@ -406,8 +411,10 @@ pub(crate) async fn cleanup_segments(segment_paths: &[PathBuf]) {
 
     let mut deleted = 0;
     for path in segment_paths {
-        if tokio::fs::remove_file(path).await.is_ok() {
-            deleted += 1;
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => deleted += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!(path:? = path; "Failed to clean up segment file: {e}"),
         }
     }
 

--- a/crates/rdlp-downloader/src/hls/segment.rs
+++ b/crates/rdlp-downloader/src/hls/segment.rs
@@ -3,6 +3,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+use reqwest::header::HeaderMap;
 use std::time::Duration;
 
 use backon::Retryable;
@@ -45,22 +47,24 @@ pub(crate) async fn download_segment_with_retry(
     let http_client = http_downloader.client().clone();
     let rate_limiter = http_downloader.rate_limiter.clone();
     let backoff = retry_config.to_backoff();
-    let hdrs = http_downloader.headers();
+    let url: Arc<str> = Arc::from(url.as_str());
+    let segment_path: Arc<Path> = Arc::from(segment_path.as_path());
+    let hdrs: Arc<HeaderMap> = Arc::new(http_downloader.headers());
 
     // Use backon for retry with exponential backoff and jitter
     (|| {
         let client = http_client.clone();
-        let url = url.clone();
-        let segment_path = segment_path.clone();
-        let progress = progress.clone();
+        let url = Arc::clone(&url);
+        let segment_path = Arc::clone(&segment_path);
+        let progress = Arc::clone(&progress);
         let rate_limiter = rate_limiter.clone();
-        let hdrs = hdrs.clone();
+        let hdrs = Arc::clone(&hdrs);
 
         async move {
             // Download segment to file
             let response = client
-                .get(&url)
-                .headers(hdrs)
+                .get(url.as_ref())
+                .headers((*hdrs).clone())
                 .timeout(Duration::from_secs(30)) // 30 second timeout per segment
                 .send()
                 .await
@@ -82,7 +86,7 @@ pub(crate) async fn download_segment_with_retry(
             }
 
             // Stream segment to file with progress tracking
-            let file = File::create(&segment_path).await.map_err(RdlpError::Io)?;
+            let file = File::create(&*segment_path).await.map_err(RdlpError::Io)?;
             let mut writer = BufWriter::with_capacity(buffer_size, file);
             let mut stream = response.bytes_stream();
             let mut downloaded = 0u64;
@@ -104,7 +108,7 @@ pub(crate) async fn download_segment_with_retry(
 
             writer.flush().await.map_err(RdlpError::Io)?;
 
-            Ok((idx, segment_path, downloaded))
+            Ok((idx, PathBuf::from(&*segment_path), downloaded))
         }
     })
     .retry(backoff)
@@ -128,20 +132,20 @@ pub(crate) async fn download_init_segment(
 ) -> Result<()> {
     let client = http_downloader.client().clone();
     let backoff = retry_config.to_backoff();
-    let url = init.url.clone();
+    let url: Arc<str> = Arc::from(init.url.as_str());
     let byte_range = init.byte_range;
-    let dest = dest.to_path_buf();
-    let hdrs = http_downloader.headers();
+    let dest: Arc<Path> = Arc::from(dest);
+    let hdrs: Arc<HeaderMap> = Arc::new(http_downloader.headers());
 
     (|| {
         let client = client.clone();
-        let url = url.clone();
-        let dest = dest.clone();
-        let hdrs = hdrs.clone();
+        let url = Arc::clone(&url);
+        let dest = Arc::clone(&dest);
+        let hdrs = Arc::clone(&hdrs);
         async move {
             let mut req = client
-                .get(&url)
-                .headers(hdrs)
+                .get(url.as_ref())
+                .headers((*hdrs).clone())
                 .timeout(Duration::from_secs(30));
 
             // Apply Range header when EXT-X-MAP specifies BYTERANGE
@@ -169,7 +173,7 @@ pub(crate) async fn download_init_segment(
                 .await
                 .map_err(|e| RdlpError::Network(format!("Init segment read error: {e}")))?;
 
-            tokio::fs::write(&dest, &bytes)
+            tokio::fs::write(&*dest, &bytes)
                 .await
                 .map_err(RdlpError::Io)?;
             debug!(bytes = bytes.len(); "Init segment downloaded");

--- a/crates/rdlp-downloader/src/hls_state.rs
+++ b/crates/rdlp-downloader/src/hls_state.rs
@@ -187,6 +187,14 @@ impl HlsDownloadState {
         Ok(())
     }
 
+    /// Serialize the state to JSON bytes (for writing outside a lock)
+    ///
+    /// # Errors
+    /// Returns a serde error if serialization fails.
+    pub fn to_json_bytes(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(self)
+    }
+
     /// Mark a segment as completed
     pub fn mark_completed(&mut self, segment_index: usize, bytes: u64) {
         self.completed_segments.insert(segment_index);

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -8,7 +8,7 @@ use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
 use crate::chunking::calculate_chunks;
 use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use rdlp_core::{DownloadStats, ProgressCallback, RdlpError, Result};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -49,8 +49,10 @@ async fn cleanup_chunk_files(
     let mut deleted = 0;
     for chunk_id in 0..total_chunks {
         let chunk_path = temp_dir.join(format!("{filename}.{download_id}.part{chunk_id}"));
-        if tokio::fs::remove_file(&chunk_path).await.is_ok() {
-            deleted += 1;
+        match tokio::fs::remove_file(&chunk_path).await {
+            Ok(()) => deleted += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!(path:? = chunk_path; "Failed to delete chunk file: {e}"),
         }
     }
     debug!(deleted; "Chunk cleanup complete");
@@ -471,8 +473,10 @@ async fn merge_chunks_ordered(
                 .await
                 .map_err(RdlpError::Io)?;
 
-            if tokio::fs::remove_file(chunk_path).await.is_ok() {
-                deleted_chunks += 1;
+            match tokio::fs::remove_file(chunk_path).await {
+                Ok(()) => deleted_chunks += 1,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => warn!(path:? = chunk_path; "Failed to delete chunk file: {e}"),
             }
 
             if (idx + 1) % 100 == 0 || idx == total - 1 {

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -31,8 +31,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use log::{debug, warn};
 use rdlp_core::{
-    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
-    SearchPageResponse, SearchQuery, SearchResultPreview,
+    ExponentialBuilder, ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, Retryable,
+    SearchExtractor, SearchPageResponse, SearchQuery, SearchResultPreview,
 };
 use scraper::Html;
 
@@ -93,10 +93,15 @@ impl PornHubExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let response =
-            ctx.http_client.get(url).send().await.map_err(|e| {
-                RdlpError::Network(format!("Failed to fetch PornHub search API: {e}"))
-            })?;
+        let response = (|| async { ctx.http_client.get(url).send().await })
+            .retry(
+                ExponentialBuilder::default()
+                    .with_max_times(2)
+                    .with_min_delay(Duration::from_millis(500)),
+            )
+            .when(|e| e.is_timeout() || e.is_connect())
+            .await
+            .map_err(|e| RdlpError::Network(format!("Failed to fetch PornHub search API: {e}")))?;
 
         rdlp_core::check_http_response(&response)?;
 

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -23,8 +23,8 @@ mod search;
 use async_trait::async_trait;
 use log::{debug, warn};
 use rdlp_core::{
-    ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, SearchExtractor,
-    SearchPageResponse,
+    ExponentialBuilder, ExtractionContext, InfoDict, InfoExtractor, RdlpError, Result, Retryable,
+    SearchExtractor, SearchPageResponse,
 };
 use regex::Regex;
 use scraper::Html;
@@ -364,10 +364,13 @@ impl RedTubeExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<(Vec<rdlp_core::SearchResultPreview>, Option<u64>)> {
-        let response = ctx
-            .http_client
-            .get(url)
-            .send()
+        let response = (|| async { ctx.http_client.get(url).send().await })
+            .retry(
+                ExponentialBuilder::default()
+                    .with_max_times(2)
+                    .with_min_delay(Duration::from_millis(500)),
+            )
+            .when(|e| e.is_timeout() || e.is_connect())
             .await
             .map_err(|e| RdlpError::Network(format!("Failed to fetch search API: {e}")))?;
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
@@ -7,7 +7,10 @@ use super::patterns;
 use crate::base::common::MAX_PLAYLIST_SIZE;
 use futures::stream::{self, StreamExt};
 use log::{debug, info};
-use rdlp_core::{ExtractionContext, InfoDict, RdlpError, Result, check_http_response};
+use rdlp_core::{
+    ExponentialBuilder, ExtractionContext, InfoDict, RdlpError, Result, Retryable,
+    check_http_response,
+};
 use regex::Regex;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -42,9 +45,17 @@ impl XHamsterExtractor {
 
             debug!(page, url:? = page_url; "[XHamster] Fetching user page");
 
-            let response = ctx.http_client.get(&page_url).send().await.map_err(|e| {
-                RdlpError::Network(format!("Failed to fetch user page {page}: {e}"))
-            })?;
+            let response = (|| async { ctx.http_client.get(&page_url).send().await })
+                .retry(
+                    ExponentialBuilder::default()
+                        .with_max_times(2)
+                        .with_min_delay(Duration::from_millis(500)),
+                )
+                .when(|e| e.is_timeout() || e.is_connect())
+                .await
+                .map_err(|e| {
+                    RdlpError::Network(format!("Failed to fetch user page {page}: {e}"))
+                })?;
 
             check_http_response(&response)?;
 


### PR DESCRIPTION
## Summary

Addresses all 8 findings from the workspace audit (`docs/development/workspace-audit-2026-03-11.md`):

- **Fix 3 flaky subtitle pipeline tests** — root cause was mockito binding to IPv6 on Windows; fix: explicit `ServerOpts { host: "127.0.0.1" }`, multi-thread runtime, client timeout
- **Replace `.expect()` with typed error** — new `OrchestratorError::InteractiveNotConfigured` variant replaces panic in `selection/mod.rs`
- **Log file cleanup failures** — `warn!` on non-NotFound errors in chunk and segment cleanup (previously silently swallowed)
- **Arc wrapping in retry closures** — `Arc<str>`, `Arc<Path>`, `Arc<HeaderMap>` replace per-retry String/PathBuf/HeaderMap clones in HLS segment download
- **Optimize HLS state save** — `to_json_bytes()` serializes inside mutex, raw bytes written outside lock
- **Search output to stderr** — human-readable search results now go to stderr, keeping stdout clean for piping
- **Retry wrappers on extractor HTTP** — backon retry (2 retries, 500ms exponential) on PornHub, RedTube, XHamster search calls
- **Cancellation support in search** — `tokio::select!` with `cancel_token.cancelled()` in `search()` and `search_page()`

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test --lib` — 1,221+ tests, 0 failures
- [x] Flaky subtitle tests now pass reliably (3/3)
- [x] QA engineer sign-off ✅