### PR TITLE
feat: implement --match-filter for metadata-based video filtering

### DIFF
--- a/crates/rdlp-api/src/lib.rs
+++ b/crates/rdlp-api/src/lib.rs
@@ -46,5 +46,6 @@ pub use rdlp_types::{
     PostProcess, RecodeAudioMode, SearchFilter, SearchFilterDescriptor, SearchFilterValue,
     SearchPageResponse, SearchQuery, SearchResultPreview, SearchSiteInfo, SubtitleFormat,
 };
+pub use rdlp_types::match_filter::MatchFilter;
 pub use request::DownloadRequest;
 pub use result::DownloadResult;

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -354,6 +354,18 @@ impl Orchestrator {
             }
         }
 
+        // Single video — check match filters
+        if !self.config.match_filters.is_empty() {
+            let info = &infos[0];
+            if !check_match_filters(&self.config.match_filters, info) {
+                info!(
+                    title = info.title.as_str();
+                    "Does not pass match filter, skipping"
+                );
+                return Ok(None);
+            }
+        }
+
         // Single video - use existing state machine
         let mut phase = DownloadPhase::Extracting {
             url: url.to_owned(),
@@ -474,4 +486,25 @@ mod download_plan_tests {
         assert!(s.contains("v1"));
         assert!(s.contains("a1"));
     }
+}
+
+/// Check if an InfoDict passes all match filters (OR logic: any filter passing = pass).
+///
+/// Returns `true` if:
+/// - No filters configured (empty list)
+/// - At least one filter evaluates to `true`
+fn check_match_filters(filter_strs: &[String], info: &rdlp_types::InfoDict) -> bool {
+    use rdlp_types::match_filter::MatchFilter;
+
+    let filters: Vec<MatchFilter> = filter_strs
+        .iter()
+        .filter_map(|s| MatchFilter::parse(s).ok())
+        .collect();
+
+    if filters.is_empty() {
+        return true;
+    }
+
+    // OR logic: at least one filter must pass
+    filters.iter().any(|f| f.evaluate_info(info))
 }

--- a/crates/rdlp-api/src/orchestrator/playlist/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/execution.rs
@@ -45,6 +45,13 @@ impl Orchestrator {
                 {
                     return None;
                 }
+                // Match filter check
+                if !self.config.match_filters.is_empty()
+                    && !super::super::check_match_filters(&self.config.match_filters, ep)
+                {
+                    log::info!(title = ep.title.as_str(); "Does not pass match filter, skipping");
+                    return None;
+                }
                 Some((i, ep.clone()))
             })
             .collect();

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -251,6 +251,11 @@ pub(crate) struct Args {
     #[arg(long)]
     pub download_archive: Option<PathBuf>,
 
+    /// Filter videos by metadata (yt-dlp syntax). Repeatable (OR logic between filters).
+    /// Examples: "duration > 60", "!is_live", "title *= cats", "like_count >? 100"
+    #[arg(long = "match-filter", action = clap::ArgAction::Append)]
+    pub match_filter: Vec<String>,
+
     // === Search options ===
     /// Perform a keyword search instead of downloading a URL
     #[arg(long)]

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -285,6 +285,18 @@ pub(crate) fn merge_config(
         );
     }
 
