### PR TITLE
chore(ci): round 2 — Rust 1.95 sort_by lint + Windows OpenSSL discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,16 @@ jobs:
           echo "FFMPEG_DIR=$dir" >> $env:GITHUB_ENV
           echo "$dir\bin" >> $env:GITHUB_PATH
 
+      - name: Set OpenSSL environment (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          # openssl-sys (transitive via wreq's BoringSSL/OpenSSL coexistence
+          # setup) needs OPENSSL_DIR on Windows. Strawberry Perl bundles
+          # OpenSSL with headers + .lib files at C:\Strawberry\c — preinstalled
+          # on the windows-latest runner image.
+          echo "OPENSSL_DIR=C:\Strawberry\c" >> $env:GITHUB_ENV
+
       # --- Toolchain setup ---
 
       - uses: actions/setup-node@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,13 @@ jobs:
           echo "FFMPEG_DIR=$dir" >> $env:GITHUB_ENV
           echo "$dir\bin" >> $env:GITHUB_PATH
 
+      - name: Set OpenSSL environment (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          # See ci.yml for rationale.
+          echo "OPENSSL_DIR=C:\Strawberry\c" >> $env:GITHUB_ENV
+
       # --- Toolchain setup ---
 
       - uses: actions/setup-node@v5

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
@@ -148,7 +148,7 @@ fn columnar_cipher(src: &[char], key: &str) -> Vec<char> {
 
     // Build sorted key-index map (sort by char code, preserving original index)
     let mut key_map: Vec<(char, usize)> = key.chars().enumerate().map(|(i, c)| (c, i)).collect();
-    key_map.sort_by(|a, b| a.0.cmp(&b.0));
+    key_map.sort_by_key(|&(c, _)| c);
 
     // Fill grid column-by-column in sorted key order
     let mut src_idx = 0;
@@ -328,7 +328,7 @@ mod tests {
         // Build sorted key-index map
         let mut key_map: Vec<(char, usize)> =
             key.chars().enumerate().map(|(i, c)| (c, i)).collect();
-        key_map.sort_by(|a, b| a.0.cmp(&b.0));
+        key_map.sort_by_key(|&(c, _)| c);
 
         // Read column by column in sorted key order
         let mut result = Vec::with_capacity(src.len());


### PR DESCRIPTION
Round 2 of CI fixes after PR #198 unblocked enough of the build to surface two more issues:

## 1. Ubuntu + macOS — `clippy::unnecessary_sort_by`

```
error: consider using `sort_by_key`
  --> crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs:151
```

Another new Rust 1.95 lint. Two occurrences (lines 151 + 331), both rewritten:

```rust
// before
key_map.sort_by(|a, b| a.0.cmp(&b.0));
// after
key_map.sort_by_key(|&(c, _)| c);
```

## 2. Windows — `openssl-sys` can't find OpenSSL

The FFmpeg 8.0 pin from PR #198 worked — Windows got past the bindgen crash. Then hit this:

```
Could not find directory of OpenSSL installation
openssl-sys = 0.9.114
$HOST = x86_64-pc-windows-msvc
$TARGET = x86_64-pc-windows-msvc
```

Latent failure masked by the earlier FFmpeg crash. `openssl-sys` is pulled in transitively via `wreq`'s BoringSSL/OpenSSL coexistence setup.

**Fix:** set `OPENSSL_DIR=C:\Strawberry\c` in both `ci.yml` and `release.yml`. Strawberry Perl is preinstalled on the windows-latest runner image and bundles OpenSSL headers + `.lib` files at `C:\Strawberry\c` — no additional install step needed.

## Verification

- `cargo clippy --workspace -- -D warnings` passes locally
- Auto-triggered CI on this PR will validate all three platforms