### PR TITLE
chore: Phase C context enrichment for rdlp-ffmpeg and rdlp-api

### DIFF
--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -243,6 +243,9 @@ impl From<OrchestratorError> for RdlpApiError {
             OrchestratorError::InteractiveNotConfigured => Self::InvalidInput {
                 message: "Interactive selection not configured".into(),
             },
+            OrchestratorError::Other(e) => Self::Soft {
+                message: format!("{e:#}"),
+            },
         }
     }
 }
@@ -516,6 +519,33 @@ mod tests {
             }
             other => panic!("Expected NetworkError, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_anyhow_converts_to_orchestrator_other() {
+        let anyhow_err = anyhow::anyhow!("inner").context("outer");
+        let orch_err: OrchestratorError = anyhow_err.into();
+        assert!(matches!(orch_err, OrchestratorError::Other(_)));
+        assert!(orch_err.to_string().contains("outer"));
+    }
+
+    #[test]
+    fn test_orchestrator_other_converts_to_api_error() {
+        let anyhow_err = anyhow::anyhow!("root cause").context("operation failed");
+        let orch_err: OrchestratorError = anyhow_err.into();
+        let api_err: RdlpApiError = orch_err.into();
+        assert!(matches!(api_err, RdlpApiError::Soft { .. }));
+        let msg = api_err.to_string();
+        assert!(msg.contains("operation failed"), "msg: {msg}");
+        assert!(msg.contains("root cause"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_orchestrator_other_not_reextractable() {
+        use crate::orchestrator::errors::is_reextractable_error;
+        let anyhow_err = anyhow::anyhow!("something");
+        let orch_err: OrchestratorError = anyhow_err.into();
+        assert!(!is_reextractable_error(&orch_err));
     }
 
     #[test]

--- a/crates/rdlp-api/src/orchestrator/errors.rs
+++ b/crates/rdlp-api/src/orchestrator/errors.rs
@@ -88,6 +88,10 @@ pub enum OrchestratorError {
     /// Interactive callback not configured but interactive mode was requested
     #[error("Interactive format selection requested but no interactive callback is configured")]
     InteractiveNotConfigured,
+
+    /// Catch-all for errors with context chains from internal operations.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 /// Check if an error warrants re-extracting fresh URLs.
@@ -95,7 +99,7 @@ pub enum OrchestratorError {
 /// CDN failures (Cloudflare challenges, expired tokens, server errors)
 /// return `Extraction` errors containing "invalid M3U8". These can be
 /// resolved by calling `extract_lazy()` again for a fresh CDN assignment.
-pub(super) fn is_reextractable_error(err: &OrchestratorError) -> bool {
+pub(crate) fn is_reextractable_error(err: &OrchestratorError) -> bool {
     match err {
         OrchestratorError::DownloadFailed(RdlpError::Extraction { message, .. }) => {
             message.contains("invalid M3U8")

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -3,7 +3,7 @@
 mod archive;
 mod container_resolver;
 mod download;
-mod errors;
+pub(crate) mod errors;
 mod execution;
 mod extraction;
 mod interactive;

--- a/crates/rdlp-api/src/orchestrator/paths.rs
+++ b/crates/rdlp-api/src/orchestrator/paths.rs
@@ -4,6 +4,7 @@
 
 use super::template::{OutputTemplate, RenderContext};
 use super::{Orchestrator, Result};
+use anyhow::Context;
 use std::path::PathBuf;
 
 impl Orchestrator {
@@ -19,7 +20,10 @@ impl Orchestrator {
     ) -> Result<PathBuf> {
         let file_ext = self.determine_file_extension(format);
         let template = OutputTemplate::parse(&self.config.output_template).map_err(|e| {
-            super::OrchestratorError::Configuration(format!("Invalid output template: {e}"))
+            super::OrchestratorError::Configuration(format!(
+                "Invalid output template '{}': {e}",
+                self.config.output_template
+            ))
         })?;
         let ctx = RenderContext {
             epoch: chrono::Utc::now().timestamp(),
@@ -28,7 +32,10 @@ impl Orchestrator {
         let rendered = template
             .render(info, format, &file_ext, &ctx)
             .map_err(|e| {
-                super::OrchestratorError::Configuration(format!("Template rendering failed: {e}"))
+                super::OrchestratorError::Configuration(format!(
+                    "Template rendering failed for '{}' (format {}): {e}",
+                    info.title, format.format_id
+                ))
             })?;
 
         let path = self.sanitize_template_path(&rendered);
@@ -43,12 +50,11 @@ impl Orchestrator {
         if let Some(parent) = full_path.parent()
             && !parent.exists()
         {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                super::OrchestratorError::Configuration(format!(
-                    "Failed to create output directory {}: {e}",
-                    parent.display()
-                ))
-            })?;
+            std::fs::create_dir_all(parent)
+                .with_context(|| {
+                    format!("failed to create output directory {}", parent.display())
+                })
+                .map_err(super::OrchestratorError::Other)?;
         }
 
         Ok(full_path)

--- a/crates/rdlp-api/src/orchestrator/playlist/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/mod.rs
@@ -11,6 +11,7 @@ mod resume;
 #[cfg(test)]
 mod tests;
 
+use anyhow::Context;
 use super::errors::is_reextractable_error;
 use super::session_state::{self, FailedEpisode, PlaylistState, SessionState};
 use super::{DownloadPlan, Orchestrator, OrchestratorError, Result, archive};
@@ -315,12 +316,13 @@ impl Orchestrator {
         if !playlist_dir.exists() {
             tokio::fs::create_dir_all(&playlist_dir)
                 .await
-                .map_err(|e| {
-                    OrchestratorError::IoError(format!(
-                        "Failed to create playlist folder '{}': {e}",
+                .with_context(|| {
+                    format!(
+                        "failed to create playlist folder '{}'",
                         playlist_dir.display()
-                    ))
-                })?;
+                    )
+                })
+                .map_err(OrchestratorError::Other)?;
             debug!(path:? = playlist_dir.display(); "Created folder");
         }
 

--- a/crates/rdlp-api/src/orchestrator/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/resume.rs
@@ -1,6 +1,7 @@
 //! Resume detection and chunk merging functionality
 
 use super::{Orchestrator, errors::*};
+use anyhow::Context;
 use log::{debug, warn};
 use std::path::{Path, PathBuf};
 use tracing::instrument;
@@ -99,7 +100,10 @@ async fn detect_chunk_files(output_path: &Path) -> Option<ChunkInfo> {
 /// Merge chunk files into the output file
 ///
 /// Supports both old-style and new-style chunk patterns
-pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo) -> Result<u64> {
+pub(crate) async fn merge_chunk_files(
+    output_path: &Path,
+    chunk_info: &ChunkInfo,
+) -> anyhow::Result<u64> {
     use tokio::fs::File;
     use tokio::io::{AsyncWriteExt, BufWriter};
 
@@ -114,7 +118,7 @@ pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo
     // Create output file
     let file = File::create(output_path)
         .await
-        .map_err(OrchestratorError::ChunkMergeFailed)?;
+        .with_context(|| format!("failed to create output file {}", output_path.display()))?;
     let mut writer = BufWriter::with_capacity(2 * 1024 * 1024, file); // 2 MB buffer
 
     let mut total_size = 0u64;
@@ -122,18 +126,16 @@ pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo
     // Merge each chunk in order
     for (idx, chunk_path) in chunk_info.chunk_paths.iter().enumerate() {
         if !chunk_path.exists() {
-            return Err(OrchestratorError::MissingChunk {
-                path: chunk_path.clone(),
-            });
+            anyhow::bail!("missing chunk file: {}", chunk_path.display());
         }
 
         let mut chunk_file = File::open(chunk_path)
             .await
-            .map_err(OrchestratorError::ChunkMergeFailed)?;
+            .with_context(|| format!("failed to open chunk file {}", chunk_path.display()))?;
 
         let bytes_copied = tokio::io::copy(&mut chunk_file, &mut writer)
             .await
-            .map_err(OrchestratorError::ChunkMergeFailed)?;
+            .with_context(|| format!("failed to copy chunk {} to output", chunk_path.display()))?;
 
         total_size += bytes_copied;
 
@@ -145,13 +147,13 @@ pub(crate) async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo
         // Delete chunk file after successful merge
         tokio::fs::remove_file(chunk_path)
             .await
-            .map_err(OrchestratorError::ChunkMergeFailed)?;
+            .with_context(|| format!("failed to remove chunk file {}", chunk_path.display()))?;
     }
 
     writer
         .flush()
         .await
-        .map_err(OrchestratorError::ChunkMergeFailed)?;
+        .context("failed to flush merged output file")?;
 
     debug!(chunk_count; "Cleaned up chunk files");
 

--- a/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
@@ -81,12 +81,11 @@ async fn test_merge_chunk_files_missing_chunk() {
     assert!(result.is_err());
 
     let err = result.unwrap_err();
-    match err {
-        OrchestratorError::MissingChunk { path } => {
-            assert!(path.to_string_lossy().contains("video.mp4.part2"));
-        }
-        _ => panic!("Expected MissingChunk error, got {err:?}"),
-    }
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("video.mp4.part2") || msg.contains("missing chunk"),
+        "Expected missing chunk error mentioning part2, got: {msg}"
+    );
 }
 
 #[tokio::test]

--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -143,6 +143,10 @@ pub enum PostProcessError {
     /// Salvage remux failed — input too corrupt to recover.
     #[error("Input corrupt and salvage failed: {message}")]
     SalvageFailed { message: String },
+
+    /// Catch-all for errors with context chains from internal operations.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 impl PostProcessError {
@@ -404,5 +408,48 @@ mod tests {
 
         let no_audio = PostProcessError::NoAudioStream;
         assert!(!no_audio.is_salvage_retryable());
+    }
+
+    #[test]
+    fn test_anyhow_converts_to_postprocess_other() {
+        let anyhow_err = anyhow::anyhow!("inner problem").context("outer context");
+        let pp_err: PostProcessError = anyhow_err.into();
+        assert!(matches!(pp_err, PostProcessError::Other(_)));
+        let msg = pp_err.to_string();
+        assert!(msg.contains("outer context"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_postprocess_other_not_mux_write() {
+        let err: PostProcessError = anyhow::anyhow!("something").into();
+        assert!(!err.is_mux_write_error());
+    }
+
+    #[test]
+    fn test_postprocess_other_not_salvage_retryable() {
+        let err: PostProcessError = anyhow::anyhow!("something").into();
+        assert!(!err.is_salvage_retryable());
+        assert!(!err.is_enomem());
+        assert!(!err.is_eio());
+        assert!(!err.is_stall());
+    }
+
+    #[test]
+    fn test_postprocess_other_converts_to_rdlp_error() {
+        let err: PostProcessError = anyhow::anyhow!("ctx problem").into();
+        let rdlp_err: RdlpError = err.into();
+        assert!(matches!(rdlp_err, RdlpError::PostProcess(_)));
+        assert!(rdlp_err.to_string().contains("ctx problem"));
+    }
+
+    #[test]
+    fn test_ffmpeg_error_preserved_through_context() {
+        let pp_err = PostProcessError::FFmpegLibraryError {
+            message: "codec not found".into(),
+        };
+        let anyhow_err = anyhow::Error::from(pp_err).context("failed to open input");
+        let msg = format!("{anyhow_err:#}");
+        assert!(msg.contains("failed to open input"), "msg: {msg}");
+        assert!(msg.contains("codec not found"), "msg: {msg}");
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context as _;
 use log::info;
 
 use crate::error::{PostProcessError, Result};
@@ -38,14 +39,14 @@ impl FFmpegRunner {
         let audio_input = audio_input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        Self::spawn_blocking("merge", move || {
-            Self::merge_sync(
+        Self::spawn_blocking("merge", move || -> Result<()> {
+            Ok(Self::merge_sync(
                 &video_input,
                 &audio_input,
                 &output,
                 &opts,
                 progress_fn.as_deref(),
-            )
+            )?)
         })
         .await
     }
@@ -57,7 +58,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &RemuxOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // Suppress FFmpeg's internal muxer trace/debug spam (e.g. matroska "Writing block"
@@ -70,26 +71,20 @@ impl FFmpegRunner {
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
         if is_mkv {
-            return Self::merge_mkv_raw_ffi(video_input, audio_input, output, progress_fn);
+            return Ok(Self::merge_mkv_raw_ffi(video_input, audio_input, output, progress_fn)?);
         }
 
-        let mut ictx_video = ffmpeg_the_third::format::input(video_input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open video input {}: {e}", video_input.display()),
-            }
-        })?;
+        let mut ictx_video = ffmpeg_the_third::format::input(video_input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open video input for merge {}", video_input.display()))?;
 
-        let mut ictx_audio = ffmpeg_the_third::format::input(audio_input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open audio input {}: {e}", audio_input.display()),
-            }
-        })?;
+        let mut ictx_audio = ffmpeg_the_third::format::input(audio_input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open audio input for merge {}", audio_input.display()))?;
 
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open output for merge {}", output.display()))?;
 
         // Find best video stream from video input
         let video_ist_index = ictx_video
@@ -102,9 +97,8 @@ impl FFmpegRunner {
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
             ))
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to add video output stream: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to add video output stream for merge")?;
         ost_video.set_parameters(
             ictx_video
                 .stream(video_ist_index)
@@ -129,9 +123,8 @@ impl FFmpegRunner {
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
             ))
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to add audio output stream: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to add audio output stream for merge")?;
         ost_audio.set_parameters(
             ictx_audio
                 .stream(audio_ist_index)
@@ -159,9 +152,8 @@ impl FFmpegRunner {
 
         // Write header with options
         octx.write_header_with(dict)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for merge")?;
 
         info!("Merge: video=stream#{video_ost_index}, audio=stream#{audio_ost_index} (DEFAULT)");
 
@@ -195,14 +187,16 @@ impl FFmpegRunner {
             if vpkt.is_null() {
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: "av_packet_alloc failed for video packet".into(),
-                });
+                }
+                .into());
             }
             let apkt = ffi::av_packet_alloc();
             if apkt.is_null() {
                 ffi::av_packet_free(&mut (vpkt as *mut _));
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: "av_packet_alloc failed for audio packet".into(),
-                });
+                }
+                .into());
             }
 
             let mut have_video = read_next_raw(video_ctx, video_ist_index, vpkt);
@@ -296,9 +290,8 @@ impl FFmpegRunner {
         }
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for merge")?;
 
         Ok(())
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use log::debug;
 use rdlp_core::PostProcessCallback;
 
@@ -33,8 +34,14 @@ impl FFmpegRunner {
         let output = output.as_ref().to_path_buf();
         let metadata = metadata.clone();
         let chapters = chapters.to_vec();
-        Self::spawn_blocking("embed_metadata", move || {
-            Self::embed_metadata_sync(&input, &output, &metadata, &chapters, callback.as_deref())
+        Self::spawn_blocking("embed_metadata", move || -> Result<()> {
+            Ok(Self::embed_metadata_sync(
+                &input,
+                &output,
+                &metadata,
+                &chapters,
+                callback.as_deref(),
+            )?)
         })
         .await
     }
@@ -50,7 +57,7 @@ impl FFmpegRunner {
         metadata: &HashMap<String, String>,
         chapters: &[ChapterEntry],
         callback: Option<&dyn PostProcessCallback>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // When a callback is provided, capture FFmpeg logs and forward them;
@@ -66,17 +73,13 @@ impl FFmpegRunner {
             None
         };
 
-        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open input {}: {e}", input.display()),
-            }
-        })?;
+        let mut ictx = ffmpeg_the_third::format::input(input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open input for metadata embed {}", input.display()))?;
 
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open output for metadata embed {}", output.display()))?;
 
         // Map all streams (stream copy)
         let stream_count = ictx.streams().count();
@@ -101,9 +104,8 @@ impl FFmpegRunner {
                 .add_stream(ffmpeg_the_third::encoder::find(
                     ffmpeg_the_third::codec::Id::None,
                 ))
-                .map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to add output stream: {e}"),
-                })?;
+                .map_err(PostProcessError::from)
+                .context("failed to add output stream for metadata embed")?;
             ost.set_parameters(ist.parameters());
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
@@ -132,9 +134,8 @@ impl FFmpegRunner {
                 ch.end_ms,
                 &ch.title,
             )
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to add chapter '{}': {e}", ch.title),
-            })?;
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to add chapter '{}'", ch.title))?;
         }
 
         // Build muxer options dictionary
@@ -151,16 +152,14 @@ impl FFmpegRunner {
 
         // Write header with options
         octx.write_header_with(dict)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for metadata embed")?;
 
         // Copy packets
         for result in ictx.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read packet: {e}"),
-                })?;
+            let (stream, mut packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during metadata embed")?;
             let ist_index = stream.index();
             let ost_idx = stream_mapping[ist_index];
             if ost_idx < 0 {
@@ -176,17 +175,15 @@ impl FFmpegRunner {
             packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
             packet.set_position(-1);
             packet.set_stream(ost_idx);
-            packet.write_interleaved(&mut octx).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to write packet: {e}"),
-                }
-            })?;
+            packet
+                .write_interleaved(&mut octx)
+                .map_err(PostProcessError::from)
+                .context("failed to write packet during metadata embed")?;
         }
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for metadata embed")?;
 
         // Forward captured FFmpeg logs to the callback
         if let (Some(guard), Some(cb)) = (&capture, callback)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
@@ -7,6 +7,7 @@
 use std::ffi::CStr;
 use std::path::Path;
 
+use anyhow::Context as _;
 use log::{debug, warn};
 
 use crate::error::{PostProcessError, Result};
@@ -35,14 +36,12 @@ pub(super) fn run_analysis_decode_loop(
         &mut ffmpeg_the_third::filter::Graph,
         &mut ffmpeg_the_third::frame::Audio,
     ) -> Result<()>,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     ensure_init()?;
 
-    let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-        PostProcessError::FFmpegLibraryError {
-            message: format!("failed to open input {}: {e}", input.display()),
-        }
-    })?;
+    let mut ictx = ffmpeg_the_third::format::input(input)
+        .map_err(PostProcessError::from)
+        .with_context(|| format!("failed to open input for analysis {}", input.display()))?;
 
     let ist_index = ictx
         .streams()
@@ -58,17 +57,14 @@ pub(super) fn run_analysis_decode_loop(
     let mut decoder_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(
         ist.parameters(),
     )
-    .map_err(|e| PostProcessError::FFmpegLibraryError {
-        message: format!("failed to create decoder context: {e}"),
-    })?;
+    .map_err(PostProcessError::from)
+    .context("failed to create decoder context for analysis")?;
     set_single_thread_codec(unsafe { decoder_ctx.as_mut_ptr() });
-    let mut decoder =
-        decoder_ctx
-            .decoder()
-            .audio()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open audio decoder: {e}"),
-            })?;
+    let mut decoder = decoder_ctx
+        .decoder()
+        .audio()
+        .map_err(PostProcessError::from)
+        .context("failed to open audio decoder for analysis")?;
 
     debug!(
         "[{label}] decoder: rate={}, fmt={}, ch_layout={}, time_base={}/{}",
@@ -94,9 +90,8 @@ pub(super) fn run_analysis_decode_loop(
     )?;
     graph
         .add(&abuffersink, "out", "")
-        .map_err(|e| PostProcessError::FFmpegLibraryError {
-            message: format!("failed to add abuffersink filter: {e}"),
-        })?;
+        .map_err(PostProcessError::from)
+        .context("failed to add abuffersink filter for analysis")?;
 
     FFmpegRunner::parse_and_validate_filter_graph(&mut graph, "in", "out", filter_spec)?;
 
@@ -112,9 +107,9 @@ pub(super) fn run_analysis_decode_loop(
     let _log_suppress = LogSuppressGuard::new();
 
     for result in ictx.packets() {
-        let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
-            message: format!("failed to read packet: {e}"),
-        })?;
+        let (stream, packet) = result
+            .map_err(PostProcessError::from)
+            .context("failed to read packet during analysis")?;
         if stream.index() != ist_index {
             continue;
         }
@@ -132,9 +127,8 @@ pub(super) fn run_analysis_decode_loop(
                 .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
                 .source()
                 .add(&frame)
-                .map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("filter source add frame failed: {e}"),
-                })?;
+                .map_err(PostProcessError::from)
+                .context("filter source add frame failed")?;
             frame_unref_audio(&mut frame);
 
             on_drain(&mut graph, &mut filtered)?;
@@ -155,9 +149,8 @@ pub(super) fn run_analysis_decode_loop(
             .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
             .source()
             .add(&frame)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("filter source add frame (flush) failed: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("filter source add frame (flush) failed")?;
         frame_unref_audio(&mut frame);
 
         on_drain(&mut graph, &mut filtered)?;
@@ -169,9 +162,8 @@ pub(super) fn run_analysis_decode_loop(
         .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
         .source()
         .flush()
-        .map_err(|e| PostProcessError::FFmpegLibraryError {
-            message: format!("filter source flush failed: {e}"),
-        })?;
+        .map_err(PostProcessError::from)
+        .context("filter source flush failed")?;
     on_drain(&mut graph, &mut filtered)?;
 
     Ok(())
@@ -257,7 +249,7 @@ pub(super) fn read_frame_metadata(
 
 impl FFmpegRunner {
     /// Analyze peak and RMS levels using `astats` filter with frame metadata.
-    pub(super) fn analyze_peak_sync(input: &Path, target_peak_db: f64) -> Result<PeakAnalysis> {
+    pub(super) fn analyze_peak_sync(input: &Path, target_peak_db: f64) -> anyhow::Result<PeakAnalysis> {
         let mut peak_db = f64::NEG_INFINITY;
         let mut rms_db = f64::NEG_INFINITY;
 
@@ -276,7 +268,8 @@ impl FFmpegRunner {
         if peak_db == f64::NEG_INFINITY {
             return Err(PostProcessError::NormalizationFailed {
                 message: "could not determine peak level from astats metadata".into(),
-            });
+            }
+            .into());
         }
 
         let gain_db = target_peak_db - peak_db;
@@ -292,7 +285,7 @@ impl FFmpegRunner {
     pub(super) fn loudnorm_pass1_sync(
         input: &Path,
         opts: &NormalizeOptions,
-    ) -> Result<LoudnormMeasurements> {
+    ) -> anyhow::Result<LoudnormMeasurements> {
         let guard = begin_loudnorm_capture()?;
 
         // loudnorm only supports AV_SAMPLE_FMT_DBL; explicitly convert from
@@ -318,7 +311,7 @@ impl FFmpegRunner {
 
         debug!("Captured {} log lines from loudnorm pass 1", lines.len());
 
-        parse_loudnorm_json(&lines)
+        Ok(parse_loudnorm_json(&lines)?)
     }
 
     /// Post-normalization loudness verification.
@@ -326,7 +319,7 @@ impl FFmpegRunner {
     /// Runs loudnorm pass 1 on the **output** file and compares measured
     /// levels against targets. Warns on significant deviations but does
     /// not fail — the output is already written.
-    pub(super) fn verify_loudness_sync(output: &Path, opts: &NormalizeOptions) -> Result<()> {
+    pub(super) fn verify_loudness_sync(output: &Path, opts: &NormalizeOptions) -> anyhow::Result<()> {
         debug!("Loudness verification: analyzing output...");
         match Self::loudnorm_pass1_sync(output, opts) {
             Ok(measured) => {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -6,7 +6,9 @@
 
 use std::path::Path;
 
-use crate::error::{PostProcessError, Result};
+use anyhow::Context as _;
+
+use crate::error::PostProcessError;
 
 use super::super::{FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis};
 use super::helpers::{
@@ -22,7 +24,7 @@ impl FFmpegRunner {
         analysis: &PeakAnalysis,
         opts: &NormalizeOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         Self::dispatch_normalize_sync(
             input,
             output,
@@ -43,7 +45,7 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
         resilient: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         let gain_db = opts.target_peak_db - analysis.peak_db;
         let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
         Self::encode_audio_only_sync(
@@ -77,7 +79,7 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
         measurements: &LoudnormMeasurements,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         Self::dispatch_normalize_sync(
             input,
             output,
@@ -98,7 +100,7 @@ impl FFmpegRunner {
         measurements: &LoudnormMeasurements,
         resilient: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
         let limiter = build_alimiter_spec(opts.target_tp);
         Self::encode_audio_only_sync(
@@ -129,16 +131,14 @@ impl FFmpegRunner {
         output: &Path,
         salvage: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-        encode_fn: impl Fn(&Path, &Path, &str, bool, Option<&(dyn Fn(f64) + Send + Sync)>) -> Result<()>,
-    ) -> Result<()> {
+        encode_fn: impl Fn(&Path, &Path, &str, bool, Option<&(dyn Fn(f64) + Send + Sync)>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
         crate::ffmpeg::ensure_init()?;
 
         let has_video = {
-            let ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to open input {}: {e}", input.display()),
-                }
-            })?;
+            let ictx = ffmpeg_the_third::format::input(input)
+                .map_err(PostProcessError::from)
+                .with_context(|| format!("failed to open input for normalize dispatch {}", input.display()))?;
             ictx.streams()
                 .best(ffmpeg_the_third::media::Type::Video)
                 .is_some()
@@ -158,7 +158,7 @@ impl FFmpegRunner {
 
             if salvage {
                 with_mux_retry(input, &temp_audio, |effective_input, resilient| {
-                    encode_fn(effective_input, &temp_audio, ext, resilient, progress_fn)
+                    Ok(encode_fn(effective_input, &temp_audio, ext, resilient, progress_fn)?)
                 })?;
             } else {
                 encode_fn(input, &temp_audio, ext, false, progress_fn)?;
@@ -174,8 +174,9 @@ impl FFmpegRunner {
             merge_result
         } else if salvage {
             with_mux_retry(input, output, |effective_input, resilient| {
-                encode_fn(effective_input, output, ext, resilient, progress_fn)
-            })
+                Ok(encode_fn(effective_input, output, ext, resilient, progress_fn)?)
+            })?;
+            Ok(())
         } else {
             encode_fn(input, output, ext, false, progress_fn)
         }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -6,9 +6,10 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use anyhow::Context as _;
 use log::{debug, warn};
 
-use crate::error::{PostProcessError, Result};
+use crate::error::PostProcessError;
 
 use super::super::FFmpegRunner;
 use super::super::ffi_helpers::set_single_thread_codec;
@@ -47,18 +48,16 @@ impl FFmpegRunner {
             /*rate:*/ u32,
             /*ch_layout:*/ &str,
         ) -> String,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         crate::ffmpeg::ensure_init()?;
 
         let mut ictx = if resilient {
             debug!("[{label}] opening input with resilient flags (discardcorrupt+genpts)");
             open_input_resilient(input)?
         } else {
-            ffmpeg_the_third::format::input(input).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to open input {}: {e}", input.display()),
-                }
-            })?
+            ffmpeg_the_third::format::input(input)
+                .map_err(PostProcessError::from)
+                .with_context(|| format!("failed to open input for audio encode {}", input.display()))?
         };
 
         // Read the format-level start_time and duration (in AV_TIME_BASE = µs) before
@@ -89,11 +88,9 @@ impl FFmpegRunner {
 
         let input_audio_bitrate = audio_ist.parameters().bit_rate() as usize;
 
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to create output for audio encode {}", output.display()))?;
 
         let enc_name = select_audio_encoder_for_container(final_output_ext);
         let enc_codec = ffmpeg_the_third::encoder::find_by_name(enc_name).ok_or_else(|| {
@@ -113,9 +110,8 @@ impl FFmpegRunner {
         {
             let ost =
                 octx.add_stream(enc_codec)
-                    .map_err(|e| PostProcessError::FFmpegLibraryError {
-                        message: format!("failed to add audio output stream: {e}"),
-                    })?;
+                    .map_err(PostProcessError::from)
+                    .context("failed to add audio output stream for encode")?;
             audio_ost_index = ost.index();
             audio_enc_context =
                 ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
@@ -170,9 +166,8 @@ impl FFmpegRunner {
         let mut audio_encoder =
             audio_encoder
                 .open_as(enc_codec)
-                .map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to open audio encoder: {e}"),
-                })?;
+                .map_err(PostProcessError::from)
+                .context("failed to open audio encoder")?;
 
         let enc_time_base = unsafe {
             let tb = (*audio_encoder.as_ptr()).time_base;
@@ -199,9 +194,8 @@ impl FFmpegRunner {
         let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
         muxer_opts.set("cluster_time_limit", "500");
         octx.write_header_with(muxer_opts)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for audio encode")?;
 
         // Validate mux header state (threading, IO, seekability, file size)
         unsafe {
@@ -305,9 +299,9 @@ impl FFmpegRunner {
         let mut last_progress = Instant::now();
         let progress_throttle = Duration::from_millis(100);
         for result in ictx.packets() {
-            let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to read packet: {e}"),
-            })?;
+            let (stream, packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during audio encode")?;
             if stream.index() != audio_ist_index {
                 continue;
             }
@@ -347,14 +341,15 @@ impl FFmpegRunner {
                     Some(output),
                 ) {
                     if drain_err.is_mux_write_error() {
-                        return Err(drain_err);
+                        return Err(drain_err.into());
                     }
                     return Err(PostProcessError::FFmpegLibraryError {
                         message: format!(
                             "({label}) mux/encode pipeline failed while \
                              draining after decoder error: {drain_err}"
                         ),
-                    });
+                    }
+                    .into());
                 }
                 continue;
             }
@@ -387,7 +382,8 @@ impl FFmpegRunner {
                 message: format!(
                     "audio decoder failed on all {packets_skipped} packets — cannot normalize"
                 ),
-            });
+            }
+            .into());
         }
 
         // Flush
@@ -442,9 +438,8 @@ impl FFmpegRunner {
         debug!("[mem] filter graph freed");
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for audio encode")?;
 
         drop(octx);
         drop(ictx);

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
@@ -68,7 +68,7 @@ impl FFmpegRunner {
                 let _ = std::fs::remove_file(temp);
             }
 
-            result
+            Ok(result?)
         })
         .await
     }
@@ -79,7 +79,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         let analysis = Self::analyze_peak_sync(input, opts.target_peak_db)?;
 
         debug!(
@@ -115,7 +115,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         info!("Loudnorm pass 1: analyzing EBU R128 levels...");
         let measurements = Self::loudnorm_pass1_sync(input, opts)?;
 
@@ -182,7 +182,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         let ceiling_db = opts.target_tp - ALIMITER_TP_HEADROOM_DB;
         let limit_linear = 10f64.powf(ceiling_db / 20.0);
         debug!(

--- a/crates/rdlp-ffmpeg/src/ffmpeg/probe.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/probe.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{PostProcessError, Result};
@@ -74,18 +75,19 @@ impl FFmpegRunner {
             return Err(PostProcessError::InputNotFound { path });
         }
 
-        Self::spawn_blocking("probe", move || Self::probe_sync(&path)).await
+        Self::spawn_blocking("probe", move || -> Result<MediaInfo> {
+            Ok(Self::probe_sync(&path)?)
+        })
+        .await
     }
 
     /// Probe a media file synchronously using ffmpeg-the-third library.
-    fn probe_sync(path: &Path) -> Result<MediaInfo> {
+    fn probe_sync(path: &Path) -> anyhow::Result<MediaInfo> {
         ensure_init()?;
 
-        let ictx = ffmpeg_the_third::format::input(path).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open {}: {e}", path.display()),
-            }
-        })?;
+        let ictx = ffmpeg_the_third::format::input(path)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to probe input {}", path.display()))?;
 
         let mut info = MediaInfo {
             path: path.to_path_buf(),

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context as _;
 use log::debug;
 
 use crate::error::{PostProcessError, Result};
@@ -28,8 +29,8 @@ impl FFmpegRunner {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
-        Self::spawn_blocking("remux", move || {
-            Self::remux_sync(&input, &output, &opts, progress_fn.as_deref())
+        Self::spawn_blocking("remux", move || -> Result<()> {
+            Ok(Self::remux_sync(&input, &output, &opts, progress_fn.as_deref())?)
         })
         .await
     }
@@ -43,7 +44,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &RemuxOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // Suppress FFmpeg's internal muxer trace/debug spam (e.g. matroska "Writing block"
@@ -59,17 +60,13 @@ impl FFmpegRunner {
             return Self::remux_mkv_raw_ffi(input, output, progress_fn);
         }
 
-        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open input {}: {e}", input.display()),
-            }
-        })?;
+        let mut ictx = ffmpeg_the_third::format::input(input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open input for remux {}", input.display()))?;
 
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open output for remux {}", output.display()))?;
 
         let stream_count = ictx.streams().count();
         let mut stream_mapping: Vec<i32> = vec![-1; stream_count];
@@ -123,9 +120,8 @@ impl FFmpegRunner {
                 .add_stream(ffmpeg_the_third::encoder::find(
                     ffmpeg_the_third::codec::Id::None,
                 ))
-                .map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to add output stream: {e}"),
-                })?;
+                .map_err(PostProcessError::from)
+                .context("failed to add output stream for remux")?;
             ost.set_parameters(ist.parameters());
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
@@ -143,9 +139,8 @@ impl FFmpegRunner {
 
         // Write header with muxer options
         octx.write_header_with(dict)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for remux")?;
 
         // Read input duration for progress reporting (AV_TIME_BASE microseconds)
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
@@ -154,10 +149,9 @@ impl FFmpegRunner {
 
         // Copy packets with PTS normalization (shifts timestamps to start at 0)
         for result in ictx.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read packet: {e}"),
-                })?;
+            let (stream, mut packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during remux")?;
             let ist_index = stream.index();
             let ost_idx = stream_mapping[ist_index];
             if ost_idx < 0 {
@@ -199,11 +193,10 @@ impl FFmpegRunner {
             packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
             packet.set_position(-1);
             packet.set_stream(ost_idx);
-            packet.write_interleaved(&mut octx).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to write packet: {e}"),
-                }
-            })?;
+            packet
+                .write_interleaved(&mut octx)
+                .map_err(PostProcessError::from)
+                .context("failed to write packet during remux")?;
         }
 
         // Emit final 1.0 on completion
@@ -212,9 +205,8 @@ impl FFmpegRunner {
         }
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for remux")?;
 
         Ok(())
     }
@@ -235,7 +227,7 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         use ffmpeg_the_third::ffi;
         use std::ffi::CString;
         use std::ptr;
@@ -265,7 +257,8 @@ impl FFmpegRunner {
             if ret < 0 {
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: format!("Failed to open input: error code {ret}"),
-                });
+                }
+                .into());
             }
 
             let ret = ffi::avformat_find_stream_info(ifmt_ctx, ptr::null_mut());
@@ -273,7 +266,8 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: format!("Failed to find stream info: error code {ret}"),
-                });
+                }
+                .into());
             }
 
             // 2. Create output context - EXPLICITLY request Matroska muxer
@@ -289,7 +283,8 @@ impl FFmpegRunner {
                 ffi::avformat_close_input(&mut ifmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: format!("Failed to create output context: error code {ret}"),
-                });
+                }
+                .into());
             }
 
             // 3. Copy streams with FULL property preservation (like CLI does)
@@ -319,7 +314,8 @@ impl FFmpegRunner {
                     ffi::avformat_free_context(ofmt_ctx);
                     return Err(PostProcessError::FFmpegLibraryError {
                         message: "Failed to create output stream".into(),
-                    });
+                    }
+                    .into());
                 }
 
                 // Copy codec parameters
@@ -329,7 +325,8 @@ impl FFmpegRunner {
                     ffi::avformat_free_context(ofmt_ctx);
                     return Err(PostProcessError::FFmpegLibraryError {
                         message: format!("Failed to copy codec params: error code {ret}"),
-                    });
+                    }
+                    .into());
                 }
 
                 // Reset codec tag for container compatibility
@@ -386,7 +383,8 @@ impl FFmpegRunner {
                     ffi::avformat_free_context(ofmt_ctx);
                     return Err(PostProcessError::FFmpegLibraryError {
                         message: format!("Failed to open output file: error code {ret}"),
-                    });
+                    }
+                    .into());
                 }
             }
 
@@ -420,7 +418,8 @@ impl FFmpegRunner {
                 ffi::avformat_free_context(ofmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: format!("avformat_init_output failed: error code {ret}"),
-                });
+                }
+                .into());
             }
 
             // 8. Write header
