### PR TITLE
fix(extractor): add Referer header to HQPorner requests

### DIFF
--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -101,8 +101,7 @@ impl RdlpApiError {
                 status: Some(429),
             } => Cow::Owned(format!("Rate limited by server. {message}")),
             Self::NetworkError {
-                status: Some(404),
-                ..
+                status: Some(404), ..
             } => Cow::Borrowed("Content not found — it may have been removed"),
             Self::NetworkError {
                 message,

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -101,6 +101,10 @@ impl RdlpApiError {
                 status: Some(429),
             } => Cow::Owned(format!("Rate limited by server. {message}")),
             Self::NetworkError {
+                status: Some(404),
+                ..
+            } => Cow::Borrowed("Content not found — it may have been removed"),
+            Self::NetworkError {
                 message,
                 status: Some(s),
             } if *s >= 500 => Cow::Owned(format!("Server error ({s}). {message}")),
@@ -257,6 +261,17 @@ mod tests {
         };
         let msg = err.user_message();
         assert!(msg.contains("Rate limited"));
+    }
+
+    #[test]
+    fn test_user_message_network_404() {
+        let err = RdlpApiError::NetworkError {
+            message: "Not Found".into(),
+            status: Some(404),
+        };
+        let msg = err.user_message();
+        assert!(msg.contains("not found"), "message: {msg}");
+        assert!(msg.contains("removed"), "message: {msg}");
     }
 
     #[test]

--- a/crates/rdlp-desktop/src-tauri/src/error.rs
+++ b/crates/rdlp-desktop/src-tauri/src/error.rs
@@ -91,6 +91,11 @@ impl From<RdlpApiError> for AppError {
                 message: err.user_message().into_owned(),
             },
             RdlpApiError::NetworkError {
+                status: Some(404), ..
+            } => AppError::ExtractionFailed {
+                message: err.user_message().into_owned(),
+            },
+            RdlpApiError::NetworkError {
                 status: Some(429), ..
             } => AppError::RateLimited {
                 retry_after_ms: Some(5000),
@@ -153,6 +158,22 @@ mod tests {
                 assert_eq!(retry_after_ms, Some(5000));
             }
             other => panic!("Expected RateLimited, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_network_404_maps_to_extraction_failed() {
+        let api_err = RdlpApiError::NetworkError {
+            message: "Not Found".into(),
+            status: Some(404),
+        };
+        let app_err = AppError::from(api_err);
+        match app_err {
+            AppError::ExtractionFailed { message } => {
+                assert!(message.contains("not found"), "message: {message}");
+                assert!(message.contains("removed"), "message: {message}");
+            }
+            other => panic!("Expected ExtractionFailed, got: {other:?}"),
         }
     }
 

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -189,7 +189,12 @@ impl InfoExtractor for HQPornerExtractor {
         let video_id = patterns::extract_video_id(url)
             .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
 
-        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
+        let webpage = BaseExtractor::fetch_webpage_with_headers(
+            url,
+            &[("Referer", "https://hqporner.com/")],
+            ctx,
+        )
+        .await?;
 
         // Extract iframe URL from raw HTML (regex, before DOM parse)
         let iframe_url = extract_iframe_url(&webpage).ok_or_else(|| {
@@ -255,7 +260,12 @@ impl InfoExtractor for HQPornerExtractor {
         let mut page_url = url.to_string();
 
         loop {
-            let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+            let webpage = BaseExtractor::fetch_webpage_with_headers(
+                &page_url,
+                &[("Referer", "https://hqporner.com/")],
+                ctx,
+            )
+            .await?;
 
             let video_urls: Vec<String> = patterns::VIDEO_LINK_PATTERN
                 .captures_iter(&webpage)
@@ -335,7 +345,12 @@ impl SearchExtractor for HQPornerExtractor {
             let sanitized = rdlp_security::sanitize_for_logging(&page_url);
             debug!("[HQPorner] Fetching search page {page}: {sanitized}");
 
-            let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+            let webpage = BaseExtractor::fetch_webpage_with_headers(
+                &page_url,
+                &[("Referer", "https://hqporner.com/")],
+                ctx,
+            )
+            .await?;
             let page_results = search::parse_search_results(&webpage);
 
             if page_results.is_empty() {
@@ -372,7 +387,12 @@ impl SearchExtractor for HQPornerExtractor {
         let page = query.page.unwrap_or(1);
         let page_url = search_patterns::build_search_url(&query.query, page);
 
-        let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+        let webpage = BaseExtractor::fetch_webpage_with_headers(
+            &page_url,
+            &[("Referer", "https://hqporner.com/")],
+            ctx,
+        )
+        .await?;
         let page_results = search::parse_search_results(&webpage);
         let has_more = search::has_next_page(&webpage);
         let total_estimate = search::extract_total_count(&webpage);


### PR DESCRIPTION
## Summary

- HQPorner returns HTTP 404 for video pages when the request lacks a `Referer: https://hqporner.com/` header. All 4 `fetch_webpage` calls in the extractor now use `fetch_webpage_with_headers` with the Referer header (video pages, category/actress listings, search, search_page).
- HTTP 404 during extraction is now mapped to `ExtractionFailed` instead of `NetworkError` in the desktop app, with message "Content not found — it may have been removed" instead of "Network error: Not Found".

## Test plan

- [x] 47 HQPorner extractor tests pass
- [x] 20 rdlp-api error tests pass (including new 404 test)
- [x] 12 rdlp-desktop error tests pass (including new 404→ExtractionFailed test)
- [x] Clippy clean on all 3 changed crates
- [x] Manual verification: "orgasmic rally" video now loads formats in desktop app