### PR TITLE
feat: prefer libfdk_aac over built-in aac when available

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
@@ -2,6 +2,15 @@
 //!
 //! Provides `AudioCodecConfig` and `AUDIO_CODECS` for mapping codec names
 //! to encoder names, file extensions, quality scale ranges, and bitrate ranges.
+//!
+//! When `libfdk_aac` is available (custom FFmpeg build with `--enable-nonfree`),
+//! it is automatically preferred over the built-in `aac` encoder for better
+//! quality at equivalent bitrates. Use [`preferred_aac_encoder()`] to resolve
+//! the best available AAC encoder at runtime.
+
+use std::sync::OnceLock;
+
+use log::info;
 
 /// Audio codec configuration for extraction/conversion.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -153,4 +162,59 @@ pub fn get_audio_codec(name: &str) -> Option<&'static AudioCodecConfig> {
         .iter()
         .find(|(n, _)| n.eq_ignore_ascii_case(name))
         .map(|(_, config)| config)
+}
+
+/// Returns the best available AAC encoder name.
+///
+/// Checks once (cached via `OnceLock`) whether `libfdk_aac` is available in the
+/// linked FFmpeg build. If so, returns `"libfdk_aac"` (Fraunhofer FDK AAC —
+/// better quality, HE-AAC support); otherwise falls back to the built-in `"aac"`.
+///
+/// This function requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn preferred_aac_encoder() -> &'static str {
+    static PREFERRED: OnceLock<&'static str> = OnceLock::new();
+    PREFERRED.get_or_init(|| {
+        if ffmpeg_the_third::codec::encoder::find_by_name("libfdk_aac").is_some() {
+            info!("Using libfdk_aac (Fraunhofer FDK) as AAC encoder");
+            "libfdk_aac"
+        } else {
+            info!("Using built-in aac encoder (libfdk_aac not available)");
+            "aac"
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preferred_aac_encoder_returns_valid_name() {
+        // Must be one of the two known AAC encoders
+        let enc = preferred_aac_encoder();
+        assert!(
+            enc == "aac" || enc == "libfdk_aac",
+            "unexpected encoder: {enc}"
+        );
+    }
+
+    #[test]
+    fn test_get_audio_codec_aac() {
+        let config = get_audio_codec("aac").unwrap();
+        assert_eq!(config.extension, "m4a");
+        assert!(config.encoder.is_some());
+    }
+
+    #[test]
+    fn test_get_audio_codec_case_insensitive() {
+        assert!(get_audio_codec("AAC").is_some());
+        assert!(get_audio_codec("Mp3").is_some());
+        assert!(get_audio_codec("FLAC").is_some());
+    }
+
+    #[test]
+    fn test_get_audio_codec_unknown() {
+        assert!(get_audio_codec("nonexistent").is_none());
+    }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -152,6 +152,21 @@ impl FFmpegRunner {
 
         set_single_thread_codec(unsafe { audio_encoder.as_mut_ptr() });
 
+        // Enable afterburner for libfdk_aac (higher quality, ~10% slower)
+        if enc_name == "libfdk_aac" {
+            unsafe {
+                let key = std::ffi::CString::new("afterburner").unwrap();
+                let val = std::ffi::CString::new("1").unwrap();
+                ffmpeg_the_third::ffi::av_opt_set(
+                    audio_encoder.as_mut_ptr().cast(),
+                    key.as_ptr(),
+                    val.as_ptr(),
+                    ffmpeg_the_third::ffi::AV_OPT_SEARCH_CHILDREN,
+                );
+            }
+            debug!("[{label}] libfdk_aac: afterburner enabled");
+        }
+
         let mut audio_encoder =
             audio_encoder
                 .open_as(enc_codec)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -207,6 +207,9 @@ pub(super) fn extract_json_value(text: &str, key: &str) -> Option<f64> {
 }
 
 /// Select the appropriate audio encoder for a container extension.
+///
+/// For AAC-compatible containers, returns the best available AAC encoder
+/// via [`preferred_aac_encoder()`] (`libfdk_aac` when available, `aac` otherwise).
 pub(super) fn select_audio_encoder_for_container(ext: &str) -> &'static str {
     if ext.eq_ignore_ascii_case("mp4")
         || ext.eq_ignore_ascii_case("m4a")
@@ -217,7 +220,7 @@ pub(super) fn select_audio_encoder_for_container(ext: &str) -> &'static str {
         || ext.eq_ignore_ascii_case("mpg")
         || ext.eq_ignore_ascii_case("flv")
     {
-        "aac"
+        crate::ffmpeg::audio_codecs::preferred_aac_encoder()
     } else if ext.eq_ignore_ascii_case("webm")
         || ext.eq_ignore_ascii_case("ogg")
         || ext.eq_ignore_ascii_case("opus")
@@ -232,14 +235,14 @@ pub(super) fn select_audio_encoder_for_container(ext: &str) -> &'static str {
     } else if ext.eq_ignore_ascii_case("wav") {
         "pcm_s16le"
     } else {
-        "aac"
+        crate::ffmpeg::audio_codecs::preferred_aac_encoder()
     }
 }
 
 /// Get a sensible default bitrate (in bps) for an encoder.
 pub(super) fn default_bitrate_for_encoder(encoder: &str) -> usize {
     match encoder {
-        "aac" => 128_000,
+        "aac" | "libfdk_aac" => 128_000,
         "libmp3lame" => 192_000,
         "libopus" => 128_000,
         "flac" | "pcm_s16le" => 0,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
@@ -5,24 +5,28 @@ use super::helpers::*;
 
 #[test]
 fn test_select_audio_encoder_for_container() {
-    assert_eq!(select_audio_encoder_for_container("mp4"), "aac");
-    assert_eq!(select_audio_encoder_for_container("m4a"), "aac");
-    assert_eq!(select_audio_encoder_for_container("mov"), "aac");
+    // AAC-compatible containers return the preferred AAC encoder
+    // (libfdk_aac if available, built-in aac otherwise)
+    let aac = crate::ffmpeg::audio_codecs::preferred_aac_encoder();
+    assert_eq!(select_audio_encoder_for_container("mp4"), aac);
+    assert_eq!(select_audio_encoder_for_container("m4a"), aac);
+    assert_eq!(select_audio_encoder_for_container("mov"), aac);
     assert_eq!(select_audio_encoder_for_container("webm"), "libopus");
     assert_eq!(select_audio_encoder_for_container("mkv"), "libopus");
     assert_eq!(select_audio_encoder_for_container("avi"), "libmp3lame");
     assert_eq!(select_audio_encoder_for_container("mp3"), "libmp3lame");
     assert_eq!(select_audio_encoder_for_container("flac"), "flac");
     assert_eq!(select_audio_encoder_for_container("wav"), "pcm_s16le");
-    assert_eq!(select_audio_encoder_for_container("ts"), "aac");
+    assert_eq!(select_audio_encoder_for_container("ts"), aac);
     assert_eq!(select_audio_encoder_for_container("ogg"), "libopus");
-    assert_eq!(select_audio_encoder_for_container("flv"), "aac");
-    assert_eq!(select_audio_encoder_for_container("xyz"), "aac");
+    assert_eq!(select_audio_encoder_for_container("flv"), aac);
+    assert_eq!(select_audio_encoder_for_container("xyz"), aac);
 }
 
 #[test]
 fn test_default_bitrate_for_encoder() {
     assert_eq!(default_bitrate_for_encoder("aac"), 128_000);
+    assert_eq!(default_bitrate_for_encoder("libfdk_aac"), 128_000);
     assert_eq!(default_bitrate_for_encoder("libmp3lame"), 192_000);
     assert_eq!(default_bitrate_for_encoder("libopus"), 128_000);
     assert_eq!(default_bitrate_for_encoder("flac"), 0);


### PR DESCRIPTION
## Summary
- Runtime detection of `libfdk_aac` (Fraunhofer FDK AAC) encoder via `find_by_name()`, cached with `OnceLock`
- All AAC encoding (normalization, audio extraction, merge) transparently upgrades when available
- Enables `afterburner` mode for higher quality encoding (~10% slower)
- OSS/release builds gracefully fall back to built-in `aac` encoder — zero impact

## Test plan
- [x] `cargo test -p rdlp-ffmpeg` — 81 tests pass (78 lib + 1 integration + 2 doc)
- [x] `cargo clippy -p rdlp-ffmpeg` — clean
- [x] `cargo check --workspace` — clean
- [ ] Manual: download + normalize with custom FFmpeg build, verify `libfdk_aac` in logs