### PR TITLE
feat(desktop): episode list UI with multi-select for playlists (SP3)

### DIFF
--- a/crates/rdlp-desktop/src/stores/uiStore.ts
+++ b/crates/rdlp-desktop/src/stores/uiStore.ts
@@ -12,6 +12,8 @@ export interface UiState {
     selectedJobId: string | null;
     commandPaletteOpen: boolean;
     analyzeUrl: string | null;
+    /** When viewing a single episode from a playlist, stores the playlist URL for back navigation. */
+    playlistBackUrl: string | null;
 }
 
 const initialState: UiState = {
@@ -22,6 +24,7 @@ const initialState: UiState = {
     selectedJobId: null,
     commandPaletteOpen: false,
     analyzeUrl: null,
+    playlistBackUrl: null,
 };
 
 export const uiStore = new Store<UiState>(initialState);
@@ -54,5 +57,10 @@ export function setCommandPaletteOpen(open: boolean): void {
 }
 
 export function setAnalyzeUrl(url: string | null): void {
-    uiStore.setState((prev) => ({ ...prev, analyzeUrl: url }));
+    uiStore.setState((prev) => ({
+        ...prev,
+        analyzeUrl: url,
+        // Clear playlist back URL when navigating to a non-playlist context
+        playlistBackUrl: url === null ? null : prev.playlistBackUrl,
+    }));
 }

--- a/crates/rdlp-desktop/src/views/analyze/AnalyzeView.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/AnalyzeView.tsx
@@ -1,5 +1,6 @@
 // AnalyzeView: media analysis workspace.
 // States: empty (dropzone), loading (skeleton), loaded (formats table), search results, error.
+// Playlist mode: shows EpisodeList instead of PresetToolbar + FormatsTable.
 
 import { useMemo } from "react";
 import { useStore } from "@tanstack/react-store";
@@ -12,6 +13,7 @@ import { EmptyState } from "./EmptyState";
 import { MediaHero } from "./MediaHero";
 import { FormatsTable } from "./FormatsTable";
 import { PresetToolbar } from "./PresetToolbar";
+import { EpisodeList } from "./EpisodeList";
 import { SearchResults } from "./SearchResults";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle } from "lucide-react";
