### PR TITLE
refactor: deduplicate encoding tag boilerplate + fix MKV raw FFI paths

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
@@ -1,8 +1,13 @@
 //! Encoder identification metadata for output files.
+//!
+//! Three helpers cover all postprocessing paths:
+//! - [`set_encoding_tool`] — high-level API (safe `octx`)
+//! - [`set_encoding_tool_ffi`] — raw FFI (`*mut AVFormatContext`)
+//! - [`set_stream_encoder`] — per-stream encoder tag
+
+use std::ffi::CString;
 
 /// Build the format-level `encoding_tool` metadata value.
-///
-/// # Examples
 ///
 /// ```ignore
 /// encoding_tool_tag("libx264 + libfdk_aac")  // → "rdlp/0.1.0 (libx264 + libfdk_aac)"
@@ -10,6 +15,50 @@
 /// ```
 pub(crate) fn encoding_tool_tag(components: &str) -> String {
     format!("rdlp/{} ({components})", env!("CARGO_PKG_VERSION"))
+}
+
+/// Set the `encoding_tool` format-level tag on a high-level output context.
+pub(crate) fn set_encoding_tool(
+    octx: &mut ffmpeg_the_third::format::context::Output,
+    components: &str,
+) {
+    let mut meta = octx.metadata().to_owned();
+    meta.set("encoding_tool", &encoding_tool_tag(components));
+    octx.set_metadata(meta);
+}
+
+/// Set the `encoding_tool` format-level tag on a raw FFI output context.
+///
+/// # Safety
+///
+/// `ofmt_ctx` must be a valid, non-null `AVFormatContext` pointer.
+pub(crate) unsafe fn set_encoding_tool_ffi(
+    ofmt_ctx: *mut ffmpeg_the_third::ffi::AVFormatContext,
+    components: &str,
+) {
+    let key = CString::new("encoding_tool").expect("static string");
+    let val = CString::new(encoding_tool_tag(components)).expect("no null bytes in version string");
+    unsafe {
+        ffmpeg_the_third::ffi::av_dict_set(
+            &mut (*ofmt_ctx).metadata,
+            key.as_ptr(),
+            val.as_ptr(),
+            0,
+        );
+    }
+}
+
+/// Set the `encoder` per-stream tag on a high-level output stream.
+pub(crate) fn set_stream_encoder(
+    octx: &mut ffmpeg_the_third::format::context::Output,
+    stream_index: usize,
+    encoder_name: &str,
+) {
+    let mut dict = ffmpeg_the_third::Dictionary::new();
+    dict.set("encoder", encoder_name);
+    octx.stream_mut(stream_index)
+        .expect("output stream exists")
+        .set_metadata(dict);
 }
 
 #[cfg(test)]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
