### PR TITLE
feat: runtime video encoder selection with Expert Mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4350,6 +4350,7 @@ dependencies = [
  "mockito",
  "rdlp-api",
  "rdlp-core",
+ "rdlp-ffmpeg",
  "rdlp-security",
  "rdlp-types",
  "reqwest 0.12.28",

--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -133,6 +133,9 @@ impl MergeOverrides for PostProcessOptions {
         if let Some(v) = self.recode_video {
             config.recode_video = Some(v);
         }
+        if let Some(ref v) = self.video_encoder {
+            config.video_encoder = Some(v.clone());
+        }
     }
 }
 

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -93,6 +93,7 @@ impl Orchestrator {
             normalize_boost: self.config.normalize_boost,
             normalize_boost_db: self.config.normalize_boost_db,
             verbose: self.config.verbose,
+            video_encoder: self.config.video_encoder.clone(),
         }
     }
 

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -205,6 +205,9 @@ pub struct PostProcessOptions {
     pub normalize_boost_db: Option<f64>,
     /// Recode (transcode) video into a different container format.
     pub recode_video: Option<ContainerFormat>,
+    /// Explicit video encoder override (e.g., "libsvtav1", "libx264").
+    /// `None` = auto-select best available encoder for the target codec.
+    pub video_encoder: Option<String>,
 }
 
 /// Network, retry, and cookie options.

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -137,6 +137,15 @@ pub(crate) struct Args {
     #[arg(long)]
     pub retry_subs: bool,
 
+    /// Video encoder to use (e.g., libsvtav1, libx264).
+    /// Overrides automatic encoder selection.
+    #[arg(long, value_name = "NAME")]
+    pub video_encoder: Option<String>,
+
+    /// List available video encoders and exit.
+    #[arg(long)]
+    pub list_encoders: bool,
+
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -177,6 +177,10 @@ pub(crate) fn merge_config(
         );
     }
 
+    if let Some(ref encoder) = args.video_encoder {
+        config.video_encoder = Some(encoder.clone());
+    }
+
     // Audio normalization: --normalize-boost / --normalize-boost-db implies --loudnorm
     // implies --normalize-audio
     let boost_enabled = args.normalize_boost || args.normalize_boost_db.is_some();

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -138,6 +138,18 @@ async fn async_main() -> Result<()> {
         return Ok(());
     }
 
