### PR TITLE
feat(extractor): XTits search support + domain fix

### DIFF
--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -3,8 +3,8 @@
 //! XTits is a KVS (Kernel Video Sharing) tube site serving direct MP4 downloads.
 //!
 //! Supports:
-//! - Video pages: `https://www.xtits.xxx/videos/183207/slug/`
-//! - Embed pages: `https://www.xtits.xxx/embed/183207`
+//! - Video pages: `https://www.xtits.com/videos/183207/slug/`
+//! - Embed pages: `https://www.xtits.com/embed/183207`
 //!
 //! ## Module Structure
 //!
@@ -23,7 +23,7 @@ use scraper::Html;
 use crate::base::common::BaseExtractor;
 
 /// Base URL for making relative hrefs absolute.
-const XTITS_BASE_URL: &str = "https://www.xtits.xxx";
+const XTITS_BASE_URL: &str = "https://www.xtits.com";
 
 /// XTits extractor
 pub struct XTitsExtractor;
@@ -403,7 +403,7 @@ mod tests {
         let html = Html::parse_document(html_str);
         assert_eq!(
             extract_model_url(&html),
-            Some("https://www.xtits.xxx/models/jenni-lee/".to_string())
+            Some("https://www.xtits.com/models/jenni-lee/".to_string())
         );
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -13,6 +13,7 @@
 
 mod formats;
 mod patterns;
+mod search;
 mod search_patterns;
 
 use async_trait::async_trait;

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -13,6 +13,7 @@
 
 mod formats;
 mod patterns;
+mod search_patterns;
 
 use async_trait::async_trait;
 use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result};

--- a/crates/rdlp-extractor/src/extractors/xtits/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/patterns.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 /// - Without trailing slash: `https://www.xtits.xxx/videos/183207/slug`
 /// - Without slug: `https://www.xtits.xxx/videos/183207/`
 pub static XTITS_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"https?://(?:www\.)?xtits\.xxx/videos/(?P<id>\d+)/")
+    Regex::new(r"https?://(?:www\.)?xtits\.(?:xxx|com)/videos/(?P<id>\d+)/")
         .expect("Valid XTits URL pattern")
 });
 
@@ -20,7 +20,7 @@ pub static XTITS_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 ///
 /// Supports: `https://www.xtits.xxx/embed/183207`
 pub static XTITS_EMBED_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"https?://(?:www\.)?xtits\.xxx/embed/(?P<id>\d+)")
+    Regex::new(r"https?://(?:www\.)?xtits\.(?:xxx|com)/embed/(?P<id>\d+)")
         .expect("Valid XTits embed pattern")
 });
 
