### PR TITLE
feat(api): download unit event model for playlist/merge progress (SP1)

### DIFF
--- a/crates/rdlp-api/src/dto.rs
+++ b/crates/rdlp-api/src/dto.rs
@@ -126,15 +126,20 @@ impl From<&Event> for EventDto {
             }
 
             Event::PlaylistItemStarted {
-                index, total, url, ..
+                index, total, url, title, ..
             } => (
                 "playlist_item_started",
                 json!({
                     "index": index,
                     "total": total,
                     "url": url,
+                    "title": title,
                 }),
             ),
+
+            Event::UnitCompleted { index, .. } => {
+                ("unit_completed", json!({ "index": index }))
+            }
 
             Event::Retrying {
                 attempt,

--- a/crates/rdlp-api/src/events.rs
+++ b/crates/rdlp-api/src/events.rs
@@ -127,12 +127,22 @@ pub enum Event {
     PlaylistItemStarted {
         /// The download this event belongs to.
         id: DownloadId,
-        /// Zero-based index of the item within the playlist.
+        /// 1-based index of the item within the playlist.
         index: usize,
         /// Total number of items in the playlist.
         total: usize,
         /// URL of the playlist item.
         url: String,
+        /// Title of the playlist item (episode name).
+        title: String,
+    },
+
+    /// A download unit (episode or merge stream) has completed.
+    UnitCompleted {
+        /// The download this event belongs to.
+        id: DownloadId,
+        /// 1-based index of the completed unit.
+        index: usize,
     },
 
     /// A download attempt is being retried.
@@ -179,6 +189,7 @@ impl Event {
             | Self::Cancelled { id }
             | Self::PlaylistDetected { id, .. }
             | Self::PlaylistItemStarted { id, .. }
+            | Self::UnitCompleted { id, .. }
             | Self::Retrying { id, .. }
             | Self::Debug { id, .. } => *id,
         }
@@ -251,10 +262,12 @@ mod tests {
             },
             Event::PlaylistItemStarted {
                 id,
-                index: 0,
+                index: 1,
                 total: 10,
                 url: "https://example.com/1".into(),
+                title: "Episode 1".into(),
             },
+            Event::UnitCompleted { id, index: 1 },
             Event::Retrying {
                 id,
                 attempt: 2,

--- a/crates/rdlp-api/src/orchestrator/merge_download.rs
+++ b/crates/rdlp-api/src/orchestrator/merge_download.rs
@@ -6,6 +6,7 @@
 
 use super::Orchestrator;
 use super::errors::*;
+use crate::events::Event;
 use log::{debug, info, warn};
 use rdlp_types::Format;
 use std::path::{Path, PathBuf};
@@ -55,6 +56,13 @@ impl Orchestrator {
         );
 
         // Download video first
+        let _ = self.event_tx.try_send(Event::PlaylistItemStarted {
+            id: self.download_id,
+            index: 1,
+            total: 2,
+            url: video.url.clone(),
+            title: "Video".to_string(),
+        });
         let video_outcome = match self
             .download_with_cdn_fallback(video, &video_path, 0)
             .await
@@ -70,13 +78,28 @@ impl Orchestrator {
                 return Err(e);
             }
         };
+        let _ = self.event_tx.try_send(Event::UnitCompleted {
+            id: self.download_id,
+            index: 1,
+        });
 
         // Then download audio
+        let _ = self.event_tx.try_send(Event::PlaylistItemStarted {
+            id: self.download_id,
+            index: 2,
+            total: 2,
+            url: audio.url.clone(),
+            title: "Audio".to_string(),
+        });
         match self
             .download_with_cdn_fallback(audio, &audio_path, 0)
             .await
         {
             Ok(Some(audio_outcome)) => {
+                let _ = self.event_tx.try_send(Event::UnitCompleted {
+                    id: self.download_id,
+                    index: 2,
+                });
                 let is_hls = video_outcome.is_hls || audio_outcome.is_hls;
                 debug!(
                     video_hls = video_outcome.is_hls,

--- a/crates/rdlp-api/src/orchestrator/merge_download.rs
+++ b/crates/rdlp-api/src/orchestrator/merge_download.rs
@@ -1,8 +1,8 @@
-//! Parallel download coordination for merge (video + audio) downloads
+//! Sequential download coordination for merge (video + audio) downloads
 //!
-//! Downloads video-only and audio-only streams in parallel via `tokio::join!`,
-//! then passes both files to the postprocessor pipeline where `FFmpegMerger`
-//! handles the actual muxing.
+//! Downloads video-only and audio-only streams sequentially (video first,
+//! then audio) so progress updates don't interleave. Both files are then
+//! passed to the postprocessor pipeline where `MergeStage` handles muxing.
 
 use super::Orchestrator;
 use super::errors::*;
@@ -22,11 +22,11 @@ pub(super) struct MergeDownloadOutcome {
 }
 
 impl Orchestrator {
-    /// Download video and audio streams in parallel for merge.
+    /// Download video and audio streams sequentially for merge.
     ///
-    /// Uses `tokio::join!` to download both streams concurrently via the
-    /// existing `download_with_cdn_fallback()` method. The actual FFmpeg
-    /// merge is handled downstream by the `FFmpegMerger` postprocessor.
+    /// Downloads video first (progress 0-100%), then audio (progress resets
+    /// 0-100%). Sequential download prevents progress bar jitter from two
+    /// streams emitting interleaved progress updates to the same job ID.
     ///
     /// # Arguments
     /// * `video` - Video-only format to download
@@ -51,32 +51,31 @@ impl Orchestrator {
             audio_format = audio.format_id.as_str(),
             video_path:? = video_path.display(),
             audio_path:? = audio_path.display();
-            "Starting parallel merge download"
+            "Starting sequential merge download (video then audio)"
         );
 
-        // Download both streams in parallel
-        let (video_result, audio_result) = tokio::join!(
-            self.download_with_cdn_fallback(video, &video_path, 0),
-            self.download_with_cdn_fallback(audio, &audio_path, 0),
-        );
-
-        // Handle results — clean up on failure
-        let video_outcome = match video_result {
+        // Download video first
+        let video_outcome = match self
+            .download_with_cdn_fallback(video, &video_path, 0)
+            .await
+        {
             Ok(Some(outcome)) => outcome,
             Ok(None) => {
                 self.cleanup_merge_file(&video_path).await;
-                self.cleanup_merge_file(&audio_path).await;
                 return Ok(None);
             }
             Err(e) => {
                 warn!("Video download failed: {e}");
                 self.cleanup_merge_file(&video_path).await;
-                self.cleanup_merge_file(&audio_path).await;
                 return Err(e);
             }
         };
 
-        match audio_result {
+        // Then download audio
+        match self
+            .download_with_cdn_fallback(audio, &audio_path, 0)
+            .await
+        {
             Ok(Some(audio_outcome)) => {
                 let is_hls = video_outcome.is_hls || audio_outcome.is_hls;
                 debug!(

--- a/crates/rdlp-api/src/orchestrator/playlist/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/execution.rs
@@ -67,6 +67,13 @@ impl Orchestrator {
             async move {
                 debug!("{}", "\u{2500}".repeat(60));
                 info!(position, total, title:? = info_owned.title; "Downloading");
+                let _ = self.event_tx.try_send(crate::events::Event::PlaylistItemStarted {
+                    id: self.download_id,
+                    index: position,
+                    total,
+                    url: info_owned.webpage_url.clone(),
+                    title: info_owned.title.clone(),
+                });
                 let result = self
                     .download_from_info_to_dir(
                         &info_owned,
@@ -93,6 +100,10 @@ impl Orchestrator {
                                 Ok(Some(path)) => {
                                     debug!(position, total, path:? = path.display(); "Saved");
                                     downloaded.push(path);
+                                    let _ = self.event_tx.try_send(crate::events::Event::UnitCompleted {
+                                        id: self.download_id,
+                                        index: position,
+                                    });
                                     self.record_in_archive(
                                         &info_owned.extractor,
                                         &info_owned.id,

--- a/crates/rdlp-api/tests/api_integration.rs
+++ b/crates/rdlp-api/tests/api_integration.rs
@@ -38,6 +38,7 @@ fn event_tag(event: &Event) -> &'static str {
         Event::Cancelled { .. } => "cancelled",
         Event::PlaylistDetected { .. } => "playlist_detected",
         Event::PlaylistItemStarted { .. } => "playlist_item_started",
+        Event::UnitCompleted { .. } => "unit_completed",
         Event::Retrying { .. } => "retrying",
         Event::Debug { .. } => "debug",
     }

--- a/crates/rdlp-desktop/src-tauri/src/commands/formats/mod.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/formats/mod.rs
@@ -54,13 +54,56 @@ pub async fn get_formats(
         .await
         .map_err(AppError::from)?;
 
-    // 3. Take the first result (single video or first playlist entry)
-    let info = info_dicts
-        .into_iter()
-        .next()
-        .ok_or_else(|| AppError::ExtractionFailed {
-            message: "No metadata returned for URL".to_owned(),
-        })?;
+    // 3. Detect playlist vs single video
+    let is_playlist = info_dicts.len() > 1;
+
+    let (first_info, playlist) = if is_playlist {
+        // Build playlist metadata from all entries
+        let playlist_title = info_dicts
+            .first()
+            .and_then(|i| i.playlist_title.clone())
+            .unwrap_or_else(|| "Untitled Playlist".to_string());
+        let playlist_count = info_dicts.len();
+
+        let entries: Vec<PlaylistEntry> = info_dicts
+            .iter()
+            .enumerate()
+            .map(|(i, info)| PlaylistEntry {
+                index: info.playlist_index.unwrap_or(i + 1),
+                title: info.title.clone(),
+                url: info.webpage_url.clone(),
+                thumbnail_url: info.thumbnail.clone(),
+                duration: info.duration,
+                has_sub: true,  // TODO: detect from info if available
+                has_dub: false, // TODO: detect from info if available
+            })
+            .collect();
+
+        let playlist_info = PlaylistInfo {
+            title: playlist_title,
+            count: playlist_count,
+            entries,
+        };
+
+        let first = info_dicts
+            .into_iter()
+            .next()
+            .ok_or_else(|| AppError::ExtractionFailed {
+                message: "No metadata returned for URL".to_owned(),
+            })?;
+
+        (first, Some(playlist_info))
+    } else {
+        let first = info_dicts
+            .into_iter()
+            .next()
+            .ok_or_else(|| AppError::ExtractionFailed {
+                message: "No metadata returned for URL".to_owned(),
+            })?;
+        (first, None)
+    };
+
+    let info = first_info;
 
     // 4. Map formats
     let formats = info
@@ -107,6 +150,8 @@ pub async fn get_formats(
         subtitles,
         thumbnail_url: info.thumbnail,
         duration: info.duration,
+        is_playlist,
+        playlist,
     })
 }
 
@@ -298,6 +343,8 @@ mod tests {
             }],
             thumbnail_url: Some("https://example.com/thumb.jpg".to_owned()),
             duration: Some(180.5),
+            is_playlist: false,
+            playlist: None,
         };
 
         let json = serde_json::to_value(&resp).expect("serialization");
@@ -306,6 +353,8 @@ mod tests {
         assert_eq!(json["subtitles"].as_array().unwrap().len(), 1);
         assert_eq!(json["thumbnail_url"], "https://example.com/thumb.jpg");
         assert_eq!(json["duration"], 180.5);
+        assert_eq!(json["is_playlist"], false);
+        assert!(json["playlist"].is_null());
     }
 
     #[test]
@@ -316,6 +365,8 @@ mod tests {
             subtitles: vec![],
             thumbnail_url: None,
             duration: None,
+            is_playlist: false,
+            playlist: None,
         };
 
         let json = serde_json::to_value(&resp).expect("serialization");
@@ -324,6 +375,8 @@ mod tests {
         assert!(json["subtitles"].as_array().unwrap().is_empty());
         assert!(json["thumbnail_url"].is_null());
         assert!(json["duration"].is_null());
+        assert_eq!(json["is_playlist"], false);
+        assert!(json["playlist"].is_null());
     }
 
     fn make_format_data(

--- a/crates/rdlp-desktop/src-tauri/src/commands/formats/models.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/formats/models.rs
@@ -71,6 +71,42 @@ pub struct FormatListResponse {
     pub thumbnail_url: Option<String>,
     /// Video duration in seconds.
     pub duration: Option<f64>,
+    /// Whether this URL resolved to a playlist (multiple episodes).
+    pub is_playlist: bool,
+    /// Playlist metadata — `None` for single videos.
+    pub playlist: Option<PlaylistInfo>,
+}
+
+/// A single episode entry in a playlist.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlaylistEntry {
+    /// 1-based position in the playlist.
+    pub index: usize,
+    /// Episode title.
+    pub title: String,
+    /// Full URL with ?ep= parameter for direct single-episode download.
+    pub url: String,
+    /// Thumbnail URL for this episode.
+    pub thumbnail_url: Option<String>,
+    /// Duration in seconds.
+    pub duration: Option<f64>,
+    /// Whether SUB (subtitled) audio is available.
+    pub has_sub: bool,
+    /// Whether DUB (dubbed) audio is available.
+    pub has_dub: bool,
+}
+
+/// Playlist metadata returned when a URL resolves to multiple episodes.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlaylistInfo {
+    /// Playlist/series title.
+    pub title: String,
+    /// Total number of episodes.
+    pub count: usize,
+    /// Episode entries with metadata.
+    pub entries: Vec<PlaylistEntry>,
 }
 
 /// Format metadata sent from the frontend for expression validation.

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -95,6 +95,24 @@ pub struct PostProcessProgressPayload {
     pub(crate) progress: f64,
 }
 
+/// Payload for "unit-started" Tauri event.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UnitStartedPayload {
+    pub(crate) job_id: String,
+    pub(crate) unit_index: usize,
+    pub(crate) unit_total: usize,
+    pub(crate) unit_title: String,
+}
+
+/// Payload for "unit-completed" Tauri event.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UnitCompletedPayload {
+    pub(crate) job_id: String,
+    pub(crate) unit_index: usize,
+}
+
 /// Log message payload emitted as `"download-log"`.
 ///
 /// Used for informational events (metadata ready, post-processing
@@ -288,7 +306,42 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             }
         }
 
-        // All other events are not forwarded to the frontend.
+        Event::PlaylistDetected { total_items, .. } => {
+            let payload = DownloadLogPayload {
+                job_id: job_id.to_owned(),
+                level: LogLevel::Info,
+                message: format!("Playlist detected: {total_items} items"),
+            };
+            if let Err(e) = app.emit("download-log", &payload) {
+                debug!("Failed to emit download-log (playlist-detected) for job {job_id}: {e}");
+            }
+        }
+
+        Event::PlaylistItemStarted {
+            index, total, title, ..
+        } => {
+            let payload = UnitStartedPayload {
+                job_id: job_id.to_owned(),
+                unit_index: *index,
+                unit_total: *total,
+                unit_title: title.clone(),
+            };
+            if let Err(e) = app.emit("unit-started", &payload) {
+                debug!("Failed to emit unit-started for job {job_id}: {e}");
+            }
+        }
+
+        Event::UnitCompleted { index, .. } => {
+            let payload = UnitCompletedPayload {
+                job_id: job_id.to_owned(),
+                unit_index: *index,
+            };
+            if let Err(e) = app.emit("unit-completed", &payload) {
+                debug!("Failed to emit unit-completed for job {job_id}: {e}");
+            }
+        }
+
+        // Remaining unhandled events (SubtitlesFound, SubtitlesMissing, Cancelled, Started, Retrying from playlist)
         _ => {}
     }
 }

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -15,6 +15,8 @@ import {
     onDownloadLog,
     onFormatSelected,
     onPostProcessProgress,
+    onUnitStarted,
+    onUnitCompleted,
 } from "../lib/tauri";
 import { queryKeys } from "../query/queryKeys";
 import { appendLog } from "../components/LogViewer";
@@ -178,6 +180,31 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                             : job,
                     ),
             );
+        }),
+    );
+
+    unlisteners.push(
+        onUnitStarted((p) => {
+            if (!mounted) return;
+            qc.setQueryData<DownloadJob[]>(
+                queryKeys.downloads.list(),
+                (old) =>
+                    old?.map((job) =>
+                        job.id === p.jobId
+                            ? {
+                                  ...job,
+                                  statusMessage: `Ep ${p.unitIndex}/${p.unitTotal} — ${p.unitTitle}`,
+                              }
+                            : job,
+                    ),
+            );
+        }),
+    );
+
+    unlisteners.push(
+        onUnitCompleted((_p) => {
+            // Future: update aggregate playlist progress
+            // For now, the next unit-started or download-complete will update status
         }),
     );
 

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -20,6 +20,8 @@ import type {
     SearchFilterDescriptor,
     SearchPageResponse,
     SearchSiteInfo,
+    UnitCompletedPayload,
+    UnitStartedPayload,
 } from "../types";
 
 // ========== Search ==========
@@ -150,6 +152,20 @@ export function onPostProcessProgress(
     return listen<PostProcessProgressPayload>("postprocess-progress", (event) =>
         callback(event.payload),
     );
+}
+
+/** Subscribe to unit-started events (playlist episode or merge stream start). Returns an unlisten function. */
+export function onUnitStarted(
+    handler: (payload: UnitStartedPayload) => void,
+): Promise<UnlistenFn> {
+    return listen<UnitStartedPayload>("unit-started", (e) => handler(e.payload));
+}
+
+/** Subscribe to unit-completed events (playlist episode or merge stream done). Returns an unlisten function. */
+export function onUnitCompleted(
+    handler: (payload: UnitCompletedPayload) => void,
+): Promise<UnlistenFn> {
+    return listen<UnitCompletedPayload>("unit-completed", (e) => handler(e.payload));
 }
 
 /** Validate a format expression and return matching format IDs. */

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -92,6 +92,26 @@ export interface FormatListResponse {
     subtitles: SubtitleInfo[];
     thumbnail_url: string | null;
     duration: number | null;
+    is_playlist: boolean;
+    playlist: PlaylistInfo | null;
+}
+
+/** A single episode entry in a playlist (camelCase — Rust uses #[serde(rename_all = "camelCase")]). */
+export interface PlaylistEntry {
+    index: number;
+    title: string;
+    url: string;
+    thumbnailUrl: string | null;
+    duration: number | null;
+    hasSub: boolean;
+    hasDub: boolean;
+}
+
+/** Playlist metadata returned when a URL resolves to multiple episodes (camelCase). */
+export interface PlaylistInfo {
+    title: string;
+    count: number;
+    entries: PlaylistEntry[];
 }
 
 // ========== Video Codec Types (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -269,6 +269,20 @@ export interface PostProcessProgressPayload {
     progress: number; // 0.0–1.0
 }
 
