### PR TITLE
fix(desktop): thumbnails disappear after table sort

### DIFF
--- a/crates/rdlp-desktop/src/components/Thumbnail.tsx
+++ b/crates/rdlp-desktop/src/components/Thumbnail.tsx
@@ -20,6 +20,10 @@ const directFailCache = new Set<string>();
  * Uses raw `invoke` (not `invokeTyped`) because `tauri::ipc::Response`
  * returns binary data as an ArrayBuffer, bypassing JSON serialization.
  * The query is dormant (`enabled: false`) until the direct <img> fails.
+ *
+ * Blob URLs are NOT revoked — they are cached by TanStack Query and must
+ * remain valid across component remounts (e.g. after table sort). The
+ * browser reclaims them when the page unloads.
  */
 function useProxyThumbnail(url: string | null | undefined, enabled: boolean) {
     return useQuery({
@@ -47,7 +51,7 @@ export function Thumbnail({ src, alt, className, decoding }: ThumbnailProps) {
     // Check module-level cache so remounted components skip the direct attempt
     const [directFailed, setDirectFailed] = useState(() => !!src && directFailCache.has(src));
     const imgRef = useRef<HTMLImageElement>(null);
-    const { data: proxyUrl, isError: proxyFailed } = useProxyThumbnail(src, directFailed);
+    const { data: proxyUrl, isError: proxyFailed, isPending: proxyPending } = useProxyThumbnail(src, directFailed);
 
     // Detect broken images that WebKitGTK doesn't fire onError for.
     // Check naturalWidth after mount — a broken image has naturalWidth === 0.
@@ -69,20 +73,24 @@ export function Thumbnail({ src, alt, className, decoding }: ThumbnailProps) {
         const img = imgRef.current;
         if (img && img.complete) {
             if (img.naturalWidth === 0) {
+                if (src) directFailCache.add(src);
                 setDirectFailed(true);
             }
         }
     }, [src]);
 
-    // Revoke Blob URL on unmount or when proxyUrl changes.
-    useEffect(() => {
-        return () => {
-            if (proxyUrl) URL.revokeObjectURL(proxyUrl);
-        };
-    }, [proxyUrl]);
+    // No source → placeholder
+    if (!src) {
+        return <div className={cn("bg-muted", className)} />;
+    }
 
-    // No source, or both layers failed → placeholder
-    if (!src || (directFailed && proxyFailed)) {
+    // Direct failed, proxy loading → placeholder (not the broken direct <img>)
+    if (directFailed && proxyPending) {
+        return <div className={cn("bg-muted animate-pulse", className)} />;
+    }
+
+    // Direct failed, proxy also failed → placeholder
+    if (directFailed && proxyFailed) {
         return <div className={cn("bg-muted", className)} />;
     }
 

--- a/crates/rdlp-desktop/src/components/__tests__/Thumbnail.test.tsx
+++ b/crates/rdlp-desktop/src/components/__tests__/Thumbnail.test.tsx
@@ -89,7 +89,7 @@ describe("Thumbnail", () => {
         });
 
         const { container } = render(
-            <Thumbnail src="https://cdn.example.com/thumb.jpg" alt="fail test" />,
+            <Thumbnail src="https://cdn.example.com/fail-both.jpg" alt="fail test" />,
             { wrapper: createWrapper() },
         );
 
@@ -99,7 +99,8 @@ describe("Thumbnail", () => {
             fireEvent.error(directImg);
         });
 
-        // Wait for proxy query to fail and placeholder to appear
+        // After direct fails, shows pulsing placeholder while proxy loads,
+        // then static placeholder when proxy also fails
         await waitFor(() => {
             expect(screen.queryByRole("img")).toBeNull();
             const placeholder = container.firstElementChild;
@@ -108,7 +109,7 @@ describe("Thumbnail", () => {
         });
     });
 
-    it("revokes blob URL on unmount", async () => {
+    it("does not revoke blob URL on unmount (cached by TanStack Query)", async () => {
         const fakeImageBytes = new Uint8Array([0x89, 0x50]).buffer;
         setInvokeHandler("proxy_thumbnail", () => fakeImageBytes);
 
@@ -117,7 +118,7 @@ describe("Thumbnail", () => {
         const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
         const { unmount } = render(
-            <Thumbnail src="https://cdn.example.com/thumb.jpg" alt="cleanup" />,
+            <Thumbnail src="https://cdn.example.com/no-revoke.jpg" alt="cleanup" />,
             { wrapper: createWrapper() },
         );
 
@@ -130,9 +131,10 @@ describe("Thumbnail", () => {
             expect(screen.getByRole("img")).toHaveAttribute("src", mockBlobUrl);
         });
 
-        // Unmount should revoke the blob URL
+        // Unmount should NOT revoke — blob URL is cached by TanStack Query
+        // and must remain valid for remounted components (e.g. after sort)
         unmount();
-        expect(revokeObjectURL).toHaveBeenCalledWith(mockBlobUrl);
+        expect(revokeObjectURL).not.toHaveBeenCalled();
 
         vi.restoreAllMocks();
     });


### PR DESCRIPTION
## Summary
- Stop revoking Blob URLs on unmount — TanStack Query cache must keep them valid across remounts
- Show pulsing placeholder during proxy fetch instead of broken direct `<img>`
- Add `directFailCache` (module-level Set) to skip direct attempt on remount

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 286 tests pass
- [ ] Manual: search HQPorner, sort by Duration, thumbnails persist