@@ -39,9 +39,8 @@ pub(crate) fn set_encoding_tool_if_missing(
     octx: &mut ffmpeg_the_third::format::context::Output,
     components: &str,
 ) {
-    let meta = octx.metadata();
-    if meta.get("encoding_tool").is_none() {
-        drop(meta);
+    let has_tag = octx.metadata().get("encoding_tool").is_some();
+    if !has_tag {
         set_encoding_tool(octx, components);
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
@@ -18,6 +18,9 @@ pub(crate) fn encoding_tool_tag(components: &str) -> String {
 }
 
 /// Set the `encoding_tool` format-level tag on a high-level output context.
+///
+/// Unconditionally sets the tag. Use for stages that create content
+/// (recode, audio extract, normalize).
 pub(crate) fn set_encoding_tool(
     octx: &mut ffmpeg_the_third::format::context::Output,
     components: &str,
@@ -27,7 +30,25 @@ pub(crate) fn set_encoding_tool(
     octx.set_metadata(meta);
 }
 
+/// Set the `encoding_tool` format-level tag only if the output context
+/// doesn't already have one (inherited from input metadata copy).
+///
+/// Use for pass-through stages (remux, merge, metadata embed, thumbnail
+/// embed, salvage) that should preserve the primary stage's tag.
+pub(crate) fn set_encoding_tool_if_missing(
+    octx: &mut ffmpeg_the_third::format::context::Output,
+    components: &str,
+) {
+    let meta = octx.metadata();
+    if meta.get("encoding_tool").is_none() {
+        drop(meta);
+        set_encoding_tool(octx, components);
+    }
+}
+
 /// Set the `encoding_tool` format-level tag on a raw FFI output context.
+///
+/// Unconditionally sets the tag. Use for stages that create content.
 ///
 /// # Safety
 ///
@@ -45,6 +66,30 @@ pub(crate) unsafe fn set_encoding_tool_ffi(
             val.as_ptr(),
             0,
         );
+    }
+}
+
+/// Set the `encoding_tool` tag on a raw FFI output context only if not
+/// already present (inherited from input via `av_dict_copy`).
+///
+/// # Safety
+///
+/// `ofmt_ctx` must be a valid, non-null `AVFormatContext` pointer.
+pub(crate) unsafe fn set_encoding_tool_ffi_if_missing(
+    ofmt_ctx: *mut ffmpeg_the_third::ffi::AVFormatContext,
+    components: &str,
+) {
+    let key = CString::new("encoding_tool").expect("static string");
+    unsafe {
+        let existing = ffmpeg_the_third::ffi::av_dict_get(
+            (*ofmt_ctx).metadata,
+            key.as_ptr(),
+            std::ptr::null(),
+            0,
+        );
+        if existing.is_null() {
+            set_encoding_tool_ffi(ofmt_ctx, components);
+        }
     }
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -321,7 +321,7 @@ impl FFmpegRunner {
             }
 
             // Set encoding_tool metadata
-            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, "merge");
+            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "merge");
 
             // 12. Write header
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -33,6 +33,7 @@ impl FFmpegRunner {
         audio_input: &Path,
         output: &Path,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        encoding_tool_override: Option<&str>,
     ) -> Result<()> {
         use ffmpeg_the_third::ffi;
         use std::ffi::CString;
@@ -320,8 +321,15 @@ impl FFmpegRunner {
                 });
             }
 
-            // Set encoding_tool metadata
-            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "merge");
+            // Copy format-level metadata from video input (preserves encoding_tool from prior stages)
+            ffi::av_dict_copy(&mut (*ofmt_ctx).metadata, (*ifmt_video).metadata, 0);
+
+            // Set encoding_tool: use override if provided, otherwise fall back to "merge"
+            if let Some(tag) = encoding_tool_override {
+                crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, tag);
+            } else {
+                crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "merge");
+            }
 
             // 12. Write header
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -315,10 +315,7 @@ impl FFmpegRunner {
             }
 
             // Set encoding_tool metadata
-            let et_key = CString::new("encoding_tool").expect("static string");
-            let et_val = CString::new(crate::ffmpeg::encoding_tag::encoding_tool_tag("merge"))
-                .expect("no null bytes in version string");
-            ffi::av_dict_set(&mut (*ofmt_ctx).metadata, et_key.as_ptr(), et_val.as_ptr(), 0);
+            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, "merge");
 
             // 12. Write header
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -185,6 +185,9 @@ impl FFmpegRunner {
             }
             (*(*out_video_stream).codecpar).codec_tag = 0;
 
+            // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
+            ffi::av_dict_copy(&mut (*out_video_stream).metadata, (*in_video_stream).metadata, 0);
+
             // CRITICAL: Copy stream timing properties for Matroska
             (*out_video_stream).time_base = (*in_video_stream).time_base;
             (*out_video_stream).avg_frame_rate = (*in_video_stream).avg_frame_rate;
@@ -235,6 +238,9 @@ impl FFmpegRunner {
                 });
             }
             (*(*out_audio_stream).codecpar).codec_tag = 0;
+
+            // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
+            ffi::av_dict_copy(&mut (*out_audio_stream).metadata, (*in_audio_stream).metadata, 0);
 
             // Copy audio stream timing properties
             (*out_audio_stream).time_base = (*in_audio_stream).time_base;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -166,12 +166,7 @@ impl FFmpegRunner {
         }
 
         // Set format-level encoding_tool metadata
