### PR TITLE
fix: add encoding_tool tag to all remaining output paths

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -314,6 +314,12 @@ impl FFmpegRunner {
                 });
             }
 
+            // Set encoding_tool metadata
+            let et_key = CString::new("encoding_tool").expect("static string");
+            let et_val = CString::new(crate::ffmpeg::encoding_tag::encoding_tool_tag("merge"))
+                .expect("no null bytes in version string");
+            ffi::av_dict_set(&mut (*ofmt_ctx).metadata, et_key.as_ptr(), et_val.as_ptr(), 0);
+
             // 12. Write header
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -133,6 +133,7 @@ impl FFmpegRunner {
             dict.set(k, v);
         }
 
+        dict.set("encoding_tool", &crate::ffmpeg::encoding_tag::encoding_tool_tag("metadata"));
         octx.set_metadata(dict);
 
         // Add chapters (time_base = 1/1000 for millisecond precision)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -398,6 +398,12 @@ impl FFmpegRunner {
                 }
             }
 
+            // Set encoding_tool metadata
+            let et_key = CString::new("encoding_tool").expect("static string");
+            let et_val = CString::new(crate::ffmpeg::encoding_tag::encoding_tool_tag("remux"))
+                .expect("no null bytes in version string");
+            ffi::av_dict_set(&mut (*ofmt_ctx).metadata, et_key.as_ptr(), et_val.as_ptr(), 0);
+
             // 6. Build options dictionary with cluster_time_limit
             let mut opts: *mut ffi::AVDictionary = ptr::null_mut();
             let key = CString::new("cluster_time_limit").expect("static string has no null bytes");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -228,6 +228,12 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
     muxer_opts.set("cluster_time_limit", "500");
 
+    {
+        let mut format_meta = octx.metadata().to_owned();
+        format_meta.set("encoding_tool", &crate::ffmpeg::encoding_tag::encoding_tool_tag("salvage"));
+        octx.set_metadata(format_meta);
+    }
+
     octx.write_header_with(muxer_opts)
         .map_err(PostProcessError::from)
         .context("failed to write salvage output header")?;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -284,6 +284,12 @@ impl FFmpegRunner {
                 });
             }
 
+            // Set encoding_tool metadata
+            let et_key = CString::new("encoding_tool").expect("static string");
+            let et_val = CString::new(crate::ffmpeg::encoding_tag::encoding_tool_tag("thumbnail"))
+                .expect("no null bytes in version string");
+            ffi::av_dict_set(&mut (*ofmt_ctx).metadata, et_key.as_ptr(), et_val.as_ptr(), 0);
+
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {
                 if !(*ofmt_ctx).pb.is_null() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -185,6 +185,11 @@ impl FFmpegRunner {
 
         // Copy format-level metadata from media input
         octx.set_metadata(ictx.metadata().to_owned());
+        {
+            let mut format_meta = octx.metadata().to_owned();
+            format_meta.set("encoding_tool", &crate::ffmpeg::encoding_tag::encoding_tool_tag("thumbnail"));
+            octx.set_metadata(format_meta);
+        }
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();


### PR DESCRIPTION
## Summary
- Add `encoding_tool` tag to 6 remaining output paths that were missing from PR #160
- Raw FFI paths (MKV remux, MKV merge, MKV thumbnail): `av_dict_set` on `(*ofmt_ctx).metadata`
- High-level paths (metadata embed, thumbnail embed, salvage remux): `Dictionary::set`
- All 12 output paths now produce `encoding_tool=rdlp/{version} ({stage})` metadata

## Test plan
- [x] `cargo check -p rdlp-ffmpeg` — zero errors
- [x] `cargo clippy -p rdlp-ffmpeg` — zero warnings
- [x] `cargo test -p rdlp-ffmpeg` — 115 tests pass