### PR TITLE
feat(types): add uploader field to SearchResultPreview

### DIFF
--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -45,6 +45,7 @@ export interface SearchResultPreview {
     title: string;
     thumbnail_url: string | null;
     duration: number | null;
+    uploader: string | null;
     view_count: number | null;
     upload_date: string | null;
 }

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -81,6 +81,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
             title,
             thumbnail_url,
             duration,
+            uploader: None,
             view_count: None,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -495,12 +495,11 @@ fn wp_post_to_preview(post: WpPost, duration: Option<f64>) -> SearchResultPrevie
 
     let upload_date = post.date.split('T').next().map(|s| s.to_string());
 
-    // Append actors to title for richer display in search results
-    let base_title = html_entities_decode(&post.title.rendered);
-    let title = if actors.is_empty() {
-        base_title
+    let title = html_entities_decode(&post.title.rendered);
+    let uploader = if actors.is_empty() {
+        None
     } else {
-        format!("{base_title} — {}", actors.join(", "))
+        Some(actors.join(", "))
     };
 
     SearchResultPreview {
@@ -508,6 +507,7 @@ fn wp_post_to_preview(post: WpPost, duration: Option<f64>) -> SearchResultPrevie
         video_url: post.link,
         thumbnail_url,
         duration,
+        uploader,
         view_count: None,
         upload_date,
     }

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
@@ -49,6 +49,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
                 title,
                 thumbnail_url,
                 duration: None, // anime search doesn't show per-episode duration
+                uploader: None,
                 view_count: None,
                 upload_date: None,
             }

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -137,6 +137,7 @@ fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
         title: video.title,
         thumbnail_url: thumbnail,
         duration,
+        uploader: None,
         view_count: video.views,
         upload_date: video.publish_date,
     })

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -132,6 +132,7 @@ fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
         title: video.title,
         thumbnail_url: video.thumb,
         duration,
+        uploader: None,
         view_count,
         upload_date: video.publish_date,
     })
@@ -194,6 +195,7 @@ pub(crate) fn parse_html_search_results(html: &str) -> Result<Vec<SearchResultPr
             title,
             thumbnail_url: thumb,
             duration,
+            uploader: None,
             view_count: None,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -119,6 +119,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
             title,
             thumbnail_url,
             duration,
+            uploader: None,
             view_count: None,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -136,6 +136,7 @@ pub fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
             title,
             thumbnail_url,
             duration,
+            uploader: None,
             view_count,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -76,6 +76,7 @@ fn parse_search_results_json_impl(initials: &Value) -> anyhow::Result<Vec<Search
             title,
             thumbnail_url,
             duration,
+            uploader: None,
             view_count,
             upload_date,
         });

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -46,6 +46,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
                 title,
                 thumbnail_url,
                 duration,
+                uploader: None,
                 view_count: None,
                 upload_date: None,
             }

--- a/crates/rdlp-types/src/search.rs
+++ b/crates/rdlp-types/src/search.rs
@@ -60,6 +60,8 @@ pub struct SearchResultPreview {
     pub thumbnail_url: Option<String>,
     /// Duration in seconds.
     pub duration: Option<f64>,
+    /// Uploader / channel / actor name(s).
+    pub uploader: Option<String>,
     /// View count.
     pub view_count: Option<u64>,
     /// Upload date string (site-specific format).
@@ -129,6 +131,7 @@ mod tests {
             title: "Test Video".to_string(),
             thumbnail_url: Some("https://thumb.jpg".to_string()),
             duration: Some(120.0),
+            uploader: None,
             view_count: Some(1000),
             upload_date: None,
         };


### PR DESCRIPTION
## Summary

Adds `uploader: Option<String>` to `SearchResultPreview` for actor/channel/uploader data in search results. KoreanPornMovie uses it for actors from embedded wp:term. All other extractors set `None`. TS contract updated.

## Test plan

- [ ] All 1,314 types + extractor tests pass
- [ ] `cargo check -p rdlp-desktop` passes
- [ ] KoreanPornMovie search shows actors in uploader field, not title