### PR TITLE
feat(extractor): add KoreanPornMovie extractor and search

### DIFF
--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -1,0 +1,577 @@
+//! KoreanPornMovie extractor and search.
+//!
+//! WordPress site (RetroTube theme) hosting Korean adult films. Videos are
+//! served via `clean-tube-player` plugin which wraps content in a
+//! `player-x.php?q=<base64>` iframe. Decoded content is either:
+//! - `type=video` — direct MP4 on `koreanporn.stream` CDN (self-hosted)
+//! - `type=iframe` — PornHub or other external embed
+//!
+//! Metadata comes from Schema.org `itemprop` meta tags in the article.
+
+mod patterns;
+
+use async_trait::async_trait;
+use log::debug;
+use regex::Regex;
+use scraper::{Html, Selector};
+use std::sync::LazyLock;
+
+use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtractor};
+use rdlp_types::{
+    DownloadProtocol, Format, InfoDict, SearchFilterDescriptor, SearchPageResponse, SearchQuery,
+    SearchResultPreview,
+};
+
+use crate::base::common::BaseExtractor;
+
+// ============================================================================
+// Selectors
+// ============================================================================
+
+static META_NAME_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="name"]"#).expect("valid selector")
+});
+
+static META_DESCRIPTION_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="description"]"#).expect("valid selector")
+});
+
+static META_DURATION_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="duration"]"#).expect("valid selector")
+});
+
+static META_THUMBNAIL_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="thumbnailUrl"]"#).expect("valid selector")
+});
+
+static META_CONTENT_URL_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="contentURL"]"#).expect("valid selector")
+});
+
+static META_EMBED_URL_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="embedURL"]"#).expect("valid selector")
+});
+
+static META_UPLOAD_DATE_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"meta[itemprop="uploadDate"]"#).expect("valid selector")
+});
+
+static PLAYER_IFRAME_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"iframe[src*="player-x.php"]"#).expect("valid selector")
+});
+
+static ACTOR_LINK_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"a[href*="/actor/"]"#).expect("valid selector")
+});
+
+static TAG_LINK_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(r#"a[href*="/tag/"]"#).expect("valid selector")
+});
+
+// Search result selectors
+static SEARCH_ARTICLE_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("article.loop-video").expect("valid selector")
+});
+
+static SEARCH_LINK_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a[href]").expect("valid selector"));
+
+static SEARCH_IMG_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("img").expect("valid selector"));
+
+static SEARCH_DURATION_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse(".duration").expect("valid selector"));
+
+static SEARCH_NEXT_PAGE_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a.next").expect("valid selector"));
+
+// ============================================================================
+// Extractor
+// ============================================================================
+
+/// KoreanPornMovie extractor.
+pub struct KoreanPornMovieExtractor;
+
+impl KoreanPornMovieExtractor {
+    /// Create a new extractor instance.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for KoreanPornMovieExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl InfoExtractor for KoreanPornMovieExtractor {
+    fn name(&self) -> &str {
+        "KoreanPornMovie"
+    }
+
+    fn valid_url(&self) -> &Regex {
+        &patterns::VIDEO_URL_PATTERN
+    }
+
+    fn suitable(&self, url: &str) -> bool {
+        patterns::is_video_url(url)
+    }
+
+    async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
+        let slug = patterns::extract_slug(url).ok_or_else(|| {
+            RdlpError::extraction(format!("Could not extract slug from URL: {url}"), url)
+        })?;
+
+        debug!("[KoreanPornMovie] Extracting: {slug}");
+
+        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
+
+        // Parse metadata and formats synchronously (Html is !Send)
+        let (mut info, formats) = {
+            let html = Html::parse_document(&webpage);
+
+            let title = meta_content(&html, &META_NAME_SELECTOR)
+                .or_else(|| BaseExtractor::extract_title_multi_strategy(&html))
+                .unwrap_or_else(|| slug.replace('-', " "));
+
+            let description = meta_content(&html, &META_DESCRIPTION_SELECTOR)
+                .or_else(|| BaseExtractor::extract_description_multi_strategy(&html));
+
+            let thumbnail = meta_content(&html, &META_THUMBNAIL_SELECTOR)
+                .or_else(|| BaseExtractor::extract_thumbnail_multi_strategy(&html));
+
+            let upload_date = meta_content(&html, &META_UPLOAD_DATE_SELECTOR);
+            let duration = meta_content(&html, &META_DURATION_SELECTOR)
+                .and_then(|d| parse_iso8601_duration(&d));
+
+            let actors: Vec<String> = html
+                .select(&ACTOR_LINK_SELECTOR)
+                .map(|a| a.text().collect::<String>().trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            let tags: Vec<String> = html
+                .select(&TAG_LINK_SELECTOR)
+                .map(|a| a.text().collect::<String>().trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            // Extract video formats from clean-tube-player iframe
+            let formats = extract_formats_from_html(&html, url);
+
+            let mut info = InfoDict::new(&slug, &title, "KoreanPornMovie", url);
+            info.description = description;
+            info.thumbnail = thumbnail;
+            info.upload_date = upload_date;
+            info.duration = duration;
+            if !actors.is_empty() {
+                info.uploader = Some(actors.join(", "));
+            }
+            info.tags = if tags.is_empty() { None } else { Some(tags) };
+
+            (info, formats)
+        }; // html dropped
+
+        if formats.is_empty() {
+            return Err(RdlpError::extraction(
+                "No video formats found. The video may require login or is an external embed only.",
+                url,
+            ));
+        }
+
+        info.formats = formats;
+        Ok(info)
+    }
+}
+
+// ============================================================================
+// Search
+// ============================================================================
+
+#[async_trait]
+impl SearchExtractor for KoreanPornMovieExtractor {
+    fn name(&self) -> &str {
+        "KoreanPornMovie"
+    }
+
+    fn supported_filters(&self) -> Vec<SearchFilterDescriptor> {
+        vec![SearchFilterDescriptor {
+            key: "ordering".to_string(),
+            display_name: "Sort order".to_string(),
+            allowed_values: vec![
+                rdlp_types::SearchFilterValue {
+                    value: "latest".to_string(),
+                    label: "Latest".to_string(),
+                },
+                rdlp_types::SearchFilterValue {
+                    value: "longest".to_string(),
+                    label: "Longest".to_string(),
+                },
+                rdlp_types::SearchFilterValue {
+                    value: "random".to_string(),
+                    label: "Random".to_string(),
+                },
+            ],
+            default: Some("latest".to_string()),
+        }]
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        let response = self.search_page(query, ctx).await?;
+        Ok(response.results)
+    }
+
+    async fn search_page(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        let page = query.page.unwrap_or(1);
+        let search_url = format!(
+            "https://koreanpornmovie.com/?s={}&paged={}",
+            urlencoding::encode(&query.query),
+            page
+        );
+
+        debug!("[KoreanPornMovie] Search: {} (page {})", query.query, page);
+
+        let webpage = BaseExtractor::fetch_webpage(&search_url, ctx).await?;
+
+        let (results, has_more) = {
+            let html = Html::parse_document(&webpage);
+
+            let results: Vec<SearchResultPreview> = html
+                .select(&SEARCH_ARTICLE_SELECTOR)
+                .filter_map(|article| {
+                    let link = article.select(&SEARCH_LINK_SELECTOR).next()?;
+                    let href = link.value().attr("href")?;
+
+                    // Skip non-video links
+                    if !patterns::VIDEO_URL_PATTERN.is_match(href) {
+                        return None;
+                    }
+
+                    let img = article.select(&SEARCH_IMG_SELECTOR).next();
+                    let thumbnail = img.and_then(|i| {
+                        i.value()
+                            .attr("src")
+                            .or_else(|| i.value().attr("data-src"))
+                            .map(|s| s.to_string())
+                    });
+
+                    let title = img
+                        .and_then(|i| i.value().attr("alt"))
+                        .map(|s| s.to_string())
+                        .unwrap_or_default();
+
+                    let duration = article
+                        .select(&SEARCH_DURATION_SELECTOR)
+                        .next()
+                        .map(|d| d.text().collect::<String>().trim().to_string())
+                        .and_then(|d| parse_hms_duration(&d));
+
+                    Some(SearchResultPreview {
+                        title,
+                        video_url: href.to_string(),
+                        thumbnail_url: thumbnail,
+                        duration,
+                        view_count: None,
+                        upload_date: None,
+                    })
+                })
+                .collect();
+
+            let has_more = html.select(&SEARCH_NEXT_PAGE_SELECTOR).next().is_some();
+
+            (results, has_more)
+        }; // html dropped
+
+        Ok(SearchPageResponse {
+            results,
+            page,
+            has_more,
+            total_estimate: None,
+        })
+    }
+}
+
+// ============================================================================
+// Format Extraction Helpers
+// ============================================================================
+
+/// Extract video formats from the page HTML.
+///
+/// Looks for the `clean-tube-player` iframe, decodes its base64 `q` parameter,
+/// and extracts the video source URL.
+fn extract_formats_from_html(html: &Html, _page_url: &str) -> Vec<Format> {
+    let mut formats = Vec::new();
+
+    // Strategy 1: Schema.org contentURL meta tag (direct MP4)
+    if let Some(content_url) = meta_content(html, &META_CONTENT_URL_SELECTOR)
+        && !content_url.is_empty() {
+            let protocol = if content_url.contains(".m3u8") {
+                DownloadProtocol::M3u8
+            } else {
+                DownloadProtocol::Https
+            };
+            let ext = content_url
+                .split('.')
+                .next_back()
+                .unwrap_or("mp4")
+                .split('?')
+                .next()
+                .unwrap_or("mp4");
+            formats.push(Format::new("kpm-direct", &content_url, ext, protocol));
+        }
+
+    // Strategy 2: Decode clean-tube-player iframe base64
+    if let Some(iframe) = html.select(&PLAYER_IFRAME_SELECTOR).next()
+        && let Some(src) = iframe.value().attr("src")
+            && let Some(decoded) = decode_player_iframe(src) {
+                for url in extract_urls_from_decoded_tag(&decoded) {
+                    // Skip if same as contentURL already added
+                    if !formats.iter().any(|f| f.url == url) {
+                        let protocol = if url.contains(".m3u8") {
+                            DownloadProtocol::M3u8
+                        } else {
+                            DownloadProtocol::Https
+                        };
+                        let ext = url
+                            .split('.')
+                            .next_back()
+                            .unwrap_or("mp4")
+                            .split('?')
+                            .next()
+                            .unwrap_or("mp4");
+                        formats.push(Format::new("kpm-player", &url, ext, protocol));
+                    }
+                }
+            }
+
+    // Strategy 3: embedURL (external embed — log but don't add as format)
+    if formats.is_empty()
+        && let Some(embed_url) = meta_content(html, &META_EMBED_URL_SELECTOR) {
+            log::info!(
+                "[KoreanPornMovie] Video is an external embed: {} — try that URL directly",
+                embed_url
+            );
+            // We could add it as a low-confidence format, but external embeds
+            // (PornHub, etc.) should be handled by their own extractors.
+            // Return empty to signal this to the user.
+            log::info!(
+                "[KoreanPornMovie] Use: rdlp \"{}\" instead",
+                embed_url.replace("/embed/", "/view_video.php?viewkey=")
+            );
+        }
+
+    formats
+}
+
+/// Decode the `player-x.php?q=<base64>` iframe URL.
+///
+/// Returns the URL-decoded `tag` parameter value (the actual player HTML).
+fn decode_player_iframe(iframe_src: &str) -> Option<String> {
+    let url = url::Url::parse(iframe_src).ok()?;
+    let q = url.query_pairs().find(|(k, _)| k == "q")?.1;
+
+    // Base64 decode
+    let decoded_bytes = base64::Engine::decode(
+        &base64::engine::general_purpose::STANDARD,
+        q.as_bytes(),
+    )
+    .ok()?;
+    let decoded = String::from_utf8(decoded_bytes).ok()?;
+
+    // URL-decode the tag parameter
+    let params: Vec<(String, String)> = url::form_urlencoded::parse(decoded.as_bytes())
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    params
+        .iter()
+        .find(|(k, _)| k == "tag")
+        .map(|(_, v)| v.clone())
+}
+
+/// Extract media URLs from the decoded player tag HTML.
+///
+/// Handles both `<video><source src="...">` and `<iframe src="...">` patterns.
+fn extract_urls_from_decoded_tag(tag_html: &str) -> Vec<String> {
+    use regex::Regex;
+
+    static SRC_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"src=["']([^"']+)["']"#).expect("valid src pattern")
+    });
+
+    SRC_PATTERN
+        .captures_iter(tag_html)
+        .filter_map(|caps| {
+            let url = caps.get(1)?.as_str();
+            // Only return actual media URLs, not embed pages
+            if url.contains(".mp4")
+                || url.contains(".m3u8")
+                || url.contains(".webm")
+                || url.contains("koreanporn.stream")
+            {
+                Some(url.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Extract `content` attribute from a meta[itemprop] element.
+fn meta_content(html: &Html, selector: &Selector) -> Option<String> {
+    html.select(selector)
+        .next()
+        .and_then(|el| el.value().attr("content"))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Parse ISO 8601 duration (e.g., "P0DT1H2M3S") to seconds.
+fn parse_iso8601_duration(duration: &str) -> Option<f64> {
+    // Extended format: P0DT1H2M3S
+    static DURATION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"P(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?")
+            .expect("valid duration pattern")
+    });
+
+    let caps = DURATION_PATTERN.captures(duration)?;
+    let hours: f64 = caps.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0.0);
+    let minutes: f64 = caps.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0.0);
+    let seconds: f64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0.0);
+
+    let total = hours * 3600.0 + minutes * 60.0 + seconds;
+    if total > 0.0 { Some(total) } else { None }
+}
+
+/// Parse "HH:MM:SS" or "MM:SS" duration string to seconds.
+fn parse_hms_duration(s: &str) -> Option<f64> {
+    let parts: Vec<&str> = s.split(':').collect();
+    match parts.len() {
+        3 => {
+            let h: f64 = parts[0].parse().ok()?;
+            let m: f64 = parts[1].parse().ok()?;
+            let s: f64 = parts[2].parse().ok()?;
+            Some(h * 3600.0 + m * 60.0 + s)
+        }
+        2 => {
+            let m: f64 = parts[0].parse().ok()?;
+            let s: f64 = parts[1].parse().ok()?;
+            Some(m * 60.0 + s)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_player_iframe_video_type() {
+        // Base64 of: post_id=9815&type=video&tag=<video ...><source src="https://koreanporn.stream/test.mp4" type="video/mp4" /></video>
+        let encoded = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            "post_id=9815&type=video&tag=%3Cvideo%3E%3Csource%20src%3D%22https%3A%2F%2Fkoreanporn.stream%2Ftest.mp4%22%20type%3D%22video%2Fmp4%22%20%2F%3E%3C%2Fvideo%3E",
+        );
+        let iframe_src = format!(
+            "https://koreanpornmovie.com/wp-content/plugins/clean-tube-player/public/player-x.php?q={encoded}"
+        );
+        let decoded = decode_player_iframe(&iframe_src).unwrap();
+        assert!(decoded.contains("koreanporn.stream/test.mp4"));
+    }
+
+    #[test]
+    fn decode_player_iframe_embed_type() {
+        let encoded = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            "post_id=987&type=iframe&tag=%3Ciframe%20src%3D%22https%3A%2F%2Fwww.pornhub.com%2Fembed%2Fph123%22%3E%3C%2Fiframe%3E",
+        );
+        let iframe_src = format!(
+            "https://koreanpornmovie.com/wp-content/plugins/clean-tube-player/public/player-x.php?q={encoded}"
+        );
+        let decoded = decode_player_iframe(&iframe_src).unwrap();
+        assert!(decoded.contains("pornhub.com/embed/ph123"));
+    }
+
+    #[test]
+    fn extract_urls_from_video_tag() {
+        let tag = r#"<video class="video-js"><source src="https://koreanporn.stream/Movie.mp4" type="video/mp4" /></video>"#;
+        let urls = extract_urls_from_decoded_tag(tag);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0], "https://koreanporn.stream/Movie.mp4");
+    }
+
+    #[test]
+    fn extract_urls_skips_embed_iframe() {
+        let tag = r#"<iframe src="https://www.pornhub.com/embed/ph123"></iframe>"#;
+        let urls = extract_urls_from_decoded_tag(tag);
+        assert!(urls.is_empty()); // PornHub embed is not a direct media URL
+    }
+
+    #[test]
+    fn parse_duration_full() {
+        assert_eq!(parse_iso8601_duration("P0DT1H1M14S"), Some(3674.0));
+        assert_eq!(parse_iso8601_duration("P0DT0H1M57S"), Some(117.0));
+        assert_eq!(parse_iso8601_duration("PT30S"), Some(30.0));
+    }
+
+    #[test]
+    fn extractor_name_and_priority() {
+        let ext = KoreanPornMovieExtractor::new();
+        assert_eq!(InfoExtractor::name(&ext), "KoreanPornMovie");
+        assert_eq!(ext.priority(), 0);
+    }
+
+    #[test]
+    fn extractor_suitable() {
+        let ext = KoreanPornMovieExtractor::new();
+        assert!(ext.suitable("https://koreanpornmovie.com/gangnam-full-salon-2024/"));
+        assert!(ext.suitable("https://koreanpornmovie.com/taste-of-a-young-woman-2025/"));
+        assert!(!ext.suitable("https://koreanpornmovie.com/tags/"));
+        assert!(!ext.suitable("https://koreanpornmovie.com/privacy-policy/"));
+        assert!(!ext.suitable("https://pornhub.com/view_video.php?viewkey=ph123"));
+    }
+
+    #[test]
+    fn meta_content_extraction() {
+        let html_str = r#"<html><head>
+            <meta itemprop="name" content="Test Video">
+            <meta itemprop="duration" content="P0DT1H30M0S">
+            <meta itemprop="contentURL" content="https://koreanporn.stream/test.mp4">
+        </head></html>"#;
+        let html = Html::parse_document(html_str);
+
+        assert_eq!(
+            meta_content(&html, &META_NAME_SELECTOR),
+            Some("Test Video".to_string())
+        );
+        assert_eq!(
+            meta_content(&html, &META_CONTENT_URL_SELECTOR),
+            Some("https://koreanporn.stream/test.mp4".to_string())
+        );
+    }
+
+    #[test]
+    fn format_extraction_with_content_url() {
+        let html_str = r#"<html><head>
+            <meta itemprop="contentURL" content="https://koreanporn.stream/Movie.mp4">
+        </head><body></body></html>"#;
+        let html = Html::parse_document(html_str);
+
+        let formats = extract_formats_from_html(&html, "https://koreanpornmovie.com/test/");
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].url, "https://koreanporn.stream/Movie.mp4");
+        assert_eq!(formats[0].ext, "mp4");
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/patterns.rs
@@ -1,0 +1,83 @@
+//! URL patterns for KoreanPornMovie.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Matches any path on koreanpornmovie.com with a slug.
+/// Non-video paths are filtered by `is_video_url()`.
+pub(crate) static VIDEO_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"https?://(?:www\.)?koreanpornmovie\.com/(?P<slug>[a-z0-9%][a-z0-9%\-]+)/?")
+        .expect("valid KoreanPornMovie URL pattern")
+});
+
+/// Non-video path prefixes to exclude.
+const EXCLUDED_SLUGS: &[&str] = &[
+    "tags", "tag", "actors", "actor", "category", "author", "page",
+    "wp-admin", "wp-content", "wp-json", "dmca", "contact-us",
+    "privacy-policy", "our-partner", "2557-statement",
+];
+
+/// Check if a URL is a video page (not a tag/actor/category/static page).
+pub(crate) fn is_video_url(url: &str) -> bool {
+    if !VIDEO_URL_PATTERN.is_match(url) {
+        return false;
+    }
+    if let Some(slug) = extract_slug(url) {
+        !EXCLUDED_SLUGS.iter().any(|&excl| slug == excl || slug.starts_with(&format!("{excl}/")))
+    } else {
+        false
+    }
+}
+
+/// Matches search URLs: `https://koreanpornmovie.com/?s=<query>`
+#[allow(dead_code)]
+pub(crate) static SEARCH_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"https?://(?:www\.)?koreanpornmovie\.com/\?s=")
+        .expect("valid KoreanPornMovie search URL pattern")
+});
+
+/// Extract slug from a video page URL.
+pub(crate) fn extract_slug(url: &str) -> Option<String> {
+    VIDEO_URL_PATTERN
+        .captures(url)
+        .and_then(|caps| caps.name("slug"))
+        .map(|m| m.as_str().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_url_matches() {
+        assert!(is_video_url("https://koreanpornmovie.com/taste-of-a-young-woman-2025/"));
+        assert!(is_video_url("https://koreanpornmovie.com/gangnam-full-salon-2024/"));
+        assert!(is_video_url("https://www.koreanpornmovie.com/some-video/"));
+        assert!(is_video_url("https://koreanpornmovie.com/%ed%99%98%ec%9e%a5%ed%95%98%eb%88%88%ea%b5%ac%eb%a8%bc/"));
+    }
+
+    #[test]
+    fn non_video_urls_excluded() {
+        assert!(!is_video_url("https://koreanpornmovie.com/tags/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/tag/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/actors/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/actor/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/category/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/dmca/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/privacy-policy/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/wp-admin/"));
+        assert!(!is_video_url("https://koreanpornmovie.com/contact-us/"));
+    }
+
+    #[test]
+    fn slug_extraction() {
+        assert_eq!(
+            extract_slug("https://koreanpornmovie.com/taste-of-a-young-woman-2025/"),
+            Some("taste-of-a-young-woman-2025".to_string())
+        );
+        assert_eq!(
+            extract_slug("https://koreanpornmovie.com/gangnam-full-salon-2024/"),
+            Some("gangnam-full-salon-2024".to_string())
+        );
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod generic;
 pub mod hqporner;
+pub mod koreanpornmovie;
 pub mod nine_anime;
 pub mod pornhub;
 pub mod redtube;
@@ -15,6 +16,7 @@ pub mod xtits;
 
 pub use generic::GenericExtractor;
 pub use hqporner::HQPornerExtractor;
+pub use koreanpornmovie::KoreanPornMovieExtractor;
 pub use nine_anime::NineAnimeExtractor;
 pub use pornhub::PornHubExtractor;
 pub use redtube::RedTubeExtractor;

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -40,9 +40,9 @@ pub mod utils;
 
 // Re-export extractors
 pub use extractors::{
-    EMPFlixSearchExtractor, GenericExtractor, HQPornerExtractor, MovieFapSearchExtractor,
-    NineAnimeExtractor, PornHubExtractor, RedTubeExtractor, TNAFlixExtractor,
-    TNAFlixSearchExtractor, XHamsterExtractor, XTitsExtractor,
+    EMPFlixSearchExtractor, GenericExtractor, HQPornerExtractor, KoreanPornMovieExtractor,
+    MovieFapSearchExtractor, NineAnimeExtractor, PornHubExtractor, RedTubeExtractor,
+    TNAFlixExtractor, TNAFlixSearchExtractor, XHamsterExtractor, XTitsExtractor,
 };
 
 // Re-export base utilities for convenient access
@@ -109,6 +109,9 @@ impl ExtractorRegistry {
         // Register HQPorner extractor
         registry.register(Arc::new(HQPornerExtractor::new()));
 
+        // Register KoreanPornMovie extractor
+        registry.register(Arc::new(KoreanPornMovieExtractor::new()));
+
         // Register Generic fallback extractor (MUST be last — lowest priority)
         registry.register(Arc::new(GenericExtractor::new()));
 
@@ -140,6 +143,9 @@ impl ExtractorRegistry {
         registry
             .search_extractors
             .push(Arc::new(NineAnimeExtractor::new()));
+        registry
+            .search_extractors
+            .push(Arc::new(KoreanPornMovieExtractor::new()));
 
         registry
     }


### PR DESCRIPTION
## Summary

New extractor for [koreanpornmovie.com](https://koreanpornmovie.com) — WordPress site (RetroTube theme) hosting Korean adult films.

- **Video extraction** via `clean-tube-player` plugin: decodes `player-x.php?q=<base64>` to get direct MP4 URLs from `koreanporn.stream` CDN, or logs external embed URLs (PornHub) as advisory
- **Metadata** from Schema.org `itemprop` tags: title, description, duration, thumbnail, upload date, actors, tags
- **Search** via WordPress `?s=query&paged=N` with paginated HTML results
- 12 unit tests

## Test plan

- [ ] 12 new unit tests pass (URL patterns, base64 decode, format extraction, duration parsing)
- [ ] All 2,138+ workspace tests pass
- [ ] `cargo clippy` clean
- [ ] Self-hosted videos (koreanporn.stream CDN) extract direct MP4 URLs
- [ ] External embeds (PornHub) log advisory message suggesting direct URL
- [ ] Search returns paginated results with thumbnails and durations