### PR TITLE
chore: add missing MIT license to rdlp-security crate

### DIFF
--- a/crates/rdlp-security/Cargo.toml
+++ b/crates/rdlp-security/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdlp-security"
 version = "0.1.0"
 edition = "2024"
+license.workspace = true
 
 [dependencies]
 regex = "1.11"


### PR DESCRIPTION
## Summary
- Add `license.workspace = true` to `rdlp-security/Cargo.toml` — the only workspace crate missing the MIT license field
- All 17 crates now show MIT in `cargo-license` output

## Test plan
- [x] `cargo check -p rdlp-security` passes
- [x] `cargo license` shows no UNKNOWN licenses