### PR TITLE
Prism Phase 2c — exactOptionalPropertyTypes via WithUndefined<T, K> bridge

### DIFF
--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -20,7 +20,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }
@@ -109,7 +108,7 @@ describe("JobCard", () => {
     });
 
     it("does not render log panel when logMessages is undefined", () => {
-        render(<JobCard job={makeJob({ logMessages: undefined })} onCancel={noop} onRemove={noop} onRetry={noop} />);
+        render(<JobCard job={makeJob()} onCancel={noop} onRemove={noop} onRetry={noop} />);
         expect(screen.queryByText(/^logs/i)).not.toBeInTheDocument();
     });
 

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
@@ -12,7 +12,7 @@
  * this file.
  */
 import { describe, test, expectTypeOf, assertType } from "vitest"
-import type { Branded, LiteralUnion, Handlers } from "./types"
+import type { Branded, LiteralUnion, Handlers, WithUndefined } from "./types"
 
 type ToastKey = Branded<string, "PrismToast">
 
@@ -50,5 +50,21 @@ describe("Prism _internal type utilities", () => {
       onClose?: () => void
       onFocusOut?: () => void
     }>()
+  })
+
+  test("WithUndefined — widens selected optional keys to accept undefined explicitly", () => {
+    interface Strict { items?: string[]; textValue?: string; other?: number }
+    type Widened = WithUndefined<Strict, "items" | "textValue">
+
+    // Widened keys accept explicit undefined
+    assertType<Widened>({ items: undefined, textValue: undefined })
+    assertType<Widened>({ items: ["a"], textValue: "x" })
+    assertType<Widened>({})
+
+    // Non-widened keys keep their strict shape
+    expectTypeOf<Widened["other"]>().toEqualTypeOf<number | undefined>() // optional inherits | undefined from T[P]
+    // ^ note: under exactOptionalPropertyTypes, `other?: number` inferred via Omit<T, K>
+    //   keeps the original strict shape — assertType<Widened>({ other: undefined })
+    //   would still fail compile-time, which is the desired behavior.
   })
 })

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.ts
@@ -46,3 +46,35 @@ export type LiteralUnion<T extends string> = T | (string & {})
 export type Handlers<Events extends string> = {
   [E in Events as `on${Capitalize<E>}`]?: () => void
 }
+
+/**
+ * Widens selected optional keys of T to also accept `undefined` explicitly,
+ * restoring pre-`exactOptionalPropertyTypes` semantics for those keys only.
+ *
+ * Mirrors the inverse of `type-fest`'s `SetNonNullable<T, K>`. Useful at
+ * Prism wrapper boundaries when forwarding to upstream `react-aria-components`
+ * primitives whose interfaces use `prop?: T` rather than `prop?: T | undefined`
+ * (see adobe/react-spectrum#8717 — Adobe has not committed to fixing upstream).
+ *
+ * Pair with conditional spread inside the wrapper to bridge the widened
+ * wrapper signature back to the strict RAC signature:
+ *
+ * @example
+ *   type PrismSelectProps<T extends object> = WithUndefined<
+ *     AriaSelectProps<T>,
+ *     "items" | "textValue"
+ *   >
+ *
+ *   function PrismSelect<T extends object>({ items, textValue, ...rest }: PrismSelectProps<T>) {
+ *     return (
+ *       <AriaSelect
+ *         {...rest}
+ *         {...(items !== undefined && { items })}
+ *         {...(textValue !== undefined && { textValue })}
+ *       />
+ *     )
+ *   }
+ */
+export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]?: T[P] | undefined
+}