+    if args.list_encoders {
+        rdlp_ffmpeg::ffmpeg::ensure_init()
+            .map_err(|e| anyhow::anyhow!("FFmpeg init failed: {e}"))?;
+        for codec in rdlp_ffmpeg::ffmpeg::video_codecs::list_available_codecs() {
+            eprintln!("{}:", codec.display_name);
+            for enc in &codec.encoders {
+                eprintln!("  {} — {}", enc.encoder_name, enc.display_name);
+            }
+        }
+        return Ok(());
+    }
+
     // === Search mode ===
     if let Some(ref query_text) = args.search {
         let site = args.search_site.as_deref().unwrap_or_else(|| {

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -203,4 +203,11 @@ pub struct PostProcessConfig {
 
     /// Enable verbose FFmpeg logging (forward muxer trace to callback).
     pub verbose: bool,
+
+    /// Explicit video encoder override (e.g., "libsvtav1", "libx264").
+    /// When `None`, the best available encoder for the target codec is
+    /// auto-selected via the encoder registry. When `Some`, the named
+    /// encoder is verified for availability before use; an unavailable
+    /// encoder causes the conversion step to return an error.
+    pub video_encoder: Option<String>,
 }

--- a/crates/rdlp-desktop/src-tauri/Cargo.toml
+++ b/crates/rdlp-desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ custom-protocol = ["tauri/custom-protocol"]
 
 [dependencies]
 rdlp-api = { path = "../../rdlp-api", features = ["serde"] }
+rdlp-ffmpeg = { path = "../../rdlp-ffmpeg" }
 rdlp-types = { path = "../../rdlp-types" }
 rdlp-core = { path = "../../rdlp-core" }
 rdlp-security = { path = "../../rdlp-security" }

--- a/crates/rdlp-desktop/src-tauri/src/commands/codecs.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/codecs.rs
@@ -1,0 +1,13 @@
+//! Video codec availability command.
+
+use rdlp_ffmpeg::{VideoCodecInfo, ffmpeg::video_codecs::list_available_codecs};
+
+/// List available video codecs and their encoders.
+///
+/// Returns only codecs with at least one available encoder in the
+/// linked FFmpeg build.
+#[tauri::command]
+pub fn get_available_codecs() -> Vec<VideoCodecInfo> {
+    rdlp_ffmpeg::ffmpeg::ensure_init().ok();
+    list_available_codecs()
+}

--- a/crates/rdlp-desktop/src-tauri/src/commands/codecs.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/codecs.rs
@@ -7,6 +7,7 @@ use rdlp_ffmpeg::{VideoCodecInfo, ffmpeg::video_codecs::list_available_codecs};
 /// Returns only codecs with at least one available encoder in the
 /// linked FFmpeg build.
 #[tauri::command]
+#[must_use]
 pub fn get_available_codecs() -> Vec<VideoCodecInfo> {
     rdlp_ffmpeg::ffmpeg::ensure_init().ok();
     list_available_codecs()

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -83,6 +83,10 @@ pub struct DownloadOptions {
     pub output_template: Option<String>,
     /// Embed subtitles into the output container. `None` = use settings default.
     pub embed_subtitles: Option<bool>,
+    /// Explicit video encoder override (e.g., "libsvtav1", "libx264").
+    /// `None` = auto-select best available encoder for the target codec.
+    #[serde(default)]
+    pub video_encoder: Option<String>,
 }
 
 /// Start a new download for the given URL.
@@ -225,6 +229,7 @@ pub async fn start_download(
             remux,
             extract_audio,
             recode_video: options.recode_video,
+            video_encoder: options.video_encoder,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
             write_thumbnail: write_thumbnail_resolved.then_some(true),
@@ -414,6 +419,7 @@ mod tests {
             rate_limit: None,
             output_template: None,
             embed_subtitles: None,
+            video_encoder: None,
         }
     }
 

--- a/crates/rdlp-desktop/src-tauri/src/commands/mod.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/mod.rs
@@ -3,6 +3,8 @@
 //! Each submodule groups related commands that are registered with
 //! [`tauri::generate_handler!`] in [`crate::run`].
 
+/// Video codec availability command.
+pub mod codecs;
 /// Download lifecycle commands (start, cancel, queue).
 pub mod download;
 /// Format listing commands.

--- a/crates/rdlp-desktop/src-tauri/src/lib.rs
+++ b/crates/rdlp-desktop/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(AppState::new())
         .invoke_handler(tauri::generate_handler![
+            commands::codecs::get_available_codecs,
             commands::search::search_content,
             commands::search::get_search_providers,
             commands::search::get_search_filters,

--- a/crates/rdlp-desktop/src/api/codecs.ts
+++ b/crates/rdlp-desktop/src/api/codecs.ts
@@ -1,0 +1,15 @@
+// TanStack Query options for video codec availability.
+
+import { queryOptions } from "@tanstack/react-query";
+import { invokeTyped } from "./invokeClient";
+import { queryKeys } from "../query/queryKeys";
+import type { VideoCodecInfo } from "../types";
+
+/** Fetch available video codecs and their encoders. Runs once per session. */
+export function codecsQueryOptions() {
+    return queryOptions({
+        queryKey: queryKeys.codecs(),
+        queryFn: () => invokeTyped<VideoCodecInfo[]>("get_available_codecs"),
+        staleTime: Infinity, // Encoder availability doesn't change at runtime
+    });
+}

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -3,7 +3,9 @@
 // Contains save directory, remux, audio extraction, subtitles, and thumbnail controls.
 
 import { cn } from "@/lib/utils";
+import { useState } from "react";
 import { ChevronUp, ChevronDown, FolderOpen, Settings2 } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -21,18 +23,23 @@ import {
 import {
     Select,
     SelectContent,
+    SelectGroup,
     SelectItem,
+    SelectLabel,
+    SelectSeparator,
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
 import { optionsSummary } from "./utils/tableHelpers";
 import { getNormSelectValue, handleNormSelectChange } from "./utils/normalization";
 import { NormalizationCustomControls } from "./NormalizationCustomControls";
+import { codecsQueryOptions } from "../api/codecs";
 import type {
     AppSettings,
     AudioFormat,
     ContainerFormat,
     DownloadOptions,
+    VideoCodecInfo,
 } from "../types";
 
 // -- Constants --------------------------------------------------------
@@ -43,11 +50,11 @@ const REMUX_OPTIONS: Array<{ value: ContainerFormat; label: string }> = [
     { value: "webm", label: "WebM" },
 ];
 
-const RECODE_OPTIONS: Array<{ value: ContainerFormat; label: string }> = [
-    { value: "mp4", label: "MP4" },
-    { value: "mkv", label: "MKV" },
-    { value: "webm", label: "WebM" },
-];
+/** Codec-level value prefix used in the Recode Select when Expert Mode is off. */
+const CODEC_VALUE_PREFIX = "codec:";
+
+/** Encoder-level value prefix used in the Recode Select when Expert Mode is on. */
+const ENCODER_VALUE_PREFIX = "encoder:";
 
 const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
     { value: "mp3", label: "MP3" },
@@ -71,6 +78,27 @@ interface DownloadOptionsPanelProps {
     onSubLangSelect: (lang: string) => void;
 }
 
+/**
+ * Derive the current Select value for the Recode dropdown from options state.
+ * Returns "none", "codec:<name>", or "encoder:<name>" depending on expert mode.
+ */
+function getRecodeSelectValue(
+    options: DownloadOptions,
+    codecs: VideoCodecInfo[],
+    expertMode: boolean,
+): string {
+    if (!options.recodeVideo) return NONE_SENTINEL;
+    if (!expertMode) return `${CODEC_VALUE_PREFIX}${options.recodeVideo}`;
+    // In expert mode: if videoEncoder is set return encoder value, else fall back to codec value
+    if (options.videoEncoder) return `${ENCODER_VALUE_PREFIX}${options.videoEncoder}`;
+    // Try to find a matching codec by the recodeVideo container field used as codec key
+    const matchingCodec = codecs.find((c) => c.codec === options.recodeVideo);
+    if (matchingCodec && matchingCodec.encoders.length > 0) {
+        return `${ENCODER_VALUE_PREFIX}${matchingCodec.encoders[0].encoderName}`;
+    }
+    return `${CODEC_VALUE_PREFIX}${options.recodeVideo}`;
+}
+
 /** Zone 3: Collapsible download options with save directory, remux, audio, subtitles, thumbnail. */
 export function DownloadOptionsPanel({
     options,
@@ -82,6 +110,37 @@ export function DownloadOptionsPanel({
     onBrowseDir,
     onSubLangSelect,
 }: DownloadOptionsPanelProps) {
+    const { data: codecs = [] } = useQuery(codecsQueryOptions());
+    const [expertMode, setExpertMode] = useState(false);
+
+    // Only include codecs that have at least one available encoder
+    const availableCodecs = codecs.filter((c) => c.encoders.length > 0);
+
+    const recodeSelectValue = getRecodeSelectValue(options, availableCodecs, expertMode);
+
+    const handleRecodeChange = (val: string) => {
+        setOptions((prev) => {
+            if (val === NONE_SENTINEL) {
+                return { ...prev, recodeVideo: null, videoEncoder: null, remux: prev.remux };
+            }
+            if (val.startsWith(CODEC_VALUE_PREFIX)) {
+                // Codec-level selection: clear videoEncoder, use codec as recodeVideo key
+                const codec = val.slice(CODEC_VALUE_PREFIX.length) as ContainerFormat;
+                return { ...prev, recodeVideo: codec, videoEncoder: null, remux: null };
+            }
+            if (val.startsWith(ENCODER_VALUE_PREFIX)) {
+                // Encoder-level selection: find the parent codec and set both fields
+                const encoderName = val.slice(ENCODER_VALUE_PREFIX.length);
+                const parentCodec = availableCodecs.find((c) =>
+                    c.encoders.some((e) => e.encoderName === encoderName)
+                );
+                const recodeVideo = parentCodec ? (parentCodec.codec as ContainerFormat) : prev.recodeVideo;
+                return { ...prev, recodeVideo, videoEncoder: encoderName, remux: null };
+            }
+            return prev;
+        });
+    };
+
     return (
         <div className="border-t border-border shrink-0">
             <Collapsible open={showOptions} onOpenChange={setShowOptions}>
@@ -158,29 +217,63 @@ export function DownloadOptionsPanel({
                         </Label>
                         <div className="flex flex-col gap-0.5">
                             <Select
-                                value={options.recodeVideo ?? NONE_SENTINEL}
-                                onValueChange={(val) => setOptions((prev) => {
-                                    const recodeVideo = val === NONE_SENTINEL ? null : (val as ContainerFormat);
-                                    return {
-                                        ...prev,
-                                        recodeVideo,
-                                        remux: recodeVideo !== null ? null : prev.remux,
-                                    };
-                                })}
+                                value={recodeSelectValue}
+                                onValueChange={handleRecodeChange}
                             >
                                 <SelectTrigger className={cn("h-7 text-xs", options.recodeVideo && "select-active")}>
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
                                     <SelectItem value={NONE_SENTINEL}>None</SelectItem>
-                                    {RECODE_OPTIONS.map((o) => (
-                                        <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-                                    ))}
+                                    {!expertMode ? (
+                                        // Default mode: one entry per codec (display name only)
+                                        availableCodecs.map((codec) => (
+                                            <SelectItem
+                                                key={codec.codec}
+                                                value={`${CODEC_VALUE_PREFIX}${codec.codec}`}
+                                            >
+                                                {codec.displayName}
+                                            </SelectItem>
+                                        ))
+                                    ) : (
+                                        // Expert mode: entries grouped by codec, showing encoder names
+                                        availableCodecs.map((codec, idx) => (
+                                            <SelectGroup key={codec.codec}>
+                                                {idx > 0 && <SelectSeparator />}
+                                                <SelectLabel>{codec.displayName}</SelectLabel>
+                                                {codec.encoders.map((enc) => (
+                                                    <SelectItem
+                                                        key={enc.encoderName}
+                                                        value={`${ENCODER_VALUE_PREFIX}${enc.encoderName}`}
+                                                    >
+                                                        {enc.encoderName}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectGroup>
+                                        ))
+                                    )}
                                 </SelectContent>
                             </Select>
-                            <p className="text-[10px] text-muted-foreground">
-                                Re-encode video — use when remux fails.
-                            </p>
+                            <div className="flex items-center justify-between">
+                                <p className="text-[10px] text-muted-foreground">
+                                    Re-encode video — use when remux fails.
+                                </p>
+                                <label className="flex items-center gap-1 text-[10px] text-muted-foreground cursor-pointer select-none">
+                                    <input
+                                        type="checkbox"
+                                        className="size-2.5 accent-primary"
+                                        checked={expertMode}
+                                        onChange={(e) => {
+                                            setExpertMode(e.target.checked);
+                                            // Switching off expert mode clears the encoder override
+                                            if (!e.target.checked) {
+                                                setOptions((prev) => ({ ...prev, videoEncoder: null }));
+                                            }
+                                        }}
+                                    />
+                                    Expert
+                                </label>
+                            </div>
                         </div>
 
                         {/* Extract Audio */}

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
@@ -63,6 +63,7 @@ const defaultOptions: DownloadOptions = {
     normalizeBoost: null,
     normalizeBoostDb: null,
     embedSubtitles: null,
+    videoEncoder: null,
 };
 
 function renderPanel(value: DownloadOptions, onChange = vi.fn()) {

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -103,6 +103,7 @@ export function buildDefaultOptions(
         normalizeBoost: settings?.normalize_boost ?? false,
         normalizeBoostDb: settings?.normalize_boost_db ?? null,
         embedSubtitles: settings?.embed_subtitles ?? false,
+        videoEncoder: null,
     };
 }
 

--- a/crates/rdlp-desktop/src/components/utils/normalization.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/normalization.test.ts
@@ -25,6 +25,7 @@ const base: DownloadOptions = {
     normalizeBoost: null,
     normalizeBoostDb: null,
     embedSubtitles: null,
+    videoEncoder: null,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -61,6 +61,7 @@ function makeOptions(overrides: Partial<DownloadOptions> = {}): DownloadOptions 
         normalizeBoost: null,
         normalizeBoostDb: null,
         embedSubtitles: null,
+        videoEncoder: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/pages/SettingsPage.tsx
+++ b/crates/rdlp-desktop/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { settingsQueryOptions, updateSettings, pickDirectory } from "../api/settings";
 import { providersQueryOptions } from "../api/search";
+import { codecsQueryOptions } from "../api/codecs";
 import type {
     AppSettings,
     AudioFormat,
@@ -35,6 +36,7 @@ import {
     Search,
     KeyRound,
     Globe,
+    Cpu,
 } from "lucide-react";
 
 /** Sentinel value for "no selection" since Radix Select does not support empty string values. */
@@ -60,6 +62,7 @@ export function validateSettings(draft: AppSettings): string | null {
 export function SettingsPage() {
     const { data: settings, isLoading: settingsLoading } = useQuery(settingsQueryOptions());
     const { data: providers = [] } = useQuery(providersQueryOptions());
+    const { data: codecs = [] } = useQuery(codecsQueryOptions());
     const [draft, setDraft] = useState<AppSettings | null>(null);
     const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -446,6 +449,24 @@ export function SettingsPage() {
                     onChange={(update) => setDraft({ ...draft, ...update })}
                 />
             </div>
+
+            {/* ── System Info ───────────────────────────────────── */}
+            {codecs.length > 0 && (
+                <section className="settings-panel" aria-labelledby="system-info-heading">
+                    <h3 id="system-info-heading" className="settings-panel-title">
+                        <Cpu className="size-3.5" />
+                        System Info
+                    </h3>
+                    <div>
+                        <p className="text-xs text-muted-foreground leading-relaxed">
+                            <span className="font-medium text-foreground">FFmpeg encoders: </span>
+                            {codecs
+                                .flatMap((c) => c.encoders.map((e) => e.encoderName))
+                                .join(", ")}
+                        </p>
+                    </div>
+                </section>
+            )}
 
             {/* ── Save ──────────────────────────────────────────── */}
             {saveError && (

--- a/crates/rdlp-desktop/src/query/queryKeys.ts
+++ b/crates/rdlp-desktop/src/query/queryKeys.ts
@@ -35,6 +35,7 @@ export const queryKeys = {
     downloads: {
         list: () => ["downloads"] as const,
     },
+    codecs: () => ["available-codecs"] as const,
     formats: (url: string) => ["formats", url] as const,
     settings: () => ["settings"] as const,
     thumbnail: {

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -89,6 +89,21 @@ export interface FormatListResponse {
     duration: number | null;
 }
 
+// ========== Video Codec Types (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========
+
+/** Info about a single video encoder available in the linked FFmpeg build. */
+export interface VideoEncoderInfo {
+    encoderName: string;
+    displayName: string;
+}
+
+/** Info about a video codec with its available encoders. */
+export interface VideoCodecInfo {
+    codec: string;
+    displayName: string;
+    encoders: VideoEncoderInfo[];
+}
+
 // ========== Download Types ==========
 
 /** Lifecycle status of a download job (#[serde(rename_all = "lowercase")]). */
@@ -168,6 +183,7 @@ export interface DownloadOptions {
     normalizeBoost: boolean | null;
     normalizeBoostDb: number | null;
     embedSubtitles: boolean | null;
+    videoEncoder: string | null;
 }
 
 // ========== Event Payloads (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -40,6 +40,7 @@ mod remux;
 pub(crate) mod salvage;
 mod thumbnail;
 mod transcode;
+pub mod video_codecs;
 
 use std::path::Path;
 use std::sync::OnceLock;
@@ -55,6 +56,10 @@ pub use normalize_types::{
 };
 pub use options::{AudioExtractOptions, ChapterEntry, RemuxOptions, VideoConvertOptions};
 pub use probe::{MediaInfo, StreamInfo};
+pub use video_codecs::{
+    VideoCodecInfo, VideoEncoderInfo, available_encoders_for_codec, is_encoder_available,
+    list_available_codecs, preferred_video_encoder, resolve_encoder,
+};
 
 /// Global initialization state for the FFmpeg library.
 /// Ensures `ffmpeg_the_third::init()` is called exactly once.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -1,0 +1,358 @@
+//! Video codec configuration registry.
+//!
+//! Provides a static `CODEC_PREFERENCES` table mapping codec names to ordered
+//! encoder preference lists. Runtime detection via `ffmpeg_the_third::codec::encoder::find_by_name()`
+//! determines which encoders are actually available in the linked FFmpeg build.
+//!
+//! Use [`preferred_video_encoder()`] to resolve the best available encoder for a
+//! given codec name. Use [`list_available_codecs()`] to enumerate all codecs with
+//! at least one available encoder (for UI population).
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use log::info;
+use serde::{Deserialize, Serialize};
+
+/// Information about a specific video encoder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoEncoderInfo {
+    /// FFmpeg encoder name (e.g., "libx264", "libsvtav1")
+    pub encoder_name: String,
+    /// Human-readable display name (e.g., "x264 (H.264)")
+    pub display_name: String,
+}
+
+/// Information about a video codec and its available encoders.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoCodecInfo {
+    /// Canonical codec name (e.g., "h264", "av1")
+    pub codec: String,
+    /// Human-readable display name (e.g., "H.264 / AVC")
+    pub display_name: String,
+    /// Encoders available in the current FFmpeg build, in preference order
+    pub encoders: Vec<VideoEncoderInfo>,
+}
+
+/// Entry in the codec preferences table.
+struct CodecEntry {
+    /// Canonical codec name
+    codec: &'static str,
+    /// Human-readable display name for the codec
+    display_name: &'static str,
+    /// Ordered encoder preference list: (encoder_name, display_name)
+    encoders: &'static [(&'static str, &'static str)],
+}
+
+/// Static table mapping codec names to ordered encoder preference lists.
+///
+/// Codecs are listed in preference order — the first available encoder
+/// in each list is selected at runtime. Aliases (e.g., "hevc" for "h265")
+/// are separate entries that share the same encoder list.
+static CODEC_PREFERENCES: &[CodecEntry] = &[
+    CodecEntry {
+        codec: "h264",
+        display_name: "H.264 / AVC",
+        encoders: &[
+            ("libx264", "x264 (H.264)"),
+            ("libopenh264", "OpenH264 (H.264)"),
+        ],
+    },
+    CodecEntry {
+        codec: "h265",
+        display_name: "H.265 / HEVC",
+        encoders: &[
+            ("libx265", "x265 (H.265/HEVC)"),
+            ("libkvazaar", "Kvazaar (H.265/HEVC)"),
+        ],
+    },
+    CodecEntry {
+        codec: "hevc",
+        display_name: "H.265 / HEVC",
+        encoders: &[
+            ("libx265", "x265 (H.265/HEVC)"),
+            ("libkvazaar", "Kvazaar (H.265/HEVC)"),
+        ],
+    },
+    CodecEntry {
+        codec: "av1",
+        display_name: "AV1",
+        encoders: &[
+            ("libsvtav1", "SVT-AV1"),
+            ("libaom-av1", "libaom AV1"),
+            ("librav1e", "rav1e AV1"),
+        ],
+    },
+    CodecEntry {
+        codec: "vp9",
+        display_name: "VP9",
+        encoders: &[("libvpx-vp9", "libvpx VP9")],
+    },
+    CodecEntry {
+        codec: "vp8",
+        display_name: "VP8",
+        encoders: &[("libvpx", "libvpx VP8")],
+    },
+    CodecEntry {
+        codec: "vvc",
+        display_name: "VVC / H.266",
+        encoders: &[("libvvenc", "VVenC (VVC/H.266)")],
+    },
+    CodecEntry {
+        codec: "h266",
+        display_name: "VVC / H.266",
+        encoders: &[("libvvenc", "VVenC (VVC/H.266)")],
+    },
+    CodecEntry {
+        codec: "theora",
+        display_name: "Theora",
+        encoders: &[("libtheora", "libtheora")],
+    },
+    CodecEntry {
+        codec: "mpeg4",
+        display_name: "MPEG-4 Part 2",
+        encoders: &[("mpeg4", "MPEG-4 (built-in)")],
+    },
+    CodecEntry {
+        codec: "mpeg2",
+        display_name: "MPEG-2 Video",
+        encoders: &[("mpeg2video", "MPEG-2 Video (built-in)")],
+    },
+    CodecEntry {
+        codec: "mpeg1",
+        display_name: "MPEG-1 Video",
+        encoders: &[("mpeg1video", "MPEG-1 Video (built-in)")],
+    },
+    CodecEntry {
+        codec: "xvid",
+        display_name: "XviD (MPEG-4)",
+        encoders: &[("libxvid", "libxvid (XviD)")],
+    },
+    CodecEntry {
+        codec: "prores",
+        display_name: "Apple ProRes",
+        encoders: &[("prores_ks", "ProRes KS")],
+    },
+    CodecEntry {
+        codec: "dnxhd",
+        display_name: "DNxHD / DNxHR",
+        encoders: &[("dnxhd", "DNxHD (built-in)")],
+    },
+    CodecEntry {
+        codec: "wmv2",
+        display_name: "WMV2",
+        encoders: &[("wmv2", "WMV2 (built-in)")],
+    },
+    CodecEntry {
+        codec: "ffv1",
+        display_name: "FFV1 (Lossless)",
+        encoders: &[("ffv1", "FFV1 (built-in)")],
+    },
+];
+
+/// Returns `true` if `encoder` is available in the current FFmpeg build.
+///
+/// Uses `ffmpeg_the_third::codec::encoder::find_by_name()` for detection.
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn is_encoder_available(encoder: &str) -> bool {
+    ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
+}
+
+/// Returns the best available video encoder for a given codec name.
+///
+/// Results are cached per codec name using a `OnceLock<HashMap>` so detection
+/// only runs once per codec. Logs which encoder was selected on first resolution.
+///
+/// Returns `None` if no encoder is available for the requested codec, or if the
+/// codec name is unknown.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn preferred_video_encoder(codec: &str) -> Option<&'static str> {
+    static CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
+
+    let cache = CACHE.get_or_init(|| {
+        let mut map = HashMap::new();
+        for entry in CODEC_PREFERENCES {
+            let selected = entry
+                .encoders
+                .iter()
+                .find(|(enc, _)| is_encoder_available(enc))
+                .map(|(enc, _)| *enc);
+
+            if let Some(enc) = selected {
+                info!("Using {enc} as {codec} encoder", codec = entry.codec);
+            }
+
+            map.insert(entry.codec, selected);
+        }
+        map
+    });
+
+    // Only canonically-known codecs are in the cache; unknown codec names return None
+    cache
+        .get(codec.to_ascii_lowercase().as_str())
+        .copied()
+        .flatten()
+}
+
+/// Resolves an encoder name.
+///
+/// Accepts either a codec name (e.g., "h264") or a direct encoder name
+/// (e.g., "libx264"). For codec names, returns the best available encoder
+/// via [`preferred_video_encoder()`]. For encoder names, checks availability
+/// directly and returns the name if available.
+///
+/// Returns `None` if no encoder can be resolved or is available.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn resolve_encoder(input: &str) -> Option<&'static str> {
+    let lower = input.to_ascii_lowercase();
+
+    // Check if input is a known codec name first
+    if let Some(enc) = preferred_video_encoder(&lower) {
+        return Some(enc);
+    }
+
+    // Otherwise treat as a direct encoder name — check if it's available
+    // and find the matching static str in our table
+    for entry in CODEC_PREFERENCES {
+        for (enc, _) in entry.encoders {
+            if enc.eq_ignore_ascii_case(input) {
+                if is_encoder_available(enc) {
+                    return Some(enc);
+                }
+                return None;
+            }
+        }
+    }
+
+    None
+}
+
+/// Returns all available encoders for a given codec name, in preference order.
+///
+/// Returns an empty `Vec` if the codec is unknown or has no available encoders.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn available_encoders_for_codec(codec: &str) -> Vec<VideoEncoderInfo> {
+    let lower = codec.to_ascii_lowercase();
+    CODEC_PREFERENCES
+        .iter()
+        .find(|e| e.codec == lower.as_str())
+        .map(|entry| {
+            entry
+                .encoders
+                .iter()
+                .filter(|(enc, _)| is_encoder_available(enc))
+                .map(|(enc, display)| VideoEncoderInfo {
+                    encoder_name: (*enc).to_string(),
+                    display_name: (*display).to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Lists all codecs that have at least one available encoder in the current
+/// FFmpeg build.
+///
+/// Alias entries (e.g., "hevc" / "h265") that share the same encoder list are
+/// both included if their encoders are available. Callers that want a deduplicated
+/// list may filter by `codec` name.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn list_available_codecs() -> Vec<VideoCodecInfo> {
+    CODEC_PREFERENCES
+        .iter()
+        .filter_map(|entry| {
+            let encoders: Vec<VideoEncoderInfo> = entry
+                .encoders
+                .iter()
+                .filter(|(enc, _)| is_encoder_available(enc))
+                .map(|(enc, display)| VideoEncoderInfo {
+                    encoder_name: (*enc).to_string(),
+                    display_name: (*display).to_string(),
+                })
+                .collect();
+
+            if encoders.is_empty() {
+                None
+            } else {
+                Some(VideoCodecInfo {
+                    codec: entry.codec.to_string(),
+                    display_name: entry.display_name.to_string(),
+                    encoders,
+                })
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preferred_video_encoder_h264() {
+        let enc = preferred_video_encoder("h264");
+        assert!(enc.is_some());
+        let name = enc.unwrap();
+        assert!(name == "libx264" || name == "libopenh264");
+    }
+
+    #[test]
+    fn test_preferred_video_encoder_unknown() {
+        assert!(preferred_video_encoder("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_resolve_encoder_codec_name() {
+        let enc = resolve_encoder("h264");
+        assert!(enc.is_some());
+    }
+
+    #[test]
+    fn test_resolve_encoder_encoder_name() {
+        // Built-in encoders are always available
+        let enc = resolve_encoder("mpeg4");
+        assert_eq!(enc, Some("mpeg4"));
+    }
+
+    #[test]
+    fn test_resolve_encoder_unknown() {
+        assert!(resolve_encoder("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_is_encoder_available_builtin() {
+        assert!(is_encoder_available("mpeg4"));
+    }
+
+    #[test]
+    fn test_list_available_codecs_nonempty() {
+        let codecs = list_available_codecs();
+        assert!(
+            !codecs.is_empty(),
+            "at least built-in codecs should be available"
+        );
+    }
+
+    #[test]
+    fn test_available_encoders_for_known_codec() {
+        let encoders = available_encoders_for_codec("h264");
+        assert!(!encoders.is_empty());
+    }
+
+    #[test]
+    fn test_available_encoders_for_unknown_codec() {
+        let encoders = available_encoders_for_codec("nonexistent");
+        assert!(encoders.is_empty());
+    }
+}

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -50,5 +50,5 @@ pub use error::{CorruptionKind, PostProcessError, Result};
 pub use ffmpeg::{
     AudioExtractOptions, AudioNormMode, ChapterEntry, FFmpegRunner, LoudnormMeasurements,
     LoudnormPreset, MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo,
-    VideoConvertOptions, set_verbose,
+    VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, set_verbose,
 };

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -87,13 +87,45 @@ impl FFmpegVideoConvertor {
     }
 
     /// Build `VideoConvertOptions` from the target format and remux decision.
-    fn build_convert_options(target_format: &str, can_remux: bool) -> VideoConvertOptions {
+    ///
+    /// When `encoder_override` is `Some`, that encoder is verified for
+    /// availability via the registry and used directly. If the requested
+    /// encoder is not available, `None` is returned so the caller can
+    /// surface an error.
+    ///
+    /// Returns `None` only when `encoder_override` is set but the encoder
+    /// is not available in the current FFmpeg build.
+    fn build_convert_options(
+        target_format: &str,
+        can_remux: bool,
+        encoder_override: Option<&str>,
+    ) -> Option<VideoConvertOptions> {
         if can_remux {
-            return VideoConvertOptions {
+            return Some(VideoConvertOptions {
                 remux_only: true,
                 audio_copy: true,
                 ..Default::default()
-            };
+            });
+        }
+
+        // If the caller supplied an explicit encoder, verify it and use it directly.
+        if let Some(requested) = encoder_override {
+            let resolved =
+                rdlp_ffmpeg::ffmpeg::video_codecs::resolve_encoder(requested);
+            // Return None to signal "encoder unavailable" to the caller.
+            let encoder_name = resolved?;
+
+            // Derive preset/crf from the encoder name for a sensible default.
+            let (preset, crf) =
+                Self::default_preset_crf_for_encoder(encoder_name);
+
+            return Some(VideoConvertOptions {
+                remux_only: false,
+                video_codec: Some(encoder_name.to_string()),
+                preset,
+                crf,
+                audio_copy: true,
+            });
         }
 
         // Determine target codec from container
@@ -113,12 +145,25 @@ impl FFmpegVideoConvertor {
             _ => (None, None),
         };
 
-        VideoConvertOptions {
+        Some(VideoConvertOptions {
             remux_only: false,
             video_codec: encoder.map(String::from),
             preset,
             crf,
             audio_copy: true,
+        })
+    }
+
+    /// Returns sensible default (preset, crf) values for a given encoder name.
+    fn default_preset_crf_for_encoder(encoder: &str) -> (Option<String>, Option<u32>) {
+        if encoder.contains("264") || encoder.contains("265") || encoder.contains("kvazaar") {
+            (Some("medium".to_string()), Some(23))
+        } else if encoder.contains("vpx") {
+            (None, Some(30))
+        } else if encoder.contains("av1") || encoder.contains("svt") || encoder.contains("aom") || encoder.contains("rav1e") {
+            (None, Some(28))
+        } else {
+            (None, None)
         }
     }
 }
@@ -202,8 +247,24 @@ impl PostProcessor for FFmpegVideoConvertor {
         // Build output path
         let output_path = input_file.with_extension(target_format);
 
-        // Build conversion options
-        let opts = Self::build_convert_options(target_format, can_remux);
+        // Build conversion options, applying any encoder override from config.
+        let opts = match Self::build_convert_options(
+            target_format,
+            can_remux,
+            config.video_encoder.as_deref(),
+        ) {
+            Some(o) => o,
+            None => {
+                let requested = config.video_encoder.as_deref().unwrap_or("");
+                return Err(PostProcessError::UnsupportedFormat {
+                    format: requested.to_string(),
+                    operation: format!(
+                        "video encoder '{requested}' is not available in this FFmpeg build"
+                    ),
+                }
+                .into());
+            }
+        };
 
         // Convert via library bindings
         let progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>> =
@@ -261,7 +322,8 @@ mod tests {
 
     #[test]
     fn test_build_convert_options_remux() {
-        let opts = FFmpegVideoConvertor::build_convert_options("mp4", true);
+        let opts = FFmpegVideoConvertor::build_convert_options("mp4", true, None)
+            .expect("remux should always succeed");
         assert!(opts.remux_only);
         assert!(opts.audio_copy);
         assert!(opts.video_codec.is_none());
@@ -269,7 +331,8 @@ mod tests {
 
     #[test]
     fn test_build_convert_options_transcode_mp4() {
-        let opts = FFmpegVideoConvertor::build_convert_options("mp4", false);
+        let opts = FFmpegVideoConvertor::build_convert_options("mp4", false, None)
+            .expect("auto encoder should resolve");
         assert!(!opts.remux_only);
         assert!(opts.video_codec.is_some());
         assert_eq!(opts.preset, Some("medium".to_string()));
@@ -279,11 +342,29 @@ mod tests {
 
     #[test]
     fn test_build_convert_options_transcode_webm() {
-        let opts = FFmpegVideoConvertor::build_convert_options("webm", false);
+        let opts = FFmpegVideoConvertor::build_convert_options("webm", false, None)
+            .expect("auto encoder should resolve");
         assert!(!opts.remux_only);
         assert!(opts.video_codec.is_some());
         assert_eq!(opts.preset, None); // VP9 has no preset
         assert_eq!(opts.crf, Some(30));
         assert!(opts.audio_copy);
+    }
+
+    #[test]
+    fn test_build_convert_options_encoder_override_unavailable() {
+        // A nonsense encoder name should return None (unavailable).
+        let result =
+            FFmpegVideoConvertor::build_convert_options("mp4", false, Some("nonexistent_enc_xyz"));
+        assert!(result.is_none(), "unavailable encoder should return None");
+    }
+
+    #[test]
+    fn test_build_convert_options_encoder_override_available() {
+        // mpeg4 is a built-in encoder; passing it by encoder name should succeed.
+        let opts = FFmpegVideoConvertor::build_convert_options("mp4", false, Some("mpeg4"))
+            .expect("mpeg4 is always available");
+        assert!(!opts.remux_only);
+        assert_eq!(opts.video_codec.as_deref(), Some("mpeg4"));
     }
 }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -17,27 +17,6 @@ use rdlp_ffmpeg::VideoConvertOptions;
 
 use rdlp_core::ContainerFormat;
 
-/// Supported video codecs for transcoding.
-const VIDEO_CODECS: &[(&str, &str)] = &[
-    ("h264", "libx264"),
-    ("h265", "libx265"),
-    ("hevc", "libx265"),
-    ("vp9", "libvpx-vp9"),
-    ("vp8", "libvpx"),
-    ("av1", "libaom-av1"),
-    ("vvc", "libvvenc"),
-    ("h266", "libvvenc"),
-    ("mpeg1", "mpeg1video"),
-    ("mpeg2", "mpeg2video"),
-    ("mpeg4", "mpeg4"),
-    ("theora", "libtheora"),
-    ("prores", "prores_ks"),
-    ("dnxhd", "dnxhd"),
-    ("wmv2", "wmv2"),
-    ("ffv1", "ffv1"),
-    ("xvid", "libxvid"),
-];
-
 ffmpeg_processor!(
     FFmpegVideoConvertor,
     "FFmpegVideoConvertor",
@@ -58,10 +37,7 @@ impl FFmpegVideoConvertor {
 
     /// Get the FFmpeg encoder for a codec.
     fn get_encoder(codec: &str) -> Option<&'static str> {
-        VIDEO_CODECS
-            .iter()
-            .find(|(c, _)| c.eq_ignore_ascii_case(codec))
-            .map(|(_, e)| *e)
+        rdlp_ffmpeg::ffmpeg::video_codecs::resolve_encoder(codec)
     }
 
     /// Determine if we can remux (copy) or need to transcode.
@@ -262,9 +238,9 @@ mod tests {
 
     #[test]
     fn test_get_encoder() {
-        assert_eq!(FFmpegVideoConvertor::get_encoder("h264"), Some("libx264"));
-        assert_eq!(FFmpegVideoConvertor::get_encoder("vp9"), Some("libvpx-vp9"));
-        assert_eq!(FFmpegVideoConvertor::get_encoder("unknown"), None);
+        assert!(FFmpegVideoConvertor::get_encoder("h264").is_some());
+        assert!(FFmpegVideoConvertor::get_encoder("vp9").is_some());
+        assert!(FFmpegVideoConvertor::get_encoder("unknown").is_none());
     }
 
     #[test]
@@ -295,7 +271,7 @@ mod tests {
     fn test_build_convert_options_transcode_mp4() {
         let opts = FFmpegVideoConvertor::build_convert_options("mp4", false);
         assert!(!opts.remux_only);
-        assert_eq!(opts.video_codec, Some("libx264".to_string()));
+        assert!(opts.video_codec.is_some());
         assert_eq!(opts.preset, Some("medium".to_string()));
         assert_eq!(opts.crf, Some(23));
         assert!(opts.audio_copy);
@@ -305,7 +281,7 @@ mod tests {
     fn test_build_convert_options_transcode_webm() {
         let opts = FFmpegVideoConvertor::build_convert_options("webm", false);
         assert!(!opts.remux_only);
-        assert_eq!(opts.video_codec, Some("libvpx-vp9".to_string()));
+        assert!(opts.video_codec.is_some());
         assert_eq!(opts.preset, None); // VP9 has no preset
         assert_eq!(opts.crf, Some(30));
         assert!(opts.audio_copy);

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -158,6 +158,11 @@ pub struct Config {
     /// Video format to recode to
     pub recode_video: Option<ContainerFormat>,
 
+    /// Explicit video encoder override (e.g., "libsvtav1").
+    /// When None, the best available encoder for the codec is auto-selected.
+    #[serde(default)]
+    pub video_encoder: Option<String>,
+
     /// Remux to container format for better seeking
     pub remux_container: Option<ContainerFormat>,
 
@@ -358,6 +363,7 @@ impl Default for Config {
             audio_format: None,
             audio_quality: None,
             recode_video: None,
+            video_encoder: None,
             remux_container: None,
             embed_thumbnail: true,
             embed_metadata: false,


### PR DESCRIPTION
## Summary
Runtime detection of available video encoders with automatic preference (e.g., libsvtav1 over libaom-av1) and graceful fallback.

### Backend
- New `video_codecs.rs` registry in rdlp-ffmpeg: runtime encoder detection via `find_by_name()`, cached with `OnceLock`
- Postprocessor uses `resolve_encoder()` instead of hardcoded map
- `video_encoder: Option<String>` config field for explicit override
- CLI: `--video-encoder` flag and `--list-encoders` command
- Tauri: `get_available_codecs` command exposes registry to frontend

### Frontend
- DownloadOptionsPanel: dynamic codec dropdown populated from available encoders
- Expert Mode toggle reveals per-encoder selection (SVT-AV1 vs libaom, x264 vs OpenH264, etc.)
- Settings page shows available FFmpeg encoders info line
- Only codecs with available encoders are shown

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace` — clean  
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 286 tests pass
- [x] `cargo run -p rdlp-cli -- --list-encoders` — shows available encoders
- [ ] Manual: desktop Expert Mode dropdown shows grouped encoders
- [ ] Manual: Settings page shows FFmpeg encoder list