### PR TITLE
feat: write encoder identification metadata to output files

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
@@ -1,0 +1,39 @@
+//! Encoder identification metadata for output files.
+
+/// Build the format-level `encoding_tool` metadata value.
+///
+/// # Examples
+///
+/// ```ignore
+/// encoding_tool_tag("libx264 + libfdk_aac")  // → "rdlp/0.1.0 (libx264 + libfdk_aac)"
+/// encoding_tool_tag("remux")                  // → "rdlp/0.1.0 (remux)"
+/// ```
+pub(crate) fn encoding_tool_tag(components: &str) -> String {
+    format!("rdlp/{} ({components})", env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encoding_tool_tag_format() {
+        let tag = encoding_tool_tag("libx264 + libfdk_aac");
+        assert!(tag.starts_with("rdlp/"), "tag: {tag}");
+        assert!(tag.contains("libx264 + libfdk_aac"), "tag: {tag}");
+        assert!(tag.ends_with(')'), "tag: {tag}");
+    }
+
+    #[test]
+    fn test_encoding_tool_tag_remux() {
+        let tag = encoding_tool_tag("remux");
+        assert!(tag.starts_with("rdlp/"), "tag: {tag}");
+        assert!(tag.contains("(remux)"), "tag: {tag}");
+    }
+
+    #[test]
+    fn test_encoding_tool_tag_single_component() {
+        let tag = encoding_tool_tag("libfdk_aac");
+        assert!(tag.contains("(libfdk_aac)"), "tag: {tag}");
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -82,7 +82,10 @@ impl FFmpegRunner {
             let mut best: Option<u32> = None;
             let mut best_dist = u32::MAX;
             loop {
-                debug_assert!(i < 1000, "FFmpeg rate array iteration exceeded safety limit");
+                debug_assert!(
+                    i < 1000,
+                    "FFmpeg rate array iteration exceeded safety limit"
+                );
                 let rate = *rates.offset(i);
                 if rate == 0 {
                     break;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -368,23 +368,13 @@ impl FFmpegRunner {
                         (false, false) => break,
                         (true, false) => {
                             bytes_written += (*vpkt).size as u64;
-                            rescale_and_write_raw(
-                                vpkt,
-                                in_video_stream,
-                                ofmt_ctx,
-                                video_out_idx,
-                            )?;
+                            rescale_and_write_raw(vpkt, in_video_stream, ofmt_ctx, video_out_idx)?;
                             ffi::av_packet_unref(vpkt);
                             have_video = read_next_raw(ifmt_video, video_stream_idx, vpkt);
                         }
                         (false, true) => {
                             bytes_written += (*apkt).size as u64;
-                            rescale_and_write_raw(
-                                apkt,
-                                in_audio_stream,
-                                ofmt_ctx,
-                                audio_out_idx,
-                            )?;
+                            rescale_and_write_raw(apkt, in_audio_stream, ofmt_ctx, audio_out_idx)?;
                             ffi::av_packet_unref(apkt);
                             have_audio = read_next_raw(ifmt_audio, audio_stream_idx, apkt);
                         }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -71,16 +71,31 @@ impl FFmpegRunner {
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
         if is_mkv {
-            return Ok(Self::merge_mkv_raw_ffi(video_input, audio_input, output, progress_fn)?);
+            return Ok(Self::merge_mkv_raw_ffi(
+                video_input,
+                audio_input,
+                output,
+                progress_fn,
+            )?);
         }
 
         let mut ictx_video = ffmpeg_the_third::format::input(video_input)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open video input for merge {}", video_input.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open video input for merge {}",
+                    video_input.display()
+                )
+            })?;
 
         let mut ictx_audio = ffmpeg_the_third::format::input(audio_input)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open audio input for merge {}", audio_input.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open audio input for merge {}",
+                    audio_input.display()
+                )
+            })?;
 
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
@@ -149,6 +164,14 @@ impl FFmpegRunner {
         if opts.faststart {
             dict.set("movflags", "+faststart");
         }
+
+        // Set format-level encoding_tool metadata
+        let mut format_meta = octx.metadata().to_owned();
+        format_meta.set(
+            "encoding_tool",
+            &crate::ffmpeg::encoding_tag::encoding_tool_tag("merge"),
+        );
+        octx.set_metadata(format_meta);
 
         // Write header with options
         octx.write_header_with(dict)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -75,11 +75,21 @@ impl FFmpegRunner {
 
         let mut ictx = ffmpeg_the_third::format::input(input)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open input for metadata embed {}", input.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open input for metadata embed {}",
+                    input.display()
+                )
+            })?;
 
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open output for metadata embed {}", output.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open output for metadata embed {}",
+                    output.display()
+                )
+            })?;
 
         // Map all streams (stream copy)
         let stream_count = ictx.streams().count();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -29,6 +29,7 @@
 
 mod audio_codecs;
 pub mod audio_encoder_registry;