+/** Unit-started payload emitted as "unit-started" (playlist episode or merge stream start). */
+export interface UnitStartedPayload {
+    jobId: string;
+    unitIndex: number;
+    unitTotal: number;
+    unitTitle: string;
+}
+
+/** Unit-completed payload emitted as "unit-completed" (playlist episode or merge stream done). */
+export interface UnitCompletedPayload {
+    jobId: string;
+    unitIndex: number;
+}
+
 // ========== Settings Types ==========
 
 /**


### PR DESCRIPTION
## Summary
Infrastructure for per-episode and per-stream progress tracking. No user-visible changes — backend events and frontend listeners that activate when SP3-5 ship.

- **PlaylistItemStarted** gains `title: String` field (episode name)
- **UnitCompleted** new event variant (signals episode/stream completion)
- **Tauri emitter** forwards `PlaylistDetected`, `PlaylistItemStarted` → `unit-started`, `UnitCompleted` → `unit-completed` (previously silently dropped)
- **Frontend** registers listeners, sets `statusMessage: "Ep 3/46 — Episode Title"` for playlist downloads
- **Merge download** sequential (prevents progress interleaving) with unit events for Video/Audio phases

Part of playlist support (#150). SP1 of 5.

## Test plan
- [x] `cargo test` — 1,636+ passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Backward compatible — existing single-video downloads unchanged