### PR TITLE
chore: add community files (CONTRIBUTORS, .mailmap, CODEOWNERS, issue + PR templates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners — auto-requested as reviewers on every PR.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default owner for everything not matched below.
+*       @crippledgeek
+
+# (Add path-specific owners here as the maintainer team grows.)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something isn't working as documented.
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more detail you provide, the faster we can fix it.
+
+        **Before opening:** search [existing issues](https://github.com/crippledgeek/rdlp/issues?q=is%3Aissue) — your bug may already be tracked.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect? What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Exact commands or actions. Include the URL pattern (you can anonymise the path) if a site extractor is involved.
+      placeholder: |
+        1. `rdlp --browser=chrome-latest "https://example.com/video/<id>"`
+        2. Observe error / wrong output
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Verbose log output
+      description: Run with `-v` (or set `RUST_LOG=debug`) and paste the relevant output.
+      render: text
+  - type: input
+    id: version
+    attributes:
+      label: rdlp version
+      description: Output of `rdlp --version`, or the commit SHA if built from source.
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust toolchain (if built from source)
+      description: Output of `rustc --version`. Skip if you're using a pre-built binary.
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and this bug isn't already reported
+          required: true
+        - label: I'm using the latest release (or HEAD of `develop`)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/crippledgeek/rdlp/discussions
+    about: For usage questions, design discussion, or anything not a bug or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new capability that isn't a new site extractor.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For new **site extractors**, please use the dedicated "New site extractor" template instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the user-facing situation, not a proposed solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would the feature look like?
+      description: Sketch the CLI flag, API surface, or UI change. Include example invocations.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds exist today? What did you try first?
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and impact
+      description: Which crates would this touch? Are there breaking changes? Any new dependencies?

--- a/.github/ISSUE_TEMPLATE/new_extractor.yml
+++ b/.github/ISSUE_TEMPLATE/new_extractor.yml
@@ -1,0 +1,54 @@
+name: New site extractor
+description: Request support for a new video site.
+labels: ["extractor", "site-request", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Adding a new extractor is one of the most welcome contributions. Before requesting, please check:
+
+        - The site's Terms of Service permit programmatic access to the content you want.
+        - There's no jurisdiction-specific reason rdlp shouldn't support it.
+
+        If you're willing to **write the extractor yourself**, see [`CONTRIBUTING.md` → Authoring with `rdlp-probe`](../../CONTRIBUTING.md#authoring-workflow-with-rdlp-probe) for the canonical contributor workflow.
+  - type: input
+    id: site
+    attributes:
+      label: Site name
+      description: Name of the site as commonly known (e.g. "ExampleTube").
+    validations:
+      required: true
+  - type: input
+    id: example-url
+    attributes:
+      label: Example video URL
+      description: A URL pattern showing what content rdlp should be able to extract. Anonymise the path if needed.
+      placeholder: https://www.example.com/video/<id>/
+    validations:
+      required: true
+  - type: textarea
+    id: features
+    attributes:
+      label: What metadata / formats does the site expose?
+      description: Resolution range (240p–1080p?), DRM (Widevine?), HLS or DASH or progressive MP4, paywall, login required, age gate.
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Estimated difficulty
+      options:
+        - Easy (static HTML, no auth, no JS challenge)
+        - Medium (some JS execution, cookie handling)
+        - Hard (Cloudflare-fronted, JS challenge, paywall)
+        - Unknown
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art
+      description: Does yt-dlp / streamlink / another tool support this site? Link to their extractor if so — useful reference.
+  - type: checkboxes
+    id: tos
+    attributes:
+      label: Legal acknowledgment
+      options:
+        - label: I have reviewed the site's Terms of Service and the requested extractor would not facilitate access to content the user isn't already authorised to view.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- 1–3 sentences: what changed and why. -->
+
+## Type of change
+
+<!-- Mark with [x] -->
+
+- [ ] Bug fix (`fix:` / `bugfix/*` branch)
+- [ ] New feature (`feat:` / `feature/*` branch)
+- [ ] New site extractor (`feat(extractor):` / `feature/*` branch)
+- [ ] Refactor (`refactor:` / `chore/*` branch)
+- [ ] Documentation (`docs:` / `chore/*` branch)
+- [ ] Chore / tooling (`chore:` / `chore/*` branch)
+- [ ] Performance (`perf:`)
+- [ ] Test (`test:`)
+
+## Test plan
+
+<!-- How did you verify the change? Include commands run + results. -->
+
+- [ ] `cargo build`
+- [ ] `cargo test --workspace`
+- [ ] `cargo clippy -- -W clippy::all`
+- [ ] `cargo fmt --check`
+- [ ] (If desktop crate touched) `cd crates/rdlp-desktop && npx tsc --noEmit && npm test -- --run`
+- [ ] Manual verification (describe the scenario)
+
+## Checklist
+
+- [ ] Branch name conforms to `gitflow-branch-policy` (`feature/*` / `bugfix/*` / `chore/*` / `spike/*` / `release/*` / `hotfix/*`, lowercase kebab-case after the prefix, ≤ 72 chars)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] If a new extractor: legal/ToS check done, test fixtures recorded via `rdlp-probe`, no live-network dependency in tests
+- [ ] If a new dependency: justified in the PR description, license compatible with `MIT OR Apache-2.0`
+- [ ] If a behavior change: docs / `CLAUDE.md` updated
+- [ ] (Implicit) By submitting this PR I agree my contribution is dual-licensed under `MIT OR Apache-2.0` per the repo's contribution clause

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Map alternate email addresses to the canonical author identity.
+# See https://git-scm.com/docs/gitmailmap
+#
+# Format: <canonical name> <canonical email> <alias name> <alias email>
+# (alias name is optional; if omitted, only the email matches)
+
+Mattias Carlsson <crippledgeek@users.noreply.github.com> <mattias.carlsson01@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,31 @@
+# Contributors
+
+People who have contributed to rdlp.
+Listed in order of first contribution.
+
+- @crippledgeek — Project author and primary maintainer
+
+---
+
+For the canonical, always-current list, see GitHub's contributor graph:
+https://github.com/crippledgeek/rdlp/graphs/contributors
+
+This file is updated periodically (and on release) from `git shortlog -sne --use-mailmap`.
+
+## How to be added
+
+You'll be added when your first PR is merged. If you'd like your name +
+handle (or pseudonym) listed differently than your git author metadata
+suggests, mention it in your PR description and a maintainer will adjust
+this file at merge time.
+
+If you'd prefer NOT to be listed by handle (e.g. you contribute under a
+pseudonym or want to remain unattributed), let us know in the PR — we'll
+respect that.
+
+## What counts as a contribution
+
+Code, documentation, bug reports with reproduction steps, test fixtures,
+extractor cassettes, accessibility audits, performance profiling, security
+disclosures, and design / UX feedback all count. Adding a single
+extractor counts; reviewing PRs counts; spotting a typo counts.

--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -20,7 +20,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }
@@ -109,7 +108,7 @@ describe("JobCard", () => {
     });
 
     it("does not render log panel when logMessages is undefined", () => {
-        render(<JobCard job={makeJob({ logMessages: undefined })} onCancel={noop} onRemove={noop} onRetry={noop} />);
+        render(<JobCard job={makeJob()} onCancel={noop} onRemove={noop} onRetry={noop} />);
         expect(screen.queryByText(/^logs/i)).not.toBeInTheDocument();
     });
 

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.test-d.ts
@@ -12,7 +12,7 @@
  * this file.
  */
 import { describe, test, expectTypeOf, assertType } from "vitest"
