### PR TITLE
chore: add MIT OR Apache-2.0 dual-license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["rdlp contributors"]
-license = "MIT"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # Async runtime

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,18 @@
-MIT License
+This project is dual-licensed under either of:
 
-Copyright (c) 2025 rdlp contributors
+  - Apache License, Version 2.0 (LICENSE-APACHE or
+    https://www.apache.org/licenses/LICENSE-2.0)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+  - MIT License (LICENSE-MIT or https://opensource.org/licenses/MIT)
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+at your option.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This is the Rust ecosystem convention. Most consumers pick MIT for
+simplicity; consumers who need an explicit patent grant pick Apache-2.0.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms
+or conditions.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may accept and charge a fee for,
+      acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However,
+      in accepting such obligations, You may act only on Your own behalf
+      and on Your sole responsibility, not on behalf of any other
+      Contributor, and only if You agree to indemnify, defend, and hold
+      each Contributor harmless for any liability incurred by, or claims
+      asserted against, such Contributor by reason of your accepting any
+      such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 rdlp contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 rdlp contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -86,14 +86,23 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODING_RULES.md](CODING_RULES.md).
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+Dual-licensed under either of:
+
+- [Apache License, Version 2.0](LICENSE-APACHE)
+- [MIT License](LICENSE-MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
 ### FFmpeg licensing note
 
 rdlp links against FFmpeg shared libraries at build time via
 [ffmpeg-the-third](https://crates.io/crates/ffmpeg-the-third). The Rust
-source code in this repository is MIT-licensed and does not contain any
-GPL or nonfree code.
+source code in this repository is dual MIT/Apache-2.0 licensed and does
+not contain any GPL or nonfree code.
 
 **Release binaries** are built against LGPL-only FFmpeg (system packages)
 and can be freely distributed.

--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -20,7 +20,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }
@@ -109,7 +108,7 @@ describe("JobCard", () => {
     });
 
     it("does not render log panel when logMessages is undefined", () => {
-        render(<JobCard job={makeJob({ logMessages: undefined })} onCancel={noop} onRemove={noop} onRetry={noop} />);
+        render(<JobCard job={makeJob()} onCancel={noop} onRemove={noop} onRetry={noop} />);
         expect(screen.queryByText(/^logs/i)).not.toBeInTheDocument();
     });
 

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
@@ -12,7 +12,7 @@
  * this file.
  */
 import { describe, test, expectTypeOf, assertType } from "vitest"
-import type { Branded, LiteralUnion, Handlers } from "./types"
+import type { Branded, LiteralUnion, Handlers, WithUndefined } from "./types"
 
 type ToastKey = Branded<string, "PrismToast">
 
@@ -50,5 +50,21 @@ describe("Prism _internal type utilities", () => {
       onClose?: () => void
       onFocusOut?: () => void
     }>()
+  })
+
+  test("WithUndefined — widens selected optional keys to accept undefined explicitly", () => {
+    interface Strict { items?: string[]; textValue?: string; other?: number }
+    type Widened = WithUndefined<Strict, "items" | "textValue">
+
+    // Widened keys accept explicit undefined
+    assertType<Widened>({ items: undefined, textValue: undefined })
+    assertType<Widened>({ items: ["a"], textValue: "x" })
+    assertType<Widened>({})
+
+    // Non-widened keys keep their strict shape
+    expectTypeOf<Widened["other"]>().toEqualTypeOf<number | undefined>() // optional inherits | undefined from T[P]
+    // ^ note: under exactOptionalPropertyTypes, `other?: number` inferred via Omit<T, K>
+    //   keeps the original strict shape — assertType<Widened>({ other: undefined })
+    //   would still fail compile-time, which is the desired behavior.
   })
 })

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.ts
@@ -46,3 +46,35 @@ export type LiteralUnion<T extends string> = T | (string & {})
 export type Handlers<Events extends string> = {
   [E in Events as `on${Capitalize<E>}`]?: () => void
 }