-        let mut format_meta = octx.metadata().to_owned();
-        format_meta.set(
-            "encoding_tool",
-            &crate::ffmpeg::encoding_tag::encoding_tool_tag("merge"),
-        );
-        octx.set_metadata(format_meta);
+        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "merge");
 
         // Write header with options
         octx.write_header_with(dict)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -166,7 +166,7 @@ impl FFmpegRunner {
         }
 
         // Set format-level encoding_tool metadata
-        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "merge");
+        crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "merge");
 
         // Write header with options
         octx.write_header_with(dict)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -76,6 +76,7 @@ impl FFmpegRunner {
                 audio_input,
                 output,
                 progress_fn,
+                opts.encoding_tool_override.as_deref(),
             )?);
         }
 
@@ -166,7 +167,11 @@ impl FFmpegRunner {
         }
 
         // Set format-level encoding_tool metadata
-        crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "merge");
+        if let Some(ref override_tag) = opts.encoding_tool_override {
+            crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, override_tag);
+        } else {
+            crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "merge");
+        }
 
         // Write header with options
         octx.write_header_with(dict)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -29,6 +29,7 @@ impl FFmpegRunner {
         metadata: &HashMap<String, String>,
         chapters: &[ChapterEntry],
         callback: Option<Arc<dyn PostProcessCallback>>,
+        encoding_tool_override: Option<String>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -41,6 +42,7 @@ impl FFmpegRunner {
                 &metadata,
                 &chapters,
                 callback.as_deref(),
+                encoding_tool_override.as_deref(),
             )?)
         })
         .await
