### PR TITLE
chore: refresh CONTRIBUTING.md (dual-license, current crates, rdlp-probe workflow)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,13 @@ cargo fmt
 | `rdlp-cookies` | Browser cookie extraction |
 | `rdlp-plugin` | Plugin system architecture |
 | `rdlp-cli` | CLI application and download orchestrator |
+| `rdlp-api` | Frontend-agnostic API layer (`RdlpClient`, event model, download handles) for CLI/Tauri/Leptos consumers |
+| `rdlp-ffmpeg` | FFmpeg library bindings (probe, remux, merge, transcode, metadata, thumbnail) via `ffmpeg-the-third` |
+| `rdlp-ratelimit` | Async token-bucket rate limiter (per-extractor throttling) |
+| `rdlp-table` | Responsive CLI table renderer with column-budget algorithm |
+| `rdlp-crypto` | PRNG-based URL decryption (XHamster — retained for cross-validation tests) |
+| `rdlp-desktop` (`src-tauri`) | Tauri v2 desktop GUI (React/TypeScript frontend + Rust IPC backend) |
+| `rdlp-probe` | Optional CLI authoring toolkit for extractor contributors (excluded from `default-members`) |
 
 ### Three-Stage Pipeline
 
@@ -94,12 +101,7 @@ Tier 2: TnaFlixNetworkBase     (shared logic for site families)
 Tier 3: Site Extractors        (individual site implementations)
 ```
 
-**Currently supported extractors:**
-- TNAFlix (via `TNAFlixExtractor`)
-- EMPFlix (via `TNAFlixExtractor`)
-- MovieFap (via `TNAFlixExtractor`)
-- RedTube (`RedTubeExtractor`)
-- PornHub (`PornHubExtractor`) - includes playlist support
+**Currently supported extractors:** 13 site extractors + a Generic fallback. See [`crates/rdlp-extractor/src/extractors/`](crates/rdlp-extractor/src/extractors/) for the canonical list. Sites include TNAFlix family (TNAFlix/EMPFlix/MovieFap), RedTube, PornHub, SpankBang, XHamster, HQPorner, NineAnime, KoreanPornMovie, XVideos, XNXX, EPorner, XTits.
 
 ## Development Workflow
 
@@ -154,6 +156,29 @@ git commit -m "docs: improve installation instructions"
 **Scope examples:** `extractor`, `downloader`, `cli`, `core`, `postprocess`
 
 ## Adding a New Extractor
+
+### Authoring Workflow with `rdlp-probe`
+
+Since the SpankBang extractor sprint, contributors author new extractors using the **`rdlp-probe`** CLI toolkit. It exposes the same HTTP / JS / cookie stack the production extractors use, so probes hit the same code paths as live extraction.
+
+```bash
+# Build the probe (excluded from default cargo build)
+cargo build -p rdlp-probe --release
+
+# Fetch a page through the production stack
+./target/release/rdlp-probe fetch "https://example.com/video/123"
+
+# Run JS through the in-tree boa engine
+./target/release/rdlp-probe eval --inline "Math.sqrt(144)"
+
+# Extract via regex / CSS / JSON path
+./target/release/rdlp-probe extract --mode css "video source[src]" --file page.html
+
+# Record a cassette for offline replay in tests
+./target/release/rdlp-probe record "https://example.com/video/123" -o tests/cassette.json
+```
+
+The `record` subcommand produces JSON cassettes that act as regression test fixtures. See `crates/rdlp-probe/README.md` for the full 6-step workflow.
 
 ### Legal Requirements
 
@@ -431,6 +456,10 @@ The `InfoDict` struct holds all extracted metadata. Required fields are set via 
 
 ## Code Style Guide
 
+> **For comprehensive coding standards**, see [`CODING_RULES.md`](CODING_RULES.md) (committed root) — covers naming, error handling, testing, module guidelines, and the pre-commit checklist.
+>
+> **For AI-assisted contributors** using Claude Code or similar tools, see [`CLAUDE.md`](CLAUDE.md) for project-specific guidance and architectural context the assistant will load automatically.
+
 ### General Principles
 
 - **Readability First**: Code is read more than written
@@ -495,6 +524,27 @@ let title = extract_title(&html);
 let formats = fetch_formats(ctx).await?; // compile error!
 ```
 
