### PR TITLE
chore(ci): add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, master]
   pull_request:
     branches: [develop, master]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `workflow_dispatch:` to the CI workflow's triggers so we can re-run it manually via `gh workflow run ci.yml` or the Actions tab without a push.

Also: this PR's auto-triggered CI run validates that the develop tip works on the matrix after Actions was re-enabled today (it had been disabled at the repo level since 2026-03-18; today's PRs all merged without CI validation, including PR #196 which fixed a workspace-wide `cargo fmt` drift specifically to clear the lint job).