### PR TITLE
fix(desktop): show formats with unknown height in resolution presets

### DIFF
--- a/crates/rdlp-desktop/src/components/FormatDialog.tsx
+++ b/crates/rdlp-desktop/src/components/FormatDialog.tsx
@@ -98,8 +98,8 @@ export function FormatDialog({ url, onConfirm, onClose }: FormatDialogProps) {
         const all = formatData?.formats ?? [];
         if (!presetId || presetId === "best") return all;
         if (presetId === "audio-only") return all.filter((f) => !f.has_video);
-        if (presetId === "1080p") return all.filter((f) => !f.has_video || (f.height !== null && f.height <= 1080));
-        if (presetId === "720p") return all.filter((f) => !f.has_video || (f.height !== null && f.height <= 720));
+        if (presetId === "1080p") return all.filter((f) => !f.has_video || f.height === null || f.height <= 1080);
+        if (presetId === "720p") return all.filter((f) => !f.has_video || f.height === null || f.height <= 720);
         return all;
     }, [formatData, presetId]);
 


### PR DESCRIPTION
## Summary

- Fixes FormatDialog showing "No formats match this filter" when 1080p/720p presets are selected and formats have `height === null`
- The filter logic `f.height !== null && f.height <= 1080` excluded formats with unknown height; changed to `f.height === null || f.height <= 1080` to include them

## Test plan

- [x] 280 Vitest tests pass
- [x] TypeScript type check clean
- [ ] Manual: open format dialog with 1080p/720p preset and verify formats appear