+## Branch Naming Convention
+
+All task branches MUST conform to the gitflow naming convention:
+
+| Branch type | Base branch | Example |
+|---|---|---|
+| `feature/*` | `develop` | `feature/youtube-extractor` |
+| `bugfix/*` | `develop` | `bugfix/hls-resume-stalls` |
+| `chore/*` | `develop` | `chore/upgrade-tokio` |
+| `spike/*` | `develop` | `spike/wasm-plugin-poc` |
+| `release/*` | `develop` | `release/v1.0.0` |
+| `hotfix/*` | `master` | `hotfix/cve-2026-1234` |
+
+Constraints:
+- Lowercase kebab-case after the prefix (`[a-z0-9]+(-[a-z0-9]+)*`)
+- Total length <= 72 characters
+- Descriptor must be specific (`feature/youtube-extractor`, NOT `feature/update`)
+- No uppercase, underscores, dots, or consecutive hyphens
+
+Direct commits to `master` or `develop` are not permitted; every change goes through a task branch.
+
 ## Pull Request Checklist
 
 Before submitting your PR, ensure:
@@ -508,4 +558,13 @@ Before submitting your PR, ensure:
 
 ## License
 
-By contributing to rdlp, you agree that your contributions will be licensed under the MIT License.
+This project is dual-licensed under either of:
+
+- [Apache License, Version 2.0](LICENSE-APACHE)
+- [MIT License](LICENSE-MIT)
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+This is the Rust ecosystem convention used by the Rust language itself, tokio, serde, wreq, hyper, and most major crates.

--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -20,7 +20,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }
@@ -109,7 +108,7 @@ describe("JobCard", () => {
     });
 
     it("does not render log panel when logMessages is undefined", () => {
-        render(<JobCard job={makeJob({ logMessages: undefined })} onCancel={noop} onRemove={noop} onRetry={noop} />);
+        render(<JobCard job={makeJob()} onCancel={noop} onRemove={noop} onRetry={noop} />);
         expect(screen.queryByText(/^logs/i)).not.toBeInTheDocument();
     });
 

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
@@ -12,7 +12,7 @@
  * this file.
  */
 import { describe, test, expectTypeOf, assertType } from "vitest"
-import type { Branded, LiteralUnion, Handlers } from "./types"
+import type { Branded, LiteralUnion, Handlers, WithUndefined } from "./types"
 
 type ToastKey = Branded<string, "PrismToast">
 
@@ -50,5 +50,21 @@ describe("Prism _internal type utilities", () => {
       onClose?: () => void
       onFocusOut?: () => void
     }>()
+  })
+
+  test("WithUndefined — widens selected optional keys to accept undefined explicitly", () => {
+    interface Strict { items?: string[]; textValue?: string; other?: number }
+    type Widened = WithUndefined<Strict, "items" | "textValue">
+
+    // Widened keys accept explicit undefined
+    assertType<Widened>({ items: undefined, textValue: undefined })
+    assertType<Widened>({ items: ["a"], textValue: "x" })
+    assertType<Widened>({})
+
+    // Non-widened keys keep their strict shape
+    expectTypeOf<Widened["other"]>().toEqualTypeOf<number | undefined>() // optional inherits | undefined from T[P]
+    // ^ note: under exactOptionalPropertyTypes, `other?: number` inferred via Omit<T, K>
+    //   keeps the original strict shape — assertType<Widened>({ other: undefined })
+    //   would still fail compile-time, which is the desired behavior.
   })
 })

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.ts
@@ -46,3 +46,35 @@ export type LiteralUnion<T extends string> = T | (string & {})
 export type Handlers<Events extends string> = {
   [E in Events as `on${Capitalize<E>}`]?: () => void
 }
+
+/**
+ * Widens selected optional keys of T to also accept `undefined` explicitly,
+ * restoring pre-`exactOptionalPropertyTypes` semantics for those keys only.
+ *
+ * Mirrors the inverse of `type-fest`'s `SetNonNullable<T, K>`. Useful at
+ * Prism wrapper boundaries when forwarding to upstream `react-aria-components`
+ * primitives whose interfaces use `prop?: T` rather than `prop?: T | undefined`
+ * (see adobe/react-spectrum#8717 — Adobe has not committed to fixing upstream).
+ *
+ * Pair with conditional spread inside the wrapper to bridge the widened
+ * wrapper signature back to the strict RAC signature:
+ *
+ * @example
+ *   type PrismSelectProps<T extends object> = WithUndefined<
+ *     AriaSelectProps<T>,
+ *     "items" | "textValue"
+ *   >
+ *
+ *   function PrismSelect<T extends object>({ items, textValue, ...rest }: PrismSelectProps<T>) {
+ *     return (
+ *       <AriaSelect
+ *         {...rest}
+ *         {...(items !== undefined && { items })}
+ *         {...(textValue !== undefined && { textValue })}
+ *       />
+ *     )
+ *   }
+ */
+export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]?: T[P] | undefined
+}

