### PR TITLE
fix(merge): use av_write_frame to prevent ENOMEM on large files

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/raw_ffi_helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/raw_ffi_helpers.rs
@@ -41,9 +41,14 @@ pub(super) unsafe fn read_next_raw(
 }
 
 /// Rescale PTS/DTS/duration from input timebase to output timebase, set the
-/// output stream index, and write via `av_interleaved_write_frame`.
+/// output stream index, and write via `av_write_frame` (direct, non-buffered).
 ///
-/// Returns `Err` on write failure instead of silently breaking.
+/// Uses direct write instead of `av_interleaved_write_frame` because the
+/// caller (merge loop) already guarantees globally DTS-ordered packets.
+/// The interleaved variant buffers packets internally, causing unbounded
+/// memory growth (ENOMEM) on large files when merging separate input files.
+///
+/// Returns `Err` on write failure.
 ///
 /// # Safety
 ///
@@ -86,10 +91,10 @@ pub(super) unsafe fn rescale_and_write_raw(
         }
         (*pkt).pos = -1;
 
-        let ret = ffmpeg_the_third::ffi::av_interleaved_write_frame(ofmt_ctx, pkt);
+        let ret = ffmpeg_the_third::ffi::av_write_frame(ofmt_ctx, pkt);
         if ret < 0 {
             return Err(PostProcessError::FFmpegLibraryError {
-                message: format!("av_interleaved_write_frame failed: error code {ret}"),
+                message: format!("av_write_frame failed: error code {ret}"),
             });
         }
         Ok(())

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -185,9 +185,11 @@ impl FFmpegRunner {
                 &temp_audio,
                 output,
                 &super::super::RemuxOptions::default(),
-                None,
+                progress_fn,
             );
-            let _ = std::fs::remove_file(&temp_audio);
+            if let Err(e) = std::fs::remove_file(&temp_audio) {
+                log::warn!("Failed to remove temp audio file {}: {e}", temp_audio.display());
+            }
             merge_result
         } else if salvage {
             with_mux_retry(input, output, |effective_input, resilient| {


### PR DESCRIPTION
## Summary

- Switch `av_interleaved_write_frame` → `av_write_frame` in merge helper — eliminates unbounded memory growth when merging separate video+audio files (e.g., after audio normalization)
- Wire progress callback through normalize merge step so UI shows merge progress
- Log temp file cleanup failures instead of silently suppressing

## Test plan

- [ ] Recode large file (>1GB) with `--normalize-audio` — completes without ENOMEM
- [ ] `ffprobe` shows matching video/audio durations
- [ ] `cargo check && cargo clippy && cargo test` pass