--- a/crates/rdlp-desktop/src/components/ui/command.tsx
+++ b/crates/rdlp-desktop/src/components/ui/command.tsx
@@ -35,7 +35,7 @@ function CommandInput({ placeholder, className }: { placeholder?: string; classN
     <AriaSearchField className="flex items-center border-b px-3" aria-label="Search">
       <Search aria-hidden="true" className="mr-2 size-4 shrink-0 opacity-50" />
       <AriaInput
-        placeholder={placeholder}
+        {...(placeholder !== undefined && { placeholder })}
         className={cn(
           "flex h-11 w-full bg-transparent py-3 text-sm outline-none",
           "placeholder:text-muted-foreground",

--- a/crates/rdlp-desktop/src/components/ui/dialog.tsx
+++ b/crates/rdlp-desktop/src/components/ui/dialog.tsx
@@ -68,9 +68,9 @@ const DialogOverlay = ({
 interface DialogContentProps
   extends Omit<React.ComponentProps<typeof AriaModal>, "children">,
     VariantProps<typeof sheetVariants> {
-  children?: AriaDialogProps["children"]
-  role?: AriaDialogProps["role"]
-  closeButton?: boolean
+  children?: AriaDialogProps["children"] | undefined
+  role?: AriaDialogProps["role"] | undefined
+  closeButton?: boolean | undefined
 }
 
 const DialogContent = ({
@@ -93,7 +93,7 @@ const DialogContent = ({
     {...props}
   >
     <AriaDialog
-      role={role}
+      {...(role !== undefined && { role })}
       className={cn(!side && "grid h-full gap-4", "h-full outline-none")}
     >
       {composeRenderProps(children, (children, renderProps) => (

--- a/crates/rdlp-desktop/src/components/ui/grid-list.tsx
+++ b/crates/rdlp-desktop/src/components/ui/grid-list.tsx
@@ -13,6 +13,8 @@ import {
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/components/ui/checkbox"
 
+import type { WithUndefined } from "./_internal/types"
+
 export function GridList<T extends object>({
   children,
   ...props
@@ -37,12 +39,14 @@ export function GridList<T extends object>({
 export function GridListItem({
   children,
   className,
+  textValue: textValueProp,
   ...props
-}: AriaGridListItemProps) {
-  let textValue = typeof children === "string" ? children : undefined
+}: WithUndefined<AriaGridListItemProps, "textValue">) {
+  let textValue =
+    textValueProp ?? (typeof children === "string" ? children : undefined)
   return (
     <AriaGridListItem
-      textValue={textValue}
+      {...(textValue !== undefined && { textValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "jolly-GridListItem relative flex w-full cursor-default select-none items-center gap-3 rounded-sm px-2 py-1.5 text-sm outline-none",

--- a/crates/rdlp-desktop/src/components/ui/select.tsx
+++ b/crates/rdlp-desktop/src/components/ui/select.tsx
@@ -29,6 +29,8 @@ import {
 
 import { cn } from "@/lib/utils"
 
+import type { WithUndefined } from "./_internal/types"
+
 const labelVariants = cva([
   "text-sm font-medium leading-none",
   /* Disabled */
@@ -57,13 +59,14 @@ const ListBoxCollection = AriaCollection
 const ListBoxItem = <T extends object>({
   className,
   children,
+  textValue,
   ...props
-}: AriaListBoxItemProps<T>) => {
+}: WithUndefined<AriaListBoxItemProps<T>, "textValue">) => {
+  const resolvedTextValue =
+    textValue || (typeof children === "string" ? children : undefined)
   return (
     <AriaListBoxItem
-      textValue={
-        props.textValue || (typeof children === "string" ? children : undefined)
-      }
+      {...(resolvedTextValue !== undefined && { textValue: resolvedTextValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
@@ -188,8 +191,9 @@ const SelectPopover = ({ className, ...props }: AriaPopoverProps) => (
 
 const SelectListBox = <T extends object>({
   className,
+  items,
   ...props
-}: AriaListBoxProps<T>) => (
+}: WithUndefined<AriaListBoxProps<T>, "items">) => (
   <AriaListBox
     className={composeRenderProps(className, (className) =>
       cn(
@@ -198,6 +202,7 @@ const SelectListBox = <T extends object>({
       )
     )}
     {...props}
+    {...(items !== undefined && { items })}
   />
 )
 
@@ -206,7 +211,7 @@ interface PrismSelectProps<T extends object>
   label?: string
   description?: string
   errorMessage?: string | ((validation: AriaValidationResult) => string)
-  items?: Iterable<T>
+  items?: Iterable<T> | undefined
   children: React.ReactNode | ((item: T) => React.ReactNode)
 }
 
@@ -237,7 +242,9 @@ function PrismSelect<T extends object>({
       )}
       <FieldError>{errorMessage}</FieldError>
       <SelectPopover>
-        <SelectListBox items={items}>{children}</SelectListBox>
+        <SelectListBox {...(items !== undefined && { items })}>
+          {children}
+        </SelectListBox>
       </SelectPopover>
     </Select>
   )

--- a/crates/rdlp-desktop/src/components/ui/sonner.tsx
+++ b/crates/rdlp-desktop/src/components/ui/sonner.tsx
@@ -26,8 +26,8 @@ export type ToastSeverity = LiteralUnion<"info" | "success" | "warning" | "error
 
 interface ToastContent {
   title: string
-  description?: string
-  severity?: ToastSeverity
+  description?: string | undefined
+  severity?: ToastSeverity | undefined
 }
 
 /** Singleton queue. Imported once at app root via <ToastRegion />. */
@@ -65,7 +65,7 @@ function ToastRegion() {
   )
 }
 
-function SeverityIcon({ severity }: { severity?: ToastSeverity }) {
+function SeverityIcon({ severity }: { severity?: ToastSeverity | undefined }) {
   switch (severity) {
     case "success":
       return <CircleCheck aria-hidden="true" className="size-5 text-green-500" />

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -25,7 +25,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/shell/IconRail.tsx
+++ b/crates/rdlp-desktop/src/shell/IconRail.tsx
@@ -2,6 +2,7 @@
 // Active icon has 2px blue left edge indicator + tinted background.
 
 import { Search, ArrowDownToLine, Clock, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useStore } from "@tanstack/react-store";
 import { useQuery } from "@tanstack/react-query";
 import { uiStore, setView } from "@/stores/uiStore";
@@ -12,7 +13,7 @@ import { TooltipTrigger } from "react-aria-components";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 
-const NAV_ITEMS: { id: AppView; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+const NAV_ITEMS: { id: AppView; icon: LucideIcon; label: string }[] = [
     { id: "analyze", icon: Search, label: "Analyze (Ctrl+1)" },
     { id: "queue", icon: ArrowDownToLine, label: "Queue (Ctrl+2)" },
     { id: "history", icon: Clock, label: "History (Ctrl+3)" },
@@ -42,7 +43,7 @@ export function IconRail() {
                             size="icon"
                             onPress={() => setView(id)}
                             aria-label={label}
-                            aria-current={isActive ? "page" : undefined}
+                            {...(isActive && { "aria-current": "page" as const })}
                             className={cn(
                                 "relative flex items-center justify-center w-10 h-10 rounded-[6px] my-0.5 transition-colors",
                                 isActive

--- a/crates/rdlp-desktop/src/test/radix-select-mock.tsx
+++ b/crates/rdlp-desktop/src/test/radix-select-mock.tsx
@@ -17,10 +17,10 @@ import * as React from "react";
 
 interface SelectCtx {
     value: string;
-    onValueChange?: (v: string) => void;
+    onValueChange?: ((v: string) => void) | undefined;
     open: boolean;
     setOpen: (o: boolean) => void;
-    disabled?: boolean;
+    disabled?: boolean | undefined;
     items: Map<string, string>; // value → label text
 }
 

--- a/crates/rdlp-desktop/tsconfig.json
+++ b/crates/rdlp-desktop/tsconfig.json
@@ -28,6 +28,7 @@
     "erasableSyntaxOnly": true,
     "noImplicitOverride": true,
     "verbatimModuleSyntax": true,
+    "exactOptionalPropertyTypes": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

Closes the original Phase 2 scope (and Task #8 in the Prism sprint). Enables ``exactOptionalPropertyTypes: true`` on the desktop crate via a new ``WithUndefined<T, K>`` mapped-type helper in ``_internal/types.ts`` that bridges Prism wrapper signatures to upstream ``react-aria-components`` primitives whose interfaces use ``prop?: T`` rather than ``prop?: T | undefined``.

Pure TypeScript pattern — no module augmentation, no runtime helper, no library dependency. Mirrors the inverse of ``type-fest``'s ``SetNonNullable<T, K>``.

## Why this approach

Researched the canonical solutions (deep dive in the prior session):
- **Module augmentation** — works but hidden side-effect on global RAC types; surprising to reviewers; collides if RAC eventually fixes upstream.
- **Runtime ``omitUndefined`` helper** — erases narrowing through ``Partial<T>``; runtime cost; opaque at call sites.
- **Conditional spread at every consumer site** — Adobe's official workaround per [react-spectrum#8717](https://github.com/adobe/react-spectrum/issues/8717), but Adobe themselves call the pattern ""ugly""; defeats Prism's design intent of friendlier-than-RAC consumer API.
- **``WithUndefined<T, K>`` mapped type** *(landed)* — localized to the wrapper layer, type-only, mirrors a recognizable type-fest convention, removable in one delete when RAC eventually fixes #8717. Sits next to ``Branded``, ``LiteralUnion``, ``Handlers`` (already in ``_internal/types.ts`` from Phase 2a).

Sources consulted: [TypeScript ``exactOptionalPropertyTypes`` docs](https://www.typescriptlang.org/tsconfig/exactOptionalPropertyTypes.html), [adobe/react-spectrum#8717](https://github.com/adobe/react-spectrum/issues/8717), [radix-ui/primitives#3535](https://github.com/radix-ui/primitives/issues/3535), [type-fest ``SetNonNullable`` source](https://github.com/sindresorhus/type-fest/blob/main/source/set-non-nullable.d.ts), [Lucide React TypeScript guide](https://lucide.dev/guide/react/advanced/typescript), typed-rocks/typescript repo (for style consistency with existing helpers), Matt Pocock's repos (confirmed nothing pre-built fits this gap).

## What lands

### New helper

```ts
// crates/rdlp-desktop/src/components/ui/_internal/types.ts
export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
  [P in K]?: T[P] | undefined
}
```

Plus a 4th typecheck-mode test in ``types.test-d.ts`` covering it. Type-test count 121 → 122.

### Per-file fixes (11 files touched)

**Two root causes; both Category-A (type-only, no behavior change):**

| File | Cause | Fix |
|---|---|---|
| ``components/ui/select.tsx`` | RAC ``items``, ``textValue`` typed ``prop?: T`` | ``WithUndefined`` widening + conditional-spread |
| ``components/ui/dialog.tsx`` | RAC ``role`` typed ``prop?: T`` | Local ``DialogContentProps`` widening + conditional-spread |
| ``components/ui/grid-list.tsx`` | RAC ``textValue`` typed ``prop?: T`` | ``WithUndefined`` widening + conditional-spread |
| ``components/ui/command.tsx`` | RAC ``placeholder`` typed ``prop?: T`` | Conditional-spread |
| ``components/ui/sonner.tsx`` | Local ``ToastContent.description``/``severity`` propagate undefined into RAC slots | Widen with ``\| undefined`` |
| ``shell/IconRail.tsx`` | Local typing used ``ComponentType<{ className?: string }>`` instead of canonical ``LucideIcon`` | Import ``LucideIcon`` from lucide-react; conditional-spread ``aria-current`` |
| ``components/JobCard.test.tsx`` | Fixture explicitly set ``logMessages: undefined`` | Drop the explicit undefined (fixture intent was ""no messages"") |
| ``events/registerDownloadEvents.test.ts`` | Same fixture pattern | Drop |
| ``test/radix-select-mock.tsx`` | Mock context provider needs to forward implicit-undefined optionals | Widen ``SelectCtx.onValueChange`` and ``disabled`` with ``\| undefined`` |
| ``tsconfig.json`` | — | Add ``"exactOptionalPropertyTypes": true`` |

### Surfaced beyond original ~10-error inventory

Implementer flagged 8 additional same-shape errors during the dry-run (``command.tsx`` placeholder, ``sonner.tsx`` 5 errors at lines 55/94/97/100/103, ``IconRail.tsx`` ``aria-current``). All triaged as Category-A and fixed with the same ``WithUndefined`` / widening / conditional-spread idiom. Documented in commit message.

## Pattern consistency

Every RAC bridge site uses ``WithUndefined<T, K>`` at the wrapper signature paired with ``{...(prop !== undefined && { prop })}`` at the JSX boundary. No type assertions, no ``as any``, no runtime helpers. The JSDoc ``@example`` in ``WithUndefined`` matches the actual idiom in ``select.tsx``.

The ``isActive ? "page" : undefined`` → ``{...(isActive && { "aria-current": "page" as const })}`` swap in ``IconRail`` uses the truthy-shortcircuit variant since ``isActive: boolean`` cannot be a falsy non-undefined value.

## Verification matrix

| Gate | Result |
|---|---|
| ``npx tsc --noEmit`` | silent |
| ``npm test -- --run`` | ``Test Files 9 passed (9), Tests 118 passed (118)`` |
| ``npm test -- --typecheck --run`` | ``Test Files 10 passed (10), Tests 122 passed (122)`` (one new ``WithUndefined`` type test) |
| ``cargo check -p rdlp-desktop`` | ``Finished`` |

## Carry-over (out of scope)

Reviewer noted 10 pre-existing ``?? undefined`` / ``|| undefined`` coercions in ``formatColumns.tsx`` / ``HistoryRow.tsx`` / ``DownloadConfig.tsx`` / ``JobCard.tsx`` / ``JobDetails.tsx`` that bridge TanStack Table accessor results to API call sites. They don't fail tsc (exactOptional only checks at object-property assignment sites, not function args), but they're a future cleanup candidate if you want to tighten those downstream signatures. Not in scope here — would require refactoring the downstream API surfaces.

## Test plan

- [ ] CI ``cargo check`` + ``cargo clippy`` + ``cargo test``
- [ ] CI desktop crate ``npx tsc --noEmit`` + ``npm test -- --run`` + ``npm test -- --typecheck --run``
- [ ] Manual sanity: open desktop app, verify Select / Dialog / GridList / Command palette / Toast / IconRail render and behave identically (this is type-only — zero behavior change expected, but worth the visual confirmation)

## Refs

- ``ca5f2db`` — Phase 2a (``_internal/types.ts`` introduced ``Branded`` / ``LiteralUnion`` / ``Handlers``)
- ``b054a52`` — Phase 2b (``verbatimModuleSyntax``)
- ``3473ee4`` — Phase 2c (this PR)
- adobe/react-spectrum#8717 — upstream RAC limitation this works around