### PR TITLE
chore: deduplicate FFmpeg stream copy and error handling

### DIFF
--- a/crates/rdlp-core/src/error.rs
+++ b/crates/rdlp-core/src/error.rs
@@ -100,6 +100,24 @@ pub enum RdlpError {
     Other(String),
 }
 
+impl RdlpError {
+    /// Create an `Extraction` error with a URL.
+    pub fn extraction(message: impl Into<String>, url: &str) -> Self {
+        Self::Extraction {
+            message: message.into(),
+            url: Some(url.to_string()),
+        }
+    }
+
+    /// Create a `Network` error with a URL.
+    pub fn network(message: impl Into<String>, url: &str) -> Self {
+        Self::Network {
+            message: message.into(),
+            url: Some(url.to_string()),
+        }
+    }
+}
+
 /// Result type alias for rdlp operations
 pub type Result<T> = std::result::Result<T, RdlpError>;
 

--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -203,6 +203,23 @@ impl PostProcessError {
 /// Result type for post-processing operations.
 pub type Result<T> = std::result::Result<T, PostProcessError>;
 
+/// Extension trait to shorten the repeated `.map_err(PostProcessError::from).context("...")` pattern.
+///
+/// Before: `result.map_err(PostProcessError::from).context("failed to open input")?;`
+/// After:  `result.ff_context("failed to open input")?;`
+pub(crate) trait FfmpegResultExt<T> {
+    /// Convert an `ffmpeg_the_third::Error` to `PostProcessError` with anyhow context.
+    fn ff_context(self, msg: &str) -> anyhow::Result<T>;
+}
+
+impl<T> FfmpegResultExt<T> for std::result::Result<T, ffmpeg_the_third::Error> {
+    fn ff_context(self, msg: &str) -> anyhow::Result<T> {
+        use anyhow::Context;
+        self.map_err(PostProcessError::from)
+            .context(msg.to_string())
+    }
+}
+
 /// Convert ffmpeg-the-third errors into PostProcessError.
 impl From<ffmpeg_the_third::Error> for PostProcessError {
     fn from(e: ffmpeg_the_third::Error) -> Self {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -11,6 +11,34 @@ use crate::error::Result;
 use super::FFmpegRunner;
 
 impl FFmpegRunner {
+    /// Add a stream-copy output stream: add stream, copy parameters, clear codec tag.
+    ///
+    /// This is the standard pattern for remuxing/metadata/merge where a stream
+    /// is copied without re-encoding. Returns the output stream index.
+    ///
+    /// # Arguments
+    /// * `octx` - Output format context
+    /// * `params` - Input stream parameters to copy
+    /// * `context_msg` - Error context message (e.g., "for remux", "for merge video")
+    pub(crate) fn add_stream_copy(
+        octx: &mut ffmpeg_the_third::format::context::Output,
+        params: impl ffmpeg_the_third::AsPtr<ffmpeg_the_third::ffi::AVCodecParameters>,
+        context_msg: &str,
+    ) -> Result<usize> {
+        use crate::error::PostProcessError;
+        use anyhow::Context;
+
+        let mut ost = octx
+            .add_stream(ffmpeg_the_third::encoder::find(
+                ffmpeg_the_third::codec::Id::None,
+            ))
+            .map_err(PostProcessError::from)
+            .context(format!("failed to add output stream {context_msg}"))?;
+        ost.set_parameters(params);
+        Self::clear_codec_tag(ost.parameters().as_ptr());
+        Ok(ost.index())
+    }
+
     /// Reset the codec tag to 0 for container compatibility.
     ///
     /// When remuxing between containers, the source codec tag may not be valid

--- a/crates/rdlp-ffmpeg/src/ffmpeg/fixup.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/fixup.rs
@@ -227,27 +227,24 @@ impl FFmpegRunner {
                 ist_time_bases[ist_index] = ist.time_base();
                 ost_index += 1;
 
-                let mut ost = octx
-                    .add_stream(ffmpeg_the_third::encoder::find(
-                        ffmpeg_the_third::codec::Id::None,
-                    ))
-                    .context("fixup: failed to add output stream")?;
-                ost.set_parameters(ist.parameters());
-                ost.set_metadata(ist.metadata().to_owned());
-                Self::clear_codec_tag(ost.parameters().as_ptr());
+                let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for fixup")?;
+                octx.stream_mut(ost_idx)
+                    .expect("just-added stream")
+                    .set_metadata(ist.metadata().to_owned());
 
                 // Fix SAR on video streams: set to 1:1 (square pixels)
-                if medium == ffmpeg_the_third::media::Type::Video {
-                    unsafe {
-                        let ost_ptr = ost.as_mut_ptr();
-                        (*ost_ptr).sample_aspect_ratio = ffmpeg_the_third::ffi::AVRational {
-                            num: 1,
-                            den: 1,
-                        };
-                        (*(*ost_ptr).codecpar).sample_aspect_ratio =
-                            ffmpeg_the_third::ffi::AVRational { num: 1, den: 1 };
+                if medium == ffmpeg_the_third::media::Type::Video
+                    && let Some(mut ost) = octx.stream_mut(ost_idx) {
+                        unsafe {
+                            let ost_ptr = ost.as_mut_ptr();
+                            (*ost_ptr).sample_aspect_ratio = ffmpeg_the_third::ffi::AVRational {
+                                num: 1,
+                                den: 1,
+                            };
+                            (*(*ost_ptr).codecpar).sample_aspect_ratio =
+                                ffmpeg_the_third::ffi::AVRational { num: 1, den: 1 };
+                        }
                     }
-                }
             }
 
             // Copy format-level metadata

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -109,13 +109,8 @@ impl FFmpegRunner {
             .map(|s| s.index())
             .ok_or(PostProcessError::NoVideoStream)?;
 
-        let mut ost_video = octx
-            .add_stream(ffmpeg_the_third::encoder::find(
-                ffmpeg_the_third::codec::Id::None,
-            ))
-            .map_err(PostProcessError::from)
-            .context("failed to add video output stream for merge")?;
-        ost_video.set_parameters(
+        let video_ost_index = Self::add_stream_copy(
+            &mut octx,
             ictx_video
                 .stream(video_ist_index)
                 .ok_or_else(|| {
@@ -124,9 +119,8 @@ impl FFmpegRunner {
                     ))
                 })?
                 .parameters(),
-        );
-        Self::clear_codec_tag(ost_video.parameters().as_ptr());
-        let video_ost_index = ost_video.index();
+            "for merge video",
+        )?;
 
         // Find best audio stream from audio input
         let audio_ist_index = ictx_audio
@@ -135,13 +129,8 @@ impl FFmpegRunner {
             .map(|s| s.index())
             .ok_or(PostProcessError::NoAudioStream)?;
 
-        let mut ost_audio = octx
-            .add_stream(ffmpeg_the_third::encoder::find(
-                ffmpeg_the_third::codec::Id::None,
-            ))
-            .map_err(PostProcessError::from)
-            .context("failed to add audio output stream for merge")?;
-        ost_audio.set_parameters(
+        let audio_ost_index = Self::add_stream_copy(
+            &mut octx,
             ictx_audio
                 .stream(audio_ist_index)
                 .ok_or_else(|| {
@@ -150,13 +139,15 @@ impl FFmpegRunner {
                     ))
                 })?
                 .parameters(),
-        );
-        Self::clear_codec_tag(ost_audio.parameters().as_ptr());
+            "for merge audio",
+        )?;
         // Set audio as default stream so players select it automatically
-        unsafe {
-            (*ost_audio.as_mut_ptr()).disposition = ffmpeg_the_third::ffi::AV_DISPOSITION_DEFAULT;
+        if let Some(mut ost_audio) = octx.stream_mut(audio_ost_index) {
+            unsafe {
+                (*ost_audio.as_mut_ptr()).disposition =
+                    ffmpeg_the_third::ffi::AV_DISPOSITION_DEFAULT;
+            }
         }
-        let audio_ost_index = ost_audio.index();
 
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -113,15 +113,10 @@ impl FFmpegRunner {
             ist_time_bases[ist_index] = ist.time_base();
             ost_index += 1;
 
-            let mut ost = octx
-                .add_stream(ffmpeg_the_third::encoder::find(
-                    ffmpeg_the_third::codec::Id::None,
-                ))
-                .map_err(PostProcessError::from)
-                .context("failed to add output stream for metadata embed")?;
-            ost.set_parameters(ist.parameters());
-            ost.set_metadata(ist.metadata().to_owned());
-            Self::clear_codec_tag(ost.parameters().as_ptr());
+            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for metadata embed")?;
+            octx.stream_mut(ost_idx)
+                .expect("just-added stream")
+                .set_metadata(ist.metadata().to_owned());
         }
 
         // Build metadata dictionary from input metadata + provided overrides

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use anyhow::Context as _;
 use log::{debug, warn};
 
-use crate::error::{PostProcessError, Result};
+use crate::error::{FfmpegResultExt as _, PostProcessError, Result};
 
 use super::super::ffi_helpers::{frame_unref_audio, set_single_thread_codec};
 use super::super::log_capture::LogSuppressGuard;
@@ -56,14 +56,12 @@ pub(super) fn run_analysis_decode_loop(
 
     let mut decoder_ctx =
         ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())
-            .map_err(PostProcessError::from)
-            .context("failed to create decoder context for analysis")?;
+            .ff_context("failed to create decoder context for analysis")?;
     set_single_thread_codec(unsafe { decoder_ctx.as_mut_ptr() });
     let mut decoder = decoder_ctx
         .decoder()
         .audio()
-        .map_err(PostProcessError::from)
-        .context("failed to open audio decoder for analysis")?;
+        .ff_context("failed to open audio decoder for analysis")?;
 
     debug!(
         "[{label}] decoder: rate={}, fmt={}, ch_layout={}, time_base={}/{}",
@@ -89,8 +87,7 @@ pub(super) fn run_analysis_decode_loop(
     )?;
     graph
         .add(&abuffersink, "out", "")
-        .map_err(PostProcessError::from)
-        .context("failed to add abuffersink filter for analysis")?;
+        .ff_context("failed to add abuffersink filter for analysis")?;
 
     FFmpegRunner::parse_and_validate_filter_graph(&mut graph, "in", "out", filter_spec)?;
 
@@ -107,8 +104,7 @@ pub(super) fn run_analysis_decode_loop(
 
     for result in ictx.packets() {
         let (stream, packet) = result
-            .map_err(PostProcessError::from)
-            .context("failed to read packet during analysis")?;
+            .ff_context("failed to read packet during analysis")?;
         if stream.index() != ist_index {
             continue;
         }
@@ -126,8 +122,7 @@ pub(super) fn run_analysis_decode_loop(
                 .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
                 .source()
                 .add(&frame)
-                .map_err(PostProcessError::from)
-                .context("filter source add frame failed")?;
+                .ff_context("filter source add frame failed")?;
             frame_unref_audio(&mut frame);
 
             on_drain(&mut graph, &mut filtered)?;
@@ -148,8 +143,7 @@ pub(super) fn run_analysis_decode_loop(
             .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
             .source()
             .add(&frame)
-            .map_err(PostProcessError::from)
-            .context("filter source add frame (flush) failed")?;
+            .ff_context("filter source add frame (flush) failed")?;
         frame_unref_audio(&mut frame);
 
         on_drain(&mut graph, &mut filtered)?;
@@ -161,8 +155,7 @@ pub(super) fn run_analysis_decode_loop(
         .ok_or_else(|| PostProcessError::ffmpeg_failed("filter node 'in' not found"))?
         .source()
         .flush()
-        .map_err(PostProcessError::from)
-        .context("filter source flush failed")?;
+        .ff_context("filter source flush failed")?;
     on_drain(&mut graph, &mut filtered)?;
 
     Ok(())

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use anyhow::Context as _;
 use log::{debug, warn};
 
-use crate::error::PostProcessError;
+use crate::error::{FfmpegResultExt as _, PostProcessError};
 
 use super::super::FFmpegRunner;
 use super::super::ffi_helpers::set_single_thread_codec;
@@ -117,8 +117,7 @@ impl FFmpegRunner {
         {
             let ost = octx
                 .add_stream(enc_codec)
-                .map_err(PostProcessError::from)
-                .context("failed to add audio output stream for encode")?;
+                .ff_context("failed to add audio output stream for encode")?;
             audio_ost_index = ost.index();
             audio_enc_context =
                 ffmpeg_the_third::codec::context::Context::from_parameters(ost.parameters())?;
@@ -172,8 +171,7 @@ impl FFmpegRunner {
 
         let mut audio_encoder = audio_encoder
             .open_as(enc_codec)
-            .map_err(PostProcessError::from)
-            .context("failed to open audio encoder")?;
+            .ff_context("failed to open audio encoder")?;
 
         let enc_time_base = unsafe {
             let tb = (*audio_encoder.as_ptr()).time_base;
@@ -206,8 +204,7 @@ impl FFmpegRunner {
         let mut muxer_opts = ffmpeg_the_third::Dictionary::new();
         muxer_opts.set("cluster_time_limit", "500");
         octx.write_header_with(muxer_opts)
-            .map_err(PostProcessError::from)
-            .context("failed to write output header for audio encode")?;
+            .ff_context("failed to write output header for audio encode")?;
 
         // Validate mux header state (threading, IO, seekability, file size)
         unsafe {
@@ -312,8 +309,7 @@ impl FFmpegRunner {
         let progress_throttle = Duration::from_millis(100);
         for result in ictx.packets() {
             let (stream, packet) = result
-                .map_err(PostProcessError::from)
-                .context("failed to read packet during audio encode")?;
+                .ff_context("failed to read packet during audio encode")?;
             if stream.index() != audio_ist_index {
                 continue;
             }
@@ -450,8 +446,7 @@ impl FFmpegRunner {
         debug!("[mem] filter graph freed");
 
         octx.write_trailer()
-            .map_err(PostProcessError::from)
-            .context("failed to write output trailer for audio encode")?;
+            .ff_context("failed to write output trailer for audio encode")?;
 
         drop(octx);
         drop(ictx);

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -126,15 +126,10 @@ impl FFmpegRunner {
 
             ost_index += 1;
 
-            let mut ost = octx
-                .add_stream(ffmpeg_the_third::encoder::find(
-                    ffmpeg_the_third::codec::Id::None,
-                ))
-                .map_err(PostProcessError::from)
-                .context("failed to add output stream for remux")?;
-            ost.set_parameters(ist.parameters());
-            ost.set_metadata(ist.metadata().to_owned());
-            Self::clear_codec_tag(ost.parameters().as_ptr());
+            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for remux")?;
+            octx.stream_mut(ost_idx)
+                .expect("just-added stream")
+                .set_metadata(ist.metadata().to_owned());
         }
 
         // Copy format-level metadata and add encoding_tool tag

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -207,14 +207,7 @@ pub(crate) fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     // Map all input streams to output (stream copy, no re-encoding)
     let stream_count = ictx.streams().count();
     for ist in ictx.streams() {
-        let mut ost = octx
-            .add_stream(ffmpeg_the_third::encoder::find(
-                ffmpeg_the_third::codec::Id::None,
-            ))
-            .map_err(PostProcessError::from)
-            .context("failed to add output stream for salvage")?;
-        ost.set_parameters(ist.parameters());
-        FFmpegRunner::clear_codec_tag(ost.parameters().as_ptr());
+        FFmpegRunner::add_stream_copy(&mut octx, ist.parameters(), "for salvage")?;
     }
 
     // Use FFmpeg's default 10s max_interleave_delta for salvage. This prevents

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -146,15 +146,10 @@ impl FFmpegRunner {
             ist_time_bases[ist_index] = ist.time_base();
             ost_index += 1;
 
-            let mut ost = octx
-                .add_stream(ffmpeg_the_third::encoder::find(
-                    ffmpeg_the_third::codec::Id::None,
-                ))
-                .map_err(PostProcessError::from)
-                .context("failed to add output stream for thumbnail embed")?;
-            ost.set_parameters(ist.parameters());
-            ost.set_metadata(ist.metadata().to_owned());
-            Self::clear_codec_tag(ost.parameters().as_ptr());
+            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for thumbnail embed")?;
+            octx.stream_mut(ost_idx)
+                .expect("just-added stream")
+                .set_metadata(ist.metadata().to_owned());
         }
 
         // Add thumbnail stream
@@ -169,23 +164,19 @@ impl FFmpegRunner {
         let thumb_params = thumb_ist.parameters();
 
         // Add thumbnail as video stream with ATTACHED_PIC disposition
-        let mut ost = octx
-            .add_stream(ffmpeg_the_third::encoder::find(
-                ffmpeg_the_third::codec::Id::None,
-            ))
-            .map_err(PostProcessError::from)
-            .context("failed to add thumbnail stream")?;
-        let thumb_ost_index = ost.index();
-        ost.set_parameters(thumb_params);
-        // SAFETY: ost is a valid output stream in a live output context.
-        Self::set_attached_pic_disposition(unsafe { ost.as_mut_ptr() });
+        let thumb_ost_index = Self::add_stream_copy(&mut octx, thumb_params, "for thumbnail")?;
+        {
+            let mut thumb_ost = octx.stream_mut(thumb_ost_index).expect("just-added thumbnail stream");
+            // SAFETY: thumb_ost is a valid output stream in a live output context.
+            Self::set_attached_pic_disposition(unsafe { thumb_ost.as_mut_ptr() });
 
-        // For MP3: set ID3v2 metadata on the thumbnail stream
-        if is_mp3 {
-            let mut dict = ffmpeg_the_third::Dictionary::new();
-            dict.set("title", "Album cover");
-            dict.set("comment", "Cover (Front)");
-            ost.set_metadata(dict);
+            // For MP3: set ID3v2 metadata on the thumbnail stream
+            if is_mp3 {
+                let mut dict = ffmpeg_the_third::Dictionary::new();
+                dict.set("title", "Album cover");
+                dict.set("comment", "Cover (Front)");
+                thumb_ost.set_metadata(dict);
+            }
         }
 
         // Copy format-level metadata from media input

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -113,13 +113,8 @@ impl FFmpegRunner {
             .time_base();
 
         // Add output stream (stream copy mode)
-        let mut ost = octx
-            .add_stream(ffmpeg_the_third::encoder::find(
-                ffmpeg_the_third::codec::Id::None,
-            ))
-            .map_err(PostProcessError::from)
-            .context("failed to add output stream for audio copy extract")?;
-        ost.set_parameters(
+        Self::add_stream_copy(
+            &mut octx,
             ictx.stream(ist_index)
                 .ok_or_else(|| {
                     PostProcessError::ffmpeg_failed(format!(
@@ -127,8 +122,8 @@ impl FFmpegRunner {
                     ))
                 })?
                 .parameters(),
-        );
-        Self::clear_codec_tag(ost.parameters().as_ptr());
+            "for audio copy extract",
+        )?;
 
         // Set format-level encoding_tool metadata (copy, no re-encoding)
         crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "copy");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -312,24 +312,19 @@ impl FFmpegRunner {
         // Add audio output stream (stream copy) if audio exists and copy requested
         let audio_ost_index = if opts.audio_copy {
             if let Some(audio_idx) = audio_ist_index {
-                let audio_ost_idx;
-                {
-                    let mut ost = octx
-                        .add_stream(ffmpeg_the_third::encoder::find(
-                            ffmpeg_the_third::codec::Id::None,
-                        ))
-                        .map_err(PostProcessError::from)
-                        .context("failed to add audio output stream for video transcode")?;
-                    let audio_ist = ictx.stream(audio_idx).ok_or_else(|| {
-                        PostProcessError::ffmpeg_failed(format!(
-                            "audio input stream {audio_idx} not found"
-                        ))
-                    })?;
-                    ost.set_parameters(audio_ist.parameters());
-                    ost.set_metadata(audio_ist.metadata().to_owned());
-                    audio_ost_idx = ost.index();
-                    Self::clear_codec_tag(ost.parameters().as_ptr());
-                }
+                let audio_ist = ictx.stream(audio_idx).ok_or_else(|| {
+                    PostProcessError::ffmpeg_failed(format!(
+                        "audio input stream {audio_idx} not found"
+                    ))
+                })?;
+                let audio_ost_idx = Self::add_stream_copy(
+                    &mut octx,
+                    audio_ist.parameters(),
+                    "for video transcode audio copy",
+                )?;
+                octx.stream_mut(audio_ost_idx)
+                    .expect("just-added stream")
+                    .set_metadata(audio_ist.metadata().to_owned());
                 Some(audio_ost_idx)
             } else {
                 None


### PR DESCRIPTION
## Summary

- **`add_stream_copy()` helper** — extracts 10 identical 5-line stream-copy blocks (add_stream + set_parameters + clear_codec_tag) into a single reusable function in `ffi_helpers`
- **`FfmpegResultExt::ff_context()` trait** — shortens `.map_err(PostProcessError::from).context("...")` to `.ff_context("...")`. Applied to 12 sites in normalize/encode.rs + analysis.rs; remaining ~126 sites can be converted incrementally
- **`RdlpError::extraction()` / `network()` constructors** — shorter error construction helpers for extractor boundaries

## Test plan

- [ ] All 2,126 workspace tests pass (0 failures)
- [ ] `cargo clippy` clean (zero new warnings)
- [ ] No behavior changes — pure mechanical extraction of repeated code
- [ ] FFmpeg pipeline stages (merge, remux, metadata, fixup, salvage, thumbnail, audio_extract, video_convert, normalize) all exercise `add_stream_copy` path