### PR TITLE
chore: switch .mailmap canonical to ID-prefixed noreply (rename-safe)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,5 +3,11 @@
 #
 # Format: <canonical name> <canonical email> <alias name> <alias email>
 # (alias name is optional; if omitted, only the email matches)
+#
+# Canonical identity uses the ID-prefixed @users.noreply.github.com format
+# (see https://docs.github.com/en/account-and-profile/reference/email-addresses-reference)
+# because it embeds the permanent GitHub user ID and survives username
+# renames. The legacy username-only format would orphan commits on rename.
 
-Mattias Carlsson <crippledgeek@users.noreply.github.com> <mattias.carlsson01@gmail.com>
+Mattias Carlsson <19933050+crippledgeek@users.noreply.github.com> <mattias.carlsson01@gmail.com>
+Mattias Carlsson <19933050+crippledgeek@users.noreply.github.com> <crippledgeek@users.noreply.github.com>


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #194. Switches the `.mailmap` canonical author identity from the legacy username-only `@users.noreply.github.com` format to the ID-prefixed format that survives GitHub username renames.

## Background

Per [GitHub's email addresses reference](https://docs.github.com/en/account-and-profile/reference/email-addresses-reference), there are two ``@users.noreply.github.com`` formats:

| Format | Example | Username-rename safety |
|---|---|---|
| Username-only (legacy) | ``crippledgeek@users.noreply.github.com`` | Breaks on rename |
| ID-prefixed (current default) | ``19933050+crippledgeek@users.noreply.github.com`` | Permanent ID survives renames |

PR #194 used the legacy format. This PR fixes that.

## Change

The `.mailmap` now reads:

```
Mattias Carlsson <19933050+crippledgeek@users.noreply.github.com> <mattias.carlsson01@gmail.com>
Mattias Carlsson <19933050+crippledgeek@users.noreply.github.com> <crippledgeek@users.noreply.github.com>
```

Both prior committer emails (gmail + legacy noreply) collapse to the single rename-safe ID-prefixed canonical. Verified via `git shortlog -sne` reporting one author with the ID-prefixed email.

## Companion local change (not in this PR)

Maintainer's repo-scoped git config has been updated:

```
git config user.email "19933050+crippledgeek@users.noreply.github.com"
```

So all new commits go in under the ID-prefixed identity. Combined with the **Block command line pushes that expose my email** server-side setting (enabled on GitHub), the gmail can no longer leak into new commits.

## Conflicts with PR #194

Both PRs touch `.mailmap`. #194 will conflict with this PR at merge time. Resolution: keep THIS PR's version (ID-prefixed canonical + both aliases). Suggested merge order: #194 first (so the `.mailmap` file exists on develop), then this PR (which overwrites it with the corrected canonical).

Alternative: close this PR, edit `.mailmap` directly on the `chore/community-files` branch behind PR #194, and force-push. Either works; this PR keeps the change auditable as its own commit.

## Refs

- [GitHub: Email addresses reference](https://docs.github.com/en/account-and-profile/reference/email-addresses-reference)
- [git mailmap docs](https://git-scm.com/docs/gitmailmap)