### PR TITLE
chore: cargo fmt workspace cleanup (pre-CI re-enable)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -450,10 +450,9 @@ impl Orchestrator {
         };
         let extractor = extractor.to_owned();
         let id = id.to_owned();
-        let result = tokio::task::spawn_blocking(move || {
-            archive::record_in_archive(&path, &extractor, &id)
-        })
-        .await;
+        let result =
+            tokio::task::spawn_blocking(move || archive::record_in_archive(&path, &extractor, &id))
+                .await;
         match result {
             Ok(Ok(())) => {}
             Ok(Err(e)) => warn!("Failed to write to download archive: {e}"),

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -6,8 +6,8 @@
 
 use anyhow::{Context, Result};
 use rdlp_api::{
-    AudioFormat, BrowserEmulation, BrowserType, Config, ContainerFormat, FixupPolicy, RecodeAudioMode,
-    SubtitleFormat, config_io,
+    AudioFormat, BrowserEmulation, BrowserType, Config, ContainerFormat, FixupPolicy,
+    RecodeAudioMode, SubtitleFormat, config_io,
 };
 
 use crate::args::Args;

--- a/crates/rdlp-cookies/src/lib.rs
+++ b/crates/rdlp-cookies/src/lib.rs
@@ -18,10 +18,10 @@ use async_trait::async_trait;
 use log::{debug, warn};
 use rdlp_core::{CookieJar, Result};
 use rdlp_types::BrowserType;
-use wreq::cookie::CookieStore;
 use std::path::Path;
 use std::sync::Arc;
 use url::Url;
+use wreq::cookie::CookieStore;
 
 /// Cookie jar backed by `wreq::cookie::Jar`.
 ///

--- a/crates/rdlp-cookies/src/util.rs
+++ b/crates/rdlp-cookies/src/util.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 
 use log::debug;
 use url::Url;
+use wreq::Uri;
 use wreq::cookie::CookieStore;
 use wreq::header::HeaderValue;
-use wreq::Uri;
 
 /// Build a URL and `Set-Cookie` header from cookie fields, then insert into the jar.
 ///

--- a/crates/rdlp-desktop/src-tauri/src/panic_hook.rs
+++ b/crates/rdlp-desktop/src-tauri/src/panic_hook.rs
@@ -33,9 +33,7 @@ pub fn install_panic_hook() {
             .unwrap_or_else(|| "<unknown>".into());
         let payload = panic_payload_str(info.payload());
 
-        log::error!(
-            "Tauri app panicked at {location}: {payload}\nbacktrace:\n{backtrace}"
-        );
+        log::error!("Tauri app panicked at {location}: {payload}\nbacktrace:\n{backtrace}");
 
         prev_hook(info);
     }));

--- a/crates/rdlp-downloader/src/hls/segment.rs
+++ b/crates/rdlp-downloader/src/hls/segment.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use wreq::header::HeaderMap;
 use std::time::Duration;
+use wreq::header::HeaderMap;
 
 use backon::Retryable;
 use futures::StreamExt;

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -20,13 +20,13 @@ use rdlp_core::{
     DownloadProgress, DownloadStats, ProgressCallback, RdlpError, Result, RetryConfig,
     check_http_response, is_retryable_error,
 };
-use wreq::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
+use wreq::header::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::chunking::ChunkSizeStrategy;
 use config::{DownloaderConfig, PROGRESS_UPDATE_INTERVAL};
@@ -88,10 +88,9 @@ impl HttpDownloader {
         // profile (ChromeLatest) is applied — otherwise this constructor
         // would hand back a wreq client with no JA4 / JA4H emulation,
         // bypassing the Phase 2 fingerprint guarantee (spec §6.8).
-        let client = rdlp_http::HttpClientFactory::from_config(
-            &rdlp_http::HttpClientConfig::default(),
-        )
-        .build();
+        let client =
+            rdlp_http::HttpClientFactory::from_config(&rdlp_http::HttpClientConfig::default())
+                .build();
         Self::with_client(client)
     }
 

