### PR TITLE
chore: fix FFmpeg 8.0 build config and Linux thumbnail fallback

### DIFF
--- a/.cargo/config.toml.example
+++ b/.cargo/config.toml.example
@@ -4,11 +4,17 @@
 #   cp .cargo/config.toml.example .cargo/config.toml
 
 [env]
+# --- Linux ---
+# Point pkg-config at a custom FFmpeg build (lib/pkgconfig/ must contain libav*.pc files).
+# Uncomment and adjust the path below:
+#PKG_CONFIG_PATH = { value = "/path/to/ffmpeg/lib/pkgconfig", force = true }
+
+# --- Windows ---
 # Path to FFmpeg shared build with include/ and lib/ subdirectories.
-# Required for building the ffmpeg-the-third dev-dependency (used in tests).
+# Required for building the ffmpeg-the-third dependency.
 #
 # Windows (WinGet):  winget install Gyan.FFmpeg.Shared
 # Windows (Choco):   choco install ffmpeg-shared
 #
 # Then set the path below to the directory containing include/ and lib/:
-FFMPEG_DIR = "C:/path/to/ffmpeg-shared"
+#FFMPEG_DIR = "C:/path/to/ffmpeg-shared"

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,6 +4,7 @@
 
 - **Rust 1.85+** (2024 edition)
 - **FFmpeg 5-8 shared libraries** (headers and `.lib`/`.so`/`.dylib`)
+- **clang/libclang** — needed by `bindgen` to generate FFmpeg FFI bindings
 - **C compiler** (MSVC on Windows, gcc on Linux, clang on macOS) — needed to compile bundled SQLite
 
 TLS is handled by Rustls. No OpenSSL or system TLS libraries are required.
@@ -19,16 +20,44 @@ Install the development packages for your distribution:
 
 ```
 # Debian/Ubuntu
-apt install libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libswscale-dev libswresample-dev
+apt install libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libswscale-dev libswresample-dev libclang-dev
 
 # Fedora
-dnf install ffmpeg-devel
+dnf install ffmpeg-devel clang-devel
 
 # Arch
-pacman -S ffmpeg
+pacman -S ffmpeg clang
 ```
 
 `pkg-config` must be able to find the FFmpeg libraries.
+
+#### Custom FFmpeg build
+
+If you have a custom FFmpeg build (e.g. with additional codecs), point
+`PKG_CONFIG_PATH` at its pkgconfig directory. Create `.cargo/config.toml`
+(gitignored) from the provided example:
+
+```
+cp .cargo/config.toml.example .cargo/config.toml
+```
+
+Then edit it to set your FFmpeg pkgconfig path. If your custom build bundles
+its own copies of system libraries (fontconfig, harfbuzz, freetype, etc.),
+isolate the FFmpeg `.pc` files into a separate directory to avoid conflicts
+with system GTK/GDK packages:
+
+```bash
+mkdir -p /path/to/ffmpeg-build/lib/pkgconfig-ffmpeg
+ln -s /path/to/ffmpeg-build/lib/pkgconfig/libav*.pc /path/to/ffmpeg-build/lib/pkgconfig-ffmpeg/
+ln -s /path/to/ffmpeg-build/lib/pkgconfig/libsw*.pc /path/to/ffmpeg-build/lib/pkgconfig-ffmpeg/
+```
+
+Then in `.cargo/config.toml`:
+
+```toml
+[env]
+PKG_CONFIG_PATH = { value = "/path/to/ffmpeg-build/lib/pkgconfig-ffmpeg:/usr/lib/pkgconfig:/usr/share/pkgconfig", force = true }
+```
 
 ### macOS
 
