### PR TITLE
feat(cli): add -F/--list-formats and fix FormatSelectError integration

### DIFF
--- a/crates/rdlp-api/src/orchestrator/selection/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/selection/mod.rs
@@ -102,7 +102,7 @@ impl Orchestrator {
         let format = {
             let selector_str = self.resolve_effective_selector();
             let format_selector = FormatSelector::parse(&selector_str)
-                .map_err(OrchestratorError::InvalidFormatSelector)?;
+                .map_err(|e| OrchestratorError::InvalidFormatSelector(e.to_string()))?;
 
             let selected_formats = format_selector.select(formats);
             if selected_formats.is_empty() {

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -60,6 +60,10 @@ pub(crate) struct Args {
     #[arg(short = 'j', long)]
     pub dump_json: bool,
 
+    /// List available formats as a table (no download)
+    #[arg(short = 'F', long)]
+    pub list_formats: bool,
+
     /// Print specific field(s) from metadata (no download)
     /// e.g., --print title or --print "id,title,extractor"
     #[arg(long)]

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -19,6 +19,7 @@ fn default_args() -> Args {
         list_codecs: false,
         simulate: false,
         dump_json: false,
+        list_formats: false,
         print: None,
         interactive: false,
         extract_audio: false,

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -262,8 +262,8 @@ async fn async_main() -> Result<()> {
         return Ok(());
     }
 
-    // Metadata-only modes: --dump-json, --print, --simulate
-    if args.dump_json || args.print.is_some() || args.simulate {
+    // Metadata-only modes: --dump-json, --print, --list-formats, --simulate
+    if args.dump_json || args.print.is_some() || args.list_formats || args.simulate {
         let infos = match client.extract_info(&url).await {
             Ok(infos) => infos,
             Err(e) => fail_with(e, verbose),
@@ -276,13 +276,25 @@ async fn async_main() -> Result<()> {
             }
         }
 
+        if args.list_formats {
+            for info in &infos {
+                let refs: Vec<&rdlp_api::Format> = info.formats.iter().collect();
+                let table = rdlp_table::render_formats_table(
+                    &refs,
+                    &rdlp_table::TableOpts::default(),
+                );
+                println!("{}", info.title);
+                println!("{table}");
+            }
+        }
+
         if let Some(ref fields) = args.print {
             for info in &infos {
                 print_fields(info, fields)?;
             }
         }
 
-        if args.simulate && !args.dump_json && args.print.is_none() {
+        if args.simulate && !args.dump_json && args.print.is_none() && !args.list_formats {
             for info in &infos {
                 debug!(
                     "[Simulate] {} | id={} | extractor={} | {} format(s)",

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -437,6 +437,7 @@ mod tests {
             video_encoder: None,
             recode_container: None,
             recode_audio: None,
+            verbose: None,
         }
     }
 

--- a/crates/rdlp-desktop/src-tauri/src/commands/formats/mod.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/formats/mod.rs
@@ -136,7 +136,7 @@ pub async fn validate_format_expression(
 
         let selector = FormatSelector::parse(&expression).map_err(|e| AppError::InvalidInput {
             field: "expression".to_owned(),
-            message: e,
+            message: e.to_string(),
         })?;
 
         if formats.is_empty() {


### PR DESCRIPTION
## Summary
- Add `-F` / `--list-formats` CLI flag — prints format table to stdout without downloading
- Fix `FormatSelectError` integration after PR #143 changed the return type from `String` to typed enum
- Fix missing `verbose` field in desktop `DownloadOptions` test helper

## Phase 1 completion status
- [x] Format Selection DSL (`-f`) — PR #143
- [x] Format Sorting (`-S`) — FormatSorter in rdlp-types
- [x] Video+Audio Merge — already implemented in orchestrator (parallel download + ffmpeg mux)
- [x] `-F` list formats — this PR
- [x] `-j` dump JSON — already existed
- [x] `--print` fields — already existed
- [x] `-s` simulate — already existed

**Phase 1 is now complete.**

## Test plan
- [x] `cargo build --workspace` — zero errors
- [x] `cargo test --workspace` — all tests pass