### PR TITLE
feat(types): add actors field to SearchResultPreview

### DIFF
--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -46,6 +46,7 @@ export interface SearchResultPreview {
     thumbnail_url: string | null;
     duration: number | null;
     uploader: string | null;
+    actors: string[];
     view_count: number | null;
     upload_date: string | null;
 }

--- a/crates/rdlp-extractor/src/extractors/hqporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/search.rs
@@ -82,6 +82,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
             thumbnail_url,
             duration,
             uploader: None,
+                    actors: vec![],
             view_count: None,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -496,18 +496,14 @@ fn wp_post_to_preview(post: WpPost, duration: Option<f64>) -> SearchResultPrevie
     let upload_date = post.date.split('T').next().map(|s| s.to_string());
 
     let title = html_entities_decode(&post.title.rendered);
-    let uploader = if actors.is_empty() {
-        None
-    } else {
-        Some(actors.join(", "))
-    };
 
     SearchResultPreview {
         title,
         video_url: post.link,
         thumbnail_url,
         duration,
-        uploader,
+        uploader: None,
+        actors,
         view_count: None,
         upload_date,
     }

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
@@ -50,6 +50,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
                 thumbnail_url,
                 duration: None, // anime search doesn't show per-episode duration
                 uploader: None,
+                    actors: vec![],
                 view_count: None,
                 upload_date: None,
             }

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -138,6 +138,7 @@ fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
         thumbnail_url: thumbnail,
         duration,
         uploader: None,
+                    actors: vec![],
         view_count: video.views,
         upload_date: video.publish_date,
     })

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -133,6 +133,7 @@ fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
         thumbnail_url: video.thumb,
         duration,
         uploader: None,
+                    actors: vec![],
         view_count,
         upload_date: video.publish_date,
     })
@@ -196,6 +197,7 @@ pub(crate) fn parse_html_search_results(html: &str) -> Result<Vec<SearchResultPr
             thumbnail_url: thumb,
             duration,
             uploader: None,
+                    actors: vec![],
             view_count: None,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -120,6 +120,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
             thumbnail_url,
             duration,
             uploader: None,
+                    actors: vec![],
             view_count: None,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -137,6 +137,7 @@ pub fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
             thumbnail_url,
             duration,
             uploader: None,
+                    actors: vec![],
             view_count,
             upload_date: None,
         });

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -77,6 +77,7 @@ fn parse_search_results_json_impl(initials: &Value) -> anyhow::Result<Vec<Search
             thumbnail_url,
             duration,
             uploader: None,
+                    actors: vec![],
             view_count,
             upload_date,
         });

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -47,6 +47,7 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
                 thumbnail_url,
                 duration,
                 uploader: None,
+                    actors: vec![],
                 view_count: None,
                 upload_date: None,
             }

--- a/crates/rdlp-types/src/search.rs
+++ b/crates/rdlp-types/src/search.rs
@@ -60,8 +60,11 @@ pub struct SearchResultPreview {
     pub thumbnail_url: Option<String>,
     /// Duration in seconds.
     pub duration: Option<f64>,
-    /// Uploader / channel / actor name(s).
+    /// Uploader / channel name.
     pub uploader: Option<String>,
+    /// Actors / performers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub actors: Vec<String>,
     /// View count.
     pub view_count: Option<u64>,
     /// Upload date string (site-specific format).
@@ -132,6 +135,7 @@ mod tests {
             thumbnail_url: Some("https://thumb.jpg".to_string()),
             duration: Some(120.0),
             uploader: None,
+                    actors: vec![],
             view_count: Some(1000),
             upload_date: None,
         };


### PR DESCRIPTION
## Summary

Adds `actors: Vec<String>` to `SearchResultPreview`, separate from `uploader: Option<String>`.

- **actors** = performers/cast (multiple people, e.g., Korean movie actors)
- **uploader** = channel/user who posted (single entity)

KoreanPornMovie populates actors from REST API embedded `wp:term` taxonomy. Other extractors (XHamster, PornHub, etc.) can populate it later. Skipped in JSON when empty (`skip_serializing_if`). TS contract updated.

## Test plan

- [ ] All 1,314 tests pass
- [ ] `cargo check -p rdlp-desktop` passes