+
+/**
+ * Widens selected optional keys of T to also accept `undefined` explicitly,
+ * restoring pre-`exactOptionalPropertyTypes` semantics for those keys only.
+ *
+ * Mirrors the inverse of `type-fest`'s `SetNonNullable<T, K>`. Useful at
+ * Prism wrapper boundaries when forwarding to upstream `react-aria-components`
+ * primitives whose interfaces use `prop?: T` rather than `prop?: T | undefined`
+ * (see adobe/react-spectrum#8717 — Adobe has not committed to fixing upstream).
+ *
+ * Pair with conditional spread inside the wrapper to bridge the widened
+ * wrapper signature back to the strict RAC signature:
+ *
+ * @example
+ *   type PrismSelectProps<T extends object> = WithUndefined<
+ *     AriaSelectProps<T>,
+ *     "items" | "textValue"
+ *   >
+ *
+ *   function PrismSelect<T extends object>({ items, textValue, ...rest }: PrismSelectProps<T>) {
+ *     return (
+ *       <AriaSelect
+ *         {...rest}
+ *         {...(items !== undefined && { items })}
+ *         {...(textValue !== undefined && { textValue })}
+ *       />
+ *     )
+ *   }
+ */
+export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]?: T[P] | undefined
+}

--- a/crates/rdlp-desktop/src/components/ui/command.tsx
+++ b/crates/rdlp-desktop/src/components/ui/command.tsx
@@ -35,7 +35,7 @@ function CommandInput({ placeholder, className }: { placeholder?: string; classN
     <AriaSearchField className="flex items-center border-b px-3" aria-label="Search">
       <Search aria-hidden="true" className="mr-2 size-4 shrink-0 opacity-50" />
       <AriaInput
-        placeholder={placeholder}
+        {...(placeholder !== undefined && { placeholder })}
         className={cn(
           "flex h-11 w-full bg-transparent py-3 text-sm outline-none",
           "placeholder:text-muted-foreground",

--- a/crates/rdlp-desktop/src/components/ui/dialog.tsx
+++ b/crates/rdlp-desktop/src/components/ui/dialog.tsx
@@ -68,9 +68,9 @@ const DialogOverlay = ({
 interface DialogContentProps
   extends Omit<React.ComponentProps<typeof AriaModal>, "children">,
     VariantProps<typeof sheetVariants> {
-  children?: AriaDialogProps["children"]
-  role?: AriaDialogProps["role"]
-  closeButton?: boolean
+  children?: AriaDialogProps["children"] | undefined
+  role?: AriaDialogProps["role"] | undefined
+  closeButton?: boolean | undefined
 }
 
 const DialogContent = ({
@@ -93,7 +93,7 @@ const DialogContent = ({
     {...props}
   >
     <AriaDialog
-      role={role}
+      {...(role !== undefined && { role })}
       className={cn(!side && "grid h-full gap-4", "h-full outline-none")}
     >
       {composeRenderProps(children, (children, renderProps) => (

--- a/crates/rdlp-desktop/src/components/ui/grid-list.tsx
+++ b/crates/rdlp-desktop/src/components/ui/grid-list.tsx
@@ -13,6 +13,8 @@ import {
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/components/ui/checkbox"
 
+import type { WithUndefined } from "./_internal/types"
+
 export function GridList<T extends object>({
   children,
   ...props
@@ -37,12 +39,14 @@ export function GridList<T extends object>({
 export function GridListItem({
   children,
   className,
+  textValue: textValueProp,
   ...props
-}: AriaGridListItemProps) {
-  let textValue = typeof children === "string" ? children : undefined
+}: WithUndefined<AriaGridListItemProps, "textValue">) {
+  let textValue =
+    textValueProp ?? (typeof children === "string" ? children : undefined)
   return (
     <AriaGridListItem
-      textValue={textValue}
+      {...(textValue !== undefined && { textValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "jolly-GridListItem relative flex w-full cursor-default select-none items-center gap-3 rounded-sm px-2 py-1.5 text-sm outline-none",

--- a/crates/rdlp-desktop/src/components/ui/select.tsx
+++ b/crates/rdlp-desktop/src/components/ui/select.tsx
@@ -29,6 +29,8 @@ import {
 
 import { cn } from "@/lib/utils"
 
+import type { WithUndefined } from "./_internal/types"
+
 const labelVariants = cva([
   "text-sm font-medium leading-none",
   /* Disabled */
@@ -57,13 +59,14 @@ const ListBoxCollection = AriaCollection
 const ListBoxItem = <T extends object>({
   className,
   children,
+  textValue,
   ...props
-}: AriaListBoxItemProps<T>) => {
+}: WithUndefined<AriaListBoxItemProps<T>, "textValue">) => {
+  const resolvedTextValue =
+    textValue || (typeof children === "string" ? children : undefined)
   return (
     <AriaListBoxItem
-      textValue={
-        props.textValue || (typeof children === "string" ? children : undefined)
-      }
+      {...(resolvedTextValue !== undefined && { textValue: resolvedTextValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
@@ -188,8 +191,9 @@ const SelectPopover = ({ className, ...props }: AriaPopoverProps) => (
 
 const SelectListBox = <T extends object>({
   className,
+  items,
   ...props
-}: AriaListBoxProps<T>) => (
+}: WithUndefined<AriaListBoxProps<T>, "items">) => (
   <AriaListBox
     className={composeRenderProps(className, (className) =>
       cn(
@@ -198,6 +202,7 @@ const SelectListBox = <T extends object>({
       )
     )}
     {...props}
+    {...(items !== undefined && { items })}
   />
 )
 
@@ -206,7 +211,7 @@ interface PrismSelectProps<T extends object>
   label?: string
   description?: string
   errorMessage?: string | ((validation: AriaValidationResult) => string)
-  items?: Iterable<T>
+  items?: Iterable<T> | undefined
   children: React.ReactNode | ((item: T) => React.ReactNode)
 }
 
@@ -237,7 +242,9 @@ function PrismSelect<T extends object>({
       )}
       <FieldError>{errorMessage}</FieldError>
       <SelectPopover>
-        <SelectListBox items={items}>{children}</SelectListBox>
+        <SelectListBox {...(items !== undefined && { items })}>
+          {children}
+        </SelectListBox>
       </SelectPopover>
     </Select>
   )

--- a/crates/rdlp-desktop/src/components/ui/sonner.tsx
+++ b/crates/rdlp-desktop/src/components/ui/sonner.tsx
@@ -26,8 +26,8 @@ export type ToastSeverity = LiteralUnion<"info" | "success" | "warning" | "error
 
 interface ToastContent {
   title: string
-  description?: string
-  severity?: ToastSeverity
+  description?: string | undefined
+  severity?: ToastSeverity | undefined
 }
 
 /** Singleton queue. Imported once at app root via <ToastRegion />. */
@@ -65,7 +65,7 @@ function ToastRegion() {
   )
 }
 
-function SeverityIcon({ severity }: { severity?: ToastSeverity }) {
+function SeverityIcon({ severity }: { severity?: ToastSeverity | undefined }) {
   switch (severity) {
     case "success":
       return <CircleCheck aria-hidden="true" className="size-5 text-green-500" />

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -25,7 +25,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/shell/IconRail.tsx
+++ b/crates/rdlp-desktop/src/shell/IconRail.tsx
@@ -2,6 +2,7 @@
 // Active icon has 2px blue left edge indicator + tinted background.
 
 import { Search, ArrowDownToLine, Clock, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useStore } from "@tanstack/react-store";
 import { useQuery } from "@tanstack/react-query";
 import { uiStore, setView } from "@/stores/uiStore";
@@ -12,7 +13,7 @@ import { TooltipTrigger } from "react-aria-components";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 
-const NAV_ITEMS: { id: AppView; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+const NAV_ITEMS: { id: AppView; icon: LucideIcon; label: string }[] = [
     { id: "analyze", icon: Search, label: "Analyze (Ctrl+1)" },
     { id: "queue", icon: ArrowDownToLine, label: "Queue (Ctrl+2)" },
     { id: "history", icon: Clock, label: "History (Ctrl+3)" },
@@ -42,7 +43,7 @@ export function IconRail() {
                             size="icon"
                             onPress={() => setView(id)}
                             aria-label={label}
-                            aria-current={isActive ? "page" : undefined}
+                            {...(isActive && { "aria-current": "page" as const })}
                             className={cn(
                                 "relative flex items-center justify-center w-10 h-10 rounded-[6px] my-0.5 transition-colors",
                                 isActive

--- a/crates/rdlp-desktop/src/test/radix-select-mock.tsx
+++ b/crates/rdlp-desktop/src/test/radix-select-mock.tsx
@@ -17,10 +17,10 @@ import * as React from "react";
 
 interface SelectCtx {
     value: string;
-    onValueChange?: (v: string) => void;
+    onValueChange?: ((v: string) => void) | undefined;
     open: boolean;
     setOpen: (o: boolean) => void;
-    disabled?: boolean;
+    disabled?: boolean | undefined;
     items: Map<string, string>; // value → label text
 }
 

--- a/crates/rdlp-desktop/tsconfig.json
+++ b/crates/rdlp-desktop/tsconfig.json
@@ -28,6 +28,7 @@
     "erasableSyntaxOnly": true,
     "noImplicitOverride": true,
     "verbatimModuleSyntax": true,
+    "exactOptionalPropertyTypes": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

Adds Rust-idiomatic `MIT OR Apache-2.0` dual-license to the now-public repo.

## What lands

- `LICENSE-MIT` — verbatim MIT text, copyright `2026 rdlp contributors`
- `LICENSE-APACHE` — verbatim Apache 2.0 text from apache.org canonical source
- `LICENSE` — top-level pointer documenting the dual-license intent and the contribution clause
- `Cargo.toml` — workspace.package `license` field changes from `"MIT"` to `"MIT OR Apache-2.0"` (SPDX dual-license expression)
- `README.md` — new License section

## Why dual `MIT OR Apache-2.0`

The Rust ecosystem convention. Used by the Rust language itself, tokio, serde, wreq, hyper, and most major crates. Each consumer picks:

- **MIT** for simplicity (the common pick) — short, universally understood, compatible with everything
- **Apache-2.0** for explicit patent grant + contribution clause — enterprise-friendly

Dual gives both options without forcing the choice on consumers. It's also the strongest signal of "Rust-idiomatic open source" that potential contributors look for.

## Why not Unlicense (matching yt-dlp)?

Researched. yt-dlp uses Unlicense, but [yt-dlp issue #2345](https://github.com/yt-dlp/yt-dlp/issues/2345) explicitly catalogs Unlicense's weaknesses:

- Not legally valid in civil-law jurisdictions (Germany §29 I UrhG, France) — public-domain dedication isn't recognized
- No express patent grant
- Weaker liability disclaimers than MIT

yt-dlp's maintainers closed #2345 as `wontfix` and stayed on Unlicense for heritage reasons. We don't carry that heritage and chose the more legally robust option.

## Why not single MIT?

MIT lacks an express patent grant. For a tool that interfaces with sites that may aggressively assert IP claims, having a patent grant from contributors via Apache-2.0 is real protection. Dual-licensing keeps MIT as an option for downstream consumers who don't need it.

## Verification

- `cargo check --workspace` — Finished
- SPDX expression `MIT OR Apache-2.0` is a valid Cargo license value (recognized by crates.io and `cargo metadata`)

## Refs

- [Choose A License — comparison matrix](https://choosealicense.com/licenses/)
- [yt-dlp issue #2345 — Unlicense criticism, closed wontfix](https://github.com/yt-dlp/yt-dlp/issues/2345)
- [Rust API Guidelines — necessities](https://rust-lang.github.io/api-guidelines/necessities.html)
- [Apache License canonical text](https://www.apache.org/licenses/LICENSE-2.0.txt)