@@ -57,6 +59,7 @@ impl FFmpegRunner {
         metadata: &HashMap<String, String>,
         chapters: &[ChapterEntry],
         callback: Option<&dyn PostProcessCallback>,
+        encoding_tool_override: Option<&str>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
 
@@ -135,7 +138,11 @@ impl FFmpegRunner {
         }
 
         octx.set_metadata(dict);
-        crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "metadata");
+        if let Some(tag) = encoding_tool_override {
+            crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, tag);
+        } else {
+            crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "metadata");
+        }
 
         // Add chapters (time_base = 1/1000 for millisecond precision)
         for ch in chapters {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -134,8 +134,8 @@ impl FFmpegRunner {
             dict.set(k, v);
         }
 
-        dict.set("encoding_tool", &crate::ffmpeg::encoding_tag::encoding_tool_tag("metadata"));
         octx.set_metadata(dict);
+        crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "metadata");
 
         // Add chapters (time_base = 1/1000 for millisecond precision)
         for ch in chapters {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -117,6 +117,7 @@ impl FFmpegRunner {
                 .map_err(PostProcessError::from)
                 .context("failed to add output stream for metadata embed")?;
             ost.set_parameters(ist.parameters());
+            ost.set_metadata(ist.metadata().to_owned());
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -198,23 +198,10 @@ impl FFmpegRunner {
         }
 
         // Set format-level encoding_tool metadata
-        {
-            let mut format_meta = octx.metadata().to_owned();
-            format_meta.set(
-                "encoding_tool",
-                &crate::ffmpeg::encoding_tag::encoding_tool_tag(enc_name),
-            );
-            octx.set_metadata(format_meta);
-        }
+        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, enc_name);
 
         // Set per-stream encoder tag on audio output stream
-        {
-            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
-            stream_dict.set("encoder", enc_name);
-            octx.stream_mut(audio_ost_index)
-                .expect("audio output stream exists")
-                .set_metadata(stream_dict);
-        }
+        crate::ffmpeg::encoding_tag::set_stream_encoder(&mut octx, audio_ost_index, enc_name);
 
         let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
         muxer_opts.set("cluster_time_limit", "500");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -10,6 +10,12 @@ pub struct RemuxOptions {
     pub faststart: bool,
     /// Force output format (e.g., "mp4", "mkv").
     pub output_format: Option<String>,
+    /// Override the `encoding_tool` metadata tag written by this operation.
+    ///
+    /// When `Some`, this value is used instead of the default stage name
+    /// (e.g., "remux", "merge", "thumbnail"). Pass `msg.encoding_tool` from
+    /// the pipeline to propagate the tag set by a prior content-creating stage.
+    pub encoding_tool_override: Option<String>,
 }
 
 /// Options for audio extraction and transcoding.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -62,7 +62,12 @@ impl FFmpegRunner {
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
         if is_mkv {
-            return Self::remux_mkv_raw_ffi(input, output, progress_fn);
+            return Self::remux_mkv_raw_ffi(
+                input,
+                output,
+                progress_fn,
+                opts.encoding_tool_override.as_deref(),
+            );
         }
 
         let mut ictx = ffmpeg_the_third::format::input(input)
@@ -134,7 +139,11 @@ impl FFmpegRunner {
 
         // Copy format-level metadata and add encoding_tool tag
         octx.set_metadata(ictx.metadata().to_owned());
-        super::encoding_tag::set_encoding_tool_if_missing(&mut octx, "remux");
+        if let Some(ref override_tag) = opts.encoding_tool_override {
+            super::encoding_tag::set_encoding_tool(&mut octx, override_tag);
+        } else {
+            super::encoding_tag::set_encoding_tool_if_missing(&mut octx, "remux");
+        }
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();
@@ -234,6 +243,7 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        encoding_tool_override: Option<&str>,
     ) -> anyhow::Result<()> {
         use ffmpeg_the_third::ffi;
         use std::ffi::CString;
@@ -398,14 +408,15 @@ impl FFmpegRunner {
                 }
             }
 
-            // 6. Set encoding_tool metadata BEFORE init_output.
-            // init_muxer (called by avformat_init_output) unconditionally sets
-            // "encoder" = LIBAVFORMAT_IDENT. The Matroska muxer's mkv_write_info
-            // checks "encoding_tool" for WritingApp — if present it uses our
-            // value, otherwise it falls back to LIBAVFORMAT_IDENT. Setting
-            // encoding_tool before init ensures it survives the metadata
-            // conversion pass.
-            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "remux");
+            // 6. Copy format-level metadata from input (preserves encoding_tool from prior stages)
+            ffi::av_dict_copy(&mut (*ofmt_ctx).metadata, (*ifmt_ctx).metadata, 0);
+
+            // Set encoding_tool: use override if provided, otherwise fall back to "remux"
+            if let Some(tag) = encoding_tool_override {
+                crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, tag);
+            } else {
+                crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "remux");
+            }
 
             // 7. Build options dictionary with cluster_time_limit
             let mut opts: *mut ffi::AVDictionary = ptr::null_mut();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -128,6 +128,7 @@ impl FFmpegRunner {
                 .map_err(PostProcessError::from)
                 .context("failed to add output stream for remux")?;
             ost.set_parameters(ist.parameters());
+            ost.set_metadata(ist.metadata().to_owned());
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 
@@ -337,6 +338,9 @@ impl FFmpegRunner {
 
                 // Reset codec tag for container compatibility
                 (*(*out_stream).codecpar).codec_tag = 0;
+
+                // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
+                ffi::av_dict_copy(&mut (*out_stream).metadata, (*in_stream).metadata, 0);
 
                 // ============================================================
                 // CRITICAL: Copy stream properties that CLI copies but we missed

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -132,12 +132,8 @@ impl FFmpegRunner {
         }
 
         // Copy format-level metadata and add encoding_tool tag
-        let mut format_meta = ictx.metadata().to_owned();
-        format_meta.set(
-            "encoding_tool",
-            &super::encoding_tag::encoding_tool_tag("remux"),
-        );
-        octx.set_metadata(format_meta);
+        octx.set_metadata(ictx.metadata().to_owned());
+        super::encoding_tag::set_encoding_tool(&mut octx, "remux");
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();
@@ -398,19 +394,22 @@ impl FFmpegRunner {
                 }
             }
 
-            // Set encoding_tool metadata
-            let et_key = CString::new("encoding_tool").expect("static string");
-            let et_val = CString::new(crate::ffmpeg::encoding_tag::encoding_tool_tag("remux"))
-                .expect("no null bytes in version string");
-            ffi::av_dict_set(&mut (*ofmt_ctx).metadata, et_key.as_ptr(), et_val.as_ptr(), 0);
+            // 6. Set encoding_tool metadata BEFORE init_output.
+            // init_muxer (called by avformat_init_output) unconditionally sets
+            // "encoder" = LIBAVFORMAT_IDENT. The Matroska muxer's mkv_write_info
+            // checks "encoding_tool" for WritingApp — if present it uses our
+            // value, otherwise it falls back to LIBAVFORMAT_IDENT. Setting
+            // encoding_tool before init ensures it survives the metadata
+            // conversion pass.
+            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, "remux");
 