--- a/crates/rdlp-desktop/src/components/ui/command.tsx
+++ b/crates/rdlp-desktop/src/components/ui/command.tsx
@@ -35,7 +35,7 @@ function CommandInput({ placeholder, className }: { placeholder?: string; classN
     <AriaSearchField className="flex items-center border-b px-3" aria-label="Search">
       <Search aria-hidden="true" className="mr-2 size-4 shrink-0 opacity-50" />
       <AriaInput
-        placeholder={placeholder}
+        {...(placeholder !== undefined && { placeholder })}
         className={cn(
           "flex h-11 w-full bg-transparent py-3 text-sm outline-none",
           "placeholder:text-muted-foreground",

--- a/crates/rdlp-desktop/src/components/ui/dialog.tsx
+++ b/crates/rdlp-desktop/src/components/ui/dialog.tsx
@@ -68,9 +68,9 @@ const DialogOverlay = ({
 interface DialogContentProps
   extends Omit<React.ComponentProps<typeof AriaModal>, "children">,
     VariantProps<typeof sheetVariants> {
-  children?: AriaDialogProps["children"]
-  role?: AriaDialogProps["role"]
-  closeButton?: boolean
+  children?: AriaDialogProps["children"] | undefined
+  role?: AriaDialogProps["role"] | undefined
+  closeButton?: boolean | undefined
 }
 
 const DialogContent = ({
@@ -93,7 +93,7 @@ const DialogContent = ({
     {...props}
   >
     <AriaDialog
-      role={role}
+      {...(role !== undefined && { role })}
       className={cn(!side && "grid h-full gap-4", "h-full outline-none")}
     >
       {composeRenderProps(children, (children, renderProps) => (

--- a/crates/rdlp-desktop/src/components/ui/grid-list.tsx
+++ b/crates/rdlp-desktop/src/components/ui/grid-list.tsx
@@ -13,6 +13,8 @@ import {
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/components/ui/checkbox"
 
+import type { WithUndefined } from "./_internal/types"
+
 export function GridList<T extends object>({
   children,
   ...props
@@ -37,12 +39,14 @@ export function GridList<T extends object>({
 export function GridListItem({
   children,
   className,
+  textValue: textValueProp,
   ...props
-}: AriaGridListItemProps) {
-  let textValue = typeof children === "string" ? children : undefined
+}: WithUndefined<AriaGridListItemProps, "textValue">) {
+  let textValue =
+    textValueProp ?? (typeof children === "string" ? children : undefined)
   return (
     <AriaGridListItem
-      textValue={textValue}
+      {...(textValue !== undefined && { textValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "jolly-GridListItem relative flex w-full cursor-default select-none items-center gap-3 rounded-sm px-2 py-1.5 text-sm outline-none",

--- a/crates/rdlp-desktop/src/components/ui/select.tsx
+++ b/crates/rdlp-desktop/src/components/ui/select.tsx
@@ -29,6 +29,8 @@ import {
 
 import { cn } from "@/lib/utils"
 
+import type { WithUndefined } from "./_internal/types"
+
 const labelVariants = cva([
   "text-sm font-medium leading-none",
   /* Disabled */
@@ -57,13 +59,14 @@ const ListBoxCollection = AriaCollection
 const ListBoxItem = <T extends object>({
   className,
   children,
+  textValue,
   ...props
-}: AriaListBoxItemProps<T>) => {
+}: WithUndefined<AriaListBoxItemProps<T>, "textValue">) => {
+  const resolvedTextValue =
+    textValue || (typeof children === "string" ? children : undefined)
   return (
     <AriaListBoxItem
-      textValue={
-        props.textValue || (typeof children === "string" ? children : undefined)
-      }
+      {...(resolvedTextValue !== undefined && { textValue: resolvedTextValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
@@ -188,8 +191,9 @@ const SelectPopover = ({ className, ...props }: AriaPopoverProps) => (
 
 const SelectListBox = <T extends object>({
   className,
+  items,
   ...props
-}: AriaListBoxProps<T>) => (
+}: WithUndefined<AriaListBoxProps<T>, "items">) => (
   <AriaListBox
     className={composeRenderProps(className, (className) =>
       cn(
@@ -198,6 +202,7 @@ const SelectListBox = <T extends object>({
       )
     )}
     {...props}
+    {...(items !== undefined && { items })}
   />
 )
 
@@ -206,7 +211,7 @@ interface PrismSelectProps<T extends object>
   label?: string
   description?: string
   errorMessage?: string | ((validation: AriaValidationResult) => string)
-  items?: Iterable<T>
+  items?: Iterable<T> | undefined
   children: React.ReactNode | ((item: T) => React.ReactNode)
 }
 
@@ -237,7 +242,9 @@ function PrismSelect<T extends object>({
       )}
       <FieldError>{errorMessage}</FieldError>
       <SelectPopover>
-        <SelectListBox items={items}>{children}</SelectListBox>
+        <SelectListBox {...(items !== undefined && { items })}>
+          {children}
+        </SelectListBox>
       </SelectPopover>
     </Select>
   )

--- a/crates/rdlp-desktop/src/components/ui/sonner.tsx
+++ b/crates/rdlp-desktop/src/components/ui/sonner.tsx
@@ -26,8 +26,8 @@ export type ToastSeverity = LiteralUnion<"info" | "success" | "warning" | "error
 
 interface ToastContent {
   title: string
-  description?: string
-  severity?: ToastSeverity
+  description?: string | undefined
+  severity?: ToastSeverity | undefined
 }
 
 /** Singleton queue. Imported once at app root via <ToastRegion />. */
@@ -65,7 +65,7 @@ function ToastRegion() {
   )
 }
 
-function SeverityIcon({ severity }: { severity?: ToastSeverity }) {
+function SeverityIcon({ severity }: { severity?: ToastSeverity | undefined }) {
   switch (severity) {
     case "success":
       return <CircleCheck aria-hidden="true" className="size-5 text-green-500" />

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -25,7 +25,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/shell/IconRail.tsx
+++ b/crates/rdlp-desktop/src/shell/IconRail.tsx
@@ -2,6 +2,7 @@
 // Active icon has 2px blue left edge indicator + tinted background.
 
 import { Search, ArrowDownToLine, Clock, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useStore } from "@tanstack/react-store";
 import { useQuery } from "@tanstack/react-query";
 import { uiStore, setView } from "@/stores/uiStore";
@@ -12,7 +13,7 @@ import { TooltipTrigger } from "react-aria-components";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 
-const NAV_ITEMS: { id: AppView; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+const NAV_ITEMS: { id: AppView; icon: LucideIcon; label: string }[] = [
     { id: "analyze", icon: Search, label: "Analyze (Ctrl+1)" },
     { id: "queue", icon: ArrowDownToLine, label: "Queue (Ctrl+2)" },
     { id: "history", icon: Clock, label: "History (Ctrl+3)" },
@@ -42,7 +43,7 @@ export function IconRail() {
                             size="icon"
                             onPress={() => setView(id)}
                             aria-label={label}
-                            aria-current={isActive ? "page" : undefined}
+                            {...(isActive && { "aria-current": "page" as const })}
                             className={cn(
                                 "relative flex items-center justify-center w-10 h-10 rounded-[6px] my-0.5 transition-colors",
                                 isActive

--- a/crates/rdlp-desktop/src/test/radix-select-mock.tsx
+++ b/crates/rdlp-desktop/src/test/radix-select-mock.tsx
@@ -17,10 +17,10 @@ import * as React from "react";
 
 interface SelectCtx {
     value: string;
-    onValueChange?: (v: string) => void;
+    onValueChange?: ((v: string) => void) | undefined;
     open: boolean;
     setOpen: (o: boolean) => void;
-    disabled?: boolean;
+    disabled?: boolean | undefined;
     items: Map<string, string>; // value → label text
 }
 

--- a/crates/rdlp-desktop/tsconfig.json
+++ b/crates/rdlp-desktop/tsconfig.json
@@ -28,6 +28,7 @@
     "erasableSyntaxOnly": true,
     "noImplicitOverride": true,
     "verbatimModuleSyntax": true,
+    "exactOptionalPropertyTypes": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

Targeted refresh of `CONTRIBUTING.md` to match current repo state after today's work landed (TLS Phase 2 / SpankBang / Prism / dual-license).

## Changes

- **License clause** — fixed contradiction with PR #192. Was "contributions licensed under MIT"; now matches the dual MIT OR Apache-2.0 + explicit Apache-2.0 contribution clause.
- **Workspace crates table** — added 7 missing crates (`rdlp-api`, `rdlp-ffmpeg`, `rdlp-ratelimit`, `rdlp-table`, `rdlp-crypto`, `rdlp-desktop`, `rdlp-probe`).
- **Supported extractors** — list went from 5 sites to 13 + Generic fallback; replaced with a source-of-truth pointer to avoid stale-list churn.
- **New section: Authoring with rdlp-probe** — the canonical contributor on-ramp since the SpankBang sprint; documents `fetch`, `eval`, `extract`, `record` subcommands.
- **New section: Branch Naming Convention** — codifies the gitflow rules.
- **Cross-references** — added pointers to CODING_RULES.md and CLAUDE.md.
- **Reqwest -> wreq** — TLS Phase 2 migration sweep (no occurrences found in CONTRIBUTING.md; no-op).

## Verification

- `grep -n -i "MIT License\|reqwest" CONTRIBUTING.md` shows only the new dual-license language; no stale references.
- No content removed beyond stale facts.