### PR TITLE
fix(desktop): thumbnail proxy fallback for CDN Referer issues

### DIFF
--- a/crates/rdlp-desktop/src-tauri/Cargo.toml
+++ b/crates/rdlp-desktop/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ rdlp-api = { path = "../../rdlp-api", features = ["serde"] }
 rdlp-types = { path = "../../rdlp-types" }
 rdlp-core = { path = "../../rdlp-core" }
 rdlp-security = { path = "../../rdlp-security" }
+reqwest = { workspace = true }
+url = { workspace = true }
 
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
@@ -35,6 +37,9 @@ dirs = { workspace = true }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+
+[dev-dependencies]
+mockito = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rdlp-desktop/src-tauri/src/commands/mod.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/mod.rs
@@ -11,3 +11,5 @@ pub mod formats;
 pub mod search;
 /// Application settings commands.
 pub mod settings;
+/// Thumbnail proxy command.
+pub mod thumbnail;

--- a/crates/rdlp-desktop/src-tauri/src/commands/thumbnail.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/thumbnail.rs
@@ -1,0 +1,194 @@
+//! Thumbnail proxy command.
+//!
+//! Fetches a remote thumbnail image server-side, injecting the correct
+//! `Referer` header that CDN servers (e.g. CDN77/phncdn) require.
+//! Returns raw image bytes via [`tauri::ipc::Response`] to bypass
+//! JSON serialization overhead.
+
+use tauri::ipc::Response;
+
+use crate::error::AppError;
+
+/// Maximum response body size (5 MB).
+const MAX_BODY_SIZE: usize = 5 * 1024 * 1024;
+
+/// Timeout for the thumbnail fetch request.
+const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Derive the origin (scheme + host) from a URL string for use as Referer.
+fn derive_referer(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    let host = parsed.host_str()?;
+    let scheme = parsed.scheme();
+    match parsed.port() {
+        Some(port) => Some(format!("{scheme}://{host}:{port}")),
+        None => Some(format!("{scheme}://{host}")),
+    }
+}
+
+/// Fetch a thumbnail image from `url` with a derived `Referer` header
+/// and return the raw bytes.
+///
+/// # Arguments
+///
+/// * `url` - HTTPS URL of the thumbnail image to proxy.
+///
+/// # Returns
+///
+/// Raw image bytes wrapped in a [`tauri::ipc::Response`].
+///
+/// # Errors
+///
+/// Returns [`AppError::InvalidInput`] if the URL is not HTTPS.
+/// Returns [`AppError::Internal`] on network failures, timeouts, or
+/// if the response exceeds [`MAX_BODY_SIZE`].
+#[tauri::command]
+pub async fn proxy_thumbnail(url: String) -> Result<Response, AppError> {
+    // Validate HTTPS
+    if !url.starts_with("https://") {
+        return Err(AppError::InvalidInput {
+            field: "url".to_owned(),
+            message: "Thumbnail proxy only supports HTTPS URLs".to_owned(),
+        });
+    }
+
+    let referer = derive_referer(&url).unwrap_or_default();
+
+    let client = reqwest::Client::builder()
+        .timeout(TIMEOUT)
+        .build()
+        .map_err(|e| AppError::Internal {
+            message: format!("Failed to create HTTP client: {e}"),
+        })?;
+
+    let resp = client
+        .get(&url)
+        .header(reqwest::header::REFERER, &referer)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal {
+            message: format!("Thumbnail fetch failed: {e}"),
+        })?;
+
+    if !resp.status().is_success() {
+        return Err(AppError::Internal {
+            message: format!("Thumbnail fetch returned HTTP {}", resp.status().as_u16()),
+        });
+    }
+
+    // Check Content-Length if available
+    if let Some(len) = resp.content_length()
+        && len as usize > MAX_BODY_SIZE
+    {
+        return Err(AppError::Internal {
+            message: format!("Thumbnail too large: {len} bytes (max {MAX_BODY_SIZE})"),
+        });
+    }
+
+    let bytes = resp.bytes().await.map_err(|e| AppError::Internal {
+        message: format!("Failed to read thumbnail body: {e}"),
+    })?;
+
+    if bytes.len() > MAX_BODY_SIZE {
+        return Err(AppError::Internal {
+            message: format!(
+                "Thumbnail too large: {} bytes (max {MAX_BODY_SIZE})",
+                bytes.len()
+            ),
+        });
+    }
+
+    Ok(Response::new(bytes.to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derive_referer_standard_url() {
+        let referer = derive_referer("https://di.phncdn.com/videos/abc/thumb.jpg");
+        assert_eq!(referer.as_deref(), Some("https://di.phncdn.com"));
+    }
+
+    #[test]
+    fn test_derive_referer_with_port() {
+        let referer = derive_referer("https://example.com:8443/image.jpg");
+        assert_eq!(referer.as_deref(), Some("https://example.com:8443"));
+    }
+
+    #[test]
+    fn test_derive_referer_invalid_url() {
+        assert!(derive_referer("not-a-url").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_rejects_http_url() {
+        let result = proxy_thumbnail("http://example.com/image.jpg".to_owned()).await;
+        match result {
+            Err(AppError::InvalidInput { field, message }) => {
+                assert_eq!(field, "url");
+                assert!(message.contains("HTTPS"));
+            }
+            Err(other) => panic!("Expected InvalidInput, got: {other:?}"),
+            Ok(_) => panic!("Expected Err(InvalidInput), got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rejects_empty_url() {
+        let result = proxy_thumbnail("".to_owned()).await;
+        match result {
+            Err(AppError::InvalidInput { .. }) => {}
+            Err(other) => panic!("Expected InvalidInput, got: {other:?}"),
+            Ok(_) => panic!("Expected Err(InvalidInput), got Ok"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_proxy_sends_referer_and_returns_bytes() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_referer = server.url();
+        let mock = server
+            .mock("GET", "/image.jpg")
+            .match_header("referer", mockito::Matcher::Exact(expected_referer.clone()))
+            .with_status(200)
+            .with_body(vec![0x89, 0x50, 0x4e, 0x47]) // PNG magic bytes
+            .create_async()
+            .await;
+
+        // mockito uses http://, so test inner logic directly (proxy_thumbnail requires https)
+        let referer = derive_referer(&format!("{}/image.jpg", server.url()))
+            .unwrap_or_default();
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("{}/image.jpg", server.url()))
+            .header(reqwest::header::REFERER, &referer)
+            .send()
+            .await
+            .expect("request should succeed");
+        assert!(resp.status().is_success());
+        let bytes = resp.bytes().await.unwrap();
+        assert_eq!(&bytes[..], &[0x89, 0x50, 0x4e, 0x47]);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_proxy_returns_error_on_403() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/forbidden.jpg")
+            .with_status(403)
+            .create_async()
+            .await;
+
+        // Test via inner HTTP logic (mockito uses http://)
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("{}/forbidden.jpg", server.url()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 403);
+    }
+}

--- a/crates/rdlp-desktop/src-tauri/src/lib.rs
+++ b/crates/rdlp-desktop/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
             commands::settings::update_settings,
             commands::settings::pick_directory,
             commands::settings::reveal_in_folder,
+            commands::thumbnail::proxy_thumbnail,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/crates/rdlp-desktop/src-tauri/tauri.conf.json
+++ b/crates/rdlp-desktop/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com"
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com"
     }
   },
   "bundle": {

--- a/crates/rdlp-desktop/src/components/FormatDialogHeader.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialogHeader.tsx
@@ -5,6 +5,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog";
+import { Thumbnail } from "./Thumbnail";
 
 interface FormatDialogHeaderProps {
     title: string | undefined;
@@ -17,11 +18,10 @@ export function FormatDialogHeader({ title, thumbnailUrl }: FormatDialogHeaderPr
         <DialogHeader className="px-5 pt-4 pb-3 border-b border-border shrink-0">
             <div className="flex items-center gap-3">
                 {thumbnailUrl && (
-                    <img
+                    <Thumbnail
                         src={thumbnailUrl}
                         alt=""
                         className="w-12 h-[27px] object-cover rounded-sm shrink-0 bg-muted"
-                        referrerPolicy="no-referrer"
                     />
                 )}
                 <div className="min-w-0 flex-1">

--- a/crates/rdlp-desktop/src/components/ResultCard.tsx
+++ b/crates/rdlp-desktop/src/components/ResultCard.tsx
@@ -7,6 +7,7 @@ import { settingsQueryOptions } from "../api/settings";
 import { FormatOptionsPanel, buildDefaultOptions } from "./FormatOptionsPanel";
 import { Button } from "@/components/ui/button";
 import { cn, parseUploadTimestamp } from "@/lib/utils";
+import { Thumbnail } from "./Thumbnail";
 import type {
     DownloadOptions,
     SearchResultPreview,
@@ -78,12 +79,11 @@ export function ResultCard({
         )}>
             <div className="relative aspect-video bg-background overflow-hidden">
                 {result.thumbnail_url ? (
-                    <img
-                        className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+                    <Thumbnail
                         src={result.thumbnail_url}
                         alt={result.title}
+                        className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
                         decoding="async"
-                        referrerPolicy="no-referrer"
                     />
                 ) : (
                     <div className="flex items-center justify-center h-full text-muted-foreground text-xs uppercase tracking-wider">

--- a/crates/rdlp-desktop/src/components/Thumbnail.tsx
+++ b/crates/rdlp-desktop/src/components/Thumbnail.tsx
@@ -1,0 +1,76 @@
+// Resilient thumbnail component with proxy fallback.
+//
+// Layer 1: Direct <img> with referrerPolicy="no-referrer".
+// Layer 2: On load failure, fetches via Rust proxy_thumbnail command
+//          which injects the correct Referer header for CDNs like CDN77.
+// Layer 3: Placeholder <div> if proxy also fails.
+
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { cn } from "@/lib/utils";
+import { queryKeys } from "@/query/queryKeys";
+
+/**
+ * Fetch a thumbnail via the Rust proxy, returning a Blob URL.
+ *
+ * Uses raw `invoke` (not `invokeTyped`) because `tauri::ipc::Response`
+ * returns binary data as an ArrayBuffer, bypassing JSON serialization.
+ * The query is dormant (`enabled: false`) until the direct <img> fails.
+ */
+function useProxyThumbnail(url: string | null | undefined, enabled: boolean) {
+    return useQuery({
+        queryKey: queryKeys.thumbnail.proxy(url),
+        queryFn: async () => {
+            const bytes = await invoke<ArrayBuffer>("proxy_thumbnail", { url });
+            return URL.createObjectURL(new Blob([new Uint8Array(bytes)]));
+        },
+        enabled: enabled && !!url,
+        staleTime: Infinity,
+        gcTime: 5 * 60 * 1000,
+        retry: false,
+    });
+}
+
+interface ThumbnailProps {
+    src: string | null | undefined;
+    alt: string;
+    className?: string;
+    decoding?: "async" | "sync" | "auto";
+}
+
+/** Thumbnail with automatic proxy fallback for CDNs requiring Referer. */
+export function Thumbnail({ src, alt, className, decoding }: ThumbnailProps) {
+    const [directFailed, setDirectFailed] = useState(false);
+    const { data: proxyUrl, isError: proxyFailed } = useProxyThumbnail(src, directFailed);
+
+    // Revoke Blob URL on unmount or when proxyUrl changes.
+    useEffect(() => {
+        return () => {
+            if (proxyUrl) URL.revokeObjectURL(proxyUrl);
+        };
+    }, [proxyUrl]);
+
+    // No source, or both layers failed → placeholder
+    if (!src || (directFailed && proxyFailed)) {
+        return <div className={cn("bg-muted", className)} />;
+    }
+
+    // Proxy succeeded → show proxied image
+    if (directFailed && proxyUrl) {
+        return <img src={proxyUrl} alt={alt} className={className} loading="lazy" decoding={decoding} />;
+    }
+
+    // Default: try direct load
+    return (
+        <img
+            src={src}
+            alt={alt}
+            className={className}
+            loading="lazy"
+            decoding={decoding}
+            referrerPolicy="no-referrer"
+            onError={() => setDirectFailed(true)}
+        />
+    );
+}

--- a/crates/rdlp-desktop/src/components/__tests__/Thumbnail.test.tsx
+++ b/crates/rdlp-desktop/src/components/__tests__/Thumbnail.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Thumbnail } from "../Thumbnail";
+import { setInvokeHandler, clearInvokeHandlers } from "../../test/tauri-mock";
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+}
+
+describe("Thumbnail", () => {
+    beforeEach(() => {
+        clearInvokeHandlers();
+    });
+
+    it("renders direct img with no-referrer policy", () => {
+        render(
+            <Thumbnail src="https://example.com/thumb.jpg" alt="test" className="w-16 h-9" />,
+            { wrapper: createWrapper() },
+        );
+        const img = screen.getByRole("img");
+        expect(img).toHaveAttribute("src", "https://example.com/thumb.jpg");
+        expect(img).toHaveAttribute("referrerPolicy", "no-referrer");
+        expect(img).toHaveAttribute("loading", "lazy");
+        expect(img).toHaveAttribute("alt", "test");
+        expect(img).toHaveClass("w-16", "h-9");
+    });
+
+    it("renders placeholder when src is null", () => {
+        const { container } = render(
+            <Thumbnail src={null} alt="test" className="w-16 h-9" />,
+            { wrapper: createWrapper() },
+        );
+        expect(screen.queryByRole("img")).toBeNull();
+        const placeholder = container.firstElementChild;
+        expect(placeholder?.tagName).toBe("DIV");
+        expect(placeholder).toHaveClass("bg-muted");
+    });
+
+    it("renders placeholder when src is undefined", () => {
+        const { container } = render(
+            <Thumbnail src={undefined} alt="test" />,
+            { wrapper: createWrapper() },
+        );
+        expect(screen.queryByRole("img")).toBeNull();
+        expect(container.firstElementChild?.tagName).toBe("DIV");
+    });
+
+    it("falls back to proxy on direct load error", async () => {
+        const fakeImageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+        setInvokeHandler("proxy_thumbnail", () => fakeImageBytes);
+
+        // Spy on URL.createObjectURL / revokeObjectURL (preserves URL class)
+        const mockBlobUrl = "blob:http://tauri.localhost/fake-uuid";
+        vi.spyOn(URL, "createObjectURL").mockReturnValue(mockBlobUrl);
+        vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+        render(
+            <Thumbnail src="https://cdn.example.com/thumb.jpg" alt="proxy test" />,
+            { wrapper: createWrapper() },
+        );
+
+        // Direct img renders first
+        const directImg = screen.getByRole("img");
+        expect(directImg).toHaveAttribute("src", "https://cdn.example.com/thumb.jpg");
+
+        // Simulate direct load failure
+        await act(async () => {
+            fireEvent.error(directImg);
+        });
+
+        // Wait for proxy query to resolve
+        await waitFor(() => {
+            const proxyImg = screen.getByRole("img");
+            expect(proxyImg).toHaveAttribute("src", mockBlobUrl);
+        });
+
+        vi.restoreAllMocks();
+    });
+
+    it("shows placeholder when both direct and proxy fail", async () => {
+        setInvokeHandler("proxy_thumbnail", () => {
+            throw new Error("Proxy failed");
+        });
+
+        const { container } = render(
+            <Thumbnail src="https://cdn.example.com/thumb.jpg" alt="fail test" />,
+            { wrapper: createWrapper() },
+        );
+
+        const directImg = screen.getByRole("img");
+
+        await act(async () => {
+            fireEvent.error(directImg);
+        });
+
+        // Wait for proxy query to fail and placeholder to appear
+        await waitFor(() => {
+            expect(screen.queryByRole("img")).toBeNull();
+            const placeholder = container.firstElementChild;
+            expect(placeholder?.tagName).toBe("DIV");
+            expect(placeholder).toHaveClass("bg-muted");
+        });
+    });
+
+    it("revokes blob URL on unmount", async () => {
+        const fakeImageBytes = new Uint8Array([0x89, 0x50]).buffer;
+        setInvokeHandler("proxy_thumbnail", () => fakeImageBytes);
+
+        const mockBlobUrl = "blob:http://tauri.localhost/cleanup-test";
+        vi.spyOn(URL, "createObjectURL").mockReturnValue(mockBlobUrl);
+        const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+        const { unmount } = render(
+            <Thumbnail src="https://cdn.example.com/thumb.jpg" alt="cleanup" />,
+            { wrapper: createWrapper() },
+        );
+
+        // Trigger proxy path
+        await act(async () => {
+            fireEvent.error(screen.getByRole("img"));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole("img")).toHaveAttribute("src", mockBlobUrl);
+        });
+
+        // Unmount should revoke the blob URL
+        unmount();
+        expect(revokeObjectURL).toHaveBeenCalledWith(mockBlobUrl);
+
+        vi.restoreAllMocks();
+    });
+});

--- a/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
+++ b/crates/rdlp-desktop/src/components/utils/searchColumns.tsx
@@ -7,6 +7,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import { Checkbox } from "@/components/ui/checkbox";
 import { parseUploadTimestamp } from "@/lib/utils";
+import { Thumbnail } from "../Thumbnail";
 import { ResultRowActions } from "../ResultRowActions";
 import { formatDuration, formatCompactDate, formatViews } from "./searchUtils";
 import type { DownloadOptions, SearchResultPreview } from "../../types";
@@ -75,16 +76,11 @@ export function useSearchColumns(callbacks: SearchColumnCallbacks): SearchColumn
             enableResizing: false,
             cell: ({ row }) => (
                 <div className="w-16 h-9 shrink-0 rounded-sm overflow-hidden bg-background">
-                    {row.original.thumbnail_url ? (
-                        <img
-                            className="w-full h-full object-cover"
-                            src={row.original.thumbnail_url}
-                            alt=""
-                            referrerPolicy="no-referrer"
-                        />
-                    ) : (
-                        <div className="w-full h-full bg-muted" />
-                    )}
+                    <Thumbnail
+                        src={row.original.thumbnail_url}
+                        alt=""
+                        className="w-full h-full object-cover"
+                    />
                 </div>
             ),
         }),

--- a/crates/rdlp-desktop/src/query/queryKeys.ts
+++ b/crates/rdlp-desktop/src/query/queryKeys.ts
@@ -37,4 +37,7 @@ export const queryKeys = {
     },
     formats: (url: string) => ["formats", url] as const,
     settings: () => ["settings"] as const,
+    thumbnail: {
+        proxy: (url: string | null | undefined) => ["proxy-thumbnail", url] as const,
+    },
 };


### PR DESCRIPTION
## Summary

- Adds a Rust `proxy_thumbnail` Tauri command that fetches images with a derived Referer header, bypassing CDN 403 blocks (e.g., PornHub's phncdn.com via CDN77)
- Adds a `<Thumbnail>` React component with three-layer fallback: direct `<img>` → Rust proxy via TanStack Query → placeholder `<div>`
- Replaces all 3 inline thumbnail `<img>` tags (ResultCard, FormatDialogHeader, searchColumns) with the new component
- Adds `blob:` to CSP `img-src` for proxy Blob URL rendering

## Details

**Rust backend** (`commands/thumbnail.rs`):
- HTTPS-only validation, 10s timeout, 5MB response cap
- Referer derived from URL origin (scheme + host)
- Returns raw bytes via `tauri::ipc::Response` (zero-copy binary transfer)
- 7 tests including mockito integration tests

**Frontend** (`Thumbnail.tsx`):
- `useProxyThumbnail` hook with TanStack Query (`staleTime: Infinity`, `retry: false`)
- Blob URL cleanup via `useEffect` / `URL.revokeObjectURL`
- 6 component tests

## Test plan

- [x] 76 Rust tests pass (`cargo test -p rdlp-desktop`)
- [x] 286 Vitest tests pass (`npm run test`)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] Zero clippy warnings
- [ ] Manual: verify PornHub thumbnails load in the app
- [ ] Manual: verify HQPorner thumbnails still work (different Referer policy)