-            // 6. Build options dictionary with cluster_time_limit
+            // 7. Build options dictionary with cluster_time_limit
             let mut opts: *mut ffi::AVDictionary = ptr::null_mut();
             let key = CString::new("cluster_time_limit").expect("static string has no null bytes");
             let value = CString::new("500").expect("static string has no null bytes");
             ffi::av_dict_set(&mut opts, key.as_ptr(), value.as_ptr(), 0);
 
-            // 7. Initialize muxer with options
+            // 8. Initialize muxer with options
             let ret = ffi::avformat_init_output(ofmt_ctx, &mut opts);
 
             // Check for unconsumed options
@@ -438,7 +437,7 @@ impl FFmpegRunner {
                 .into());
             }
 
-            // 8. Write header
+            // 9. Write header
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {
                 if !(*ofmt_ctx).pb.is_null() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -134,7 +134,7 @@ impl FFmpegRunner {
 
         // Copy format-level metadata and add encoding_tool tag
         octx.set_metadata(ictx.metadata().to_owned());
-        super::encoding_tag::set_encoding_tool(&mut octx, "remux");
+        super::encoding_tag::set_encoding_tool_if_missing(&mut octx, "remux");
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();
@@ -405,7 +405,7 @@ impl FFmpegRunner {
             // value, otherwise it falls back to LIBAVFORMAT_IDENT. Setting
             // encoding_tool before init ensures it survives the metadata
             // conversion pass.
-            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, "remux");
+            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "remux");
 
             // 7. Build options dictionary with cluster_time_limit
             let mut opts: *mut ffi::AVDictionary = ptr::null_mut();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -228,7 +228,7 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
     muxer_opts.set("cluster_time_limit", "500");
 
-    crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "salvage");
+    crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "salvage");
 
     octx.write_header_with(muxer_opts)
         .map_err(PostProcessError::from)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -228,11 +228,7 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
     muxer_opts.set("cluster_time_limit", "500");
 
-    {
-        let mut format_meta = octx.metadata().to_owned();
-        format_meta.set("encoding_tool", &crate::ffmpeg::encoding_tag::encoding_tool_tag("salvage"));
-        octx.set_metadata(format_meta);
-    }
+    crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "salvage");
 
     octx.write_header_with(muxer_opts)
         .map_err(PostProcessError::from)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -154,6 +154,9 @@ impl FFmpegRunner {
                 }
                 (*(*out_stream).codecpar).codec_tag = 0;
 
+                // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
+                ffi::av_dict_copy(&mut (*out_stream).metadata, (*in_stream).metadata, 0);
+
                 // Copy stream properties (critical for VLC)
                 (*out_stream).time_base = (*in_stream).time_base;
                 (*out_stream).avg_frame_rate = (*in_stream).avg_frame_rate;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -288,7 +288,7 @@ impl FFmpegRunner {
             }
 
             // Set encoding_tool metadata
-            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, "thumbnail");
+            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "thumbnail");
 
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -285,10 +285,7 @@ impl FFmpegRunner {
             }
 
             // Set encoding_tool metadata
-            let et_key = CString::new("encoding_tool").expect("static string");
-            let et_val = CString::new(crate::ffmpeg::encoding_tag::encoding_tool_tag("thumbnail"))
-                .expect("no null bytes in version string");
-            ffi::av_dict_set(&mut (*ofmt_ctx).metadata, et_key.as_ptr(), et_val.as_ptr(), 0);
+            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, "thumbnail");
 
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -26,6 +26,7 @@ impl FFmpegRunner {
         media: &std::path::Path,
         thumbnail: &std::path::Path,
         output: &std::path::Path,
+        encoding_tool_override: Option<&str>,
     ) -> Result<()> {
         debug!("MKV thumbnail embed as native Matroska attachment via raw FFI");
 
@@ -287,8 +288,15 @@ impl FFmpegRunner {
                 });
             }
 