@@ -433,7 +432,8 @@ impl FFmpegRunner {
                 ffi::avformat_free_context(ofmt_ctx);
                 return Err(PostProcessError::FFmpegLibraryError {
                     message: format!("avformat_write_header failed: error code {ret}"),
-                });
+                }
+                .into());
             }
 
             // 9. Copy packets

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -27,6 +27,7 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::Context as _;
 use log::{debug, info, warn};
 
 use crate::error::{CorruptionKind, PostProcessError, Result};
@@ -151,7 +152,7 @@ pub(crate) fn check_matroska_integrity(input: &Path) -> Result<()> {
 ///
 /// Returns the path to the salvaged temporary file. The caller is responsible
 /// for cleaning up this file when done.
-pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
+pub(crate) fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     ensure_init()?;
 
     // Always use MKV for salvage output. Matroska writes metadata
@@ -190,19 +191,18 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
     let _log_suppress = LogSuppressGuard::new();
 
     // Open corrupt input — FFmpeg will log warnings but continue reading
-    let mut ictx =
-        ffmpeg_the_third::format::input(input).map_err(|e| PostProcessError::SalvageFailed {
-            message: format!("failed to open corrupt input {}: {e}", input.display()),
-        })?;
+    let mut ictx = ffmpeg_the_third::format::input(input)
+        .map_err(PostProcessError::from)
+        .with_context(|| format!("failed to open corrupt input for salvage {}", input.display()))?;
 
-    let mut octx = ffmpeg_the_third::format::output(&salvage_path).map_err(|e| {
-        PostProcessError::SalvageFailed {
-            message: format!(
-                "failed to create salvage output {}: {e}",
+    let mut octx = ffmpeg_the_third::format::output(&salvage_path)
+        .map_err(PostProcessError::from)
+        .with_context(|| {
+            format!(
+                "failed to create salvage output {}",
                 salvage_path.display()
-            ),
-        }
-    })?;
+            )
+        })?;
 
     // Map all input streams to output (stream copy, no re-encoding)
     let stream_count = ictx.streams().count();
@@ -211,9 +211,8 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
             ))