--- a/crates/rdlp-extractor/src/extractors/spankbang/metadata.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/metadata.rs
@@ -153,8 +153,7 @@ mod tests {
         // Amateur uploads render the profile link with leading icon SVG +
         // <span class="name"> + chevron SVG instead of plain text. Captured
         // 2026-04-26 from /a4fcc/video/porn (uploader: shocker4).
-        const AMATEUR_PAGE: &str =
-            include_str!("tests/spankbang_video_page_amateur.html");
+        const AMATEUR_PAGE: &str = include_str!("tests/spankbang_video_page_amateur.html");
         let m = parse(AMATEUR_PAGE);
         assert_eq!(
             m.uploader.as_deref(),
@@ -171,8 +170,7 @@ mod tests {
         // and /profile/. Captured 2026-04-26 from
         // /a4eth/video/petite+with+shaved+pussy+and+stepdad+hardcore+xxx
         // (creator: Oopsfamily, URL /knp9/creator/oopsfamily/).
-        const CREATOR: &str =
-            include_str!("tests/spankbang_video_page_creator.html");
+        const CREATOR: &str = include_str!("tests/spankbang_video_page_creator.html");
         let m = parse(CREATOR);
         assert_eq!(
             m.uploader.as_deref(),
@@ -188,8 +186,7 @@ mod tests {
         // Captured 2026-04-26 from /6ydqv/video/jodi+bj — uploader slug is
         // `coutinho.vasconcelos61` (dot + digits). Locks the regression
         // where `[a-z0-9_-]+` rejected the period.
-        const DOTTED: &str =
-            include_str!("tests/spankbang_video_page_dotted_user.html");
+        const DOTTED: &str = include_str!("tests/spankbang_video_page_dotted_user.html");
         let m = parse(DOTTED);
         assert_eq!(
             m.uploader_id.as_deref(),
@@ -238,9 +235,7 @@ mod tests {
         // No tag string should be empty or the "Exclusive" badge label.
         assert!(m.tags.iter().all(|t| !t.is_empty()));
         assert!(
-            m.tags
-                .iter()
-                .all(|t| !t.eq_ignore_ascii_case("exclusive")),
+            m.tags.iter().all(|t| !t.eq_ignore_ascii_case("exclusive")),
             "Exclusive promo badge must be filtered out"
         );
     }

--- a/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
@@ -11,9 +11,9 @@
 //! Reference: yt-dlp `yt_dlp/extractor/spankbang.py` — uses `impersonate=True`
 //! for the equivalent calls.
 
-mod patterns;
 mod formats;
 mod metadata;
+mod patterns;
 mod search;
 
 use async_trait::async_trait;
@@ -71,13 +71,14 @@ impl SpankBangExtractor {
             });
         }
 
-        resp.json::<Value>().await.map_err(|e| RdlpError::Extraction {
-            message: format!("SpankBang formats API JSON parse failed: {e:#}"),
-            url: Some(FORMATS_API_URL.to_string()),
-        })
+        resp.json::<Value>()
+            .await
+            .map_err(|e| RdlpError::Extraction {
+                message: format!("SpankBang formats API JSON parse failed: {e:#}"),
+                url: Some(FORMATS_API_URL.to_string()),
+            })
     }
 }
-
 
 #[async_trait]
 impl InfoExtractor for SpankBangExtractor {
@@ -98,11 +99,10 @@ impl InfoExtractor for SpankBangExtractor {
     }
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
-        let video_id =
-            patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-                message: format!("SpankBang: could not extract video ID from URL: {url}"),
-                url: Some(url.to_string()),
-            })?;
+        let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
+            message: format!("SpankBang: could not extract video ID from URL: {url}"),
+            url: Some(url.to_string()),
+        })?;
 
         // Playlist URLs match VIDEO_URL but require a different fetch path
         // (anchor scrape, not stream_data parse). Surface a clear error