-            // Set encoding_tool metadata
-            crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "thumbnail");
+            // Copy format-level metadata from media input (preserves encoding_tool from prior stages)
+            ffi::av_dict_copy(&mut (*ofmt_ctx).metadata, (*media_ctx).metadata, 0);
+
+            // Set encoding_tool: use override if provided, otherwise fall back to "thumbnail"
+            if let Some(tag) = encoding_tool_override {
+                crate::ffmpeg::encoding_tag::set_encoding_tool_ffi(ofmt_ctx, tag);
+            } else {
+                crate::ffmpeg::encoding_tag::set_encoding_tool_ffi_if_missing(ofmt_ctx, "thumbnail");
+            }
 
             let ret = ffi::avformat_write_header(ofmt_ctx, ptr::null_mut());
             if ret < 0 {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -186,7 +186,7 @@ impl FFmpegRunner {
 
         // Copy format-level metadata from media input
         octx.set_metadata(ictx.metadata().to_owned());
-        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "thumbnail");
+        crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "thumbnail");
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -149,6 +149,7 @@ impl FFmpegRunner {
                 .map_err(PostProcessError::from)
                 .context("failed to add output stream for thumbnail embed")?;
             ost.set_parameters(ist.parameters());
+            ost.set_metadata(ist.metadata().to_owned());
             Self::clear_codec_tag(ost.parameters().as_ptr());
         }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -185,11 +185,7 @@ impl FFmpegRunner {
 
         // Copy format-level metadata from media input
         octx.set_metadata(ictx.metadata().to_owned());
-        {
-            let mut format_meta = octx.metadata().to_owned();
-            format_meta.set("encoding_tool", &crate::ffmpeg::encoding_tag::encoding_tool_tag("thumbnail"));
-            octx.set_metadata(format_meta);
-        }
+        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "thumbnail");
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -35,6 +35,7 @@ impl FFmpegRunner {
         output: impl AsRef<Path>,
         container: &str,
         callback: Option<Arc<dyn PostProcessCallback>>,
+        encoding_tool_override: Option<String>,
     ) -> Result<()> {
         let media = media.as_ref().to_path_buf();
         let thumbnail = thumbnail.as_ref().to_path_buf();
@@ -47,6 +48,7 @@ impl FFmpegRunner {
                 &output,
                 &container,
                 callback.as_deref(),
+                encoding_tool_override.as_deref(),
             )?)
         })
         .await
@@ -65,6 +67,7 @@ impl FFmpegRunner {
         output: &Path,
         container: &str,
         callback: Option<&dyn PostProcessCallback>,
+        encoding_tool_override: Option<&str>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
 
@@ -84,7 +87,8 @@ impl FFmpegRunner {
         // MKV: use raw FFI with proper stream property copying for VLC compatibility
         let is_mkv = container.eq_ignore_ascii_case("mkv") || container.eq_ignore_ascii_case("mka");
         if is_mkv {
-            let result = Self::embed_thumbnail_mkv_raw_ffi(media, thumbnail, output);
+            let result =
+                Self::embed_thumbnail_mkv_raw_ffi(media, thumbnail, output, encoding_tool_override);
             // Forward captured logs before returning
             Self::forward_captured_logs(&capture, callback);
             return Ok(result?);
@@ -186,7 +190,11 @@ impl FFmpegRunner {
 
         // Copy format-level metadata from media input
         octx.set_metadata(ictx.metadata().to_owned());
-        crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "thumbnail");
+        if let Some(tag) = encoding_tool_override {
+            crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, tag);
+        } else {
+            crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "thumbnail");
+        }
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -131,12 +131,7 @@ impl FFmpegRunner {
         Self::clear_codec_tag(ost.parameters().as_ptr());
 
         // Set format-level encoding_tool metadata (copy, no re-encoding)
-        let mut format_meta = octx.metadata().to_owned();
-        format_meta.set(
-            "encoding_tool",
-            &crate::ffmpeg::encoding_tag::encoding_tool_tag("copy"),
-        );
-        octx.set_metadata(format_meta);
+        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "copy");
 
         octx.write_header()
             .map_err(PostProcessError::from)
@@ -351,23 +346,10 @@ impl FFmpegRunner {
 
         // Set format-level encoding_tool metadata
         let enc_display_name = enc_codec.name();
-        {
-            let mut format_meta = octx.metadata().to_owned();
-            format_meta.set(
-                "encoding_tool",
-                &crate::ffmpeg::encoding_tag::encoding_tool_tag(enc_display_name),
-            );
-            octx.set_metadata(format_meta);
-        }
+        crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, enc_display_name);
 
         // Set per-stream encoder tag on audio output stream
-        {
-            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
-            stream_dict.set("encoder", enc_display_name);
-            octx.stream_mut(ost_index)
-                .expect("audio output stream exists")
-                .set_metadata(stream_dict);
-        }
+        crate::ffmpeg::encoding_tag::set_stream_encoder(&mut octx, ost_index, enc_display_name);
 
         octx.write_header()
             .map_err(PostProcessError::from)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -320,15 +320,13 @@ impl FFmpegRunner {
                         ))
                         .map_err(PostProcessError::from)
                         .context("failed to add audio output stream for video transcode")?;