+    // Match filters (CLI appends to config file values)
+    if !args.match_filter.is_empty() {
+        config.match_filters.extend(args.match_filter.iter().cloned());
+    }
+
+    // Validate match filter syntax early
+    for filter_str in &config.match_filters {
+        rdlp_api::MatchFilter::parse(filter_str)
+            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| format!("invalid match filter '{filter_str}'"))?;
+    }
+
     // Derived settings
     config.progress = !config.quiet;
 

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -68,6 +68,7 @@ fn default_args() -> Args {
         recode_container: None,
         recode_audio: "copy".to_string(),
         fixup: "detect_or_warn".to_string(),
+        match_filter: vec![],
     }
 }
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -222,6 +222,12 @@ pub struct Config {
     /// Path to download archive file (logs completed downloads to skip on re-run)
     pub download_archive: Option<PathBuf>,
 
+    // === Filtering ===
+    /// Match filter expressions (OR logic between multiple filters, AND within each).
+    /// Evaluated against InfoDict before download — non-matching videos are skipped.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub match_filters: Vec<String>,
+
     // === Plugin system ===
     /// Directories to search for plugins
     pub plugin_directories: Vec<PathBuf>,
@@ -318,6 +324,9 @@ impl Default for Config {
 
             // Archive
             download_archive: None,
+
+            // Filtering
+            match_filters: Vec::new(),
 
             // Plugin system
             plugin_directories: Vec::new(),

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod container;
 pub mod fixup_policy;
 pub mod format;
 pub mod info_dict;
+pub mod match_filter;
 pub mod parse_error;
 pub mod postprocess;
 pub mod protocol;

--- a/crates/rdlp-types/src/match_filter/eval.rs
+++ b/crates/rdlp-types/src/match_filter/eval.rs
@@ -1,0 +1,139 @@
+//! Evaluation of match filter conditions against JSON values.
+
+use serde_json::Value;
+
+use super::{ComparisonOp, Condition, FilterValue};
+
+/// Evaluate a single condition against a JSON object.
+pub(super) fn evaluate_condition(condition: &Condition, data: &Value) -> bool {
+    match condition {
+        Condition::Unary { key, negated } => {
+            let value = data.get(key);
+            let present = match value {
+                None | Some(Value::Null) => false,
+                Some(Value::Bool(b)) => *b,
+                Some(_) => true,
+            };
+            if *negated { !present } else { present }
+        }
+        Condition::Comparison {
+            key,
+            op,
+            negated,
+            none_inclusive,
+            value,
+        } => {
+            let actual = data.get(key);
+            match actual {
+                None | Some(Value::Null) => {
+                    // Field missing — pass if none_inclusive, fail otherwise
+                    *none_inclusive
+                }
+                Some(actual) => {
+                    let result = evaluate_comparison(*op, actual, value);
+                    if *negated { !result } else { result }
+                }
+            }
+        }
+    }
+}
+
+/// Evaluate a comparison between an actual JSON value and a filter value.
+fn evaluate_comparison(op: ComparisonOp, actual: &Value, filter_val: &FilterValue) -> bool {
+    match op {
+        // Numeric/string comparison operators
+        ComparisonOp::Lt | ComparisonOp::Le | ComparisonOp::Gt | ComparisonOp::Ge => {
+            if let Some(actual_num) = as_number(actual)
+                && let FilterValue::Number(filter_num) = filter_val {
+                    return match op {
+                        ComparisonOp::Lt => actual_num < *filter_num,
+                        ComparisonOp::Le => actual_num <= *filter_num,
+                        ComparisonOp::Gt => actual_num > *filter_num,
+                        ComparisonOp::Ge => actual_num >= *filter_num,
+                        _ => unreachable!(),
+                    };
+                }
+            // String comparison fallback
+            let actual_str = as_string(actual);
+            let filter_str = filter_value_as_string(filter_val);
+            match op {
+                ComparisonOp::Lt => actual_str < filter_str,
+                ComparisonOp::Le => actual_str <= filter_str,
+                ComparisonOp::Gt => actual_str > filter_str,
+                ComparisonOp::Ge => actual_str >= filter_str,
+                _ => unreachable!(),
+            }
+        }
+
+        // Equality
+        ComparisonOp::Eq | ComparisonOp::Ne => {
+            let equal = if let Some(actual_num) = as_number(actual) {
+                if let FilterValue::Number(filter_num) = filter_val {
+                    (actual_num - *filter_num).abs() < f64::EPSILON
+                } else {
+                    as_string(actual) == filter_value_as_string(filter_val)
+                }
+            } else {
+                as_string(actual) == filter_value_as_string(filter_val)
+            };
+            match op {
+                ComparisonOp::Eq => equal,
+                ComparisonOp::Ne => !equal,
+                _ => unreachable!(),
+            }
+        }
+
+        // String-only operators
+        ComparisonOp::Contains => {
+            let actual_str = as_string(actual);
+            let filter_str = filter_value_as_string(filter_val);
+            actual_str.contains(&filter_str)
+        }
+        ComparisonOp::StartsWith => {
+            let actual_str = as_string(actual);
+            let filter_str = filter_value_as_string(filter_val);
+            actual_str.starts_with(&filter_str)
+        }
+        ComparisonOp::EndsWith => {
+            let actual_str = as_string(actual);
+            let filter_str = filter_value_as_string(filter_val);
+            actual_str.ends_with(&filter_str)
+        }
+        ComparisonOp::Regex => {
+            let actual_str = as_string(actual);
+            let filter_str = filter_value_as_string(filter_val);
+            regex::Regex::new(&filter_str)
+                .map(|re| re.is_match(&actual_str))
+                .unwrap_or(false)
+        }
+    }
+}
+
+/// Extract a numeric value from a JSON value.
+fn as_number(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(n) => n.as_f64(),
+        // Also try parsing string fields as numbers (e.g., "1200")
+        Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// Convert a JSON value to a string for comparison.
+fn as_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => String::new(),
+        _ => value.to_string(),
+    }
+}
+
+/// Convert a filter value to a string.
+fn filter_value_as_string(value: &FilterValue) -> String {
+    match value {
+        FilterValue::Number(n) => n.to_string(),
+        FilterValue::String(s) => s.clone(),
+    }
+}

--- a/crates/rdlp-types/src/match_filter/mod.rs
+++ b/crates/rdlp-types/src/match_filter/mod.rs
@@ -1,0 +1,139 @@
+//! Match filter for skipping videos by metadata.
+//!
+//! Implements yt-dlp-compatible `--match-filter` syntax:
+//!
+//! ```text
+//! --match-filter "duration > 60 & !is_live"
+//! --match-filter "title *= cats"
+//! --match-filter "like_count >? 100"   # pass if field missing
+//! ```
+//!
+//! Multiple `--match-filter` flags use OR logic.
+
+mod eval;
+mod parser;
+
+#[cfg(test)]
+mod tests;
+
+use std::fmt;
+
+/// A parsed match filter expression (one or more `&`-separated conditions).
+#[derive(Debug, Clone)]
+pub struct MatchFilter {
+    /// Conditions joined by `&` (all must pass).
+    pub(crate) conditions: Vec<Condition>,
+    /// Original input string (for display).
+    raw: String,
+}
+
+/// A single filter condition.
+#[derive(Debug, Clone)]
+pub(crate) enum Condition {
+    /// Field presence/absence: `field` (present) or `!field` (absent).
+    Unary { key: String, negated: bool },
+    /// Comparison: `field [!]op[?] value`.
+    Comparison {
+        key: String,
+        op: ComparisonOp,
+        negated: bool,
+        none_inclusive: bool,
+        value: FilterValue,
+    },
+}
+
+/// Comparison operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ComparisonOp {
+    /// `<`
+    Lt,
+    /// `<=`
+    Le,
+    /// `>`
+    Gt,
+    /// `>=`
+    Ge,
+    /// `=`
+    Eq,
+    /// `!=`
+    Ne,
+    /// `*=` — string contains
+    Contains,
+    /// `^=` — string starts with
+    StartsWith,
+    /// `$=` — string ends with
+    EndsWith,
+    /// `~=` — regex match
+    Regex,
+}
+
+/// A filter value (right-hand side of comparison).
+#[derive(Debug, Clone)]
+pub(crate) enum FilterValue {
+    Number(f64),
+    String(String),
+}
+
+/// Error from parsing a match filter expression.
+#[derive(Debug, Clone)]
+pub struct MatchFilterError {
+    /// The original input.
+    pub input: String,
+    /// Human-readable error message.
+    pub message: String,
+}
+
+impl fmt::Display for MatchFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid match filter '{}': {}", self.input, self.message)
+    }
+}
+
+impl std::error::Error for MatchFilterError {}
+
+impl MatchFilter {
+    /// Parse a match filter expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rdlp_types::match_filter::MatchFilter;
+    ///
+    /// let filter = MatchFilter::parse("duration > 60 & !is_live").unwrap();
+    /// ```
+    pub fn parse(input: &str) -> Result<Self, MatchFilterError> {
+        let conditions = parser::parse_filter(input).map_err(|msg| MatchFilterError {
+            input: input.to_string(),
+            message: msg,
+        })?;
+        Ok(Self {
+            conditions,
+            raw: input.to_string(),
+        })
+    }
+
+    /// Evaluate against a JSON value (InfoDict serialized as JSON).
+    ///
+    /// Returns `true` if the filter passes (video should be downloaded).
+    #[must_use] 
+    pub fn evaluate(&self, value: &serde_json::Value) -> bool {
+        self.conditions
+            .iter()
+            .all(|c| eval::evaluate_condition(c, value))
+    }
+
+    /// Evaluate against an InfoDict by serializing to JSON first.
+    #[must_use] 
+    pub fn evaluate_info(&self, info: &crate::InfoDict) -> bool {
+        match serde_json::to_value(info) {
+            Ok(value) => self.evaluate(&value),
+            Err(_) => false,
+        }
+    }
+}
+
+impl fmt::Display for MatchFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}

