### PR TITLE
chore(desktop): revoke thumbnail Blob URLs via QueryCache GC

### DIFF
--- a/crates/rdlp-desktop/src/query/queryClient.ts
+++ b/crates/rdlp-desktop/src/query/queryClient.ts
@@ -22,3 +22,19 @@ export const queryClient = new QueryClient({
         },
     },
 });
+
+// Revoke Blob URLs when thumbnail proxy queries are garbage collected.
+// Blob URLs are NOT revoked on component unmount (they must stay valid
+// for TanStack Query cache hits on remount, e.g. after table sort).
+// Instead, we clean them up here when the query is actually removed
+// from the cache after gcTime expires.
+queryClient.getQueryCache().subscribe((event) => {
+    if (
+        event.type === "removed" &&
+        event.query.queryKey[0] === "proxy-thumbnail" &&
+        typeof event.query.state.data === "string" &&
+        event.query.state.data.startsWith("blob:")
+    ) {
+        URL.revokeObjectURL(event.query.state.data);
+    }
+});


### PR DESCRIPTION
## Summary
- Subscribe to `queryCache.subscribe()` for `removed` events on `proxy-thumbnail` queries
- Revoke Blob URLs when TanStack Query garbage collects the query (after `gcTime` = 5min)
- Correct cleanup lifecycle: not on unmount (breaks cache), not never (leaks)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 286 tests pass
- [ ] Manual: sort table, thumbnails persist; wait 5min inactive, Blob URLs freed