### PR TITLE
chore: restructure error variants with url context

### DIFF
--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -155,6 +155,7 @@ impl RdlpClient {
                         .to_string();
                     error!("Cookie loading failed (explicit request): {e}");
                     let api_err = RdlpApiError::IoError { message: safe_msg };
+                    // intentional: receiver may have disconnected
                     let _ = tx
                         .send(Event::Failed {
                             id,
@@ -163,6 +164,7 @@ impl RdlpClient {
                         .await;
                     return Err(api_err);
                 }
+                // intentional: receiver may have disconnected
                 let _ = tx
                     .send(Event::Warning {
                         id,
@@ -190,6 +192,7 @@ impl RdlpClient {
                         MAX_REEXTRACT_RETRIES + 1,
                         reason,
                     );
+                    // intentional: receiver may have disconnected
                     let _ = tx
                         .send(Event::Retrying {
                             id,
@@ -216,6 +219,7 @@ impl RdlpClient {
                             info: InfoDict::new("", "", "", &url),
                             stats: DownloadStats::new(0, Duration::ZERO, 0),
                         };
+                        // intentional: receiver may have disconnected
                         let _ = tx
                             .send(Event::Completed {
                                 id,
@@ -235,6 +239,7 @@ impl RdlpClient {
                             continue;
                         }
                         // Final failure — emit and return
+                        // intentional: receiver may have disconnected
                         let _ = tx
                             .send(Event::Failed {
                                 id,
@@ -251,6 +256,7 @@ impl RdlpClient {
                 message: "All re-extraction attempts failed".into(),
                 status: None,
             });
+            // intentional: receiver may have disconnected
             let _ = tx
                 .send(Event::Failed {
                     id,
@@ -505,6 +511,7 @@ impl RdlpClient {
                 "local",
                 format!("file://{}", path.display()),
             );
+            // intentional: receiver may have disconnected
             let _ = tx
                 .send(Event::PostProcessing {
                     id,
@@ -516,6 +523,7 @@ impl RdlpClient {
                 let err = RdlpApiError::IoError {
                     message: format!("File not found: {}", path.display()),
                 };
+                // intentional: receiver may have disconnected
                 let _ = tx
                     .send(Event::Failed {
                         id,
@@ -536,6 +544,7 @@ impl RdlpClient {
                         info,
                         stats: rdlp_core::DownloadStats::new(0, std::time::Duration::ZERO, 0),
                     };
+                    // intentional: receiver may have disconnected
                     let _ = tx
                         .send(Event::Completed {
                             id,
@@ -546,6 +555,7 @@ impl RdlpClient {
                 }
                 Err(e) => {
                     let err = RdlpApiError::from(e);
+                    // intentional: receiver may have disconnected
                     let _ = tx
                         .send(Event::Failed {
                             id,

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -161,22 +161,22 @@ impl From<RdlpError> for RdlpApiError {
     /// of relying on this `From` impl.
     fn from(err: RdlpError) -> Self {
         match err {
-            RdlpError::Network(msg) => Self::NetworkError {
-                message: msg,
+            RdlpError::Network { message, .. } => Self::NetworkError {
+                message,
                 status: None,
             },
             RdlpError::Http { status, reason } => Self::NetworkError {
                 message: reason,
                 status: Some(status),
             },
-            RdlpError::Extraction(msg) => Self::ExtractError {
-                message: msg,
-                source_url: String::new(),
+            RdlpError::Extraction { message, url } => Self::ExtractError {
+                message,
+                source_url: url.unwrap_or_default(),
             },
             RdlpError::NoExtractor(url) => Self::UnsupportedUrl { url },
             RdlpError::InvalidUrl(msg) => Self::InvalidInput { message: msg },
-            RdlpError::Download(msg) => Self::NetworkError {
-                message: msg,
+            RdlpError::Download { message, .. } => Self::NetworkError {
+                message,
                 status: None,
             },
             RdlpError::PostProcess(msg) => Self::FfmpegError { message: msg },
@@ -455,6 +455,91 @@ mod tests {
                 assert!(message.contains("file missing"));
             }
             other => panic!("Expected IoError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extraction_url_propagates_to_api_error() {
+        let err: RdlpApiError = RdlpError::Extraction {
+            message: "no formats".into(),
+            url: Some("https://example.com/video".into()),
+        }
+        .into();
+        match err {
+            RdlpApiError::ExtractError { source_url, .. } => {
+                assert_eq!(source_url, "https://example.com/video");
+            }
+            other => panic!("Expected ExtractError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extraction_none_url_becomes_empty() {
+        let err: RdlpApiError = RdlpError::Extraction {
+            message: "parse failed".into(),
+            url: None,
+        }
+        .into();
+        match err {
+            RdlpApiError::ExtractError { source_url, .. } => {
+                assert!(source_url.is_empty());
+            }
+            other => panic!("Expected ExtractError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_network_url_propagates_to_api_error() {
+        let err: RdlpApiError = RdlpError::Network {
+            message: "timeout".into(),
+            url: Some("https://cdn.example.com".into()),
+        }
+        .into();
+        match err {
+            RdlpApiError::NetworkError { message, .. } => {
+                assert!(message.contains("timeout"));
+            }
+            other => panic!("Expected NetworkError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_download_url_propagates_to_api_error() {
+        let err: RdlpApiError = RdlpError::Download {
+            message: "chunk failed".into(),
+            url: Some("https://cdn.example.com/seg.ts".into()),
+        }
+        .into();
+        match err {
+            RdlpApiError::NetworkError { message, .. } => {
+                assert!(message.contains("chunk failed"));
+            }
+            other => panic!("Expected NetworkError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_all_rdlp_error_variants_convert() {
+        let variants: Vec<RdlpError> = vec![
+            RdlpError::Network { message: "a".into(), url: None },
+            RdlpError::Http { status: 500, reason: "b".into() },
+            RdlpError::Extraction { message: "c".into(), url: None },
+            RdlpError::NoExtractor("d".into()),
+            RdlpError::InvalidUrl("e".into()),
+            RdlpError::Download { message: "f".into(), url: None },
+            RdlpError::PostProcess("g".into()),
+            RdlpError::FFmpeg("h".into()),
+            RdlpError::JavaScript("i".into()),
+            RdlpError::Cookie("j".into()),
+            RdlpError::Plugin("k".into()),
+            RdlpError::FormatSelection("l".into()),
+            RdlpError::Config("m".into()),
+            RdlpError::Io(std::io::Error::new(std::io::ErrorKind::Other, "n")),
+            RdlpError::Unsupported("o".into()),
+            RdlpError::Other("p".into()),
+        ];
+        for v in variants {
+            let _api: RdlpApiError = v.into();
         }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -62,9 +62,10 @@ impl Orchestrator {
 
         // SSRF protection: validate primary URL before passing to downloader
         validate_url_security(&format.url).map_err(|e| {
-            OrchestratorError::DownloadFailed(RdlpError::Network(format!(
-                "Security validation failed for format URL: {e}"
-            )))
+            OrchestratorError::DownloadFailed(RdlpError::Network {
+                message: format!("Security validation failed for format URL: {e}"),
+                url: Some(format.url.clone()),
+            })
         })?;
 
         // Find downloader (with extra HTTP headers if the format specifies them)
@@ -90,9 +91,10 @@ impl Orchestrator {
                 // SSRF protection: validate each fallback URL before use
                 if let Err(e) = validate_url_security(download_url) {
                     warn!(fallback = i; "Skipping fallback URL that failed security validation: {e}");
-                    last_err = Some(OrchestratorError::DownloadFailed(RdlpError::Network(
-                        format!("Security validation failed for fallback URL: {e}"),
-                    )));
+                    last_err = Some(OrchestratorError::DownloadFailed(RdlpError::Network {
+                        message: format!("Security validation failed for fallback URL: {e}"),
+                        url: Some(download_url.to_string()),
+                    }));
                     continue;
                 }
                 warn!(
@@ -179,9 +181,10 @@ impl Orchestrator {
 
         // SSRF protection: validate URL before passing to downloader
         validate_url_security(&format.url).map_err(|e| {
-            OrchestratorError::DownloadFailed(RdlpError::Network(format!(
-                "Security validation failed for format URL: {e}"
-            )))
+            OrchestratorError::DownloadFailed(RdlpError::Network {
+                message: format!("Security validation failed for format URL: {e}"),
+                url: Some(format.url.clone()),
+            })
         })?;
 
         let downloader = self
@@ -222,12 +225,13 @@ impl Orchestrator {
                 .unwrap_or_default()
                 .as_secs();
             if now >= expires {
-                return Err(OrchestratorError::DownloadFailed(RdlpError::Network(
-                    format!(
+                return Err(OrchestratorError::DownloadFailed(RdlpError::Network {
+                    message: format!(
                         "CDN token expired {}s ago — re-run the command to get a fresh URL",
                         now - expires
                     ),
-                )));
+                    url: Some(url.to_string()),
+                }));
             } else if expires - now < 60 {
                 warn!("CDN token expires in less than 60 seconds — download may fail");
             }

--- a/crates/rdlp-api/src/orchestrator/errors.rs
+++ b/crates/rdlp-api/src/orchestrator/errors.rs
@@ -97,8 +97,8 @@ pub enum OrchestratorError {
 /// resolved by calling `extract_lazy()` again for a fresh CDN assignment.
 pub(super) fn is_reextractable_error(err: &OrchestratorError) -> bool {
     match err {
-        OrchestratorError::DownloadFailed(RdlpError::Extraction(msg)) => {
-            msg.contains("invalid M3U8")
+        OrchestratorError::DownloadFailed(RdlpError::Extraction { message, .. }) => {
+            message.contains("invalid M3U8")
         }
         OrchestratorError::DownloadFailed(RdlpError::Http {
             status: 403 | 503, ..

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -281,15 +281,17 @@ impl Orchestrator {
         }
 
         let (download_files, is_hls, merge_formats) = download_result.ok_or_else(|| {
-            OrchestratorError::DownloadFailed(rdlp_core::RdlpError::Extraction(
-                "All extraction retry attempts exhausted".to_string(),
-            ))
+            OrchestratorError::DownloadFailed(rdlp_core::RdlpError::Extraction {
+                message: "All extraction retry attempts exhausted".to_string(),
+                url: None,
+            })
         })?;
 
         let output_path = output_path.ok_or_else(|| {
-            OrchestratorError::DownloadFailed(rdlp_core::RdlpError::Extraction(
-                "output path was not set during download".to_string(),
-            ))
+            OrchestratorError::DownloadFailed(rdlp_core::RdlpError::Extraction {
+                message: "output path was not set during download".to_string(),
+                url: None,
+            })
         })?;
         let mut final_info_owned = last_info_ref.unwrap_or_else(|| info.clone());
         if let Some(fmts) = merge_formats {
@@ -315,12 +317,15 @@ impl Orchestrator {
         if !subtitle_langs.is_empty() && downloaded_subs.is_empty() {
             if self.config.strict_subs {
                 return Err(OrchestratorError::DownloadFailed(
-                    rdlp_core::RdlpError::Extraction(format!(
-                        "Strict subtitle mode: no subtitles downloaded for '{}' \
-                         (expected [{}])",
-                        final_info.title,
-                        subtitle_langs.join(", ")
-                    )),
+                    rdlp_core::RdlpError::Extraction {
+                        message: format!(
+                            "Strict subtitle mode: no subtitles downloaded for '{}' \
+                             (expected [{}])",
+                            final_info.title,
+                            subtitle_langs.join(", ")
+                        ),
+                        url: None,
+                    },
                 ));
             }
             warn!(
@@ -344,11 +349,14 @@ impl Orchestrator {
                 .unwrap_or("");
             if ext.eq_ignore_ascii_case("ts") {
                 return Err(OrchestratorError::DownloadFailed(
-                    rdlp_core::RdlpError::Extraction(format!(
-                        "Post-processing failed for '{}': \
-                         HLS container still .ts (FFmpeg remux did not complete)",
-                        final_info.title,
-                    )),
+                    rdlp_core::RdlpError::Extraction {
+                        message: format!(
+                            "Post-processing failed for '{}': \
+                             HLS container still .ts (FFmpeg remux did not complete)",
+                            final_info.title,
+                        ),
+                        url: None,
+                    },
                 ));
             }
         }

--- a/crates/rdlp-api/src/orchestrator/playlist/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/mod.rs
@@ -404,9 +404,10 @@ impl Orchestrator {
 
         if downloaded.is_empty() {
             Err(OrchestratorError::ExtractionFailed(
-                rdlp_core::RdlpError::Extraction(
-                    "All playlist videos failed to download".to_string(),
-                ),
+                rdlp_core::RdlpError::Extraction {
+                    message: "All playlist videos failed to download".to_string(),
+                    url: None,
+                },
             ))
         } else {
             Ok(Some(downloaded))

--- a/crates/rdlp-api/src/orchestrator/subtitle/download.rs
+++ b/crates/rdlp-api/src/orchestrator/subtitle/download.rs
@@ -167,7 +167,10 @@ impl Orchestrator {
                 .error_message
                 .unwrap_or_else(|| "Subtitle policy check failed".to_string());
             return Err(super::super::OrchestratorError::DownloadFailed(
-                rdlp_core::RdlpError::Extraction(msg),
+                rdlp_core::RdlpError::Extraction {
+                    message: msg,
+                    url: None,
+                },
             ));
         }
 

--- a/crates/rdlp-core/src/error.rs
+++ b/crates/rdlp-core/src/error.rs
@@ -4,8 +4,13 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum RdlpError {
     /// HTTP/Network related errors
-    #[error("Network error: {0}")]
-    Network(String),
+    #[error("Network error: {message}")]
+    Network {
+        /// Human-readable description of the error
+        message: String,
+        /// The URL that was being accessed, if applicable
+        url: Option<String>,
+    },
 
     /// HTTP response error with status code
     #[error("HTTP error {status}: {reason}")]
@@ -17,8 +22,13 @@ pub enum RdlpError {
     },
 
     /// Extraction errors
-    #[error("Extraction failed: {0}")]
-    Extraction(String),
+    #[error("Extraction failed: {message}")]
+    Extraction {
+        /// Human-readable description of the error
+        message: String,
+        /// The URL that was being extracted, if applicable
+        url: Option<String>,
+    },
 
     /// No suitable extractor found for URL
     #[error("No extractor found for URL: {0}")]
@@ -29,8 +39,13 @@ pub enum RdlpError {
     InvalidUrl(String),
 
     /// Download errors
-    #[error("Download failed: {0}")]
-    Download(String),
+    #[error("Download failed: {message}")]
+    Download {
+        /// Human-readable description of the error
+        message: String,
+        /// The URL that was being downloaded, if applicable
+        url: Option<String>,
+    },
 
     /// Post-processing errors
     #[error("Post-processing failed: {0}")]
@@ -116,4 +131,65 @@ pub fn check_http_response(response: &reqwest::Response) -> Result<()> {
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_network_error_with_url() {
+        let err = RdlpError::Network {
+            message: "timeout".into(),
+            url: Some("https://example.com".into()),
+        };
+        assert!(err.to_string().contains("timeout"));
+        if let RdlpError::Network { url, .. } = &err {
+            assert_eq!(url.as_deref(), Some("https://example.com"));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn test_network_error_without_url() {
+        let err = RdlpError::Network {
+            message: "dns failed".into(),
+            url: None,
+        };
+        assert!(err.to_string().contains("dns failed"));
+        if let RdlpError::Network { url, .. } = &err {
+            assert!(url.is_none());
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn test_extraction_error_with_url() {
+        let err = RdlpError::Extraction {
+            message: "no formats".into(),
+            url: Some("https://example.com/video".into()),
+        };
+        assert!(err.to_string().contains("no formats"));
+        if let RdlpError::Extraction { url, .. } = &err {
+            assert_eq!(url.as_deref(), Some("https://example.com/video"));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn test_download_error_with_url() {
+        let err = RdlpError::Download {
+            message: "chunk failed".into(),
+            url: Some("https://cdn.example.com/seg1.ts".into()),
+        };
+        assert!(err.to_string().contains("chunk failed"));
+        if let RdlpError::Download { url, .. } = &err {
+            assert_eq!(url.as_deref(), Some("https://cdn.example.com/seg1.ts"));
+        } else {
+            panic!("wrong variant");
+        }
+    }
 }

--- a/crates/rdlp-core/src/retry.rs
+++ b/crates/rdlp-core/src/retry.rs
@@ -109,7 +109,7 @@ impl Default for RetryConfig {
 /// use rdlp_core::{is_retryable_error, RetryConfig, Retryable, RdlpError};
 ///
 /// async fn fetch_data() -> Result<String, RdlpError> {
-///     Err(RdlpError::Network("timeout".to_string()))
+///     Err(RdlpError::Network { message: "timeout".to_string(), url: None })
 /// }
 ///
 /// #[tokio::main]
@@ -127,7 +127,7 @@ pub fn is_retryable_error(error: &RdlpError) -> bool {
         // Structured HTTP errors: retry 5xx and 429, not other 4xx
         RdlpError::Http { status, .. } => *status == 429 || *status >= 500,
         // Network and I/O errors are generally retryable (transient)
-        RdlpError::Network(_) | RdlpError::Io(_) => true,
+        RdlpError::Network { .. } | RdlpError::Io(_) => true,
         _ => false,
     }
 }
@@ -190,10 +190,11 @@ mod tests {
             reason: "Forbidden".to_string(),
         }));
 
-        // Legacy network errors are retryable
-        assert!(is_retryable_error(&RdlpError::Network(
-            "timeout".to_string()
-        )));
+        // Network errors are retryable
+        assert!(is_retryable_error(&RdlpError::Network {
+            message: "timeout".to_string(),
+            url: None,
+        }));
 
         // I/O errors are retryable
         assert!(is_retryable_error(&RdlpError::Io(std::io::Error::new(
@@ -202,9 +203,10 @@ mod tests {
         ))));
 
         // Other errors are not retryable
-        assert!(!is_retryable_error(&RdlpError::Extraction(
-            "invalid format".to_string()
-        )));
+        assert!(!is_retryable_error(&RdlpError::Extraction {
+            message: "invalid format".to_string(),
+            url: None,
+        }));
     }
 
     // =========================================================================
@@ -226,7 +228,7 @@ mod tests {
                 let attempts = counter.fetch_add(1, Ordering::SeqCst);
                 if attempts < 1 {
                     // Fail on first attempt
-                    Err(RdlpError::Network("temporary failure".to_string()))
+                    Err(RdlpError::Network { message: "temporary failure".to_string(), url: None })
                 } else {
                     // Succeed on second attempt
                     Ok(42)
@@ -261,7 +263,7 @@ mod tests {
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
                 // Always fail with retryable error
-                Err(RdlpError::Network("persistent failure".to_string()))
+                Err(RdlpError::Network { message: "persistent failure".to_string(), url: None })
             }
         })
         .retry(config.to_backoff())
@@ -317,7 +319,7 @@ mod tests {
             let counter = counter_clone.clone();
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
-                Err(RdlpError::Network("always fails".to_string()))
+                Err(RdlpError::Network { message: "always fails".to_string(), url: None })
             }
         })
         .retry(config.to_backoff())
@@ -347,7 +349,7 @@ mod tests {
                 let attempts = counter.fetch_add(1, Ordering::SeqCst);
                 if attempts < 2 {
                     // First two attempts: retryable error
-                    Err(RdlpError::Network("timeout".to_string()))
+                    Err(RdlpError::Network { message: "timeout".to_string(), url: None })
                 } else {
                     // Third attempt: permanent error
                     Err(RdlpError::Http {

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -190,7 +190,7 @@ pub(crate) async fn download_segments_with_resume(
                 let _permit = sem
                     .acquire_owned()
                     .await
-                    .map_err(|_| RdlpError::Download("Semaphore closed".to_string()))?;
+                    .map_err(|_| RdlpError::Download { message: "Semaphore closed".to_string(), url: Some(seg_url.clone()) })?;
 
                 let download_start = Instant::now();
 
@@ -267,9 +267,10 @@ pub(crate) async fn download_segments_with_resume(
                 if segment_failures >= max_segment_failures {
                     let snapshot = state.lock().await.clone();
                     let _ = snapshot.save(output_path).await;
-                    return Err(RdlpError::Download(format!(
-                        "Too many segment failures ({segment_failures}), aborting"
-                    )));
+                    return Err(RdlpError::Download {
+                        message: format!("Too many segment failures ({segment_failures}), aborting"),
+                        url: None,
+                    });
                 }
             }
         }
@@ -303,9 +304,10 @@ pub(crate) async fn download_segments_with_resume(
     let expected_count = total_segments - segment_failures;
     let actual_count = all_segment_paths.len();
     if actual_count != expected_count {
-        return Err(RdlpError::Download(format!(
-            "Missing segments: expected {expected_count}, got {actual_count}"
-        )));
+        return Err(RdlpError::Download {
+            message: format!("Missing segments: expected {expected_count}, got {actual_count}"),
+            url: None,
+        });
     }
 
     let segment_paths: Vec<PathBuf> = all_segment_paths
@@ -386,11 +388,9 @@ pub(crate) async fn merge_segments(
         Ok(total_bytes)
     })
     .await
-    .map_err(|_| {
-        RdlpError::Download(format!(
-            "Merge timed out after {}s",
-            merge_timeout.as_secs()
-        ))
+    .map_err(|_| RdlpError::Download {
+        message: format!("Merge timed out after {}s", merge_timeout.as_secs()),
+        url: None,
     })?
 }
 

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -359,8 +359,9 @@ impl Downloader for HlsDownloader {
             Ok(stats)
         })
         .await
-        .map_err(|_| {
-            RdlpError::Download(format!("Download timed out after {}s", timeout.as_secs()))
+        .map_err(|_| RdlpError::Download {
+            message: format!("Download timed out after {}s", timeout.as_secs()),
+            url: Some(url.to_string()),
         })?
     }
 }

--- a/crates/rdlp-downloader/src/hls/playlist.rs
+++ b/crates/rdlp-downloader/src/hls/playlist.rs
@@ -31,21 +31,25 @@ pub(crate) async fn parse_playlist(
         .headers(http_downloader.headers())
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch playlist: {e}")))?
+        .map_err(|e| RdlpError::Network { message: format!("Failed to fetch playlist: {e}"), url: Some(m3u8_url.to_string()) })?
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read playlist: {e}")))?;
+        .map_err(|e| RdlpError::Network { message: format!("Failed to read playlist: {e}"), url: Some(m3u8_url.to_string()) })?;
 
     // Parse with m3u8-rs
     let playlist = m3u8_rs::parse_playlist_res(playlist_text.as_bytes()).map_err(|e| {
         // Show the actual response content when parsing fails (e.g. CDN error pages)
         if !playlist_text.trim().starts_with("#EXTM3U") {
             let preview: String = playlist_text.chars().take(200).collect();
-            RdlpError::Extraction(format!(
-                "Server returned invalid M3U8 (likely expired token or CDN error): {preview}"
-            ))
+            RdlpError::Extraction {
+                message: format!("Server returned invalid M3U8 (likely expired token or CDN error): {preview}"),
+                url: Some(m3u8_url.to_string()),
+            }
         } else {
-            RdlpError::Extraction(format!("M3U8 parse error: {e:?}"))
+            RdlpError::Extraction {
+                message: format!("M3U8 parse error: {e:?}"),
+                url: Some(m3u8_url.to_string()),
+            }
         }
     })?;
 
@@ -73,7 +77,7 @@ fn parse_media_playlist(
 
     // Direct media playlist - extract segments with durations
     let base_url = url::Url::parse(m3u8_url)
-        .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+        .map_err(|e| RdlpError::Extraction { message: format!("Invalid base URL: {e}"), url: Some(m3u8_url.to_string()) })?;
 
     // Build per-segment init info from EXT-X-MAP.
     // m3u8_rs sets `seg.map` on each segment the tag applies to,
@@ -107,7 +111,7 @@ fn parse_media_playlist(
         .collect();
 
     if segments.is_empty() {
-        return Err(RdlpError::Extraction("Playlist has no segments".into()));
+        return Err(RdlpError::Extraction { message: "Playlist has no segments".into(), url: Some(m3u8_url.to_string()) });
     }
 
     // Log init segment info
@@ -125,10 +129,10 @@ fn parse_media_playlist(
     // Security check: limit max segments
     const MAX_SEGMENTS: usize = 10_000;
     if segments.len() > MAX_SEGMENTS {
-        return Err(RdlpError::Extraction(format!(
-            "Playlist has too many segments: {} (max: {MAX_SEGMENTS})",
-            segments.len()
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("Playlist has too many segments: {} (max: {MAX_SEGMENTS})", segments.len()),
+            url: Some(m3u8_url.to_string()),
+        });
     }
 
     // Check for potentially incomplete playlists (XHamster CDN bug: first segment > 1)
@@ -156,9 +160,10 @@ async fn parse_master_playlist(
     m3u8_url: &str,
 ) -> Result<PlaylistParseResult> {
     if master.variants.is_empty() {
-        return Err(RdlpError::Extraction(
-            "Master playlist has no variants".into(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "Master playlist has no variants".into(),
+            url: Some(m3u8_url.to_string()),
+        });
     }
 
     let variant = master
@@ -170,11 +175,11 @@ async fn parse_master_playlist(
         .expect("master playlist has at least one variant");
 
     let base_url = url::Url::parse(m3u8_url)
-        .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+        .map_err(|e| RdlpError::Extraction { message: format!("Invalid base URL: {e}"), url: Some(m3u8_url.to_string()) })?;
 
     let media_playlist_url = base_url
         .join(&variant.uri)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to join URL: {e}")))?
+        .map_err(|e| RdlpError::Extraction { message: format!("Failed to join URL: {e}"), url: Some(m3u8_url.to_string()) })?
         .to_string();
 
     debug!(

--- a/crates/rdlp-downloader/src/hls/segment.rs
+++ b/crates/rdlp-downloader/src/hls/segment.rs
@@ -70,11 +70,11 @@ pub(crate) async fn download_segment_with_retry(
                 .await
                 .map_err(|e| {
                     if e.is_timeout() {
-                        RdlpError::Network(format!("Segment {idx} timeout"))
+                        RdlpError::Network { message: format!("Segment {idx} timeout"), url: Some(url.to_string()) }
                     } else if e.is_connect() {
-                        RdlpError::Network(format!("Segment {idx} connection failed"))
+                        RdlpError::Network { message: format!("Segment {idx} connection failed"), url: Some(url.to_string()) }
                     } else {
-                        RdlpError::Network(format!("Segment {idx} request failed: {e}"))
+                        RdlpError::Network { message: format!("Segment {idx} request failed: {e}"), url: Some(url.to_string()) }
                     }
                 })?;
 
@@ -93,7 +93,7 @@ pub(crate) async fn download_segment_with_retry(
 
             while let Some(chunk_result) = stream.next().await {
                 let chunk = chunk_result
-                    .map_err(|e| RdlpError::Network(format!("Segment {idx} read error: {e}")))?;
+                    .map_err(|e| RdlpError::Network { message: format!("Segment {idx} read error: {e}"), url: Some(url.to_string()) })?;
 
                 writer.write_all(&chunk).await.map_err(RdlpError::Io)?;
                 downloaded += chunk.len() as u64;
@@ -159,7 +159,7 @@ pub(crate) async fn download_init_segment(
             let response = req
                 .send()
                 .await
-                .map_err(|e| RdlpError::Network(format!("Init segment request failed: {e}")))?;
+                .map_err(|e| RdlpError::Network { message: format!("Init segment request failed: {e}"), url: Some(url.to_string()) })?;
 
             if !response.status().is_success() {
                 return Err(RdlpError::Http {
@@ -171,7 +171,7 @@ pub(crate) async fn download_init_segment(
             let bytes = response
                 .bytes()
                 .await
-                .map_err(|e| RdlpError::Network(format!("Init segment read error: {e}")))?;
+                .map_err(|e| RdlpError::Network { message: format!("Init segment read error: {e}"), url: Some(url.to_string()) })?;
 
             tokio::fs::write(&*dest, &bytes)
                 .await

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -207,7 +207,7 @@ impl HttpDownloader {
                     .headers(hdrs)
                     .send()
                     .await
-                    .map_err(|e| RdlpError::Network(format!("HEAD request failed: {e}")))
+                    .map_err(|e| RdlpError::Network { message: format!("HEAD request failed: {e}"), url: Some(url.clone()) })
             }
         })
         .await?;
@@ -243,7 +243,7 @@ impl HttpDownloader {
                     .header("Range", format!("bytes={start}-{end}"))
                     .send()
                     .await
-                    .map_err(|e| RdlpError::Network(format!("Range request failed: {e}")))?;
+                    .map_err(|e| RdlpError::Network { message: format!("Range request failed: {e}"), url: Some(url.clone()) })?;
 
                 check_http_response(&response)?;
                 Ok(response)
@@ -260,15 +260,13 @@ impl HttpDownloader {
 
         while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
             .await
-            .map_err(|_| {
-                RdlpError::Network(format!(
-                    "Read timed out (no data for {}s)",
-                    read_timeout.as_secs()
-                ))
+            .map_err(|_| RdlpError::Network {
+                message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
+                url: Some(url.clone()),
             })?
         {
             let chunk = chunk_result
-                .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
+                .map_err(|e| RdlpError::Network { message: format!("Failed to read chunk: {e}"), url: Some(url.clone()) })?;
 
             writer.write_all(&chunk).await.map_err(RdlpError::Io)?;
             downloaded += chunk.len() as u64;
@@ -296,7 +294,7 @@ impl HttpDownloader {
         let progress: Option<Arc<dyn ProgressCallback>> = progress.map(Arc::from);
         let start_time = Instant::now();
         let client = self.client.clone();
-        let url_string = url.to_string();
+        let url_string: Arc<str> = Arc::from(url);
         let hdrs = self.headers();
 
         let response = with_retry(&self.config.retry_config, "HTTP GET", || {
@@ -305,11 +303,11 @@ impl HttpDownloader {
             let hdrs = hdrs.clone();
             async move {
                 let response = client
-                    .get(&url)
+                    .get(&*url)
                     .headers(hdrs)
                     .send()
                     .await
-                    .map_err(|e| RdlpError::Network(format!("GET request failed: {e}")))?;
+                    .map_err(|e| RdlpError::Network { message: format!("GET request failed: {e}"), url: Some(url.to_string()) })?;
 
                 check_http_response(&response)?;
                 Ok(response)
@@ -329,15 +327,13 @@ impl HttpDownloader {
 
         while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
             .await
-            .map_err(|_| {
-                RdlpError::Network(format!(
-                    "Read timed out (no data for {}s)",
-                    read_timeout.as_secs()
-                ))
+            .map_err(|_| RdlpError::Network {
+                message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
+                url: Some(url_string.to_string()),
             })?
         {
             let chunk = chunk_result
-                .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
+                .map_err(|e| RdlpError::Network { message: format!("Failed to read chunk: {e}"), url: Some(url_string.to_string()) })?;
 
             writer.write_all(&chunk).await.map_err(RdlpError::Io)?;
             downloaded += chunk.len() as u64;

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -129,7 +129,7 @@ impl HttpDownloader {
         let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let filename = path
             .file_name()
-            .ok_or_else(|| RdlpError::Download("Invalid output path: no filename".to_string()))?
+            .ok_or_else(|| RdlpError::Download { message: "Invalid output path: no filename".to_string(), url: Some(url.to_string()) })?
             .to_string_lossy()
             .into_owned();
 
@@ -215,7 +215,7 @@ impl HttpDownloader {
         let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let filename = path
             .file_name()
-            .ok_or_else(|| RdlpError::Download("Invalid output path: no filename".to_string()))?
+            .ok_or_else(|| RdlpError::Download { message: "Invalid output path: no filename".to_string(), url: Some(url.to_string()) })?
             .to_string_lossy()
             .into_owned();
 
@@ -364,7 +364,7 @@ impl HttpDownloader {
                         let _permit = sem
                             .acquire_owned()
                             .await
-                            .map_err(|_| RdlpError::Download("Semaphore closed".to_string()))?;
+                            .map_err(|_| RdlpError::Download { message: "Semaphore closed".to_string(), url: Some(url.to_string()) })?;
                         let start_time = Instant::now();
                         let abs_start = byte_offset + chunk.start;
                         // end is exclusive in ChunkRequest, but HTTP Range is inclusive
@@ -549,10 +549,8 @@ async fn merge_chunks_ordered(
         Ok(())
     })
     .await
-    .map_err(|_| {
-        RdlpError::Download(format!(
-            "Merge timed out after {}s",
-            merge_timeout.as_secs()
-        ))
+    .map_err(|_| RdlpError::Download {
+        message: format!("Merge timed out after {}s", merge_timeout.as_secs()),
+        url: None,
     })?
 }

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -82,7 +82,7 @@ async fn test_resume_fails_when_server_returns_200() {
 
     // Verify the error message mentions resume not supported
     let err = result.unwrap_err();
-    assert!(matches!(err, RdlpError::Download(_)));
+    assert!(matches!(err, RdlpError::Download { .. }));
     assert!(err.to_string().contains("does not support resume"));
     assert!(err.to_string().contains("206"));
 
@@ -194,7 +194,7 @@ async fn test_parallel_download_error_propagation() {
 
     let err = result.unwrap_err();
     assert!(
-        matches!(err, RdlpError::Http { .. } | RdlpError::Network(_)),
+        matches!(err, RdlpError::Http { .. } | RdlpError::Network { .. }),
         "Should be an HTTP or network error, got: {err:?}"
     );
 

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -6,6 +6,7 @@
 use async_trait::async_trait;
 use futures::StreamExt;
 use log::debug;
+use std::sync::Arc;
 use rdlp_core::{
     DownloadProgress, DownloadStats, Downloader, ProgressCallback, RdlpError, Result,
     check_http_response,
@@ -59,7 +60,7 @@ impl Downloader for HttpDownloader {
                             .header("Range", "bytes=0-0")
                             .send()
                             .await
-                            .map_err(|e| RdlpError::Network(format!("Size check failed: {e}")))
+                            .map_err(|e| RdlpError::Network { message: format!("Size check failed: {e}"), url: Some(url.clone()) })
                     }
                 })
                 .await
@@ -115,11 +116,9 @@ impl Downloader for HttpDownloader {
             self.download_sequential(url, path, progress).await
         })
         .await
-        .map_err(|_| {
-            RdlpError::Download(format!(
-                "Download timed out after {}s",
-                timeout.as_secs()
-            ))
+        .map_err(|_| RdlpError::Download {
+            message: format!("Download timed out after {}s", timeout.as_secs()),
+            url: Some(url.to_string()),
         })?
     }
 
@@ -149,7 +148,7 @@ impl Downloader for HttpDownloader {
                     async move {
                         let response =
                             client.get(&url).headers(hdrs).send().await.map_err(|e| {
-                                RdlpError::Network(format!("GET request failed: {e}"))
+                                RdlpError::Network { message: format!("GET request failed: {e}"), url: Some(url.clone()) }
                             })?;
 
                         check_http_response(&response)?;
@@ -169,14 +168,12 @@ impl Downloader for HttpDownloader {
 
             while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
                 .await
-                .map_err(|_| {
-                RdlpError::Network(format!(
-                    "Read timed out (no data for {}s)",
-                    read_timeout.as_secs()
-                ))
-            })? {
+                .map_err(|_| RdlpError::Network {
+                    message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
+                    url: Some(url_string.clone()),
+                })? {
                 let chunk = chunk_result
-                    .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
+                    .map_err(|e| RdlpError::Network { message: format!("Failed to read chunk: {e}"), url: Some(url_string.clone()) })?;
 
                 match buf_writer.write_all(&chunk).await {
                     Ok(()) => {}
@@ -235,8 +232,9 @@ impl Downloader for HttpDownloader {
             Ok(stats)
         })
         .await
-        .map_err(|_| {
-            RdlpError::Download(format!("Download timed out after {}s", timeout.as_secs()))
+        .map_err(|_| RdlpError::Download {
+            message: format!("Download timed out after {}s", timeout.as_secs()),
+            url: Some(url.to_string()),
         })?
     }
 
@@ -259,7 +257,7 @@ impl Downloader for HttpDownloader {
                     .headers(hdrs)
                     .send()
                     .await
-                    .map_err(|e| RdlpError::Network(format!("HEAD request failed: {e}")))
+                    .map_err(|e| RdlpError::Network { message: format!("HEAD request failed: {e}"), url: Some(url.clone()) })
             }
         })
         .await?;
@@ -278,29 +276,32 @@ impl Downloader for HttpDownloader {
         tokio::time::timeout(timeout, async {
             let start_time = Instant::now();
             let client = self.client.clone();
-            let url_string = url.to_string();
+            let url_string: Arc<str> = Arc::from(url);
             let hdrs = self.headers();
 
             let response = with_retry(&self.config.retry_config, "HTTP GET (resume)", || {
                 let client = client.clone();
-                let url = url_string.clone();
+                let url = Arc::clone(&url_string);
                 let hdrs = hdrs.clone();
                 async move {
                     let response = client
-                        .get(&url)
+                        .get(url.as_ref())
                         .headers(hdrs)
                         .header("Range", format!("bytes={resume_from}-"))
                         .send()
                         .await
-                        .map_err(|e| RdlpError::Network(format!("Resume request failed: {e}")))?;
+                        .map_err(|e| RdlpError::Network { message: format!("Resume request failed: {e}"), url: Some(url.to_string()) })?;
 
                     if response.status().as_u16() != 206 {
-                        return Err(RdlpError::Download(format!(
-                            "Server does not support resume (expected HTTP 206, got {}). \
-                             Cannot continue download without overwriting existing data. \
-                             Please delete the partial file and restart the download.",
-                            response.status()
-                        )));
+                        return Err(RdlpError::Download {
+                            url: Some(url.to_string()),
+                            message: format!(
+                                "Server does not support resume (expected HTTP 206, got {}). \
+                                 Cannot continue download without overwriting existing data. \
+                                 Please delete the partial file and restart the download.",
+                                response.status()
+                            ),
+                        });
                     }
 
                     Ok(response)
@@ -377,15 +378,13 @@ impl Downloader for HttpDownloader {
 
             while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
                 .await
-                .map_err(|_| {
-                    RdlpError::Network(format!(
-                        "Read timed out (no data for {}s)",
-                        read_timeout.as_secs()
-                    ))
+                .map_err(|_| RdlpError::Network {
+                    message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
+                    url: Some(url_string.to_string()),
                 })?
             {
                 let chunk = chunk_result
-                    .map_err(|e| RdlpError::Network(format!("Failed to read chunk: {e}")))?;
+                    .map_err(|e| RdlpError::Network { message: format!("Failed to read chunk: {e}"), url: Some(url_string.to_string()) })?;
 
                 writer.write_all(&chunk).await.map_err(RdlpError::Io)?;
                 downloaded += chunk.len() as u64;
@@ -423,11 +422,9 @@ impl Downloader for HttpDownloader {
             Ok(stats)
         })
         .await
-        .map_err(|_| {
-            RdlpError::Download(format!(
-                "Download timed out after {}s",
-                timeout.as_secs()
-            ))
+        .map_err(|_| RdlpError::Download {
+            message: format!("Download timed out after {}s", timeout.as_secs()),
+            url: Some(url.to_string()),
         })?
     }
 }

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -108,10 +108,10 @@ impl BaseExtractor {
     pub(crate) async fn fetch_webpage(url: &str, ctx: &ExtractionContext) -> Result<String> {
         // Security: Validate URL length
         if url.len() > MAX_URL_LENGTH {
-            return Err(RdlpError::Extraction(format!(
-                "URL too long: {} bytes (max: {MAX_URL_LENGTH})",
-                url.len()
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("URL too long: {} bytes (max: {MAX_URL_LENGTH})", url.len()),
+                url: Some(url.to_string()),
+            });
         }
 
         let response = ctx
@@ -119,14 +119,20 @@ impl BaseExtractor {
             .get(url)
             .send()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to fetch webpage: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to fetch webpage: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         check_http_response(&response)?;
 
         let webpage = response
             .text()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to read response body: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to read response body: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         // Debug output if verbose
         if ctx.config.verbose {
@@ -161,10 +167,10 @@ impl BaseExtractor {
     ) -> Result<String> {
         // Security: Validate URL length
         if url.len() > MAX_URL_LENGTH {
-            return Err(RdlpError::Extraction(format!(
-                "URL too long: {} bytes (max: {MAX_URL_LENGTH})",
-                url.len()
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("URL too long: {} bytes (max: {MAX_URL_LENGTH})", url.len()),
+                url: Some(url.to_string()),
+            });
         }
 
         let mut request = ctx.http_client.get(url);
@@ -176,14 +182,20 @@ impl BaseExtractor {
         let response = request
             .send()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to fetch webpage: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to fetch webpage: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         check_http_response(&response)?;
 
         let webpage = response
             .text()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to read response body: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to read response body: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         if ctx.config.verbose {
             crate::utils::debug_print_webpage_sample(&webpage, DEFAULT_DEBUG_SAMPLE_SIZE);
@@ -220,7 +232,10 @@ impl BaseExtractor {
     /// BaseExtractor::validate_url_security(segment_url)?;
     /// ```
     pub(crate) fn validate_url_security(url: &str) -> Result<()> {
-        rdlp_security::validate_url_security(url).map_err(|e| RdlpError::Extraction(e.to_string()))
+        rdlp_security::validate_url_security(url).map_err(|e| RdlpError::Extraction {
+            message: e.to_string(),
+            url: Some(url.to_string()),
+        })
     }
 
     // ========================================================================

--- a/crates/rdlp-extractor/src/base/tnaflix_network/mod.rs
+++ b/crates/rdlp-extractor/src/base/tnaflix_network/mod.rs
@@ -244,9 +244,10 @@ impl TnaFlixNetworkBase {
 
     /// Extract all metadata from HTML
     pub(crate) fn extract_metadata(&self, html: &Html) -> Result<ExtractedMetadata> {
-        let title = self
-            .extract_title(html)
-            .ok_or_else(|| RdlpError::Extraction("Could not find video title".to_string()))?;
+        let title = self.extract_title(html).ok_or_else(|| RdlpError::Extraction {
+            message: "Could not find video title".to_string(),
+            url: None,
+        })?;
 
         let description = self.extract_description(html);
         let uploader = self.extract_uploader(html);

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -184,8 +184,10 @@ impl InfoExtractor for HQPornerExtractor {
     }
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
-        let video_id = patterns::extract_video_id(url)
-            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
+        let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!("Could not extract video ID: {url}"),
+            url: Some(url.to_string()),
+        })?;
 
         let webpage = BaseExtractor::fetch_webpage_with_headers(
             url,
@@ -195,8 +197,9 @@ impl InfoExtractor for HQPornerExtractor {
         .await?;
 
         // Extract iframe URL from raw HTML (regex, before DOM parse)
-        let iframe_url = extract_iframe_url(&webpage).ok_or_else(|| {
-            RdlpError::Extraction("No mydaddy.cc iframe found on page".to_string())
+        let iframe_url = extract_iframe_url(&webpage).ok_or_else(|| RdlpError::Extraction {
+            message: "No mydaddy.cc iframe found on page".to_string(),
+            url: Some(url.to_string()),
         })?;
 
         // Parse HTML once for all metadata extraction
@@ -216,9 +219,10 @@ impl InfoExtractor for HQPornerExtractor {
         let mydaddy_result = mydaddy::resolve_formats(&iframe_url, ctx).await?;
 
         if mydaddy_result.formats.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "No video formats found for URL: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("No video formats found for URL: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         // Detect file sizes

--- a/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
@@ -79,9 +79,11 @@ pub(crate) async fn resolve_formats(
 
     // Check for blocked response
     if html.contains("This domain has been blocked") {
-        return Err(RdlpError::Extraction(
-            "mydaddy.cc embed blocked — Referer header may not have been accepted".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "mydaddy.cc embed blocked — Referer header may not have been accepted"
+                .to_string(),
+            url: Some(full_url),
+        });
     }
 
     let formats = parse_formats(&html);
@@ -106,9 +108,10 @@ fn resolve_from_html(html: &str) -> Result<MyDaddyResult> {
     let formats = parse_formats(html);
 
     if formats.is_empty() {
-        return Err(RdlpError::Extraction(
-            "No video formats found in mydaddy.cc embed or alt player".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "No video formats found in mydaddy.cc embed or alt player".to_string(),
+            url: None,
+        });
     }
 
     let thumbnail = extract_thumbnail(html);
@@ -123,14 +126,20 @@ async fn fetch_embed(url: &str, ctx: &ExtractionContext) -> Result<String> {
         .header("Referer", "https://hqporner.com/")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch mydaddy.cc embed: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch mydaddy.cc embed: {e}"),
+            url: Some(url.to_string()),
+        })?;
 
     rdlp_core::check_http_response(&response)?;
 
     response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read mydaddy.cc response: {e}")))
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read mydaddy.cc response: {e}"),
+            url: Some(url.to_string()),
+        })
 }
 
 /// Parse MP4 format URLs from the embed HTML.

--- a/crates/rdlp-extractor/src/extractors/nine_anime/api.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/api.rs
@@ -89,12 +89,18 @@ pub async fn fetch_servers(episode_id: &str, ctx: &ExtractionContext) -> Result<
         .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch servers: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch servers: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     let json: serde_json::Value = response
         .json()
         .await
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse servers JSON: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to parse servers JSON: {e}"),
+            url: Some(url),
+        })?;
 
     let html = json["html"].as_str().unwrap_or_default();
 
@@ -201,24 +207,34 @@ pub async fn fetch_source(data_id: &str, ctx: &ExtractionContext) -> Result<Sour
         .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch source: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch source: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     let json: serde_json::Value = response
         .json()
         .await
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse source JSON: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to parse source JSON: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     let embed_url = json["link"]
         .as_str()
-        .ok_or_else(|| RdlpError::Extraction("No 'link' field in source response".to_string()))?
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "No 'link' field in source response".to_string(),
+            url: Some(url.clone()),
+        })?
         .to_string();
 
     let server_id = json["server"].as_u64().unwrap_or(0) as u32;
 
     if embed_url.is_empty() {
-        return Err(RdlpError::Extraction(
-            "Empty embed URL in source response".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "Empty embed URL in source response".to_string(),
+            url: Some(url),
+        });
     }
 
     debug!(embed_url:%, server_id; "Resolved 9anime source");

--- a/crates/rdlp-extractor/src/extractors/nine_anime/episodes.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/episodes.rs
@@ -69,12 +69,18 @@ pub async fn fetch_episode_info(
         .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch episode list: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch episode list: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     let json: serde_json::Value = response
         .json()
         .await
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse episode list: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to parse episode list: {e}"),
+            url: Some(url),
+        })?;
 
     let html = json["html"].as_str().unwrap_or_default();
 
@@ -156,12 +162,18 @@ pub async fn fetch_all_episodes(
         .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch episode list: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch episode list: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     let json: serde_json::Value = response
         .json()
         .await
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse episode list: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to parse episode list: {e}"),
+            url: Some(url),
+        })?;
 
     let html = json["html"].as_str().unwrap_or_default();
     let episodes = parse_all_episodes(html);

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
@@ -40,7 +40,10 @@ pub fn decrypt_src(src: &str, client_key: &str, megacloud_key: &str) -> Result<S
     let gen_key = keygen(megacloud_key, client_key);
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(src)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to base64 decode sources: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to base64 decode sources: {e}"),
+            url: None,
+        })?;
     let mut dec_src: Vec<char> = decoded.iter().map(|&b| b as char).collect();
     let chars = char_array();
 
@@ -56,17 +59,19 @@ pub fn decrypt_src(src: &str, client_key: &str, megacloud_key: &str) -> Result<S
     let data_len: usize = result
         .get(..4)
         .and_then(|s| s.parse().ok())
-        .ok_or_else(|| {
-            RdlpError::Extraction("Invalid data length prefix in decrypted source".to_string())
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "Invalid data length prefix in decrypted source".to_string(),
+            url: None,
         })?;
 
     result
         .get(4..4 + data_len)
         .map(|s| s.to_string())
-        .ok_or_else(|| {
-            RdlpError::Extraction(format!(
+        .ok_or_else(|| RdlpError::Extraction {
+            message: format!(
                 "Decrypted source too short: expected {data_len} chars after prefix"
-            ))
+            ),
+            url: None,
         })
 }
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/client_key.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/client_key.rs
@@ -60,12 +60,18 @@ pub(super) async fn extract_client_key(source_id: &str, ctx: &ExtractionContext)
         .header("Referer", "https://9animetv.to/")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch v3 embed page: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch v3 embed page: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     let html = response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read v3 embed body: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read v3 embed body: {e}"),
+            url: Some(url),
+        })?;
 
     parse_client_key(&html)
 }
@@ -77,17 +83,17 @@ pub(super) fn parse_client_key(html: &str) -> Result<String> {
         .iter()
         .enumerate()
         .find_map(|(idx, pattern)| pattern.find(html).map(|m| (idx, m.as_str().to_string())))
-        .ok_or_else(|| {
-            RdlpError::Extraction(
-                "Could not find client key in embed page (no pattern matched)".to_string(),
-            )
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "Could not find client key in embed page (no pattern matched)".to_string(),
+            url: None,
         })?;
 
     match pattern_idx {
         // Pattern 1: Comment -- key follows colon, no quotes
         1 => {
-            let key_match = COMMENT_KEY.find(&text).ok_or_else(|| {
-                RdlpError::Extraction("Failed to extract key from comment".to_string())
+            let key_match = COMMENT_KEY.find(&text).ok_or_else(|| RdlpError::Extraction {
+                message: "Failed to extract key from comment".to_string(),
+                url: None,
             })?;
             Ok(key_match.as_str().replace([':', ' '], ""))
         }
@@ -95,11 +101,13 @@ pub(super) fn parse_client_key(html: &str) -> Result<String> {
         2 => {
             let mut parts = Vec::new();
             for part_re in LK_DB_PARTS.iter() {
-                let part_match = part_re.find(&text).ok_or_else(|| {
-                    RdlpError::Extraction("Failed to extract _lk_db key part".to_string())
+                let part_match = part_re.find(&text).ok_or_else(|| RdlpError::Extraction {
+                    message: "Failed to extract _lk_db key part".to_string(),
+                    url: None,
                 })?;
-                let val = QUOTED_KEY.find(part_match.as_str()).ok_or_else(|| {
-                    RdlpError::Extraction("Failed to extract quoted value from _lk_db".to_string())
+                let val = QUOTED_KEY.find(part_match.as_str()).ok_or_else(|| RdlpError::Extraction {
+                    message: "Failed to extract quoted value from _lk_db".to_string(),
+                    url: None,
                 })?;
                 parts.push(val.as_str().replace('"', ""));
             }
@@ -107,8 +115,9 @@ pub(super) fn parse_client_key(html: &str) -> Result<String> {
         }
         // All other patterns -- extract quoted key
         _ => {
-            let key_match = QUOTED_KEY.find(&text).ok_or_else(|| {
-                RdlpError::Extraction("Failed to extract quoted key from matched pattern".into())
+            let key_match = QUOTED_KEY.find(&text).ok_or_else(|| RdlpError::Extraction {
+                message: "Failed to extract quoted key from matched pattern".to_string(),
+                url: None,
             })?;
             Ok(key_match.as_str().replace('"', ""))
         }

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
@@ -96,10 +96,9 @@ const KEYS_URL: &str = "https://raw.githubusercontent.com/yogesh-hacker/Megaclou
 /// 2. **v3 megacloud.blog**: Client key extraction + custom 3-layer cipher
 ///    (works for `megacloud.blog` embeds)
 pub async fn extract_sources(embed_url: &str, ctx: &ExtractionContext) -> Result<MegacloudSources> {
-    let source_id = extract_source_id(embed_url).ok_or_else(|| {
-        RdlpError::Extraction(format!(
-            "Could not extract source ID from embed URL: {embed_url}"
-        ))
+    let source_id = extract_source_id(embed_url).ok_or_else(|| RdlpError::Extraction {
+        message: format!("Could not extract source ID from embed URL: {embed_url}"),
+        url: Some(embed_url.to_string()),
     })?;
     debug!(source_id:%; "Extracted Megacloud source ID");
 
@@ -127,9 +126,10 @@ pub async fn extract_sources(embed_url: &str, ctx: &ExtractionContext) -> Result
         }
     }
 
-    Err(RdlpError::Extraction(
-        "All Megacloud extraction strategies failed".to_string(),
-    ))
+    Err(RdlpError::Extraction {
+        message: "All Megacloud extraction strategies failed".to_string(),
+        url: Some(embed_url.to_string()),
+    })
 }
 
 /// Strategy 2: v3 endpoint on megacloud.blog with client key + custom cipher.
@@ -176,31 +176,45 @@ async fn fetch_megacloud_key(ctx: &ExtractionContext) -> Result<String> {
         .get(KEYS_URL)
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch megacloud keys: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch megacloud keys: {e}"),
+            url: Some(KEYS_URL.to_string()),
+        })?;
 
     let json: serde_json::Value = response
         .json()
         .await
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse megacloud keys: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to parse megacloud keys: {e}"),
+            url: Some(KEYS_URL.to_string()),
+        })?;
 
-    let key = json["mega"].as_str().ok_or_else(|| {
-        RdlpError::Extraction("No 'mega' field in megacloud keys response".to_string())
+    let key = json["mega"].as_str().ok_or_else(|| RdlpError::Extraction {
+        message: "No 'mega' field in megacloud keys response".to_string(),
+        url: Some(KEYS_URL.to_string()),
     })?;
 
     // Validate key: non-empty, ASCII-only printable characters, reasonable length
     if key.is_empty() {
-        return Err(RdlpError::Extraction("Megacloud key is empty".to_string()));
+        return Err(RdlpError::Extraction {
+            message: "Megacloud key is empty".to_string(),
+            url: Some(KEYS_URL.to_string()),
+        });
     }
     if !key.bytes().all(|b| (0x20..=0x7E).contains(&b)) {
-        return Err(RdlpError::Extraction(
-            "Megacloud key contains non-ASCII or non-printable characters".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "Megacloud key contains non-ASCII or non-printable characters".to_string(),
+            url: Some(KEYS_URL.to_string()),
+        });
     }
     if key.len() > 512 {
-        return Err(RdlpError::Extraction(format!(
-            "Megacloud key length {} exceeds maximum of 512 bytes",
-            key.len()
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!(
+                "Megacloud key length {} exceeds maximum of 512 bytes",
+                key.len()
+            ),
+            url: Some(KEYS_URL.to_string()),
+        });
     }
 
     Ok(key.to_string())
@@ -223,28 +237,38 @@ async fn fetch_get_sources(
         .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch getSources: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch getSources: {e}"),
+            url: Some(url.to_string()),
+        })?;
 
     let status = response.status();
     let body = response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read getSources body: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read getSources body: {e}"),
+            url: Some(url.to_string()),
+        })?;
 
     if !status.is_success() {
-        return Err(RdlpError::Extraction(format!(
-            "getSources returned HTTP {status}: {}",
-            &body[..body.len().min(200)]
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!(
+                "getSources returned HTTP {status}: {}",
+                &body[..body.len().min(200)]
+            ),
+            url: Some(url.to_string()),
+        });
     }
 
     debug!(body_len = body.len(); "getSources response received");
 
-    serde_json::from_str(&body).map_err(|e| {
-        RdlpError::Extraction(format!(
+    serde_json::from_str(&body).map_err(|e| RdlpError::Extraction {
+        message: format!(
             "Failed to parse getSources JSON: {e}. Body: {}",
             &body[..body.len().min(200)]
-        ))
+        ),
+        url: Some(url.to_string()),
     })
 }
 
@@ -259,8 +283,9 @@ fn parse_sources_response(
     let encrypted = json["encrypted"].as_bool().unwrap_or(false);
 
     let sources = if encrypted {
-        let encrypted_str = json["sources"].as_str().ok_or_else(|| {
-            RdlpError::Extraction("Encrypted sources field is not a string".to_string())
+        let encrypted_str = json["sources"].as_str().ok_or_else(|| RdlpError::Extraction {
+            message: "Encrypted sources field is not a string".to_string(),
+            url: None,
         })?;
 
         match (client_key, megacloud_key) {
@@ -268,15 +293,17 @@ fn parse_sources_response(
                 debug!("Decrypting sources with custom cipher");
                 let decrypted = cipher::decrypt_src(encrypted_str, ck, mk)?;
                 let arr: Vec<serde_json::Value> =
-                    serde_json::from_str(&decrypted).map_err(|e| {
-                        RdlpError::Extraction(format!("Failed to parse decrypted sources: {e}"))
+                    serde_json::from_str(&decrypted).map_err(|e| RdlpError::Extraction {
+                        message: format!("Failed to parse decrypted sources: {e}"),
+                        url: None,
                     })?;
                 parse_source_array_from_values(&arr)
             }
             _ => {
-                return Err(RdlpError::Extraction(
-                    "Sources are encrypted but no decryption keys available".to_string(),
-                ));
+                return Err(RdlpError::Extraction {
+                    message: "Sources are encrypted but no decryption keys available".to_string(),
+                    url: None,
+                });
             }
         }
     } else {
@@ -307,9 +334,10 @@ fn parse_sources_response(
 
 /// Parse a plaintext sources array from JSON.
 fn parse_source_array(sources_json: &serde_json::Value) -> Result<Vec<VideoSource>> {
-    let arr = sources_json
-        .as_array()
-        .ok_or_else(|| RdlpError::Extraction("Sources field is not an array".to_string()))?;
+    let arr = sources_json.as_array().ok_or_else(|| RdlpError::Extraction {
+        message: "Sources field is not an array".to_string(),
+        url: None,
+    })?;
 
     Ok(parse_source_array_from_values(arr))
 }

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -90,9 +90,10 @@ pub(crate) async fn resolve_episode_formats(
 ) -> Result<(Vec<Format>, HlsStreamFlags, Vec<megacloud::SubtitleTrack>)> {
     let mut servers = api::fetch_servers(episode_id, ctx).await?;
     if servers.is_empty() {
-        return Err(RdlpError::Extraction(
-            "No streaming servers found for this episode".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "No streaming servers found for this episode".to_string(),
+            url: None,
+        });
     }
 
     api::sort_by_preference(&mut servers);
@@ -216,8 +217,9 @@ pub(crate) async fn resolve_episode_formats(
     }
 
     if all_formats.is_empty() {
-        return Err(last_error.unwrap_or_else(|| {
-            RdlpError::Extraction("No video sources found from any server".to_string())
+        return Err(last_error.unwrap_or_else(|| RdlpError::Extraction {
+            message: "No video sources found from any server".to_string(),
+            url: None,
         }));
     }
 
@@ -291,15 +293,17 @@ impl InfoExtractor for NineAnimeExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         // Extract IDs from URL
-        let anime_id = patterns::extract_anime_id(url).ok_or_else(|| {
-            RdlpError::Extraction(format!("Could not extract anime ID from URL: {url}"))
+        let anime_id = patterns::extract_anime_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!("Could not extract anime ID from URL: {url}"),
+            url: Some(url.to_string()),
         })?;
 
-        let episode_id = patterns::extract_episode_id(url).ok_or_else(|| {
-            RdlpError::Extraction(format!(
+        let episode_id = patterns::extract_episode_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!(
                 "Could not extract episode ID from URL: {url}. \
                  Use a URL with ?ep= parameter."
-            ))
+            ),
+            url: Some(url.to_string()),
         })?;
 
         let slug = patterns::extract_slug(url).unwrap_or_default();
@@ -369,11 +373,12 @@ impl InfoExtractor for NineAnimeExtractor {
     /// already available from playlist extraction). Only resolves Megacloud
     /// video sources and subtitles, avoiding Cloudflare rate-limiting.
     async fn extract_lazy(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
-        let episode_id = patterns::extract_episode_id(url).ok_or_else(|| {
-            RdlpError::Extraction(format!(
+        let episode_id = patterns::extract_episode_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!(
                 "Could not extract episode ID from URL: {url}. \
                  Use a URL with ?ep= parameter."
-            ))
+            ),
+            url: Some(url.to_string()),
         })?;
 
         debug!(episode_id:%; "Lazily resolving 9anime episode formats");

--- a/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
@@ -37,8 +37,9 @@ use crate::base::common::BaseExtractor;
 /// 5. Build remaining episodes as lightweight `InfoDict` with proper `webpage_url`
 /// 6. Return `Vec<InfoDict>` with playlist fields set
 pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<InfoDict>> {
-    let anime_id = patterns::extract_anime_id(url).ok_or_else(|| {
-        RdlpError::Extraction(format!("Could not extract anime ID from URL: {url}"))
+    let anime_id = patterns::extract_anime_id(url).ok_or_else(|| RdlpError::Extraction {
+        message: format!("Could not extract anime ID from URL: {url}"),
+        url: Some(url.to_string()),
     })?;
 
     let slug = patterns::extract_slug(url).unwrap_or_default();
@@ -59,9 +60,10 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
     let episodes = episodes::fetch_all_episodes(&anime_id, ctx).await?;
 
     if episodes.is_empty() {
-        return Err(RdlpError::Extraction(format!(
-            "No episodes found for anime ID {anime_id}"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("No episodes found for anime ID {anime_id}"),
+            url: Some(url.to_string()),
+        });
     }
 
     let total = episodes.len();
@@ -69,9 +71,10 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
 
     // Security: limit playlist size
     if total > MAX_PLAYLIST_SIZE {
-        return Err(RdlpError::Extraction(format!(
-            "Playlist too large: {total} episodes (max: {MAX_PLAYLIST_SIZE})"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("Playlist too large: {total} episodes (max: {MAX_PLAYLIST_SIZE})"),
+            url: Some(url.to_string()),
+        });
     }
 
     // Resolve one episode fully for audio type detection + subtitles.
@@ -159,9 +162,10 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
     }
 
     if results.is_empty() {
-        return Err(RdlpError::Extraction(format!(
-            "Failed to extract any episodes from anime: {url}"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("Failed to extract any episodes from anime: {url}"),
+            url: Some(url.to_string()),
+        });
     }
 
     info!(

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -56,9 +56,10 @@ pub async fn extract_all_formats(webpage: &str, ctx: &ExtractionContext) -> Resu
     );
 
     if all_formats.is_empty() {
-        return Err(RdlpError::Extraction(
-            "No video formats found with any strategy".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "No video formats found with any strategy".to_string(),
+            url: None,
+        });
     }
 
     dedup_format_ids(&mut all_formats);
@@ -81,17 +82,25 @@ async fn extract_from_flashvars(webpage: &str, ctx: &ExtractionContext) -> Resul
         .captures(webpage)
         .and_then(|cap| cap.get(1))
         .map(|m| m.as_str())
-        .ok_or_else(|| RdlpError::Extraction("No flashvars found".to_string()))?;
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "No flashvars found".to_string(),
+            url: None,
+        })?;
 
-    let flashvars: Value = serde_json::from_str(flashvars_json)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse flashvars: {e}")))?;
+    let flashvars: Value = serde_json::from_str(flashvars_json).map_err(|e| RdlpError::Extraction {
+        message: format!("Failed to parse flashvars: {e}"),
+        url: None,
+    })?;
 
     let mut formats = Vec::new();
 
     let media_definitions = flashvars
         .get("mediaDefinitions")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| RdlpError::Extraction("No mediaDefinitions in flashvars".to_string()))?;
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "No mediaDefinitions in flashvars".to_string(),
+            url: None,
+        })?;
 
     // Separate get_media endpoints (need async fetch) from direct URLs (sync)
     let mut media_futures = Vec::new();
@@ -115,9 +124,10 @@ async fn extract_from_flashvars(webpage: &str, ctx: &ExtractionContext) -> Resul
     }
 
     if formats.is_empty() {
-        return Err(RdlpError::Extraction(
-            "No formats in mediaDefinitions".to_string(),
-        ));
+        return Err(RdlpError::Extraction {
+            message: "No formats in mediaDefinitions".to_string(),
+            url: None,
+        });
     }
 
     Ok(formats)

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -102,14 +102,20 @@ impl PornHubExtractor {
             )
             .when(|e| e.is_timeout() || e.is_connect())
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to fetch PornHub search API: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to fetch PornHub search API: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         rdlp_core::check_http_response(&response)?;
 
         let body = response
             .text()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to read PornHub API response: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to read PornHub API response: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         search::parse_api_search_results(&body)
     }
@@ -129,9 +135,10 @@ impl PornHubExtractor {
         _url: &str,
         _ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        Err(RdlpError::Extraction(
-            "PornHub HTML search fallback not yet implemented".to_string(),
-        ))
+        Err(RdlpError::Extraction {
+            message: "PornHub HTML search fallback not yet implemented".to_string(),
+            url: None,
+        })
     }
 
     /// Paginated search across all pages, collecting up to `max_results` results.
@@ -291,12 +298,18 @@ impl InfoExtractor for PornHubExtractor {
 
         // Check for video unavailability errors
         if let Some(error_msg) = utils::detect_video_unavailable(&webpage) {
-            return Err(RdlpError::Extraction(error_msg));
+            return Err(RdlpError::Extraction {
+                message: error_msg,
+                url: Some(url.to_string()),
+            });
         }
 
         // Get video ID
         let video_id = patterns::extract_video_id(url)
-            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
+            .ok_or_else(|| RdlpError::Extraction {
+                message: format!("Could not extract video ID: {url}"),
+                url: Some(url.to_string()),
+            })?;
 
         // Parse HTML and extract all metadata before async operations
         // Extract duration from flashvars (before HTML parsing drops webpage borrow)
@@ -331,9 +344,10 @@ impl InfoExtractor for PornHubExtractor {
         let formats = formats::extract_all_formats(&webpage, ctx).await?;
 
         if formats.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "No video formats found for URL: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("No video formats found for URL: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         // Detect file sizes and segment counts

--- a/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
@@ -47,7 +47,10 @@ pub async fn extract_playlist(
     ctx: &ExtractionContext,
 ) -> Result<Vec<InfoDict>> {
     let playlist_id = super::patterns::extract_playlist_id(url)
-        .ok_or_else(|| RdlpError::Extraction(format!("Could not extract playlist ID: {url}")))?;
+        .ok_or_else(|| RdlpError::Extraction {
+            message: format!("Could not extract playlist ID: {url}"),
+            url: Some(url.to_string()),
+        })?;
 
     let host = extract_host(url);
 
@@ -62,14 +65,20 @@ pub async fn extract_playlist(
         .get(url)
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch playlist: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch playlist: {e}"),
+            url: Some(url.to_string()),
+        })?;
 
     check_http_response(&response)?;
 
     let webpage = response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read response: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read response: {e}"),
+            url: Some(url.to_string()),
+        })?;
 
     // Extract metadata
     let (playlist_title, pagination_info, mut all_video_urls) = {
@@ -90,9 +99,10 @@ pub async fn extract_playlist(
     );
 
     if all_video_urls.is_empty() {
-        return Err(RdlpError::Extraction(format!(
-            "No videos found in playlist: {url}"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("No videos found in playlist: {url}"),
+            url: Some(url.to_string()),
+        });
     }
 
     // Handle pagination
@@ -129,9 +139,10 @@ pub async fn extract_playlist(
 
     // Security check: limit playlist size to prevent memory exhaustion
     if total > MAX_PLAYLIST_SIZE {
-        return Err(RdlpError::Extraction(format!(
-            "Playlist too large: {total} videos (max: {MAX_PLAYLIST_SIZE})"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("Playlist too large: {total} videos (max: {MAX_PLAYLIST_SIZE})"),
+            url: Some(url.to_string()),
+        });
     }
 
     // Extract videos in parallel using buffer_unordered for concurrent processing
@@ -199,9 +210,10 @@ pub async fn extract_playlist(
     let results: Vec<InfoDict> = extracted.into_iter().map(|(_, info)| info).collect();
 
     if results.is_empty() {
-        return Err(RdlpError::Extraction(format!(
-            "Failed to extract any videos from playlist: {url}"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("Failed to extract any videos from playlist: {url}"),
+            url: Some(url.to_string()),
+        });
     }
 
     info!(extracted = results.len(), total; "[PornHub] Successfully extracted videos");
@@ -316,14 +328,20 @@ async fn download_page(
         ])
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch page {page_num}: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch page {page_num}: {e}"),
+            url: Some(url.clone()),
+        })?;
 
     check_http_response(&response)?;
 
     response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read page {page_num}: {e}")))
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read page {page_num}: {e}"),
+            url: Some(url),
+        })
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -92,8 +92,10 @@ pub(crate) struct ApiCategory {
 /// # Returns
 /// A vector of search result previews.
 pub(crate) fn parse_api_search_results(json: &str) -> Result<Vec<SearchResultPreview>> {
-    let response: ApiSearchResponse = serde_json::from_str(json)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse PornHub API response: {e}")))?;
+    let response: ApiSearchResponse = serde_json::from_str(json).map_err(|e| RdlpError::Extraction {
+        message: format!("Failed to parse PornHub API response: {e}"),
+        url: None,
+    })?;
 
     let results: Vec<SearchResultPreview> = response
         .videos
@@ -177,11 +179,14 @@ pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
         match descriptor {
             None => {
                 let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
-                return Err(RdlpError::Extraction(format!(
-                    "Unknown filter '{}' for PornHub. Available: {}",
-                    filter.key,
-                    valid_keys.join(", ")
-                )));
+                return Err(RdlpError::Extraction {
+                    message: format!(
+                        "Unknown filter '{}' for PornHub. Available: {}",
+                        filter.key,
+                        valid_keys.join(", ")
+                    ),
+                    url: None,
+                });
             }
             Some(desc) => {
                 // category and tags accept free-text — API validates server-side
@@ -196,12 +201,15 @@ pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
                         .iter()
                         .map(|v| v.value.as_str())
                         .collect();
-                    return Err(RdlpError::Extraction(format!(
-                        "Invalid value '{}' for filter '{}'. Allowed: {}",
-                        filter.value,
-                        filter.key,
-                        allowed.join(", ")
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Invalid value '{}' for filter '{}'. Allowed: {}",
+                            filter.value,
+                            filter.key,
+                            allowed.join(", ")
+                        ),
+                        url: None,
+                    });
                 }
             }
         }

--- a/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/utils.rs
@@ -67,7 +67,10 @@ pub async fn set_age_cookies(host: &str, ctx: &ExtractionContext) -> Result<()> 
         ctx.cookie_jar
             .add_cookie(&base_url, cookie)
             .await
-            .map_err(|e| RdlpError::Extraction(format!("Failed to set age cookie: {e}")))?;
+            .map_err(|e| RdlpError::Extraction {
+                message: format!("Failed to set age cookie: {e}"),
+                url: None,
+            })?;
     }
 
     Ok(())

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -105,8 +105,9 @@ pub(crate) struct ApiVideoMetadata {
 /// # Returns
 /// Parsed `ApiVideoMetadata` or an error if JSON parsing fails.
 pub(crate) fn parse_api_video_response(json: &str) -> Result<ApiVideoMetadata> {
-    let response: ApiVideoInfoResponse = serde_json::from_str(json).map_err(|e| {
-        RdlpError::Extraction(format!("Failed to parse RedTube video API response: {e}"))
+    let response: ApiVideoInfoResponse = serde_json::from_str(json).map_err(|e| RdlpError::Extraction {
+        message: format!("Failed to parse RedTube video API response: {e}"),
+        url: None,
     })?;
 
     let video = response.video;

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -73,14 +73,16 @@ impl RedTubeExtractor {
         debug!("[RedTube] Fetching API video info: {api_url}");
 
         let response =
-            ctx.http_client.get(&api_url).send().await.map_err(|e| {
-                RdlpError::Network(format!("Failed to fetch RedTube video API: {e}"))
+            ctx.http_client.get(&api_url).send().await.map_err(|e| RdlpError::Network {
+                message: format!("Failed to fetch RedTube video API: {e}"),
+                url: Some(api_url.clone()),
             })?;
 
         rdlp_core::check_http_response(&response)?;
 
-        let body = response.text().await.map_err(|e| {
-            RdlpError::Network(format!("Failed to read RedTube video API response: {e}"))
+        let body = response.text().await.map_err(|e| RdlpError::Network {
+            message: format!("Failed to read RedTube video API response: {e}"),
+            url: Some(api_url),
         })?;
 
         BaseExtractor::log_content_if_verbose(ctx, "RedTube", "API video response", &body, 500);
@@ -198,8 +200,9 @@ impl InfoExtractor for RedTubeExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         // Get video ID using BaseExtractor
-        let video_id = self.extract_id(url).ok_or_else(|| {
-            RdlpError::Extraction(format!("Could not extract video ID from URL: {url}"))
+        let video_id = self.extract_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!("Could not extract video ID from URL: {url}"),
+            url: Some(url.to_string()),
         })?;
 
         // Try API first for metadata
@@ -230,10 +233,13 @@ impl InfoExtractor for RedTubeExtractor {
 
         // Return error if still no sources found
         if formats.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "No video sources found in JavaScript or HTML. \
-                 Video may be unavailable. URL: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!(
+                    "No video sources found in JavaScript or HTML. \
+                     Video may be unavailable. URL: {url}"
+                ),
+                url: Some(url.to_string()),
+            });
         }
 
         // Convert relative URLs to absolute using utility
@@ -373,14 +379,20 @@ impl RedTubeExtractor {
             )
             .when(|e| e.is_timeout() || e.is_connect())
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to fetch search API: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to fetch search API: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         rdlp_core::check_http_response(&response)?;
 
         let body = response
             .text()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to read search API response: {e}")))?;
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to read search API response: {e}"),
+                url: Some(url.to_string()),
+            })?;
 
         search::parse_api_search_results(&body)
     }

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -92,8 +92,10 @@ where
 pub(crate) fn parse_api_search_results(
     json: &str,
 ) -> Result<(Vec<SearchResultPreview>, Option<u64>)> {
-    let response: ApiSearchResponse = serde_json::from_str(json)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse RedTube API response: {e}")))?;
+    let response: ApiSearchResponse = serde_json::from_str(json).map_err(|e| RdlpError::Extraction {
+        message: format!("Failed to parse RedTube API response: {e}"),
+        url: None,
+    })?;
 
     let total_count = response.count;
     let results: Vec<SearchResultPreview> = response
@@ -214,11 +216,14 @@ pub(crate) fn validate_search_filters(
         match descriptor {
             None => {
                 let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
-                return Err(RdlpError::Extraction(format!(
-                    "Unknown filter '{}' for RedTube. Available: {}",
-                    filter.key,
-                    valid_keys.join(", ")
-                )));
+                return Err(RdlpError::Extraction {
+                    message: format!(
+                        "Unknown filter '{}' for RedTube. Available: {}",
+                        filter.key,
+                        valid_keys.join(", ")
+                    ),
+                    url: None,
+                });
             }
             Some(desc) => {
                 // "category" and "tags" have suggested values for UI display,
@@ -234,12 +239,15 @@ pub(crate) fn validate_search_filters(
                         .iter()
                         .map(|v| v.value.as_str())
                         .collect();
-                    return Err(RdlpError::Extraction(format!(
-                        "Invalid value '{}' for filter '{}'. Allowed: {}",
-                        filter.value,
-                        filter.key,
-                        allowed.join(", ")
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Invalid value '{}' for filter '{}'. Allowed: {}",
+                            filter.value,
+                            filter.key,
+                            allowed.join(", ")
+                        ),
+                        url: None,
+                    });
                 }
             }
         }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
@@ -29,34 +29,47 @@ pub async fn parse_empflix_ajax(
         .header("Referer", referer)
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch EMPFlix AJAX: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch EMPFlix AJAX: {e}"),
+            url: Some(ajax_url.clone()),
+        })?;
 
     check_http_response(&response)?;
 
     let json_text = response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read AJAX response: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read AJAX response: {e}"),
+            url: Some(ajax_url.clone()),
+        })?;
 
     BaseExtractor::log_content_if_verbose(ctx, "EMPFlix", "AJAX Response", &json_text, 500);
 
     // Parse JSON to extract HTML field
     let json: serde_json::Value = serde_json::from_str(&json_text)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse AJAX JSON: {e}")))?;
+        .map_err(|e| RdlpError::Extraction {
+            message: format!("Failed to parse AJAX JSON: {e}"),
+            url: Some(ajax_url.clone()),
+        })?;
 
     let html_str = json
         .get("html")
         .and_then(|h| h.as_str())
-        .ok_or_else(|| RdlpError::Extraction("No 'html' field in AJAX response".to_string()))?;
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "No 'html' field in AJAX response".to_string(),
+            url: Some(ajax_url.clone()),
+        })?;
 
     // Parse the HTML to extract <source> tags using base
     let html = Html::parse_document(html_str);
     let video_data = base.parse_video_sources(&html);
 
     if video_data.is_empty() {
-        return Err(RdlpError::Extraction(format!(
-            "No video sources found in EMPFlix AJAX HTML. URL: {referer}"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("No video sources found in EMPFlix AJAX HTML. URL: {referer}"),
+            url: Some(ajax_url),
+        });
     }
 
     Ok(video_data)
@@ -79,14 +92,20 @@ pub async fn parse_moviefap_xml(
         .header("X-Requested-With", "XMLHttpRequest")
         .send()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to fetch MovieFap XML: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to fetch MovieFap XML: {e}"),
+            url: Some(cdn_url.to_string()),
+        })?;
 
     check_http_response(&response)?;
 
     let xml_text = response
         .text()
         .await
-        .map_err(|e| RdlpError::Network(format!("Failed to read XML response: {e}")))?;
+        .map_err(|e| RdlpError::Network {
+            message: format!("Failed to read XML response: {e}"),
+            url: Some(cdn_url.to_string()),
+        })?;
 
     BaseExtractor::log_content_if_verbose(ctx, "MovieFap", "XML Response", &xml_text, 1000);
 
@@ -94,9 +113,10 @@ pub async fn parse_moviefap_xml(
     let video_data = base.parse_moviefap_xml(&xml_text);
 
     if video_data.is_empty() {
-        return Err(RdlpError::Extraction(format!(
-            "No video sources found in MovieFap XML response from: {cdn_url}"
-        )));
+        return Err(RdlpError::Extraction {
+            message: format!("No video sources found in MovieFap XML response from: {cdn_url}"),
+            url: Some(cdn_url.to_string()),
+        });
     }
 
     Ok(video_data)

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -96,8 +96,9 @@ impl InfoExtractor for TNAFlixExtractor {
         let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 
         // Get video ID using BaseExtractor
-        let video_id = self.extract_id(url).ok_or_else(|| {
-            RdlpError::Extraction(format!("Could not extract video ID from URL: {url}"))
+        let video_id = self.extract_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!("Could not extract video ID from URL: {url}"),
+            url: Some(url.to_string()),
         })?;
 
         // Check if this is MovieFap (uses different video loading mechanism)
@@ -123,10 +124,9 @@ impl InfoExtractor for TNAFlixExtractor {
         // Parse video data based on site type
         let video_data = if is_moviefap {
             // MovieFap: fetch XML from cdn.php
-            let cdn_url = cdn_url_opt.ok_or_else(|| {
-                RdlpError::Extraction(format!(
-                    "Could not find cdn.php URL in MovieFap page: {url}"
-                ))
+            let cdn_url = cdn_url_opt.ok_or_else(|| RdlpError::Extraction {
+                message: format!("Could not find cdn.php URL in MovieFap page: {url}"),
+                url: Some(url.to_string()),
             })?;
 
             BaseExtractor::log_if_verbose(ctx, "MovieFap", &format!("cdn.php URL: {cdn_url}"));
@@ -153,9 +153,12 @@ impl InfoExtractor for TNAFlixExtractor {
 
             // Return error if still no sources found
             if video_data.is_empty() {
-                return Err(RdlpError::Extraction(format!(
-                    "No video source tags found in HTML. Video may be unavailable. URL: {url}"
-                )));
+                return Err(RdlpError::Extraction {
+                    message: format!(
+                        "No video source tags found in HTML. Video may be unavailable. URL: {url}"
+                    ),
+                    url: Some(url.to_string()),
+                });
             }
 
             video_data
@@ -165,9 +168,10 @@ impl InfoExtractor for TNAFlixExtractor {
         let mut formats = self.base.build_formats(video_data, ctx).await;
 
         if formats.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "No video formats found for URL: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("No video formats found for URL: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         // Set Referer header on all formats so the CDN receives it during download.

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -153,17 +153,21 @@ pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
         match filter.key.as_str() {
             "ordering" => {
                 if !moviefap_search_patterns::VALID_ORDERINGS.contains(&filter.value.as_str()) {
-                    return Err(RdlpError::Extraction(format!(
-                        "Invalid MovieFap ordering value '{}'. Valid values: {}",
-                        filter.value,
-                        moviefap_search_patterns::VALID_ORDERINGS.join(", ")
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Invalid MovieFap ordering value '{}'. Valid values: {}",
+                            filter.value,
+                            moviefap_search_patterns::VALID_ORDERINGS.join(", ")
+                        ),
+                        url: None,
+                    });
                 }
             }
             other => {
-                return Err(RdlpError::Extraction(format!(
-                    "Unknown MovieFap search filter key '{other}'"
-                )));
+                return Err(RdlpError::Extraction {
+                    message: format!("Unknown MovieFap search filter key '{other}'"),
+                    url: None,
+                });
             }
         }
     }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -172,25 +172,32 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
         match filter.key.as_str() {
             "ordering" => {
                 if !VALID_ORDERINGS.contains(&filter.value.as_str()) {
-                    return Err(RdlpError::Extraction(format!(
-                        "Invalid TNAFlix ordering value '{}'. Valid values: {}",
-                        filter.value,
-                        VALID_ORDERINGS.join(", ")
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Invalid TNAFlix ordering value '{}'. Valid values: {}",
+                            filter.value,
+                            VALID_ORDERINGS.join(", ")
+                        ),
+                        url: None,
+                    });
                 }
             }
             "category" => {
                 if !search_patterns::is_valid_category(&filter.value) {
-                    return Err(RdlpError::Extraction(format!(
-                        "Invalid TNAFlix category '{}'. Use search_filters() to see valid values.",
-                        filter.value
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Invalid TNAFlix category '{}'. Use search_filters() to see valid values.",
+                            filter.value
+                        ),
+                        url: None,
+                    });
                 }
             }
             other => {
-                return Err(RdlpError::Extraction(format!(
-                    "Unknown TNAFlix search filter key '{other}'"
-                )));
+                return Err(RdlpError::Extraction {
+                    message: format!("Unknown TNAFlix search filter key '{other}'"),
+                    url: None,
+                });
             }
         }
     }

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -78,7 +78,10 @@ impl XHamsterExtractor {
 
         // Extract video ID and display ID
         let video_id = patterns::extract_video_id(&url)
-            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
+            .ok_or_else(|| RdlpError::Extraction {
+                message: format!("Could not extract video ID: {url}"),
+                url: Some(url.to_string()),
+            })?;
         let display_id = patterns::extract_display_id(&url);
 
         // Fetch the webpage
@@ -86,7 +89,10 @@ impl XHamsterExtractor {
 
         // Check for video unavailability
         if let Some(error_msg) = utils::detect_video_unavailable(&webpage) {
-            return Err(RdlpError::Extraction(error_msg));
+            return Err(RdlpError::Extraction {
+                message: error_msg,
+                url: Some(url.to_string()),
+            });
         }
 
         // Extract age limit
@@ -157,9 +163,10 @@ impl XHamsterExtractor {
         };
 
         if formats.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "No video formats found for URL: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("No video formats found for URL: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         // Detect file sizes and segment counts for HLS
@@ -206,9 +213,10 @@ impl XHamsterExtractor {
             return self.extract_video(&video_url, ctx).await;
         }
 
-        Err(RdlpError::Extraction(format!(
-            "Could not extract video URL from embed page: {url}"
-        )))
+        Err(RdlpError::Extraction {
+            message: format!("Could not extract video URL from embed page: {url}"),
+            url: Some(url.to_string()),
+        })
     }
 
     /// Fetch a single search page, returning its results and the max page count.

--- a/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
@@ -28,7 +28,10 @@ impl XHamsterExtractor {
         ctx: &ExtractionContext,
     ) -> Result<Vec<InfoDict>> {
         let (user_id, _is_user) = patterns::extract_user_info(url)
-            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract user ID: {url}")))?;
+            .ok_or_else(|| RdlpError::Extraction {
+                message: format!("Could not extract user ID: {url}"),
+                url: Some(url.to_string()),
+            })?;
 
         info!(user_id:?; "[XHamster] Extracting user playlist");
 
@@ -53,8 +56,9 @@ impl XHamsterExtractor {
                 )
                 .when(|e| e.is_timeout() || e.is_connect())
                 .await
-                .map_err(|e| {
-                    RdlpError::Network(format!("Failed to fetch user page {page}: {e}"))
+                .map_err(|e| RdlpError::Network {
+                    message: format!("Failed to fetch user page {page}: {e}"),
+                    url: Some(page_url.clone()),
                 })?;
 
             check_http_response(&response)?;
@@ -62,7 +66,10 @@ impl XHamsterExtractor {
             let webpage = response
                 .text()
                 .await
-                .map_err(|e| RdlpError::Network(format!("Failed to read user page {page}: {e}")))?;
+                .map_err(|e| RdlpError::Network {
+                    message: format!("Failed to read user page {page}: {e}"),
+                    url: Some(page_url.clone()),
+                })?;
 
             // Extract video URLs from the page
             let page_urls = extract_user_video_urls(&webpage);
@@ -97,15 +104,17 @@ impl XHamsterExtractor {
         debug!(total; "[XHamster] Found videos in user playlist");
 
         if total == 0 {
-            return Err(RdlpError::Extraction(format!(
-                "No videos found on user page: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("No videos found on user page: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         if total > MAX_PLAYLIST_SIZE {
-            return Err(RdlpError::Extraction(format!(
-                "Playlist too large: {total} videos (max: {MAX_PLAYLIST_SIZE})"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("Playlist too large: {total} videos (max: {MAX_PLAYLIST_SIZE})"),
+                url: Some(url.to_string()),
+            });
         }
 
         // Extract videos in parallel
@@ -163,9 +172,10 @@ impl XHamsterExtractor {
         let results: Vec<InfoDict> = extracted.into_iter().map(|(_, info)| info).collect();
 
         if results.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "Failed to extract any videos from user page: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("Failed to extract any videos from user page: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         info!(extracted = results.len(), total; "[XHamster] Successfully extracted videos");

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -17,12 +17,15 @@ pub fn extract_initials_json(html: &str) -> Result<Value> {
     .find_map(|pat| pat.captures(html))
     .and_then(|caps| caps.get(1))
     .map(|m| m.as_str())
-    .ok_or_else(|| {
-        RdlpError::Extraction("Could not find window.initials in search page".to_string())
+    .ok_or_else(|| RdlpError::Extraction {
+        message: "Could not find window.initials in search page".to_string(),
+        url: None,
     })?;
 
-    serde_json::from_str(json_str)
-        .map_err(|e| RdlpError::Extraction(format!("Failed to parse window.initials JSON: {e}")))
+    serde_json::from_str(json_str).map_err(|e| RdlpError::Extraction {
+        message: format!("Failed to parse window.initials JSON: {e}"),
+        url: None,
+    })
 }
 
 /// Parse search result previews from the `window.initials` JSON.
@@ -30,8 +33,9 @@ pub fn parse_search_results_json(initials: &Value) -> Result<Vec<SearchResultPre
     let data = initials
         .pointer("/searchResult/videoThumbProps")
         .and_then(|d| d.as_array())
-        .ok_or_else(|| {
-            RdlpError::Extraction("Missing searchResult.videoThumbProps array".to_string())
+        .ok_or_else(|| RdlpError::Extraction {
+            message: "Missing searchResult.videoThumbProps array".to_string(),
+            url: None,
         })?;
 
     let mut results = Vec::with_capacity(data.len());
@@ -92,20 +96,26 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
         match descriptor {
             None => {
                 let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
-                return Err(RdlpError::Extraction(format!(
-                    "Unknown filter '{}' for XHamster. Available: {}",
-                    filter.key,
-                    valid_keys.join(", ")
-                )));
+                return Err(RdlpError::Extraction {
+                    message: format!(
+                        "Unknown filter '{}' for XHamster. Available: {}",
+                        filter.key,
+                        valid_keys.join(", ")
+                    ),
+                    url: None,
+                });
             }
             Some(desc) => {
                 // Duration min/max are numeric, allow any reasonable value
                 if filter.key == "min-duration" || filter.key == "max-duration" {
                     if filter.value.parse::<u32>().is_err() {
-                        return Err(RdlpError::Extraction(format!(
-                            "Invalid value '{}' for filter '{}'. Must be a number.",
-                            filter.value, filter.key
-                        )));
+                        return Err(RdlpError::Extraction {
+                            message: format!(
+                                "Invalid value '{}' for filter '{}'. Must be a number.",
+                                filter.value, filter.key
+                            ),
+                            url: None,
+                        });
                     }
                     continue;
                 }
@@ -117,12 +127,15 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
                         .iter()
                         .map(|v| v.value.as_str())
                         .collect();
-                    return Err(RdlpError::Extraction(format!(
-                        "Invalid value '{}' for filter '{}'. Allowed: {}",
-                        filter.value,
-                        filter.key,
-                        allowed.join(", ")
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Invalid value '{}' for filter '{}'. Allowed: {}",
+                            filter.value,
+                            filter.key,
+                            allowed.join(", ")
+                        ),
+                        url: None,
+                    });
                 }
             }
         }

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -186,27 +186,31 @@ impl InfoExtractor for XTitsExtractor {
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 
-        let video_id = patterns::extract_video_id(url)
-            .ok_or_else(|| RdlpError::Extraction(format!("Could not extract video ID: {url}")))?;
+        let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!("Could not extract video ID: {url}"),
+            url: Some(url.to_string()),
+        })?;
 
         // Extract flashvars block
         let flashvars_content = patterns::FLASHVARS_PATTERN
             .captures(&webpage)
             .and_then(|caps| caps.get(1))
             .map(|m| m.as_str().to_string())
-            .ok_or_else(|| {
-                RdlpError::Extraction(format!(
+            .ok_or_else(|| RdlpError::Extraction {
+                message: format!(
                     "Could not find KVS flashvars on page. Video may be unavailable. URL: {url}"
-                ))
+                ),
+                url: Some(url.to_string()),
             })?;
 
         // Extract formats from flashvars
         let video_formats = formats::extract_formats(&flashvars_content);
 
         if video_formats.is_empty() {
-            return Err(RdlpError::Extraction(format!(
-                "No video formats found in flashvars. URL: {url}"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!("No video formats found in flashvars. URL: {url}"),
+                url: Some(url.to_string()),
+            });
         }
 
         // Parse flashvars for metadata

--- a/crates/rdlp-extractor/src/hls/detector.rs
+++ b/crates/rdlp-extractor/src/hls/detector.rs
@@ -222,25 +222,37 @@ impl HlsSizeDetector {
         }
         let response = request.send().await.map_err(|e| {
             if e.is_timeout() {
-                RdlpError::Network(format!("Timeout fetching playlist: {m3u8_url}"))
+                RdlpError::Network {
+                    message: format!("Timeout fetching playlist: {m3u8_url}"),
+                    url: Some(m3u8_url.to_string()),
+                }
             } else if e.is_connect() {
-                RdlpError::Network(format!("Connection failed for playlist: {m3u8_url}: {e}"))
+                RdlpError::Network {
+                    message: format!("Connection failed for playlist: {m3u8_url}: {e}"),
+                    url: Some(m3u8_url.to_string()),
+                }
             } else {
-                RdlpError::Network(format!("Failed to fetch playlist: {e}"))
+                RdlpError::Network {
+                    message: format!("Failed to fetch playlist: {e}"),
+                    url: Some(m3u8_url.to_string()),
+                }
             }
         })?;
 
         if !response.status().is_success() {
-            return Err(RdlpError::Network(format!(
-                "HTTP {} for playlist: {m3u8_url}",
-                response.status()
-            )));
+            return Err(RdlpError::Network {
+                message: format!("HTTP {} for playlist: {m3u8_url}", response.status()),
+                url: Some(m3u8_url.to_string()),
+            });
         }
 
         response
             .text()
             .await
-            .map_err(|e| RdlpError::Network(format!("Failed to read playlist response: {e}")))
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to read playlist response: {e}"),
+                url: Some(m3u8_url.to_string()),
+            })
     }
 
     /// Fetch a media playlist and extract its metadata
@@ -252,11 +264,17 @@ impl HlsSizeDetector {
         let playlist = m3u8_rs::parse_playlist_res(text.as_bytes()).map_err(|e| {
             if !text.trim().starts_with("#EXTM3U") {
                 let preview: String = text.chars().take(200).collect();
-                RdlpError::Extraction(format!(
-                    "Server returned invalid M3U8 (likely expired token or CDN error): {preview}"
-                ))
+                RdlpError::Extraction {
+                    message: format!(
+                        "Server returned invalid M3U8 (likely expired token or CDN error): {preview}"
+                    ),
+                    url: Some(media_url.to_string()),
+                }
             } else {
-                RdlpError::Extraction(format!("M3U8 parse error: {e:?}"))
+                RdlpError::Extraction {
+                    message: format!("M3U8 parse error: {e:?}"),
+                    url: Some(media_url.to_string()),
+                }
             }
         })?;
 

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -39,11 +39,17 @@ impl HlsSizeDetector {
         let playlist = m3u8_rs::parse_playlist_res(playlist_text.as_bytes()).map_err(|e| {
             if !playlist_text.trim().starts_with("#EXTM3U") {
                 let preview: String = playlist_text.chars().take(200).collect();
-                RdlpError::Extraction(format!(
-                    "Server returned invalid M3U8 (likely expired token or CDN error): {preview}"
-                ))
+                RdlpError::Extraction {
+                    message: format!(
+                        "Server returned invalid M3U8 (likely expired token or CDN error): {preview}"
+                    ),
+                    url: Some(m3u8_url.to_string()),
+                }
             } else {
-                RdlpError::Extraction(format!("M3U8 parse error: {e:?}"))
+                RdlpError::Extraction {
+                    message: format!("M3U8 parse error: {e:?}"),
+                    url: Some(m3u8_url.to_string()),
+                }
             }
         })?;
 
@@ -51,7 +57,10 @@ impl HlsSizeDetector {
         match playlist {
             m3u8_rs::Playlist::MediaPlaylist(media) => {
                 let base_url = url::Url::parse(m3u8_url)
-                    .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+                    .map_err(|e| RdlpError::Extraction {
+                        message: format!("Invalid base URL: {e}"),
+                        url: Some(m3u8_url.to_string()),
+                    })?;
 
                 let segments: Vec<String> = media
                     .segments
@@ -67,10 +76,13 @@ impl HlsSizeDetector {
 
                 // Security check: limit max segments
                 if segments.len() > MAX_SEGMENTS {
-                    return Err(RdlpError::Extraction(format!(
-                        "Playlist has too many segments: {} (max: {MAX_SEGMENTS})",
-                        segments.len()
-                    )));
+                    return Err(RdlpError::Extraction {
+                        message: format!(
+                            "Playlist has too many segments: {} (max: {MAX_SEGMENTS})",
+                            segments.len()
+                        ),
+                        url: Some(m3u8_url.to_string()),
+                    });
                 }
 
                 // Validate segment URLs using BaseExtractor SSRF protection
@@ -88,9 +100,10 @@ impl HlsSizeDetector {
             m3u8_rs::Playlist::MasterPlaylist(master) => {
                 // Master playlist contains variants - select the first one
                 if master.variants.is_empty() {
-                    return Err(RdlpError::Extraction(
-                        "Master playlist has no variants".into(),
-                    ));
+                    return Err(RdlpError::Extraction {
+                        message: "Master playlist has no variants".to_string(),
+                        url: Some(m3u8_url.to_string()),
+                    });
                 }
 
                 // Select the non-I-frame variant with the highest bandwidth (best quality)
@@ -114,12 +127,16 @@ impl HlsSizeDetector {
 
                 // Resolve relative URL for media playlist
                 let base_url = url::Url::parse(m3u8_url)
-                    .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+                    .map_err(|e| RdlpError::Extraction {
+                        message: format!("Invalid base URL: {e}"),
+                        url: Some(m3u8_url.to_string()),
+                    })?;
 
                 let media_playlist_url = base_url
                     .join(media_playlist_uri)
-                    .map_err(|e| {
-                        RdlpError::Extraction(format!("Failed to join media playlist URL: {e}"))
+                    .map_err(|e| RdlpError::Extraction {
+                        message: format!("Failed to join media playlist URL: {e}"),
+                        url: Some(m3u8_url.to_string()),
                     })?
                     .to_string();
 
@@ -174,19 +191,28 @@ impl HlsSizeDetector {
             .await
             .map_err(|e| {
                 if e.is_timeout() {
-                    RdlpError::Network(format!("Timeout for segment: {segment_url}"))
+                    RdlpError::Network {
+                        message: format!("Timeout for segment: {segment_url}"),
+                        url: Some(segment_url.to_string()),
+                    }
                 } else if e.is_connect() {
-                    RdlpError::Network(format!("Connection failed for segment: {segment_url}: {e}"))
+                    RdlpError::Network {
+                        message: format!("Connection failed for segment: {segment_url}: {e}"),
+                        url: Some(segment_url.to_string()),
+                    }
                 } else {
-                    RdlpError::Network(format!("Failed to fetch segment: {e}"))
+                    RdlpError::Network {
+                        message: format!("Failed to fetch segment: {e}"),
+                        url: Some(segment_url.to_string()),
+                    }
                 }
             })?;
 
         if !range_response.status().is_success() {
-            return Err(RdlpError::Network(format!(
-                "HTTP {} for segment: {segment_url}",
-                range_response.status()
-            )));
+            return Err(RdlpError::Network {
+                message: format!("HTTP {} for segment: {segment_url}", range_response.status()),
+                url: Some(segment_url.to_string()),
+            });
         }
 
         // Try Content-Range header: "bytes 0-0/123456"
@@ -205,9 +231,10 @@ impl HlsSizeDetector {
             return Ok(size);
         }
 
-        Err(RdlpError::Extraction(format!(
-            "Could not detect segment size for: {segment_url}"
-        )))
+        Err(RdlpError::Extraction {
+            message: format!("Could not detect segment size for: {segment_url}"),
+            url: Some(segment_url.to_string()),
+        })
     }
 
     /// Calculate total size from all segments using parallel requests
@@ -275,9 +302,12 @@ impl HlsSizeDetector {
 
         // Require at least 50% success rate
         if success_rate < 0.5 {
-            return Err(RdlpError::Extraction(format!(
-                "Too many segment failures: {failed}/{total_segments} failed (< 50% success rate)"
-            )));
+            return Err(RdlpError::Extraction {
+                message: format!(
+                    "Too many segment failures: {failed}/{total_segments} failed (< 50% success rate)"
+                ),
+                url: None,
+            });
         }
 
         // Warn if success rate is below 90%

--- a/crates/rdlp-extractor/src/hls/variants.rs
+++ b/crates/rdlp-extractor/src/hls/variants.rs
@@ -114,11 +114,15 @@ impl HlsSizeDetector {
 
                 // Resolve and fetch the media playlist for segment info
                 let base_url = url::Url::parse(m3u8_url)
-                    .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+                    .map_err(|e| RdlpError::Extraction {
+                        message: format!("Invalid base URL: {e}"),
+                        url: Some(m3u8_url.to_string()),
+                    })?;
                 let media_url = base_url
                     .join(&variant.uri)
-                    .map_err(|e| {
-                        RdlpError::Extraction(format!("Failed to join media playlist URL: {e}"))
+                    .map_err(|e| RdlpError::Extraction {
+                        message: format!("Failed to join media playlist URL: {e}"),
+                        url: Some(m3u8_url.to_string()),
                     })?
                     .to_string();
 
@@ -235,7 +239,10 @@ impl HlsSizeDetector {
         }
 
         let base_url = url::Url::parse(m3u8_url)
-            .map_err(|e| RdlpError::Extraction(format!("Invalid base URL: {e}")))?;
+            .map_err(|e| RdlpError::Extraction {
+                message: format!("Invalid base URL: {e}"),
+                url: Some(m3u8_url.to_string()),
+            })?;
 
         // Resolve all variant media playlist URLs and extract per-variant metadata.
         // Skip I-frame-only variants (EXT-X-I-FRAME-STREAM-INF) — these are trick-play
@@ -279,7 +286,10 @@ impl HlsSizeDetector {
             .expect("master playlist has at least one non-I-frame variant");
         let best_media_url = base_url
             .join(&best_variant.uri)
-            .map_err(|e| RdlpError::Extraction(format!("Failed to join media URL: {e}")))?
+            .map_err(|e| RdlpError::Extraction {
+                message: format!("Failed to join media URL: {e}"),
+                url: Some(m3u8_url.to_string()),
+            })?
             .to_string();
 
         if let Ok(Some(media_info)) = self.fetch_and_extract_media_info(&best_media_url).await {


### PR DESCRIPTION
## Summary
- Restructure `Network`, `Extraction`, `Download` error variants from `(String)` to `{ message: String, url: Option<String> }`
- Update `From<RdlpError> for RdlpApiError` to propagate `url` into `ExtractError::source_url`
- Update `is_retryable_error` and `is_reextractable_error` match patterns
- Migrate 227 construction sites across 47 files (rdlp-extractor, rdlp-downloader, rdlp-api, rdlp-core)
- Document intentional channel send error swallowing (10 sites)
- 11 new tests: variant construction, retry classification, conversion propagation, exhaustive smoke test

## Test plan
- [x] `cargo check` — zero errors
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 1375+ tests pass, zero failures
- [x] `cargo check -p rdlp-desktop` — compiles