-import type { Branded, LiteralUnion, Handlers } from "./types"
+import type { Branded, LiteralUnion, Handlers, WithUndefined } from "./types"
 
 type ToastKey = Branded<string, "PrismToast">
 
@@ -50,5 +50,21 @@ describe("Prism _internal type utilities", () => {
       onClose?: () => void
       onFocusOut?: () => void
     }>()
+  })
+
+  test("WithUndefined — widens selected optional keys to accept undefined explicitly", () => {
+    interface Strict { items?: string[]; textValue?: string; other?: number }
+    type Widened = WithUndefined<Strict, "items" | "textValue">
+
+    // Widened keys accept explicit undefined
+    assertType<Widened>({ items: undefined, textValue: undefined })
+    assertType<Widened>({ items: ["a"], textValue: "x" })
+    assertType<Widened>({})
+
+    // Non-widened keys keep their strict shape
+    expectTypeOf<Widened["other"]>().toEqualTypeOf<number | undefined>() // optional inherits | undefined from T[P]
+    // ^ note: under exactOptionalPropertyTypes, `other?: number` inferred via Omit<T, K>
+    //   keeps the original strict shape — assertType<Widened>({ other: undefined })
+    //   would still fail compile-time, which is the desired behavior.
   })
 })

--- a/crates/rdlp-desktop/src/components/ui/_internal/types.ts
+++ b/crates/rdlp-desktop/src/components/ui/_internal/types.ts
@@ -46,3 +46,35 @@ export type LiteralUnion<T extends string> = T | (string & {})
 export type Handlers<Events extends string> = {
   [E in Events as `on${Capitalize<E>}`]?: () => void
 }