-            .map_err(|e| PostProcessError::SalvageFailed {
-                message: format!("failed to add output stream: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to add output stream for salvage")?;
         ost.set_parameters(ist.parameters());
         FFmpegRunner::clear_codec_tag(ost.parameters().as_ptr());
     }
@@ -230,9 +229,8 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
     muxer_opts.set("cluster_time_limit", "500");
 
     octx.write_header_with(muxer_opts)
-        .map_err(|e| PostProcessError::SalvageFailed {
-            message: format!("failed to write salvage output header: {e}"),
-        })?;
+        .map_err(PostProcessError::from)
+        .context("failed to write salvage output header")?;
 
     // Copy all recoverable packets, skipping ones that fail to read or write
     let mut copied = 0u64;
@@ -277,9 +275,8 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
     drop(_log_suppress);
 
     octx.write_trailer()
-        .map_err(|e| PostProcessError::SalvageFailed {
-            message: format!("failed to write salvage output trailer: {e}"),
-        })?;
+        .map_err(PostProcessError::from)
+        .context("failed to write salvage output trailer")?;
 
     info!("Salvage remux complete: {copied} packets copied, {skipped} skipped");
 
@@ -287,7 +284,8 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> Result<PathBuf> {
         let _ = std::fs::remove_file(&salvage_path);
         return Err(PostProcessError::SalvageFailed {
             message: "no packets could be recovered from corrupt input".into(),
-        });
+        }
+        .into());
     }
 
     Ok(salvage_path)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -11,6 +11,7 @@ mod mkv_raw_ffi;
 use std::path::Path;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use rdlp_core::PostProcessCallback;
 
 use crate::error::{PostProcessError, Result};
