### PR TITLE
feat(types): add actors field to InfoDict

### DIFF
--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -169,9 +169,7 @@ impl InfoExtractor for KoreanPornMovieExtractor {
             info.thumbnail = thumbnail;
             info.upload_date = upload_date;
             info.duration = duration;
-            if !actors.is_empty() {
-                info.uploader = Some(actors.join(", "));
-            }
+            info.actors = actors;
             info.tags = if tags.is_empty() { None } else { Some(tags) };
 
             (info, formats)

--- a/crates/rdlp-types/src/info_dict.rs
+++ b/crates/rdlp-types/src/info_dict.rs
@@ -54,6 +54,10 @@ pub struct InfoDict {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uploader_url: Option<String>,
 
+    /// Actors / performers / cast
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub actors: Vec<String>,
+
     /// Channel name (may differ from uploader)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
@@ -197,6 +201,7 @@ impl InfoDict {
             uploader: None,
             uploader_id: None,
             uploader_url: None,
+            actors: Vec::new(),
             channel: None,
             channel_id: None,
             channel_url: None,


### PR DESCRIPTION
## Summary

Adds `actors: Vec<String>` to `InfoDict` — performers/cast, distinct from `uploader` (channel/poster). KoreanPornMovie uses `info.actors` instead of joining into `info.uploader`. Skipped in JSON when empty.

Now both `InfoDict` and `SearchResultPreview` have proper `actors` fields for sites that support cast data (KoreanPornMovie, XHamster, etc.).

## Test plan

- [ ] All 1,314 tests pass
- [ ] `cargo check -p rdlp-desktop` passes
- [ ] `--dump-json` shows `actors: ["Sae Bom I", ...]` when available