### PR TITLE
chore(ci): fix matrix failures (pkgconf conflict + Rust 1.95 clippy + FFmpeg pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,10 @@ jobs:
             libswresample-dev \
             cmake \
             perl \
-            pkg-config \
             libclang-dev \
             musl-tools
+        # Note: pkg-config dropped — runner's preinstalled pkgconf provides
+        # the same interface and Breaks pkg-config (>= 0.29-1) via apt.
 
       - name: Install NASM (Windows)
         if: matrix.platform == 'windows-latest'
@@ -79,13 +80,18 @@ jobs:
         uses: actions/cache@v5
         with:
           path: C:\ffmpeg
-          key: ffmpeg-win64-shared-7
+          # Pinned to a specific FFmpeg 8.0 build because ffmpeg-sys-the-third
+          # v4.1.0+ffmpeg-8.0 declares 8.0 bindings; FFmpeg 8.1 headers
+          # crash clang/bindgen on Windows (STATUS_ACCESS_VIOLATION).
+          # Bump key whenever the FFmpeg version below changes.
+          key: ffmpeg-win64-shared-8.0
 
       - name: Download FFmpeg shared build (Windows)
         if: matrix.platform == 'windows-latest' && steps.ffmpeg-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z" -OutFile ffmpeg.7z
+          $url = "https://github.com/GyanD/codexffmpeg/releases/download/8.0/ffmpeg-8.0-full_build-shared.7z"
+          Invoke-WebRequest -Uri $url -OutFile ffmpeg.7z
           7z x ffmpeg.7z -oC:\ffmpeg
 
       - name: Set FFmpeg environment (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, master]
   pull_request:
     branches: [develop, master]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,15 @@ jobs:
         uses: actions/cache@v5
         with:
           path: C:\ffmpeg
-          key: ffmpeg-win64-shared-7
+          # Pinned — see ci.yml for the rationale.
+          key: ffmpeg-win64-shared-8.0
 
       - name: Download FFmpeg shared build (Windows)
         if: matrix.platform == 'windows-latest' && steps.ffmpeg-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z" -OutFile ffmpeg.7z
+          $url = "https://github.com/GyanD/codexffmpeg/releases/download/8.0/ffmpeg-8.0-full_build-shared.7z"
+          Invoke-WebRequest -Uri $url -OutFile ffmpeg.7z
           7z x ffmpeg.7z -oC:\ffmpeg
 
       - name: Set FFmpeg environment (Windows)

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -231,11 +231,11 @@ impl DownloadProgress {
 
         let eta = if speed > 1.0 && total_segments > 0 {
             let remaining_segments = total_segments.saturating_sub(segments_downloaded);
-            let avg_segment_size = if segments_downloaded > 0 {
-                bytes_downloaded / segments_downloaded
-            } else {
-                2 * 1024 * 1024 // Default 2MB estimate
-            };
+            // Default 2MB estimate when no segments have completed yet.
+            // checked_div + unwrap_or matches clippy::manual_checked_ops (Rust 1.95+).
+            let avg_segment_size = bytes_downloaded
+                .checked_div(segments_downloaded)
+                .unwrap_or(2 * 1024 * 1024);
             let remaining_bytes = remaining_segments * avg_segment_size;
             let secs = remaining_bytes as f64 / speed;
             if secs <= 86_400.0 {


### PR DESCRIPTION
## Summary

First CI run after re-enabling Actions today (run [24959429222](https://github.com/crippledgeek/rdlp/actions/runs/24959429222)) failed all three matrix platforms with three distinct, real issues. This PR fixes all three.

## Failures and fixes

### 1. Ubuntu — `pkg-config` apt conflict (24s, dies before any compile)

```
pkgconf : Breaks: pkg-config (>= 0.29-1)
E: Unable to correct problems, you have held broken packages.
```

GitHub's `ubuntu-22.04` runner now ships `pkgconf` preinstalled; trying to install `pkg-config` via apt triggers a `Breaks` clause. **Fix:** drop `pkg-config` from the apt list (pkgconf provides the same `pkg-config` CLI interface that `pkg-config` does).

### 2. macOS — Rust 1.95 clippy lint `clippy::manual_checked_ops`

```
error: manual checked division
   --> crates/rdlp-core/src/traits/downloader.rs:234:39
234 |             let avg_segment_size = if segments_downloaded > 0 {
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^ check performed here
```

A new lint in Rust 1.95 (just released) flags the `if x > 0 { a / x } else { default }` pattern. CI runs `cargo clippy -- -D warnings`, so any new warning is fatal. **Fix:** rewrite to `bytes_downloaded.checked_div(segments_downloaded).unwrap_or(2 * 1024 * 1024)` — same semantics, idiomatic, lint-clean.

### 3. Windows — `STATUS_ACCESS_VIOLATION` in `ffmpeg-sys-the-third` build script

```
Caused by:
  process didn't exit successfully: ...build-script-build (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

Clang 20.1.8 / bindgen segfaulted while parsing FFmpeg headers. **Root cause:** the cache step uses `ffmpeg-release-full-shared.7z` (gyan.dev's rolling URL), which is now serving FFmpeg 8.1. But `ffmpeg-sys-the-third v4.1.0+ffmpeg-8.0` declares 8.0 bindings; 8.1's header drift crashes bindgen on Windows.

**Fix:**
- Pin both `ci.yml` and `release.yml` to the explicit FFmpeg 8.0 archive from gyan's GitHub mirror: `https://github.com/GyanD/codexffmpeg/releases/download/8.0/ffmpeg-8.0-full_build-shared.7z`
- Bump the cache key from the misleading `ffmpeg-win64-shared-7` to `ffmpeg-win64-shared-8.0` so stale cache doesn't keep returning a broken 8.1 build
- Inline comment explaining the pin so the next maintainer knows to bump it alongside any ffmpeg-the-third update

## Verification

- `cargo clippy --workspace -- -D warnings` passes locally on this branch (silent + Finished)
- `cargo fmt --check` passes (handled in PR #196)
- Auto-triggered CI run on this PR will validate all three platforms; if green, merging unlocks the develop tip