@@ -39,8 +40,14 @@ impl FFmpegRunner {
         let thumbnail = thumbnail.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
         let container = container.to_string();
-        Self::spawn_blocking("embed_thumbnail", move || {
-            Self::embed_thumbnail_sync(&media, &thumbnail, &output, &container, callback.as_deref())
+        Self::spawn_blocking("embed_thumbnail", move || -> Result<()> {
+            Ok(Self::embed_thumbnail_sync(
+                &media,
+                &thumbnail,
+                &output,
+                &container,
+                callback.as_deref(),
+            )?)
         })
         .await
     }
@@ -58,7 +65,7 @@ impl FFmpegRunner {
         output: &Path,
         container: &str,
         callback: Option<&dyn PostProcessCallback>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // When a callback is provided, capture FFmpeg logs and forward them;
@@ -80,29 +87,23 @@ impl FFmpegRunner {
             let result = Self::embed_thumbnail_mkv_raw_ffi(media, thumbnail, output);
             // Forward captured logs before returning
             Self::forward_captured_logs(&capture, callback);
-            return result;
+            return Ok(result?);
         }
 
         // Open media input
-        let mut ictx = ffmpeg_the_third::format::input(media).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open media input {}: {e}", media.display()),
-            }
-        })?;
+        let mut ictx = ffmpeg_the_third::format::input(media)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open media input for thumbnail embed {}", media.display()))?;
 
         // Open thumbnail input
