### PR TITLE
fix(plugin): honour manifest matches in PluginExtractor::suitable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,21 @@ Thumbs.db
 
 # Plugin build artifacts
 plugins/*/target/
+
+# Plugin build artifacts produced by `rdlp plugin build-from-ytdlp`
+# (and signed via `scripts/sign-plugin.sh`). Each ported plugin lives at
+# `examples/plugins/<name>/<name>.py` (source — TRACKED, byte-identical
+# to upstream yt-dlp); the build output goes to a sibling directory
+# `examples/plugins/<name>/<name>/` containing `plugin.wasm` (~35 MB),
+# `plugin.toml.template` (unsigned manifest), and `plugin.toml` (signed
+# with the build host's Ed25519 key). All three regenerate on every
+# build and MUST NOT be committed — both because they're large binaries
+# and because the signed manifest carries a per-developer key. The
+# goldens build the wasm at test time from the .py source, so this
+# directory is purely an install-staging artefact.
+examples/plugins/*/*/plugin.wasm
+examples/plugins/*/*/plugin.toml
+examples/plugins/*/*/plugin.toml.template
 docs/
 CLAUDE.md
 debug_tnaflix.rs

--- a/crates/rdlp-plugin/src/adapter.rs
+++ b/crates/rdlp-plugin/src/adapter.rs
@@ -176,6 +176,21 @@ impl InfoExtractor for PluginExtractor {
         &self.valid_url_regex
     }
 
+    /// Honour the manifest's `matches` patterns at dispatch time.
+    ///
+    /// The default trait implementation calls `valid_url().is_match(url)`,
+    /// but for plugins without an explicit `url_regex` the adapter's
+    /// fallback regex is the permissive `^https?://` — which would make
+    /// every plugin claim every URL and shadow the Generic extractor.
+    /// Delegating to [`crate::dispatch::claims_url`] uses the manifest's
+    /// declared Chrome-style match patterns as the authoritative source
+    /// of truth, so plugins only claim URLs they were configured for.
+    /// See `claims_url` for the godresource regression that motivated
+    /// this override.
+    fn suitable(&self, url: &str) -> bool {
+        crate::dispatch::claims_url(&self.manifest, url)
+    }
+
     fn priority(&self) -> i32 {
         self.plugin_priority()
     }

--- a/crates/rdlp-plugin/src/dispatch.rs
+++ b/crates/rdlp-plugin/src/dispatch.rs
@@ -197,6 +197,45 @@ pub fn compile_url_regex(plugin: &str, source: &str) -> Result<regex::Regex, Plu
     })
 }
 
+/// Returns `true` if `url` is claimed by the plugin's manifest.
+///
+/// The manifest's `matches` array (Chrome-style match patterns) is the
+/// authoritative declaration of which URLs a plugin handles. This function
+/// parses the URL once, then checks every pattern.
+///
+/// **Empty `matches`:** returns `true` for any `http`/`https` URL that
+/// parses cleanly. This preserves backwards compatibility with the
+/// adapter's permissive `^https?://` regex fallback for plugins that
+/// were authored before manifest patterns were enforced — but any
+/// plugin shipping today MUST declare `matches` to scope its claim.
+///
+/// **Malformed URL:** returns `false` (no panic, no claim).
+///
+/// This is the fix for the godresource case: manifest declares
+/// `["https://new.godresource.com/*"]` but the plugin's `valid_url()`
+/// regex (the legacy fallback) was the permissive `^https?://`. Result:
+/// the plugin claimed the apex `https://godresource.com/...` URL even
+/// though the manifest didn't, the dispatcher picked it because of its
+/// priority over Generic, and the wasm rejected the URL internally
+/// after the user already paid the dispatch cost. Honoring `matches`
+/// at `suitable()` time means the dispatcher correctly falls through
+/// to Generic for URLs the plugin never claimed.
+#[must_use]
+pub fn claims_url(manifest: &crate::manifest::Manifest, url: &str) -> bool {
+    let parsed = match Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    if manifest.matches.is_empty() {
+        return matches!(parsed.scheme(), "http" | "https");
+    }
+    manifest.matches.iter().any(|raw| {
+        MatchPattern::parse(raw)
+            .map(|p| p.matches(&parsed))
+            .unwrap_or(false)
+    })
+}
+
 /// Dispatcher backed by a linear scan over registered patterns.
 ///
 /// MVP-grade — good enough for hundreds of plugins. Future optimization:
