### PR TITLE
fix: search thumbnail, CDN referer, x265 warnings, audio desync

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/commands/thumbnail.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/thumbnail.rs
@@ -33,16 +33,19 @@ fn derive_referer(url: &str) -> Option<String> {
         };
     }
 
-    // Strip CDN subdomains: keep last 2 segments
-    // e.g. fastporndelivery.hqporner.com → hqporner.com
+    // Strip CDN subdomains: keep last 2 segments, prepend www.
+    // e.g. fastporndelivery.hqporner.com → www.hqporner.com
+    //      i.xtits.com                   → www.xtits.com
+    // The www. prefix is required by some CDNs (e.g. xtits) that
+    // reject the bare registrable domain as Referer.
     let parts: Vec<&str> = host.split('.').collect();
-    let site_host = if parts.len() > 2 {
+    let registrable = if parts.len() > 2 {
         parts[parts.len() - 2..].join(".")
     } else {
         host.to_string()
     };
 
-    Some(format!("{scheme}://{site_host}"))
+    Some(format!("{scheme}://www.{registrable}"))
 }
 
 /// Fetch a thumbnail image from `url` with a derived `Referer` header
@@ -126,21 +129,28 @@ mod tests {
 
     #[test]
     fn test_derive_referer_standard_url() {
-        // CDN subdomain stripped to registrable domain
+        // CDN subdomain stripped to registrable domain with www prefix
         let referer = derive_referer("https://di.phncdn.com/videos/abc/thumb.jpg");
-        assert_eq!(referer.as_deref(), Some("https://phncdn.com"));
+        assert_eq!(referer.as_deref(), Some("https://www.phncdn.com"));
     }
 
     #[test]
     fn test_derive_referer_cdn_subdomain() {
         let referer = derive_referer("https://fastporndelivery.hqporner.com/imgs/123/thumb.jpg");
-        assert_eq!(referer.as_deref(), Some("https://hqporner.com"));
+        assert_eq!(referer.as_deref(), Some("https://www.hqporner.com"));
+    }
+
+    #[test]
+    fn test_derive_referer_xtits_cdn() {
+        // i.xtits.com CDN requires www.xtits.com Referer (bare xtits.com → 403)
+        let referer = derive_referer("https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg");
+        assert_eq!(referer.as_deref(), Some("https://www.xtits.com"));
     }
 
     #[test]
     fn test_derive_referer_no_subdomain() {
         let referer = derive_referer("https://example.com/image.jpg");
-        assert_eq!(referer.as_deref(), Some("https://example.com"));
+        assert_eq!(referer.as_deref(), Some("https://www.example.com"));
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -166,7 +166,7 @@ mod tests {
         r#"<div id="list_videos_videos_list_search_result" class="box">
 <h1 class="title">Videos for: amateur, Page 1</h1>
 <div class="item thumb-item">
-    <a class="link js-open-popup" href="https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/" title="Blonde Amateur GF - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/50088/blonde-amateur-gf-amateur/" title="Blonde Amateur GF - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg" vthumb="https://www.xtits.com/get_file/5/abc/50088vthumbs.mp4/">
         <div class="img-holder">
             <img class="thumb img" src="https://i.xtits.com/contents/videos_screenshots/50000/50088/402x225/2.jpg" alt="Blonde Amateur GF - Amateur">
             <span class="label hd"><i class="icon-hd"></i></span>
@@ -178,7 +178,7 @@ mod tests {
     </a>
 </div>
 <div class="item thumb-item">
-    <a class="link js-open-popup" href="https://www.xtits.com/videos/180969/chubby-amateur-fucked-amateur/" title="Chubby Amateur Fucked - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/180000/180969/402x225/10.jpg">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/180969/chubby-amateur-fucked-amateur/" title="Chubby Amateur Fucked - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/180000/180969/402x225/10.jpg" vthumb="https://www.xtits.com/get_file/6/def/180969vthumbs.mp4/">
         <div class="img-holder">
             <img class="thumb img" src="https://i.xtits.com/contents/videos_screenshots/180000/180969/402x225/10.jpg" alt="Chubby Amateur Fucked - Amateur">
             <span class="label time"><i class="icon-hd"></i>26:47</span>
@@ -189,7 +189,7 @@ mod tests {
     </a>
 </div>
 <div class="item thumb-item">
-    <a class="link js-open-popup" href="https://www.xtits.com/videos/172127/amateur-bbw-2k-amateur/" title="Amateur BBW(2K) - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/172000/172127/402x225/20.jpg">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/172127/amateur-bbw-2k-amateur/" title="Amateur BBW(2K) - Amateur" thumb="https://i.xtits.com/contents/videos_screenshots/172000/172127/402x225/20.jpg" vthumb="https://www.xtits.com/get_file/5/ghi/172127vthumbs.mp4/">
         <div class="img-holder">
             <img class="thumb img" src="https://i.xtits.com/contents/videos_screenshots/172000/172127/402x225/20.jpg" alt="Amateur BBW(2K) - Amateur">
             <span class="label time"><i class="icon-hd"></i>19:04</span>
@@ -213,7 +213,7 @@ mod tests {
         r#"<div id="list_videos_videos_list_search_result" class="box">
 <h1 class="title">Videos for: amateur, Page 3</h1>
 <div class="item thumb-item">
-    <a class="link js-open-popup" href="https://www.xtits.com/videos/99999/last-video/" title="Last Video" thumb="https://i.xtits.com/thumb.jpg">
+    <a class="link js-open-popup" href="https://www.xtits.com/videos/99999/last-video/" title="Last Video" thumb="https://i.xtits.com/thumb.jpg" vthumb="https://www.xtits.com/get_file/5/xyz/99999vthumbs.mp4/">
         <div class="img-holder">
             <span class="label time"><i class="icon-hd"></i>5:00</span>
         </div>

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -16,7 +16,7 @@ pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 /// Captures: (1) video URL, (2) title, (3) thumbnail URL.
 pub(crate) static ITEM_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r#"<a\s+[^>]*class="[^"]*js-open-popup[^"]*"\s+href="([^"]+)"\s+title="([^"]+)"[^>]*thumb="([^"]*)"#,
+        r#"<a\s+[^>]*class="[^"]*js-open-popup[^"]*"\s+href="([^"]+)"\s+title="([^"]+)"[^>]*\sthumb="([^"]*)"#,
     )
     .expect("Valid item pattern")
 });
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_item_pattern_matches() {
-        let html = r#"<a class="link js-open-popup" href="https://www.xtits.com/videos/50088/test/" title="Test Video" thumb="https://i.xtits.com/thumb.jpg">"#;
+        let html = r#"<a class="link js-open-popup" href="https://www.xtits.com/videos/50088/test/" title="Test Video" thumb="https://i.xtits.com/thumb.jpg" vthumb="https://www.xtits.com/get_file/5/abc/50088vthumbs.mp4/">"#;
         let cap = ITEM_PATTERN.captures(html).unwrap();
         assert_eq!(&cap[1], "https://www.xtits.com/videos/50088/test/");
         assert_eq!(&cap[2], "Test Video");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -345,6 +345,7 @@ impl FFmpegRunner {
             ffmpeg_the_third::Rational,      // encoder time_base
             usize,                           // audio_ost_index for transcode
             ffmpeg_the_third::filter::Graph, // audio format conversion filter
+            i32,                             // input sample rate (for monotonic PTS)
         )> = if let Some(enc_name) = audio_encode_codec {
             if let Some(audio_idx) = audio_ist_index {
                 // Open audio decoder
@@ -395,8 +396,9 @@ impl FFmpegRunner {
                 let mut audio_encoder = audio_enc_context.encoder().audio()?;
 
                 // Pick sample rate compatible with encoder (prefer decoder rate)
+                let audio_input_sample_rate = audio_decoder.rate();
                 let target_rate =
-                    Self::pick_audio_sample_rate(&audio_enc_codec, audio_decoder.rate());
+                    Self::pick_audio_sample_rate(&audio_enc_codec, audio_input_sample_rate);
                 let enc_time_base = ffmpeg_the_third::Rational(1, target_rate as i32);
                 audio_encoder.set_rate(target_rate as i32);
                 audio_encoder.set_time_base(enc_time_base);
@@ -447,6 +449,7 @@ impl FFmpegRunner {
                     enc_time_base,
                     audio_enc_ost_idx,
                     audio_filter,
+                    audio_input_sample_rate as i32,
                 ))
             } else {
                 None
@@ -484,7 +487,7 @@ impl FFmpegRunner {
         crate::ffmpeg::encoding_tag::set_stream_encoder(&mut octx, video_ost_index, video_codec_name);
 
         // Set per-stream encoder tag on audio output stream (only if re-encoding)
-        if let Some((_, _, _, audio_enc_ost_idx, _)) = audio_transcode_state.as_ref()
+        if let Some((_, _, _, audio_enc_ost_idx, _, _)) = audio_transcode_state.as_ref()
             && let Some(enc_name) = audio_encode_codec
         {
             crate::ffmpeg::encoding_tag::set_stream_encoder(&mut octx, *audio_enc_ost_idx, enc_name);
@@ -509,12 +512,17 @@ impl FFmpegRunner {
             audio_transcode_enc_tb,
             audio_transcode_ost_idx,
             mut audio_transcode_filter,
+            audio_transcode_input_rate,
         ) = match audio_transcode_state {
-            Some((dec, enc, enc_tb, idx, filter)) => {
-                (Some(dec), Some(enc), Some(enc_tb), Some(idx), Some(filter))
+            Some((dec, enc, enc_tb, idx, filter, rate)) => {
+                (Some(dec), Some(enc), Some(enc_tb), Some(idx), Some(filter), Some(rate))
             }
-            None => (None, None, None, None, None),
+            None => (None, None, None, None, None, None),
         };
+
+        // Monotonic audio PTS counter (in sample units, i.e. 1/sample_rate).
+        // Overrides source PTS to handle timestamp discontinuities.
+        let mut audio_sample_counter: i64 = 0;
 
         // Process packets: video -> decode/filter/encode, audio -> copy or transcode
         for result in ictx.packets() {
@@ -575,13 +583,16 @@ impl FFmpegRunner {
                     Some(enc_tb),
                     Some(audio_ost_idx),
                     Some(ref mut audio_filter),
+                    Some(input_rate),
                 ) = (
                     audio_transcode_decoder.as_mut(),
                     audio_transcode_encoder.as_mut(),
                     audio_transcode_enc_tb,
                     audio_transcode_ost_idx,
                     audio_transcode_filter.as_mut(),
+                    audio_transcode_input_rate,
                 ) {
+                    let input_tb = audio_ist_time_base.unwrap_or(ffmpeg_the_third::Rational(1, input_rate));
                     // Audio transcode path: decode → filter (format convert + frame size) → encode → write
                     audio_dec.send_packet(&packet)?;
                     Self::drain_audio_transcode_filtered(
@@ -591,6 +602,9 @@ impl FFmpegRunner {
                         &mut octx,
                         enc_tb,
                         audio_ost_idx,
+                        &mut audio_sample_counter,
+                        input_rate,
+                        input_tb,
                     )?;
                 }
             }
@@ -641,13 +655,16 @@ impl FFmpegRunner {
             Some(enc_tb),
             Some(audio_ost_idx),
             Some(ref mut audio_filter),
+            Some(input_rate),
         ) = (
             audio_transcode_decoder.as_mut(),
             audio_transcode_encoder.as_mut(),
             audio_transcode_enc_tb,
             audio_transcode_ost_idx,
             audio_transcode_filter.as_mut(),
+            audio_transcode_input_rate,
         ) {
+            let input_tb = audio_ist_time_base.unwrap_or(ffmpeg_the_third::Rational(1, input_rate));
             // Flush decoder
             audio_dec.send_eof()?;
             Self::drain_audio_transcode_filtered(
@@ -657,6 +674,9 @@ impl FFmpegRunner {
                 &mut octx,
                 enc_tb,
                 audio_ost_idx,
+                &mut audio_sample_counter,
+                input_rate,
+                input_tb,
             )?;
             // Flush filter graph
             audio_filter
@@ -774,6 +794,15 @@ impl FFmpegRunner {
     }
 
     /// Decode audio frames → push through filter → encode → write.
+    ///
+    /// `sample_counter` tracks cumulative decoded samples to generate monotonic
+    /// PTS, overriding source timestamps that may contain discontinuities
+    /// (common in streaming site downloads). Without this, a source timestamp
+    /// jump produces a burst of near-identical DTS values in the output,
+    /// causing audible desync.
+    ///
+    /// The counter is in sample units (1/sample_rate) and rescaled to the
+    /// filter graph's input time_base via `Rescale::rescale`.
     fn drain_audio_transcode_filtered(
         decoder: &mut ffmpeg_the_third::decoder::Audio,
         filter: &mut ffmpeg_the_third::filter::Graph,
@@ -781,9 +810,23 @@ impl FFmpegRunner {
         octx: &mut ffmpeg_the_third::format::context::Output,
         enc_time_base: ffmpeg_the_third::Rational,
         ost_index: usize,
+        sample_counter: &mut i64,
+        sample_rate: i32,
+        input_time_base: ffmpeg_the_third::Rational,
     ) -> Result<()> {
+        use ffmpeg_the_third::Rescale as _;
+
+        let sample_tb = ffmpeg_the_third::Rational(1, sample_rate);
         let mut frame = ffmpeg_the_third::frame::Audio::empty();
         while decoder.receive_frame(&mut frame).is_ok() {
+            // Override source PTS with monotonic counter to handle
+            // timestamp discontinuities in the source stream.
+            // Convert from sample units (1/sample_rate) to the filter
+            // graph's input time_base.
+            let pts = sample_counter.rescale(sample_tb, input_time_base);
+            frame.set_pts(Some(pts));
+            *sample_counter += frame.samples() as i64;
+
             // Push decoded frame into filter graph
             filter
                 .get("in")

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_pipeline.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_pipeline.rs
@@ -140,6 +140,10 @@ impl FFmpegRunner {
             if out_node.sink().frame(&mut filtered).is_err() {
                 break;
             }
+            // Clear source frame type hints — let the encoder decide GOP structure.
+            // Without this, x265 warns "specified frame type is not compatible
+            // with max B-frames" on every frame whose source pict_type conflicts.
+            filtered.set_kind(ffmpeg_the_third::util::picture::Type::None);
             encoder.send_frame(&filtered)?;
             frame_unref_video(&mut filtered);
             Self::drain_video_encoder_packets(encoder, octx, ost_index, enc_time_base)?;


### PR DESCRIPTION
## Summary

- **XTits search thumbnails**: regex matched `vthumb` (MP4 preview) instead of `thumb` (JPEG) — added `\s` anchor
- **Thumbnail proxy Referer**: `i.xtits.com` CDN rejects bare domain; prepend `www.` to derived Referer
- **x265 frame type warnings**: clear `pict_type` on filtered frames before encoding via safe `set_kind(Type::None)` API
- **Audio desync during recode**: source timestamp discontinuities caused DTS bursts; generate monotonic PTS from sample counter rescaled via `av_rescale_q`

## Test plan

- [ ] Search XTits in desktop — thumbnails load (JPEG, not black MP4 frames)
- [ ] Recode with `--recode-video=mp4 --video-encoder=libx265` — no frame type warnings in log
- [ ] Verify recoded file: `ffprobe` shows matching video/audio durations (within ~50ms AAC rounding)
- [ ] Audio DTS histogram shows no interval=1 bursts: `ffprobe -select_streams a:0 -show_entries packet=dts -of csv FILE | awk -F, 'NR>1{d=$2-p;h[d]++}{p=$2}END{for(k in h)print k,h[k]}'`