@@ -20,14 +22,15 @@ export function AnalyzeView() {
     const analyzeUrl = useStore(uiStore, (s) => s.analyzeUrl);
     const searchQuery = useStore(searchStore, (s) => s.query);
     const searchSite = useStore(searchStore, (s) => s.site);
+    const playlistBackUrl = useStore(uiStore, (s) => s.playlistBackUrl);
 
     const isSearchMode = useMemo(
         () => searchQuery.trim().length > 0 && !analyzeUrl,
         [searchQuery, analyzeUrl],
     );
     const cameFromSearch = useMemo(
-        () => !!analyzeUrl && searchQuery.trim().length > 0,
-        [analyzeUrl, searchQuery],
+        () => !!analyzeUrl && searchQuery.trim().length > 0 && !playlistBackUrl,
+        [analyzeUrl, searchQuery, playlistBackUrl],
     );
 
     const {
@@ -78,9 +81,11 @@ export function AnalyzeView() {
         return <EmptyState />;
     }
 
+    const isPlaylist = formats.is_playlist && formats.playlist !== null;
+
     return (
         <div className="flex flex-col h-full overflow-hidden">
-            {/* Back to search results */}
+            {/* Back to search results (only when not in episode drill-down) */}
             {cameFromSearch && (
                 <button
                     onClick={() => setAnalyzeUrl(null)}
@@ -91,16 +96,41 @@ export function AnalyzeView() {
                 </button>
             )}
 
+            {/* Back to episode list (when viewing a single episode from a playlist) */}
+            {playlistBackUrl && (
+                <button
+                    onClick={() => {
+                        uiStore.setState((prev) => ({
+                            ...prev,
+                            playlistBackUrl: null,
+                        }));
+                        setAnalyzeUrl(playlistBackUrl);
+                    }}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[#4a9eff] hover:text-[#3a8ef0] transition-colors border-b border-[#1a1a2e] shrink-0 bg-transparent cursor-pointer"
+                >
+                    <ArrowLeft className="w-3 h-3" />
+                    Back to episode list
+                </button>
+            )}
+
             {/* Media hero card */}
             <MediaHero data={formats} url={analyzeUrl ?? ""} />
 
-            {/* Preset toolbar */}
-            <PresetToolbar formats={formats.formats} />
-
-            {/* Formats table */}
-            <div className="flex-1 overflow-hidden">
-                <FormatsTable formats={formats.formats} />
-            </div>
+            {/* Playlist mode: episode list */}
+            {isPlaylist ? (
+                <EpisodeList
+                    episodes={formats.playlist!.entries}
+                    playlistUrl={analyzeUrl ?? ""}
+                />
+            ) : (
+                <>
+                    {/* Single video mode: preset toolbar + formats table */}
+                    <PresetToolbar formats={formats.formats} />
+                    <div className="flex-1 overflow-hidden">
+                        <FormatsTable formats={formats.formats} />
+                    </div>
+                </>
+            )}
         </div>
     );
 }

--- a/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
@@ -1,0 +1,232 @@
+// EpisodeList: virtualized multi-select episode list for playlist URLs.
+// Uses Jolly GridList for selection + keyboard nav, TanStack Virtual for DOM windowing.
+
+import { useRef, useMemo, useCallback } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { type Selection } from "react-aria-components";
+import { useState } from "react";
+import { Download } from "lucide-react";
+import { GridList, GridListItem } from "@/components/ui/grid-list";
+import { Toolbar } from "@/components/ui/toolbar";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Thumbnail } from "@/components/Thumbnail";
+import { setAnalyzeUrl } from "@/stores/uiStore";
+import { uiStore } from "@/stores/uiStore";
+import type { PlaylistEntry } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface EpisodeListProps {
+    episodes: PlaylistEntry[];
+    playlistUrl: string;
+}
+
+function formatDuration(seconds: number): string {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    if (h > 0) {
+        return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+    }
+    return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+const ROW_HEIGHT = 48;
+const OVERSCAN = 10;
+
+export function EpisodeList({ episodes, playlistUrl }: EpisodeListProps) {
+    const parentRef = useRef<HTMLDivElement>(null);
+    const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set<string>());
+
+    const selectedCount = useMemo(() => {
+        if (selectedKeys === "all") return episodes.length;
+        return selectedKeys.size;
+    }, [selectedKeys, episodes.length]);
+
+    const isAllSelected = selectedCount === episodes.length && episodes.length > 0;
+    const isIndeterminate = selectedCount > 0 && selectedCount < episodes.length;
+
+    const virtualizer = useVirtualizer({
+        count: episodes.length,
+        getScrollElement: () => parentRef.current,
+        estimateSize: () => ROW_HEIGHT,
+        overscan: OVERSCAN,
+    });
+
+    const handleSelectAll = useCallback(
+        (isSelected: boolean) => {
+            if (isSelected) {
+                setSelectedKeys("all");
+            } else {
+                setSelectedKeys(new Set<string>());
+            }
+        },
+        [],
+    );
+
+    const handleRowAction = useCallback(
+        (key: React.Key) => {
+            const ep = episodes.find((e) => e.url === String(key));
+            if (!ep) return;
+            // Store current playlist URL for back navigation
+            uiStore.setState((prev) => ({
+                ...prev,
+                playlistBackUrl: playlistUrl,
+            }));
+            setAnalyzeUrl(ep.url);
+        },
+        [episodes, playlistUrl],
+    );
+
+    const handleDownloadSelected = useCallback(() => {
+        // Gather selected episode URLs for batch download (wired in SP4)
+        const _selected =
+            selectedKeys === "all"
+                ? episodes
+                : episodes.filter((ep) => (selectedKeys as Set<string>).has(ep.url));
+        // TODO(SP4): invoke start_download for each selected episode with PlaylistContext
+        void _selected;
+    }, [selectedKeys, episodes]);
+
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            {/* Selection toolbar */}
+            <div className="flex items-center gap-3 px-3 py-1.5 border-b border-[#1a1a2e] bg-[var(--surface-raised)] shrink-0">
+                <Toolbar aria-label="Episode selection" className="flex items-center gap-3 flex-1">
+                    <Checkbox
+                        isSelected={isAllSelected}
+                        isIndeterminate={isIndeterminate}
+                        onChange={handleSelectAll}
+                        aria-label={isAllSelected ? "Deselect all episodes" : "Select all episodes"}
+                        className="text-[12px]"
+                    >
+                        <span className="text-[11px] text-[#888888]">
+                            {isAllSelected ? "Deselect All" : "Select All"}
+                        </span>
+                    </Checkbox>
+
+                    <span
+                        className="text-[11px] text-[#666666] tabular-nums"
+                        aria-live="polite"
+                    >
+                        {selectedCount > 0
+                            ? `${selectedCount} of ${episodes.length} selected`
+                            : `${episodes.length} episodes`}
+                    </span>
+
+                    <div className="flex-1" />
+
+                    <button
+                        onClick={handleDownloadSelected}
+                        disabled={selectedCount === 0}
+                        className={cn(
+                            "flex items-center gap-1.5 px-3 py-1 rounded-[6px] text-[12px] font-medium transition-colors cursor-pointer",
+                            selectedCount > 0
+                                ? "bg-[#4a9eff] text-white hover:bg-[#3a8ef0]"
+                                : "bg-[#1a1a2e] text-[#444444] cursor-not-allowed",
+                        )}
+                    >
+                        <Download className="w-3 h-3" />
+                        Download Selected
+                    </button>
+                </Toolbar>
+            </div>
+
+            <Separator />
+
+            {/* Virtualized episode list */}
+            <div ref={parentRef} className="flex-1 overflow-y-auto">
+                <GridList
+                    aria-label="Episodes"
+                    selectionMode="multiple"
+                    selectionBehavior="toggle"
+                    selectedKeys={selectedKeys}
+                    onSelectionChange={setSelectedKeys}
+                    onAction={handleRowAction}
+                    className="p-0 border-0 rounded-none shadow-none bg-transparent gap-0"
+                    style={{
+                        height: virtualizer.getTotalSize(),
+                        position: "relative",
+                    }}
+                >
+                    {virtualizer.getVirtualItems().map((vItem) => {
+                        const ep = episodes[vItem.index];
+                        if (!ep) return null;
+                        return (
+                            <GridListItem
+                                key={ep.url}
+                                id={ep.url}
+                                textValue={ep.title}
+                                className={cn(
+                                    "flex items-center gap-3 px-3 cursor-pointer rounded-none border-b border-[#1a1a2e]/50",
+                                    "data-[hovered]:bg-[#1a1a2e]/60",
+                                    "data-[selected]:bg-[#1a2a4a]/40",
+                                    "data-[focus-visible]:ring-1 data-[focus-visible]:ring-[#4a9eff] data-[focus-visible]:ring-inset",
+                                )}
+                                style={{
+                                    position: "absolute",
+                                    top: vItem.start,
+                                    left: 0,
+                                    width: "100%",
+                                    height: ROW_HEIGHT,
+                                }}
+                            >
+                                {/* Checkbox auto-rendered by GridListItem for selectionMode="multiple" + selectionBehavior="toggle" */}
+
+                                {/* Index */}
+                                <span className="w-8 text-right text-[12px] text-[#888888] tabular-nums shrink-0">
+                                    {ep.index}
+                                </span>
+
+                                {/* Thumbnail */}
+                                <div className="w-16 h-9 shrink-0 rounded-[4px] overflow-hidden bg-[#0e0e1e]">
+                                    <Thumbnail
+                                        src={ep.thumbnailUrl}
+                                        alt={ep.title}
+                                        className="w-full h-full object-cover"
+                                        decoding="async"
+                                    />
+                                </div>
+
+                                {/* Title */}
+                                <span
+                                    className="flex-1 min-w-0 text-[13px] text-[#F8FAFC] truncate"
+                                >
+                                    {ep.title}
+                                </span>
+
+                                {/* Duration */}
+                                {ep.duration !== null && (
+                                    <span className="text-[11px] text-[#888888] tabular-nums shrink-0">
+                                        {formatDuration(ep.duration)}
+                                    </span>
+                                )}
+
+                                {/* SUB/DUB badges */}
+                                <div className="flex items-center gap-1 shrink-0">
+                                    {ep.hasSub && (
+                                        <Badge
+                                            variant="outline"
+                                            className="text-[9px] px-1.5 py-0 h-4 uppercase tracking-wider"
+                                        >
+                                            SUB
+                                        </Badge>
+                                    )}
+                                    {ep.hasDub && (
+                                        <Badge
+                                            variant="outline"
+                                            className="text-[9px] px-1.5 py-0 h-4 uppercase tracking-wider"
+                                        >
+                                            DUB
+                                        </Badge>
+                                    )}
+                                </div>
+                            </GridListItem>
+                        );
+                    })}
+                </GridList>
+            </div>
+        </div>
+    );
+}

--- a/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
@@ -9,8 +9,7 @@ import { Download } from "lucide-react";
 import { GridList, GridListItem } from "@/components/ui/grid-list";
 import { Toolbar } from "@/components/ui/toolbar";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
+import { StreamBadge } from "@/components/StreamBadge";
 import { Thumbnail } from "@/components/Thumbnail";
 import { setAnalyzeUrl } from "@/stores/uiStore";
 import { uiStore } from "@/stores/uiStore";
@@ -106,16 +105,13 @@ export function EpisodeList({ episodes, playlistUrl }: EpisodeListProps) {
                         </span>
                     </Checkbox>
 
-                    <span
-                        className="text-[11px] text-[#666666] tabular-nums"
-                        aria-live="polite"
-                    >
+                    <div className="flex-1" />
+
+                    <span className="text-[11px] text-[#666666] tabular-nums" aria-live="polite">
                         {selectedCount > 0
                             ? `${selectedCount} of ${episodes.length} selected`
                             : `${episodes.length} episodes`}
                     </span>
-
-                    <div className="flex-1" />
 
                     <button
                         onClick={handleDownloadSelected}
@@ -124,7 +120,7 @@ export function EpisodeList({ episodes, playlistUrl }: EpisodeListProps) {
                             "flex items-center gap-1.5 px-3 py-1 rounded-[6px] text-[12px] font-medium transition-colors cursor-pointer",
                             selectedCount > 0
                                 ? "bg-[#4a9eff] text-white hover:bg-[#3a8ef0]"
-                                : "bg-[#1a1a2e] text-[#444444] cursor-not-allowed",
+                                : "bg-[#1a1a2e] text-[#444444] cursor-not-allowed pointer-events-none",
                         )}
                     >
                         <Download className="w-3 h-3" />
@@ -132,8 +128,6 @@ export function EpisodeList({ episodes, playlistUrl }: EpisodeListProps) {
                     </button>
                 </Toolbar>
             </div>
-
-            <Separator />
 
             {/* Virtualized episode list */}
             <div ref={parentRef} className="flex-1 overflow-y-auto">
@@ -206,20 +200,10 @@ export function EpisodeList({ episodes, playlistUrl }: EpisodeListProps) {
                                 {/* SUB/DUB badges */}
                                 <div className="flex items-center gap-1 shrink-0">
                                     {ep.hasSub && (
-                                        <Badge
-                                            variant="outline"
-                                            className="text-[9px] px-1.5 py-0 h-4 uppercase tracking-wider"
-                                        >
-                                            SUB
-                                        </Badge>
+                                        <StreamBadge value="SUB" category="feature" />
                                     )}
                                     {ep.hasDub && (
-                                        <Badge
-                                            variant="outline"
-                                            className="text-[9px] px-1.5 py-0 h-4 uppercase tracking-wider"
-                                        >
-                                            DUB
-                                        </Badge>
+                                        <StreamBadge value="DUB" category="feature" />
                                     )}
                                 </div>
                             </GridListItem>

--- a/crates/rdlp-desktop/src/views/analyze/MediaHero.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/MediaHero.tsx
@@ -1,4 +1,5 @@
 // MediaHero: compact card showing thumbnail, title, metadata, and stream badges.
+// Adapts display for playlist mode: shows playlist title + episode count.
 
 import { Thumbnail } from "@/components/Thumbnail";
 import { StreamBadge } from "@/components/StreamBadge";
@@ -41,13 +42,15 @@ export function MediaHero({ data, url }: MediaHeroProps) {
         }
     })();
 
+    const isPlaylist = data.is_playlist && data.playlist !== null;
+
     return (
         <div className="flex items-start gap-3 p-3 border-b border-[#1a1a2e] bg-[var(--surface-raised)] shrink-0">
             {/* Thumbnail */}
             <div className="w-20 h-[52px] shrink-0 rounded-[4px] overflow-hidden bg-[#0e0e1e]">
                 <Thumbnail
                     src={data.thumbnail_url}
-                    alt={data.title}
+                    alt={isPlaylist ? (data.playlist?.title ?? data.title) : data.title}
                     className="w-full h-full object-cover"
                 />
             </div>
@@ -63,30 +66,44 @@ export function MediaHero({ data, url }: MediaHeroProps) {
                         overflow: "hidden",
                     }}
                 >
-                    {data.title || "Untitled"}
+                    {isPlaylist
+                        ? (data.playlist?.title ?? "Untitled Playlist")
+                        : (data.title || "Untitled")}
                 </h1>
 
                 <div className="flex items-center gap-2 flex-wrap mt-0.5">
-                    <span className="text-[11px] text-[#666666]">{hostname}</span>
-                    {data.duration !== null && (
+                    {isPlaylist ? (
                         <>
-                            <span className="text-[#444444]">·</span>
                             <span className="text-[11px] text-[#666666]">
-                                {formatDuration(data.duration)}
+                                {data.playlist!.count} {data.playlist!.count === 1 ? "episode" : "episodes"}
                             </span>
-                        </>
-                    )}
-                    {bestFormat?.height && (
-                        <>
                             <span className="text-[#444444]">·</span>
-                            <StreamBadge value={`${bestFormat.height}p`} category="resolution" />
+                            <span className="text-[11px] text-[#666666]">{hostname}</span>
                         </>
-                    )}
-                    {bestFormat?.protocol && (
-                        <StreamBadge value={bestFormat.protocol.toUpperCase()} category="protocol" />
-                    )}
-                    {bestFormat?.vcodec && bestFormat.vcodec !== "none" && (
-                        <StreamBadge value={bestFormat.vcodec} category="codec" />
+                    ) : (
+                        <>
+                            <span className="text-[11px] text-[#666666]">{hostname}</span>
+                            {data.duration !== null && (
+                                <>
+                                    <span className="text-[#444444]">·</span>
+                                    <span className="text-[11px] text-[#666666]">
+                                        {formatDuration(data.duration)}
+                                    </span>
+                                </>
+                            )}
+                            {bestFormat?.height && (
+                                <>
+                                    <span className="text-[#444444]">·</span>
+                                    <StreamBadge value={`${bestFormat.height}p`} category="resolution" />
+                                </>
+                            )}
+                            {bestFormat?.protocol && (
+                                <StreamBadge value={bestFormat.protocol.toUpperCase()} category="protocol" />
+                            )}
+                            {bestFormat?.vcodec && bestFormat.vcodec !== "none" && (
+                                <StreamBadge value={bestFormat.vcodec} category="codec" />
+                            )}
+                        </>
                     )}
                 </div>
             </div>

--- a/crates/rdlp-desktop/src/views/analyze/MediaHero.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/MediaHero.tsx
@@ -74,7 +74,7 @@ export function MediaHero({ data, url }: MediaHeroProps) {
                 <div className="flex items-center gap-2 flex-wrap mt-0.5">
                     {isPlaylist ? (
                         <>
-                            <span className="text-[11px] text-[#666666]">
+                            <span className="text-[11px] text-[#aaaaaa]">
                                 {data.playlist!.count} {data.playlist!.count === 1 ? "episode" : "episodes"}
                             </span>
                             <span className="text-[#444444]">·</span>


### PR DESCRIPTION
## Summary
When a playlist URL is analyzed, the Analyze view now shows an episode list instead of a formats table. Users can select episodes and drill down into individual episode formats.

- **EpisodeList component** — Jolly GridList with `selectionMode="multiple"`, TanStack Virtual for 50+ episodes, selection toolbar (Select All with indeterminate state, count, Download Selected button)
- **AnalyzeView conditional** — `isPlaylist` gates between EpisodeList and FormatsTable
- **MediaHero playlist mode** — shows playlist title + episode count instead of format badges
- **Episode drill-down** — clicking a row loads that episode's formats via `get_formats` with `?ep=` URL, with back navigation

Part of playlist support (#150). SP3 of 5. Depends on SP1+SP2 (merged in PR #151).

## Components used
- Jolly UI: GridList, Checkbox (indeterminate), Toolbar, Badge
- TanStack Virtual: `useVirtualizer` with 48px row height
- Existing: Thumbnail proxy component, StreamBadge

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] UX review — signed off (2 findings fixed: StreamBadge for badges, removed double border)
- [x] Backward compatible — single-video URLs render as before