@@ -91,5 +91,37 @@ mod tests {
         let webpage =
             r#"var flashvars = { video_id: '123', video_url: 'https://example.com/v.mp4' };"#;
         assert!(FLASHVARS_PATTERN.is_match(webpage));
+    }
+
+    #[test]
+    fn test_url_pattern_com_domain() {
+        assert!(XTITS_URL_PATTERN.is_match(
+            "https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/"
+        ));
+        assert!(XTITS_URL_PATTERN.is_match("https://xtits.com/videos/12345/test-title/"));
+    }
+
+    #[test]
+    fn test_embed_pattern_com_domain() {
+        assert!(XTITS_EMBED_PATTERN.is_match("https://www.xtits.com/embed/50088"));
+        assert!(XTITS_EMBED_PATTERN.is_match("https://xtits.com/embed/50088"));
+    }
+
+    #[test]
+    fn test_extract_video_id_com_domain() {
+        assert_eq!(
+            extract_video_id("https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/"),
+            Some("50088".to_string())
+        );
+        assert_eq!(
+            extract_video_id("https://www.xtits.com/embed/50088"),
+            Some("50088".to_string())
+        );
+    }
+
+    #[test]
+    fn test_suitable_com_domain() {
+        assert!(is_suitable("https://www.xtits.com/videos/50088/test/"));
+        assert!(is_suitable("https://www.xtits.com/embed/50088"));
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xtits/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/patterns.rs
@@ -95,9 +95,10 @@ mod tests {
 
     #[test]
     fn test_url_pattern_com_domain() {
-        assert!(XTITS_URL_PATTERN.is_match(
-            "https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/"
-        ));
+        assert!(
+            XTITS_URL_PATTERN
+                .is_match("https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/")
+        );
         assert!(XTITS_URL_PATTERN.is_match("https://xtits.com/videos/12345/test-title/"));
     }
 

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -1,0 +1,311 @@
+//! Search result parsing and SearchExtractor implementation for XTits.
+//!
+//! XTits uses KVS AJAX pagination. All pages (including page 1) are fetched
+//! from the same async endpoint that returns HTML fragments.
+
+use async_trait::async_trait;
+use log::debug;
+use rdlp_core::{ExtractionContext, Result, SearchExtractor};
+use rdlp_types::{SearchPageResponse, SearchQuery, SearchResultPreview};
+use std::time::Duration;
+
+use super::search_patterns;
+use super::XTitsExtractor;
+use crate::base::common::BaseExtractor;
+
+const MAX_PLAYLIST_SIZE: usize = 500;
+
+/// Parse search result items from KVS AJAX response HTML.
+pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
+    let items: Vec<_> = search_patterns::ITEM_PATTERN.captures_iter(html).collect();
+    let durations: Vec<_> = search_patterns::DURATION_PATTERN
+        .captures_iter(html)
+        .collect();
+
+    items
+        .iter()
+        .enumerate()
+        .map(|(i, cap)| {
+            let video_url = cap[1].to_string();
+            let title = cap[2].to_string();
+            let thumbnail_url = {
+                let thumb = &cap[3];
+                if thumb.is_empty() {
+                    None
+                } else {
+                    Some(thumb.to_string())
+                }
+            };
+
+            let duration = durations
+                .get(i)
+                .and_then(|d| search_patterns::parse_duration(&d[1]));
+
+            SearchResultPreview {
+                video_url,
+                title,
+                thumbnail_url,
+                duration,
+                view_count: None,
+                upload_date: None,
+            }
+        })
+        .collect()
+}
+
+/// Detect the highest page number in pagination links.
+///
+/// Returns the max page number found, or the current page if no pagination links exist.
+pub(crate) fn detect_max_page(html: &str) -> u32 {
+    search_patterns::PAGE_NUMBER_PATTERN
+        .captures_iter(html)
+        .filter_map(|c| c.get(1)?.as_str().parse::<u32>().ok())
+        .max()
+        .unwrap_or(1)
+}
+
+#[async_trait]
+impl SearchExtractor for XTitsExtractor {
+    fn name(&self) -> &str {
+        "XTits"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
+        search_patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
+        let mut all_results = Vec::new();
+        let mut page = 1_u32;
+
+        loop {
+            let page_url = search_patterns::build_search_url(query, page);
+            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
+            debug!("[XTits] Fetching search page {page}: {sanitized}");
+
+            let webpage = BaseExtractor::fetch_webpage_with_headers(
+                &page_url,
+                &[
+                    ("X-Requested-With", "XMLHttpRequest"),
+                    ("Referer", "https://www.xtits.com/search/"),
+                ],
+                ctx,
+            )
+            .await?;
+
+            let page_results = parse_search_results(&webpage);
+            if page_results.is_empty() {
+                break;
+            }
+
+            let max_page = detect_max_page(&webpage);
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if page >= max_page {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(Duration::from_millis(search_patterns::PAGE_RATE_LIMIT_MS)).await;
+        }
+
+        debug!(
+            "[XTits] Search complete: {} results across {page} pages",
+            all_results.len()
+        );
+        Ok(all_results)
+    }
+
+    async fn search_page(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        let page = query.page.unwrap_or(1);
+        let page_url = search_patterns::build_search_url(query, page);
+
+        let webpage = BaseExtractor::fetch_webpage_with_headers(
+            &page_url,
+            &[
+                ("X-Requested-With", "XMLHttpRequest"),
+                ("Referer", "https://www.xtits.com/search/"),
+            ],
+            ctx,
+        )
+        .await?;
+
+        let page_results = parse_search_results(&webpage);
+        let max_page = detect_max_page(&webpage);
+        let has_more = page < max_page && !page_results.is_empty();
+        let total_estimate = Some(max_page as u64 * search_patterns::RESULTS_PER_PAGE);
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page,
+            has_more,
+            total_estimate,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_search_html() -> &'static str {
+        r#"<div id="list_videos_videos_list_search_result" class="box">
+<h1 class="title">Videos for: amateur, Page 1</h1>
+<div class="item thumb-item">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/" title="Blonde Amateur GF - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg">
+        <div class="img-holder">
+            <img class="thumb img" src="https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg" alt="Blonde Amateur GF - Amateur">
+            <span class="label hd"><i class="icon-hd"></i></span>
+            <span class="label time"><i class="icon-hd"></i>10:35</span>
+        </div>
+        <div class="info-holder">
+            <p class="title">Blonde Amateur GF - Amateur</p>
+        </div>
+    </a>
+</div>
+<div class="item thumb-item">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/180969/chubby-amateur-fucked-amateur/" title="Chubby Amateur Fucked - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/180000/180969/402x225/10.jpg">
+        <div class="img-holder">
+            <img class="thumb img" src="https://i.xtits.com/contents/videos_screenshots/180000/180969/402x225/10.jpg" alt="Chubby Amateur Fucked - Amateur">
+            <span class="label time"><i class="icon-hd"></i>26:47</span>
+        </div>
+        <div class="info-holder">
+            <p class="title">Chubby Amateur Fucked - Amateur</p>
+        </div>
+    </a>
+</div>
+<div class="item thumb-item">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/172127/amateur-bbw-2k-amateur/" title="Amateur BBW(2K) - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/172000/172127/402x225/20.jpg">
+        <div class="img-holder">
+            <img class="thumb img" src="https://i.xtits.com/contents/videos_screenshots/172000/172127/402x225/20.jpg" alt="Amateur BBW(2K) - Amateur">
+            <span class="label time"><i class="icon-hd"></i>19:04</span>
+        </div>
+        <div class="info-holder">
+            <p class="title">Amateur BBW(2K) - Amateur</p>
+        </div>
+    </a>
+</div>
+<div class="pagination" id="list_videos_videos_list_search_result_pagination">
+    <ul class="pagination-holder">
+        <li class="item-pagin active"><span class="link">01</span></li>
+        <li class="item-pagin"><a class="link" data-parameters="q:amateur;sort_by:;from_videos+from_albums:02">02</a></li>
+        <li class="item-pagin"><a class="link" data-parameters="q:amateur;sort_by:;from_videos+from_albums:03">03</a></li>
+    </ul>
+</div>
+</div>"#
+    }
+
+    fn sample_last_page_html() -> &'static str {
+        r#"<div id="list_videos_videos_list_search_result" class="box">
+<h1 class="title">Videos for: amateur, Page 3</h1>
+<div class="item thumb-item">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/99999/last-video/" title="Last Video" thumb="https://i.xtits.com/thumb.jpg">
+        <div class="img-holder">
+            <span class="label time"><i class="icon-hd"></i>5:00</span>
+        </div>
+    </a>
+</div>
+<div class="pagination" id="list_videos_videos_list_search_result_pagination">
+    <ul class="pagination-holder">
+        <li class="item-pagin"><a class="link" data-parameters="q:amateur;sort_by:;from_videos+from_albums:02">02</a></li>
+        <li class="item-pagin active"><span class="link">03</span></li>
+    </ul>
+</div>
+</div>"#
+    }
+
+    #[test]
+    fn test_parse_search_results() {
+        let results = parse_search_results(sample_search_html());
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].title, "Blonde Amateur GF - Amateur");
+        assert_eq!(
+            results[0].video_url,
+            "https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/"
+        );
+        assert_eq!(
+            results[0].thumbnail_url.as_deref(),
+            Some("https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg")
+        );
+        assert_eq!(results[0].duration, Some(635.0)); // 10:35
+    }
+
+    #[test]
+    fn test_parse_search_results_second_item() {
+        let results = parse_search_results(sample_search_html());
+        assert_eq!(results[1].title, "Chubby Amateur Fucked - Amateur");
+        assert_eq!(results[1].duration, Some(1607.0)); // 26:47
+    }
+
+    #[test]
+    fn test_parse_search_results_third_item() {
+        let results = parse_search_results(sample_search_html());
+        assert_eq!(results[2].title, "Amateur BBW(2K) - Amateur");
+        assert_eq!(results[2].duration, Some(1144.0)); // 19:04
+    }
+
+    #[test]
+    fn test_parse_search_results_empty() {
+        let results = parse_search_results("<html><body></body></html>");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_detect_max_page_with_pagination() {
+        assert_eq!(detect_max_page(sample_search_html()), 3);
+    }
+
+    #[test]
+    fn test_detect_max_page_last_page() {
+        // Last page: highest link is 03 (active), links point to 02
+        assert_eq!(detect_max_page(sample_last_page_html()), 2);
+    }
+
+    #[test]
+    fn test_detect_max_page_no_pagination() {
+        assert_eq!(detect_max_page("<html>no pagination</html>"), 1);
+    }
+
+    #[test]
+    fn test_has_more_page_1() {
+        let max_page = detect_max_page(sample_search_html());
+        let current_page = 1_u32;
+        assert!(current_page < max_page); // has_more = true
+    }
+
+    #[test]
+    fn test_has_more_last_page() {
+        let max_page = detect_max_page(sample_last_page_html());
+        let current_page = 3_u32;
+        assert!(current_page >= max_page); // has_more = false
+    }
+
+    #[test]
+    fn test_search_name() {
+        let ext = XTitsExtractor::new();
+        assert_eq!(ext.name(), "XTits");
+    }
+
+    #[test]
+    fn test_supported_filters() {
+        let ext = XTitsExtractor::new();
+        let filters = SearchExtractor::supported_filters(&ext);
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0].key, "ordering");
+        assert_eq!(filters[1].key, "period");
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -9,8 +9,8 @@ use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{SearchPageResponse, SearchQuery, SearchResultPreview};
 use std::time::Duration;
 
