### PR TITLE
feat(extractor): populate actors on PornHub, HQPorner, XTits

### DIFF
--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -134,11 +134,19 @@ fn extract_duration_from_html(html: &Html) -> Option<f64> {
     })
 }
 
-/// Extract the actress name from an HQPorner page.
+/// Extract the actress name from an HQPorner page (first match).
 fn extract_actress(html: &Html) -> Option<String> {
     html.select(&ACTRESS_SELECTOR)
         .next()
         .map(|el| el.text().collect::<String>().trim().to_string())
+}
+
+/// Extract all actress names from an HQPorner page.
+fn extract_all_actresses(html: &Html) -> Vec<String> {
+    html.select(&ACTRESS_SELECTOR)
+        .map(|el| el.text().collect::<String>().trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 /// Extract the actress profile URL from an HQPorner page.
@@ -203,13 +211,14 @@ impl InfoExtractor for HQPornerExtractor {
         })?;
 
         // Parse HTML once for all metadata extraction
-        let (title, duration, actress, actress_url, categories, description) = {
+        let (title, duration, actress, actress_url, all_actresses, categories, description) = {
             let html = Html::parse_document(&webpage);
             (
                 extract_title(&html),
                 extract_duration_from_html(&html),
                 extract_actress(&html),
                 extract_actress_url(&html),
+                extract_all_actresses(&html),
                 extract_categories(&html),
                 extract_description(&html),
             )
@@ -235,6 +244,7 @@ impl InfoExtractor for HQPornerExtractor {
         info.thumbnail = mydaddy_result.thumbnail;
         info.uploader = actress;
         info.uploader_url = actress_url;
+        info.actors = all_actresses;
         info.duration = duration;
         info.age_limit = Some(18);
         info.formats = formats_with_size;

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -56,7 +56,6 @@ pub(crate) struct ApiVideo {
     pub tags: Vec<ApiTag>,
     /// Pornstar list.
     #[serde(default)]
-    #[allow(dead_code)]
     pub pornstars: Vec<ApiPornstar>,
     /// Category list.
     #[serde(default)]
@@ -74,7 +73,6 @@ pub(crate) struct ApiTag {
 /// A single pornstar entry.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
 pub(crate) struct ApiPornstar {
-    #[allow(dead_code)]
     pub pornstar_name: String,
 }
 
@@ -115,7 +113,7 @@ fn parse_api_search_results_impl(json: &str) -> anyhow::Result<Vec<SearchResultP
 /// Convert an `ApiVideo` into a `SearchResultPreview`.
 ///
 /// Returns `None` if the URL is empty (skips invalid entries).
-fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
+fn api_video_to_preview(mut video: ApiVideo) -> Option<SearchResultPreview> {
     if video.url.is_empty() {
         debug!(
             "[PornHub] Search result missing URL for video_id={}, skipping",
@@ -138,7 +136,7 @@ fn api_video_to_preview(video: ApiVideo) -> Option<SearchResultPreview> {
         thumbnail_url: thumbnail,
         duration,
         uploader: None,
-                    actors: vec![],
+        actors: video.pornstars.drain(..).map(|p| p.pornstar_name).collect(),
         view_count: video.views,
         upload_date: video.publish_date,
     })

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -284,10 +284,11 @@ impl InfoExtractor for XTitsExtractor {
         info.formats = formats_with_size;
         info.propagate_duration();
 
-        // Store first model as uploader (KVS convention)
+        // Store models as actors + first model as uploader (KVS convention)
         if !models.is_empty() {
-            info.uploader = Some(models.join(", "));
+            info.uploader = Some(models[0].clone());
             info.uploader_url = model_url;
+            info.actors = models;
         }
 
         Ok(info)


### PR DESCRIPTION
## Summary

Three more extractors now populate the `actors` field:

| Extractor | Source | Before | After |
|-----------|--------|--------|-------|
| PornHub | API `pornstars[].pornstar_name` | Parsed but `#[allow(dead_code)]` | Used in search results |
| HQPorner | HTML `a[href^='/actress/']` | Only first actress as `uploader` | All actresses in `actors` |
| XTits | HTML `.list-items` models | Joined as `uploader` string | `Vec<String>` in `actors` |

**5 extractors now support actors:** XHamster, KoreanPornMovie, PornHub, HQPorner, XTits

## Test plan

- [ ] All 751 extractor tests pass
- [ ] PornHub search results include pornstar names
- [ ] HQPorner `--dump-json` shows all actresses
- [ ] XTits models appear as individual actor entries