--- a/crates/rdlp-types/src/match_filter/parser.rs
+++ b/crates/rdlp-types/src/match_filter/parser.rs
@@ -1,0 +1,275 @@
+//! winnow parser for match filter expressions.
+//!
+//! Grammar:
+//! ```text
+//! filter      = condition ("&" condition)*
+//! condition   = comparison | unary
+//! comparison  = key ws negation? op none_inclusive? ws value
+//! unary       = "!"? key
+//! key         = [a-z_][a-z0-9_]*
+//! op          = "<=" | ">=" | "!=" | "*=" | "^=" | "$=" | "~=" | "<" | ">" | "="
+//! value       = quoted_string | bare_value
+//! ```
+
+use winnow::ascii::multispace0;
+use winnow::combinator::{alt, opt};
+use winnow::error::ContextError;
+use winnow::prelude::*;
+use winnow::token::{take_till, take_while};
+
+use super::{ComparisonOp, Condition, FilterValue};
+
+/// Parse a complete filter expression (multiple `&`-separated conditions).
+pub(super) fn parse_filter(input: &str) -> Result<Vec<Condition>, String> {
+    // Split on unescaped `&` first (like yt-dlp), then parse each part.
+    let parts: Vec<&str> = split_on_unescaped_ampersand(input);
+
+    let mut conditions = Vec::new();
+    for part in parts {
+        let trimmed = part.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let condition = parse_condition(trimmed)
+            .map_err(|e| format!("in condition '{}': {}", trimmed, e))?;
+        conditions.push(condition);
+    }
+
+    if conditions.is_empty() {
+        return Err("empty filter expression".to_string());
+    }
+
+    Ok(conditions)
+}
+
+/// Split input on `&` that is not preceded by `\`.
+fn split_on_unescaped_ampersand(input: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let bytes = input.as_bytes();
+
+    for i in 0..bytes.len() {
+        if bytes[i] == b'&' && (i == 0 || bytes[i - 1] != b'\\') {
+            parts.push(&input[start..i]);
+            start = i + 1;
+        }
+    }
+    parts.push(&input[start..]);
+    parts
+}
+
+/// Parse a single condition (comparison or unary).
+fn parse_condition(input: &str) -> Result<Condition, String> {
+    let mut s = input;
+
+    // Try comparison first (has an operator)
+    if let Ok(cond) = try_parse_comparison(&mut s) {
+        return Ok(cond);
+    }
+
+    // Fall back to unary (field presence/absence)
+    parse_unary(input)
+}
+
+/// Try to parse a comparison condition.
+fn try_parse_comparison(input: &mut &str) -> Result<Condition, String> {
+    let original = *input;
+
+    // key
+    let key = parse_key
+        .parse_next(input)
+        .map_err(|_: winnow::error::ErrMode<ContextError>| "expected field name".to_string())?;
+
+    // optional whitespace
+    let _ = multispace0::<_, ContextError>.parse_next(input);
+
+    // optional negation prefix on operator
+    let negated = opt('!')
+        .parse_next(input)
+        .map_err(|_: winnow::error::ErrMode<ContextError>| "parse error".to_string())?
+        .is_some();
+
+    // optional whitespace after negation
+    let _ = multispace0::<_, ContextError>.parse_next(input);
+
+    // operator (must match)
+    let op = parse_op.parse_next(input).map_err(|_: winnow::error::ErrMode<ContextError>| {
+        *input = original;
+        "no operator found".to_string()
+    })?;
+
+    // optional none-inclusive `?`
+    let none_inclusive = opt('?')
+        .parse_next(input)
+        .map_err(|_: winnow::error::ErrMode<ContextError>| "parse error".to_string())?
+        .is_some();
+
+    // optional whitespace before value
+    let _ = multispace0::<_, ContextError>.parse_next(input);
+
+    // value
+    let raw_value = parse_value
+        .parse_next(input)
+        .map_err(|_: winnow::error::ErrMode<ContextError>| "expected value after operator".to_string())?;
+
+    // Unescape literal `\&` in the value
+    let raw_value = raw_value.replace("\\&", "&");
+
+    // Determine if value is numeric
+    let value = if let Some(num) = try_parse_numeric(&raw_value) {
+        FilterValue::Number(num)
+    } else {
+        FilterValue::String(raw_value)
+    };
+
+    // String operators can't be used with numeric values
+    if matches!(
+        op,
+        ComparisonOp::Contains
+            | ComparisonOp::StartsWith
+            | ComparisonOp::EndsWith
+            | ComparisonOp::Regex
+    ) && matches!(value, FilterValue::Number(_))
+    {
+        // Treat as string anyway for these operators
+        let string_val = match &value {
+            FilterValue::Number(n) => FilterValue::String(n.to_string()),
+            FilterValue::String(s) => FilterValue::String(s.clone()),
+        };
+        return Ok(Condition::Comparison {
+            key: key.to_string(),
+            op,
+            negated,
+            none_inclusive,
+            value: string_val,
+        });
+    }
+
+    Ok(Condition::Comparison {
+        key: key.to_string(),
+        op,
+        negated,
+        none_inclusive,
+        value,
+    })
+}
+
+/// Parse a unary condition: `field` or `!field`.
+fn parse_unary(input: &str) -> Result<Condition, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("empty condition".to_string());
+    }
+
+    let (negated, key) = if let Some(rest) = trimmed.strip_prefix('!') {
+        (true, rest.trim())
+    } else {
+        (false, trimmed)
+    };
+
+    // Validate key format
+    if !key
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(format!("invalid field name '{key}'"));
+    }
+
+    Ok(Condition::Unary {
+        key: key.to_string(),
+        negated,
+    })
+}
+
+/// Parse a field key: `[a-z_][a-z0-9_]*`.
+fn parse_key<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+    take_while(1.., |c: char| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        .parse_next(input)
+}
+
+/// Parse an operator token (longest match first).
+fn parse_op(input: &mut &str) -> ModalResult<ComparisonOp> {
+    alt((
+        "<=".value(ComparisonOp::Le),
+        ">=".value(ComparisonOp::Ge),
+        "!=".value(ComparisonOp::Ne),
+        "*=".value(ComparisonOp::Contains),
+        "^=".value(ComparisonOp::StartsWith),
+        "$=".value(ComparisonOp::EndsWith),
+        "~=".value(ComparisonOp::Regex),
+        "<".value(ComparisonOp::Lt),
+        ">".value(ComparisonOp::Gt),
+        "=".value(ComparisonOp::Eq),
+    ))
+    .parse_next(input)
+}
+
+/// Parse a value: quoted string or bare value.
+fn parse_value(input: &mut &str) -> ModalResult<String> {
+    alt((parse_quoted_string, parse_bare_value)).parse_next(input)
+}
+
+/// Parse a double-quoted or single-quoted string.
+fn parse_quoted_string(input: &mut &str) -> ModalResult<String> {
+    let quote = alt(('\"', '\'')).parse_next(input)?;
+    let content: String = take_till(0.., move |c: char| c == quote)
+        .parse_next(input)?
+        .to_string();
+    let _ = winnow::token::one_of(move |c: char| c == quote).parse_next(input)?;
+    Ok(content)
+}
+
+/// Parse a bare (unquoted) value — everything until end of input.
+fn parse_bare_value(input: &mut &str) -> ModalResult<String> {
+    let val = take_while(1.., |c: char| !c.is_ascii_whitespace() || c == ' ')
+        .parse_next(input)?
+        .trim()
+        .to_string();
+    Ok(val)
+}
+
+/// Try to parse a string as a numeric value.
+///
+/// Supports: integers, filesize suffixes (K/M/G), duration (H:M:S).
+fn try_parse_numeric(s: &str) -> Option<f64> {
+    // Plain number
+    if let Ok(n) = s.parse::<f64>() {
+        return Some(n);
+    }
+
+    // Filesize suffixes: 1K = 1000, 1M = 1_000_000, 1G = 1_000_000_000
+    let s_upper = s.to_uppercase();
+    if let Some(num_str) = s_upper.strip_suffix('K')
+        && let Ok(n) = num_str.parse::<f64>() {
+            return Some(n * 1000.0);
+        }
+    if let Some(num_str) = s_upper.strip_suffix('M')
+        && let Ok(n) = num_str.parse::<f64>() {
+            return Some(n * 1_000_000.0);
+        }
+    if let Some(num_str) = s_upper.strip_suffix('G')
+        && let Ok(n) = num_str.parse::<f64>() {
+            return Some(n * 1_000_000_000.0);
+        }
+    if let Some(num_str) = s_upper.strip_suffix('B')
+        && let Ok(n) = num_str.parse::<f64>() {
+            return Some(n);
+        }
+
+    // Duration: H:M:S or M:S
+    let parts: Vec<&str> = s.split(':').collect();
+    match parts.len() {
+        3 => {
+            let h = parts[0].parse::<f64>().ok()?;
+            let m = parts[1].parse::<f64>().ok()?;
+            let sec = parts[2].parse::<f64>().ok()?;
+            Some(h * 3600.0 + m * 60.0 + sec)
+        }
+        2 => {
+            let m = parts[0].parse::<f64>().ok()?;
+            let sec = parts[1].parse::<f64>().ok()?;
+            Some(m * 60.0 + sec)
+        }
+        _ => None,
+    }
+}