-use super::search_patterns;
 use super::XTitsExtractor;
+use super::search_patterns;
 use crate::base::common::BaseExtractor;
 
 const MAX_PLAYLIST_SIZE: usize = 500;

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -94,16 +94,20 @@ pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
             display_name: "Sort By".to_string(),
             default: Some("relevance".to_string()),
             allowed_values: vec![
-                SearchFilterValue { value: "relevance".to_string(),
+                SearchFilterValue {
+                    value: "relevance".to_string(),
                     label: "Relevance".to_string(),
                 },
-                SearchFilterValue { value: "newest".to_string(),
+                SearchFilterValue {
+                    value: "newest".to_string(),
                     label: "Newest".to_string(),
                 },
-                SearchFilterValue { value: "rating".to_string(),
+                SearchFilterValue {
+                    value: "rating".to_string(),
                     label: "Top Rated".to_string(),
                 },
-                SearchFilterValue { value: "mostviewed".to_string(),
+                SearchFilterValue {
+                    value: "mostviewed".to_string(),
                     label: "Most Viewed".to_string(),
                 },
             ],
@@ -113,16 +117,20 @@ pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
             display_name: "Time Period".to_string(),
             default: Some("alltime".to_string()),
             allowed_values: vec![
-                SearchFilterValue { value: "alltime".to_string(),
+                SearchFilterValue {
+                    value: "alltime".to_string(),
                     label: "All Time".to_string(),
                 },
-                SearchFilterValue { value: "monthly".to_string(),
+                SearchFilterValue {
+                    value: "monthly".to_string(),
                     label: "This Month".to_string(),
                 },
-                SearchFilterValue { value: "weekly".to_string(),
+                SearchFilterValue {
+                    value: "weekly".to_string(),
                     label: "This Week".to_string(),
                 },
-                SearchFilterValue { value: "today".to_string(),
+                SearchFilterValue {
+                    value: "today".to_string(),
                     label: "Today".to_string(),
                 },
             ],
@@ -305,7 +313,6 @@ mod tests {
     }
 
     #[test]
-
     #[test]
     fn test_page_number_pattern() {
         let cap = PAGE_NUMBER_PATTERN

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -27,11 +27,6 @@ pub(crate) static DURATION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
         .expect("Valid duration pattern")
 });
 
-/// Regex to extract video ID from URL path `/videos/{id}/`.
-pub(crate) static VIDEO_ID_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"/videos/(\d+)/").expect("Valid video ID pattern")
-});
-
 /// Regex to detect the highest page number in pagination links.
 pub(crate) static PAGE_NUMBER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"from_videos\+from_albums:(\d+)").expect("Valid page number pattern")
@@ -310,12 +305,6 @@ mod tests {
     }
 
     #[test]
-    fn test_video_id_pattern() {
-        let cap = VIDEO_ID_PATTERN
-            .captures("/videos/50088/slug/")
-            .unwrap();
-        assert_eq!(&cap[1], "50088");
-    }
 
     #[test]
     fn test_page_number_pattern() {

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -1,0 +1,339 @@
+//! URL builders, regex patterns, and filter descriptors for XTits search.
+
+use rdlp_types::{SearchFilterDescriptor, SearchFilterValue, SearchQuery};
+use regex::Regex;
+use std::sync::LazyLock;
+use url::form_urlencoded;
+
+/// Results per page (XTits KVS default).
+pub(crate) const RESULTS_PER_PAGE: u64 = 100;
+
+/// Rate limit between page fetches (milliseconds).
+pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
+
+/// Regex to extract video items from KVS AJAX response HTML.
+///
+/// Captures: (1) video URL, (2) title, (3) thumbnail URL.
+pub(crate) static ITEM_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"<a\s+[^>]*class="[^"]*js-open-popup[^"]*"\s+href="([^"]+)"\s+title="([^"]+)"[^>]*thumb="([^"]*)"#,
+    )
+    .expect("Valid item pattern")
+});
+
+/// Regex to extract duration from `<span class="label time">`.
+pub(crate) static DURATION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"<span\s+class="label\s+time"[^>]*>\s*(?:<[^>]+>\s*)*(\d+:\d+)\s*</span>"#)
+        .expect("Valid duration pattern")
+});
+
+/// Regex to extract video ID from URL path `/videos/{id}/`.
+pub(crate) static VIDEO_ID_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"/videos/(\d+)/").expect("Valid video ID pattern")
+});
+
+/// Regex to detect the highest page number in pagination links.
+pub(crate) static PAGE_NUMBER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"from_videos\+from_albums:(\d+)").expect("Valid page number pattern")
+});
+
+/// Build the AJAX search URL for a given query and page.
+pub(crate) fn build_search_url(query: &SearchQuery, page: u32) -> String {
+    let sort_by = resolve_sort_by(query);
+    let page_str = format!("{page:02}");
+    let encoded_query: String = form_urlencoded::byte_serialize(query.query.as_bytes()).collect();
+
+    format!(
+        "https://www.xtits.com/search/?q={encoded_query}&mode=async&function=get_block\
+         &block_id=list_videos_videos_list_search_result\
+         &sort_by={sort_by}&from_videos={page_str}&from_albums={page_str}"
+    )
+}
+
+/// Resolve the `sort_by` parameter from query filters.
+///
+/// Combines `ordering` and `period` filters:
+/// - `ordering=newest` → `post_date`
+/// - `ordering=rating` + `period=monthly` → `rating_month`
+/// - `ordering=mostviewed` + `period=today` → `video_viewed_today`
+fn resolve_sort_by(query: &SearchQuery) -> String {
+    let ordering = query
+        .filters
+        .iter()
+        .find(|f| f.key == "ordering")
+        .map(|f| f.value.as_str())
+        .unwrap_or("relevance");
+
+    let base = match ordering {
+        "newest" => "post_date",
+        "rating" => "rating",
+        "mostviewed" => "video_viewed",
+        _ => return String::new(), // relevance = empty sort_by
+    };
+
+    // Period only applies to rating and mostviewed
+    if ordering == "newest" {
+        return base.to_string();
+    }
+
+    let period = query
+        .filters
+        .iter()
+        .find(|f| f.key == "period")
+        .map(|f| f.value.as_str())
+        .unwrap_or("alltime");
+
+    match period {
+        "monthly" => format!("{base}_month"),
+        "weekly" => format!("{base}_week"),
+        "today" => format!("{base}_today"),
+        _ => base.to_string(), // alltime = no suffix
+    }
+}
+
+/// Return the filter descriptors for XTits search.
+pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
+    vec![
+        SearchFilterDescriptor {
+            key: "ordering".to_string(),
+            display_name: "Sort By".to_string(),
+            default: Some("relevance".to_string()),
+            allowed_values: vec![
+                SearchFilterValue { value: "relevance".to_string(),
+                    label: "Relevance".to_string(),
+                },
+                SearchFilterValue { value: "newest".to_string(),
+                    label: "Newest".to_string(),
+                },
+                SearchFilterValue { value: "rating".to_string(),
+                    label: "Top Rated".to_string(),
+                },
+                SearchFilterValue { value: "mostviewed".to_string(),
+                    label: "Most Viewed".to_string(),
+                },
+            ],
+        },
+        SearchFilterDescriptor {
+            key: "period".to_string(),
+            display_name: "Time Period".to_string(),
+            default: Some("alltime".to_string()),
+            allowed_values: vec![
+                SearchFilterValue { value: "alltime".to_string(),
+                    label: "All Time".to_string(),
+                },
+                SearchFilterValue { value: "monthly".to_string(),
+                    label: "This Month".to_string(),
+                },
+                SearchFilterValue { value: "weekly".to_string(),
+                    label: "This Week".to_string(),
+                },
+                SearchFilterValue { value: "today".to_string(),
+                    label: "Today".to_string(),
+                },
+            ],
+        },
+    ]
+}
+
+/// Parse a `MM:SS` duration string into seconds.
+pub(crate) fn parse_duration(text: &str) -> Option<f64> {
+    let parts: Vec<&str> = text.trim().split(':').collect();
+    match parts.len() {
+        2 => {
+            let mins: f64 = parts[0].parse().ok()?;
+            let secs: f64 = parts[1].parse().ok()?;
+            Some(mins * 60.0 + secs)
+        }
+        3 => {
+            let hours: f64 = parts[0].parse().ok()?;
+            let mins: f64 = parts[1].parse().ok()?;
+            let secs: f64 = parts[2].parse().ok()?;
+            Some(hours * 3600.0 + mins * 60.0 + secs)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rdlp_types::SearchFilter;
+
+    #[test]
+    fn test_build_search_url_default() {
+        let query = SearchQuery {
+            query: "amateur".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("q=amateur"));
+        assert!(url.contains("mode=async"));
+        assert!(url.contains("from_videos=01"));
+        assert!(url.contains("sort_by="));
+    }
+
+    #[test]
+    fn test_build_search_url_page_2() {
+        let query = SearchQuery {
+            query: "test".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 2);
+        assert!(url.contains("from_videos=02"));
+        assert!(url.contains("from_albums=02"));
+    }
+
+    #[test]
+    fn test_resolve_sort_by_newest() {
+        let query = SearchQuery {
+            query: "test".to_string(),
+            filters: vec![SearchFilter {
+                key: "ordering".to_string(),
+                value: "newest".to_string(),
+            }],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("sort_by=post_date"));
+    }
+
+    #[test]
+    fn test_resolve_sort_by_rating_monthly() {
+        let query = SearchQuery {
+            query: "test".to_string(),
+            filters: vec![
+                SearchFilter {
+                    key: "ordering".to_string(),
+                    value: "rating".to_string(),
+                },
+                SearchFilter {
+                    key: "period".to_string(),
+                    value: "monthly".to_string(),
+                },
+            ],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("sort_by=rating_month"));
+    }
+
+    #[test]
+    fn test_resolve_sort_by_mostviewed_today() {
+        let query = SearchQuery {
+            query: "test".to_string(),
+            filters: vec![
+                SearchFilter {
+                    key: "ordering".to_string(),
+                    value: "mostviewed".to_string(),
+                },
+                SearchFilter {
+                    key: "period".to_string(),
+                    value: "today".to_string(),
+                },
+            ],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("sort_by=video_viewed_today"));
+    }
+
+    #[test]
+    fn test_resolve_sort_by_relevance_ignores_period() {
+        let query = SearchQuery {
+            query: "test".to_string(),
+            filters: vec![
+                SearchFilter {
+                    key: "ordering".to_string(),
+                    value: "relevance".to_string(),
+                },
+                SearchFilter {
+                    key: "period".to_string(),
+                    value: "monthly".to_string(),
+                },
+            ],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("sort_by=&"));
+    }
+
+    #[test]
+    fn test_parse_duration_mm_ss() {
+        assert_eq!(parse_duration("10:35"), Some(635.0));
+        assert_eq!(parse_duration("0:30"), Some(30.0));
+        assert_eq!(parse_duration("26:47"), Some(1607.0));
+    }
+
+    #[test]
+    fn test_parse_duration_hh_mm_ss() {
+        assert_eq!(parse_duration("1:30:00"), Some(5400.0));
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert_eq!(parse_duration(""), None);
+        assert_eq!(parse_duration("abc"), None);
+    }
+
+    #[test]
+    fn test_search_filter_descriptors() {
+        let filters = search_filter_descriptors();
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0].key, "ordering");
+        assert_eq!(filters[1].key, "period");
+        assert_eq!(filters[0].allowed_values.len(), 4);
+        assert_eq!(filters[1].allowed_values.len(), 4);
+    }
+
+    #[test]
+    fn test_item_pattern_matches() {
+        let html = r#"<a class="link js-open-popup" href="https://www.xtits.com/videos/50088/test/" title="Test Video" thumb="https://i.xtits.com/thumb.jpg">"#;
+        let cap = ITEM_PATTERN.captures(html).unwrap();
+        assert_eq!(&cap[1], "https://www.xtits.com/videos/50088/test/");
+        assert_eq!(&cap[2], "Test Video");
+        assert_eq!(&cap[3], "https://i.xtits.com/thumb.jpg");
+    }
+
+    #[test]
+    fn test_duration_pattern_matches() {
+        let html = r#"<span class="label time"><i class="icon-hd"></i>10:35</span>"#;
+        let cap = DURATION_PATTERN.captures(html).unwrap();
+        assert_eq!(&cap[1], "10:35");
+    }
+
+    #[test]
+    fn test_video_id_pattern() {
+        let cap = VIDEO_ID_PATTERN
+            .captures("/videos/50088/slug/")
+            .unwrap();
+        assert_eq!(&cap[1], "50088");
+    }
+
+    #[test]
+    fn test_page_number_pattern() {
+        let cap = PAGE_NUMBER_PATTERN
+            .captures("from_videos+from_albums:03")
+            .unwrap();
+        assert_eq!(&cap[1], "03");
+    }
+
+    #[test]
+    fn test_url_encodes_query() {
+        let query = SearchQuery {
+            query: "big tits".to_string(),
+            filters: vec![],
+            max_results: None,
+            page: None,
+        };
+        let url = build_search_url(&query, 1);
+        assert!(url.contains("q=big+tits") || url.contains("q=big%20tits"));
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -313,7 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn test_page_number_pattern() {
         let cap = PAGE_NUMBER_PATTERN
             .captures("from_videos+from_albums:03")

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -131,6 +131,9 @@ impl ExtractorRegistry {
         registry
             .search_extractors
             .push(Arc::new(MovieFapSearchExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(XTitsExtractor::new()));
 
         registry
     }


### PR DESCRIPTION
## Summary
- **Domain fix**: URL patterns now match both `xtits.xxx` and `xtits.com` (the active domain)
- **Search extractor**: `SearchExtractor` implementation using KVS AJAX pagination
- **Filters**: `ordering` (relevance/newest/rating/mostviewed) + `period` (alltime/monthly/weekly/today)
- Registered as 8th search extractor

Closes #109

## Search support matrix (updated)

| Site | Search | Filters |
|------|--------|---------|
| XTits | **NEW** | ordering, period |
| TNAFlix | existing | ordering, category |
| EMPFlix | existing | ordering, category |
| MovieFap | existing | ordering |
| RedTube | existing | ordering, period, category, tags |
| PornHub | existing | ordering, period, category, tags |
| XHamster | existing | — |
| HQPorner | existing | — |

## Test plan
- [x] `cargo test -p rdlp-extractor` — 626 passed (50 xtits-specific)
- [x] `cargo clippy -p rdlp-extractor -- -D warnings` — clean
- [x] `cargo test -p rdlp-api -p rdlp-cli` — no regressions
- [x] Both `.xxx` and `.com` domain patterns tested