### PR TITLE
feat: recode format selection — container and audio codec control

### DIFF
--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -136,6 +136,12 @@ impl MergeOverrides for PostProcessOptions {
         if let Some(ref v) = self.video_encoder {
             config.video_encoder = Some(v.clone());
         }
+        if let Some(v) = self.recode_container {
+            config.recode_container = Some(v);
+        }
+        if let Some(ref v) = self.recode_audio {
+            config.recode_audio = v.clone();
+        }
     }
 }
 

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -94,6 +94,8 @@ impl Orchestrator {
             normalize_boost_db: self.config.normalize_boost_db,
             verbose: self.config.verbose,
             video_encoder: self.config.video_encoder.clone(),
+            recode_audio: self.config.recode_audio.clone(),
+            recode_container: self.config.recode_container,
         }
     }
 
@@ -104,6 +106,7 @@ impl Orchestrator {
             || self.config.embed_thumbnail
             || self.config.embed_subtitles
             || self.config.recode_video.is_some()
+            || self.config.recode_container.is_some()
             || self.config.remux_container.is_some()
             || self.config.normalize_audio
     }

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -208,6 +208,11 @@ pub struct PostProcessOptions {
     /// Explicit video encoder override (e.g., "libsvtav1", "libx264").
     /// `None` = auto-select best available encoder for the target codec.
     pub video_encoder: Option<String>,
+    /// Target container for recode (overrides `recode_video` when set).
+    pub recode_container: Option<ContainerFormat>,
+    /// Audio handling during video recode.
+    /// `None` preserves base config (defaults to Copy).
+    pub recode_audio: Option<rdlp_core::RecodeAudioMode>,
 }
 
 /// Network, retry, and cookie options.

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -151,6 +151,18 @@ pub(crate) struct Args {
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
     pub recode_video: Option<String>,
 
+    /// Target container format for video recode (e.g., mp4, mkv, webm).
+    /// Takes precedence over --recode-video when both are specified.
+    #[arg(long, value_name = "FMT")]
+    pub recode_container: Option<String>,
+
+    /// Audio mode during video recode: copy (default), auto, or an encoder name
+    /// (e.g., libopus, aac, libmp3lame).
+    /// `copy` copies audio unchanged; `auto` selects the best encoder for the
+    /// target container; any other value is treated as an explicit encoder name.
+    #[arg(long, value_name = "MODE", default_value = "copy")]
+    pub recode_audio: String,
+
     /// Remux to container for better seeking - no re-encoding
     /// Use --remux for interactive, --remux=mp4 for direct
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -5,7 +5,9 @@
 //! a three-layer precedence: CLI > config file > defaults.
 
 use anyhow::Result;
-use rdlp_core::{AudioFormat, BrowserType, Config, ContainerFormat, SubtitleFormat, config_io};
+use rdlp_core::{
+    AudioFormat, BrowserType, Config, ContainerFormat, RecodeAudioMode, SubtitleFormat, config_io,
+};
 
 use crate::args::Args;
 use crate::selection::{select_audio_format, select_recode_video, select_remux_container};
@@ -179,6 +181,25 @@ pub(crate) fn merge_config(
 
     if let Some(ref encoder) = args.video_encoder {
         config.video_encoder = Some(encoder.clone());
+    }
+
+    // recode_container: explicit container for recode (overrides recode_video container)
+    if let Some(ref fmt) = args.recode_container {
+        config.recode_container = Some(
+            fmt.parse::<ContainerFormat>()
+                .map_err(|e| anyhow::anyhow!(e))?,
+        );
+    }
+
+    // recode_audio: "copy", "auto", or an encoder name
+    match args.recode_audio.as_str() {
+        "copy" => config.recode_audio = RecodeAudioMode::Copy,
+        "auto" => config.recode_audio = RecodeAudioMode::Auto,
+        name => {
+            config.recode_audio = RecodeAudioMode::Encoder {
+                name: name.to_string(),
+            };
+        }
     }
 
     // Audio normalization: --normalize-boost / --normalize-boost-db implies --loudnorm

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -64,6 +64,8 @@ fn default_args() -> Args {
         config_location: None,
         video_encoder: None,
         list_encoders: false,
+        recode_container: None,
+        recode_audio: "copy".to_string(),
     }
 }
 

--- a/crates/rdlp-core/src/lib.rs
+++ b/crates/rdlp-core/src/lib.rs
@@ -40,9 +40,9 @@ pub mod traits;
 // Re-export types from rdlp-types for convenience
 pub use rdlp_types::{
     AudioFormat, BrowserType, Chapter, Config, ContainerFormat, DownloadProtocol, Format,
-    FormatSelector, Fragment, InfoDict, SearchFilter, SearchFilterDescriptor, SearchFilterValue,
-    SearchPageResponse, SearchQuery, SearchResultPreview, SearchSiteInfo, Subtitle,
-    SubtitleDiagnostic, SubtitleFormat, SubtitleKind, SubtitleReason, SubtitleResult,
+    FormatSelector, Fragment, InfoDict, RecodeAudioMode, SearchFilter, SearchFilterDescriptor,
+    SearchFilterValue, SearchPageResponse, SearchQuery, SearchResultPreview, SearchSiteInfo,
+    Subtitle, SubtitleDiagnostic, SubtitleFormat, SubtitleKind, SubtitleReason, SubtitleResult,
     SubtitleStatus, SubtitleTrack, Thumbnail, normalize_from_info_dict,
 };
 

--- a/crates/rdlp-core/src/traits/postprocessor.rs
+++ b/crates/rdlp-core/src/traits/postprocessor.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::{AudioFormat, ContainerFormat};
+use crate::{AudioFormat, ContainerFormat, RecodeAudioMode};
 
 /// Callback for reporting post-processing progress.
 ///
@@ -130,4 +130,12 @@ pub struct PostProcessConfig {
     /// encoder is verified for availability before use; an unavailable
     /// encoder causes the conversion step to return an error.
     pub video_encoder: Option<String>,
+
+    /// How to handle audio during video recode.
+    /// Default is Copy (stream copy audio unchanged).
+    pub recode_audio: RecodeAudioMode,
+
+    /// Output container override for video recode.
+    /// When `None`, the container is derived from the video codec.
+    pub recode_container: Option<ContainerFormat>,
 }

--- a/crates/rdlp-desktop/src-tauri/src/commands/codecs.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/codecs.rs
@@ -1,6 +1,10 @@
-//! Video codec availability command.
+//! Video and audio codec availability commands.
 
-use rdlp_ffmpeg::{VideoCodecInfo, ffmpeg::video_codecs::list_available_codecs};
+use rdlp_ffmpeg::{
+    AudioCodecInfo, VideoCodecInfo, ffmpeg::audio_encoder_registry::list_available_audio_codecs,
+    ffmpeg::video_codecs::list_available_codecs,
+};
+use rdlp_types::ContainerFormat;
 
 /// List available video codecs and their encoders.
 ///
@@ -11,4 +15,28 @@ use rdlp_ffmpeg::{VideoCodecInfo, ffmpeg::video_codecs::list_available_codecs};
 pub fn get_available_codecs() -> Vec<VideoCodecInfo> {
     rdlp_ffmpeg::ffmpeg::ensure_init().ok();
     list_available_codecs()
+}
+
+/// List available audio codecs (optionally filtered by target container).
+///
+/// When `container` is supplied, only codecs compatible with that container
+/// are returned. When `container` is `None`, all available audio codecs
+/// are returned.
+#[tauri::command]
+#[must_use]
+pub fn get_available_audio_codecs(container: Option<ContainerFormat>) -> Vec<AudioCodecInfo> {
+    rdlp_ffmpeg::ffmpeg::ensure_init().ok();
+    let all = list_available_audio_codecs();
+    if let Some(c) = container {
+        all.into_iter()
+            .filter(|codec| {
+                rdlp_ffmpeg::ffmpeg::audio_encoder_registry::container_supports_audio_codec(
+                    c,
+                    &codec.codec,
+                )
+            })
+            .collect()
+    } else {
+        all
+    }
 }

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -18,7 +18,7 @@ use rdlp_api::request::{
     DownloadRequest, FormatOptions, NetworkOptions, OutputOptions, PostProcessOptions,
     SubtitleOptions,
 };
-use rdlp_types::{AudioFormat, BrowserType, ContainerFormat};
+use rdlp_types::{AudioFormat, BrowserType, ContainerFormat, RecodeAudioMode};
 
 /// Frontend-supplied download options.
 ///
@@ -87,6 +87,15 @@ pub struct DownloadOptions {
     /// `None` = auto-select best available encoder for the target codec.
     #[serde(default)]
     pub video_encoder: Option<String>,
+    /// Target container for recode (e.g. `Mp4`, `Mkv`, `WebM`).
+    /// Takes precedence over `recode_video` when both are set.
+    /// `None` = use `recode_video` value.
+    #[serde(default)]
+    pub recode_container: Option<ContainerFormat>,
+    /// Audio handling during video recode.
+    /// `None` = use default (Copy).
+    #[serde(default)]
+    pub recode_audio: Option<RecodeAudioMode>,
 }
 
 /// Start a new download for the given URL.
@@ -230,6 +239,8 @@ pub async fn start_download(
             extract_audio,
             recode_video: options.recode_video,
             video_encoder: options.video_encoder,
+            recode_container: options.recode_container,
+            recode_audio: options.recode_audio,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
             write_thumbnail: write_thumbnail_resolved.then_some(true),
@@ -420,6 +431,8 @@ mod tests {
             output_template: None,
             embed_subtitles: None,
             video_encoder: None,
+            recode_container: None,
+            recode_audio: None,
         }
     }
 

--- a/crates/rdlp-desktop/src-tauri/src/lib.rs
+++ b/crates/rdlp-desktop/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ pub fn run() {
         .manage(AppState::new())
         .invoke_handler(tauri::generate_handler![
             commands::codecs::get_available_codecs,
+            commands::codecs::get_available_audio_codecs,
             commands::search::search_content,
             commands::search::get_search_providers,
             commands::search::get_search_filters,

--- a/crates/rdlp-desktop/src/api/audioCodecs.ts
+++ b/crates/rdlp-desktop/src/api/audioCodecs.ts
@@ -1,0 +1,22 @@
+// TanStack Query options for audio codec availability.
+
+import { queryOptions } from "@tanstack/react-query";
+import { invokeTyped } from "./invokeClient";
+import { queryKeys } from "../query/queryKeys";
+import type { AudioCodecInfo } from "../types";
+
+/**
+ * Fetch available audio codecs, optionally filtered by container.
+ * When container is null, returns all available audio codecs.
+ * Runs once per (container) value — encoder availability doesn't change at runtime.
+ */
+export function audioCodecsQueryOptions(container: string | null) {
+    return queryOptions({
+        queryKey: queryKeys.audioCodecs.byContainer(container),
+        queryFn: () =>
+            invokeTyped<AudioCodecInfo[]>("get_available_audio_codecs", {
+                container,
+            }),
+        staleTime: Infinity,
+    });
+}

--- a/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/DownloadOptionsPanel.tsx
@@ -4,7 +4,7 @@
 
 import { cn } from "@/lib/utils";
 import { useState } from "react";
-import { ChevronUp, ChevronDown, FolderOpen, Settings2 } from "lucide-react";
+import { ChevronUp, ChevronDown, FolderOpen, Settings2, AlertTriangle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -30,15 +30,19 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { optionsSummary } from "./utils/tableHelpers";
 import { getNormSelectValue, handleNormSelectChange } from "./utils/normalization";
 import { NormalizationCustomControls } from "./NormalizationCustomControls";
 import { codecsQueryOptions } from "../api/codecs";
+import { audioCodecsQueryOptions } from "../api/audioCodecs";
 import type {
     AppSettings,
+    AudioCodecInfo,
     AudioFormat,
     ContainerFormat,
     DownloadOptions,
+    RecodeAudioMode,
     VideoCodecInfo,
 } from "../types";
 
@@ -50,11 +54,31 @@ const REMUX_OPTIONS: Array<{ value: ContainerFormat; label: string }> = [
     { value: "webm", label: "WebM" },
 ];
 
-/** Codec-level value prefix used in the Recode Select when Expert Mode is off. */
+/** Recode container options (includes Auto which maps to null). */
+const RECODE_CONTAINER_OPTIONS: Array<{ value: string; label: string }> = [
+    { value: "mp4", label: "MP4" },
+    { value: "mkv", label: "MKV" },
+    { value: "webm", label: "WebM" },
+    { value: "mov", label: "MOV" },
+    { value: "ogg", label: "OGG" },
+    { value: "ts", label: "TS" },
+    { value: "avi", label: "AVI" },
+];
+
+/** Codec-level value prefix used in the video Recode Select when Expert Mode is off. */
 const CODEC_VALUE_PREFIX = "codec:";
 
-/** Encoder-level value prefix used in the Recode Select when Expert Mode is on. */
+/** Encoder-level value prefix used in the video Recode Select when Expert Mode is on. */
 const ENCODER_VALUE_PREFIX = "encoder:";
+
+/** Prefix for audio codec selection (default mode). */
+const AUDIO_CODEC_PREFIX = "audio-codec:";
+
+/** Prefix for audio encoder selection (expert mode). */
+const AUDIO_ENCODER_PREFIX = "audio-encoder:";
+
+/** Sentinel value for "copy" audio (stream copy unchanged). */
+const AUDIO_COPY_VALUE = "audio-copy";
 
 const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
     { value: "mp3", label: "MP3" },
@@ -65,21 +89,10 @@ const AUDIO_OPTIONS: Array<{ value: AudioFormat; label: string }> = [
 
 const NONE_SENTINEL = "none";
 
-// -- Types ----------------------------------------------------------------
-
-interface DownloadOptionsPanelProps {
-    options: DownloadOptions;
-    setOptions: React.Dispatch<React.SetStateAction<DownloadOptions>>;
-    settings: AppSettings | null;
-    subtitleLangs: string[];
-    showOptions: boolean;
-    setShowOptions: (open: boolean) => void;
-    onBrowseDir: () => void;
-    onSubLangSelect: (lang: string) => void;
-}
+// -- Helpers ----------------------------------------------------------------
 
 /**
- * Derive the current Select value for the Recode dropdown from options state.
+ * Derive the current Select value for the video Recode dropdown from options state.
  * Returns "none", "codec:<name>", or "encoder:<name>" depending on expert mode.
  */
 function getRecodeSelectValue(
@@ -99,6 +112,74 @@ function getRecodeSelectValue(
     return `${CODEC_VALUE_PREFIX}${options.recodeVideo}`;
 }
 
+/**
+ * Derive the current Select value for the audio recode dropdown.
+ * Returns AUDIO_COPY_VALUE, "audio-codec:<name>", or "audio-encoder:<name>" depending on mode/expert.
+ */
+function getAudioRecodeSelectValue(
+    recodeAudio: RecodeAudioMode | null,
+    audioExpert: boolean,
+): string {
+    if (!recodeAudio || recodeAudio.mode === "copy") return AUDIO_COPY_VALUE;
+    if (recodeAudio.mode === "auto") {
+        // auto is used in default mode; show as codec value if we can derive it
+        return AUDIO_COPY_VALUE; // fallback — auto without a named codec shows as Copy
+    }
+    if (recodeAudio.mode === "encoder") {
+        if (audioExpert) return `${AUDIO_ENCODER_PREFIX}${recodeAudio.name}`;
+        // Non-expert: show as copy since we can't easily reverse-map encoder→codec here
+        return AUDIO_COPY_VALUE;
+    }
+    return AUDIO_COPY_VALUE;
+}
+
+/**
+ * Check if the current audio selection is compatible with the given container.
+ * Returns null when compatible (or Copy is selected), or an incompatibility message.
+ */
+function getAudioCompatibilityWarning(
+    recodeAudio: RecodeAudioMode | null,
+    container: string | null,
+    audioCodecs: AudioCodecInfo[],
+): string | null {
+    if (!container) return null;
+    if (!recodeAudio || recodeAudio.mode === "copy") return null;
+
+    let codecName: string | null = null;
+    if (recodeAudio.mode === "encoder") {
+        // Find the parent codec for this encoder
+        const parentCodec = audioCodecs.find((c) =>
+            c.encoders.some((e) => e.encoderName === recodeAudio.name),
+        );
+        codecName = parentCodec?.codec ?? null;
+    }
+
+    if (!codecName) return null;
+
+    const codecInfo = audioCodecs.find((c) => c.codec === codecName);
+    if (!codecInfo) return null;
+
+    if (!codecInfo.supportedContainers.includes(container)) {
+        const containerLabel = container.toUpperCase();
+        return `${codecInfo.displayName} is not compatible with ${containerLabel}. Audio reset to Copy.`;
+    }
+
+    return null;
+}
+
+// -- Types ----------------------------------------------------------------
+
+interface DownloadOptionsPanelProps {
+    options: DownloadOptions;
+    setOptions: React.Dispatch<React.SetStateAction<DownloadOptions>>;
+    settings: AppSettings | null;
+    subtitleLangs: string[];
+    showOptions: boolean;
+    setShowOptions: (open: boolean) => void;
+    onBrowseDir: () => void;
+    onSubLangSelect: (lang: string) => void;
+}
+
 /** Zone 3: Collapsible download options with save directory, remux, audio, subtitles, thumbnail. */
 export function DownloadOptionsPanel({
     options,
@@ -111,33 +192,92 @@ export function DownloadOptionsPanel({
     onSubLangSelect,
 }: DownloadOptionsPanelProps) {
     const { data: codecs = [] } = useQuery(codecsQueryOptions());
-    const [expertMode, setExpertMode] = useState(false);
+    const [videoExpert, setVideoExpert] = useState(false);
+    const [audioExpert, setAudioExpert] = useState(false);
+    const [audioCompatWarning, setAudioCompatWarning] = useState<string | null>(null);
 
-    // Only include codecs that have at least one available encoder
+    // Only include video codecs that have at least one available encoder
     const availableCodecs = codecs.filter((c) => c.encoders.length > 0);
 
-    const recodeSelectValue = getRecodeSelectValue(options, availableCodecs, expertMode);
+    const recodeActive = !!options.recodeVideo;
+
+    // Fetch audio codecs filtered by current recode container
+    const { data: audioCodecs = [] } = useQuery({
+        ...audioCodecsQueryOptions(options.recodeContainer),
+        enabled: recodeActive,
+    });
+
+    const recodeSelectValue = getRecodeSelectValue(options, availableCodecs, videoExpert);
+    const audioSelectValue = getAudioRecodeSelectValue(options.recodeAudio, audioExpert);
 
     const handleRecodeChange = (val: string) => {
         setOptions((prev) => {
             if (val === NONE_SENTINEL) {
-                return { ...prev, recodeVideo: null, videoEncoder: null, remux: prev.remux };
+                return {
+                    ...prev,
+                    recodeVideo: null,
+                    videoEncoder: null,
+                    recodeContainer: null,
+                    recodeAudio: null,
+                    remux: prev.remux,
+                };
             }
             if (val.startsWith(CODEC_VALUE_PREFIX)) {
-                // Codec-level selection: use backend-provided default container
                 const codec = val.slice(CODEC_VALUE_PREFIX.length);
                 const codecInfo = availableCodecs.find((c) => c.codec === codec);
                 const container = (codecInfo?.defaultContainer ?? "mp4") as ContainerFormat;
                 return { ...prev, recodeVideo: container, videoEncoder: null, remux: null };
             }
             if (val.startsWith(ENCODER_VALUE_PREFIX)) {
-                // Encoder-level selection: use parent codec's default container
                 const encoderName = val.slice(ENCODER_VALUE_PREFIX.length);
                 const parentCodec = availableCodecs.find((c) =>
-                    c.encoders.some((e) => e.encoderName === encoderName)
+                    c.encoders.some((e) => e.encoderName === encoderName),
                 );
                 const container = (parentCodec?.defaultContainer ?? "mp4") as ContainerFormat;
                 return { ...prev, recodeVideo: container, videoEncoder: encoderName, remux: null };
+            }
+            return prev;
+        });
+        // Clear compat warning when recode is deactivated
+        if (val === NONE_SENTINEL) setAudioCompatWarning(null);
+    };
+
+    const handleContainerChange = (val: string) => {
+        const newContainer = val === NONE_SENTINEL ? null : val;
+        setOptions((prev) => {
+            const newOptions = { ...prev, recodeContainer: newContainer };
+
+            // Check if current audio selection is still compatible
+            if (prev.recodeAudio && prev.recodeAudio.mode !== "copy" && newContainer) {
+                const warning = getAudioCompatibilityWarning(
+                    prev.recodeAudio,
+                    newContainer,
+                    audioCodecs,
+                );
+                if (warning) {
+                    setAudioCompatWarning(warning);
+                    return { ...newOptions, recodeAudio: { mode: "copy" } };
+                }
+            }
+
+            setAudioCompatWarning(null);
+            return newOptions;
+        });
+    };
+
+    const handleAudioRecodeChange = (val: string) => {
+        setAudioCompatWarning(null);
+        setOptions((prev) => {
+            if (val === AUDIO_COPY_VALUE) {
+                return { ...prev, recodeAudio: { mode: "copy" } };
+            }
+            if (val.startsWith(AUDIO_CODEC_PREFIX)) {
+                // Default mode: codec selected → auto-pick best encoder
+                return { ...prev, recodeAudio: { mode: "auto" } };
+            }
+            if (val.startsWith(AUDIO_ENCODER_PREFIX)) {
+                const encoderName = val.slice(AUDIO_ENCODER_PREFIX.length);
+                return { ...prev, recodeAudio: { mode: "encoder", name: encoderName } };
             }
             return prev;
         });
@@ -227,7 +367,7 @@ export function DownloadOptionsPanel({
                                 </SelectTrigger>
                                 <SelectContent>
                                     <SelectItem value={NONE_SENTINEL}>None</SelectItem>
-                                    {!expertMode ? (
+                                    {!videoExpert ? (
                                         // Default mode: one entry per codec (display name only)
                                         availableCodecs.map((codec) => (
                                             <SelectItem
@@ -264,10 +404,10 @@ export function DownloadOptionsPanel({
                                     <input
                                         type="checkbox"
                                         className="size-2.5 accent-primary"
-                                        checked={expertMode}
+                                        checked={videoExpert}
                                         onChange={(e) => {
-                                            setExpertMode(e.target.checked);
-                                            // Switching off expert mode clears the encoder override
+                                            setVideoExpert(e.target.checked);
+                                            // Switching off video expert mode clears the encoder override
                                             if (!e.target.checked) {
                                                 setOptions((prev) => ({ ...prev, videoEncoder: null }));
                                             }
@@ -277,6 +417,105 @@ export function DownloadOptionsPanel({
                                 </label>
                             </div>
                         </div>
+
+                        {/* Recode sub-options: Container + Audio (only when Recode is active) */}
+                        {recodeActive && (
+                            <>
+                                {/* Container */}
+                                <Label className="options-label pl-3 text-muted-foreground/70">
+                                    Container
+                                </Label>
+                                <Select
+                                    value={options.recodeContainer ?? NONE_SENTINEL}
+                                    onValueChange={handleContainerChange}
+                                >
+                                    <SelectTrigger className={cn("h-7 text-xs", options.recodeContainer && "select-active")}>
+                                        <SelectValue placeholder="Auto" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={NONE_SENTINEL}>Auto</SelectItem>
+                                        {RECODE_CONTAINER_OPTIONS.map((o) => (
+                                            <SelectItem key={o.value} value={o.value}>
+                                                {o.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+
+                                {/* Audio recode */}
+                                <Label className="options-label pl-3 text-muted-foreground/70 self-start pt-1">
+                                    Audio
+                                </Label>
+                                <div className="flex flex-col gap-0.5">
+                                    <Select
+                                        value={audioSelectValue}
+                                        onValueChange={handleAudioRecodeChange}
+                                    >
+                                        <SelectTrigger className={cn("h-7 text-xs", options.recodeAudio && options.recodeAudio.mode !== "copy" && "select-active")}>
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value={AUDIO_COPY_VALUE}>Copy</SelectItem>
+                                            {!audioExpert ? (
+                                                // Default mode: codec display names
+                                                audioCodecs.map((codec) => (
+                                                    <SelectItem
+                                                        key={codec.codec}
+                                                        value={`${AUDIO_CODEC_PREFIX}${codec.codec}`}
+                                                    >
+                                                        {codec.displayName}
+                                                    </SelectItem>
+                                                ))
+                                            ) : (
+                                                // Expert mode: encoder names grouped by codec
+                                                audioCodecs.map((codec, idx) => (
+                                                    <SelectGroup key={codec.codec}>
+                                                        {idx > 0 && <SelectSeparator />}
+                                                        <SelectLabel>{codec.displayName}</SelectLabel>
+                                                        {codec.encoders.map((enc) => (
+                                                            <SelectItem
+                                                                key={enc.encoderName}
+                                                                value={`${AUDIO_ENCODER_PREFIX}${enc.encoderName}`}
+                                                            >
+                                                                {enc.encoderName}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectGroup>
+                                                ))
+                                            )}
+                                        </SelectContent>
+                                    </Select>
+                                    <div className="flex items-center justify-end">
+                                        <label className="flex items-center gap-1 text-[10px] text-muted-foreground cursor-pointer select-none">
+                                            <input
+                                                type="checkbox"
+                                                className="size-2.5 accent-primary"
+                                                checked={audioExpert}
+                                                onChange={(e) => {
+                                                    setAudioExpert(e.target.checked);
+                                                    // Switching off audio expert mode resets to Copy
+                                                    if (!e.target.checked) {
+                                                        setOptions((prev) => ({
+                                                            ...prev,
+                                                            recodeAudio: { mode: "copy" },
+                                                        }));
+                                                    }
+                                                }}
+                                            />
+                                            Expert
+                                        </label>
+                                    </div>
+                                    {audioCompatWarning && (
+                                        <Alert className="mt-1 py-2 px-3 col-span-2">
+                                            <AlertTriangle className="size-3.5" />
+                                            <AlertDescription className="text-[10px]">
+                                                {audioCompatWarning}
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+                                </div>
+                            </>
+                        )}
 
                         {/* Extract Audio */}
                         <Label className="options-label">

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.test.tsx
@@ -64,6 +64,8 @@ const defaultOptions: DownloadOptions = {
     normalizeBoostDb: null,
     embedSubtitles: null,
     videoEncoder: null,
+    recodeAudio: null,
+    recodeContainer: null,
 };
 
 function renderPanel(value: DownloadOptions, onChange = vi.fn()) {

--- a/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
+++ b/crates/rdlp-desktop/src/components/FormatOptionsPanel.tsx
@@ -104,6 +104,8 @@ export function buildDefaultOptions(
         normalizeBoostDb: settings?.normalize_boost_db ?? null,
         embedSubtitles: settings?.embed_subtitles ?? false,
         videoEncoder: null,
+        recodeAudio: null,
+        recodeContainer: null,
     };
 }
 

--- a/crates/rdlp-desktop/src/components/utils/normalization.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/normalization.test.ts
@@ -26,6 +26,8 @@ const base: DownloadOptions = {
     normalizeBoostDb: null,
     embedSubtitles: null,
     videoEncoder: null,
+    recodeAudio: null,
+    recodeContainer: null,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
+++ b/crates/rdlp-desktop/src/components/utils/tableHelpers.test.ts
@@ -62,6 +62,8 @@ function makeOptions(overrides: Partial<DownloadOptions> = {}): DownloadOptions 
         normalizeBoostDb: null,
         embedSubtitles: null,
         videoEncoder: null,
+        recodeAudio: null,
+        recodeContainer: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/query/queryKeys.ts
+++ b/crates/rdlp-desktop/src/query/queryKeys.ts
@@ -36,6 +36,10 @@ export const queryKeys = {
         list: () => ["downloads"] as const,
     },
     codecs: () => ["available-codecs"] as const,
+    audioCodecs: {
+        all: () => ["audioCodecs"] as const,
+        byContainer: (container: string | null) => ["audioCodecs", container] as const,
+    },
     formats: (url: string) => ["formats", url] as const,
     settings: () => ["settings"] as const,
     thumbnail: {

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -105,6 +105,34 @@ export interface VideoCodecInfo {
     encoders: VideoEncoderInfo[];
 }
 
+// ========== Audio Codec Types (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========
+
+/** Info about a single audio encoder available in the linked FFmpeg build. */
+export interface AudioEncoderInfo {
+    encoderName: string;
+    displayName: string;
+}
+
+/** Info about an audio codec with its available encoders and compatible containers. */
+export interface AudioCodecInfo {
+    codec: string;
+    displayName: string;
+    encoders: AudioEncoderInfo[];
+    /** ContainerFormat enum values serialized as lowercase strings (e.g. "mp4", "mkv"). */
+    supportedContainers: string[];
+}
+
+/**
+ * How to handle audio during video recode.
+ *
+ * Mirrors Rust `RecodeAudioMode` with `#[serde(tag = "mode")]`:
+ *   { mode: "copy" } | { mode: "auto" } | { mode: "encoder", name: "libfdk_aac" }
+ */
+export type RecodeAudioMode =
+    | { mode: "copy" }
+    | { mode: "auto" }
+    | { mode: "encoder"; name: string };
+
 // ========== Download Types ==========
 
 /** Lifecycle status of a download job (#[serde(rename_all = "lowercase")]). */
@@ -185,6 +213,8 @@ export interface DownloadOptions {
     normalizeBoostDb: number | null;
     embedSubtitles: boolean | null;
     videoEncoder: string | null;
+    recodeAudio: RecodeAudioMode | null;
+    recodeContainer: string | null;
 }
 
 // ========== Event Payloads (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
@@ -8,9 +8,7 @@
 //! quality at equivalent bitrates. Use [`preferred_aac_encoder()`] to resolve
 //! the best available AAC encoder at runtime.
 
-use std::sync::OnceLock;
-
-use log::info;
+use super::audio_encoder_registry;
 
 /// Audio codec configuration for extraction/conversion.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -166,23 +164,14 @@ pub fn get_audio_codec(name: &str) -> Option<&'static AudioCodecConfig> {
 
 /// Returns the best available AAC encoder name.
 ///
-/// Checks once (cached via `OnceLock`) whether `libfdk_aac` is available in the
-/// linked FFmpeg build. If so, returns `"libfdk_aac"` (Fraunhofer FDK AAC —
-/// better quality, HE-AAC support); otherwise falls back to the built-in `"aac"`.
+/// Delegates to [`audio_encoder_registry::preferred_audio_encoder`] for a single
+/// source of truth. Returns `"libfdk_aac"` when the Fraunhofer FDK build is
+/// available, otherwise `"aac"` (built-in).
 ///
 /// This function requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn preferred_aac_encoder() -> &'static str {
-    static PREFERRED: OnceLock<&'static str> = OnceLock::new();
-    PREFERRED.get_or_init(|| {
-        if ffmpeg_the_third::codec::encoder::find_by_name("libfdk_aac").is_some() {
-            info!("Using libfdk_aac (Fraunhofer FDK) as AAC encoder");
-            "libfdk_aac"
-        } else {
-            info!("Using built-in aac encoder (libfdk_aac not available)");
-            "aac"
-        }
-    })
+    audio_encoder_registry::preferred_audio_encoder("aac").unwrap_or("aac")
 }
 
 #[cfg(test)]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -1,0 +1,514 @@
+//! Audio encoder registry.
+//!
+//! Provides a static preference table mapping audio codec names to encoder
+//! preference lists and container compatibility information. Runtime detection
+//! via `ffmpeg_the_third::codec::encoder::find_by_name()` determines which
+//! encoders are actually available in the linked FFmpeg build.
+//!
+//! Mirrors the pattern of `video_codecs.rs`.
+//!
+//! # Key Functions
+//!
+//! - [`preferred_audio_encoder`] — best available encoder for a codec name
+//! - [`resolve_audio_encoder`] — accepts codec or encoder name
+//! - [`list_available_audio_codecs`] — all codecs with at least one available encoder
+//! - [`audio_codecs_for_container`] — filtered by container compatibility
+//! - [`container_supports_audio_codec`] — point query for validation
+//! - [`select_audio_encoder_for_container`] — best default encoder for a container
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use log::info;
+use rdlp_core::ContainerFormat;
+use serde::{Deserialize, Serialize};
+
+/// Information about a specific audio encoder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioEncoderInfo {
+    /// FFmpeg encoder name (e.g., "libfdk_aac", "libopus").
+    pub encoder_name: String,
+    /// Human-readable display name (e.g., "FDK AAC", "Opus (libopus)").
+    pub display_name: String,
+}
+
+/// Information about an audio codec and its available encoders.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioCodecInfo {
+    /// Canonical codec name (e.g., "aac", "opus").
+    pub codec: String,
+    /// Human-readable display name (e.g., "AAC", "Opus").
+    pub display_name: String,
+    /// Encoders available in the current FFmpeg build, in preference order.
+    pub encoders: Vec<AudioEncoderInfo>,
+    /// Containers this codec is compatible with.
+    pub supported_containers: Vec<ContainerFormat>,
+}
+
+/// Entry in the audio codec preference table.
+struct AudioCodecEntry {
+    /// Canonical codec name.
+    codec: &'static str,
+    /// Human-readable display name.
+    display_name: &'static str,
+    /// Ordered encoder preference list: (encoder_name, display_name).
+    encoders: &'static [(&'static str, &'static str)],
+    /// Container formats this codec is compatible with.
+    supported_containers: &'static [ContainerFormat],
+}
+
+/// Static preference table for audio codecs.
+///
+/// For each codec, encoders are listed in preference order — the first
+/// available encoder wins. Container compatibility is authoritative for
+/// the `container_supports_audio_codec` gate and the frontend greying logic.
+static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
+    AudioCodecEntry {
+        codec: "aac",
+        display_name: "AAC",
+        encoders: &[
+            ("libfdk_aac", "FDK AAC (libfdk_aac)"),
+            ("aac", "AAC (built-in)"),
+        ],
+        supported_containers: &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::Mkv,
+            ContainerFormat::Avi,
+            ContainerFormat::Ts,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "mp3",
+        display_name: "MP3",
+        encoders: &[("libmp3lame", "MP3 (libmp3lame)")],
+        supported_containers: &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::Mkv,
+            ContainerFormat::Avi,
+            ContainerFormat::Ts,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "opus",
+        display_name: "Opus",
+        encoders: &[("libopus", "Opus (libopus)")],
+        supported_containers: &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mkv,
+            ContainerFormat::WebM,
+            ContainerFormat::Ogg,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "vorbis",
+        display_name: "Vorbis",
+        encoders: &[("libvorbis", "Vorbis (libvorbis)")],
+        supported_containers: &[
+            ContainerFormat::Mkv,
+            ContainerFormat::WebM,
+            ContainerFormat::Ogg,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "flac",
+        display_name: "FLAC",
+        encoders: &[("flac", "FLAC (built-in)")],
+        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Ogg],
+    },
+    AudioCodecEntry {
+        codec: "alac",
+        display_name: "ALAC",
+        encoders: &[("alac", "ALAC (built-in)")],
+        supported_containers: &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::Mkv,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "ac3",
+        display_name: "AC-3 (Dolby Digital)",
+        encoders: &[("ac3", "AC-3 (built-in)")],
+        supported_containers: &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::Mkv,
+            ContainerFormat::Avi,
+            ContainerFormat::Ts,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "eac3",
+        display_name: "E-AC-3 (Dolby Digital Plus)",
+        encoders: &[("eac3", "E-AC-3 (built-in)")],
+        supported_containers: &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::Mkv,
+            ContainerFormat::Ts,
+        ],
+    },
+    AudioCodecEntry {
+        codec: "dts",
+        display_name: "DTS",
+        encoders: &[("dca", "DTS (built-in)")],
+        supported_containers: &[ContainerFormat::Mkv],
+    },
+    AudioCodecEntry {
+        codec: "mp2",
+        display_name: "MP2",
+        encoders: &[("mp2", "MP2 (built-in)")],
+        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Ts],
+    },
+    AudioCodecEntry {
+        codec: "pcm",
+        display_name: "WAV/PCM",
+        encoders: &[("pcm_s16le", "PCM 16-bit (built-in)")],
+        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Avi],
+    },
+    AudioCodecEntry {
+        codec: "wavpack",
+        display_name: "WavPack",
+        encoders: &[("wavpack", "WavPack (built-in)")],
+        supported_containers: &[ContainerFormat::Mkv],
+    },
+    AudioCodecEntry {
+        codec: "tta",
+        display_name: "TTA",
+        encoders: &[("tta", "TTA (built-in)")],
+        supported_containers: &[ContainerFormat::Mkv],
+    },
+];
+
+/// Returns `true` if the named audio encoder is available in the current FFmpeg build.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn is_audio_encoder_available(encoder: &str) -> bool {
+    ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
+}
+
+/// Returns the best available audio encoder for a given codec name.
+///
+/// Results are cached via a `OnceLock<HashMap>` so detection only runs once.
+/// Returns `None` if no encoder is available or the codec is unknown.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn preferred_audio_encoder(codec: &str) -> Option<&'static str> {
+    static CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
+
+    let cache = CACHE.get_or_init(|| {
+        let mut map = HashMap::new();
+        for entry in AUDIO_CODEC_PREFERENCES {
+            let selected = entry
+                .encoders
+                .iter()
+                .find(|(enc, _)| is_audio_encoder_available(enc))
+                .map(|(enc, _)| *enc);
+
+            if let Some(enc) = selected {
+                info!("Using {enc} as {codec} audio encoder", codec = entry.codec);
+            }
+
+            map.insert(entry.codec, selected);
+        }
+        map
+    });
+
+    cache
+        .get(codec.to_ascii_lowercase().as_str())
+        .copied()
+        .flatten()
+}
+
+/// Resolves an audio encoder name.
+///
+/// Accepts either a codec name (e.g., "aac") or a direct encoder name
+/// (e.g., "libfdk_aac"). For codec names, returns the best available encoder
+/// via [`preferred_audio_encoder`]. For encoder names, checks availability
+/// directly and returns the static str if available.
+///
+/// Returns `None` if no encoder can be resolved or is available.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn resolve_audio_encoder(input: &str) -> Option<&'static str> {
+    let lower = input.to_ascii_lowercase();
+
+    // Check if input is a known codec name first
+    if let Some(enc) = preferred_audio_encoder(&lower) {
+        return Some(enc);
+    }
+
+    // Otherwise treat as a direct encoder name — find matching static str
+    for entry in AUDIO_CODEC_PREFERENCES {
+        for (enc, _) in entry.encoders {
+            if enc.eq_ignore_ascii_case(input) {
+                if is_audio_encoder_available(enc) {
+                    return Some(enc);
+                }
+                return None;
+            }
+        }
+    }
+
+    None
+}
+
+/// Returns all available encoders for a given audio codec name, in preference order.
+///
+/// Returns an empty `Vec` if the codec is unknown or has no available encoders.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn available_audio_encoders_for_codec(codec: &str) -> Vec<AudioEncoderInfo> {
+    let lower = codec.to_ascii_lowercase();
+    AUDIO_CODEC_PREFERENCES
+        .iter()
+        .find(|e| e.codec == lower.as_str())
+        .map(|entry| {
+            entry
+                .encoders
+                .iter()
+                .filter(|(enc, _)| is_audio_encoder_available(enc))
+                .map(|(enc, display)| AudioEncoderInfo {
+                    encoder_name: (*enc).to_string(),
+                    display_name: (*display).to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Lists all audio codecs that have at least one available encoder in the
+/// current FFmpeg build.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn list_available_audio_codecs() -> Vec<AudioCodecInfo> {
+    AUDIO_CODEC_PREFERENCES
+        .iter()
+        .filter_map(|entry| {
+            let encoders: Vec<AudioEncoderInfo> = entry
+                .encoders
+                .iter()
+                .filter(|(enc, _)| is_audio_encoder_available(enc))
+                .map(|(enc, display)| AudioEncoderInfo {
+                    encoder_name: (*enc).to_string(),
+                    display_name: (*display).to_string(),
+                })
+                .collect();
+
+            if encoders.is_empty() {
+                None
+            } else {
+                Some(AudioCodecInfo {
+                    codec: entry.codec.to_string(),
+                    display_name: entry.display_name.to_string(),
+                    encoders,
+                    supported_containers: entry.supported_containers.to_vec(),
+                })
+            }
+        })
+        .collect()
+}
+
+/// Returns audio codecs compatible with the given container format.
+///
+/// Filters `list_available_audio_codecs()` to only those codecs whose
+/// `supported_containers` list includes `container`.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn audio_codecs_for_container(container: ContainerFormat) -> Vec<AudioCodecInfo> {
+    list_available_audio_codecs()
+        .into_iter()
+        .filter(|codec| codec.supported_containers.contains(&container))
+        .collect()
+}
+
+/// Returns `true` if `codec` is compatible with `container`.
+///
+/// Uses the static compatibility matrix — does NOT check runtime availability.
+/// The `codec` argument accepts canonical codec names (e.g., "aac", "opus").
+///
+/// # Examples
+///
+/// ```no_run
+/// use rdlp_ffmpeg::ffmpeg::audio_encoder_registry::container_supports_audio_codec;
+/// use rdlp_core::ContainerFormat;
+///
+/// assert!(container_supports_audio_codec(ContainerFormat::Mp4, "aac"));
+/// assert!(!container_supports_audio_codec(ContainerFormat::Mp4, "vorbis"));
+/// assert!(container_supports_audio_codec(ContainerFormat::WebM, "opus"));
+/// assert!(!container_supports_audio_codec(ContainerFormat::Mov, "opus"));
+/// ```
+#[must_use]
+pub fn container_supports_audio_codec(container: ContainerFormat, codec: &str) -> bool {
+    let lower = codec.to_ascii_lowercase();
+    AUDIO_CODEC_PREFERENCES
+        .iter()
+        .find(|e| e.codec == lower.as_str())
+        .is_some_and(|entry| entry.supported_containers.contains(&container))
+}
+
+/// Returns the best default audio encoder for the given container format.
+///
+/// Selection is based on what is most universally compatible:
+/// - MP4, MOV, TS → AAC (best available)
+/// - WebM → Opus
+/// - OGG → Opus (if available) or Vorbis
+/// - MKV → Opus (quality/size efficiency)
+/// - AVI → MP3
+/// - Default fallback → AAC
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn select_audio_encoder_for_container(container: ContainerFormat) -> &'static str {
+    match container {
+        ContainerFormat::WebM => preferred_audio_encoder("opus").unwrap_or("libopus"),
+        ContainerFormat::Ogg => preferred_audio_encoder("opus")
+            .or_else(|| preferred_audio_encoder("vorbis"))
+            .unwrap_or("libopus"),
+        ContainerFormat::Mkv => {
+            // MKV supports everything; prefer Opus for quality/size efficiency
+            preferred_audio_encoder("opus").unwrap_or("libopus")
+        }
+        ContainerFormat::Avi => preferred_audio_encoder("mp3").unwrap_or("libmp3lame"),
+        _ => {
+            // MP4, MOV, TS, and everything else → AAC
+            preferred_audio_encoder("aac").unwrap_or("aac")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preferred_aac_encoder_returns_valid() {
+        let enc = preferred_audio_encoder("aac");
+        assert!(enc.is_some(), "aac encoder should be available");
+        let name = enc.unwrap();
+        assert!(
+            name == "aac" || name == "libfdk_aac",
+            "unexpected aac encoder: {name}"
+        );
+    }
+
+    #[test]
+    fn resolve_encoder_by_codec_name() {
+        let enc = resolve_audio_encoder("aac");
+        assert!(enc.is_some(), "should resolve aac codec");
+    }
+
+    #[test]
+    fn resolve_encoder_by_encoder_name() {
+        // Built-in "aac" encoder is always available
+        let enc = resolve_audio_encoder("aac");
+        assert!(enc.is_some());
+    }
+
+    #[test]
+    fn list_available_audio_codecs_nonempty() {
+        let codecs = list_available_audio_codecs();
+        assert!(
+            !codecs.is_empty(),
+            "at least built-in codecs should be available"
+        );
+    }
+
+    #[test]
+    fn audio_codecs_for_webm_only_opus_vorbis() {
+        let codecs = audio_codecs_for_container(ContainerFormat::WebM);
+        let codec_names: Vec<&str> = codecs.iter().map(|c| c.codec.as_str()).collect();
+        // WebM only supports Opus and Vorbis
+        for name in &codec_names {
+            assert!(
+                *name == "opus" || *name == "vorbis",
+                "unexpected codec for webm: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn audio_codecs_for_mkv_includes_all() {
+        let codecs = audio_codecs_for_container(ContainerFormat::Mkv);
+        let codec_names: Vec<&str> = codecs.iter().map(|c| c.codec.as_str()).collect();
+        // MKV supports everything; at minimum aac should be present
+        assert!(codec_names.contains(&"aac"), "mkv should support aac");
+    }
+
+    #[test]
+    fn container_supports_mp4_opus() {
+        assert!(container_supports_audio_codec(ContainerFormat::Mp4, "opus"));
+    }
+
+    #[test]
+    fn container_does_not_support_mp4_vorbis() {
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mp4,
+            "vorbis"
+        ));
+    }
+
+    #[test]
+    fn container_does_not_support_mov_opus() {
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mov,
+            "opus"
+        ));
+    }
+
+    #[test]
+    fn select_encoder_for_mp4_returns_aac() {
+        let enc = select_audio_encoder_for_container(ContainerFormat::Mp4);
+        assert!(
+            enc == "aac" || enc == "libfdk_aac",
+            "expected aac encoder for mp4, got {enc}"
+        );
+    }
+
+    #[test]
+    fn preferred_aac_encoder_wrapper_consistency() {
+        // The audio_codecs.rs preferred_aac_encoder() should match registry
+        let registry_result = preferred_audio_encoder("aac").unwrap_or("aac");
+        let legacy_result = crate::ffmpeg::audio_codecs::preferred_aac_encoder();
+        assert_eq!(
+            registry_result, legacy_result,
+            "registry and legacy preferred_aac_encoder must agree"
+        );
+    }
+
+    #[test]
+    fn compatibility_rejects_vorbis_mp4() {
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mp4,
+            "vorbis"
+        ));
+    }
+
+    #[test]
+    fn compatibility_accepts_opus_mkv() {
+        assert!(container_supports_audio_codec(ContainerFormat::Mkv, "opus"));
+    }
+
+    #[test]
+    fn unknown_codec_returns_false() {
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mp4,
+            "nonexistent_codec"
+        ));
+    }
+
+    #[test]
+    fn unknown_codec_resolve_returns_none() {
+        assert!(resolve_audio_encoder("nonexistent_codec_xyz").is_none());
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -28,6 +28,7 @@
 //! ```
 
 mod audio_codecs;
+pub mod audio_encoder_registry;
 mod ffi_helpers;
 pub(crate) mod log_capture;
 mod merge;
@@ -51,6 +52,7 @@ use crate::error::{PostProcessError, Result};
 
 // Re-export public types from submodules
 pub use audio_codecs::{AUDIO_CODECS, AudioCodecConfig, get_audio_codec};
+pub use audio_encoder_registry::{AudioCodecInfo, AudioEncoderInfo};
 pub use normalize_types::{
     AudioNormMode, LoudnormMeasurements, LoudnormPreset, NormalizeOptions, PeakAnalysis,
 };

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -208,32 +208,26 @@ pub(super) fn extract_json_value(text: &str, key: &str) -> Option<f64> {
 
 /// Select the appropriate audio encoder for a container extension.
 ///
-/// For AAC-compatible containers, returns the best available AAC encoder
-/// via [`preferred_aac_encoder()`] (`libfdk_aac` when available, `aac` otherwise).
+/// Handles both video containers and audio-only output formats (e.g., mp3, flac, wav).
+/// For recognized audio-only extensions, returns the canonical encoder directly.
+/// For video containers, delegates to [`audio_encoder_registry::select_audio_encoder_for_container`].
+/// Falls back to the best available AAC encoder for unknown extensions.
 pub(super) fn select_audio_encoder_for_container(ext: &str) -> &'static str {
-    if ext.eq_ignore_ascii_case("mp4")
-        || ext.eq_ignore_ascii_case("m4a")
-        || ext.eq_ignore_ascii_case("mov")
-        || ext.eq_ignore_ascii_case("f4v")
-        || ext.eq_ignore_ascii_case("3gp")
-        || ext.eq_ignore_ascii_case("ts")
-        || ext.eq_ignore_ascii_case("mpg")
-        || ext.eq_ignore_ascii_case("flv")
-    {
-        crate::ffmpeg::audio_codecs::preferred_aac_encoder()
-    } else if ext.eq_ignore_ascii_case("webm")
-        || ext.eq_ignore_ascii_case("ogg")
-        || ext.eq_ignore_ascii_case("opus")
-        || ext.eq_ignore_ascii_case("mkv")
-        || ext.eq_ignore_ascii_case("mka")
-    {
-        "libopus"
-    } else if ext.eq_ignore_ascii_case("avi") || ext.eq_ignore_ascii_case("mp3") {
-        "libmp3lame"
-    } else if ext.eq_ignore_ascii_case("flac") {
-        "flac"
-    } else if ext.eq_ignore_ascii_case("wav") {
-        "pcm_s16le"
+    // Audio-only output formats: these are not ContainerFormat variants but
+    // appear as extensions when normalizing standalone audio files.
+    if ext.eq_ignore_ascii_case("mp3") {
+        return "libmp3lame";
+    }
+    if ext.eq_ignore_ascii_case("flac") {
+        return "flac";
+    }
+    if ext.eq_ignore_ascii_case("wav") {
+        return "pcm_s16le";
+    }
+
+    // For proper container formats, delegate to the registry
+    if let Ok(container) = ext.parse::<rdlp_core::ContainerFormat>() {
+        crate::ffmpeg::audio_encoder_registry::select_audio_encoder_for_container(container)
     } else {
         crate::ffmpeg::audio_codecs::preferred_aac_encoder()
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
@@ -12,6 +12,7 @@ fn test_select_audio_encoder_for_container() {
     assert_eq!(select_audio_encoder_for_container("m4a"), aac);
     assert_eq!(select_audio_encoder_for_container("mov"), aac);
     assert_eq!(select_audio_encoder_for_container("webm"), "libopus");
+    // MKV supports everything; registry prefers Opus for quality/size efficiency
     assert_eq!(select_audio_encoder_for_container("mkv"), "libopus");
     assert_eq!(select_audio_encoder_for_container("avi"), "libmp3lame");
     assert_eq!(select_audio_encoder_for_container("mp3"), "libmp3lame");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -40,7 +40,15 @@ pub struct VideoConvertOptions {
     /// Constant Rate Factor for quality-based encoding.
     pub crf: Option<u32>,
     /// If true, copy audio stream without re-encoding.
+    ///
+    /// Takes precedence over `audio_codec`. When `audio_copy` is true and
+    /// `audio_codec` is `Some`, audio is still copied unchanged.
     pub audio_copy: bool,
+    /// Audio encoder name to use for audio re-encoding (e.g., "libfdk_aac", "libopus").
+    ///
+    /// Only used when `audio_copy` is false. When `None` and `audio_copy` is false,
+    /// the existing behavior is preserved (implementation decides the encoder).
+    pub audio_codec: Option<String>,
 }
 
 /// A chapter entry for metadata embedding.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -228,6 +228,16 @@ impl FFmpegRunner {
             video_encoder.as_ptr()
         });
 
+        // Determine audio handling mode:
+        // - audio_copy=true → stream copy (existing path)
+        // - audio_codec=Some → re-encode with specified encoder
+        // - neither → no audio output stream
+        let audio_encode_codec: Option<&str> = if !opts.audio_copy {
+            opts.audio_codec.as_deref()
+        } else {
+            None
+        };
+
         // Add audio output stream (stream copy) if audio exists and copy requested
         let audio_ost_index = if opts.audio_copy {
             if let Some(audio_idx) = audio_ist_index {
@@ -260,6 +270,114 @@ impl FFmpegRunner {
             None
         };
 
+        // Audio transcode: open decoder + encoder when audio_codec is specified
+        let audio_transcode_state: Option<(
+            ffmpeg_the_third::decoder::Audio,
+            ffmpeg_the_third::encoder::audio::Encoder,
+            ffmpeg_the_third::Rational, // encoder time_base
+            usize,                      // audio_ost_index for transcode
+        )> = if let Some(enc_name) = audio_encode_codec {
+            if let Some(audio_idx) = audio_ist_index {
+                // Open audio decoder
+                let audio_ist = ictx.stream(audio_idx).ok_or_else(|| {
+                    PostProcessError::ffmpeg_failed(format!(
+                        "audio input stream {audio_idx} not found"
+                    ))
+                })?;
+                let audio_dec_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(
+                    audio_ist.parameters(),
+                )?;
+                let mut audio_decoder = audio_dec_ctx.decoder().audio()?;
+                // Set packet timebase for accurate audio timestamps
+                let pkt_tb = audio_ist_time_base.unwrap_or(ffmpeg_the_third::Rational(1, 44100));
+                unsafe {
+                    (*audio_decoder.as_mut_ptr()).pkt_timebase =
+                        ffmpeg_the_third::ffi::AVRational {
+                            num: pkt_tb.numerator(),
+                            den: pkt_tb.denominator(),
+                        };
+                }
+
+                // Find and open audio encoder
+                let audio_enc_codec = ffmpeg_the_third::encoder::find_by_name(enc_name)
+                    .ok_or_else(|| PostProcessError::UnsupportedCodec {
+                        codec: enc_name.to_string(),
+                        operation: "audio re-encode during video recode".into(),
+                    })?;
+
+                // Add audio output stream with encoder
+                let audio_enc_ost_idx;
+                {
+                    let ost = octx.add_stream(audio_enc_codec).map_err(|e| {
+                        PostProcessError::FFmpegLibraryError {
+                            message: format!("failed to add audio encode output stream: {e}"),
+                        }
+                    })?;
+                    audio_enc_ost_idx = ost.index();
+                }
+
+                // Configure audio encoder from decoder properties
+                let audio_enc_context = ffmpeg_the_third::codec::context::Context::from_parameters(
+                    octx.stream(audio_enc_ost_idx)
+                        .ok_or_else(|| {
+                            PostProcessError::ffmpeg_failed("audio encode ost not found")
+                        })?
+                        .parameters(),
+                )?;
+                let mut audio_encoder = audio_enc_context.encoder().audio()?;
+
+                // Pick sample rate compatible with encoder (prefer decoder rate)
+                let target_rate =
+                    Self::pick_audio_sample_rate(&audio_enc_codec, audio_decoder.rate());
+                let enc_time_base = ffmpeg_the_third::Rational(1, target_rate as i32);
+                audio_encoder.set_rate(target_rate as i32);
+                audio_encoder.set_time_base(enc_time_base);
+
+                // Set channel layout matching decoder channel count
+                let channels = audio_decoder.ch_layout().channels();
+                // SAFETY: audio_encoder is a valid pre-open encoder context.
+                Self::set_default_channel_layout(
+                    unsafe { audio_encoder.as_mut_ptr() },
+                    channels as i32,
+                );
+
+                // Pick sample format compatible with encoder (prefer decoder format)
+                let target_fmt =
+                    Self::pick_audio_sample_format(&audio_enc_codec, audio_decoder.format());
+                audio_encoder.set_format(target_fmt);
+
+                if needs_global_header {
+                    unsafe { Self::set_global_header_flag(audio_encoder.as_mut_ptr()) };
+                }
+
+                let audio_encoder = audio_encoder.open_as(audio_enc_codec).map_err(|e| {
+                    PostProcessError::FFmpegLibraryError {
+                        message: format!("failed to open audio encoder '{enc_name}': {e}"),
+                    }
+                })?;
+
+                // Copy encoder parameters back to output stream
+                unsafe {
+                    Self::copy_encoder_params_to_stream(
+                        &mut octx,
+                        audio_enc_ost_idx,
+                        audio_encoder.as_ptr(),
+                    );
+                }
+
+                Some((
+                    audio_decoder,
+                    audio_encoder,
+                    enc_time_base,
+                    audio_enc_ost_idx,
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();
 
@@ -285,7 +403,18 @@ impl FFmpegRunner {
         let mut last_progress = Instant::now();
         let progress_throttle = Duration::from_millis(100);
 
-        // Process packets: video -> decode/filter/encode, audio -> copy
+        // Destructure transcode state to allow mutable borrows in loop
+        let (
+            mut audio_transcode_decoder,
+            mut audio_transcode_encoder,
+            audio_transcode_enc_tb,
+            audio_transcode_ost_idx,
+        ) = match audio_transcode_state {
+            Some((dec, enc, enc_tb, idx)) => (Some(dec), Some(enc), Some(enc_tb), Some(idx)),
+            None => (None, None, None, None),
+        };
+
+        // Process packets: video -> decode/filter/encode, audio -> copy or transcode
         for result in ictx.packets() {
             let (stream, mut packet) =
                 result.map_err(|e| PostProcessError::FFmpegLibraryError {
@@ -317,8 +446,9 @@ impl FFmpegRunner {
                     video_ost_index,
                 )?;
             } else if Some(ist_index) == audio_ist_index {
-                // Audio: stream copy
+                // Audio: stream copy or transcode
                 if let Some(audio_ost_idx) = audio_ost_index {
+                    // Stream copy path
                     let ost_time_base = octx
                         .stream(audio_ost_idx)
                         .ok_or_else(|| {
@@ -338,6 +468,26 @@ impl FFmpegRunner {
                             message: format!("failed to write audio packet: {e}"),
                         }
                     })?;
+                } else if let (
+                    Some(ref mut audio_dec),
+                    Some(ref mut audio_enc),
+                    Some(enc_tb),
+                    Some(audio_ost_idx),
+                ) = (
+                    audio_transcode_decoder.as_mut(),
+                    audio_transcode_encoder.as_mut(),
+                    audio_transcode_enc_tb,
+                    audio_transcode_ost_idx,
+                ) {
+                    // Audio transcode path: decode → encode → write
+                    audio_dec.send_packet(&packet)?;
+                    Self::drain_audio_transcode(
+                        audio_dec,
+                        audio_enc,
+                        &mut octx,
+                        enc_tb,
+                        audio_ost_idx,
+                    )?;
                 }
             }
         }
@@ -373,6 +523,24 @@ impl FFmpegRunner {
         video_encoder.send_eof()?;
         Self::drain_video_encoder_packets(&mut video_encoder, &mut octx, video_ost_index)?;
 
+        // Flush audio encoder (transcode path)
+        if let (
+            Some(ref mut audio_dec),
+            Some(ref mut audio_enc),
+            Some(enc_tb),
+            Some(audio_ost_idx),
+        ) = (
+            audio_transcode_decoder.as_mut(),
+            audio_transcode_encoder.as_mut(),
+            audio_transcode_enc_tb,
+            audio_transcode_ost_idx,
+        ) {
+            audio_dec.send_eof()?;
+            Self::drain_audio_transcode(audio_dec, audio_enc, &mut octx, enc_tb, audio_ost_idx)?;
+            audio_enc.send_eof()?;
+            Self::drain_audio_encoder_packets(audio_enc, &mut octx, enc_tb, audio_ost_idx)?;
+        }
+
         // Flush interleave queue before trailer
         flush_interleave_queue(&mut octx);
 
@@ -381,6 +549,52 @@ impl FFmpegRunner {
                 message: format!("failed to write output trailer: {e}"),
             })?;
 
+        Ok(())
+    }
+
+    /// Receive decoded audio frames and encode them to the output stream.
+    ///
+    /// Used for the audio transcode path in `convert_video_transcode_sync`
+    /// when `audio_codec` is specified in [`VideoConvertOptions`].
+    fn drain_audio_transcode(
+        decoder: &mut ffmpeg_the_third::decoder::Audio,
+        encoder: &mut ffmpeg_the_third::encoder::audio::Encoder,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        enc_time_base: ffmpeg_the_third::Rational,
+        ost_index: usize,
+    ) -> Result<()> {
+        let mut frame = ffmpeg_the_third::frame::Audio::empty();
+        while decoder.receive_frame(&mut frame).is_ok() {
+            encoder.send_frame(&frame)?;
+            Self::drain_audio_encoder_packets(encoder, octx, enc_time_base, ost_index)?;
+        }
+        Ok(())
+    }
+
+    /// Drain encoded audio packets to the output context (interleaved write).
+    fn drain_audio_encoder_packets(
+        encoder: &mut ffmpeg_the_third::encoder::audio::Encoder,
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        enc_time_base: ffmpeg_the_third::Rational,
+        ost_index: usize,
+    ) -> Result<()> {
+        let ost_time_base = octx
+            .stream(ost_index)
+            .ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!("audio ost {ost_index} not found"))
+            })?
+            .time_base();
+        let mut packet = ffmpeg_the_third::Packet::empty();
+        while encoder.receive_packet(&mut packet).is_ok() {
+            packet.rescale_ts(enc_time_base, ost_time_base);
+            packet.set_stream(ost_index);
+            packet.set_position(-1);
+            packet
+                .write_interleaved(octx)
+                .map_err(|e| PostProcessError::FFmpegLibraryError {
+                    message: format!("failed to write encoded audio packet: {e}"),
+                })?;
+        }
         Ok(())
     }
 }

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -48,7 +48,7 @@ pub mod ffmpeg;
 // Re-export main types at crate root
 pub use error::{CorruptionKind, PostProcessError, Result};
 pub use ffmpeg::{
-    AudioExtractOptions, AudioNormMode, ChapterEntry, FFmpegRunner, LoudnormMeasurements,
-    LoudnormPreset, MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo,
-    VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, set_verbose,
+    AudioCodecInfo, AudioEncoderInfo, AudioExtractOptions, AudioNormMode, ChapterEntry,
+    FFmpegRunner, LoudnormMeasurements, LoudnormPreset, MediaInfo, NormalizeOptions, PeakAnalysis,
+    RemuxOptions, StreamInfo, VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, set_verbose,
 };

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -1,15 +1,16 @@
 //! RecodeStage — transcodes video to a different container format.
 //!
-//! This stage runs at index 4 when `config.recode_video` is `Some`.
+//! This stage runs at index 4 when `config.recode_video` is `Some` or
+//! `config.recode_container` is `Some`.
 //! Uses `rdlp_ffmpeg::FFmpegRunner::convert_video()`.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::{debug, info, warn};
 
-use rdlp_core::ContainerFormat;
-use rdlp_ffmpeg::ffmpeg::video_codecs;
+use rdlp_core::{ContainerFormat, RecodeAudioMode};
+use rdlp_ffmpeg::ffmpeg::{audio_encoder_registry, video_codecs};
 use rdlp_ffmpeg::{FFmpegRunner, PostProcessError, VideoConvertOptions};
 
 use crate::pipeline::{PipelineMessage, PipelineStage};
@@ -69,10 +70,13 @@ impl RecodeStage {
     /// Build video conversion options.
     ///
     /// Returns `None` when an explicit encoder override is requested but not available.
+    /// `audio_codec` is `None` for copy, `Some(name)` for re-encode.
     fn build_convert_options(
         target_format: &str,
         can_remux: bool,
         encoder_override: Option<&str>,
+        audio_copy: bool,
+        audio_codec: Option<String>,
     ) -> Option<VideoConvertOptions> {
         if can_remux {
             return Some(VideoConvertOptions {
@@ -90,7 +94,8 @@ impl RecodeStage {
                 video_codec: Some(encoder_name.to_string()),
                 preset,
                 crf,
-                audio_copy: true,
+                audio_copy,
+                audio_codec,
             });
         }
 
@@ -114,7 +119,8 @@ impl RecodeStage {
             video_codec: encoder.map(String::from),
             preset,
             crf,
-            audio_copy: true,
+            audio_copy,
+            audio_codec,
         })
     }
 
@@ -142,7 +148,7 @@ impl PipelineStage for RecodeStage {
     }
 
     fn should_run(&self, msg: &PipelineMessage) -> bool {
-        msg.config.recode_video.is_some()
+        msg.config.recode_video.is_some() || msg.config.recode_container.is_some()
     }
 
     async fn process(&self, mut msg: PipelineMessage) -> anyhow::Result<PipelineMessage> {
@@ -152,7 +158,10 @@ impl PipelineStage for RecodeStage {
 
         let input_file = msg.tracker.primary();
 
-        let target_format = match msg.config.recode_video {
+        // Resolve target container: prefer recode_container, fallback to recode_video
+        let target_container = msg.config.recode_container.or(msg.config.recode_video);
+
+        let target_format = match target_container {
             Some(c) => c.as_ext(),
             None => {
                 debug!("RecodeStage: no recode target configured; defaulting to MP4");
@@ -197,12 +206,69 @@ impl PipelineStage for RecodeStage {
             debug!("RecodeStage: transcoding video");
         }
 
+        // Resolve audio mode — force Copy when audio normalization is active
+        // (normalizer already re-encoded audio; re-encoding again degrades quality)
+        let recode_audio = if msg.config.normalize_audio {
+            if !matches!(msg.config.recode_audio, RecodeAudioMode::Copy) {
+                warn!(
+                    "RecodeStage: normalize_audio is active — forcing audio copy mode \
+                     (re-encoding normalized audio degrades quality)"
+                );
+            }
+            RecodeAudioMode::Copy
+        } else {
+            msg.config.recode_audio.clone()
+        };
+
+        // Derive audio_copy / audio_codec from the resolved mode
+        let (audio_copy, audio_codec) = if can_remux {
+            // Remux path always copies audio — no re-encoding needed
+            (true, None)
+        } else {
+            match recode_audio {
+                RecodeAudioMode::Copy => (true, None),
+                RecodeAudioMode::Auto => {
+                    // Select best audio encoder for the target container
+                    let encoder = target_container
+                        .map(audio_encoder_registry::select_audio_encoder_for_container)
+                        .unwrap_or("aac");
+                    debug!("RecodeStage: auto audio encoder for {target_format}: {encoder}");
+                    (false, Some(encoder.to_string()))
+                }
+                RecodeAudioMode::Encoder { ref name } => {
+                    // Validate compatibility with target container
+                    if let Some(container) = target_container
+                        && !audio_encoder_registry::container_supports_audio_codec(container, name)
+                    {
+                        warn!(
+                            "RecodeStage: audio codec '{name}' may not be compatible with \
+                             container '{target_format}'; proceeding anyway"
+                        );
+                    }
+                    let resolved = audio_encoder_registry::resolve_audio_encoder(name)
+                        .unwrap_or_else(|| {
+                            warn!(
+                                "RecodeStage: audio encoder '{name}' not available; \
+                                 falling back to container default"
+                            );
+                            target_container
+                                .map(audio_encoder_registry::select_audio_encoder_for_container)
+                                .unwrap_or("aac")
+                        });
+                    debug!("RecodeStage: using audio encoder: {resolved}");
+                    (false, Some(resolved.to_string()))
+                }
+            }
+        };
+
         let output_path = msg.tracker.temp_path(&input_file, target_format);
 
         let opts = match Self::build_convert_options(
             target_format,
             can_remux,
             msg.config.video_encoder.as_deref(),
+            audio_copy,
+            audio_codec,
         ) {
             Some(o) => o,
             None => {
@@ -321,23 +387,45 @@ mod tests {
 
     #[test]
     fn build_convert_options_remux() {
-        let opts = RecodeStage::build_convert_options("mp4", true, None).unwrap();
+        let opts = RecodeStage::build_convert_options("mp4", true, None, true, None).unwrap();
         assert!(opts.remux_only);
         assert!(opts.audio_copy);
     }
 
     #[test]
     fn build_convert_options_transcode_mp4() {
-        let opts = RecodeStage::build_convert_options("mp4", false, None).unwrap();
+        let opts = RecodeStage::build_convert_options("mp4", false, None, true, None).unwrap();
         assert!(!opts.remux_only);
         assert!(opts.video_codec.is_some());
         assert_eq!(opts.preset, Some("medium".to_string()));
         assert_eq!(opts.crf, Some(23));
+        assert!(opts.audio_copy);
+        assert!(opts.audio_codec.is_none());
+    }
+
+    #[test]
+    fn build_convert_options_with_audio_codec() {
+        let opts = RecodeStage::build_convert_options(
+            "mp4",
+            false,
+            None,
+            false,
+            Some("libopus".to_string()),
+        )
+        .unwrap();
+        assert!(!opts.audio_copy);
+        assert_eq!(opts.audio_codec, Some("libopus".to_string()));
     }
 
     #[test]
     fn build_convert_options_unavailable_encoder_returns_none() {
-        let result = RecodeStage::build_convert_options("mp4", false, Some("nonexistent_enc_xyz"));
+        let result = RecodeStage::build_convert_options(
+            "mp4",
+            false,
+            Some("nonexistent_enc_xyz"),
+            true,
+            None,
+        );
         assert!(result.is_none());
     }
 }

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -95,24 +95,24 @@ impl FileTracker {
 
         // Rename current files from UUID temp names back to clean names
         for file in &mut self.current_files {
-            if let Some(name) = file.file_name().and_then(|n| n.to_str()) {
-                if let Some(idx) = name.find(".rdlp-tmp-") {
-                    let clean_stem = &name[..idx];
-                    let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
-                    let clean_name = format!("{clean_stem}.{ext}");
-                    let clean_path = file.with_file_name(&clean_name);
-                    match std::fs::rename(&file, &clean_path) {
-                        Ok(()) => {
-                            self.temp_registry.release(file);
-                            *file = clean_path;
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "FileTracker: failed to rename {} → {}: {e}",
-                                file.display(),
-                                clean_name,
-                            );
-                        }
+            if let Some(name) = file.file_name().and_then(|n| n.to_str())
+                && let Some(idx) = name.find(".rdlp-tmp-")
+            {
+                let clean_stem = &name[..idx];
+                let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
+                let clean_name = format!("{clean_stem}.{ext}");
+                let clean_path = file.with_file_name(&clean_name);
+                match std::fs::rename(&file, &clean_path) {
+                    Ok(()) => {
+                        self.temp_registry.release(file);
+                        *file = clean_path;
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "FileTracker: failed to rename {} → {}: {e}",
+                            file.display(),
+                            clean_name,
+                        );
                     }
                 }
             }

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use crate::audio_format::AudioFormat;
 use crate::browser_type::BrowserType;
 use crate::container::ContainerFormat;
+use crate::recode_audio_mode::RecodeAudioMode;
 use crate::subtitle_format::SubtitleFormat;
 
 /// Errors from configuration validation.
@@ -162,6 +163,16 @@ pub struct Config {
     /// When None, the best available encoder for the codec is auto-selected.
     #[serde(default)]
     pub video_encoder: Option<String>,
+
+    /// How to handle audio during video recode.
+    /// Default is Copy (stream copy audio unchanged).
+    #[serde(default)]
+    pub recode_audio: RecodeAudioMode,
+
+    /// Output container override for video recode.
+    /// When None, the container is derived from the video codec.
+    #[serde(default)]
+    pub recode_container: Option<ContainerFormat>,
 
     /// Remux to container format for better seeking
     pub remux_container: Option<ContainerFormat>,
@@ -364,6 +375,8 @@ impl Default for Config {
             audio_quality: None,
             recode_video: None,
             video_encoder: None,
+            recode_audio: RecodeAudioMode::Copy,
+            recode_container: None,
             remux_container: None,
             embed_thumbnail: true,
             embed_metadata: false,

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -31,6 +31,7 @@ pub mod format;
 pub mod info_dict;
 pub mod parse_error;
 pub mod protocol;
+pub mod recode_audio_mode;
 pub mod search;
 pub mod subtitle_format;
 pub mod subtitle_kind;
@@ -46,6 +47,7 @@ pub use format::{Format, FormatSelector, Fragment};
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use parse_error::ParseEnumError;
 pub use protocol::DownloadProtocol;
+pub use recode_audio_mode::RecodeAudioMode;
 pub use search::{
     SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery,
     SearchResultPreview, SearchSiteInfo,

--- a/crates/rdlp-types/src/recode_audio_mode.rs
+++ b/crates/rdlp-types/src/recode_audio_mode.rs
@@ -1,0 +1,90 @@
+//! Audio handling mode for video recode operations.
+
+use serde::{Deserialize, Serialize};
+
+/// How to handle audio during video recode.
+///
+/// Collapses the audio copy/encoder decision into a single discriminated type,
+/// eliminating the two-field interaction matrix.
+///
+/// # Examples
+///
+/// ```rust
+/// use rdlp_types::RecodeAudioMode;
+/// use serde_json;
+///
+/// // Default is Copy
+/// let mode = RecodeAudioMode::default();
+/// assert_eq!(mode, RecodeAudioMode::Copy);
+///
+/// // Serde roundtrip
+/// let json = serde_json::to_string(&RecodeAudioMode::Copy).unwrap();
+/// assert_eq!(json, r#"{"mode":"copy"}"#);
+///
+/// let encoder = RecodeAudioMode::Encoder { name: "libopus".to_string() };
+/// let json = serde_json::to_string(&encoder).unwrap();
+/// assert_eq!(json, r#"{"mode":"encoder","name":"libopus"}"#);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", tag = "mode")]
+pub enum RecodeAudioMode {
+    /// Stream copy audio unchanged (default).
+    #[default]
+    Copy,
+    /// Auto-select best encoder for the output container.
+    Auto,
+    /// Use a specific encoder (e.g., "libfdk_aac", "libopus").
+    Encoder {
+        /// FFmpeg encoder name (e.g., "libfdk_aac", "libopus").
+        name: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_copy() {
+        assert_eq!(RecodeAudioMode::default(), RecodeAudioMode::Copy);
+    }
+
+    #[test]
+    fn serde_copy_roundtrip() {
+        let mode = RecodeAudioMode::Copy;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, r#"{"mode":"copy"}"#);
+        let parsed: RecodeAudioMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, parsed);
+    }
+
+    #[test]
+    fn serde_auto_roundtrip() {
+        let mode = RecodeAudioMode::Auto;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, r#"{"mode":"auto"}"#);
+        let parsed: RecodeAudioMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, parsed);
+    }
+
+    #[test]
+    fn serde_encoder_roundtrip() {
+        let mode = RecodeAudioMode::Encoder {
+            name: "libfdk_aac".to_string(),
+        };
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, r#"{"mode":"encoder","name":"libfdk_aac"}"#);
+        let parsed: RecodeAudioMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, parsed);
+    }
+
+    #[test]
+    fn serde_encoder_libopus_roundtrip() {
+        let mode = RecodeAudioMode::Encoder {
+            name: "libopus".to_string(),
+        };
+        let json = serde_json::to_string(&mode).unwrap();
+        let parsed: RecodeAudioMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, parsed);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds three-dimensional recode control: video codec (existing) + container format (new) + audio codec (new)
- `RecodeAudioMode` enum (Copy/Auto/Encoder{name}) with internally-tagged serde for type-safe audio handling
- Audio encoder registry (13 codecs, runtime detection, container compatibility matrix)
- CLI flags: `--recode-audio` and `--recode-container`
- Desktop UI: Container and Audio Select dropdowns with independent Expert mode toggles
- Normalization interlock: forces audio stream copy when `normalize_audio` is active

## Changes across 7 crates

| Crate | Changes |
|-------|---------|
| rdlp-types | `RecodeAudioMode` enum, `recode_audio`/`recode_container` Config fields |
| rdlp-ffmpeg | Audio encoder registry, `container_supports_audio_codec()`, audio transcode in `video_convert.rs` |
| rdlp-core | `PostProcessConfig` new fields |
| rdlp-postprocess | RecodeStage container/audio resolution + compatibility validation |
| rdlp-cli | `--recode-audio` and `--recode-container` flags |
| rdlp-api | `PostProcessOptions` new fields, merge path, orchestrator mapping |
| rdlp-desktop | Tauri command, DownloadOptions, Container/Audio UI with Expert mode |

## Test plan

- [x] `cargo test --workspace` — 1504 tests pass (223 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 286/286 pass
- [x] RecodeAudioMode serde roundtrip verified
- [x] MOV excludes Opus in compatibility matrix
- [x] Normalization forces Copy in RecodeStage
- [x] libfdk_aac confirmed as preferred AAC encoder