-        let mut thumb_ictx = ffmpeg_the_third::format::input(thumbnail).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open thumbnail {}: {e}", thumbnail.display()),
-            }
-        })?;
+        let mut thumb_ictx = ffmpeg_the_third::format::input(thumbnail)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open thumbnail {}", thumbnail.display()))?;
 
         // Create output
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to create output for thumbnail embed {}", output.display()))?;
 
         let is_mp3 = container.eq_ignore_ascii_case("mp3");
 
@@ -135,9 +136,8 @@ impl FFmpegRunner {
                 .add_stream(ffmpeg_the_third::encoder::find(
                     ffmpeg_the_third::codec::Id::None,
                 ))
-                .map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to add output stream: {e}"),
-                })?;
+                .map_err(PostProcessError::from)
+                .context("failed to add output stream for thumbnail embed")?;
             ost.set_parameters(ist.parameters());
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
@@ -158,9 +158,8 @@ impl FFmpegRunner {
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
             ))
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to add thumbnail stream: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to add thumbnail stream")?;
         let thumb_ost_index = ost.index();
         ost.set_parameters(thumb_params);
         // SAFETY: ost is a valid output stream in a live output context.
@@ -191,9 +190,8 @@ impl FFmpegRunner {
 
         // Write header with options
         octx.write_header_with(dict)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for thumbnail embed")?;
 
         // For FLAC/OGG/Opus: write thumbnail packets BEFORE media packets.
         // These formats store picture metadata in the file header (METADATA_BLOCK_PICTURE
@@ -215,10 +213,9 @@ impl FFmpegRunner {
 
         // Copy media packets
         for result in ictx.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read media packet: {e}"),
-                })?;
+            let (stream, mut packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read media packet during thumbnail embed")?;
             let ist_index = stream.index();
             let ost_idx = stream_mapping[ist_index];
             if ost_idx < 0 {
@@ -234,11 +231,10 @@ impl FFmpegRunner {
             packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
             packet.set_position(-1);
             packet.set_stream(ost_idx);
-            packet.write_interleaved(&mut octx).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to write media packet: {e}"),
-                }
-            })?;
+            packet
+                .write_interleaved(&mut octx)
+                .map_err(PostProcessError::from)
+                .context("failed to write media packet during thumbnail embed")?;
         }
 
         // Copy thumbnail packet(s) for formats that don't need them in the header.
