### PR TITLE
fix: video recode deletes output when same container format

### DIFF
--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -277,10 +277,18 @@ impl PostProcessor for FFmpegVideoConvertor {
 
         info!(output:? = output_path.display(); "Converted");
 
+        // Don't mark input as temp when output path equals input path
+        // (same extension → convert_video overwrites in place)
+        let temp_files = if config.keep_video || output_path == *input_file {
+            Vec::new()
+        } else {
+            files
+        };
+
         Ok(PostProcessResult {
             info: info.clone(),
             files: vec![output_path],
-            temp_files: if config.keep_video { Vec::new() } else { files },
+            temp_files,
         })
     }
 }


### PR DESCRIPTION
## Summary
When recoding to the same container (e.g., h264 mp4 → libx264 mp4), the output path equals the input path. `convert_video` overwrites in place, then the registry deletes the input as a temp file — destroying the transcoded output.

Fix: don't mark input as temp when `output_path == input_file`.

## Root cause
`input_file.with_extension("mp4")` returns the same path when the input is already `.mp4`. The `PostProcessResult.temp_files` field then contains the output path, causing the registry to delete it.

## Test plan
- [x] `cargo check --workspace` — clean
- [ ] Manual: download with Recode=mp4 + Expert=libx264, verify file saved