### PR TITLE
feat: support local file post-processing in CLI

### DIFF
--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -438,6 +438,78 @@ impl RdlpClient {
             .collect()
     }
 
+    /// Post-process a local file without downloading.
+    ///
+    /// Applies the configured post-processing pipeline (normalization, remux,
+    /// audio extraction, etc.) to an existing local file. Returns a
+    /// [`DownloadHandle`] with the same event/progress interface as `download()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the local file to process.
+    #[must_use]
+    pub fn process_local_file(&self, path: std::path::PathBuf) -> DownloadHandle {
+        let id = DownloadId::next();
+        let (tx, rx) = mpsc::channel::<Event>(256);
+        let cancel_token = CancellationToken::new();
+        let config = Arc::clone(&self.config);
+        let token = cancel_token.clone();
+
+        let join_handle = tokio::spawn(async move {
+            let orchestrator = Orchestrator::new(config, tx.clone(), id, token, None);
+
+            // Build a minimal InfoDict from the file path
+            let file_name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let info = rdlp_core::InfoDict::new(&file_name, &file_name, "local", format!("file://{}", path.display()));
+            let _ = tx
+                .send(Event::PostProcessing {
+                    id,
+                    stage: "Starting post-processing".to_string(),
+                })
+                .await;
+
+            if !path.exists() {
+                let err = RdlpApiError::IoError {
+                    message: format!("File not found: {}", path.display()),
+                };
+                let _ = tx.send(Event::Failed { id, error: err.clone() }).await;
+                return Err(err);
+            }
+
+            match orchestrator
+                .run_postprocessing(&info, vec![path], false)
+                .await
+            {
+                Ok(output_files) => {
+                    let result = crate::DownloadResult {
+                        id,
+                        output_files,
+                        info,
+                        stats: rdlp_core::DownloadStats::new(0, std::time::Duration::ZERO, 0),
+                    };
+                    let _ = tx
+                        .send(Event::Completed {
+                            id,
+                            result: Box::new(result.clone()),
+                        })
+                        .await;
+                    Ok(result)
+                }
+                Err(e) => {
+                    let err = RdlpApiError::from(e);
+                    let _ = tx.send(Event::Failed { id, error: err.clone() }).await;
+                    Err(err)
+                }
+            }
+        });
+
+        DownloadHandle::new(id, rx, cancel_token, join_handle)
+    }
+
     /// Merge request options into a Config, applying overrides from the request.
     fn build_config(&self, request: &DownloadRequest) -> Config {
         let mut config = (*self.config).clone();

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -117,7 +117,7 @@ impl Orchestrator {
     /// # Returns
     /// * `Ok(paths)` - Processed file paths (may differ from input if conversion occurred)
     /// * `Err(e)` - Post-processing failed
-    pub(super) async fn run_postprocessing(
+    pub(crate) async fn run_postprocessing(
         &self,
         info: &rdlp_core::InfoDict,
         files: Vec<PathBuf>,

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -273,6 +273,28 @@ async fn async_main() -> Result<()> {
         return Ok(());
     }
 
+    // Local file path: skip extraction/download, run post-processing only
+    let local_path = std::path::Path::new(&url);
+    if !url.contains("://") && local_path.exists() {
+        info!("Processing local file: {}", local_path.display());
+        let mut handle = client.process_local_file(local_path.to_path_buf());
+        let mut event_handler = CliEventHandler::new(Arc::clone(&multi_progress), quiet);
+
+        while let Some(event) = handle.events().recv().await {
+            event_handler.handle_event(&event);
+        }
+
+        return match handle.wait().await {
+            Ok(result) => {
+                if let Some(path) = result.output_files.first() {
+                    info!("Success! Processed file: {}", path.display());
+                }
+                Ok(())
+            }
+            Err(e) => fail_with(e, verbose),
+        };
+    }
+
     // Build download request from config
     let request = rdlp_api::DownloadRequest {
         url: url.clone(),


### PR DESCRIPTION
## Summary
- Detect local file paths in CLI (no `://` scheme + file exists) and route directly to post-processing pipeline
- Add `process_local_file()` to `RdlpClient` returning standard `DownloadHandle` with events
- All post-processing flags work on local files: `--loudnorm`, `--normalize-audio`, `--normalize-boost`, `--remux`, `-x`, etc.

## Test plan
- [x] `cargo clippy -p rdlp-cli -p rdlp-api` — clean
- [x] Manual: `rdlp --loudnorm "/path/to/file.mp4"` — processes local file with libfdk_aac
- [ ] Manual: `rdlp --remux=mkv "/path/to/file.mp4"` — remux local file
- [ ] Manual: `rdlp -x --audio-format=mp3 "/path/to/file.mp4"` — extract audio