+mod encoding_tag;
 mod ffi_helpers;
 pub mod log_capture;
 mod merge;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
@@ -54,11 +54,10 @@ pub(super) fn run_analysis_decode_loop(
     })?;
     let ist_time_base = ist.time_base();
 
-    let mut decoder_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(
-        ist.parameters(),
-    )
-    .map_err(PostProcessError::from)
-    .context("failed to create decoder context for analysis")?;
+    let mut decoder_ctx =
+        ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())
+            .map_err(PostProcessError::from)
+            .context("failed to create decoder context for analysis")?;
     set_single_thread_codec(unsafe { decoder_ctx.as_mut_ptr() });
     let mut decoder = decoder_ctx
         .decoder()
@@ -249,7 +248,10 @@ pub(super) fn read_frame_metadata(
 
 impl FFmpegRunner {
     /// Analyze peak and RMS levels using `astats` filter with frame metadata.
-    pub(super) fn analyze_peak_sync(input: &Path, target_peak_db: f64) -> anyhow::Result<PeakAnalysis> {
+    pub(super) fn analyze_peak_sync(
+        input: &Path,
+        target_peak_db: f64,
+    ) -> anyhow::Result<PeakAnalysis> {
         let mut peak_db = f64::NEG_INFINITY;
         let mut rms_db = f64::NEG_INFINITY;
 
@@ -319,7 +321,10 @@ impl FFmpegRunner {
     /// Runs loudnorm pass 1 on the **output** file and compares measured
     /// levels against targets. Warns on significant deviations but does
     /// not fail — the output is already written.
-    pub(super) fn verify_loudness_sync(output: &Path, opts: &NormalizeOptions) -> anyhow::Result<()> {
+    pub(super) fn verify_loudness_sync(
+        output: &Path,
+        opts: &NormalizeOptions,
+    ) -> anyhow::Result<()> {
         debug!("Loudness verification: analyzing output...");
         match Self::loudnorm_pass1_sync(output, opts) {
             Ok(measured) => {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -131,14 +131,25 @@ impl FFmpegRunner {
         output: &Path,
         salvage: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-        encode_fn: impl Fn(&Path, &Path, &str, bool, Option<&(dyn Fn(f64) + Send + Sync)>) -> anyhow::Result<()>,
+        encode_fn: impl Fn(
+            &Path,
+            &Path,
+            &str,
+            bool,
+            Option<&(dyn Fn(f64) + Send + Sync)>,
+        ) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         crate::ffmpeg::ensure_init()?;
 
         let has_video = {
             let ictx = ffmpeg_the_third::format::input(input)
                 .map_err(PostProcessError::from)
-                .with_context(|| format!("failed to open input for normalize dispatch {}", input.display()))?;
+                .with_context(|| {
+                    format!(
+                        "failed to open input for normalize dispatch {}",
+                        input.display()
+                    )
+                })?;
             ictx.streams()
                 .best(ffmpeg_the_third::media::Type::Video)
                 .is_some()
@@ -158,7 +169,13 @@ impl FFmpegRunner {
 
             if salvage {
                 with_mux_retry(input, &temp_audio, |effective_input, resilient| {
-                    Ok(encode_fn(effective_input, &temp_audio, ext, resilient, progress_fn)?)
+                    Ok(encode_fn(
+                        effective_input,
+                        &temp_audio,
+                        ext,
+                        resilient,
+                        progress_fn,
+                    )?)
                 })?;
             } else {
                 encode_fn(input, &temp_audio, ext, false, progress_fn)?;
@@ -174,7 +191,13 @@ impl FFmpegRunner {
             merge_result
         } else if salvage {
             with_mux_retry(input, output, |effective_input, resilient| {
-                Ok(encode_fn(effective_input, output, ext, resilient, progress_fn)?)
+                Ok(encode_fn(
+                    effective_input,
+                    output,
+                    ext,
+                    resilient,
+                    progress_fn,
+                )?)
             })?;
             Ok(())
         } else {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -57,7 +57,9 @@ impl FFmpegRunner {
         } else {
             ffmpeg_the_third::format::input(input)
                 .map_err(PostProcessError::from)
-                .with_context(|| format!("failed to open input for audio encode {}", input.display()))?
+                .with_context(|| {
+                    format!("failed to open input for audio encode {}", input.display())
+                })?
         };
 
         // Read the format-level start_time and duration (in AV_TIME_BASE = µs) before
@@ -90,7 +92,12 @@ impl FFmpegRunner {
 
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to create output for audio encode {}", output.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to create output for audio encode {}",
+                    output.display()
+                )
+            })?;
 
         let enc_name = select_audio_encoder_for_container(final_output_ext);
         let enc_codec = ffmpeg_the_third::encoder::find_by_name(enc_name).ok_or_else(|| {
@@ -108,10 +115,10 @@ impl FFmpegRunner {
         let audio_ost_index;
         let audio_enc_context;
         {
-            let ost =
-                octx.add_stream(enc_codec)
-                    .map_err(PostProcessError::from)
-                    .context("failed to add audio output stream for encode")?;
+            let ost = octx
+                .add_stream(enc_codec)
+                .map_err(PostProcessError::from)
+                .context("failed to add audio output stream for encode")?;
             audio_ost_index = ost.index();
             audio_enc_context =
                 ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
@@ -163,11 +170,10 @@ impl FFmpegRunner {
             debug!("[{label}] libfdk_aac: afterburner enabled");
         }
 
-        let mut audio_encoder =
-            audio_encoder
-                .open_as(enc_codec)
-                .map_err(PostProcessError::from)
-                .context("failed to open audio encoder")?;
+        let mut audio_encoder = audio_encoder
+            .open_as(enc_codec)
+            .map_err(PostProcessError::from)
+            .context("failed to open audio encoder")?;
 
         let enc_time_base = unsafe {
             let tb = (*audio_encoder.as_ptr()).time_base;
@@ -189,6 +195,25 @@ impl FFmpegRunner {
             (*ctx).avoid_negative_ts = ffmpeg_the_third::ffi::AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
             (*ctx).flags |= ffmpeg_the_third::ffi::AVFMT_FLAG_FLUSH_PACKETS;
             (*ctx).max_interleave_delta = 0;
+        }
+
+        // Set format-level encoding_tool metadata
+        {
+            let mut format_meta = octx.metadata().to_owned();
+            format_meta.set(
+                "encoding_tool",
+                &crate::ffmpeg::encoding_tag::encoding_tool_tag(enc_name),
+            );
+            octx.set_metadata(format_meta);
+        }
+
+        // Set per-stream encoder tag on audio output stream
+        {
+            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
+            stream_dict.set("encoder", enc_name);
+            octx.stream_mut(audio_ost_index)
+                .expect("audio output stream exists")
+                .set_metadata(stream_dict);
         }
 
         let mut muxer_opts = ffmpeg_the_third::Dictionary::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -30,7 +30,12 @@ impl FFmpegRunner {
         let output = output.as_ref().to_path_buf();
         let opts = opts.clone();
         Self::spawn_blocking("remux", move || -> Result<()> {
-            Ok(Self::remux_sync(&input, &output, &opts, progress_fn.as_deref())?)
+            Ok(Self::remux_sync(
+                &input,
+                &output,
+                &opts,
+                progress_fn.as_deref(),
+            )?)
         })
         .await
     }
@@ -126,8 +131,13 @@ impl FFmpegRunner {
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 
-        // Copy format-level metadata
-        octx.set_metadata(ictx.metadata().to_owned());
+        // Copy format-level metadata and add encoding_tool tag
+        let mut format_meta = ictx.metadata().to_owned();
+        format_meta.set(
+            "encoding_tool",
+            &super::encoding_tag::encoding_tool_tag("remux"),
+        );
+        octx.set_metadata(format_meta);
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -193,16 +193,16 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     // Open corrupt input — FFmpeg will log warnings but continue reading
     let mut ictx = ffmpeg_the_third::format::input(input)
         .map_err(PostProcessError::from)
-        .with_context(|| format!("failed to open corrupt input for salvage {}", input.display()))?;
+        .with_context(|| {
+            format!(
+                "failed to open corrupt input for salvage {}",
+                input.display()
+            )
+        })?;
 
     let mut octx = ffmpeg_the_third::format::output(&salvage_path)
         .map_err(PostProcessError::from)
-        .with_context(|| {
-            format!(
-                "failed to create salvage output {}",
-                salvage_path.display()
-            )
-        })?;
+        .with_context(|| format!("failed to create salvage output {}", salvage_path.display()))?;
 
     // Map all input streams to output (stream copy, no re-encoding)
     let stream_count = ictx.streams().count();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -93,7 +93,12 @@ impl FFmpegRunner {
         // Open media input
         let mut ictx = ffmpeg_the_third::format::input(media)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open media input for thumbnail embed {}", media.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open media input for thumbnail embed {}",
+                    media.display()
+                )
+            })?;
 
         // Open thumbnail input
         let mut thumb_ictx = ffmpeg_the_third::format::input(thumbnail)
@@ -103,7 +108,12 @@ impl FFmpegRunner {
         // Create output
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to create output for thumbnail embed {}", output.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to create output for thumbnail embed {}",
+                    output.display()
+                )
+            })?;
 
         let is_mp3 = container.eq_ignore_ascii_case("mp3");
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -80,13 +80,23 @@ impl FFmpegRunner {
 
         let mut ictx = ffmpeg_the_third::format::input(input)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open input for audio copy extract {}", input.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open input for audio copy extract {}",
+                    input.display()
+                )
+            })?;
 
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to create output for audio copy extract {}", output.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to create output for audio copy extract {}",
+                    output.display()
+                )
+            })?;
 
         // Find best audio stream
         let ist_index = ictx
@@ -119,6 +129,14 @@ impl FFmpegRunner {
                 .parameters(),
         );
         Self::clear_codec_tag(ost.parameters().as_ptr());
+
+        // Set format-level encoding_tool metadata (copy, no re-encoding)
+        let mut format_meta = octx.metadata().to_owned();
+        format_meta.set(
+            "encoding_tool",
+            &crate::ffmpeg::encoding_tag::encoding_tool_tag("copy"),
+        );
+        octx.set_metadata(format_meta);
 
         octx.write_header()
             .map_err(PostProcessError::from)
@@ -190,7 +208,12 @@ impl FFmpegRunner {
         // Open input and find audio stream
         let mut ictx = ffmpeg_the_third::format::input(input)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open input for audio transcode {}", input.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open input for audio transcode {}",
+                    input.display()
+                )
+            })?;
 
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
@@ -218,7 +241,12 @@ impl FFmpegRunner {
         // Open output
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to create output for audio transcode {}", output.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to create output for audio transcode {}",
+                    output.display()
+                )
+            })?;
 
         // Find encoder codec
         let enc_codec = if let Some(ref name) = opts.encoder_name {
@@ -247,10 +275,10 @@ impl FFmpegRunner {
         let ost_index;
         let enc_context;
         {
-            let ost =
-                octx.add_stream(enc_codec)
-                    .map_err(PostProcessError::from)
-                    .context("failed to add output stream for audio transcode")?;
+            let ost = octx
+                .add_stream(enc_codec)
+                .map_err(PostProcessError::from)
+                .context("failed to add output stream for audio transcode")?;
             ost_index = ost.index();
             enc_context =
                 ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
@@ -297,11 +325,10 @@ impl FFmpegRunner {
         }
 
         // Open encoder
-        let mut audio_encoder =
-            audio_encoder
-                .open_as(enc_codec)
-                .map_err(PostProcessError::from)
-                .context("failed to open audio encoder for transcode")?;
+        let mut audio_encoder = audio_encoder
+            .open_as(enc_codec)
+            .map_err(PostProcessError::from)
+            .context("failed to open audio encoder for transcode")?;
 
         // Read actual encoder time_base via FFI (may differ from configured after open)
         // SAFETY: audio_encoder is a valid opened encoder context.
@@ -321,6 +348,26 @@ impl FFmpegRunner {
         Self::copy_encoder_params_to_stream(&mut octx, ost_index, unsafe {
             audio_encoder.as_ptr()
         });
+
+        // Set format-level encoding_tool metadata
+        let enc_display_name = enc_codec.name();
+        {
+            let mut format_meta = octx.metadata().to_owned();
+            format_meta.set(
+                "encoding_tool",
+                &crate::ffmpeg::encoding_tag::encoding_tool_tag(enc_display_name),
+            );
+            octx.set_metadata(format_meta);
+        }
+
+        // Set per-stream encoder tag on audio output stream
+        {
+            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
+            stream_dict.set("encoder", enc_display_name);
+            octx.stream_mut(ost_index)
+                .expect("audio output stream exists")
+                .set_metadata(stream_dict);
+        }
 
         octx.write_header()
             .map_err(PostProcessError::from)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -113,7 +113,12 @@ impl FFmpegRunner {
         // Open input
         let mut ictx = ffmpeg_the_third::format::input(input)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to open input for video transcode {}", input.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to open input for video transcode {}",
+                    input.display()
+                )
+            })?;
 
         let input_duration_us: i64 = unsafe { (*ictx.as_mut_ptr()).duration };
 
@@ -193,7 +198,12 @@ impl FFmpegRunner {
         // Open output
         let mut octx = ffmpeg_the_third::format::output(output)
             .map_err(PostProcessError::from)
-            .with_context(|| format!("failed to create output for video transcode {}", output.display()))?;
+            .with_context(|| {
+                format!(
+                    "failed to create output for video transcode {}",
+                    output.display()
+                )
+            })?;
 
         // Find video encoder
         let video_codec_name = opts.video_codec.as_deref().unwrap_or("libx264");
@@ -413,7 +423,9 @@ impl FFmpegRunner {
                 let audio_encoder = audio_encoder
                     .open_as(audio_enc_codec)
                     .map_err(PostProcessError::from)
-                    .with_context(|| format!("failed to open audio encoder '{enc_name}' for video transcode"))?;
+                    .with_context(|| {
+                        format!("failed to open audio encoder '{enc_name}' for video transcode")
+                    })?;
 
                 // Copy encoder parameters back to output stream
                 unsafe {
@@ -455,6 +467,44 @@ impl FFmpegRunner {
         if is_mkv {
             dict.set("cluster_time_limit", "500");
             debug!("MKV detected, setting cluster_time_limit=500ms via dictionary");
+        }
+
+        // Set format-level encoding_tool metadata
+        {
+            let audio_component = if let Some(enc_name) = audio_encode_codec {
+                enc_name
+            } else if opts.audio_copy {
+                "copy"
+            } else {
+                "none"
+            };
+            let tool_components = format!("{video_codec_name} + {audio_component}");
+            let mut format_meta = octx.metadata().to_owned();
+            format_meta.set(
+                "encoding_tool",
+                &crate::ffmpeg::encoding_tag::encoding_tool_tag(&tool_components),
+            );
+            octx.set_metadata(format_meta);
+        }
+
+        // Set per-stream encoder tag on video output stream
+        {
+            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
+            stream_dict.set("encoder", video_codec_name);
+            octx.stream_mut(video_ost_index)
+                .expect("video output stream exists")
+                .set_metadata(stream_dict);
+        }
+
+        // Set per-stream encoder tag on audio output stream (only if re-encoding)
+        if let Some((_, _, _, audio_enc_ost_idx, _)) = audio_transcode_state.as_ref()
+            && let Some(enc_name) = audio_encode_codec
+        {
+            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
+            stream_dict.set("encoder", enc_name);
+            octx.stream_mut(*audio_enc_ost_idx)
+                .expect("audio output stream exists")
+                .set_metadata(stream_dict);
         }
 
         // Write header with options


### PR DESCRIPTION
## Summary
- Add `encoding_tool` format-level tag to all postprocessing outputs: `rdlp/{version} ({components})`
- Add per-stream `encoder` tag on re-encoded streams (video and audio)
- Stream-copied streams get no per-stream encoder tag
- Covers all 5 stages: recode, audio extract, normalize, remux, merge
- Shared `encoding_tool_tag()` helper in new `encoding_tag.rs` module

## Verifiable with ffprobe
```bash
ffprobe -v quiet -show_format -show_streams output.mp4 | grep -i encoder
```

## Test plan
- [x] `cargo check` — zero errors
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all tests pass
- [x] `cargo check -p rdlp-desktop` — compiles