### PR TITLE
feat: EMPFlix/MovieFap search, AIMD floor, FFmpeg log forwarding, progress bar fixes

### DIFF
--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -198,16 +198,21 @@ async fn async_main() -> Result<()> {
             query: query_text.clone(),
             filters,
             max_results: None,
-            page: None,
+            page: Some(1),
         };
 
-        match client.search(site, &search_query).await {
-            Ok(results) => {
-                if results.is_empty() {
+        match client.search_page(site, &search_query).await {
+            Ok(response) => {
+                if response.results.is_empty() {
                     eprintln!("No results found for '{query_text}'.");
                 } else {
-                    eprintln!("Found {} results:\n", results.len());
-                    for (i, r) in results.iter().enumerate() {
+                    let page_info = if response.has_more {
+                        format!(" (page {}, more available)", response.page)
+                    } else {
+                        format!(" (page {})", response.page)
+                    };
+                    eprintln!("Found {} results{}:\n", response.results.len(), page_info);
+                    for (i, r) in response.results.iter().enumerate() {
                         eprintln!("{:>3}. {}", i + 1, r.title);
                         eprintln!("     {}", r.video_url);
                         if let Some(d) = r.duration {

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -187,10 +187,16 @@ impl DownloadProgress {
             }
         });
 
-        let eta = if speed > 0.0 {
-            total_bytes.map(|total| {
+        let eta = if speed > 1.0 {
+            total_bytes.and_then(|total| {
                 let remaining = total.saturating_sub(bytes_downloaded);
-                Duration::from_secs_f64(remaining as f64 / speed)
+                let secs = remaining as f64 / speed;
+                // Cap at 24 hours — anything larger is not a useful estimate
+                if secs <= 86_400.0 {
+                    Some(Duration::from_secs_f64(secs))
+                } else {
+                    None
+                }
             })
         } else {
             None
@@ -223,8 +229,7 @@ impl DownloadProgress {
             None
         };
 
-        let eta = if speed > 0.0 && total_segments > 0 {
-            // Estimate based on segments remaining and current speed
+        let eta = if speed > 1.0 && total_segments > 0 {
             let remaining_segments = total_segments.saturating_sub(segments_downloaded);
             let avg_segment_size = if segments_downloaded > 0 {
                 bytes_downloaded / segments_downloaded
@@ -232,7 +237,8 @@ impl DownloadProgress {
                 2 * 1024 * 1024 // Default 2MB estimate
             };
             let remaining_bytes = remaining_segments * avg_segment_size;
-            Some(Duration::from_secs_f64(remaining_bytes as f64 / speed))
+            let secs = remaining_bytes as f64 / speed;
+            if secs <= 86_400.0 { Some(Duration::from_secs_f64(secs)) } else { None }
         } else {
             None
         };
@@ -269,8 +275,7 @@ impl DownloadProgress {
             None
         };
 
-        let eta = if speed > 0.0 && total_duration > 0.0 && duration_downloaded < total_duration {
-            // Estimate remaining bytes based on duration ratio and current progress
+        let eta = if speed > 1.0 && total_duration > 0.0 && duration_downloaded < total_duration {
             let remaining_duration = total_duration - duration_downloaded;
             let duration_ratio = if duration_downloaded > 0.0 {
                 remaining_duration / duration_downloaded
@@ -278,9 +283,8 @@ impl DownloadProgress {
                 1.0
             };
             let estimated_remaining_bytes = (bytes_downloaded as f64 * duration_ratio) as u64;
-            Some(Duration::from_secs_f64(
-                estimated_remaining_bytes as f64 / speed,
-            ))
+            let secs = estimated_remaining_bytes as f64 / speed;
+            if secs <= 86_400.0 { Some(Duration::from_secs_f64(secs)) } else { None }
         } else {
             None
         };

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -170,6 +170,9 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                         job.id === p.jobId
                             ? {
                                   ...job,
+                                  progress: pct,
+                                  speed: null,
+                                  eta: null,
                                   statusMessage: `${p.stage}… ${pct}%`,
                               }
                             : job,

--- a/crates/rdlp-downloader/src/adaptive.rs
+++ b/crates/rdlp-downloader/src/adaptive.rs
@@ -635,7 +635,10 @@ mod tests {
             let state = ctrl.state.lock().unwrap();
             (state.current_chunk_level, state.current_connections)
         };
-        assert_eq!(level1, 4, "chunk level should have increased by 2 from floor");
+        assert_eq!(
+            level1, 4,
+            "chunk level should have increased by 2 from floor"
+        );
         assert_eq!(conns1, 3, "connections should have increased by 1");
 
         // Second interval — throughput still high (increasing) → another ramp.

--- a/crates/rdlp-downloader/src/adaptive.rs
+++ b/crates/rdlp-downloader/src/adaptive.rs
@@ -40,6 +40,13 @@ pub(crate) const CHUNK_LEVELS: [usize; 8] = [
     8 * 1024 * 1024, // 8 MB
 ];
 
+/// Minimum chunk level for multiplicative decrease.
+///
+/// Prevents the AIMD death spiral where ever-smaller chunks increase HTTP
+/// overhead, further reducing throughput, triggering more decreases. At level 2
+/// (256KB), per-request overhead is <1% of payload.
+const MIN_CHUNK_LEVEL: u8 = 2;
+
 /// Maximum number of throughput samples retained in history.
 const MAX_HISTORY: usize = 8;
 
@@ -111,7 +118,7 @@ impl Default for AdaptiveConfig {
             max_connections: 8,
             decision_interval: 4,
             initial_connections: 2,
-            initial_chunk_level: 0,
+            initial_chunk_level: MIN_CHUNK_LEVEL,
         }
     }
 }
@@ -137,7 +144,7 @@ struct AdaptiveState {
 impl AdaptiveState {
     fn new(initial_connections: usize, initial_chunk_level: u8) -> Self {
         Self {
-            current_chunk_level: initial_chunk_level.min(7),
+            current_chunk_level: initial_chunk_level.clamp(MIN_CHUNK_LEVEL, 7),
             current_connections: initial_connections.max(1),
             throughput_history: VecDeque::with_capacity(MAX_HISTORY),
             chunks_since_last_adjust: 0,
@@ -466,7 +473,7 @@ impl AdaptiveController {
         self.log(&msg);
     }
 
-    /// Increase the chunk level by `delta`, clamped to [0, 7].
+    /// Adjust the chunk level by `delta`, clamped to [MIN_CHUNK_LEVEL, 7].
     ///
     /// In HLS mode the chunk level is not adjusted.
     fn bump_chunk_level(&self, state: &mut AdaptiveState, delta: i8) {
@@ -474,7 +481,7 @@ impl AdaptiveController {
             return;
         }
         let old_level = state.current_chunk_level;
-        let new_level = (old_level as i16 + delta as i16).clamp(0, 7) as u8;
+        let new_level = (old_level as i16 + delta as i16).clamp(MIN_CHUNK_LEVEL as i16, 7) as u8;
         state.current_chunk_level = new_level;
         if new_level != old_level {
             let msg = format!(
@@ -567,9 +574,9 @@ mod tests {
     fn test_next_chunk_basic() {
         let ctrl = make_controller(1024 * 1024); // 1 MB
         let chunk = ctrl.next_chunk().unwrap();
-        // Level 0 = 64 KB
+        // Level 2 (MIN_CHUNK_LEVEL) = 256 KB
         assert_eq!(chunk.start, 0);
-        assert_eq!(chunk.end, 64 * 1024);
+        assert_eq!(chunk.end, 256 * 1024);
     }
 
     #[test]
@@ -618,7 +625,7 @@ mod tests {
             max_connections: 8,
             decision_interval: 4,
             initial_connections: 2,
-            initial_chunk_level: 0,
+            initial_chunk_level: 2, // MIN_CHUNK_LEVEL (was 0)
         };
         let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
 
@@ -628,7 +635,7 @@ mod tests {
             let state = ctrl.state.lock().unwrap();
             (state.current_chunk_level, state.current_connections)
         };
-        assert_eq!(level1, 2, "chunk level should have increased by 2");
+        assert_eq!(level1, 4, "chunk level should have increased by 2 from floor");
         assert_eq!(conns1, 3, "connections should have increased by 1");
 
         // Second interval — throughput still high (increasing) → another ramp.
@@ -831,7 +838,7 @@ mod tests {
             max_connections: 2,
             decision_interval: 1,
             initial_connections: 1,
-            initial_chunk_level: 0,
+            initial_chunk_level: 2, // MIN_CHUNK_LEVEL (was 0)
         };
         let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
 
@@ -842,11 +849,11 @@ mod tests {
         let level = ctrl.state.lock().unwrap().current_chunk_level;
         assert!(level <= 7, "chunk level must not exceed 7, got {level}");
 
-        // Now force into Steady and apply many MDs to try to go below 0.
+        // Now force into Steady and apply many MDs to try to go below MIN_CHUNK_LEVEL.
         {
             let mut state = ctrl.state.lock().unwrap();
             state.phase = Phase::Steady;
-            state.current_chunk_level = 0;
+            state.current_chunk_level = 2; // MIN_CHUNK_LEVEL (was 0)
             state.last_ewma = Some(10_000_000.0);
             for _ in 0..MAX_HISTORY {
                 state.throughput_history.push_back(100.0);
@@ -855,7 +862,7 @@ mod tests {
             ctrl.adjust(&mut state);
         }
         let level = ctrl.state.lock().unwrap().current_chunk_level;
-        assert_eq!(level, 0, "chunk level must not go below 0");
+        assert_eq!(level, 2, "chunk level must not go below MIN_CHUNK_LEVEL");
     }
 
     #[test]
@@ -914,6 +921,68 @@ mod tests {
             final_level, initial_level,
             "HLS mode must not adjust chunk level"
         );
+    }
+
+    // ── chunk level floor tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_chunk_level_floor_on_multiplicative_decrease() {
+        // Controller at level 3 with many MD triggers should never go below MIN_CHUNK_LEVEL (2).
+        let cfg = AdaptiveConfig {
+            max_connections: 8,
+            decision_interval: 2,
+            initial_connections: 4,
+            initial_chunk_level: 3,
+        };
+        let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Drive into Steady phase first with good throughput.
+        drive(&ctrl, 8, 10_000_000.0);
+
+        // Now simulate severe throughput drops to trigger repeated MD.
+        for _ in 0..10 {
+            drive(&ctrl, 2, 100_000.0); // Very low throughput → MD triggers
+        }
+
+        let state = ctrl.state.lock().unwrap();
+        assert!(
+            state.current_chunk_level >= 2,
+            "Chunk level {} dropped below floor 2",
+            state.current_chunk_level
+        );
+    }
+
+    #[test]
+    fn test_initial_chunk_level_clamped_to_floor() {
+        // Constructing with initial_chunk_level=0 should clamp to MIN_CHUNK_LEVEL (2).
+        let cfg = AdaptiveConfig {
+            initial_chunk_level: 0,
+            ..Default::default()
+        };
+        let ctrl = make_controller_cfg(1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        let state = ctrl.state.lock().unwrap();
+        assert_eq!(
+            state.current_chunk_level, 2,
+            "Initial chunk level should be clamped to floor"
+        );
+    }
+
+    #[test]
+    fn test_floor_does_not_block_upward_movement() {
+        // From level 2 (the floor), bumping +1 should reach level 3.
+        let cfg = AdaptiveConfig {
+            initial_chunk_level: 2,
+            ..Default::default()
+        };
+        let ctrl = make_controller_cfg(100 * 1024 * 1024, cfg, ControllerMode::HttpChunked);
+
+        // Manually bump up.
+        {
+            let mut state = ctrl.state.lock().unwrap();
+            ctrl.bump_chunk_level(&mut state, 1);
+            assert_eq!(state.current_chunk_level, 3);
+        }
     }
 
     // ── realtime ratio test ───────────────────────────────────────────────────

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -10,6 +10,8 @@ mod trait_impl;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use parallel::download_chunk_with_retry;
+
 use backon::Retryable;
 use futures::StreamExt;
 use log::warn;

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -10,6 +10,7 @@ mod trait_impl;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
 pub(crate) use parallel::download_chunk_with_retry;
 
 use backon::Retryable;

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -370,22 +370,23 @@ impl HttpDownloader {
                         // end is exclusive in ChunkRequest, but HTTP Range is inclusive
                         let abs_end = byte_offset + chunk.end - 1;
 
-                        let result = downloader
-                            .download_range_with_progress(
-                                &url,
-                                abs_start,
-                                abs_end,
-                                &chunk_path,
-                                Some(progress),
-                            )
-                            .await;
+                        let result = download_chunk_with_retry(
+                            &downloader,
+                            &url,
+                            abs_start,
+                            abs_end,
+                            &chunk_path,
+                            Some(progress),
+                            chunk_id,
+                        )
+                        .await;
 
                         match &result {
                             Ok(bytes) => {
                                 ctrl_report.report_chunk_complete(*bytes, start_time.elapsed());
                             }
                             Err(e) => {
-                                error!("Adaptive chunk {chunk_id} failed: {e}");
+                                error!("Adaptive chunk {chunk_id} failed after retries: {e}");
                             }
                         }
 
@@ -460,11 +461,18 @@ impl HttpDownloader {
                 let progress = Some(progress_counter.clone());
 
                 async move {
-                    let result = downloader
-                        .download_range_with_progress(&url, start, end, &chunk_path, progress)
-                        .await;
+                    let result = download_chunk_with_retry(
+                        &downloader,
+                        &url,
+                        start,
+                        end,
+                        &chunk_path,
+                        progress,
+                        chunk_id as u64,
+                    )
+                    .await;
                     if let Err(ref e) = result {
-                        error!("Chunk {chunk_id} failed: {e}");
+                        error!("Chunk {chunk_id} failed after retries: {e}");
                     }
                     result.map(|bytes| (chunk_id, chunk_path, bytes))
                 }

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -9,13 +9,65 @@ use crate::chunking::calculate_chunks;
 use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use log::{debug, error, info, warn};
-use rdlp_core::{DownloadStats, ProgressCallback, RdlpError, Result};
+use rdlp_core::{DownloadStats, ProgressCallback, RdlpError, Result, is_retryable_error};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
+
+/// Maximum number of retry attempts for a single chunk download.
+///
+/// Covers body-stream failures (decode errors, read timeouts mid-transfer)
+/// that occur after the initial HTTP connection succeeds. The inner
+/// `download_range_with_progress` handles connection-level retries separately.
+const MAX_CHUNK_RETRIES: u32 = 3;
+
+/// Download a single chunk with retry for transient body-stream failures.
+///
+/// Wraps `download_range_with_progress` in a retry loop with linear backoff
+/// (1s, 2s, 3s). Partial files are cleaned up between attempts. Only
+/// retryable errors (5xx, 429, network, I/O) trigger retries.
+///
+/// This is a different retry domain from the inner `with_retry` on
+/// `send()` — this handles failures that occur *during* body transfer,
+/// not connection-level failures.
+pub(crate) async fn download_chunk_with_retry(
+    downloader: &HttpDownloader,
+    url: &str,
+    start: u64,
+    end: u64,
+    chunk_path: &Path,
+    progress: Option<Arc<AtomicU64>>,
+    chunk_id: u64,
+) -> Result<u64> {
+    let mut retries = 0u32;
+
+    loop {
+        match downloader
+            .download_range_with_progress(url, start, end, chunk_path, progress.clone())
+            .await
+        {
+            Ok(bytes) => return Ok(bytes),
+            Err(e) => {
+                if retries < MAX_CHUNK_RETRIES && is_retryable_error(&e) {
+                    retries += 1;
+                    warn!(
+                        "Chunk {chunk_id} failed (attempt {}/{}): {e}",
+                        retries,
+                        MAX_CHUNK_RETRIES + 1
+                    );
+                    // Clean up partial file before retry
+                    let _ = tokio::fs::remove_file(chunk_path).await;
+                    tokio::time::sleep(Duration::from_secs(retries as u64)).await;
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+}
 
 /// Mode for chunk merging operations
 #[derive(Clone, Copy)]

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use rdlp_core::Downloader;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 
 #[allow(dead_code)]
@@ -251,6 +252,213 @@ async fn test_download_to_writer_streams_bytes() {
 
     let received = reader_handle.await.unwrap();
     assert_eq!(received, body.as_slice());
+}
+
+#[tokio::test]
+async fn test_chunk_retry_succeeds_on_second_attempt() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // Mockito matches in LIFO order (last-created matched first).
+    // Create success mock FIRST so it's matched SECOND.
+    let body = vec![0xABu8; 1024];
+    let _mock_ok = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(body.clone())
+        .expect(1)
+        .create_async()
+        .await;
+
+    // Create fail mock LAST so it's matched FIRST (LIFO).
+    let _mock_fail = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(500)
+        .with_body("error")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let progress = Arc::new(AtomicU64::new(0));
+
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(progress),
+        0,
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 1024);
+}
+
+#[tokio::test]
+async fn test_chunk_retry_exhausted_returns_error() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // All requests fail with 500
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(500)
+        .with_body("error")
+        .expect_at_least(3)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let progress = Arc::new(AtomicU64::new(0));
+
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(progress),
+        0,
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_chunk_retry_non_retryable_fails_immediately() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // 403 is not retryable — should fail immediately, not retry
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(403)
+        .with_body("forbidden")
+        .expect(1) // Only 1 request — no retries
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let progress = Arc::new(AtomicU64::new(0));
+
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(progress),
+        0,
+    )
+    .await;
+
+    assert!(result.is_err());
+    // mockito's expect(1) will panic on Drop if more than 1 request was made
+}
+
+#[tokio::test]
+async fn test_chunk_retry_cleans_partial_file() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // Write a partial file to simulate a failed download
+    tokio::fs::write(&chunk_path, b"partial data").await.unwrap();
+    assert!(chunk_path.exists());
+
+    // Mockito matches in LIFO order. Create success mock FIRST (matched second).
+    let body = vec![0xCDu8; 512];
+    let _mock_ok = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    // Create fail mock LAST (matched first — LIFO).
+    let _mock_fail = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(500)
+        .with_body("error")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let progress = Arc::new(AtomicU64::new(0));
+
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        511,
+        &chunk_path,
+        Some(progress),
+        0,
+    )
+    .await;
+
+    assert!(result.is_ok());
+    // The file should contain the successful download, not the partial data
+    let contents = tokio::fs::read(&chunk_path).await.unwrap();
+    assert_eq!(contents.len(), 512);
+    assert!(contents.iter().all(|&b| b == 0xCD));
 }
 
 #[tokio::test]

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -146,12 +146,14 @@ async fn test_parallel_download_error_propagation() {
         .create_async()
         .await;
 
-    // Mock FAILURE for chunk 2 (this should trigger fail-fast)
+    // Mock FAILURE for chunk 2 (this should trigger fail-fast after retries)
+    // With chunk-level retry, the failing chunk may be retried up to MAX_CHUNK_RETRIES (3) times.
     let mock_chunk_2_fail = server
         .mock("GET", "/test-video.mp4")
         .match_header("range", "bytes=10485760-15728639")
         .with_status(500)
         .with_body("Internal Server Error")
+        .expect_at_least(1)
         .create_async()
         .await;
 
@@ -296,16 +298,8 @@ async fn test_chunk_retry_succeeds_on_second_attempt() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result = download_chunk_with_retry(
-        &downloader,
-        &url,
-        0,
-        1023,
-        &chunk_path,
-        Some(progress),
-        0,
-    )
-    .await;
+    let result =
+        download_chunk_with_retry(&downloader, &url, 0, 1023, &chunk_path, Some(progress), 0).await;
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1024);
@@ -340,16 +334,8 @@ async fn test_chunk_retry_exhausted_returns_error() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result = download_chunk_with_retry(
-        &downloader,
-        &url,
-        0,
-        1023,
-        &chunk_path,
-        Some(progress),
-        0,
-    )
-    .await;
+    let result =
+        download_chunk_with_retry(&downloader, &url, 0, 1023, &chunk_path, Some(progress), 0).await;
 
     assert!(result.is_err());
 }
@@ -383,16 +369,8 @@ async fn test_chunk_retry_non_retryable_fails_immediately() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result = download_chunk_with_retry(
-        &downloader,
-        &url,
-        0,
-        1023,
-        &chunk_path,
-        Some(progress),
-        0,
-    )
-    .await;
+    let result =
+        download_chunk_with_retry(&downloader, &url, 0, 1023, &chunk_path, Some(progress), 0).await;
 
     assert!(result.is_err());
     // mockito's expect(1) will panic on Drop if more than 1 request was made
@@ -408,7 +386,9 @@ async fn test_chunk_retry_cleans_partial_file() {
     let chunk_path = temp_dir.path().join("chunk_0");
 
     // Write a partial file to simulate a failed download
-    tokio::fs::write(&chunk_path, b"partial data").await.unwrap();
+    tokio::fs::write(&chunk_path, b"partial data")
+        .await
+        .unwrap();
     assert!(chunk_path.exists());
 
     // Mockito matches in LIFO order. Create success mock FIRST (matched second).
@@ -443,16 +423,8 @@ async fn test_chunk_retry_cleans_partial_file() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result = download_chunk_with_retry(
-        &downloader,
-        &url,
-        0,
-        511,
-        &chunk_path,
-        Some(progress),
-        0,
-    )
-    .await;
+    let result =
+        download_chunk_with_retry(&downloader, &url, 0, 511, &chunk_path, Some(progress), 0).await;
 
     assert!(result.is_ok());
     // The file should contain the successful download, not the partial data

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -134,17 +134,33 @@ pub fn spawn_progress_reporter(
 ) -> ProgressGuard {
     let task = callback.map(|cb| {
         tokio::spawn(async move {
+            // EWMA speed state: per-tick delta smoothed with alpha=0.3.
+            // Matches wget/curl responsiveness without a ring buffer.
+            const EWMA_ALPHA: f64 = 0.3;
+            let mut prev_bytes: u64 = config.resume_from;
+            let mut prev_time: Instant = config.start_time;
+            let mut smooth_speed: f64 = 0.0;
+
             loop {
                 tokio::time::sleep(config.update_interval).await;
 
                 let bytes = metrics.downloaded.load(Ordering::Relaxed);
-                let elapsed = Instant::now()
-                    .duration_since(config.start_time)
-                    .as_secs_f64();
-                let speed = if elapsed > 0.0 {
-                    (bytes - config.resume_from) as f64 / elapsed
+                let now = Instant::now();
+                let delta_bytes = bytes.saturating_sub(prev_bytes);
+                let delta_secs = now.duration_since(prev_time).as_secs_f64();
+
+                let speed = if delta_secs > 0.01 {
+                    let instant_speed = delta_bytes as f64 / delta_secs;
+                    smooth_speed = if smooth_speed == 0.0 {
+                        instant_speed
+                    } else {
+                        EWMA_ALPHA * instant_speed + (1.0 - EWMA_ALPHA) * smooth_speed
+                    };
+                    prev_bytes = bytes;
+                    prev_time = now;
+                    smooth_speed
                 } else {
-                    0.0
+                    smooth_speed
                 };
 
                 let progress_info = if let (Some(segments_counter), Some(duration_counter)) =

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -359,6 +359,37 @@ impl BaseExtractor {
         None
     }
 
+    /// Detect file sizes for multiple formats in parallel.
+    ///
+    /// Runs HEAD requests concurrently for all formats, reducing latency from
+    /// `O(n × RTT)` to `O(RTT)`. Each format's `filesize` field is populated
+    /// with the detected size (or left as `None` if detection fails).
+    ///
+    /// # Arguments
+    /// * `formats` - Mutable slice of formats whose `url` fields will be probed.
+    /// * `http_client` - HTTP client for HEAD requests.
+    /// * `log_prefix` - Optional prefix for debug log messages (e.g. `"TNAFlix"`).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// BaseExtractor::detect_file_sizes_parallel(&mut formats, &ctx.http_client, Some("RedTube")).await;
+    /// ```
+    pub(crate) async fn detect_file_sizes_parallel(
+        formats: &mut [rdlp_types::Format],
+        http_client: &reqwest::Client,
+        log_prefix: Option<&str>,
+    ) {
+        let futures: Vec<_> = formats
+            .iter()
+            .map(|f| Self::detect_file_size(&f.url, http_client, log_prefix))
+            .collect();
+        let sizes = futures::future::join_all(futures).await;
+        for (format, size) in formats.iter_mut().zip(sizes) {
+            format.filesize = size;
+        }
+    }
+
     /// Parse total file size from a Content-Range header.
     ///
     /// Parses the format `bytes 0-0/123456` and returns the total size.

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -359,37 +359,6 @@ impl BaseExtractor {
         None
     }
 
-    /// Detect file sizes for multiple formats in parallel.
-    ///
-    /// Runs HEAD requests concurrently for all formats, reducing latency from
-    /// `O(n × RTT)` to `O(RTT)`. Each format's `filesize` field is populated
-    /// with the detected size (or left as `None` if detection fails).
-    ///
-    /// # Arguments
-    /// * `formats` - Mutable slice of formats whose `url` fields will be probed.
-    /// * `http_client` - HTTP client for HEAD requests.
-    /// * `log_prefix` - Optional prefix for debug log messages (e.g. `"TNAFlix"`).
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// BaseExtractor::detect_file_sizes_parallel(&mut formats, &ctx.http_client, Some("RedTube")).await;
-    /// ```
-    pub(crate) async fn detect_file_sizes_parallel(
-        formats: &mut [rdlp_types::Format],
-        http_client: &reqwest::Client,
-        log_prefix: Option<&str>,
-    ) {
-        let futures: Vec<_> = formats
-            .iter()
-            .map(|f| Self::detect_file_size(&f.url, http_client, log_prefix))
-            .collect();
-        let sizes = futures::future::join_all(futures).await;
-        for (format, size) in formats.iter_mut().zip(sizes) {
-            format.filesize = size;
-        }
-    }
-
     /// Parse total file size from a Content-Range header.
     ///
     /// Parses the format `bytes 0-0/123456` and returns the total size.

--- a/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
+++ b/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
@@ -164,15 +164,8 @@ pub(crate) async fn build_formats(
         .collect();
 
     // Parallel filesize detection — all HEAD requests run concurrently
-    let futures: Vec<_> = formats
-        .iter()
-        .map(|f| BaseExtractor::detect_file_size(&f.url, &ctx.http_client, Some("TNAFlix")))
-        .collect();
-    let sizes = futures::future::join_all(futures).await;
-
-    for (format, size) in formats.iter_mut().zip(sizes) {
-        format.filesize = size;
-    }
+    BaseExtractor::detect_file_sizes_parallel(&mut formats, &ctx.http_client, Some("TNAFlix"))
+        .await;
 
     BaseExtractor::dedup_format_ids(&mut formats);
     formats

--- a/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
+++ b/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
@@ -139,29 +139,39 @@ const CODEC_H264: &str = "h264";
 const CODEC_AAC: &str = "aac";
 use rdlp_types::DownloadProtocol;
 
-/// Build format list from video metadata and fetch filesizes
+/// Build format list from video metadata and fetch filesizes.
+///
+/// Filesize detection is parallelized — all HEAD requests run concurrently
+/// instead of sequentially, reducing latency from O(n × RTT) to O(RTT).
 pub(crate) async fn build_formats(
     video_data: Vec<VideoMetadata>,
     ctx: &ExtractionContext,
 ) -> Vec<Format> {
-    let mut formats = Vec::new();
+    // Build format structs (sync, no I/O)
+    let mut formats: Vec<Format> = video_data
+        .into_iter()
+        .map(|(format_id, video_url, ext, height, width)| {
+            let mut format = Format::new(&format_id, &video_url, &ext, DownloadProtocol::Https);
+            format.height = height;
+            format.width = width;
+            format.format_note = height.map(|h| format!("{h}p"));
+            if ext == "mp4" {
+                format.vcodec = Some(CODEC_H264.to_owned());
+                format.acodec = Some(CODEC_AAC.to_owned());
+            }
+            format
+        })
+        .collect();
 
-    for (format_id, video_url, ext, height, width) in video_data {
-        let mut format = Format::new(&format_id, &video_url, &ext, DownloadProtocol::Https);
+    // Parallel filesize detection — all HEAD requests run concurrently
+    let futures: Vec<_> = formats
+        .iter()
+        .map(|f| BaseExtractor::detect_file_size(&f.url, &ctx.http_client, Some("TNAFlix")))
+        .collect();
+    let sizes = futures::future::join_all(futures).await;
 
-        format.height = height;
-        format.width = width;
-        format.format_note = height.map(|h| format!("{h}p"));
-
-        if ext == "mp4" {
-            format.vcodec = Some(CODEC_H264.to_owned());
-            format.acodec = Some(CODEC_AAC.to_owned());
-        }
-
-        format.filesize =
-            BaseExtractor::detect_file_size(&video_url, &ctx.http_client, Some("TNAFlix")).await;
-
-        formats.push(format);
+    for (format, size) in formats.iter_mut().zip(sizes) {
+        format.filesize = size;
     }
 
     BaseExtractor::dedup_format_ids(&mut formats);

--- a/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
+++ b/crates/rdlp-extractor/src/base/tnaflix_network/formats.rs
@@ -141,14 +141,14 @@ use rdlp_types::DownloadProtocol;
 
 /// Build format list from video metadata and fetch filesizes.
 ///
-/// Filesize detection is parallelized — all HEAD requests run concurrently
-/// instead of sequentially, reducing latency from O(n × RTT) to O(RTT).
+/// Filesize detection uses `detect_format_sizes` (the shared HLS module
+/// helper) which runs all HEAD requests in parallel via `join_all`.
 pub(crate) async fn build_formats(
     video_data: Vec<VideoMetadata>,
     ctx: &ExtractionContext,
 ) -> Vec<Format> {
     // Build format structs (sync, no I/O)
-    let mut formats: Vec<Format> = video_data
+    let formats: Vec<Format> = video_data
         .into_iter()
         .map(|(format_id, video_url, ext, height, width)| {
             let mut format = Format::new(&format_id, &video_url, &ext, DownloadProtocol::Https);
@@ -163,9 +163,11 @@ pub(crate) async fn build_formats(
         })
         .collect();
 
-    // Parallel filesize detection — all HEAD requests run concurrently
-    BaseExtractor::detect_file_sizes_parallel(&mut formats, &ctx.http_client, Some("TNAFlix"))
-        .await;
+    // Parallel filesize detection — reuses the shared HLS module helper
+    // which runs HEAD requests concurrently. HLS flags are discarded
+    // since TNAFlix network formats are all direct HTTPS.
+    let (mut formats, _hls_flags) =
+        crate::hls::detect_format_sizes(formats, ctx, "TNAFlix").await;
 
     BaseExtractor::dedup_format_ids(&mut formats);
     formats

--- a/crates/rdlp-extractor/src/extractors/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/mod.rs
@@ -16,6 +16,8 @@ pub use hqporner::HQPornerExtractor;
 pub use nine_anime::NineAnimeExtractor;
 pub use pornhub::PornHubExtractor;
 pub use redtube::RedTubeExtractor;
-pub use tnaflix::{TNAFlixExtractor, TNAFlixSearchExtractor};
+pub use tnaflix::{
+    EMPFlixSearchExtractor, MovieFapSearchExtractor, TNAFlixExtractor, TNAFlixSearchExtractor,
+};
 pub use xhamster::XHamsterExtractor;
 pub use xtits::XTitsExtractor;

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -93,24 +93,25 @@ async fn extract_from_flashvars(webpage: &str, ctx: &ExtractionContext) -> Resul
         .and_then(|v| v.as_array())
         .ok_or_else(|| RdlpError::Extraction("No mediaDefinitions in flashvars".to_string()))?;
 
+    // Separate get_media endpoints (need async fetch) from direct URLs (sync)
+    let mut media_futures = Vec::new();
     for (idx, definition) in media_definitions.iter().enumerate() {
         let video_url = match definition.get("videoUrl").and_then(|v| v.as_str()) {
             Some(url) if !url.is_empty() => url,
             _ => continue,
         };
 
-        // Handle get_media endpoints (returns JSON with actual URLs)
         if video_url.contains("/video/get_media") {
-            if let Some(media_formats) = fetch_media_formats(video_url, idx, ctx).await {
-                formats.extend(media_formats);
-            }
-            continue;
-        }
-
-        // Direct video URL
-        if let Some(format) = build_format_from_definition(definition, video_url, idx) {
+            media_futures.push(fetch_media_formats(video_url, idx, ctx));
+        } else if let Some(format) = build_format_from_definition(definition, video_url, idx) {
             formats.push(format);
         }
+    }
+
+    // Fetch all get_media endpoints in parallel
+    let media_results = futures::future::join_all(media_futures).await;
+    for result in media_results.into_iter().flatten() {
+        formats.extend(result);
     }
 
     if formats.is_empty() {

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -322,6 +322,9 @@ pub async fn extract_from_media_definition(webpage: &str, ctx: &ExtractionContex
                     &format!("Found {} media items", arr.len()),
                 );
 
+                // Separate endpoints needing async fetch from direct formats
+                let mut fetch_futures = Vec::new();
+
                 for (idx, item) in arr.iter().enumerate() {
                     BaseExtractor::log_if_verbose(
                         ctx,
@@ -335,14 +338,11 @@ pub async fn extract_from_media_definition(webpage: &str, ctx: &ExtractionContex
 
                         let has_quality = item.get("quality").is_some();
 
-                        // If format is mp4/hls without quality, fetch JSON to get actual formats
                         if matches!(format_type, "mp4" | "hls") && !has_quality {
-                            if let Some(fetched) = fetch_formats_from_endpoint(video_url, ctx).await
-                            {
-                                formats.extend(fetched);
-                            }
+                            // Queue for parallel fetch
+                            fetch_futures.push(fetch_formats_from_endpoint(video_url, ctx));
                         } else {
-                            // Has quality field, process directly
+                            // Has quality field, process directly (sync)
                             let quality_str = parse_quality(item);
                             let format =
                                 build_format(&quality_str, video_url.to_string(), format_type);
@@ -362,6 +362,12 @@ pub async fn extract_from_media_definition(webpage: &str, ctx: &ExtractionContex
                             formats.push(format);
                         }
                     }
+                }
+
+                // Fetch all endpoints in parallel
+                let fetch_results = futures::future::join_all(fetch_futures).await;
+                for result in fetch_results.into_iter().flatten() {
+                    formats.extend(result);
                 }
             }
             Err(e) => {

--- a/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
@@ -68,12 +68,15 @@ pub async fn parse_empflix_ajax(
 pub async fn parse_moviefap_xml(
     base: &TnaFlixNetworkBase,
     cdn_url: &str,
+    referer: &str,
     ctx: &ExtractionContext,
 ) -> Result<Vec<VideoMetadata>> {
-    // Fetch the XML from cdn.php
+    // Fetch the XML from cdn.php (matching browser headers)
     let response = ctx
         .http_client
         .get(cdn_url)
+        .header("Referer", referer)
+        .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
         .map_err(|e| RdlpError::Network(format!("Failed to fetch MovieFap XML: {e}")))?;

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -13,6 +13,8 @@
 //! - `search_patterns` - Search URL builders and filter descriptors
 
 mod ajax;
+mod moviefap_search;
+mod moviefap_search_patterns;
 mod patterns;
 mod search;
 mod search_patterns;
@@ -349,6 +351,294 @@ impl SearchExtractor for TNAFlixSearchExtractor {
     }
 }
 
+/// EMPFlix search extractor
+///
+/// EMPFlix shares the same HTML structure as TNAFlix.  This extractor reuses
+/// the same HTML parser (`search::parse_search_results` /
+/// `search::parse_pagination`) but targets `empflix.com` URLs.
+pub struct EMPFlixSearchExtractor;
+
+impl EMPFlixSearchExtractor {
+    /// Create a new EMPFlix search extractor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// EMPFlix base URL.
+    const BASE_URL: &'static str = "https://www.empflix.com";
+
+    /// Build the URL for a given page, dispatching to browse or search URL builders.
+    fn build_page_url(query: &rdlp_types::SearchQuery, page: usize) -> String {
+        if let Some(cat) = query.filters.iter().find(|f| f.key == "category") {
+            if page <= 1 {
+                search_patterns::build_browse_url_for(Self::BASE_URL, &cat.value)
+            } else {
+                search_patterns::build_browse_url_page_for(Self::BASE_URL, &cat.value, page)
+            }
+        } else {
+            search_patterns::build_search_url_page_for(Self::BASE_URL, query, page)
+        }
+    }
+
+    /// Fetch a single search results page and return `(results, max_page_number)`.
+    async fn fetch_single_search_page(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        page: usize,
+        ctx: &ExtractionContext,
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, usize)> {
+        let page_url = Self::build_page_url(query, page);
+        debug!(page; "[EMPFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
+
+        let webpage = crate::base::common::BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+        let page_results = search::parse_search_results(&webpage);
+        let max_pages = search::parse_pagination(&webpage).unwrap_or(1);
+
+        debug!(
+            count = page_results.len(),
+            max_pages;
+            "[EMPFlix] Search page {page} returned {} results",
+            page_results.len()
+        );
+
+        Ok((page_results, max_pages))
+    }
+
+    /// Collect all pages up to `MAX_PLAYLIST_SIZE` results.
+    async fn search_all_pages(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
+        search::validate_search_filters(&query.filters)?;
+
+        let max_results = query
+            .max_results
+            .unwrap_or(crate::base::common::MAX_PLAYLIST_SIZE);
+
+        let mut all_results = Vec::new();
+        let mut page = 1usize;
+
+        loop {
+            let (page_results, max_pages) = match self
+                .fetch_single_search_page(query, page, ctx)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    debug!(page; "[EMPFlix] Failed to fetch search page, returning partial results: {e}");
+                    break;
+                }
+            };
+
+            if page_results.is_empty() {
+                debug!(page; "[EMPFlix] No results on page, stopping pagination");
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if page >= max_pages {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        debug!(count = all_results.len(), pages = page; "[EMPFlix] Search complete");
+
+        Ok(all_results)
+    }
+}
+
+impl Default for EMPFlixSearchExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl rdlp_core::SearchExtractor for EMPFlixSearchExtractor {
+    fn name(&self) -> &str {
+        "EMPFlix"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
+        // EMPFlix uses the same filter set as TNAFlix
+        search_patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<rdlp_types::SearchPageResponse> {
+        search::validate_search_filters(&query.filters)?;
+
+        let page = query.page.unwrap_or(1) as usize;
+        let (page_results, max_pages) = self.fetch_single_search_page(query, page, ctx).await?;
+
+        let has_more = page < max_pages && !page_results.is_empty();
+
+        Ok(rdlp_types::SearchPageResponse {
+            results: page_results,
+            page: page as u32,
+            has_more,
+            total_estimate: None,
+        })
+    }
+}
+
+/// MovieFap search extractor
+///
+/// Parses MovieFap's distinct HTML search result structure.
+/// Uses `moviefap_search` and `moviefap_search_patterns` internally.
+pub struct MovieFapSearchExtractor;
+
+impl MovieFapSearchExtractor {
+    /// Create a new MovieFap search extractor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Fetch a single search results page and return `(results, max_page_number)`.
+    async fn fetch_single_search_page(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        page: usize,
+        ctx: &ExtractionContext,
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, usize)> {
+        let page_url = moviefap_search_patterns::build_search_url(query, page);
+        debug!(page; "[MovieFap] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
+
+        let webpage = crate::base::common::BaseExtractor::fetch_webpage(&page_url, ctx).await?;
+        let page_results = moviefap_search::parse_search_results(&webpage);
+        let max_pages = moviefap_search::parse_pagination(&webpage).unwrap_or(1);
+
+        debug!(
+            count = page_results.len(),
+            max_pages;
+            "[MovieFap] Search page {page} returned {} results",
+            page_results.len()
+        );
+
+        Ok((page_results, max_pages))
+    }
+
+    /// Collect all pages up to `MAX_PLAYLIST_SIZE` results.
+    async fn search_all_pages(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
+        moviefap_search::validate_search_filters(&query.filters)?;
+
+        let max_results = query
+            .max_results
+            .unwrap_or(crate::base::common::MAX_PLAYLIST_SIZE);
+
+        let mut all_results = Vec::new();
+        let mut page = 1usize;
+
+        loop {
+            let (page_results, max_pages) = match self
+                .fetch_single_search_page(query, page, ctx)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    debug!(page; "[MovieFap] Failed to fetch search page, returning partial results: {e}");
+                    break;
+                }
+            };
+
+            if page_results.is_empty() {
+                debug!(page; "[MovieFap] No results on page, stopping pagination");
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if page >= max_pages {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        debug!(count = all_results.len(), pages = page; "[MovieFap] Search complete");
+
+        Ok(all_results)
+    }
+}
+
+impl Default for MovieFapSearchExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl rdlp_core::SearchExtractor for MovieFapSearchExtractor {
+    fn name(&self) -> &str {
+        "MovieFap"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
+        moviefap_search_patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<rdlp_types::SearchPageResponse> {
+        moviefap_search::validate_search_filters(&query.filters)?;
+
+        let page = query.page.unwrap_or(1) as usize;
+        let (page_results, max_pages) = self.fetch_single_search_page(query, page, ctx).await?;
+
+        let has_more = page < max_pages && !page_results.is_empty();
+
+        Ok(rdlp_types::SearchPageResponse {
+            results: page_results,
+            page: page as u32,
+            has_more,
+            total_estimate: None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -441,5 +731,115 @@ mod tests {
         let filters = extractor.supported_filters();
         assert_eq!(filters.len(), 2);
         assert_eq!(filters[0].key, "ordering");
+    }
+
+    // --- EMPFlix search extractor tests ---
+
+    #[test]
+    fn test_empflix_search_extractor_name() {
+        let extractor = EMPFlixSearchExtractor::new();
+        assert_eq!(rdlp_core::SearchExtractor::name(&extractor), "EMPFlix");
+    }
+
+    #[test]
+    fn test_empflix_search_extractor_supported_filters() {
+        let extractor = EMPFlixSearchExtractor::new();
+        let filters = extractor.supported_filters();
+        // EMPFlix shares the TNAFlix filter set (ordering + category)
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0].key, "ordering");
+        assert_eq!(filters[1].key, "category");
+    }
+
+    #[test]
+    fn test_empflix_search_url_uses_empflix_domain() {
+        let query = rdlp_types::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = EMPFlixSearchExtractor::build_page_url(&query, 1);
+        assert!(url.contains("empflix.com"), "URL must use empflix.com");
+        assert!(!url.contains("tnaflix.com"), "URL must NOT use tnaflix.com");
+    }
+
+    #[test]
+    fn test_empflix_search_url_page_2() {
+        let query = rdlp_types::SearchQuery {
+            query: "test query".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = EMPFlixSearchExtractor::build_page_url(&query, 2);
+        assert!(url.contains("empflix.com"));
+        assert!(url.contains("page=2"));
+    }
+
+    #[test]
+    fn test_empflix_search_url_with_filter() {
+        let query = rdlp_types::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![rdlp_types::SearchFilter {
+                key: "ordering".to_string(),
+                value: "newest".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = EMPFlixSearchExtractor::build_page_url(&query, 1);
+        assert!(url.contains("empflix.com"));
+        assert!(url.contains("ordering=newest"));
+    }
+
+    #[test]
+    fn test_empflix_browse_url_uses_empflix_domain() {
+        let query = rdlp_types::SearchQuery {
+            query: String::new(),
+            filters: vec![rdlp_types::SearchFilter {
+                key: "category".to_string(),
+                value: "teen-porn".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = EMPFlixSearchExtractor::build_page_url(&query, 1);
+        assert!(
+            url.contains("empflix.com"),
+            "Browse URL must use empflix.com"
+        );
+        assert!(
+            url.contains("teen-porn"),
+            "Browse URL must contain category slug"
+        );
+        assert!(
+            !url.contains("tnaflix.com"),
+            "Browse URL must NOT use tnaflix.com"
+        );
+    }
+
+    // --- MovieFap search extractor tests ---
+
+    #[test]
+    fn test_moviefap_search_extractor_name() {
+        let extractor = MovieFapSearchExtractor::new();
+        assert_eq!(rdlp_core::SearchExtractor::name(&extractor), "MovieFap");
+    }
+
+    #[test]
+    fn test_moviefap_search_extractor_supported_filters() {
+        let extractor = MovieFapSearchExtractor::new();
+        let filters = extractor.supported_filters();
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].key, "ordering");
+        assert_eq!(filters[0].allowed_values.len(), 5);
+    }
+
+    #[test]
+    fn test_moviefap_search_extractor_default_ordering() {
+        let extractor = MovieFapSearchExtractor::new();
+        let filters = extractor.supported_filters();
+        assert_eq!(filters[0].default, Some("relevance".to_string()));
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -842,4 +842,471 @@ mod tests {
         let filters = extractor.supported_filters();
         assert_eq!(filters[0].default, Some("relevance".to_string()));
     }
+
+    // --- Negative tests: extract_id failure paths ---
+
+    #[test]
+    fn test_tnaflix_extract_id_non_matching_url() {
+        let extractor = &*TEST_TNAFLIX;
+        assert_eq!(extractor.extract_id("https://youtube.com/watch?v=123"), None);
+    }
+
+    #[test]
+    fn test_empflix_extract_id_non_matching_url() {
+        let extractor = &*TEST_EMPFLIX;
+        assert_eq!(extractor.extract_id("https://www.tnaflix.com/cat/title/video123"), None);
+    }
+
+    #[test]
+    fn test_moviefap_extract_id_non_matching_url() {
+        let extractor = &*TEST_MOVIEFAP;
+        assert_eq!(extractor.extract_id("https://www.empflix.com/videos/title-123"), None);
+    }
+
+    #[test]
+    fn test_moviefap_extract_id_uppercase_hex_fails() {
+        let extractor = &*TEST_MOVIEFAP;
+        // Regex is [0-9a-f] only; uppercase hex doesn't match
+        assert_eq!(extractor.extract_id("https://www.moviefap.com/videos/ABCDEF/title.html"), None);
+    }
+
+    #[test]
+    fn test_tnaflix_extract_id_empty_url() {
+        let extractor = &*TEST_TNAFLIX;
+        assert_eq!(extractor.extract_id(""), None);
+    }
+
+    #[test]
+    fn test_empflix_search_url_browse_page_2() {
+        // Browse URL for page > 1 uses different format
+        let query = rdlp_types::SearchQuery {
+            query: String::new(),
+            filters: vec![rdlp_types::SearchFilter {
+                key: "category".to_string(),
+                value: "new".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = EMPFlixSearchExtractor::build_page_url(&query, 2);
+        // Section pages use /{slug}/{page} format
+        assert!(url.contains("empflix.com/new/2"));
+    }
+
+    #[test]
+    fn test_tnaflix_search_url_category_page_1_no_page_param() {
+        let query = rdlp_types::SearchQuery {
+            query: String::new(),
+            filters: vec![rdlp_types::SearchFilter {
+                key: "category".to_string(),
+                value: "teen-porn".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = TNAFlixSearchExtractor::build_page_url(&query, 1);
+        // Page 1 uses browse URL without page param
+        assert!(url.contains("tnaflix.com/teen-porn"));
+        assert!(!url.contains("page="));
+    }
+
+    #[test]
+    fn test_tnaflix_search_url_category_page_2_has_page_param() {
+        let query = rdlp_types::SearchQuery {
+            query: String::new(),
+            filters: vec![rdlp_types::SearchFilter {
+                key: "category".to_string(),
+                value: "teen-porn".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = TNAFlixSearchExtractor::build_page_url(&query, 2);
+        assert!(url.contains("teen-porn?page=2"));
+    }
+}
+
+/// Async integration tests using mockito HTTP server.
+///
+/// These test the full search_page / search flow including HTTP fetch,
+/// HTML parsing, pagination, and error handling.
+#[cfg(test)]
+mod async_tests {
+    use super::*;
+    use mockito::Server;
+    use rdlp_core::{CookieJar, ExtractionContext, JsEngine};
+    use rdlp_types::Config;
+    use std::sync::Arc;
+
+    /// Minimal no-op JsEngine for tests.
+    struct NoOpJsEngine;
+
+    #[async_trait]
+    impl JsEngine for NoOpJsEngine {
+        async fn eval(&self, _code: &str) -> Result<serde_json::Value> {
+            Ok(serde_json::Value::Null)
+        }
+        async fn eval_with_context(
+            &self,
+            _code: &str,
+            _context: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            Ok(serde_json::Value::Null)
+        }
+        async fn call_function(
+            &self,
+            _name: &str,
+            _args: &[serde_json::Value],
+        ) -> Result<serde_json::Value> {
+            Ok(serde_json::Value::Null)
+        }
+    }
+
+    /// Minimal no-op CookieJar for tests.
+    struct NoOpCookieJar;
+
+    #[async_trait]
+    impl CookieJar for NoOpCookieJar {
+        async fn get_cookies(&self, _url: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn add_cookie(&self, _url: &str, _cookie: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn load_from_browser(&self, _browser: rdlp_types::BrowserType) -> Result<usize> {
+            Ok(0)
+        }
+        async fn load_from_file(&self, _path: &std::path::Path) -> Result<usize> {
+            Ok(0)
+        }
+    }
+
+    /// Build a test `ExtractionContext` pointing at the mockito server.
+    fn test_ctx(_server: &Server) -> ExtractionContext {
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let mut config = Config::default();
+        config.verbose = false;
+        ExtractionContext::new(
+            Arc::new(client),
+            Arc::new(NoOpJsEngine),
+            Arc::new(NoOpCookieJar),
+            Arc::new(config),
+        )
+    }
+
+    /// Build a TNAFlix-style search results HTML page.
+    fn tnaflix_search_html(items: &[(&str, &str, &str)], max_page: usize) -> String {
+        let items_html: String = items
+            .iter()
+            .enumerate()
+            .map(|(i, (url, title, duration))| {
+                format!(
+                    r#"<div data-vid="{i}" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+                        <a class="thumb video-thumb bg-dark" href="{url}">
+                            <img data-src="thumb{i}.jpg" alt="{title}" />
+                            <div class="thumb-icon video-duration">{duration}</div>
+                        </a>
+                        <a href="{url}" class="video-title text-break">{title}</a>
+                        <div class="d-flex"><div class="text-small d-flex">
+                            <div><i class="icon-eye"></i>1K</div>
+                        </div></div>
+                    </div>"#
+                )
+            })
+            .collect();
+
+        let pagination = if max_page > 1 {
+            let links: String = (2..=max_page)
+                .map(|p| format!(r#"<li><a class="page-link" href="?page={p}">{p}</a></li>"#))
+                .collect();
+            format!(
+                r#"<ul class="pagination justify-content-center mt-4">
+                    <li class="page-item active"><span class="page-link">1</span></li>
+                    {links}
+                </ul>"#
+            )
+        } else {
+            String::new()
+        };
+
+        format!("<html><body><div class=\"row\">{items_html}</div>{pagination}</body></html>")
+    }
+
+    /// Build a MovieFap-style search results HTML page.
+    fn moviefap_search_html(items: &[(&str, &str, &str)], max_page: usize) -> String {
+        let items_html: String = items
+            .iter()
+            .map(|(url, title, duration)| {
+                format!(
+                    r#"<div class="videothumb">
+                        <span class="thumbtitle"><a href="{url}" title="{title}">{title}</a></span>
+                        <a href="{url}" class="videothumb"><img src="thumb.jpg" alt="{title}" /></a>
+                        <div class="videoleft">{duration}<br />1 year ago</div>
+                    </div>"#
+                )
+            })
+            .collect();
+
+        let pagination = if max_page > 1 {
+            let links: String = (2..=max_page)
+                .map(|p| format!(r#"<a href="/search/q/relevance/{p}">{p}</a>"#))
+                .collect();
+            format!(r#"<div class="pagination"><span class="current">1</span>{links}</div>"#)
+        } else {
+            String::new()
+        };
+
+        format!("<html><body>{items_html}{pagination}</body></html>")
+    }
+
+    // ---- TNAFlix search_page: server returns results ----
+
+    #[tokio::test]
+    async fn test_tnaflix_search_page_returns_results() {
+        let mut server = Server::new_async().await;
+        let html = tnaflix_search_html(
+            &[("/video/test/video1", "Test Video", "05:00")],
+            1,
+        );
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_body(&html)
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+
+        // Fetch from mock server and parse
+        let webpage = ctx.http_client
+            .get(format!("{}/search?what=test&tab=&page=1", server.url()))
+            .send().await.unwrap()
+            .text().await.unwrap();
+        let results = search::parse_search_results(&webpage);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Test Video");
+        mock.assert_async().await;
+    }
+
+    // ---- TNAFlix search_page: server returns 404 ----
+
+    #[tokio::test]
+    async fn test_tnaflix_fetch_404_returns_error() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_body("Not Found")
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+        let url = format!("{}/search?what=test&tab=&page=1", server.url());
+        let result = BaseExtractor::fetch_webpage(&url, &ctx).await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("404") || err_msg.contains("Not Found") || err_msg.contains("HTTP"),
+            "Error should mention HTTP status: {err_msg}"
+        );
+        mock.assert_async().await;
+    }
+
+    // ---- TNAFlix search_page: server returns 500 ----
+
+    #[tokio::test]
+    async fn test_tnaflix_fetch_500_returns_error() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(500)
+            .with_body("Internal Server Error")
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+        let url = format!("{}/search?what=test&tab=&page=1", server.url());
+        let result = BaseExtractor::fetch_webpage(&url, &ctx).await;
+
+        assert!(result.is_err());
+        mock.assert_async().await;
+    }
+
+    // ---- TNAFlix search_page: server returns empty body ----
+
+    #[tokio::test]
+    async fn test_tnaflix_fetch_empty_body_returns_empty_results() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+        let url = format!("{}/search?what=test&tab=&page=1", server.url());
+        let webpage = BaseExtractor::fetch_webpage(&url, &ctx).await.unwrap();
+        let results = search::parse_search_results(&webpage);
+
+        assert!(results.is_empty());
+        mock.assert_async().await;
+    }
+
+    // ---- TNAFlix search_page: server returns no-results page ----
+
+    #[tokio::test]
+    async fn test_tnaflix_fetch_no_results_html() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_body("<html><body><i>No results</i></body></html>")
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+        let url = format!("{}/search?what=zzzzz&tab=&page=1", server.url());
+        let webpage = BaseExtractor::fetch_webpage(&url, &ctx).await.unwrap();
+        let results = search::parse_search_results(&webpage);
+
+        assert!(results.is_empty());
+        mock.assert_async().await;
+    }
+
+    // ---- MovieFap search: server returns results ----
+
+    #[tokio::test]
+    async fn test_moviefap_fetch_and_parse_results() {
+        let mut server = Server::new_async().await;
+        let html = moviefap_search_html(
+            &[("https://moviefap.com/videos/abc123/title.html", "Test", "10:00")],
+            3,
+        );
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_body(&html)
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+        let url = format!("{}/search/test/relevance/1", server.url());
+        let webpage = BaseExtractor::fetch_webpage(&url, &ctx).await.unwrap();
+        let results = moviefap_search::parse_search_results(&webpage);
+        let max_pages = moviefap_search::parse_pagination(&webpage);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Test");
+        assert_eq!(max_pages, Some(3));
+        mock.assert_async().await;
+    }
+
+    // ---- MovieFap search: server returns 403 ----
+
+    #[tokio::test]
+    async fn test_moviefap_fetch_403_returns_error() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_body("Forbidden")
+            .create_async()
+            .await;
+
+        let ctx = test_ctx(&server);
+        let url = format!("{}/search/test/relevance/1", server.url());
+        let result = BaseExtractor::fetch_webpage(&url, &ctx).await;
+
+        assert!(result.is_err());
+        mock.assert_async().await;
+    }
+
+    // ---- Pagination: multi-page HTML then empty second page ----
+
+    #[tokio::test]
+    async fn test_tnaflix_multi_page_then_empty() {
+        let mut server = Server::new_async().await;
+
+        // Page 1: results + pagination showing 3 pages
+        let page1_html = tnaflix_search_html(
+            &[
+                ("/video/a/video1", "Video 1", "01:00"),
+                ("/video/b/video2", "Video 2", "02:00"),
+            ],
+            3,
+        );
+        // Page 2: no results (empty)
+        let page2_html = tnaflix_search_html(&[], 3);
+
+        let _mock1 = server
+            .mock("GET", "/search?what=test&tab=&page=1")
+            .with_body(&page1_html)
+            .create_async()
+            .await;
+        let _mock2 = server
+            .mock("GET", "/search?what=test&tab=&page=2")
+            .with_body(&page2_html)
+            .create_async()
+            .await;
+
+        // Parse page 1
+        let ctx = test_ctx(&server);
+        let url1 = format!("{}/search?what=test&tab=&page=1", server.url());
+        let webpage1 = BaseExtractor::fetch_webpage(&url1, &ctx).await.unwrap();
+        let results1 = search::parse_search_results(&webpage1);
+        let max_pages1 = search::parse_pagination(&webpage1).unwrap_or(1);
+
+        assert_eq!(results1.len(), 2);
+        assert_eq!(max_pages1, 3);
+
+        // Parse page 2 — empty results should signal stop
+        let url2 = format!("{}/search?what=test&tab=&page=2", server.url());
+        let webpage2 = BaseExtractor::fetch_webpage(&url2, &ctx).await.unwrap();
+        let results2 = search::parse_search_results(&webpage2);
+
+        assert!(results2.is_empty());
+    }
+
+    // ---- Connection refused (server not running) ----
+
+    #[tokio::test]
+    async fn test_fetch_connection_refused() {
+        // Use a port that's definitely not listening
+        let config = Config::default();
+        let ctx = ExtractionContext::new(
+            Arc::new(reqwest::Client::new()),
+            Arc::new(NoOpJsEngine),
+            Arc::new(NoOpCookieJar),
+            Arc::new(config),
+        );
+
+        let result = BaseExtractor::fetch_webpage("http://127.0.0.1:1/nonexistent", &ctx).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Failed to fetch") || err_msg.contains("connection") || err_msg.contains("Network"),
+            "Error should mention network failure: {err_msg}"
+        );
+    }
+
+    // ---- URL too long ----
+
+    #[tokio::test]
+    async fn test_fetch_url_too_long() {
+        let config = Config::default();
+        let ctx = ExtractionContext::new(
+            Arc::new(reqwest::Client::new()),
+            Arc::new(NoOpJsEngine),
+            Arc::new(NoOpCookieJar),
+            Arc::new(config),
+        );
+
+        let long_url = format!("https://example.com/{}", "a".repeat(10_000));
+        let result = BaseExtractor::fetch_webpage(&long_url, &ctx).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("too long"), "Error should mention URL too long: {err_msg}");
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -131,7 +131,7 @@ impl InfoExtractor for TNAFlixExtractor {
 
             BaseExtractor::log_if_verbose(ctx, "MovieFap", &format!("cdn.php URL: {cdn_url}"));
 
-            ajax::parse_moviefap_xml(&self.base, &cdn_url, ctx).await?
+            ajax::parse_moviefap_xml(&self.base, &cdn_url, url, ctx).await?
         } else {
             // TNAFlix/EMPFlix: try HTML <source> tags first, fallback to AJAX
             let video_data = {
@@ -162,12 +162,22 @@ impl InfoExtractor for TNAFlixExtractor {
         };
 
         // Build formats and fetch filesizes using base (asynchronous)
-        let formats = self.base.build_formats(video_data, ctx).await;
+        let mut formats = self.base.build_formats(video_data, ctx).await;
 
         if formats.is_empty() {
             return Err(RdlpError::Extraction(format!(
                 "No video formats found for URL: {url}"
             )));
+        }
+
+        // Set Referer header on all formats so the CDN receives it during download.
+        // MovieFap's CDN may throttle requests without a proper Referer.
+        if is_moviefap {
+            let mut headers = std::collections::HashMap::new();
+            headers.insert("Referer".to_string(), url.to_string());
+            for format in &mut formats {
+                format.http_headers = Some(headers.clone());
+            }
         }
 
         // Build InfoDict with all extracted metadata

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -474,4 +474,218 @@ mod tests {
         assert_eq!(parse_duration_secs("not-a-duration"), None);
         assert_eq!(parse_duration_secs(""), None);
     }
+
+    // ---- Negative tests ----
+
+    #[test]
+    fn test_parse_results_missing_title_link() {
+        // videothumb with no .thumbtitle a[href] → should skip item
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle"></span>
+            <a href="https://moviefap.com/videos/abc/test.html" class="videothumb">
+                <img src="thumb.jpg" alt="test" />
+            </a>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_results_empty_href() {
+        // Title link with empty href → should skip
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle">
+                <a href="" title="Test">Test</a>
+            </span>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_results_empty_title_text_uses_unknown() {
+        // Title link with whitespace-only text → falls back to "Unknown"
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle">
+                <a href="https://moviefap.com/videos/abc/test.html" title=""> </a>
+            </span>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Unknown");
+    }
+
+    #[test]
+    fn test_parse_results_missing_thumbnail() {
+        // No img inside a.videothumb → thumbnail should be None
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle">
+                <a href="https://moviefap.com/videos/abc/test.html" title="Test">Test</a>
+            </span>
+            <a href="https://moviefap.com/videos/abc/test.html" class="videothumb">
+            </a>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].thumbnail_url, None);
+    }
+
+    #[test]
+    fn test_parse_results_empty_thumbnail_src() {
+        // img with empty src → thumbnail should be None
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle">
+                <a href="https://moviefap.com/videos/abc/test.html" title="Test">Test</a>
+            </span>
+            <a href="https://moviefap.com/videos/abc/test.html" class="videothumb">
+                <img src="" alt="Test" />
+            </a>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].thumbnail_url, None);
+    }
+
+    #[test]
+    fn test_parse_results_missing_videoleft() {
+        // No .videoleft element → duration should be None
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle">
+                <a href="https://moviefap.com/videos/abc/test.html" title="Test">Test</a>
+            </span>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].duration, None);
+    }
+
+    #[test]
+    fn test_parse_results_videoleft_no_duration() {
+        // .videoleft with only "3 years ago" (no duration before br)
+        let item = r#"<div class="videothumb">
+            <span class="thumbtitle">
+                <a href="https://moviefap.com/videos/abc/test.html" title="Test">Test</a>
+            </span>
+            <div class="videoleft">3 years ago</div>
+        </div>"#;
+        let html = make_search_html(&[item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        // "3 years ago" can't parse as mm:ss → duration is None
+        assert_eq!(results[0].duration, None);
+    }
+
+    #[test]
+    fn test_parse_results_malformed_html_no_panic() {
+        let html = "<html><body><div class=\"videothumb\"><span class=\"thumbtitle\"><a href=\"";
+        let results = parse_search_results(html);
+        // Should not panic; may return empty or partial results
+        let _ = results;
+    }
+
+    #[test]
+    fn test_parse_results_completely_empty_html() {
+        let results = parse_search_results("");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_results_no_videothumb_divs() {
+        let html = "<html><body><p>No results found</p></body></html>";
+        let results = parse_search_results(html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pagination_with_next_link() {
+        // "next >>" is not a page number → should be ignored
+        let pagination = r#"<div class="pagination">
+            <span class="current">1</span>
+            <a href="/search/query/relevance/2">2</a>
+            <a href="/search/query/relevance/3">3</a>
+            <a href="/search/query/relevance/2">next &gt;&gt;</a>
+        </div>"#;
+        let html = make_search_html(&[], Some(pagination));
+        let max_pages = parse_pagination(&html);
+        assert_eq!(max_pages, Some(3)); // "next >>" is not numeric, ignored
+    }
+
+    #[test]
+    fn test_parse_pagination_empty_html() {
+        assert_eq!(parse_pagination(""), None);
+    }
+
+    #[test]
+    fn test_parse_pagination_only_current_span() {
+        // Only <span class="current">1</span>, no <a> links
+        let pagination = r#"<div class="pagination"><span class="current">1</span></div>"#;
+        let html = make_search_html(&[], Some(pagination));
+        assert_eq!(parse_pagination(&html), None);
+    }
+
+    #[test]
+    fn test_validate_filters_multiple_orderings() {
+        // Two ordering filters — both valid individually
+        let filters = vec![
+            SearchFilter { key: "ordering".to_string(), value: "adddate".to_string() },
+            SearchFilter { key: "ordering".to_string(), value: "rate".to_string() },
+        ];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_filters_category_key_rejected() {
+        // MovieFap doesn't support "category" filter (unlike TNAFlix)
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "milf".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_empty_key() {
+        let filters = vec![SearchFilter {
+            key: String::new(),
+            value: "value".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_empty_ordering_value() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: String::new(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_parse_duration_single_number() {
+        // "123" — not mm:ss format
+        assert_eq!(parse_duration_secs("123"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_four_parts() {
+        // "1:2:3:4" — too many parts
+        assert_eq!(parse_duration_secs("1:2:3:4"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_non_numeric_parts() {
+        assert_eq!(parse_duration_secs("ab:cd"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_zero() {
+        assert_eq!(parse_duration_secs("0:00"), Some(0.0));
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -1,0 +1,477 @@
+//! HTML search result parsing for MovieFap.
+//!
+//! Provides scraper-based extraction of search result thumbnails,
+//! pagination detection, and filter validation.
+//!
+//! ## Real HTML Structure (as of 2026-02)
+//!
+//! Each video item is a `<div class="videothumb">` element (note: `<a>` with the
+//! same class name also exists — selectors must be specific to `div`):
+//!
+//! ```html
+//! <div class="videothumb">
+//!   <span class="thumbtitle">
+//!     <a href="https://www.moviefap.com/videos/{hex_id}/{title}.html" title="Title">Title</a>
+//!   </span>
+//!   <a href="..." class="videothumb">
+//!     <img src="https://imgh.moviefap.com/w162h122/..." alt="Title" />
+//!   </a>
+//!   <div class="videoleft">21:00<br />3 years ago</div>
+//!   <div class="videoright">
+//!     <div class="rating">...</div>
+//!   </div>
+//! </div>
+//! ```
+//!
+//! ## Pagination
+//!
+//! ```html
+//! <div class="pagination">
+//!   <span class="current">1</span>
+//!   <a href="/search/query/sort/2">2</a>
+//!   ...
+//! </div>
+//! ```
+
+use rdlp_core::{RdlpError, Result};
+use rdlp_types::{SearchFilter, SearchResultPreview};
+use scraper::{Html, Selector};
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use super::moviefap_search_patterns;
+
+/// Container for each video result: `<div class="videothumb">`.
+/// We target only `div` elements to avoid matching the `<a class="videothumb">` anchor.
+static VIDEO_ITEM_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("div.videothumb").expect("Valid MovieFap video item selector")
+});
+
+/// Title anchor inside `.thumbtitle`: `<span class="thumbtitle"> <a href="...">Title</a> </span>`.
+static THUMB_TITLE_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(".thumbtitle a[href]").expect("Valid MovieFap title selector")
+});
+
+/// Thumbnail image inside the `<a class="videothumb">` anchor.
+static THUMB_IMG_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("a.videothumb img").expect("Valid MovieFap thumbnail img selector")
+});
+
+/// Duration/upload-date container: `<div class="videoleft">`.
+static VIDEO_LEFT_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse(".videoleft").expect("Valid MovieFap videoleft selector"));
+
+/// Pagination links: `<div class="pagination"> <a href="...">N</a> </div>`.
+static PAGINATION_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse(".pagination a").expect("Valid MovieFap pagination selector"));
+
+/// Parse search results from a MovieFap search results HTML page.
+///
+/// Returns a `Vec` of [`SearchResultPreview`] items; an empty vec indicates
+/// no results were found.
+///
+/// # Arguments
+/// * `html` - Raw HTML string of the search results page.
+pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
+    let document = Html::parse_document(html);
+
+    let mut results = Vec::new();
+    let mut seen_urls = HashSet::new();
+
+    for item in document.select(&VIDEO_ITEM_SELECTOR) {
+        // Title and video URL from `.thumbtitle a[href]`
+        let title_link = item.select(&THUMB_TITLE_SELECTOR).next();
+
+        let video_url = title_link
+            .and_then(|a| a.value().attr("href"))
+            .filter(|href| !href.is_empty())
+            .map(str::to_string);
+
+        let Some(video_url) = video_url else {
+            continue;
+        };
+
+        // Deduplicate by URL
+        if !seen_urls.insert(video_url.clone()) {
+            continue;
+        }
+
+        // Title text from the link
+        let title = title_link
+            .map(|a| a.text().collect::<String>())
+            .map(|s| s.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        // Thumbnail URL from `a.videothumb img` — prefer `src` attribute
+        let thumbnail_url = item
+            .select(&THUMB_IMG_SELECTOR)
+            .next()
+            .and_then(|img| img.value().attr("src"))
+            .filter(|url| !url.is_empty())
+            .map(str::to_string);
+
+        // Duration from `.videoleft` — first text node before the `<br>` (e.g. "21:00")
+        let (duration, _upload_date) = parse_video_left(&item);
+
+        results.push(SearchResultPreview {
+            video_url,
+            title,
+            thumbnail_url,
+            duration,
+            view_count: None,
+            upload_date: None,
+        });
+    }
+
+    results
+}
+
+/// Detect the maximum page number available from a MovieFap pagination bar.
+///
+/// Returns `None` when no pagination links are found (single-page results).
+///
+/// # Arguments
+/// * `html` - Raw HTML string of the search results page.
+pub(crate) fn parse_pagination(html: &str) -> Option<usize> {
+    let document = Html::parse_document(html);
+    document
+        .select(&PAGINATION_SELECTOR)
+        .filter_map(|a| a.text().collect::<String>().trim().parse::<usize>().ok())
+        .max()
+}
+
+/// Validate that all supplied search filters are recognised MovieFap keys and values.
+///
+/// # Arguments
+/// * `filters` - Slice of [`SearchFilter`] items to validate.
+///
+/// # Errors
+/// Returns [`RdlpError::Extraction`] if an unrecognised key or value is encountered.
+pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
+    for filter in filters {
+        match filter.key.as_str() {
+            "ordering" => {
+                if !moviefap_search_patterns::VALID_ORDERINGS.contains(&filter.value.as_str()) {
+                    return Err(RdlpError::Extraction(format!(
+                        "Invalid MovieFap ordering value '{}'. Valid values: {}",
+                        filter.value,
+                        moviefap_search_patterns::VALID_ORDERINGS.join(", ")
+                    )));
+                }
+            }
+            other => {
+                return Err(RdlpError::Extraction(format!(
+                    "Unknown MovieFap search filter key '{other}'"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse the `.videoleft` element to extract duration and upload date strings.
+///
+/// The element contains text like `"21:00\n3 years ago"` where the first
+/// part is the duration and the second part is the upload date. The two
+/// pieces of text are separated by a `<br>` element.
+///
+/// Returns `(duration_secs, upload_date_string)` — either can be `None` when
+/// the text is absent or unparseable.
+fn parse_video_left(item: &scraper::ElementRef<'_>) -> (Option<f64>, Option<String>) {
+    let video_left = item.select(&VIDEO_LEFT_SELECTOR).next();
+    let Some(el) = video_left else {
+        return (None, None);
+    };
+
+    // Collect all text nodes; the first is duration, the second is date
+    let texts: Vec<String> = el
+        .text()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    let duration = texts.first().and_then(|s| parse_duration_secs(s));
+    let upload_date = texts.get(1).cloned();
+
+    (duration, upload_date)
+}
+
+/// Parse a duration string like `"21:00"` or `"1:23:45"` into seconds.
+fn parse_duration_secs(s: &str) -> Option<f64> {
+    let parts: Vec<u64> = s
+        .split(':')
+        .map(|p| p.trim().parse::<u64>().ok())
+        .collect::<Option<Vec<_>>>()?;
+
+    let secs = match parts.as_slice() {
+        [m, s] => m * 60 + s,
+        [h, m, s] => h * 3600 + m * 60 + s,
+        _ => return None,
+    };
+
+    Some(secs as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal MovieFap search results page.
+    fn make_search_html(items: &[&str], pagination_html: Option<&str>) -> String {
+        let items_html = items.join("\n");
+        let pagination = pagination_html.unwrap_or("");
+        format!(
+            r#"<html><body>
+            <div id="searchresults">
+                {items_html}
+            </div>
+            {pagination}
+            </body></html>"#
+        )
+    }
+
+    /// Build a single video item matching the real MovieFap HTML structure.
+    fn sample_item(url: &str, title: &str, duration: &str, thumb: &str) -> String {
+        format!(
+            r#"<div class="videothumb">
+                <span class="thumbtitle">
+                    <a href="{url}" title="{title}">{title}</a>
+                </span>
+                <a href="{url}" class="videothumb">
+                    <img src="{thumb}" alt="{title}" />
+                </a>
+                <div class="videoleft">{duration}<br />3 years ago</div>
+            </div>"#
+        )
+    }
+
+    #[test]
+    fn test_parse_search_results_basic() {
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test-video.html",
+            "Test Video",
+            "21:00",
+            "https://imgh.moviefap.com/w162h122/thumb.jpg",
+        );
+        let html = make_search_html(&[&item], None);
+        let results = parse_search_results(&html);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Test Video");
+        assert_eq!(
+            results[0].video_url,
+            "https://www.moviefap.com/videos/abc123/test-video.html"
+        );
+    }
+
+    #[test]
+    fn test_parse_search_results_thumbnail() {
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test.html",
+            "Test",
+            "05:00",
+            "https://imgh.moviefap.com/w162h122/thumb.jpg",
+        );
+        let html = make_search_html(&[&item], None);
+        let results = parse_search_results(&html);
+
+        assert_eq!(
+            results[0].thumbnail_url,
+            Some("https://imgh.moviefap.com/w162h122/thumb.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_search_results_duration_mm_ss() {
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test.html",
+            "Test",
+            "21:00",
+            "thumb.jpg",
+        );
+        let html = make_search_html(&[&item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results[0].duration, Some(1260.0));
+    }
+
+    #[test]
+    fn test_parse_search_results_duration_hh_mm_ss() {
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test.html",
+            "Test",
+            "1:23:45",
+            "thumb.jpg",
+        );
+        let html = make_search_html(&[&item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results[0].duration, Some(5025.0));
+    }
+
+    #[test]
+    fn test_parse_search_results_multiple() {
+        let item1 = sample_item(
+            "https://www.moviefap.com/videos/aaa/title-1.html",
+            "Title 1",
+            "01:00",
+            "thumb1.jpg",
+        );
+        let item2 = sample_item(
+            "https://www.moviefap.com/videos/bbb/title-2.html",
+            "Title 2",
+            "02:00",
+            "thumb2.jpg",
+        );
+        let html = make_search_html(&[&item1, &item2], None);
+        let results = parse_search_results(&html);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Title 1");
+        assert_eq!(results[1].title, "Title 2");
+    }
+
+    #[test]
+    fn test_parse_search_results_empty() {
+        let html = make_search_html(&[], None);
+        let results = parse_search_results(&html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_search_results_deduplicates_by_url() {
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test.html",
+            "Same Video",
+            "01:00",
+            "thumb.jpg",
+        );
+        let html = make_search_html(&[&item, &item, &item], None);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Same Video");
+    }
+
+    #[test]
+    fn test_parse_search_results_no_view_count() {
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test.html",
+            "Test",
+            "05:00",
+            "thumb.jpg",
+        );
+        let html = make_search_html(&[&item], None);
+        let results = parse_search_results(&html);
+        // MovieFap search results don't include view counts
+        assert_eq!(results[0].view_count, None);
+    }
+
+    #[test]
+    fn test_parse_search_results_upload_date_not_in_preview() {
+        // upload_date is currently always None in the preview (not surfaced)
+        let item = sample_item(
+            "https://www.moviefap.com/videos/abc123/test.html",
+            "Test",
+            "05:00",
+            "thumb.jpg",
+        );
+        let html = make_search_html(&[&item], None);
+        let results = parse_search_results(&html);
+        // upload_date field is not populated from search results
+        assert_eq!(results[0].upload_date, None);
+    }
+
+    #[test]
+    fn test_parse_pagination() {
+        let pagination = r#"<div class="pagination">
+            <span class="current">1</span>
+            <a href="/search/query/relevance/2">2</a>
+            <a href="/search/query/relevance/3">3</a>
+            <a href="/search/query/relevance/4">4</a>
+        </div>"#;
+        let html = make_search_html(&[], Some(pagination));
+        let max_pages = parse_pagination(&html);
+        assert_eq!(max_pages, Some(4));
+    }
+
+    #[test]
+    fn test_parse_pagination_no_pager() {
+        let html = "<html><body><p>No pagination</p></body></html>";
+        let max_pages = parse_pagination(html);
+        assert_eq!(max_pages, None);
+    }
+
+    #[test]
+    fn test_parse_pagination_single_page() {
+        let pagination = r#"<div class="pagination">
+            <span class="current">1</span>
+        </div>"#;
+        let html = make_search_html(&[], Some(pagination));
+        let max_pages = parse_pagination(&html);
+        // Only a <span> with no numeric <a> links — returns None
+        assert_eq!(max_pages, None);
+    }
+
+    #[test]
+    fn test_validate_search_filters_valid() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "adddate".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_search_filters_all_valid_orderings() {
+        for ordering in ["relevance", "adddate", "viewnum", "rate", "duration"] {
+            let filters = vec![SearchFilter {
+                key: "ordering".to_string(),
+                value: ordering.to_string(),
+            }];
+            assert!(
+                validate_search_filters(&filters).is_ok(),
+                "ordering '{ordering}' should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_search_filters_invalid_value() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "invalid_value".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_search_filters_unknown_key() {
+        let filters = vec![SearchFilter {
+            key: "unknown_key".to_string(),
+            value: "value".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_search_filters_empty() {
+        assert!(validate_search_filters(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_parse_duration_secs_mm_ss() {
+        assert_eq!(parse_duration_secs("21:00"), Some(1260.0));
+        assert_eq!(parse_duration_secs("05:30"), Some(330.0));
+    }
+
+    #[test]
+    fn test_parse_duration_secs_hh_mm_ss() {
+        assert_eq!(parse_duration_secs("1:23:45"), Some(5025.0));
+    }
+
+    #[test]
+    fn test_parse_duration_secs_invalid() {
+        assert_eq!(parse_duration_secs("not-a-duration"), None);
+        assert_eq!(parse_duration_secs(""), None);
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
@@ -1,0 +1,168 @@
+//! Search URL patterns and filter descriptors for MovieFap.
+//!
+//! Contains the URL builder and filter descriptor definitions used by
+//! `MovieFapSearchExtractor`.
+
+/// MovieFap base URL.
+pub const MOVIEFAP_BASE_URL: &str = "https://www.moviefap.com";
+
+/// Valid sort options for MovieFap search.
+pub const VALID_ORDERINGS: &[&str] = &["relevance", "adddate", "viewnum", "rate", "duration"];
+
+/// Build a MovieFap search URL for a specific page.
+///
+/// Format: `https://www.moviefap.com/search/{encoded_query}/{sort}/{page}`
+///
+/// # Arguments
+/// * `query` - The search query with optional filters.
+/// * `page` - 1-based page number.
+///
+/// # Returns
+/// A fully-formed MovieFap search URL string for the given page.
+pub fn build_search_url(query: &rdlp_types::SearchQuery, page: usize) -> String {
+    let encoded_query = query.query.split_whitespace().collect::<Vec<_>>().join("+");
+
+    let sort = query
+        .filters
+        .iter()
+        .find(|f| f.key == "ordering")
+        .map(|f| f.value.as_str())
+        .unwrap_or("relevance");
+
+    format!("{MOVIEFAP_BASE_URL}/search/{encoded_query}/{sort}/{page}")
+}
+
+/// Return the static filter descriptors for MovieFap search.
+///
+/// # Supported Filters
+/// - `ordering` - Sort order (relevance, adddate, viewnum, rate, duration)
+pub fn search_filter_descriptors() -> Vec<rdlp_types::SearchFilterDescriptor> {
+    vec![rdlp_types::SearchFilterDescriptor {
+        key: "ordering".to_string(),
+        display_name: "Sort by".to_string(),
+        allowed_values: vec![
+            rdlp_types::SearchFilterValue {
+                value: "relevance".to_string(),
+                label: "Relevance".to_string(),
+            },
+            rdlp_types::SearchFilterValue {
+                value: "adddate".to_string(),
+                label: "Newest".to_string(),
+            },
+            rdlp_types::SearchFilterValue {
+                value: "viewnum".to_string(),
+                label: "Most Viewed".to_string(),
+            },
+            rdlp_types::SearchFilterValue {
+                value: "rate".to_string(),
+                label: "Top Rated".to_string(),
+            },
+            rdlp_types::SearchFilterValue {
+                value: "duration".to_string(),
+                label: "Duration".to_string(),
+            },
+        ],
+        default: Some("relevance".to_string()),
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_query(query: &str, ordering: Option<&str>) -> rdlp_types::SearchQuery {
+        let filters = ordering
+            .map(|o| {
+                vec![rdlp_types::SearchFilter {
+                    key: "ordering".to_string(),
+                    value: o.to_string(),
+                }]
+            })
+            .unwrap_or_default();
+
+        rdlp_types::SearchQuery {
+            query: query.to_string(),
+            filters,
+            max_results: None,
+            page: None,
+        }
+    }
+
+    #[test]
+    fn test_build_search_url_basic() {
+        let query = make_query("test query", None);
+        let url = build_search_url(&query, 1);
+        assert_eq!(
+            url,
+            "https://www.moviefap.com/search/test+query/relevance/1"
+        );
+    }
+
+    #[test]
+    fn test_build_search_url_with_ordering() {
+        let query = make_query("test", Some("adddate"));
+        let url = build_search_url(&query, 1);
+        assert_eq!(url, "https://www.moviefap.com/search/test/adddate/1");
+    }
+
+    #[test]
+    fn test_build_search_url_page_2() {
+        let query = make_query("hello world", None);
+        let url = build_search_url(&query, 2);
+        assert_eq!(
+            url,
+            "https://www.moviefap.com/search/hello+world/relevance/2"
+        );
+    }
+
+    #[test]
+    fn test_build_search_url_no_raw_spaces() {
+        let query = make_query("hello world test", None);
+        let url = build_search_url(&query, 1);
+        assert!(!url.contains(' '), "URL must not contain raw spaces");
+        assert!(url.contains("hello+world+test"));
+    }
+
+    #[test]
+    fn test_build_search_url_contains_moviefap_domain() {
+        let query = make_query("test", None);
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("moviefap.com"), "URL must use moviefap.com");
+        assert!(!url.contains("tnaflix.com"), "URL must NOT use tnaflix.com");
+        assert!(!url.contains("empflix.com"), "URL must NOT use empflix.com");
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_not_empty() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].key, "ordering");
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_values() {
+        let filters = search_filter_descriptors();
+        let values: Vec<&str> = filters[0]
+            .allowed_values
+            .iter()
+            .map(|v| v.value.as_str())
+            .collect();
+        assert!(values.contains(&"relevance"));
+        assert!(values.contains(&"adddate"));
+        assert!(values.contains(&"viewnum"));
+        assert!(values.contains(&"rate"));
+        assert!(values.contains(&"duration"));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_default() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters[0].default, Some("relevance".to_string()));
+    }
+
+    #[test]
+    fn test_search_filter_descriptors_five_values() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters[0].allowed_values.len(), 5);
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
@@ -214,4 +214,29 @@ mod tests {
         // Whitespace-only splits to empty segments, joined is empty
         assert!(url.contains("/search//"));
     }
+
+    #[test]
+    fn test_build_search_url_duplicate_ordering_uses_first() {
+        // Two ordering filters — .find() returns the first one
+        let query = rdlp_types::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![
+                rdlp_types::SearchFilter { key: "ordering".to_string(), value: "adddate".to_string() },
+                rdlp_types::SearchFilter { key: "ordering".to_string(), value: "rate".to_string() },
+            ],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("/adddate/")); // first match wins
+        assert!(!url.contains("/rate/"));
+    }
+
+    #[test]
+    fn test_build_search_url_tabs_and_newlines_in_query() {
+        let query = make_query("hello\tworld\nfoo", None);
+        let url = build_search_url(&query, 1);
+        // split_whitespace splits on tabs/newlines too
+        assert!(url.contains("hello+world+foo"));
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
@@ -165,4 +165,53 @@ mod tests {
         let filters = search_filter_descriptors();
         assert_eq!(filters[0].allowed_values.len(), 5);
     }
+
+    // ---- Negative tests ----
+
+    #[test]
+    fn test_build_search_url_empty_query() {
+        let query = make_query("", None);
+        let url = build_search_url(&query, 1);
+        // Empty query → empty segment between /search/ and /relevance/
+        assert!(url.contains("/search/"));
+        assert!(url.contains("/relevance/1"));
+    }
+
+    #[test]
+    fn test_build_search_url_special_chars_in_query() {
+        let query = make_query("test&foo=bar", None);
+        let url = build_search_url(&query, 1);
+        // Special chars are not URL-encoded (matches yt-dlp behavior)
+        assert!(url.contains("test&foo=bar"));
+    }
+
+    #[test]
+    fn test_build_search_url_page_zero() {
+        let query = make_query("test", None);
+        let url = build_search_url(&query, 0);
+        assert!(url.ends_with("/0"));
+    }
+
+    #[test]
+    fn test_build_search_url_page_large() {
+        let query = make_query("test", None);
+        let url = build_search_url(&query, 99999);
+        assert!(url.ends_with("/99999"));
+    }
+
+    #[test]
+    fn test_build_search_url_invalid_ordering_still_builds() {
+        // URL builder doesn't validate ordering — validation is separate
+        let query = make_query("test", Some("invalid_sort"));
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("/invalid_sort/"));
+    }
+
+    #[test]
+    fn test_build_search_url_whitespace_only_query() {
+        let query = make_query("   ", None);
+        let url = build_search_url(&query, 1);
+        // Whitespace-only splits to empty segments, joined is empty
+        assert!(url.contains("/search//"));
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/patterns.rs
@@ -75,6 +75,64 @@ mod tests {
         assert_eq!(caps.get(1).unwrap().as_str(), "123456");
     }
 
+    // ---- Negative URL pattern tests ----
+
+    #[test]
+    fn test_tnaflix_rejects_missing_video_prefix() {
+        assert!(!TNAFLIX_URL_PATTERN.is_match("https://www.tnaflix.com/category/title/123"));
+    }
+
+    #[test]
+    fn test_tnaflix_rejects_non_numeric_id() {
+        assert!(!TNAFLIX_URL_PATTERN.is_match("https://www.tnaflix.com/cat/title/videoABC"));
+    }
+
+    #[test]
+    fn test_tnaflix_rejects_single_path_segment() {
+        assert!(!TNAFLIX_URL_PATTERN.is_match("https://www.tnaflix.com/video123"));
+    }
+
+    #[test]
+    fn test_tnaflix_rejects_wrong_domain() {
+        assert!(!TNAFLIX_URL_PATTERN.is_match("https://www.empflix.com/cat/title/video123"));
+    }
+
+    #[test]
+    fn test_empflix_rejects_wrong_domain() {
+        assert!(!EMPFLIX_URL_PATTERN.is_match("https://www.tnaflix.com/videos/title-123"));
+    }
+
+    #[test]
+    fn test_empflix_rejects_missing_id() {
+        assert!(!EMPFLIX_URL_PATTERN.is_match("https://www.empflix.com/videos/title-"));
+    }
+
+    #[test]
+    fn test_empflix_rejects_random_path() {
+        assert!(!EMPFLIX_URL_PATTERN.is_match("https://www.empflix.com/search?q=test"));
+    }
+
+    #[test]
+    fn test_moviefap_rejects_uppercase_hex() {
+        // Regex is [0-9a-f] only — uppercase hex should not match
+        assert!(!MOVIEFAP_URL_PATTERN.is_match("https://www.moviefap.com/videos/ABCDEF/title.html"));
+    }
+
+    #[test]
+    fn test_moviefap_rejects_missing_html_extension() {
+        assert!(!MOVIEFAP_URL_PATTERN.is_match("https://www.moviefap.com/videos/abc123/title"));
+    }
+
+    #[test]
+    fn test_moviefap_rejects_non_hex_id() {
+        assert!(!MOVIEFAP_URL_PATTERN.is_match("https://www.moviefap.com/videos/xyz!/title.html"));
+    }
+
+    #[test]
+    fn test_moviefap_rejects_wrong_domain() {
+        assert!(!MOVIEFAP_URL_PATTERN.is_match("https://www.empflix.com/videos/abc123/title.html"));
+    }
+
     #[test]
     fn test_empflix_id_extraction() {
         // /videos/title-ID format

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -689,4 +689,73 @@ mod tests {
     fn test_parse_view_count_whitespace_only() {
         assert_eq!(parse_view_count("   "), None);
     }
+
+    // ---- Additional negative tests (round 2) ----
+
+    #[test]
+    fn test_parse_duration_four_parts() {
+        // "1:2:3:4" — too many parts for TNAFlix parser
+        assert_eq!(parse_duration_secs("1:2:3:4"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_single_number() {
+        assert_eq!(parse_duration_secs("123"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_zero() {
+        assert_eq!(parse_duration_secs("0:00"), Some(0.0));
+    }
+
+    #[test]
+    fn test_parse_duration_leading_zeros() {
+        assert_eq!(parse_duration_secs("01:02:03"), Some(3723.0));
+    }
+
+    #[test]
+    fn test_parse_view_count_k_suffix_invalid_number() {
+        // "abc.defK" → strip 'k' → "abc.def" can't parse → None
+        assert_eq!(parse_view_count("abc.defK"), None);
+    }
+
+    #[test]
+    fn test_parse_view_count_m_suffix_invalid_number() {
+        assert_eq!(parse_view_count("xyzM"), None);
+    }
+
+    #[test]
+    fn test_parse_view_count_uppercase_k() {
+        // "5K" → lowercase to "5k" → strip 'k' → 5000
+        assert_eq!(parse_view_count("5K"), Some(5000));
+    }
+
+    #[test]
+    fn test_parse_view_count_uppercase_m() {
+        assert_eq!(parse_view_count("2M"), Some(2_000_000));
+    }
+
+    #[test]
+    fn test_parse_view_count_double_suffix() {
+        // "5K5K" → lowercase "5k5k" → strip trailing 'k' → "5k5" → parse fails → None
+        assert_eq!(parse_view_count("5K5K"), None);
+    }
+
+    #[test]
+    fn test_validate_filters_empty_category_value() {
+        let filters = vec![SearchFilter {
+            key: "category".to_string(),
+            value: String::new(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_multiple_different_keys() {
+        let filters = vec![
+            SearchFilter { key: "ordering".to_string(), value: "newest".to_string() },
+            SearchFilter { key: "category".to_string(), value: "teen-porn".to_string() },
+        ];
+        assert!(validate_search_filters(&filters).is_ok());
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -530,4 +530,163 @@ mod tests {
         ];
         assert!(validate_search_filters(&filters).is_ok());
     }
+
+    // ---- Negative tests ----
+
+    #[test]
+    fn test_parse_results_missing_thumb_link() {
+        // Item with no a.video-thumb → should skip
+        let item = r#"<div data-vid="789" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="video-title text-break" href="https://tnaflix.com/video/123">Title</a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_results_empty_href() {
+        // Thumb link with empty href → should skip
+        let item = r#"<div data-vid="789" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="thumb video-thumb bg-dark" href="">
+                <img data-src="thumb.jpg" alt="Test" />
+            </a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_results_missing_img_thumbnail_none() {
+        // No img inside thumb link → thumbnail should be None
+        let item = r#"<div data-vid="789" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="thumb video-thumb bg-dark" href="https://tnaflix.com/v/test/video789">
+            </a>
+            <a class="video-title text-break" href="https://tnaflix.com/v/test/video789">Test</a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].thumbnail_url, None);
+    }
+
+    #[test]
+    fn test_parse_results_placeholder_img_filtered() {
+        // Placeholder image src → thumbnail should be None
+        let item = r#"<div data-vid="789" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="thumb video-thumb bg-dark" href="https://tnaflix.com/v/test/video789">
+                <img src="/assets/img/video_cover_placeholder.jpg" alt="Test" />
+            </a>
+            <a class="video-title text-break" href="https://tnaflix.com/v/test/video789">Test</a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].thumbnail_url, None);
+    }
+
+    #[test]
+    fn test_parse_results_missing_duration() {
+        // No .video-duration div → duration should be None
+        let item = r#"<div data-vid="789" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="thumb video-thumb bg-dark" href="https://tnaflix.com/v/test/video789">
+                <img data-src="thumb.jpg" alt="Test" />
+            </a>
+            <a class="video-title text-break" href="https://tnaflix.com/v/test/video789">Test</a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].duration, None);
+    }
+
+    #[test]
+    fn test_parse_results_missing_views() {
+        // No icon-eye element → view_count should be None
+        let item = r#"<div data-vid="789" class="col-xs-6 col-md-4 col-xl-3 mb-3">
+            <a class="thumb video-thumb bg-dark" href="https://tnaflix.com/v/test/video789">
+                <img data-src="thumb.jpg" alt="Test" />
+                <div class="thumb-icon video-duration">05:00</div>
+            </a>
+            <a class="video-title text-break" href="https://tnaflix.com/v/test/video789">Test</a>
+        </div>"#;
+        let html = make_search_html(&[item], false);
+        let results = parse_search_results(&html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].view_count, None);
+    }
+
+    #[test]
+    fn test_parse_results_malformed_html_no_panic() {
+        let html = "<div data-vid=\"123\" class=\"col\"><a class=\"video-thumb\" href=\"";
+        let results = parse_search_results(html);
+        let _ = results; // Should not panic
+    }
+
+    #[test]
+    fn test_parse_results_empty_html() {
+        assert!(parse_search_results("").is_empty());
+    }
+
+    #[test]
+    fn test_parse_results_no_data_vid_divs() {
+        let html = "<html><body><p>No results</p></body></html>";
+        assert!(parse_search_results(html).is_empty());
+    }
+
+    #[test]
+    fn test_parse_pagination_next_link_ignored() {
+        let html = r#"<html><body>
+            <ul class="pagination justify-content-center mt-4">
+                <li class="page-item active"><span class="page-link">1</span></li>
+                <li class="page-item"><a class="page-link" href="?page=2">2</a></li>
+                <li class="page-item"><a class="page-link" href="?page=2">Next</a></li>
+            </ul>
+        </body></html>"#;
+        // "Next" is not numeric → should be ignored, max = 2
+        assert_eq!(parse_pagination(html), Some(2));
+    }
+
+    #[test]
+    fn test_parse_pagination_empty_html() {
+        assert_eq!(parse_pagination(""), None);
+    }
+
+    #[test]
+    fn test_validate_filters_empty_key() {
+        let filters = vec![SearchFilter {
+            key: String::new(),
+            value: "newest".to_string(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_empty_ordering_value() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: String::new(),
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_case_sensitive_ordering() {
+        let filters = vec![SearchFilter {
+            key: "ordering".to_string(),
+            value: "Newest".to_string(), // uppercase N
+        }];
+        assert!(validate_search_filters(&filters).is_err());
+    }
+
+    #[test]
+    fn test_parse_view_count_empty() {
+        assert_eq!(parse_view_count(""), None);
+    }
+
+    #[test]
+    fn test_parse_view_count_whitespace_only() {
+        assert_eq!(parse_view_count("   "), None);
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -533,4 +533,106 @@ mod tests {
         assert!(cat.default.is_none());
         assert!(cat.allowed_values.len() > 74); // sections + categories
     }
+
+    // ---- Negative tests ----
+
+    fn make_neg_query(q: &str) -> rdlp_types::SearchQuery {
+        rdlp_types::SearchQuery {
+            query: q.to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        }
+    }
+
+    // EMPFlix _for variant coverage
+
+    #[test]
+    fn test_build_search_url_for_empflix() {
+        let query = make_neg_query("test");
+        let url = build_search_url_for("https://www.empflix.com", &query);
+        assert!(url.starts_with("https://www.empflix.com/search?what=test"));
+        assert!(!url.contains("tnaflix.com"));
+    }
+
+    #[test]
+    fn test_build_search_url_page_for_empflix() {
+        let query = make_neg_query("test");
+        let url = build_search_url_page_for("https://www.empflix.com", &query, 3);
+        assert!(url.starts_with("https://www.empflix.com/search?what=test"));
+        assert!(url.contains("&page=3"));
+    }
+
+    #[test]
+    fn test_build_browse_url_for_empflix_section() {
+        let url = build_browse_url_for("https://www.empflix.com", "new");
+        assert_eq!(url, "https://www.empflix.com/new");
+    }
+
+    #[test]
+    fn test_build_browse_url_page_for_empflix_section() {
+        let url = build_browse_url_page_for("https://www.empflix.com", "new", 5);
+        assert_eq!(url, "https://www.empflix.com/new/5");
+    }
+
+    #[test]
+    fn test_build_browse_url_page_for_empflix_category() {
+        let url = build_browse_url_page_for("https://www.empflix.com", "teen-porn", 2);
+        assert_eq!(url, "https://www.empflix.com/teen-porn?page=2");
+    }
+
+    // Edge cases for _for variants
+
+    #[test]
+    fn test_build_search_url_for_empty_query() {
+        let query = make_neg_query("");
+        let url = build_search_url_for("https://www.empflix.com", &query);
+        assert!(url.contains("what=&tab="));
+    }
+
+    #[test]
+    fn test_build_search_url_for_with_multiple_filters() {
+        let query = rdlp_types::SearchQuery {
+            query: "test".to_string(),
+            filters: vec![
+                rdlp_types::SearchFilter { key: "ordering".to_string(), value: "newest".to_string() },
+                rdlp_types::SearchFilter { key: "other".to_string(), value: "val".to_string() },
+            ],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url_for("https://www.empflix.com", &query);
+        assert!(url.contains("&ordering=newest"));
+        assert!(url.contains("&other=val"));
+    }
+
+    // is_valid_category negative (renamed to avoid duplicate)
+
+    #[test]
+    fn test_is_valid_category_rejects_empty() {
+        assert!(!is_valid_category(""));
+    }
+
+    #[test]
+    fn test_is_valid_category_case_sensitive() {
+        assert!(!is_valid_category("New"));
+        assert!(!is_valid_category("TEEN-PORN"));
+    }
+
+    // slug_to_label edge cases
+
+    #[test]
+    fn test_slug_to_label_empty() {
+        assert_eq!(slug_to_label(""), "");
+    }
+
+    #[test]
+    fn test_slug_to_label_single_word() {
+        assert_eq!(slug_to_label("solo"), "Solo");
+    }
+
+    #[test]
+    fn test_slug_to_label_only_suffix() {
+        assert_eq!(slug_to_label("porn"), "Porn");
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -1,7 +1,7 @@
 //! Search URL patterns and filter descriptors for TNAFlix.
 //!
 //! Contains the search URL builder, page URL builder, and filter descriptor
-//! definitions used by `TNAFlixSearchExtractor`.
+//! definitions used by `TNAFlixSearchExtractor` and `EMPFlixSearchExtractor`.
 
 /// Built-in browse sections (non-category pages).
 const BROWSE_SECTIONS: &[&str] = &["new", "toprated", "featured"];
@@ -84,6 +84,54 @@ const BROWSE_CATEGORIES: &[&str] = &[
     "webcam-shows",
 ];
 
+/// Build a search URL from a [`SearchQuery`](rdlp_types::SearchQuery) for a given base URL.
+///
+/// Format: `{base_url}/search?what={encoded_query}&tab=`
+///
+/// Filters are appended as additional query parameters.
+///
+/// # Arguments
+/// * `base_url` - Site base URL, e.g. `"https://www.tnaflix.com"`.
+/// * `query` - The search query with optional filters.
+///
+/// # Returns
+/// A fully-formed search URL string.
+pub fn build_search_url_for(base_url: &str, query: &rdlp_types::SearchQuery) -> String {
+    let encoded_query = query.query.split_whitespace().collect::<Vec<_>>().join("+");
+
+    let mut url = format!("{base_url}/search?what={encoded_query}&tab=");
+
+    for filter in &query.filters {
+        url.push('&');
+        url.push_str(&filter.key);
+        url.push('=');
+        url.push_str(&filter.value);
+    }
+
+    url
+}
+
+/// Build a search URL for a specific page number for the given base URL.
+///
+/// Appends `&page={page}` to the base search URL.
+///
+/// # Arguments
+/// * `base_url` - Site base URL, e.g. `"https://www.tnaflix.com"`.
+/// * `query` - The search query with optional filters.
+/// * `page` - 1-based page number.
+///
+/// # Returns
+/// A fully-formed search URL string for the given page.
+pub fn build_search_url_page_for(
+    base_url: &str,
+    query: &rdlp_types::SearchQuery,
+    page: usize,
+) -> String {
+    let mut url = build_search_url_for(base_url, query);
+    url.push_str(&format!("&page={page}"));
+    url
+}
+
 /// Build a TNAFlix search URL from a [`SearchQuery`](rdlp_types::SearchQuery).
 ///
 /// Format: `https://www.tnaflix.com/search?what={encoded_query}&tab=`
@@ -96,18 +144,7 @@ const BROWSE_CATEGORIES: &[&str] = &[
 /// # Returns
 /// A fully-formed search URL string.
 pub fn build_search_url(query: &rdlp_types::SearchQuery) -> String {
-    let encoded_query = query.query.split_whitespace().collect::<Vec<_>>().join("+");
-
-    let mut url = format!("https://www.tnaflix.com/search?what={encoded_query}&tab=");
-
-    for filter in &query.filters {
-        url.push('&');
-        url.push_str(&filter.key);
-        url.push('=');
-        url.push_str(&filter.value);
-    }
-
-    url
+    build_search_url_for("https://www.tnaflix.com", query)
 }
 
 /// Build a TNAFlix search URL for a specific page number.
@@ -137,6 +174,34 @@ pub fn is_valid_category(value: &str) -> bool {
     BROWSE_SECTIONS.contains(&value) || BROWSE_CATEGORIES.contains(&value)
 }
 
+/// Build a browse URL for page 1 of a section or category for the given base URL.
+///
+/// # Arguments
+/// * `base_url` - Site base URL, e.g. `"https://www.empflix.com"`.
+/// * `slug` - A browse section ("new") or category slug ("teen-porn").
+///
+/// # Returns
+/// `{base_url}/{slug}`
+pub fn build_browse_url_for(base_url: &str, slug: &str) -> String {
+    format!("{base_url}/{slug}")
+}
+
+/// Build a browse URL for a specific page number for the given base URL.
+///
+/// Sections use `/{slug}/{page}`, categories use `/{slug}?page={page}`.
+///
+/// # Arguments
+/// * `base_url` - Site base URL, e.g. `"https://www.empflix.com"`.
+/// * `slug` - A browse section or category slug.
+/// * `page` - 1-based page number.
+pub fn build_browse_url_page_for(base_url: &str, slug: &str, page: usize) -> String {
+    if BROWSE_SECTIONS.contains(&slug) {
+        format!("{base_url}/{slug}/{page}")
+    } else {
+        format!("{base_url}/{slug}?page={page}")
+    }
+}
+
 /// Build a TNAFlix browse URL for page 1 of a section or category.
 ///
 /// # Arguments
@@ -145,7 +210,7 @@ pub fn is_valid_category(value: &str) -> bool {
 /// # Returns
 /// `https://www.tnaflix.com/{slug}`
 pub fn build_browse_url(slug: &str) -> String {
-    format!("https://www.tnaflix.com/{slug}")
+    build_browse_url_for("https://www.tnaflix.com", slug)
 }
 
 /// Build a TNAFlix browse URL for a specific page number.
@@ -156,11 +221,7 @@ pub fn build_browse_url(slug: &str) -> String {
 /// * `slug` - A browse section or category slug.
 /// * `page` - 1-based page number.
 pub fn build_browse_url_page(slug: &str, page: usize) -> String {
-    if BROWSE_SECTIONS.contains(&slug) {
-        format!("https://www.tnaflix.com/{slug}/{page}")
-    } else {
-        format!("https://www.tnaflix.com/{slug}?page={page}")
-    }
+    build_browse_url_page_for("https://www.tnaflix.com", slug, page)
 }
 
 /// Convert a kebab-case slug to a human-readable label.

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -635,4 +635,38 @@ mod tests {
     fn test_slug_to_label_only_suffix() {
         assert_eq!(slug_to_label("porn"), "Porn");
     }
+
+    #[test]
+    fn test_build_browse_url_page_for_page_zero() {
+        // Page 0 is allowed by the builder (no validation)
+        let url = build_browse_url_page_for("https://www.tnaflix.com", "new", 0);
+        assert_eq!(url, "https://www.tnaflix.com/new/0");
+    }
+
+    #[test]
+    fn test_build_browse_url_for_empty_slug() {
+        let url = build_browse_url_for("https://www.tnaflix.com", "");
+        assert_eq!(url, "https://www.tnaflix.com/");
+    }
+
+    #[test]
+    fn test_build_browse_url_for_trailing_slash_base() {
+        // Trailing slash on base_url produces double slash
+        let url = build_browse_url_for("https://www.tnaflix.com/", "new");
+        assert_eq!(url, "https://www.tnaflix.com//new");
+    }
+
+    #[test]
+    fn test_build_search_url_for_leading_trailing_whitespace_query() {
+        // split_whitespace handles leading/trailing spaces
+        let query = rdlp_types::SearchQuery {
+            query: "  hello   world  ".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url_for("https://www.empflix.com", &query);
+        assert!(url.contains("what=hello+world"));
+        assert!(!url.contains("  ")); // no double spaces
+    }
 }

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -40,8 +40,9 @@ pub mod utils;
 
 // Re-export extractors
 pub use extractors::{
-    HQPornerExtractor, NineAnimeExtractor, PornHubExtractor, RedTubeExtractor, TNAFlixExtractor,
-    TNAFlixSearchExtractor, XHamsterExtractor, XTitsExtractor,
+    EMPFlixSearchExtractor, HQPornerExtractor, MovieFapSearchExtractor, NineAnimeExtractor,
+    PornHubExtractor, RedTubeExtractor, TNAFlixExtractor, TNAFlixSearchExtractor,
+    XHamsterExtractor, XTitsExtractor,
 };
 
 // Re-export base utilities for convenient access
@@ -124,6 +125,12 @@ impl ExtractorRegistry {
         registry
             .search_extractors
             .push(Arc::new(HQPornerExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(EMPFlixSearchExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(MovieFapSearchExtractor::new()));
 
         registry
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -129,6 +129,50 @@ impl Drop for LogForwarderGuard {
     }
 }
 
+/// Opaque guard that holds both a `LogCaptureGuard` (installs `capture_callback`)
+/// and a `LogForwarderGuard` (routes messages through `PostProcessCallback::on_log`).
+///
+/// Hold this until the FFmpeg operation completes. Both guards are dropped together.
+pub struct FfmpegLogBridge {
+    _capture: LogCaptureGuard,
+    _forwarder: LogForwarderGuard,
+}
+
+/// Activate both FFmpeg log capture and real-time forwarding to a
+/// `PostProcessCallback`.
+///
+/// Returns an opaque `FfmpegLogBridge` — hold it until the FFmpeg operation
+/// completes. Internally creates a `LogCaptureGuard` (installs
+/// `capture_callback`) and a `LogForwarderGuard` (routes messages through
+/// `cb.on_log()`).
+///
+/// Level mapping:
+/// - `AV_LOG_ERROR` / `AV_LOG_FATAL` → `[ERROR] message`
+/// - `AV_LOG_WARNING` → `[WARN] message`
+/// - `AV_LOG_INFO` → `message` (no prefix)
+pub fn bridge_ffmpeg_logs(
+    cb: &Arc<dyn rdlp_core::PostProcessCallback>,
+) -> std::result::Result<FfmpegLogBridge, PostProcessError> {
+    let capture_guard = LogCaptureGuard::begin()?;
+    let cb = cb.clone();
+    let forwarder_guard = LogForwarderGuard::new(Arc::new(move |level: i32, msg: String| {
+        let trimmed = msg.trim_end();
+        if trimmed.is_empty() {
+            return;
+        }
+        let prefixed = match level {
+            l if l <= 16 => format!("[ERROR] {trimmed}"),
+            24 => format!("[WARN] {trimmed}"),
+            _ => trimmed.to_string(),
+        };
+        cb.on_log(&prefixed);
+    }));
+    Ok(FfmpegLogBridge {
+        _capture: capture_guard,
+        _forwarder: forwarder_guard,
+    })
+}
+
 /// RAII guard for FFmpeg log capture.
 ///
 /// While active, FFmpeg log messages at `AV_LOG_INFO` level and below (i.e.,
@@ -334,6 +378,51 @@ mod tests {
         assert!(!buffered.is_empty(), "buffer should still capture");
 
         drop(guard);
+    }
+
+    #[test]
+    fn test_bridge_ffmpeg_logs_captures_and_forwards() {
+        use std::sync::Arc;
+
+        let received = Arc::new(Mutex::new(Vec::<String>::new()));
+        let received_clone = received.clone();
+
+        // Create a mock PostProcessCallback
+        struct MockCallback {
+            logs: Arc<Mutex<Vec<String>>>,
+        }
+        impl rdlp_core::PostProcessCallback for MockCallback {
+            fn on_progress(&self, _progress: f64) {}
+            fn on_log(&self, message: &str) {
+                if let Ok(mut v) = self.logs.lock() {
+                    v.push(message.to_string());
+                }
+            }
+        }
+
+        let cb: Arc<dyn rdlp_core::PostProcessCallback> = Arc::new(MockCallback {
+            logs: received_clone,
+        });
+
+        let _bridge = bridge_ffmpeg_logs(&cb).unwrap();
+
+        // Trigger a log message
+        unsafe {
+            let msg = std::ffi::CString::new("bridge test\n").unwrap();
+            ffmpeg_the_third::ffi::av_log(
+                std::ptr::null_mut(),
+                ffmpeg_the_third::ffi::AV_LOG_INFO,
+                msg.as_ptr(),
+            );
+        }
+
+        let msgs = received.lock().unwrap();
+        assert!(!msgs.is_empty(), "bridge should forward to PostProcessCallback");
+        assert!(
+            msgs.iter().any(|m| m.contains("bridge test")),
+            "message should contain 'bridge test', got: {:?}",
+            *msgs
+        );
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -330,7 +330,10 @@ mod tests {
 
         // Forwarder should have received the message
         let msgs = received.lock().unwrap();
-        assert!(!msgs.is_empty(), "forwarder should have received at least one message");
+        assert!(
+            !msgs.is_empty(),
+            "forwarder should have received at least one message"
+        );
         assert_eq!(msgs[0].0, ffmpeg_the_third::ffi::AV_LOG_INFO);
         assert!(msgs[0].1.contains("test log message"));
 
@@ -417,7 +420,10 @@ mod tests {
         }
 
         let msgs = received.lock().unwrap();
-        assert!(!msgs.is_empty(), "bridge should forward to PostProcessCallback");
+        assert!(
+            !msgs.is_empty(),
+            "bridge should forward to PostProcessCallback"
+        );
         assert!(
             msgs.iter().any(|m| m.contains("bridge test")),
             "message should contain 'bridge test', got: {:?}",

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -301,8 +301,14 @@ unsafe extern "C" fn capture_callback(
 mod tests {
     use super::*;
 
+    /// All tests in this module share process-global state (`LOG_BUFFER`,
+    /// `LOG_FORWARDER`, `av_log_set_level`, `av_log_set_callback`). This mutex
+    /// serializes them to prevent races when `cargo test` runs in parallel.
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
     #[test]
     fn test_log_forwarder_receives_messages() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         use std::sync::Arc;
 
         let received = Arc::new(Mutex::new(Vec::<(i32, String)>::new()));
@@ -347,6 +353,7 @@ mod tests {
 
     #[test]
     fn test_clear_log_forwarder_stops_forwarding() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         use std::sync::Arc;
 
         let received = Arc::new(Mutex::new(Vec::<(i32, String)>::new()));
@@ -385,6 +392,7 @@ mod tests {
 
     #[test]
     fn test_bridge_ffmpeg_logs_captures_and_forwards() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         use std::sync::Arc;
 
         let received = Arc::new(Mutex::new(Vec::<String>::new()));
@@ -433,6 +441,7 @@ mod tests {
 
     #[test]
     fn test_log_forwarder_guard_drop_clears() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         use std::sync::Arc;
 
         let received = Arc::new(Mutex::new(Vec::<(i32, String)>::new()));
@@ -453,6 +462,7 @@ mod tests {
 
     #[test]
     fn test_log_buffer_init_and_clear() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         // Ensure buffer starts as None
         {
             let buf = LOG_BUFFER.lock().unwrap();
@@ -485,6 +495,7 @@ mod tests {
 
     #[test]
     fn test_log_suppress_guard_error_level() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         // error_level() sets AV_LOG_ERROR; drop restores the saved level
         unsafe { ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_WARNING) };
         let guard = LogSuppressGuard::error_level();
@@ -500,6 +511,7 @@ mod tests {
 
     #[test]
     fn test_log_suppress_guard_fatal_level() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         // new() sets AV_LOG_FATAL; drop restores the saved level
         unsafe { ffmpeg_the_third::ffi::av_log_set_level(ffmpeg_the_third::ffi::AV_LOG_WARNING) };
         let guard = LogSuppressGuard::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -5,7 +5,7 @@
 //! callback and error-only log level.
 
 use std::ffi::{CStr, c_char, c_int, c_void};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::error::PostProcessError;
 
@@ -80,6 +80,55 @@ impl Drop for LogSuppressGuard {
 /// - A `debug_assert!` in `begin()` that fires in debug builds if violated.
 static LOG_BUFFER: Mutex<Option<Vec<String>>> = Mutex::new(None);
 
+/// Type alias for the real-time log forwarding callback.
+///
+/// Receives `(level, formatted_message)` where `level` is the raw `AV_LOG_*`
+/// constant (lower = more severe).
+type LogForwarder = Arc<dyn Fn(i32, String) + Send + Sync>;
+
+/// Global real-time log forwarder.
+///
+/// When set, `capture_callback` forwards each formatted message through this
+/// callback in addition to pushing it into `LOG_BUFFER`.
+static LOG_FORWARDER: Mutex<Option<LogForwarder>> = Mutex::new(None);
+
+/// Install a real-time log forwarder.
+///
+/// While active, each FFmpeg log message captured by `capture_callback` is also
+/// forwarded through `cb(level, message)`. The callback is called while the
+/// `LOG_FORWARDER` mutex is held — it must not block or panic.
+pub fn set_log_forwarder(cb: Arc<dyn Fn(i32, String) + Send + Sync>) {
+    if let Ok(mut guard) = LOG_FORWARDER.lock() {
+        *guard = Some(cb);
+    }
+}
+
+/// Remove the real-time log forwarder.
+pub fn clear_log_forwarder() {
+    if let Ok(mut guard) = LOG_FORWARDER.lock() {
+        *guard = None;
+    }
+}
+
+/// RAII guard that clears the log forwarder on drop.
+pub struct LogForwarderGuard {
+    _private: (),
+}
+
+impl LogForwarderGuard {
+    /// Create a new guard that installs the forwarder.
+    pub fn new(cb: Arc<dyn Fn(i32, String) + Send + Sync>) -> Self {
+        set_log_forwarder(cb);
+        Self { _private: () }
+    }
+}
+
+impl Drop for LogForwarderGuard {
+    fn drop(&mut self) {
+        clear_log_forwarder();
+    }
+}
+
 /// RAII guard for FFmpeg log capture.
 ///
 /// While active, FFmpeg log messages at `AV_LOG_INFO` level and below (i.e.,
@@ -102,10 +151,12 @@ impl LogCaptureGuard {
             .map_err(|e| PostProcessError::LogCaptureFailed {
                 message: format!("failed to lock log buffer: {e}"),
             })?;
-        // Single-session invariant: nested capture overwrites the active buffer.
-        // This fires in debug builds to catch misuse early.
-        debug_assert!(buf.is_none(), "LogCaptureGuard: nested capture detected");
-        *buf = Some(Vec::new());
+        // Allow nested capture when bridge_ffmpeg_logs creates an outer guard
+        // and an FFmpeg function creates an inner guard (e.g., convert_video
+        // in verbose mode). Both install the same capture_callback.
+        if buf.is_none() {
+            *buf = Some(Vec::new());
+        }
         drop(buf);
 
         // Set log level to INFO so loudnorm output is emitted
@@ -191,7 +242,13 @@ unsafe extern "C" fn capture_callback(
         if let Ok(mut guard) = LOG_BUFFER.lock()
             && let Some(v) = guard.as_mut()
         {
-            v.push(msg);
+            v.push(msg.clone());
+        }
+        // Forward in real-time if a forwarder is active
+        if let Ok(guard) = LOG_FORWARDER.lock()
+            && let Some(ref forwarder) = *guard
+        {
+            forwarder(level, msg);
         }
     }
 }
@@ -199,6 +256,105 @@ unsafe extern "C" fn capture_callback(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_log_forwarder_receives_messages() {
+        use std::sync::Arc;
+
+        let received = Arc::new(Mutex::new(Vec::<(i32, String)>::new()));
+        let received_clone = received.clone();
+
+        // Set forwarder
+        set_log_forwarder(Arc::new(move |level, msg| {
+            if let Ok(mut v) = received_clone.lock() {
+                v.push((level, msg));
+            }
+        }));
+
+        // Begin capture (installs capture_callback)
+        let guard = LogCaptureGuard::begin().unwrap();
+
+        // Trigger an FFmpeg log message by setting level to INFO then logging
+        unsafe {
+            let msg = std::ffi::CString::new("test log message\n").unwrap();
+            ffmpeg_the_third::ffi::av_log(
+                std::ptr::null_mut(),
+                ffmpeg_the_third::ffi::AV_LOG_INFO,
+                msg.as_ptr(),
+            );
+        }
+
+        // Forwarder should have received the message
+        let msgs = received.lock().unwrap();
+        assert!(!msgs.is_empty(), "forwarder should have received at least one message");
+        assert_eq!(msgs[0].0, ffmpeg_the_third::ffi::AV_LOG_INFO);
+        assert!(msgs[0].1.contains("test log message"));
+
+        // Buffer should also have it (dual delivery)
+        let buffered = guard.take_captured().unwrap();
+        assert!(!buffered.is_empty(), "buffer should also have the message");
+
+        drop(guard);
+        clear_log_forwarder();
+    }
+
+    #[test]
+    fn test_clear_log_forwarder_stops_forwarding() {
+        use std::sync::Arc;
+
+        let received = Arc::new(Mutex::new(Vec::<(i32, String)>::new()));
+        let received_clone = received.clone();
+
+        set_log_forwarder(Arc::new(move |level, msg| {
+            if let Ok(mut v) = received_clone.lock() {
+                v.push((level, msg));
+            }
+        }));
+
+        let guard = LogCaptureGuard::begin().unwrap();
+
+        // Clear forwarder before logging
+        clear_log_forwarder();
+
+        unsafe {
+            let msg = std::ffi::CString::new("after clear\n").unwrap();
+            ffmpeg_the_third::ffi::av_log(
+                std::ptr::null_mut(),
+                ffmpeg_the_third::ffi::AV_LOG_INFO,
+                msg.as_ptr(),
+            );
+        }
+
+        // Forwarder should NOT have received it
+        let msgs = received.lock().unwrap();
+        assert!(msgs.is_empty(), "forwarder should not receive after clear");
+
+        // Buffer should still have it
+        let buffered = guard.take_captured().unwrap();
+        assert!(!buffered.is_empty(), "buffer should still capture");
+
+        drop(guard);
+    }
+
+    #[test]
+    fn test_log_forwarder_guard_drop_clears() {
+        use std::sync::Arc;
+
+        let received = Arc::new(Mutex::new(Vec::<(i32, String)>::new()));
+        let received_clone = received.clone();
+
+        {
+            let _guard = LogForwarderGuard::new(Arc::new(move |level, msg| {
+                if let Ok(mut v) = received_clone.lock() {
+                    v.push((level, msg));
+                }
+            }));
+            // Forwarder is set inside this scope
+            assert!(LOG_FORWARDER.lock().unwrap().is_some());
+        }
+        // After drop, forwarder should be cleared
+        assert!(LOG_FORWARDER.lock().unwrap().is_none());
+    }
 
     #[test]
     fn test_log_buffer_init_and_clear() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -52,8 +52,8 @@ use crate::error::{PostProcessError, Result};
 
 // Re-export public types from submodules
 pub use audio_codecs::{AUDIO_CODECS, AudioCodecConfig, get_audio_codec};
-pub use log_capture::{FfmpegLogBridge, LogForwarderGuard, bridge_ffmpeg_logs};
 pub use audio_encoder_registry::{AudioCodecInfo, AudioEncoderInfo};
+pub use log_capture::{FfmpegLogBridge, LogForwarderGuard, bridge_ffmpeg_logs};
 pub use normalize_types::{
     AudioNormMode, LoudnormMeasurements, LoudnormPreset, NormalizeOptions, PeakAnalysis,
 };

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -30,7 +30,7 @@
 mod audio_codecs;
 pub mod audio_encoder_registry;
 mod ffi_helpers;
-pub(crate) mod log_capture;
+pub mod log_capture;
 mod merge;
 mod metadata;
 mod normalize;
@@ -52,6 +52,7 @@ use crate::error::{PostProcessError, Result};
 
 // Re-export public types from submodules
 pub use audio_codecs::{AUDIO_CODECS, AudioCodecConfig, get_audio_codec};
+pub use log_capture::{FfmpegLogBridge, LogForwarderGuard, bridge_ffmpeg_logs};
 pub use audio_encoder_registry::{AudioCodecInfo, AudioEncoderInfo};
 pub use normalize_types::{
     AudioNormMode, LoudnormMeasurements, LoudnormPreset, NormalizeOptions, PeakAnalysis,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/tests.rs
@@ -299,12 +299,7 @@ fn test_fix_audio_timestamps_with_sample_clock_noop() {
 
 /// Helper: compute expected DTS/duration for sample-clock synthesis
 /// using `av_rescale_q(samples, 1/sample_rate, ost_tb)`.
-fn sample_clock_rescale(
-    samples: i64,
-    sample_rate: i32,
-    ost_tb_num: i32,
-    ost_tb_den: i32,
-) -> i64 {
+fn sample_clock_rescale(samples: i64, sample_rate: i32, ost_tb_num: i32, ost_tb_den: i32) -> i64 {
     // av_rescale_q(a, bq, cq) = a * bq.num * cq.den / (bq.den * cq.num)
     // bq = {1, sample_rate}, cq = {ost_tb_num, ost_tb_den}
     // = samples * 1 * ost_tb_den / (sample_rate * ost_tb_num)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -16,6 +16,9 @@ use super::super::salvage::prepare_input_with_salvage;
 use super::super::{FFmpegRunner, RemuxOptions, VideoConvertOptions, ensure_init};
 use super::mux_timing::flush_interleave_queue;
 
+/// Callback type for forwarding FFmpeg log lines to the UI.
+type LogFn = Arc<dyn Fn(&str) + Send + Sync>;
+
 impl FFmpegRunner {
     /// Convert a video file, either by remuxing or transcoding.
     ///
@@ -31,7 +34,7 @@ impl FFmpegRunner {
         output: impl AsRef<Path>,
         opts: &VideoConvertOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
-        log_fn: Option<Arc<dyn Fn(&str) + Send + Sync>>,
+        log_fn: Option<LogFn>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -50,15 +53,14 @@ impl FFmpegRunner {
                 Self::convert_video_sync(&effective_input, &output, &opts, progress_fn.as_deref());
 
             // Drain captured logs and forward to the UI log viewer.
-            if let Some(ref guard) = log_guard {
-                if let Ok(lines) = guard.take_captured() {
-                    if let Some(ref log) = log_fn {
-                        for line in lines {
-                            let trimmed = line.trim();
-                            if !trimmed.is_empty() {
-                                log(trimmed);
-                            }
-                        }
+            if let Some(ref guard) = log_guard
+                && let Ok(lines) = guard.take_captured()
+                && let Some(ref log) = log_fn
+            {
+                for line in lines {
+                    let trimmed = line.trim();
+                    if !trimmed.is_empty() {
+                        log(trimmed);
                     }
                 }
             }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -46,12 +46,8 @@ impl FFmpegRunner {
                 None
             };
 
-            let result = Self::convert_video_sync(
-                &effective_input,
-                &output,
-                &opts,
-                progress_fn.as_deref(),
-            );
+            let result =
+                Self::convert_video_sync(&effective_input, &output, &opts, progress_fn.as_deref());
 
             // Drain captured logs and forward to the UI log viewer.
             if let Some(ref guard) = log_guard {
@@ -163,7 +159,10 @@ impl FFmpegRunner {
             } else if r_rate.numerator() > 0 && r_rate.denominator() > 0 {
                 debug!(
                     "video_convert: avg_frame_rate={}/{} ({avg_fps:.1} fps) looks wrong, using r_frame_rate={}/{}",
-                    avg.numerator(), avg.denominator(), r_rate.numerator(), r_rate.denominator()
+                    avg.numerator(),
+                    avg.denominator(),
+                    r_rate.numerator(),
+                    r_rate.denominator()
                 );
                 r_rate
             } else {
@@ -338,9 +337,9 @@ impl FFmpegRunner {
         let audio_transcode_state: Option<(
             ffmpeg_the_third::decoder::Audio,
             ffmpeg_the_third::encoder::audio::Encoder,
-            ffmpeg_the_third::Rational,        // encoder time_base
-            usize,                             // audio_ost_index for transcode
-            ffmpeg_the_third::filter::Graph,   // audio format conversion filter
+            ffmpeg_the_third::Rational,      // encoder time_base
+            usize,                           // audio_ost_index for transcode
+            ffmpeg_the_third::filter::Graph, // audio format conversion filter
         )> = if let Some(enc_name) = audio_encode_codec {
             if let Some(audio_idx) = audio_ist_index {
                 // Open audio decoder
@@ -603,7 +602,12 @@ impl FFmpegRunner {
 
         // Flush video encoder
         video_encoder.send_eof()?;
-        Self::drain_video_encoder_packets(&mut video_encoder, &mut octx, video_ost_index, video_enc_time_base)?;
+        Self::drain_video_encoder_packets(
+            &mut video_encoder,
+            &mut octx,
+            video_ost_index,
+            video_enc_time_base,
+        )?;
 
         // Flush audio encoder (transcode path)
         if let (
@@ -622,7 +626,12 @@ impl FFmpegRunner {
             // Flush decoder
             audio_dec.send_eof()?;
             Self::drain_audio_transcode_filtered(
-                audio_dec, audio_filter, audio_enc, &mut octx, enc_tb, audio_ost_idx,
+                audio_dec,
+                audio_filter,
+                audio_enc,
+                &mut octx,
+                enc_tb,
+                audio_ost_idx,
             )?;
             // Flush filter graph
             audio_filter
@@ -631,7 +640,11 @@ impl FFmpegRunner {
                 .source()
                 .flush()?;
             Self::drain_audio_filter_to_encoder(
-                audio_filter, audio_enc, &mut octx, enc_tb, audio_ost_idx,
+                audio_filter,
+                audio_enc,
+                &mut octx,
+                enc_tb,
+                audio_ost_idx,
             )?;
             // Flush encoder
             audio_enc.send_eof()?;
@@ -661,18 +674,18 @@ impl FFmpegRunner {
         let mut graph = ffmpeg_the_third::filter::Graph::new();
 
         let sample_fmt_name = unsafe {
-            let name_ptr =
-                ffmpeg_the_third::ffi::av_get_sample_fmt_name(decoder.format().into());
+            let name_ptr = ffmpeg_the_third::ffi::av_get_sample_fmt_name(decoder.format().into());
             if name_ptr.is_null() {
                 "fltp"
             } else {
-                std::ffi::CStr::from_ptr(name_ptr).to_str().unwrap_or("fltp")
+                std::ffi::CStr::from_ptr(name_ptr)
+                    .to_str()
+                    .unwrap_or("fltp")
             }
         };
 
         let enc_fmt_name = unsafe {
-            let name_ptr =
-                ffmpeg_the_third::ffi::av_get_sample_fmt_name(encoder.format().into());
+            let name_ptr = ffmpeg_the_third::ffi::av_get_sample_fmt_name(encoder.format().into());
             if name_ptr.is_null() {
                 "s16"
             } else {
@@ -694,9 +707,8 @@ impl FFmpegRunner {
         );
         graph
             .add(
-                &ffmpeg_the_third::filter::find("abuffer").ok_or_else(|| {
-                    PostProcessError::ffmpeg_failed("abuffer filter not found")
-                })?,
+                &ffmpeg_the_third::filter::find("abuffer")
+                    .ok_or_else(|| PostProcessError::ffmpeg_failed("abuffer filter not found"))?,
                 "in",
                 &abuffer_args,
             )
@@ -726,12 +738,11 @@ impl FFmpegRunner {
 
         // Set buffersink frame_size to match encoder's required frame size
         let frame_size = encoder.frame_size();
-        if frame_size > 0 && let Some(mut sink) = graph.get("out") {
+        if frame_size > 0
+            && let Some(mut sink) = graph.get("out")
+        {
             unsafe {
-                ffmpeg_the_third::ffi::av_buffersink_set_frame_size(
-                    sink.as_mut_ptr(),
-                    frame_size,
-                );
+                ffmpeg_the_third::ffi::av_buffersink_set_frame_size(sink.as_mut_ptr(), frame_size);
             }
         }
 

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -49,6 +49,7 @@ pub mod ffmpeg;
 pub use error::{CorruptionKind, PostProcessError, Result};
 pub use ffmpeg::{
     AudioCodecInfo, AudioEncoderInfo, AudioExtractOptions, AudioNormMode, ChapterEntry,
-    FFmpegRunner, LoudnormMeasurements, LoudnormPreset, MediaInfo, NormalizeOptions, PeakAnalysis,
-    RemuxOptions, StreamInfo, VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, set_verbose,
+    FFmpegRunner, FfmpegLogBridge, LogForwarderGuard, LoudnormMeasurements, LoudnormPreset,
+    MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo, VideoCodecInfo,
+    VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs, set_verbose,
 };

--- a/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
@@ -121,7 +121,11 @@ impl PipelineStage for AudioExtractStage {
             msg.config.audio_quality.as_deref(),
         );
 
-        let callback = msg.callback_factory.as_ref().map(|f| f(self.name())).map(
+        let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        let _log_bridge = stage_callback
+            .as_ref()
+            .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
+        let callback = stage_callback.map(
             |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
         );
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
@@ -125,9 +125,9 @@ impl PipelineStage for AudioExtractStage {
         let _log_bridge = stage_callback
             .as_ref()
             .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
-        let callback = stage_callback.map(
-            |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
-        );
+        let callback = stage_callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+            Arc::new(move |frac| cb.on_progress(frac))
+        });
 
         self.ffmpeg
             .extract_audio(&input_file, &output_path, &opts, callback)

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -105,7 +105,11 @@ impl PipelineStage for MergeStage {
             ..Default::default()
         };
 
-        let callback = msg.callback_factory.as_ref().map(|f| f(self.name())).map(
+        let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        let _log_bridge = stage_callback
+            .as_ref()
+            .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
+        let callback = stage_callback.map(
             |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
         );
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -109,9 +109,9 @@ impl PipelineStage for MergeStage {
         let _log_bridge = stage_callback
             .as_ref()
             .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
-        let callback = stage_callback.map(
-            |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
-        );
+        let callback = stage_callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+            Arc::new(move |frac| cb.on_progress(frac))
+        });
 
         self.ffmpeg
             .merge(&video_file, &audio_file, &output_path, &opts, callback)

--- a/crates/rdlp-postprocess/src/pipeline/stages/metadata.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/metadata.rs
@@ -140,8 +140,26 @@ impl PipelineStage for MetadataStage {
         let metadata = Self::build_metadata(&msg.info);
         let chapters = Self::build_chapters(&msg.info);
 
+        let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        let _log_forwarder = stage_callback.as_ref().map(|cb| {
+            let cb = cb.clone();
+            rdlp_ffmpeg::LogForwarderGuard::new(std::sync::Arc::new(
+                move |level: i32, msg: String| {
+                    let trimmed = msg.trim_end();
+                    if trimmed.is_empty() {
+                        return;
+                    }
+                    let prefixed = match level {
+                        l if l <= 16 => format!("[ERROR] {trimmed}"),
+                        24 => format!("[WARN] {trimmed}"),
+                        _ => trimmed.to_string(),
+                    };
+                    cb.on_log(&prefixed);
+                },
+            ))
+        });
         let log_callback = if msg.config.verbose {
-            msg.callback_factory.as_ref().map(|f| f(self.name()))
+            stage_callback
         } else {
             None
         };

--- a/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
@@ -102,7 +102,11 @@ impl PipelineStage for NormalizeStage {
 
         let output_path = msg.tracker.temp_path(&input_file, ext);
 
-        let callback = msg.callback_factory.as_ref().map(|f| f(self.name())).map(
+        let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        let _log_bridge = stage_callback
+            .as_ref()
+            .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
+        let callback = stage_callback.map(
             |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
         );
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
@@ -106,9 +106,9 @@ impl PipelineStage for NormalizeStage {
         let _log_bridge = stage_callback
             .as_ref()
             .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
-        let callback = stage_callback.map(
-            |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
-        );
+        let callback = stage_callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+            Arc::new(move |frac| cb.on_progress(frac))
+        });
 
         self.ffmpeg
             .normalize_audio(&input_file, &output_path, &opts, callback)

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -310,29 +310,42 @@ impl PipelineStage for RecodeStage {
             cb.on_log(&format!("Recode: container={target_format}"));
         }
 
-        let progress_callback = stage_callback.as_ref().cloned().map(
-            |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
-        );
+        let progress_callback =
+            stage_callback
+                .as_ref()
+                .cloned()
+                .map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+                    Arc::new(move |frac| cb.on_progress(frac))
+                });
 
-        let log_callback: Option<Arc<dyn Fn(&str) + Send + Sync>> =
-            if opts.verbose {
-                stage_callback.as_ref().cloned().map(
-                    |cb| -> Arc<dyn Fn(&str) + Send + Sync> {
-                        Arc::new(move |msg| cb.on_log(msg))
-                    },
-                )
-            } else {
-                None
-            };
+        let log_callback: Option<Arc<dyn Fn(&str) + Send + Sync>> = if opts.verbose {
+            stage_callback
+                .as_ref()
+                .cloned()
+                .map(|cb| -> Arc<dyn Fn(&str) + Send + Sync> {
+                    Arc::new(move |msg| cb.on_log(msg))
+                })
+        } else {
+            None
+        };
 
         self.ffmpeg
-            .convert_video(&input_file, &output_path, &opts, progress_callback, log_callback)
+            .convert_video(
+                &input_file,
+                &output_path,
+                &opts,
+                progress_callback,
+                log_callback,
+            )
             .await?;
 
         if let Some(ref cb) = stage_callback {
             cb.on_log(&format!(
                 "Recode: complete → {}",
-                output_path.file_name().unwrap_or_default().to_string_lossy()
+                output_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
             ));
         }
         info!("RecodeStage: converted to {}", output_path.display());

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -289,6 +289,10 @@ impl PipelineStage for RecodeStage {
         opts.verbose = msg.config.verbose;
 
         let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        // Bridge FFmpeg logs to the callback for real-time encoder output
+        let _log_bridge = stage_callback
+            .as_ref()
+            .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
 
         // Log recode parameters to the UI
         if let Some(ref cb) = stage_callback {

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -106,9 +106,9 @@ impl PipelineStage for RemuxStage {
         let _log_bridge = stage_callback
             .as_ref()
             .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
-        let callback = stage_callback.map(
-            |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
-        );
+        let callback = stage_callback.map(|cb| -> Arc<dyn Fn(f64) + Send + Sync> {
+            Arc::new(move |frac| cb.on_progress(frac))
+        });
 
         self.ffmpeg
             .remux(&input_file, &output_path, &opts, callback)

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -102,7 +102,11 @@ impl PipelineStage for RemuxStage {
             ),
         };
 
-        let callback = msg.callback_factory.as_ref().map(|f| f(self.name())).map(
+        let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        let _log_bridge = stage_callback
+            .as_ref()
+            .and_then(|cb| rdlp_ffmpeg::bridge_ffmpeg_logs(cb).ok());
+        let callback = stage_callback.map(
             |cb| -> Arc<dyn Fn(f64) + Send + Sync> { Arc::new(move |frac| cb.on_progress(frac)) },
         );
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -195,8 +195,26 @@ impl PipelineStage for ThumbnailStage {
 
         let temp_output = msg.tracker.temp_path(&media_file, &extension);
 
+        let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
+        let _log_forwarder = stage_callback.as_ref().map(|cb| {
+            let cb = cb.clone();
+            rdlp_ffmpeg::LogForwarderGuard::new(std::sync::Arc::new(
+                move |level: i32, msg: String| {
+                    let trimmed = msg.trim_end();
+                    if trimmed.is_empty() {
+                        return;
+                    }
+                    let prefixed = match level {
+                        l if l <= 16 => format!("[ERROR] {trimmed}"),
+                        24 => format!("[WARN] {trimmed}"),
+                        _ => trimmed.to_string(),
+                    };
+                    cb.on_log(&prefixed);
+                },
+            ))
+        });
         let log_callback = if msg.config.verbose {
-            msg.callback_factory.as_ref().map(|f| f(self.name()))
+            stage_callback
         } else {
             None
         };


### PR DESCRIPTION
## Summary
- **EMPFlix + MovieFap search extractors** — new `SearchExtractor` implementations for both sites
- **AIMD chunk level floor** — `MIN_CHUNK_LEVEL = 2` (256KB) prevents death spiral under CDN rate limiting
- **Chunk-level retry** — `download_chunk_with_retry` with 3 attempts + linear backoff for body-stream errors
- **Real-time FFmpeg log forwarding** — encoder output (x265 info, codec selection) streams to LogViewer during post-processing via `bridge_ffmpeg_logs()` / `FfmpegLogBridge`
- **Progress bar fix** — post-processing stages reset progress bar, clear stale speed/ETA; ETA capped at 24h
- **MovieFap CDN headers** — Referer added to cdn.php and download requests
- **EWMA speed display** — replaces cumulative average with smoothed per-tick delta
- **Parallel format detection** — filesize detection parallelized for TNAFlix network, PornHub, RedTube

## Key changes by area

### rdlp-downloader
- `MIN_CHUNK_LEVEL = 2` floor in AIMD controller (3 new tests)
- `download_chunk_with_retry()` helper (4 new tests)
- Both download paths wired through retry helper
- EWMA speed display in progress reporter

### rdlp-ffmpeg
- `LOG_FORWARDER` global + `LogForwarderGuard` + `FfmpegLogBridge` in `log_capture.rs`
- `bridge_ffmpeg_logs()` public API for pipeline stages
- Serialized test mutex for log_capture tests
- Fixed 3 pre-existing clippy warnings in `video_convert.rs`

### rdlp-postprocess
- All 7 pipeline stages wired with FFmpeg log forwarding

### rdlp-extractor
- EMPFlix + MovieFap search extractors (45+ new tests)
- MovieFap cdn.php: Referer + X-Requested-With headers
- MovieFap formats: Referer header on download URLs
- Parallel filesize detection for TNAFlix/PornHub/RedTube

### rdlp-core
- ETA capped at 24h, suppressed when speed ≤ 1 B/s

### rdlp-desktop
- Post-processing progress resets bar, clears stale speed/ETA

## Test plan
- [x] `cargo test -p rdlp-downloader` — 71 passed (7 new)
- [x] `cargo test -p rdlp-ffmpeg` — 106 passed (4 new)
- [x] `cargo test -p rdlp-postprocess` — 83 passed
- [x] `cargo test -p rdlp-extractor` — 496+ passed (45+ new)
- [x] `cargo test -p rdlp-api` — passed
- [x] `cargo test -p rdlp-cli` — passed
- [x] `cargo clippy -p rdlp-ffmpeg -- -D warnings` — clean
- [x] Manual: MovieFap download with AIMD + retry working (332 KiB/s vs yt-dlp's 48 KiB/s)
- [x] Manual: x265 encoder info visible in LogViewer during recode
- [x] Manual: Progress bar resets cleanly per post-processing stage