+
+/**
+ * Widens selected optional keys of T to also accept `undefined` explicitly,
+ * restoring pre-`exactOptionalPropertyTypes` semantics for those keys only.
+ *
+ * Mirrors the inverse of `type-fest`'s `SetNonNullable<T, K>`. Useful at
+ * Prism wrapper boundaries when forwarding to upstream `react-aria-components`
+ * primitives whose interfaces use `prop?: T` rather than `prop?: T | undefined`
+ * (see adobe/react-spectrum#8717 — Adobe has not committed to fixing upstream).
+ *
+ * Pair with conditional spread inside the wrapper to bridge the widened
+ * wrapper signature back to the strict RAC signature:
+ *
+ * @example
+ *   type PrismSelectProps<T extends object> = WithUndefined<
+ *     AriaSelectProps<T>,
+ *     "items" | "textValue"
+ *   >
+ *
+ *   function PrismSelect<T extends object>({ items, textValue, ...rest }: PrismSelectProps<T>) {
+ *     return (
+ *       <AriaSelect
+ *         {...rest}
+ *         {...(items !== undefined && { items })}
+ *         {...(textValue !== undefined && { textValue })}
+ *       />
+ *     )
+ *   }
+ */
+export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]?: T[P] | undefined
+}

--- a/crates/rdlp-desktop/src/components/ui/command.tsx
+++ b/crates/rdlp-desktop/src/components/ui/command.tsx
@@ -35,7 +35,7 @@ function CommandInput({ placeholder, className }: { placeholder?: string; classN
     <AriaSearchField className="flex items-center border-b px-3" aria-label="Search">
       <Search aria-hidden="true" className="mr-2 size-4 shrink-0 opacity-50" />
       <AriaInput
-        placeholder={placeholder}
+        {...(placeholder !== undefined && { placeholder })}
         className={cn(
           "flex h-11 w-full bg-transparent py-3 text-sm outline-none",
           "placeholder:text-muted-foreground",

--- a/crates/rdlp-desktop/src/components/ui/dialog.tsx
+++ b/crates/rdlp-desktop/src/components/ui/dialog.tsx
@@ -68,9 +68,9 @@ const DialogOverlay = ({
 interface DialogContentProps
   extends Omit<React.ComponentProps<typeof AriaModal>, "children">,
     VariantProps<typeof sheetVariants> {
-  children?: AriaDialogProps["children"]
-  role?: AriaDialogProps["role"]
-  closeButton?: boolean
+  children?: AriaDialogProps["children"] | undefined
+  role?: AriaDialogProps["role"] | undefined
+  closeButton?: boolean | undefined
 }
 
 const DialogContent = ({
@@ -93,7 +93,7 @@ const DialogContent = ({
     {...props}
   >
     <AriaDialog
-      role={role}
+      {...(role !== undefined && { role })}
       className={cn(!side && "grid h-full gap-4", "h-full outline-none")}
     >
       {composeRenderProps(children, (children, renderProps) => (

--- a/crates/rdlp-desktop/src/components/ui/grid-list.tsx
+++ b/crates/rdlp-desktop/src/components/ui/grid-list.tsx
@@ -13,6 +13,8 @@ import {
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/components/ui/checkbox"
 
+import type { WithUndefined } from "./_internal/types"
+
 export function GridList<T extends object>({
   children,
   ...props
@@ -37,12 +39,14 @@ export function GridList<T extends object>({
 export function GridListItem({
   children,
   className,
+  textValue: textValueProp,
   ...props
-}: AriaGridListItemProps) {
-  let textValue = typeof children === "string" ? children : undefined
+}: WithUndefined<AriaGridListItemProps, "textValue">) {
+  let textValue =
+    textValueProp ?? (typeof children === "string" ? children : undefined)
   return (
     <AriaGridListItem
-      textValue={textValue}
+      {...(textValue !== undefined && { textValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "jolly-GridListItem relative flex w-full cursor-default select-none items-center gap-3 rounded-sm px-2 py-1.5 text-sm outline-none",

--- a/crates/rdlp-desktop/src/components/ui/select.tsx
+++ b/crates/rdlp-desktop/src/components/ui/select.tsx
@@ -29,6 +29,8 @@ import {
 
 import { cn } from "@/lib/utils"
 
+import type { WithUndefined } from "./_internal/types"
+
 const labelVariants = cva([
   "text-sm font-medium leading-none",
   /* Disabled */
@@ -57,13 +59,14 @@ const ListBoxCollection = AriaCollection
 const ListBoxItem = <T extends object>({
   className,
   children,
+  textValue,
   ...props
-}: AriaListBoxItemProps<T>) => {
+}: WithUndefined<AriaListBoxItemProps<T>, "textValue">) => {
+  const resolvedTextValue =
+    textValue || (typeof children === "string" ? children : undefined)
   return (
     <AriaListBoxItem
-      textValue={
-        props.textValue || (typeof children === "string" ? children : undefined)
-      }
+      {...(resolvedTextValue !== undefined && { textValue: resolvedTextValue })}
       className={composeRenderProps(className, (className) =>
         cn(
           "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
@@ -188,8 +191,9 @@ const SelectPopover = ({ className, ...props }: AriaPopoverProps) => (
 
 const SelectListBox = <T extends object>({
   className,
+  items,
   ...props
-}: AriaListBoxProps<T>) => (
+}: WithUndefined<AriaListBoxProps<T>, "items">) => (
   <AriaListBox
     className={composeRenderProps(className, (className) =>
       cn(
@@ -198,6 +202,7 @@ const SelectListBox = <T extends object>({
       )
     )}
     {...props}
+    {...(items !== undefined && { items })}
   />
 )
 
@@ -206,7 +211,7 @@ interface PrismSelectProps<T extends object>
   label?: string
   description?: string
   errorMessage?: string | ((validation: AriaValidationResult) => string)
-  items?: Iterable<T>
+  items?: Iterable<T> | undefined
   children: React.ReactNode | ((item: T) => React.ReactNode)
 }
 
@@ -237,7 +242,9 @@ function PrismSelect<T extends object>({
       )}
       <FieldError>{errorMessage}</FieldError>
       <SelectPopover>
-        <SelectListBox items={items}>{children}</SelectListBox>
+        <SelectListBox {...(items !== undefined && { items })}>
+          {children}
+        </SelectListBox>
       </SelectPopover>
     </Select>
   )

--- a/crates/rdlp-desktop/src/components/ui/sonner.tsx
+++ b/crates/rdlp-desktop/src/components/ui/sonner.tsx
@@ -26,8 +26,8 @@ export type ToastSeverity = LiteralUnion<"info" | "success" | "warning" | "error
 
 interface ToastContent {
   title: string
-  description?: string
-  severity?: ToastSeverity
+  description?: string | undefined
+  severity?: ToastSeverity | undefined
 }
 
 /** Singleton queue. Imported once at app root via <ToastRegion />. */
@@ -65,7 +65,7 @@ function ToastRegion() {
   )
 }
 
-function SeverityIcon({ severity }: { severity?: ToastSeverity }) {
+function SeverityIcon({ severity }: { severity?: ToastSeverity | undefined }) {
   switch (severity) {
     case "success":
       return <CircleCheck aria-hidden="true" className="size-5 text-green-500" />

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -25,7 +25,6 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
-        logMessages: undefined,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/shell/IconRail.tsx
+++ b/crates/rdlp-desktop/src/shell/IconRail.tsx
@@ -2,6 +2,7 @@
 // Active icon has 2px blue left edge indicator + tinted background.
 
 import { Search, ArrowDownToLine, Clock, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useStore } from "@tanstack/react-store";
 import { useQuery } from "@tanstack/react-query";
 import { uiStore, setView } from "@/stores/uiStore";
@@ -12,7 +13,7 @@ import { TooltipTrigger } from "react-aria-components";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 
-const NAV_ITEMS: { id: AppView; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+const NAV_ITEMS: { id: AppView; icon: LucideIcon; label: string }[] = [
     { id: "analyze", icon: Search, label: "Analyze (Ctrl+1)" },
     { id: "queue", icon: ArrowDownToLine, label: "Queue (Ctrl+2)" },
     { id: "history", icon: Clock, label: "History (Ctrl+3)" },
@@ -42,7 +43,7 @@ export function IconRail() {
                             size="icon"
                             onPress={() => setView(id)}
                             aria-label={label}
-                            aria-current={isActive ? "page" : undefined}
+                            {...(isActive && { "aria-current": "page" as const })}
                             className={cn(
                                 "relative flex items-center justify-center w-10 h-10 rounded-[6px] my-0.5 transition-colors",
                                 isActive

--- a/crates/rdlp-desktop/src/test/radix-select-mock.tsx
+++ b/crates/rdlp-desktop/src/test/radix-select-mock.tsx
@@ -17,10 +17,10 @@ import * as React from "react";
 
 interface SelectCtx {
     value: string;
-    onValueChange?: (v: string) => void;
+    onValueChange?: ((v: string) => void) | undefined;
     open: boolean;
     setOpen: (o: boolean) => void;
-    disabled?: boolean;
+    disabled?: boolean | undefined;
     items: Map<string, string>; // value → label text
 }
 

--- a/crates/rdlp-desktop/tsconfig.json
+++ b/crates/rdlp-desktop/tsconfig.json
@@ -28,6 +28,7 @@
     "erasableSyntaxOnly": true,
     "noImplicitOverride": true,
     "verbatimModuleSyntax": true,
+    "exactOptionalPropertyTypes": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

Standard GitHub-side intake infrastructure for the now-public repo. Pairs with PR #192 (dual-license) and PR #193 (CONTRIBUTING refresh).

## What lands

| File | Purpose |
|---|---|
| `CONTRIBUTORS` | Recognition list keyed on GitHub handle; documents opt-in / opt-out / pseudonym path |
| `.mailmap` | Maps the gmail alias to the canonical `@users.noreply.github.com` identity. After this, `git shortlog --use-mailmap` + GitHub UI display the noreply for ALL commits regardless of which email was used at commit time |
| `.github/CODEOWNERS` | Routes PR review to `@crippledgeek` by default |
| `.github/PULL_REQUEST_TEMPLATE.md` | Type-of-change, test plan, branch-name conformance, license acknowledgment |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured bug intake (env, reproduction, verbose logs, version) |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Problem-first feature framing |
| `.github/ISSUE_TEMPLATE/new_extractor.yml` | Site-extractor request with ToS check + `rdlp-probe` workflow pointer |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues; routes Q&A to Discussions |

## On the mailmap direction

Per [`gitmailmap` docs](https://git-scm.com/docs/gitmailmap), the LEFT side is the canonical (display) identity, RIGHT side is the alias being mapped TO it. The entry direction here makes the GitHub noreply canonical, so historical commits authored under the gmail display as the noreply going forward — without rewriting history.

## Caveats worth knowing

- **Mailmap is display-time, not a history rewrite.** Raw `git log` still shows the gmail historically. `git log --use-mailmap`, `git shortlog`, GitHub's contributor graphs, and the API all use the mailmap.
- **The gmail is already public** in commits made since the repo flipped public earlier today. Mailmap reduces visibility going forward but doesn't undo what's already been cloned/forked/indexed. Full scrub would require `git filter-repo --replace-text`, which would break every clone and invalidate open-PR SHAs — not worth the destruction.
- **For future commits**, separately update local `git config user.email` to `crippledgeek@users.noreply.github.com` so new commits don't add to the historical gmail set. Optionally enable "Block command line pushes that expose my email" on GitHub Settings → Emails.
- **Username-only noreply format** (what's in use here — `crippledgeek@users.noreply.github.com`) is the legacy format. Per [GitHub's email reference](https://docs.github.com/en/account-and-profile/reference/email-addresses-reference), it does NOT survive a GitHub username rename — commits would become orphaned. Switching to the ID-prefixed format (`<numericID>+crippledgeek@users.noreply.github.com`) via Settings → Emails → "Keep my email addresses private" is the long-term-stable choice; can be done in a follow-up mailmap update.

## Not in scope (deliberate)

- `.github/FUNDING.yml` — out of scope.
- All Contributors bot — overkill for a 1-maintainer project.
- History rewrite to scrub historical gmail — too destructive for already-public commits.
- Switch to ID-prefixed noreply format — requires GitHub UI action by the maintainer; can be a follow-up.

## Refs

- [git mailmap docs](https://git-scm.com/docs/gitmailmap)
- [GitHub: Email addresses reference](https://docs.github.com/en/account-and-profile/reference/email-addresses-reference)
- [GitHub: About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners)
- [GitHub: Issue forms YAML schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)