-                    ost.set_parameters(
-                        ictx.stream(audio_idx)
-                            .ok_or_else(|| {
-                                PostProcessError::ffmpeg_failed(format!(
-                                    "audio input stream {audio_idx} not found"
-                                ))
-                            })?
-                            .parameters(),
-                    );
+                    let audio_ist = ictx.stream(audio_idx).ok_or_else(|| {
+                        PostProcessError::ffmpeg_failed(format!(
+                            "audio input stream {audio_idx} not found"
+                        ))
+                    })?;
+                    ost.set_parameters(audio_ist.parameters());
+                    ost.set_metadata(audio_ist.metadata().to_owned());
                     audio_ost_idx = ost.index();
                     Self::clear_codec_tag(ost.parameters().as_ptr());
                 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -479,32 +479,17 @@ impl FFmpegRunner {
                 "none"
             };
             let tool_components = format!("{video_codec_name} + {audio_component}");
-            let mut format_meta = octx.metadata().to_owned();
-            format_meta.set(
-                "encoding_tool",
-                &crate::ffmpeg::encoding_tag::encoding_tool_tag(&tool_components),
-            );
-            octx.set_metadata(format_meta);
+            crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, &tool_components);
         }
 
         // Set per-stream encoder tag on video output stream
-        {
-            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
-            stream_dict.set("encoder", video_codec_name);
-            octx.stream_mut(video_ost_index)
-                .expect("video output stream exists")
-                .set_metadata(stream_dict);
-        }
+        crate::ffmpeg::encoding_tag::set_stream_encoder(&mut octx, video_ost_index, video_codec_name);
 
         // Set per-stream encoder tag on audio output stream (only if re-encoding)
         if let Some((_, _, _, audio_enc_ost_idx, _)) = audio_transcode_state.as_ref()
             && let Some(enc_name) = audio_encode_codec
         {
-            let mut stream_dict = ffmpeg_the_third::Dictionary::new();
-            stream_dict.set("encoder", enc_name);
-            octx.stream_mut(*audio_enc_ost_idx)
-                .expect("audio output stream exists")
-                .set_metadata(stream_dict);
+            crate::ffmpeg::encoding_tag::set_stream_encoder(&mut octx, *audio_enc_ost_idx, enc_name);
         }
 
         // Write header with options

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -61,6 +61,12 @@ pub struct PipelineMessage {
     pub error_tx: Option<oneshot::Sender<PipelineError>>,
     /// Non-fatal warnings accumulated by stages during processing.
     pub warnings: Vec<String>,
+    /// Encoding tool tag set by the primary content-creating stage (recode,
+    /// audio extract, normalize). Pass-through stages (remux, metadata,
+    /// thumbnail) propagate this to the output file's `encoding_tool`
+    /// metadata instead of stamping their own name. `None` means no
+    /// prior stage set it — pass-through stages use their own name.
+    pub encoding_tool: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -153,6 +159,7 @@ impl Pipeline {
             callback_factory,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         };
 
         // Build channel chain: one mpsc(1) between consecutive stages.

--- a/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
@@ -139,6 +139,17 @@ impl PipelineStage for AudioExtractStage {
             .await
             .context("audio extract stage failed")?;
 
+        // Capture the encoding_tool for downstream pass-through stages.
+        let encoder_display = if opts.copy {
+            "copy".to_string()
+        } else {
+            opts.encoder_name
+                .as_deref()
+                .unwrap_or(target_format)
+                .to_string()
+        };
+        msg.encoding_tool = Some(encoder_display);
+
         info!(
             "AudioExtractStage: audio extracted to {}",
             output_path.display()
@@ -179,6 +190,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -111,6 +111,7 @@ impl PipelineStage for MergeStage {
 
         let opts = RemuxOptions {
             faststart: matches!(output_format, "mp4" | "mov"),
+            encoding_tool_override: msg.encoding_tool.clone(),
             ..Default::default()
         };
 
@@ -165,6 +166,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/metadata.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/metadata.rs
@@ -172,6 +172,7 @@ impl PipelineStage for MetadataStage {
                 &metadata,
                 &chapters,
                 log_callback,
+                msg.encoding_tool.clone(),
             )
             .await
         {
@@ -222,6 +223,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
@@ -120,6 +120,9 @@ impl PipelineStage for NormalizeStage {
             .await
             .context("normalize stage failed")?;
 
+        // Capture the encoding_tool for downstream pass-through stages.
+        msg.encoding_tool = Some(format!("normalize ({})", mode_name));
+
         info!(
             "NormalizeStage: normalization complete: {}",
             output_path.display()
@@ -160,6 +163,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -345,6 +345,19 @@ impl PipelineStage for RecodeStage {
             .await
             .context("recode stage failed")?;
 
+        // Capture the encoding_tool for downstream pass-through stages.
+        {
+            let audio_part = if let Some(ref ac) = opts.audio_codec {
+                ac.as_str()
+            } else if opts.audio_copy {
+                "copy"
+            } else {
+                "none"
+            };
+            let video_part = opts.video_codec.as_deref().unwrap_or("libx264");
+            msg.encoding_tool = Some(format!("{video_part} + {audio_part}"));
+        }
+
         if let Some(ref cb) = stage_callback {
             cb.on_log(&format!(
                 "Recode: complete → {}",
@@ -391,6 +404,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -101,6 +101,7 @@ impl PipelineStage for RemuxStage {
                     .map(|c| c.to_string())
                     .unwrap_or_else(|| "mp4".to_string()),
             ),
+            encoding_tool_override: msg.encoding_tool.clone(),
         };
 
         let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
@@ -157,6 +158,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 
@@ -234,6 +236,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         };
         assert!(RemuxStage::target_ext(&msg, "mp4").is_none());
     }
@@ -256,6 +259,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         };
         assert_eq!(RemuxStage::target_ext(&msg, "ts"), Some("mp4"));
     }

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
@@ -232,6 +232,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -154,6 +154,7 @@ impl PipelineStage for ThumbnailStage {
 
             let opts = RemuxOptions {
                 faststart: true,
+                encoding_tool_override: msg.encoding_tool.clone(),
                 ..Default::default()
             };
             match self
@@ -230,6 +231,7 @@ impl PipelineStage for ThumbnailStage {
                 &temp_output,
                 &extension,
                 log_callback,
+                msg.encoding_tool.clone(),
             )
             .await
         {
@@ -293,6 +295,7 @@ mod tests {
             callback_factory: None,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
+            encoding_tool: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Add 3 shared helpers to `encoding_tag.rs`: `set_encoding_tool()`, `set_encoding_tool_ffi()`, `set_stream_encoder()`
- Replace duplicated boilerplate across 10 files with helper calls
- Fix MKV raw FFI encoding_tool timing (set before `avformat_init_output`)
- All 12 output paths verified with `mkvinfo` and `strings`
- Net -17 lines

## Test plan
- [x] `cargo check` — zero errors
- [x] `cargo clippy` — zero warnings
- [x] `cargo test -p rdlp-ffmpeg` — all tests pass
- [x] Manual: `mkvinfo output.mkv | grep writing` shows `rdlp/0.1.0 (stage)`