@@ -254,9 +250,8 @@ impl FFmpegRunner {
         }
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for thumbnail embed")?;
 
         // Forward captured FFmpeg logs to the callback
         Self::forward_captured_logs(&capture, callback);

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context as _;
 use log::{debug, info};
 
 use crate::error::{PostProcessError, Result};
@@ -45,7 +46,7 @@ impl FFmpegRunner {
                 let _ = std::fs::remove_file(temp);
             }
 
-            result
+            Ok(result?)
         })
         .await
     }
@@ -56,7 +57,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &AudioExtractOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         if opts.copy {
             Self::extract_audio_copy_sync(input, output, progress_fn)
         } else {
@@ -71,25 +72,21 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // Suppress FFmpeg's internal muxer trace/debug spam while keeping errors visible.
         let _log_suppress = LogSuppressGuard::error_level();
 
-        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open input {}: {e}", input.display()),
-            }
-        })?;
+        let mut ictx = ffmpeg_the_third::format::input(input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open input for audio copy extract {}", input.display()))?;
 
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to create output for audio copy extract {}", output.display()))?;
 
         // Find best audio stream
         let ist_index = ictx
@@ -110,9 +107,8 @@ impl FFmpegRunner {
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
             ))
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to add output stream: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to add output stream for audio copy extract")?;
         ost.set_parameters(
             ictx.stream(ist_index)
                 .ok_or_else(|| {
@@ -125,19 +121,17 @@ impl FFmpegRunner {
         Self::clear_codec_tag(ost.parameters().as_ptr());
 
         octx.write_header()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for audio copy extract")?;
 
         let mut last_progress = Instant::now();
         let throttle = Duration::from_millis(100);
 
         // Copy only audio packets
         for result in ictx.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read packet: {e}"),
-                })?;
+            let (stream, mut packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during audio copy extract")?;
             if stream.index() != ist_index {
                 continue;
             }
@@ -160,11 +154,10 @@ impl FFmpegRunner {
             packet.rescale_ts(ist_time_base, ost_time_base);
             packet.set_position(-1);
             packet.set_stream(0);
-            packet.write_interleaved(&mut octx).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to write packet: {e}"),
-                }
-            })?;
+            packet
+                .write_interleaved(&mut octx)
+                .map_err(PostProcessError::from)
+                .context("failed to write packet during audio copy extract")?;
         }
 
         if let Some(ref progress) = progress_fn {
@@ -172,9 +165,8 @@ impl FFmpegRunner {
         }
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for audio copy extract")?;
 
         Ok(())
     }