@@ -119,12 +119,9 @@ impl InfoExtractor for SpankBangExtractor {
         debug!("[spankbang] fetching video page id={video_id}");
 
         // SpankBang gates some content by country; matches yt-dlp's default.
-        let webpage = BaseExtractor::fetch_webpage_with_headers(
-            &canonical,
-            &[("Cookie", "country=US")],
-            ctx,
-        )
-        .await?;
+        let webpage =
+            BaseExtractor::fetch_webpage_with_headers(&canonical, &[("Cookie", "country=US")], ctx)
+                .await?;
 
         if metadata::is_removed(&webpage) {
             return Err(RdlpError::Extraction {
@@ -137,7 +134,10 @@ impl InfoExtractor for SpankBangExtractor {
         let mut formats: Vec<Format> = Vec::new();
         if let Some(data) = formats::parse_inline_stream_data(&webpage) {
             formats = formats::build_formats(&data);
-            debug!("[spankbang] inline stream_data produced {} formats", formats.len());
+            debug!(
+                "[spankbang] inline stream_data produced {} formats",
+                formats.len()
+            );
         }
 
         if formats.is_empty() {
@@ -210,5 +210,4 @@ mod tests {
         let ext = SpankBangExtractor::new();
         assert_eq!(ext.name(), "SpankBang");
     }
-
 }

--- a/crates/rdlp-extractor/src/extractors/spankbang/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/patterns.rs
@@ -37,8 +37,7 @@ pub(super) fn is_suitable(url: &str) -> bool {
 /// Primary format source on current pages. Body is captured (curlies inclusive)
 /// for conversion to JSON via [`pydict_to_json`].
 pub(super) static STREAM_DATA_INLINE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?s)stream_data\s*=\s*(\{.*?\});")
-        .expect("SpankBang STREAM_DATA_INLINE regex")
+    Regex::new(r"(?s)stream_data\s*=\s*(\{.*?\});").expect("SpankBang STREAM_DATA_INLINE regex")
 });
 
 /// `data-streamkey="..."` — opaque token used by the formats-API fallback.
@@ -75,18 +74,15 @@ pub(super) fn pydict_to_json(s: &str) -> String {
 }
 
 /// `<h1 ... title="...">` — primary title source on video pages.
-pub(super) static TITLE_H1: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"<h1[^>]+title="([^"]+)""#).expect("SpankBang TITLE_H1 regex")
-});
+pub(super) static TITLE_H1: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"<h1[^>]+title="([^"]+)""#).expect("SpankBang TITLE_H1 regex"));
 
 /// `<meta property="og:KEY" content="VALUE">` — captures key + value.
 /// Tolerant of attribute order (`property` before `content` or vice versa)
 /// and of additional unrelated attributes inside the meta tag.
 pub(super) static OG_META: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"<meta\b[^>]*\bproperty="og:([^"]+)"[^>]*\bcontent="([^"]*)"[^>]*>"#,
-    )
-    .expect("SpankBang OG_META regex")
+    Regex::new(r#"<meta\b[^>]*\bproperty="og:([^"]+)"[^>]*\bcontent="([^"]*)"[^>]*>"#)
+        .expect("SpankBang OG_META regex")
 });
 
 /// `<a href="/profile/SLUG">DISPLAY</a>` — uploader profile link in the
@@ -125,10 +121,8 @@ pub(super) static UPLOADER_LINK_NAMED: LazyLock<Regex> = LazyLock::new(|| {
 /// the title-bearing form is the one with `title="..."`. Capture group 1 =
 /// video ID, group 2 = slug, group 3 = title text.
 pub(super) static SEARCH_RESULT: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"<a[^>]*\bhref="/([a-z0-9]+)/video/([^"]+)"[^>]*\btitle="([^"]+)"[^>]*>"#,
-    )
-    .expect("SpankBang SEARCH_RESULT regex")
+    Regex::new(r#"<a[^>]*\bhref="/([a-z0-9]+)/video/([^"]+)"[^>]*\btitle="([^"]+)"[^>]*>"#)
+        .expect("SpankBang SEARCH_RESULT regex")
 });
 
 /// Search-result image-wrapper anchor: captures (id, thumbnail URL,
@@ -216,8 +210,7 @@ pub(super) static TAG_LINK_BAR: LazyLock<Regex> = LazyLock::new(|| {
 
 /// `<id|class="video_removed">` — yt-dlp's removed-video sentinel.
 pub(super) static VIDEO_REMOVED: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"<[^>]+\b(?:id|class)=["']video_removed"#)
-        .expect("SpankBang VIDEO_REMOVED regex")
+    Regex::new(r#"<[^>]+\b(?:id|class)=["']video_removed"#).expect("SpankBang VIDEO_REMOVED regex")
 });
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/spankbang/search.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/search.rs
@@ -13,8 +13,7 @@ use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{
-    SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery,
-    SearchResultPreview,
+    SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery, SearchResultPreview,
 };
 
 use super::SpankBangExtractor;
@@ -390,12 +389,9 @@ impl SearchExtractor for SpankBangExtractor {
         let page = query.page.unwrap_or(0);
         let page_url = build_search_url(query, page);
 
-        let webpage = BaseExtractor::fetch_webpage_with_headers(
-            &page_url,
-            &[("Cookie", "country=US")],
-            ctx,
-        )
-        .await?;
+        let webpage =
+            BaseExtractor::fetch_webpage_with_headers(&page_url, &[("Cookie", "country=US")], ctx)
+                .await?;
 
         let results = parse_results(&webpage);
         let more = has_more_pages(&webpage, query, page);
@@ -540,10 +536,7 @@ mod tests {
             thumb.starts_with("https://") && thumb.contains("sb-cd.com"),
             "unexpected thumbnail host: {thumb}"
         );
-        assert!(
-            sample.duration.unwrap() > 0.0,
-            "duration must be positive"
-        );
+        assert!(sample.duration.unwrap() > 0.0, "duration must be positive");
     }
 
     #[test]
@@ -566,10 +559,7 @@ mod tests {
         // carry an uploader. (Lower bound is intentionally below the badge
         // count fraction because dedup, recommendation rails, and ad-cards
         // all reduce the count.)
-        let with_uploader = results
-            .iter()
-            .filter(|r| r.uploader.is_some())
-            .count();
+        let with_uploader = results.iter().filter(|r| r.uploader.is_some()).count();
         assert!(
             with_uploader * 100 / results.len() >= 30,
             "expected ≥30% of {} results to carry a creator-badge uploader; got {with_uploader}",

--- a/crates/rdlp-extractor/src/hls/format_detection.rs
+++ b/crates/rdlp-extractor/src/hls/format_detection.rs
@@ -232,11 +232,7 @@ async fn detect_format_sizes_inner(
                         // OR when any audio-only rendition is present (even
                         // if there's only one video-only variant paired with
                         // it — the XHamster AV1 case).
-                        Ok(Ok(v))
-                            if v.len() > 1 || v.iter().any(|x| x.is_audio_only) =>
-                        {
-                            v
-                        }
+                        Ok(Ok(v)) if v.len() > 1 || v.iter().any(|x| x.is_audio_only) => v,
                         _ => {
                             // Not a master playlist or detection failed — fall back to
                             // single-format enrichment via detect_hls_metadata
@@ -329,10 +325,8 @@ async fn detect_format_sizes_inner(
                         // Surface the rendition language on the Format so the
                         // UI can label multi-language audio tracks. Fall back
                         // to the parent format's language for video variants.
-                        expanded_format.language = variant
-                            .language
-                            .clone()
-                            .or_else(|| format.language.clone());
+                        expanded_format.language =
+                            variant.language.clone().or_else(|| format.language.clone());
                         // Propagate the HLS audio-rendition group:
                         //   - video-only rows carry the AUDIO= reference (the
                         //     group their paired audio lives in)
@@ -342,10 +336,11 @@ async fn detect_format_sizes_inner(
                         expanded_format.audio_group_id = variant.audio_group_id.clone();
                         expanded_format.duration = variant.total_duration;
                         // Estimate size from bitrate × duration (bytes = bps × s / 8)
-                        expanded_format.filesize_approx = match (variant.bandwidth, variant.total_duration) {
-                            (bw, Some(dur)) if bw > 0 => Some((bw as f64 * dur / 8.0) as u64),
-                            _ => None,
-                        };
+                        expanded_format.filesize_approx =
+                            match (variant.bandwidth, variant.total_duration) {
+                                (bw, Some(dur)) if bw > 0 => Some((bw as f64 * dur / 8.0) as u64),
+                                _ => None,
+                            };
                         expanded_format.container = variant.segment_container.clone();
                         if variant.has_encryption {
                             expanded_format.has_drm = Some(true);

--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -252,10 +252,7 @@ mod tests {
         assert_eq!(a.audio_group_id.as_deref(), Some("aac"));
         assert_eq!(a.rendition_name.as_deref(), Some("Stereo"));
         assert!(a.resolution.is_none());
-        assert_eq!(
-            a.media_playlist_url,
-            "https://cdn.example.com/p/audio.m3u8"
-        );
+        assert_eq!(a.media_playlist_url, "https://cdn.example.com/p/audio.m3u8");
     }
 
     /// Masters without EXT-X-MEDIA (typical XVideos / XNXX / older

--- a/crates/rdlp-extractor/src/lib.rs
+++ b/crates/rdlp-extractor/src/lib.rs
@@ -419,8 +419,7 @@ mod tests {
         assert!(hqporner.is_some());
         assert_eq!(hqporner.unwrap().name(), "HQPorner");
 
-        let spankbang =
-            registry.find_extractor("https://spankbang.com/56b3d/video/the+slut+maker");
+        let spankbang = registry.find_extractor("https://spankbang.com/56b3d/video/the+slut+maker");
         assert!(spankbang.is_some());
         assert_eq!(spankbang.unwrap().name(), "SpankBang");
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
@@ -66,10 +66,7 @@ impl SubtitleStage {
     ///
     /// Uses `tokio::fs::read_dir` so the async runtime thread isn't stalled
     /// by blocking directory-scan syscalls on slow / network filesystems.
-    async fn find_subtitle_files(
-        media_file: &Path,
-        original_stem: &str,
-    ) -> Vec<(String, PathBuf)> {
+    async fn find_subtitle_files(media_file: &Path, original_stem: &str) -> Vec<(String, PathBuf)> {
         let Some(parent) = media_file.parent() else {
             return Vec::new();
         };

--- a/crates/rdlp-probe/src/commands/extract.rs
+++ b/crates/rdlp-probe/src/commands/extract.rs
@@ -87,8 +87,8 @@ fn extract_regex(input: &str, pattern: &str, first: bool) -> Result<()> {
 
 fn extract_css(input: &str, selector: &str, first: bool) -> Result<()> {
     let doc = Html::parse_document(input);
-    let sel = Selector::parse(selector)
-        .map_err(|e| anyhow::anyhow!("invalid CSS selector: {e:?}"))?;
+    let sel =
+        Selector::parse(selector).map_err(|e| anyhow::anyhow!("invalid CSS selector: {e:?}"))?;
     let mut iter = doc.select(&sel);
     if first {
         if let Some(el) = iter.next() {

--- a/crates/rdlp-types/src/browser_emulation.rs
+++ b/crates/rdlp-types/src/browser_emulation.rs
@@ -125,7 +125,10 @@ mod tests {
     #[test]
     fn pinned_valid_resolves() {
         assert_eq!(
-            format!("{:?}", BrowserEmulation::Pinned("chrome-137".into()).resolve()),
+            format!(
+                "{:?}",
+                BrowserEmulation::Pinned("chrome-137".into()).resolve()
+            ),
             format!("{:?}", Emulation::Chrome137)
         );
     }
@@ -134,7 +137,10 @@ mod tests {
     fn pinned_invalid_falls_back() {
         // Unknown pin maps to Chrome139 (current *Latest target).
         assert_eq!(
-            format!("{:?}", BrowserEmulation::Pinned("nonsense".into()).resolve()),
+            format!(
+                "{:?}",
+                BrowserEmulation::Pinned("nonsense".into()).resolve()
+            ),
             format!("{:?}", Emulation::Chrome139)
         );
     }

--- a/crates/rdlp-types/src/format/selector/tests.rs
+++ b/crates/rdlp-types/src/format/selector/tests.rs
@@ -376,8 +376,8 @@ fn test_parse_extension_webm() {
 #[test]
 fn test_parse_extension_prefix_collision_is_format_id() {
     for id in &["mp4-hd", "mp4-low", "mp4-high", "webm-720", "aac-128"] {
-        let sel = FormatSelector::parse(id)
-            .unwrap_or_else(|e| panic!("failed to parse `{id}`: {e:?}"));
+        let sel =
+            FormatSelector::parse(id).unwrap_or_else(|e| panic!("failed to parse `{id}`: {e:?}"));
         let spec = &sel.selectors[0].fallbacks[0];
         match spec {
             FormatSpec::Single(s) => assert!(


### PR DESCRIPTION
## Summary

Workspace-wide `cargo fmt` cleanup. 18 files, all pure mechanical formatting changes, no logic touched. Net `+72 / -105`.

## Why now

GitHub Actions CI is disabled at the repo level (`gh api repos/crippledgeek/rdlp/actions/permissions` → ``enabled: false``). Last CI run was 2026-03-18. Today's TLS Phase 2 / SpankBang / Prism / dual-license sprints all merged without CI validation, and 18 files of fmt drift accumulated — most from PR #189 (TLS Phase 2 + SpankBang + rdlp-probe) plus follow-ups in files touched during later sprints.

This PR resets the formatting baseline so the very first CI run after re-enabling Actions is green.

## Verification

```
cargo fmt --check
```

Silent (exit 0).

## Files

- `rdlp-api/src/orchestrator/mod.rs`
- `rdlp-cli/src/config.rs`
- `rdlp-cookies/src/{lib,util}.rs`
- `rdlp-desktop/src-tauri/src/panic_hook.rs`
- `rdlp-downloader/src/hls/segment.rs` + `src/http/mod.rs`
- `rdlp-extractor/src/extractors/spankbang/{metadata,mod,patterns,search}.rs`
- `rdlp-extractor/src/hls/{format_detection,mod}.rs` + `src/lib.rs`
- `rdlp-postprocess/src/pipeline/stages/subtitle.rs`
- `rdlp-probe/src/commands/extract.rs`
- `rdlp-types/src/browser_emulation.rs` + `src/format/selector/tests.rs`