### PR TITLE
perf(async): downgrade unnecessary tokio::sync::Mutex + enable await_holding_lock deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,8 @@ tempfile = "3.14"
 
 [workspace.lints.clippy]
 must_use_candidate = "warn"
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
 
 # ── Dev profile: prioritize compile speed ──────────────────────────────
 [profile.dev]

--- a/crates/rdlp-downloader/src/hls/merge.rs
+++ b/crates/rdlp-downloader/src/hls/merge.rs
@@ -1,9 +1,15 @@
 //! HLS segment merging and cleanup.
+//!
+//! std::sync::Mutex is intentional for `Arc<Mutex<HlsDownloadState>>`: guards
+//! never cross an .await point. Snapshots are cloned out of the lock before
+//! any `.save().await` call, and all critical sections are pure sync
+//! (HashSet edits, counter updates, clone-out-for-save).
+//! See docs/implementation/tls-impersonation/phase-1-report.md Finding 2.2.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
@@ -11,7 +17,6 @@ use log::{debug, warn};
 use rdlp_core::{ProgressCallback, RdlpError, Result, RetryConfig};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
-use tokio::sync::Mutex;
 use tracing::instrument;
 
 use super::segment::download_segment_with_retry;
@@ -65,7 +70,11 @@ pub(crate) async fn download_segments_with_resume(
     let total_segments = segments.len();
 
     // Get already completed segments and validate they exist on disk
-    let original_completed: HashSet<usize> = state.lock().await.completed_segments.clone();
+    let original_completed: HashSet<usize> = state
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .completed_segments
+        .clone();
 
     // Verify completed segments actually exist on disk (handles corrupted/deleted files)
     let is_valid_on_disk = |idx: &usize| -> bool {
@@ -94,7 +103,7 @@ pub(crate) async fn download_segments_with_resume(
         );
         // Update state to remove invalid entries
         {
-            let mut state_guard = state.lock().await;
+            let mut state_guard = state.lock().unwrap_or_else(|e| e.into_inner());
             for idx in &missing_segments {
                 state_guard.completed_segments.remove(idx);
             }
@@ -176,7 +185,7 @@ pub(crate) async fn download_segments_with_resume(
                     let bytes = meta.len();
                     // Mark as completed in state
                     {
-                        let mut state_guard = state.lock().await;
+                        let mut state_guard = state.lock().unwrap_or_else(|e| e.into_inner());
                         state_guard.mark_completed(idx, bytes);
                     }
                     segments.fetch_add(1, Ordering::Relaxed);
@@ -217,9 +226,9 @@ pub(crate) async fn download_segments_with_resume(
 
                         // Update state on success; clone if periodic save needed
                         let snapshot = {
-                            let mut guard = state.lock().await;
+                            let mut guard = state.lock().unwrap_or_else(|e| e.into_inner());
                             guard.mark_completed(idx, *bytes);
-                            if guard.completed_segments.len() % 50 == 0 {
+                            if guard.completed_segments.len().is_multiple_of(50) {
                                 Some(guard.clone())
                             } else {
                                 None
@@ -237,7 +246,7 @@ pub(crate) async fn download_segments_with_resume(
                     }
                     Err(e) => {
                         // Save state on error before propagating
-                        let snapshot = state.lock().await.clone();
+                        let snapshot = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
                         if let Err(save_err) = snapshot.save(&output_path).await {
                             warn!("Failed to save HLS state on error: {save_err}");
                         }
@@ -265,7 +274,7 @@ pub(crate) async fn download_segments_with_resume(
                     "Segment failed: {e}"
                 );
                 if segment_failures >= max_segment_failures {
-                    let snapshot = state.lock().await.clone();
+                    let snapshot = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
                     let _ = snapshot.save(output_path).await;
                     return Err(RdlpError::Download {
                         message: format!(
@@ -282,7 +291,7 @@ pub(crate) async fn download_segments_with_resume(
     }
 
     // Save final state (clone under lock, then save outside lock)
-    let snapshot = state.lock().await.clone();
+    let snapshot = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
     if let Err(e) = snapshot.save(output_path).await {
         warn!("Failed to save final HLS state: {e}");
     }

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -23,14 +23,17 @@ mod types;
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+// std::sync::Mutex is intentional for `Arc<Mutex<HlsDownloadState>>`: guards
+// never cross an .await point. Snapshots are cloned out of the lock before
+// any `.save().await` call.
+// See docs/implementation/tls-impersonation/phase-1-report.md Finding 2.2.
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use log::{debug, info, warn};
 use rdlp_core::{DownloadStats, Downloader, ProgressCallback, RdlpError, Result, RetryConfig};
-use tokio::sync::Mutex;
 use tracing::instrument;
 
 use crate::hls_state::HlsDownloadState;
@@ -235,9 +238,18 @@ impl Downloader for HlsDownloader {
             };
 
             // Step 3: Setup progress tracking
-            let downloaded = Arc::new(AtomicU64::new(state.lock().await.total_bytes_downloaded));
+            let downloaded = Arc::new(AtomicU64::new(
+                state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .total_bytes_downloaded,
+            ));
             let segments_completed = Arc::new(AtomicU64::new(
-                state.lock().await.completed_segments.len() as u64,
+                state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .completed_segments
+                    .len() as u64,
             ));
             // Duration in centiseconds for atomic precision (f64 -> u64)
             let duration_completed = Arc::new(AtomicU64::new(0));
@@ -285,7 +297,7 @@ impl Downloader for HlsDownloader {
                 Ok(paths) => paths,
                 Err(e) => {
                     // Save state on error (so we can resume later)
-                    let snapshot = state.lock().await.clone();
+                    let snapshot = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
                     if let Err(save_err) = snapshot.save(path).await {
                         warn!("Failed to save HLS state: {save_err}");
                     }

--- a/crates/rdlp-ratelimit/src/limiter.rs
+++ b/crates/rdlp-ratelimit/src/limiter.rs
@@ -1,7 +1,6 @@
 //! Token-bucket rate limiter implementation.
 
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tokio::time::{Duration, Instant};
 
 /// Internal mutable state for the token bucket.
@@ -27,6 +26,9 @@ struct TokenBucketState {
 #[derive(Clone)]
 pub struct RateLimiter {
     bytes_per_second: f64,
+    // std::sync::Mutex is intentional: guards never cross an .await point.
+    // The critical section is pure arithmetic; the sleep is outside the guard.
+    // See docs/implementation/tls-impersonation/phase-1-report.md Finding 2.1.
     state: Arc<Mutex<TokenBucketState>>,
 }
 
@@ -50,7 +52,7 @@ impl RateLimiter {
     /// The mutex is released before sleeping so other tasks are not blocked.
     pub async fn acquire(&self, bytes: usize) {
         let sleep_duration = {
-            let mut state = self.state.lock().await;
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
             let now = Instant::now();
             let elapsed = now.duration_since(state.last_refill).as_secs_f64();
 


### PR DESCRIPTION
## Summary

Closes Class 2 findings from the TLS impersonation Phase 1 async audit (spec §5.1.2).

- `TokenBucketState` mutex in `rdlp-ratelimit` (Finding 2.1): downgraded `tokio::sync::Mutex` → `std::sync::Mutex`. Guard scope is pure arithmetic; `tokio::time::sleep` is outside the lock.
- `HlsDownloadState` mutex in `rdlp-downloader/src/hls/*` (Finding 2.2): 10 call sites across 2 files, all short sync critical sections (HashSet edits, counter updates, clone-out-for-save). Snapshots are explicitly cloned out before any `.save().await`.

Both sites get an explanatory in-source comment mirroring Vector's idiom (`// std::sync::Mutex is intentional: ...`). Poisoning recovery via the project's `.unwrap_or_else(|e| e.into_inner())` convention.

## Structural regression guard

Enables `clippy::await_holding_lock = "deny"` and `clippy::await_holding_refcell_ref = "deny"` workspace-wide. Any future re-introduction of a `!Send` guard held across `.await` will fail CI. Workspace members opt in via `[lints] workspace = true`.

## Test rationale (bug-fix-requires-failing-test.md §Exception Handling)

This is a perf/style change with zero behaviour change. No synthetic runtime test meaningfully fails on the unpatched code — the guard-across-await property is compile-time `!Send` enforcement, already in the type system for `std::sync::MutexGuard`. The deny lint is the regression guard.

## Research basis

- `docs/implementation/tls-impersonation/phase-1-report.md` Appendix A §Q1 + §Q5 (validated against tokio 1.49 docs + matklad's poisoning analysis)
- Appendix B §Pattern 1 + §Pattern 4 (industry cross-reference: Vector's comment idiom, EmbarkStudios / mun-lang / kanidm / pg_exporter deny-lint pattern, vicnaum's rust-magic-linter recommendation for AI-generated code)

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean (including the two new deny lints)
- [ ] `cargo test --workspace` passes — total count matches pre-PR baseline
- [ ] `rg '\.lock\(\)\.await' crates/rdlp-ratelimit crates/rdlp-downloader/src/hls` returns no hits