@@ -189,18 +181,16 @@ impl FFmpegRunner {
         output: &Path,
         opts: &AudioExtractOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // Suppress FFmpeg's internal muxer trace/debug spam while keeping errors visible.
         let _log_suppress = LogSuppressGuard::error_level();
 
         // Open input and find audio stream
-        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open input {}: {e}", input.display()),
-            }
-        })?;
+        let mut ictx = ffmpeg_the_third::format::input(input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open input for audio transcode {}", input.display()))?;
 
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
@@ -226,11 +216,9 @@ impl FFmpegRunner {
         let mut decoder = decoder_ctx.decoder().audio()?;
 
         // Open output
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to create output for audio transcode {}", output.display()))?;
 
         // Find encoder codec
         let enc_codec = if let Some(ref name) = opts.encoder_name {
@@ -261,9 +249,8 @@ impl FFmpegRunner {
         {
             let ost =
                 octx.add_stream(enc_codec)
-                    .map_err(|e| PostProcessError::FFmpegLibraryError {
-                        message: format!("failed to add output stream: {e}"),
-                    })?;
+                    .map_err(PostProcessError::from)
+                    .context("failed to add output stream for audio transcode")?;
             ost_index = ost.index();
             enc_context =
                 ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
@@ -313,9 +300,8 @@ impl FFmpegRunner {
         let mut audio_encoder =
             audio_encoder
                 .open_as(enc_codec)
-                .map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to open audio encoder: {e}"),
-                })?;
+                .map_err(PostProcessError::from)
+                .context("failed to open audio encoder for transcode")?;
 
         // Read actual encoder time_base via FFI (may differ from configured after open)
         // SAFETY: audio_encoder is a valid opened encoder context.
@@ -337,9 +323,8 @@ impl FFmpegRunner {
         });
 
         octx.write_header()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for audio transcode")?;
 
         // Read ost_time_base AFTER write_header (Matroska may change it)
         let ost_time_base = octx
@@ -388,9 +373,9 @@ impl FFmpegRunner {
 
         // Transcode loop: read -> decode -> filter -> encode -> write
         for result in ictx.packets() {
-            let (stream, packet) = result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to read packet: {e}"),
-            })?;
+            let (stream, packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during audio transcode")?;
             if stream.index() != ist_index {
                 continue;
             }
@@ -463,9 +448,8 @@ impl FFmpegRunner {
         flush_interleave_queue(&mut octx);
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for audio transcode")?;
 
         Ok(())
     }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context as _;
 use log::debug;
 
 use crate::error::{PostProcessError, Result};
@@ -69,7 +70,7 @@ impl FFmpegRunner {
                 let _ = std::fs::remove_file(temp);
             }
 
-            result
+            Ok(result?)
         })
         .await
     }
@@ -80,7 +81,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &VideoConvertOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         if opts.remux_only {
             // Determine if output is MP4/MOV for faststart
             let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -88,7 +89,8 @@ impl FFmpegRunner {
                 faststart: ext.eq_ignore_ascii_case("mp4") || ext.eq_ignore_ascii_case("mov"),
                 ..Default::default()
             };
-            Self::remux_sync(input, output, &remux_opts, progress_fn)
+            Ok(Self::remux_sync(input, output, &remux_opts, progress_fn)
+                .map_err(|e| PostProcessError::ffmpeg_failed(format!("{e:#}")))?)
         } else {
             Self::convert_video_transcode_sync(input, output, opts, progress_fn)
         }
@@ -105,15 +107,13 @@ impl FFmpegRunner {
         output: &Path,
         opts: &VideoConvertOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         ensure_init()?;
 
         // Open input
-        let mut ictx = ffmpeg_the_third::format::input(input).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open input {}: {e}", input.display()),
-            }
-        })?;
+        let mut ictx = ffmpeg_the_third::format::input(input)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open input for video transcode {}", input.display()))?;
 
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
@@ -191,11 +191,9 @@ impl FFmpegRunner {
         let mut video_decoder = video_dec_ctx.decoder().video()?;
 
         // Open output
-        let mut octx = ffmpeg_the_third::format::output(output).map_err(|e| {
-            PostProcessError::FFmpegLibraryError {
-                message: format!("failed to create output {}: {e}", output.display()),
-            }
-        })?;
+        let mut octx = ffmpeg_the_third::format::output(output)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to create output for video transcode {}", output.display()))?;
 
         // Find video encoder
         let video_codec_name = opts.video_codec.as_deref().unwrap_or("libx264");
@@ -214,11 +212,10 @@ impl FFmpegRunner {
         // Add video output stream (scoped to release octx borrow)
         let video_ost_index;
         {
-            let ost = octx.add_stream(video_enc_codec).map_err(|e| {
-                PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to add video output stream: {e}"),
-                }
-            })?;
+            let ost = octx
+                .add_stream(video_enc_codec)
+                .map_err(PostProcessError::from)
+                .context("failed to add video output stream for transcode")?;
             video_ost_index = ost.index();
         }
 
@@ -269,9 +266,8 @@ impl FFmpegRunner {
         }
         let mut video_encoder = video_encoder
             .open_as_with(video_enc_codec, enc_opts)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to open video encoder: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to open video encoder for transcode")?;
 
         // The encoder's ctx->time_base is NOT the timebase of output packets.
         // Packets inherit the timebase from the filter graph input, which is
@@ -312,9 +308,8 @@ impl FFmpegRunner {
                         .add_stream(ffmpeg_the_third::encoder::find(
                             ffmpeg_the_third::codec::Id::None,
                         ))
-                        .map_err(|e| PostProcessError::FFmpegLibraryError {
-                            message: format!("failed to add audio output stream: {e}"),
-                        })?;
+                        .map_err(PostProcessError::from)
+                        .context("failed to add audio output stream for video transcode")?;
                     ost.set_parameters(
                         ictx.stream(audio_idx)
                             .ok_or_else(|| {
@@ -374,11 +369,10 @@ impl FFmpegRunner {
                 // Add audio output stream with encoder
                 let audio_enc_ost_idx;
                 {
-                    let ost = octx.add_stream(audio_enc_codec).map_err(|e| {
-                        PostProcessError::FFmpegLibraryError {
-                            message: format!("failed to add audio encode output stream: {e}"),
-                        }
-                    })?;
+                    let ost = octx
+                        .add_stream(audio_enc_codec)
+                        .map_err(PostProcessError::from)
+                        .context("failed to add audio encode output stream for video transcode")?;
                     audio_enc_ost_idx = ost.index();
                 }
 
@@ -416,11 +410,10 @@ impl FFmpegRunner {
                     unsafe { Self::set_global_header_flag(audio_encoder.as_mut_ptr()) };
                 }
 
-                let audio_encoder = audio_encoder.open_as(audio_enc_codec).map_err(|e| {
-                    PostProcessError::FFmpegLibraryError {
-                        message: format!("failed to open audio encoder '{enc_name}': {e}"),
-                    }
-                })?;
+                let audio_encoder = audio_encoder
+                    .open_as(audio_enc_codec)
+                    .map_err(PostProcessError::from)
+                    .with_context(|| format!("failed to open audio encoder '{enc_name}' for video transcode"))?;
 
                 // Copy encoder parameters back to output stream
                 unsafe {
@@ -466,9 +459,8 @@ impl FFmpegRunner {
 
         // Write header with options
         octx.write_header_with(dict)
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output header: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for video transcode")?;
 
         // Build video filter graph for pixel format conversion
         let mut filter_graph =
@@ -493,10 +485,9 @@ impl FFmpegRunner {
 
         // Process packets: video -> decode/filter/encode, audio -> copy or transcode
         for result in ictx.packets() {
-            let (stream, mut packet) =
-                result.map_err(|e| PostProcessError::FFmpegLibraryError {
-                    message: format!("failed to read packet: {e}"),
-                })?;
+            let (stream, mut packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during video transcode")?;
             let ist_index = stream.index();
 
             if ist_index == video_ist_index {
@@ -541,11 +532,10 @@ impl FFmpegRunner {
                     packet.rescale_ts(audio_tb, ost_time_base);
                     packet.set_position(-1);
                     packet.set_stream(audio_ost_idx);
-                    packet.write_interleaved(&mut octx).map_err(|e| {
-                        PostProcessError::FFmpegLibraryError {
-                            message: format!("failed to write audio packet: {e}"),
-                        }
-                    })?;
+                    packet
+                        .write_interleaved(&mut octx)
+                        .map_err(PostProcessError::from)
+                        .context("failed to write audio packet during video transcode")?;
                 } else if let (
                     Some(ref mut audio_dec),
                     Some(ref mut audio_enc),
@@ -657,9 +647,8 @@ impl FFmpegRunner {
         flush_interleave_queue(&mut octx);
 
         octx.write_trailer()
-            .map_err(|e| PostProcessError::FFmpegLibraryError {
-                message: format!("failed to write output trailer: {e}"),
-            })?;
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for video transcode")?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Add `#[error(transparent)] Other(#[from] anyhow::Error)` catch-all to `PostProcessError` and `OrchestratorError`
- Switch 20 `*_sync` FFmpeg functions to `anyhow::Result` with `.context()` on every `?` site
- FFmpeg library calls use `map_err(PostProcessError::from)` before `.context()` to preserve typed `FFmpegLibraryError` variants
- Switch orchestrator internals to `anyhow::Result` with `.context()` — typed `ExtractionFailed`/`DownloadFailed` variants preserved for CDN retry logic
- Add `Other` arm to `From<OrchestratorError> for RdlpApiError` (maps to `Soft`)
- 8 new tests: variant conversion, classification methods, From chain, context preservation

## Test plan
- [x] `cargo check` — zero errors
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 1407+ tests pass, zero failures
- [x] `cargo check -p rdlp-desktop` — compiles