### PR TITLE
fix: downloaded files silently deleted during post-processing

### DIFF
--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -174,9 +174,13 @@ impl Orchestrator {
             });
         }
 
-        // Run FFmpeg remux to fix container (faststart, timestamps)
-        // Applied to both HLS and HTTP downloads for consistent output
-        let result_files = if !self.config.extract_audio {
+        // Run FFmpeg remux to fix container (faststart, timestamps).
+        // Skip when there are multiple files — those are separate video/audio
+        // streams for a merge download.  The FFmpegMerger processor (priority 100)
+        // handles those files and produces a properly-muxed output on its own.
+        // Remuxing each stream individually before the merge is wasteful and
+        // forces unnecessary encode/decode cycles on the raw stream files.
+        let result_files = if !self.config.extract_audio && files.len() == 1 {
             self.emit(Event::PostProcessing {
                 id: self.download_id,
                 stage: "Remuxing container".into(),
@@ -265,8 +269,17 @@ impl Orchestrator {
                 Ok(()) => {
                     // Replace original with fixed file — only delete original
                     // after verifying the remuxed temp file exists and has content
-                    if !temp_path.exists() || tokio::fs::metadata(&temp_path).await.map(|m| m.len()).unwrap_or(0) == 0 {
-                        warn!("Remux produced empty or missing output: {}", temp_path.display());
+                    if !temp_path.exists()
+                        || tokio::fs::metadata(&temp_path)
+                            .await
+                            .map(|m| m.len())
+                            .unwrap_or(0)
+                            == 0
+                    {
+                        warn!(
+                            "Remux produced empty or missing output: {}",
+                            temp_path.display()
+                        );
                         output_files.push(file.clone());
                         continue;
                     }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_merger.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::{debug, info, warn};
 use rdlp_core::{
     InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
 };
@@ -121,8 +121,18 @@ impl PostProcessor for FFmpegMerger {
         let audio_ext = audio_file.extension().and_then(|e| e.to_str());
         let output_format = self.determine_output_format(config, video_ext, audio_ext);
 
-        // Create output filename
-        let output_path = video_file.with_extension(output_format);
+        // Build the intended final output path by replacing the video file's
+        // extension with the output format.  This may produce the same path as
+        // the video input when both share the same extension (e.g. mp4→mp4).
+        // In that case we write to a collision-free temp path and rename afterward
+        // so we never overwrite the input while it is still needed by FFmpeg.
+        let intended_path = video_file.with_extension(output_format);
+        let collision = intended_path == *video_file;
+        let merge_output = if collision {
+            video_file.with_extension(format!("merging.{output_format}"))
+        } else {
+            intended_path.clone()
+        };
 
         // Merge using library bindings (stream copy, no re-encoding).
         // The MP4 muxer automatically handles AAC ADTS→ASC conversion,
@@ -136,16 +146,36 @@ impl PostProcessor for FFmpegMerger {
                 Arc::new(move |frac| cb.on_progress(frac))
             });
         self.ffmpeg
-            .merge(video_file, audio_file, &output_path, &opts, progress_fn)
+            .merge(video_file, audio_file, &merge_output, &opts, progress_fn)
             .await?;
+
+        // If we used a temp path because of a naming collision, rename it to
+        // the intended path now that both inputs are no longer needed.
+        let output_path = if collision {
+            if let Err(e) = tokio::fs::rename(&merge_output, &intended_path).await {
+                warn!(
+                    from:? = merge_output.display(),
+                    to:? = intended_path.display();
+                    "Could not rename merged output: {e}"
+                );
+                // Fall back to keeping the temp-named file rather than losing the data.
+                merge_output
+            } else {
+                intended_path
+            }
+        } else {
+            intended_path
+        };
 
         debug!(output:? = output_path.display(); "Merged output");
 
-        // Return result with merged file and original files as temp
+        // Return result with merged file and original files as temp.
+        // The original inputs are now safe to delete because the merge is complete
+        // and the output_path is a distinct file from both of them.
         Ok(PostProcessResult {
             info: info.clone(),
             files: vec![output_path],
-            temp_files: files, // Original files can be deleted
+            temp_files: files, // Original video + audio streams can be deleted
         })
     }
 }

--- a/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
+++ b/crates/rdlp-postprocess/src/processors/ffmpeg_video_convertor.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::{debug, info, warn};
 use rdlp_core::{
     InfoDict, PostProcessCallback, PostProcessConfig, PostProcessResult, PostProcessor, Result,
 };
@@ -110,14 +110,12 @@ impl FFmpegVideoConvertor {
 
         // If the caller supplied an explicit encoder, verify it and use it directly.
         if let Some(requested) = encoder_override {
-            let resolved =
-                rdlp_ffmpeg::ffmpeg::video_codecs::resolve_encoder(requested);
+            let resolved = rdlp_ffmpeg::ffmpeg::video_codecs::resolve_encoder(requested);
             // Return None to signal "encoder unavailable" to the caller.
             let encoder_name = resolved?;
 
             // Derive preset/crf from the encoder name for a sensible default.
-            let (preset, crf) =
-                Self::default_preset_crf_for_encoder(encoder_name);
+            let (preset, crf) = Self::default_preset_crf_for_encoder(encoder_name);
 
             return Some(VideoConvertOptions {
                 remux_only: false,
@@ -160,7 +158,11 @@ impl FFmpegVideoConvertor {
             (Some("medium".to_string()), Some(23))
         } else if encoder.contains("vpx") {
             (None, Some(30))
-        } else if encoder.contains("av1") || encoder.contains("svt") || encoder.contains("aom") || encoder.contains("rav1e") {
+        } else if encoder.contains("av1")
+            || encoder.contains("svt")
+            || encoder.contains("aom")
+            || encoder.contains("rav1e")
+        {
             (None, Some(28))
         } else {
             (None, None)
@@ -244,8 +246,14 @@ impl PostProcessor for FFmpegVideoConvertor {
             debug!("Transcoding video");
         }
 
-        // Build output path
-        let output_path = input_file.with_extension(target_format);
+        // Build output path — use temp suffix when extensions match to avoid
+        // reading and writing the same file (FFmpeg can't do that).
+        let same_ext = input_ext.eq_ignore_ascii_case(target_format);
+        let convert_path = if same_ext {
+            input_file.with_extension(format!("recode.{target_format}"))
+        } else {
+            input_file.with_extension(target_format)
+        };
 
         // Build conversion options, applying any encoder override from config.
         let opts = match Self::build_convert_options(
@@ -272,14 +280,28 @@ impl PostProcessor for FFmpegVideoConvertor {
                 Arc::new(move |frac| cb.on_progress(frac))
             });
         self.ffmpeg
-            .convert_video(input_file, &output_path, &opts, progress_fn)
+            .convert_video(input_file, &convert_path, &opts, progress_fn)
             .await?;
+
+        // If we used a temp suffix, rename to the final path and delete the original
+        let output_path = if same_ext {
+            let final_path = input_file.with_extension(target_format);
+            if let Err(e) = tokio::fs::remove_file(input_file).await {
+                warn!("Could not remove original before rename: {e}");
+            }
+            if let Err(e) = tokio::fs::rename(&convert_path, &final_path).await {
+                warn!("Could not rename recode output: {e}");
+                convert_path // fall back to .recode.mp4
+            } else {
+                final_path
+            }
+        } else {
+            convert_path
+        };
 
         info!(output:? = output_path.display(); "Converted");
 
-        // Don't mark input as temp when output path equals input path
-        // (same extension → convert_video overwrites in place)
-        let temp_files = if config.keep_video || output_path == *input_file {
+        let temp_files = if config.keep_video || same_ext {
             Vec::new()
         } else {
             files


### PR DESCRIPTION
## Summary
Three file-loss bugs in the post-processing pipeline:

1. **FFmpegMerger path collision**: `with_extension("mp4")` on a `.mp4` input produces the same path → merged output overwrites input → deleted as temp
2. **Unnecessary pre-remux**: `ffmpeg_remux` ran on raw stream files before merge, creating/deleting temps pointlessly  
3. **Recode same-extension**: mp4→mp4 transcode reads and writes the same file

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p rdlp-postprocess` — passes
- [ ] Manual: download from desktop, verify file exists at expected path