@@ -121,12 +150,11 @@ and enable the bundled `rust-lld` linker:
 linker = "rust-lld"
 ```
 
-On Linux, use `mold` instead:
+On Linux, use `mold` instead (requires GCC 12+ or mold 2.0+):
 
 ```toml
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-Clink-arg=-fuse-ld=mold"]
+[target.'cfg(target_os = "linux")']
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 ```
 
 On macOS, the default linker is already fast; no override is needed.
@@ -135,6 +163,12 @@ With these settings, incremental rebuilds of a single crate take 2–6 seconds
 instead of ~50 seconds.
 
 ## Troubleshooting
+
+**`Cannot find clang` / `libclang.so not found`**
+
+Install clang/libclang. On Arch: `pacman -S clang`. On Debian/Ubuntu:
+`apt install libclang-dev`. Or set `LIBCLANG_PATH` to the directory
+containing `libclang.so`.
 
 **FFmpeg not found (Windows)**
 
@@ -147,6 +181,13 @@ to the root of your shared FFmpeg build and ensure it contains `include/` and
 FFmpeg shared libraries are not installed or not on the library search path.
 On Linux, verify with `pkg-config --libs libavcodec`. On macOS, verify
 Homebrew's FFmpeg is linked: `brew link ffmpeg`.
+
+**`gdk-3.0` / `fontconfig` / `harfbuzz` version mismatch**
+
+If using a custom FFmpeg build that bundles its own copies of system
+libraries, their `.pc` files can shadow system versions and cause version
+conflicts with GTK/GDK. See the "Custom FFmpeg build" section above for the
+pkgconfig isolation workaround.
 
 **`cc` crate fails to find a C compiler**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,20 +366,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.116",
 ]
@@ -457,7 +455,7 @@ dependencies = [
  "boa_string",
  "indexmap 2.13.0",
  "num-bigint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -498,7 +496,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.2",
  "regress",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "ryu-js",
  "serde",
  "serde_json",
@@ -536,7 +534,7 @@ dependencies = [
  "indexmap 2.13.0",
  "once_cell",
  "phf 0.13.1",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "static_assertions",
 ]
 
@@ -569,7 +567,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash 2.1.1",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -581,7 +579,7 @@ dependencies = [
  "fast-float2",
  "itoa",
  "paste",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "ryu-js",
  "static_assertions",
 ]
@@ -1559,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "4.0.0+ffmpeg-8.0"
+version = "4.1.0+ffmpeg-8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc211d0448e9ba775923b7cac39c19d350b47b4994b658f096cd0232d09ef97"
+checksum = "e0c1bf5e362dfb2fbdf9b3e634f3d7f7f0f057103689f518ba4fd96813faf1ef"
 dependencies = [
  "bindgen",
  "cc",
@@ -1573,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-the-third"
-version = "4.0.1+ffmpeg-8.0"
+version = "4.1.0+ffmpeg-8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b90ff7c38b228afb4d1abaf9fce9336acb7c0674f7c99fdb4aee157820bb"
+checksum = "71a274244c87178cd01144536061d63114cecea74cb1037a3614c81cc7ca01e0"
 dependencies = [
  "bitflags 2.11.0",
  "ffmpeg-sys-the-third",
@@ -2788,12 +2786,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -4042,7 +4034,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4062,7 +4054,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4355,10 +4347,12 @@ dependencies = [
  "chrono",
  "dirs",
  "log",
+ "mockito",
  "rdlp-api",
  "rdlp-core",
  "rdlp-security",
  "rdlp-types",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -4367,6 +4361,7 @@ dependencies = [
  "tauri-plugin-opener",
  "thiserror 2.0.18",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -4728,12 +4723,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4947,7 +4936,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "servo_arc 0.4.3",
  "smallvec",
 ]

--- a/crates/rdlp-desktop/src-tauri/src/commands/thumbnail.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/thumbnail.rs
@@ -158,8 +158,7 @@ mod tests {
             .await;
 
         // mockito uses http://, so test inner logic directly (proxy_thumbnail requires https)
-        let referer = derive_referer(&format!("{}/image.jpg", server.url()))
-            .unwrap_or_default();
+        let referer = derive_referer(&format!("{}/image.jpg", server.url())).unwrap_or_default();
         let client = reqwest::Client::new();
         let resp = client
             .get(format!("{}/image.jpg", server.url()))

--- a/crates/rdlp-desktop/src/components/Thumbnail.tsx
+++ b/crates/rdlp-desktop/src/components/Thumbnail.tsx
@@ -5,7 +5,7 @@
 //          which injects the correct Referer header for CDNs like CDN77.
 // Layer 3: Placeholder <div> if proxy also fails.
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
@@ -42,7 +42,29 @@ interface ThumbnailProps {
 /** Thumbnail with automatic proxy fallback for CDNs requiring Referer. */
 export function Thumbnail({ src, alt, className, decoding }: ThumbnailProps) {
     const [directFailed, setDirectFailed] = useState(false);
+    const imgRef = useRef<HTMLImageElement>(null);
     const { data: proxyUrl, isError: proxyFailed } = useProxyThumbnail(src, directFailed);
+
+    // Detect broken images that WebKitGTK doesn't fire onError for.
+    // Check naturalWidth after mount — a broken image has naturalWidth === 0.
+    const handleLoad = useCallback(() => {
+        if (imgRef.current && imgRef.current.naturalWidth === 0) {
+            setDirectFailed(true);
+        }
+    }, []);
+
+    const handleError = useCallback(() => setDirectFailed(true), []);
+
+    // Also check on mount in case the image was already cached/broken before
+    // React attached event handlers (WebKitGTK race condition).
+    useEffect(() => {
+        const img = imgRef.current;
+        if (img && img.complete) {
+            if (img.naturalWidth === 0) {
+                setDirectFailed(true);
+            }
+        }
+    }, [src]);
 
     // Revoke Blob URL on unmount or when proxyUrl changes.
     useEffect(() => {
@@ -64,13 +86,15 @@ export function Thumbnail({ src, alt, className, decoding }: ThumbnailProps) {
     // Default: try direct load
     return (
         <img
+            ref={imgRef}
             src={src}
             alt={alt}
             className={className}
             loading="lazy"
             decoding={decoding}
             referrerPolicy="no-referrer"
-            onError={() => setDirectFailed(true)}
+            onLoad={handleLoad}
+            onError={handleError}
         />
     );
 }

--- a/crates/rdlp-ffmpeg/Cargo.toml
+++ b/crates/rdlp-ffmpeg/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 serde = { workspace = true }
 
 # FFmpeg library bindings (FFmpeg 5-8)
-ffmpeg-the-third = "4.0"
+ffmpeg-the-third = "4.1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/rdlp-postprocess/build.rs
+++ b/crates/rdlp-postprocess/build.rs
@@ -39,20 +39,23 @@ fn detect_ffmpeg() -> Option<PathBuf> {
         println!("cargo:warning=FFMPEG_DIR={dir} is set but missing include/ or lib/");
     }
 
-    // 2. Search common installation paths (Windows)
-    if cfg!(target_os = "windows")
-        && let Some(dir) = search_windows_paths()
-    {
-        println!("cargo:warning=Auto-detected FFmpeg at: {}", dir.display());
+    // 2. Derive from PKG_CONFIG_PATH (finds custom FFmpeg builds on Linux)
+    if let Some(dir) = derive_from_pkg_config_path() {
+        eprintln!("FFmpeg detected via PKG_CONFIG_PATH: {}", dir.display());
         return Some(dir);
     }
 
-    // 3. Derive from ffmpeg.exe in PATH
+    // 3. Search common installation paths (Windows)
+    if cfg!(target_os = "windows")
+        && let Some(dir) = search_windows_paths()
+    {
+        eprintln!("FFmpeg auto-detected at: {}", dir.display());
+        return Some(dir);
+    }
+
+    // 4. Derive from ffmpeg in PATH
     if let Some(dir) = derive_from_path() {
-        println!(
-            "cargo:warning=Derived FFmpeg dir from PATH: {}",
-            dir.display()
-        );
+        eprintln!("FFmpeg derived from PATH: {}", dir.display());
         return Some(dir);
     }
 
@@ -130,6 +133,30 @@ fn search_windows_paths() -> Option<PathBuf> {
         let ffmpeg_dir = PathBuf::from(pf).join("FFmpeg");
         if is_valid_ffmpeg_dir(&ffmpeg_dir) {
             return Some(ffmpeg_dir);
+        }
+    }
+
+    None
+}
+
+/// Try to derive the FFmpeg directory from `PKG_CONFIG_PATH`.
+///
+/// Searches each directory in `PKG_CONFIG_PATH` for `libavcodec.pc` and derives
+/// the parent directory (e.g., `.../lib/pkgconfig/libavcodec.pc` → `...`).
+fn derive_from_pkg_config_path() -> Option<PathBuf> {
+    let pkg_path = std::env::var("PKG_CONFIG_PATH").ok()?;
+
+    for dir in pkg_path.split(':') {
+        let pc_file = PathBuf::from(dir).join("libavcodec.pc");
+        if pc_file.is_file() {
+            // .../lib/pkgconfig -> .../lib -> ...
+            if let Some(pkgconfig_dir) = pc_file.parent()
+                && let Some(lib_dir) = pkgconfig_dir.parent()
+                && let Some(parent) = lib_dir.parent()
+                && is_valid_ffmpeg_dir(parent)
+            {
+                return Some(parent.to_path_buf());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Bump `ffmpeg-the-third` 4.0 → 4.1 to fix FFmpeg 8.0 opaque struct breakage (`AVFormatContext.streams`)
- Add `PKG_CONFIG_PATH` detection in postprocess build script for custom FFmpeg builds; demote success messages from `cargo:warning` to `eprintln` (visible only in `cargo build -vv`)
- Update `.cargo/config.toml.example` with Linux `PKG_CONFIG_PATH` and correct mold linker config (`cfg`-based, not clang wrapper — avoids LTO object conflicts)
- Update `BUILDING.md`: add clang/libclang requirement, custom FFmpeg build section with pkgconfig isolation for bundled fontconfig/harfbuzz, new troubleshooting entries
- Fix `Thumbnail` component for WebKitGTK: add `naturalWidth === 0` check on load and mount to detect broken images that don't fire `onError`

## Test plan

- [ ] `cargo build -p rdlp-cli` succeeds with mold linker on Linux
- [ ] `cargo build -p rdlp-ffmpeg` links against FFmpeg 8.0 without opaque struct errors
- [ ] `npx tauri dev` launches desktop app on Linux without build warnings
- [ ] Search thumbnails render on Linux (WebKitGTK) via proxy fallback
- [ ] Search thumbnails still render on Windows (no regression)