### PR TITLE
fix: guard against silent file loss during post-processing

### DIFF
--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -263,7 +263,13 @@ impl Orchestrator {
             // Remux using library bindings (stream copy + faststart)
             match registry.remux_faststart(file, &temp_path).await {
                 Ok(()) => {
-                    // Replace original with fixed file
+                    // Replace original with fixed file — only delete original
+                    // after verifying the remuxed temp file exists and has content
+                    if !temp_path.exists() || tokio::fs::metadata(&temp_path).await.map(|m| m.len()).unwrap_or(0) == 0 {
+                        warn!("Remux produced empty or missing output: {}", temp_path.display());
+                        output_files.push(file.clone());
+                        continue;
+                    }
                     if let Err(e) = tokio::fs::remove_file(file).await {
                         warn!("Could not remove original file: {e}");
                     }

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -455,6 +455,14 @@ impl DownloadPhase {
                     .await?;
                 let final_path = final_files.into_iter().next().unwrap_or(output_path);
 
+                // Verify the output file actually exists
+                if !final_path.exists() {
+                    warn!(
+                        "Output file missing after post-processing: {}",
+                        final_path.display()
+                    );
+                }
+
                 // Delete session state on successful completion
                 let sanitized = orchestrator.sanitize_filename(&info.title);
                 let state_path = session_state::single_video_state_path(


### PR DESCRIPTION
## Summary
- Verify output file exists after post-processing before reporting Completed
- Guard remux cleanup: don't delete original until temp file is verified non-empty
- Prevents silent data loss when FFmpeg remux/recode produces empty output

## Test plan
- [x] `cargo check --workspace` — clean
- [ ] Manual: download with recode, verify file exists at expected path