@@ -221,5 +260,96 @@ impl<T: Clone> MatchTrie<T> {
             .filter(|(p, _)| p.matches(url))
             .map(|(_, v)| v.clone())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod claims_url_tests {
+    use super::claims_url;
+    use crate::manifest::parse_manifest_str;
+
+    fn manifest_with_matches(patterns: &[&str]) -> crate::manifest::Manifest {
+        let matches_toml = patterns
+            .iter()
+            .map(|p| format!("\"{p}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let toml = format!(
+            r#"
+name = "test"
+version = "1.0.0"
+wit_version = "0.1.0"
+matches = [{matches_toml}]
+priority = 150
+capabilities = ["log"]
+
+[signature]
+type = "ed25519"
+pubkey = "ZA"
+signature = "ZA"
+"#,
+        );
+        parse_manifest_str(&toml).expect("parse")
+    }
+
+    #[test]
+    fn matches_exact_host_pattern() {
+        let m = manifest_with_matches(&["https://new.godresource.com/*"]);
+        assert!(claims_url(&m, "https://new.godresource.com/video/abc"));
+    }
+
+    #[test]
+    fn rejects_apex_when_pattern_requires_subdomain() {
+        // Regression: the godresource plugin's manifest declares
+        // `["https://new.godresource.com/*"]`, but before the
+        // claims_url fix the adapter's permissive `^https?://` fallback
+        // claimed every URL. Apex URL `godresource.com/...` must be
+        // rejected so the dispatcher falls through to Generic.
+        let m = manifest_with_matches(&["https://new.godresource.com/*"]);
+        assert!(!claims_url(&m, "https://godresource.com/video/abc"));
+    }
+
+    #[test]
+    fn rejects_other_host() {
+        let m = manifest_with_matches(&["https://new.godresource.com/*"]);
+        assert!(!claims_url(&m, "https://example.com/video/abc"));
+    }
+
+    #[test]
+    fn rejects_wrong_scheme() {
+        let m = manifest_with_matches(&["https://new.godresource.com/*"]);
+        assert!(!claims_url(&m, "http://new.godresource.com/video/abc"));
+    }
+
+    // Note: the empty-matches fallback in claims_url is defensive code
+    // — parse_manifest_str rejects manifests with empty `matches`, so
+    // the branch is unreachable through normal manifest construction.
+    // Kept in the implementation in case future refactors loosen the
+    // schema; not tested here because we cannot construct a Manifest
+    // that triggers it.
+
+    #[test]
+    fn malformed_url_returns_false() {
+        let m = manifest_with_matches(&["https://example.com/*"]);
+        assert!(!claims_url(&m, "not a url"));
+    }
+
+    #[test]
+    fn multiple_match_patterns_or_together() {
+        let m =
+            manifest_with_matches(&["https://a.example.com/*", "https://b.example.com/*"]);
+        assert!(claims_url(&m, "https://a.example.com/x"));
+        assert!(claims_url(&m, "https://b.example.com/x"));
+        assert!(!claims_url(&m, "https://c.example.com/x"));
+    }
+
+    #[test]
+    fn subdomain_wildcard_pattern() {
+        let m = manifest_with_matches(&["https://*.example.com/*"]);
+        assert!(claims_url(&m, "https://api.example.com/x"));
+        assert!(claims_url(&m, "https://www.example.com/x"));
+        // Match-pattern semantics: *.example.com also matches the apex.
+        assert!(claims_url(&m, "https://example.com/x"));
+        assert!(!claims_url(&m, "https://example.org/x"));
     }
 }

--- a/crates/rdlp-plugin/src/dispatch.rs
+++ b/crates/rdlp-plugin/src/dispatch.rs
@@ -336,8 +336,7 @@ signature = "ZA"
 
     #[test]
     fn multiple_match_patterns_or_together() {
-        let m =
-            manifest_with_matches(&["https://a.example.com/*", "https://b.example.com/*"]);
+        let m = manifest_with_matches(&["https://a.example.com/*", "https://b.example.com/*"]);
         assert!(claims_url(&m, "https://a.example.com/x"));
         assert!(claims_url(&m, "https://b.example.com/x"));
         assert!(!claims_url(&m, "https://c.example.com/x"));


### PR DESCRIPTION
## Summary

Plugins shipped without an explicit `url_regex` field (the common case — `build-from-ytdlp` only emits `matches`) fell back to the adapter's permissive `^https?://` regex. Default `InfoExtractor::suitable` impl is `valid_url().is_match(url)`, so every such plugin claimed every http/https URL — shadowing the Generic extractor and built-ins for sites the manifest never declared.

## Bug repro

`https://godresource.com/video/A01mTKjyf6w` (apex) was claimed by the godresource plugin even though its manifest declared `matches = ["https://new.godresource.com/*"]`. The wasm rejected the URL internally; user saw `plugin 'godresource' does not support URL` instead of dispatcher falling through to Generic.

## Fix

- New `dispatch::claims_url(manifest, url)` parses the URL once, runs every Chrome match-pattern from `manifest.matches`, returns true iff any matches.
- `PluginExtractor::suitable` overrides the default trait impl to delegate to `claims_url`.

## Verification

| URL | Before | After |
|---|---|---|
| `https://godresource.com/video/A01mTKjyf6w` (apex) | godresource plugin → ❌ "plugin doesn't support URL" | Generic → honest "no media found, JS-rendered site" |
| `https://new.godresource.com/video/A01mTKjyf6w` (canonical) | godresource plugin → ✅ extract | godresource plugin → ✅ extract (unchanged) |

- 7 new unit tests in `dispatch::claims_url_tests` covering exact host, apex rejection (godresource regression), wrong host, wrong scheme, OR-logic across multiple patterns, subdomain wildcards, malformed URLs
- 41/41 `rdlp-plugin` lib tests pass
- `cargo test --workspace`: all green
- `cargo clippy --all-targets -- -D warnings`: clean

## Test plan

- [ ] CI Lint
- [ ] CI Build & Test (3 platforms)
- [ ] CI Run Golden Build (svt + xxxymovies — verifies existing plugins still claim their canonical URLs)

## Follow-ups (not in this PR)

- Tasks 35 + 39 (empty-title handling), 36 (FinalizeMetadataStage) — separate branches per gitflow policy.