--- a/crates/rdlp-types/src/match_filter/tests.rs
+++ b/crates/rdlp-types/src/match_filter/tests.rs
@@ -1,0 +1,319 @@
+//! Tests for match filter parsing and evaluation.
+
+use serde_json::json;
+
+use super::MatchFilter;
+
+// ============================================================================
+// Parser tests
+// ============================================================================
+
+#[test]
+fn parse_unary_present() {
+    let f = MatchFilter::parse("is_live").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+}
+
+#[test]
+fn parse_unary_negated() {
+    let f = MatchFilter::parse("!is_live").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+}
+
+#[test]
+fn parse_comparison_gt() {
+    let f = MatchFilter::parse("duration > 60").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+}
+
+#[test]
+fn parse_none_inclusive() {
+    let f = MatchFilter::parse("like_count >? 100").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+}
+
+#[test]
+fn parse_and_conditions() {
+    let f = MatchFilter::parse("duration > 60 & !is_live").unwrap();
+    assert_eq!(f.conditions.len(), 2);
+}
+
+#[test]
+fn parse_string_contains() {
+    let f = MatchFilter::parse("title *= cats").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+}
+
+#[test]
+fn parse_quoted_string() {
+    let f = MatchFilter::parse("title = \"hello world\"").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+}
+
+#[test]
+fn parse_filesize_suffix() {
+    let f = MatchFilter::parse("filesize > 1M").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+    // Should evaluate as 1_000_000
+    let data = json!({"filesize": 2_000_000});
+    assert!(f.evaluate(&data));
+}
+
+#[test]
+fn parse_duration_value() {
+    let f = MatchFilter::parse("duration > 1:30:00").unwrap();
+    assert_eq!(f.conditions.len(), 1);
+    // 1:30:00 = 5400 seconds
+    let data = json!({"duration": 6000});
+    assert!(f.evaluate(&data));
+    let data = json!({"duration": 3000});
+    assert!(!f.evaluate(&data));
+}
+
+#[test]
+fn parse_empty_fails() {
+    assert!(MatchFilter::parse("").is_err());
+}
+
+#[test]
+fn parse_invalid_fails() {
+    assert!(MatchFilter::parse("!!!").is_err());
+}
+
+// ============================================================================
+// Unary evaluation tests
+// ============================================================================
+
+#[test]
+fn eval_unary_present_true() {
+    let f = MatchFilter::parse("title").unwrap();
+    assert!(f.evaluate(&json!({"title": "abc"})));
+}
+
+#[test]
+fn eval_unary_present_empty_string() {
+    let f = MatchFilter::parse("title").unwrap();
+    // yt-dlp: empty string is "present" (not None)
+    assert!(f.evaluate(&json!({"title": ""})));
+}
+
+#[test]
+fn eval_unary_present_missing() {
+    let f = MatchFilter::parse("title").unwrap();
+    assert!(!f.evaluate(&json!({})));
+}
+
+#[test]
+fn eval_unary_present_null() {
+    let f = MatchFilter::parse("title").unwrap();
+    assert!(!f.evaluate(&json!({"title": null})));
+}
+
+#[test]
+fn eval_unary_negated_missing() {
+    let f = MatchFilter::parse("!title").unwrap();
+    assert!(f.evaluate(&json!({})));
+}
+
+#[test]
+fn eval_unary_negated_present() {
+    let f = MatchFilter::parse("!title").unwrap();
+    assert!(!f.evaluate(&json!({"title": "abc"})));
+}
+
+#[test]
+fn eval_unary_bool_true() {
+    let f = MatchFilter::parse("is_live").unwrap();
+    assert!(f.evaluate(&json!({"is_live": true})));
+}
+
+#[test]
+fn eval_unary_bool_false() {
+    let f = MatchFilter::parse("is_live").unwrap();
+    assert!(!f.evaluate(&json!({"is_live": false})));
+}
+
+#[test]
+fn eval_unary_negated_bool_false() {
+    let f = MatchFilter::parse("!is_live").unwrap();
+    assert!(f.evaluate(&json!({"is_live": false})));
+}
+
+#[test]
+fn eval_unary_negated_bool_true() {
+    let f = MatchFilter::parse("!is_live").unwrap();
+    assert!(!f.evaluate(&json!({"is_live": true})));
+}
+
+// ============================================================================
+// Numeric comparison tests
+// ============================================================================
+
+#[test]
+fn eval_numeric_gt_pass() {
+    let f = MatchFilter::parse("duration > 60").unwrap();
+    assert!(f.evaluate(&json!({"duration": 120})));
+}
+
+#[test]
+fn eval_numeric_gt_fail() {
+    let f = MatchFilter::parse("duration > 60").unwrap();
+    assert!(!f.evaluate(&json!({"duration": 30})));
+}
+
+#[test]
+fn eval_numeric_gt_equal_fail() {
+    let f = MatchFilter::parse("duration > 60").unwrap();
+    assert!(!f.evaluate(&json!({"duration": 60})));
+}
+
+#[test]
+fn eval_numeric_ge() {
+    let f = MatchFilter::parse("duration >= 60").unwrap();
+    assert!(f.evaluate(&json!({"duration": 60})));
+    assert!(f.evaluate(&json!({"duration": 120})));
+    assert!(!f.evaluate(&json!({"duration": 59})));
+}
+
+#[test]
+fn eval_numeric_lt() {
+    let f = MatchFilter::parse("duration < 600").unwrap();
+    assert!(f.evaluate(&json!({"duration": 300})));
+    assert!(!f.evaluate(&json!({"duration": 600})));
+}
+
+#[test]
+fn eval_numeric_le() {
+    let f = MatchFilter::parse("duration <= 600").unwrap();
+    assert!(f.evaluate(&json!({"duration": 600})));
+    assert!(!f.evaluate(&json!({"duration": 601})));
+}
+
+#[test]
+fn eval_numeric_eq() {
+    let f = MatchFilter::parse("view_count = 1000").unwrap();
+    assert!(f.evaluate(&json!({"view_count": 1000})));
+    assert!(!f.evaluate(&json!({"view_count": 999})));
+}
+
+#[test]
+fn eval_numeric_ne() {
+    let f = MatchFilter::parse("view_count != 0").unwrap();
+    assert!(f.evaluate(&json!({"view_count": 100})));
+    assert!(!f.evaluate(&json!({"view_count": 0})));
+}
+
+#[test]
+fn eval_filesize_1k() {
+    let f = MatchFilter::parse("filesize > 1K").unwrap();
+    assert!(f.evaluate(&json!({"filesize": 1200})));
+    assert!(!f.evaluate(&json!({"filesize": 500})));
+}
+
+// ============================================================================
+// Missing field / none-inclusive tests
+// ============================================================================
+
+#[test]
+fn eval_missing_field_fails() {
+    let f = MatchFilter::parse("duration > 60").unwrap();
+    assert!(!f.evaluate(&json!({})));
+}
+
+#[test]
+fn eval_none_inclusive_missing_passes() {
+    let f = MatchFilter::parse("like_count >? 100").unwrap();
+    assert!(f.evaluate(&json!({})));
+}
+
+#[test]
+fn eval_none_inclusive_present_evaluates() {
+    let f = MatchFilter::parse("like_count >? 100").unwrap();
+    assert!(f.evaluate(&json!({"like_count": 200})));
+    assert!(!f.evaluate(&json!({"like_count": 50})));
+}
+
+// ============================================================================
+// String comparison tests
+// ============================================================================
+
+#[test]
+fn eval_string_eq() {
+    let f = MatchFilter::parse("title = foobar42").unwrap();
+    assert!(f.evaluate(&json!({"title": "foobar42"})));
+    assert!(!f.evaluate(&json!({"title": "other"})));
+}
+
+#[test]
+fn eval_string_ne() {
+    let f = MatchFilter::parse("title != foobar42").unwrap();
+    assert!(f.evaluate(&json!({"title": "other"})));
+    assert!(!f.evaluate(&json!({"title": "foobar42"})));
+}
+
+#[test]
+fn eval_string_contains() {
+    let f = MatchFilter::parse("title *= cats").unwrap();
+    assert!(f.evaluate(&json!({"title": "I love cats"})));
+    assert!(!f.evaluate(&json!({"title": "I love dogs"})));
+}
+
+#[test]
+fn eval_string_negated_contains() {
+    let f = MatchFilter::parse("title !*= ads").unwrap();
+    assert!(f.evaluate(&json!({"title": "great video"})));
+    assert!(!f.evaluate(&json!({"title": "ads everywhere"})));
+}
+
+#[test]
+fn eval_string_starts_with() {
+    let f = MatchFilter::parse("title ^= hello").unwrap();
+    assert!(f.evaluate(&json!({"title": "hello world"})));
+    assert!(!f.evaluate(&json!({"title": "world hello"})));
+}
+
+#[test]
+fn eval_string_ends_with() {
+    let f = MatchFilter::parse("title $= world").unwrap();
+    assert!(f.evaluate(&json!({"title": "hello world"})));
+    assert!(!f.evaluate(&json!({"title": "world hello"})));
+}
+
+#[test]
+fn eval_regex_match() {
+    let f = MatchFilter::parse(r"title ~= \d+").unwrap();
+    assert!(f.evaluate(&json!({"title": "video 123"})));
+    assert!(!f.evaluate(&json!({"title": "no numbers"})));
+}
+
+// ============================================================================
+// AND logic tests
+// ============================================================================
+
+#[test]
+fn eval_and_both_pass() {
+    let f = MatchFilter::parse("duration > 60 & !is_live").unwrap();
+    assert!(f.evaluate(&json!({"duration": 120})));
+}
+
+#[test]
+fn eval_and_first_fails() {
+    let f = MatchFilter::parse("duration > 60 & !is_live").unwrap();
+    assert!(!f.evaluate(&json!({"duration": 30})));
+}
+
+#[test]
+fn eval_and_second_fails() {
+    let f = MatchFilter::parse("duration > 60 & !is_live").unwrap();
+    assert!(!f.evaluate(&json!({"duration": 120, "is_live": true})));
+}
+
+// ============================================================================
+// Display
+// ============================================================================
+
+#[test]
+fn display_roundtrip() {
+    let f = MatchFilter::parse("duration > 60 & !is_live").unwrap();
+    assert_eq!(f.to_string(), "duration > 60 & !is_live");
+}


### PR DESCRIPTION
## Summary

Full yt-dlp-compatible `--match-filter` implementation with winnow parser.

### Operators (10)
| Numeric | String | Unary |
|---------|--------|-------|
| `<` `<=` `>` `>=` `=` `!=` | `*=` (contains) `^=` (starts) `$=` (ends) `~=` (regex) | `field` (present) `!field` (absent) |

### Modifiers
- `!` prefix: negate any operator
- `?` suffix: none-inclusive (pass if field missing)
- `&`: AND conditions within a filter
- Multiple `--match-filter` flags: OR logic

### Value types
- Integers, filesize (`1K`, `1M`, `1G`), duration (`1:30:00`), quoted strings

### Integration
- Config: `match_filters: Vec<String>`
- CLI: `--match-filter` (repeatable)
- Orchestrator: filters in both single-video and playlist paths
- Syntax validated at config build time

## Test plan

- [ ] 44 unit tests (parser + evaluator) pass
- [ ] All workspace tests pass
- [ ] `cargo check -p rdlp-desktop` passes
- [ ] `rdlp --match-filter "duration > 60" PLAYLIST_URL` skips short videos
- [ ] `rdlp --match-filter "!is_live"` skips live streams
- [ ] Multiple `--match-filter` uses OR logic