### PR TITLE
chore(ci): share rust-cache per platform + single workspace pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,12 @@ jobs:
           components: clippy
 
       - uses: swatinem/rust-cache@v2
+        with:
+          # Share one cache pool per platform across all branches/PRs so
+          # cold-cache rebuilds of boring-sys (multi-minute C++ build) and
+          # the workspace tree don't repeat on every PR. Cache is keyed by
+          # platform + Cargo.lock + rustc version under the hood.
+          shared-key: rust-${{ matrix.platform }}
 
       # --- Fast linker (rust-lld bundled with Rust, lld via apt) ---
 
@@ -144,15 +150,8 @@ jobs:
           mkdir -p .cargo
           printf '[target.x86_64-pc-windows-msvc]\nlinker = "rust-lld"\n' >> .cargo/config.toml
 
-      # --- Workspace lint & test (default members: libs + CLI) ---
-
-      - name: Clippy (workspace)
-        run: cargo clippy -- -D warnings
-
-      - name: Test (workspace)
-        run: cargo test
-
-      # --- Desktop frontend (must build before Rust desktop checks) ---
+      # --- Desktop frontend (must build before any Rust pass, because
+      #     rdlp-desktop's tauri build script reads dist/ via tauri.conf.json) ---
 
       - name: Install frontend dependencies
         working-directory: crates/rdlp-desktop
@@ -168,10 +167,12 @@ jobs:
           npx tsc --noEmit
           npm test
 
-      # --- Desktop Rust backend (requires frontend dist/) ---
+      # --- Single workspace lint & test pass (covers libs + CLI + desktop +
+      #     probe; eliminates the prior double-compile of the shared dep tree
+      #     that happened when desktop was a second pass). ---
 
-      - name: Clippy (desktop)
-        run: cargo clippy -p rdlp-desktop -- -D warnings
+      - name: Clippy (workspace)
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Test (desktop)
-        run: cargo test -p rdlp-desktop
+      - name: Test (workspace)
+        run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,6 +3542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3549,6 +3558,7 @@ checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]


### PR DESCRIPTION
## Summary

- **rust-cache shared pool**: Adds `shared-key: rust-${{ matrix.platform }}` so every PR + develop run share one cache pool per platform. Stops the per-(branch, lockfile) cache fragmentation that left fresh PR branches cold (see PR #208's ~30 min Windows job vs PR #200's 6m11s).
- **Single workspace pass**: Collapses the two-pass `Clippy/Test (workspace)` + `Clippy/Test (desktop)` into one `cargo clippy --workspace --all-targets` + `cargo test --workspace`, placed after the frontend build so Tauri's build script finds `dist/`. Eliminates the duplicate compile of the shared dep tree.
- **Bonus lint coverage**: `rdlp-cli` and `rdlp-probe` are outside `default-members`, so they were never linted by the prior `cargo clippy --` invocation. The new `--workspace` pass covers them.
- **Cargo.lock**: Adds `openssl-src 300.6.0+3.6.2`, already required by the windows-vendored openssl-sys feature from PR #200. Lockfile was stale because no workspace-wide cargo command had run since.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean locally
- [x] `cargo test --workspace --no-run` compiles all test binaries
- [ ] First CI run: cold cache miss expected (normal)
- [ ] Second run (push trivial commit): Windows time should drop to <10 min
- [ ] After merge: open a throwaway branch with a one-liner change, verify it hits the shared cache from the start

## Don't merge until

- First-run CI is green on all platforms
- Cache-hit verification on the second push confirms the shared key works