### PR TITLE
fix(api,desktop): treat empty/whitespace titles as missing; default template includes ID

### DIFF
--- a/crates/rdlp-api/src/orchestrator/template/render.rs
+++ b/crates/rdlp-api/src/orchestrator/template/render.rs
@@ -92,7 +92,14 @@ impl OutputTemplate {
     }
 
     /// Look up a single field reference, applying accessors/arithmetic/date format.
-    /// Returns `None` if the field doesn't exist or is null.
+    /// Returns `None` if the field doesn't exist, is null, or is an
+    /// effectively-empty string. Empty/whitespace-only strings are
+    /// treated as missing so the `|default` pipe fallback fires for
+    /// them — matching yt-dlp's behaviour. Without this, godresource-
+    /// style extractors that produce `title: ""` (because the upstream
+    /// API returned null) render as a literal empty segment in the
+    /// output filename and the user gets `.mp4` instead of `NA.mp4`
+    /// or `Unknown.mp4`.
     fn lookup_field(
         &self,
         field_ref: &FieldRef,
@@ -110,7 +117,7 @@ impl OutputTemplate {
                 // Priority: InfoDict → Format
                 let val = lookup_key(info_json, &field_ref.name)
                     .or_else(|| lookup_key(format_json, &field_ref.name));
-                val.filter(|v| !v.is_null())
+                val.filter(|v| !is_missing(v))
             }
         };
 
@@ -174,6 +181,27 @@ impl OutputTemplate {
 }
 
 // === Helper functions ===
+
+/// Returns `true` for JSON values that should be treated as "missing"
+/// for `|default` pipe-fallback purposes:
+///
+/// - `null`
+/// - `""` (empty string)
+/// - any whitespace-only string (`"   "`, `"\t\n"`, etc.)
+///
+/// Without the empty/whitespace check, an extractor that produces a
+/// blank title (the godresource case: API returns `title: null` and
+/// the plugin sets `'title': ''`) renders into the filename as a
+/// literal empty segment — `.mp4` instead of `NA.mp4` or
+/// `Unknown.mp4`. yt-dlp's `_NO_DEFAULT` sentinel handling treats
+/// empty strings the same as missing fields; this matches that.
+fn is_missing(val: &serde_json::Value) -> bool {
+    match val {
+        serde_json::Value::Null => true,
+        serde_json::Value::String(s) => s.trim().is_empty(),
+        _ => false,
+    }
+}
 
 /// Look up a key in a JSON value (object field lookup)
 fn lookup_key(val: &serde_json::Value, key: &str) -> Option<serde_json::Value> {

--- a/crates/rdlp-api/src/orchestrator/template/tests_render.rs
+++ b/crates/rdlp-api/src/orchestrator/template/tests_render.rs
@@ -57,6 +57,45 @@ fn test_render_missing_field_defaults_to_na() {
     assert_eq!(result, "NA");
 }
 
+/// godresource regression: API returns `title: null` and the plugin's
+/// `_real_extract` sets `'title': ''` (empty string). `lookup_field`
+/// previously returned `Some("")` for empty strings — so the
+/// `|Unknown` pipe-default never fired and the rendered filename was
+/// `mp4.mkv` (empty title + dot + ext, leading dot stripped). yt-dlp
+/// treats empty strings as missing for default-fallback purposes; we
+/// must match.
+#[test]
+fn test_render_empty_title_triggers_pipe_default() {
+    let mut info = test_info();
+    info.title = String::new();
+    let t = OutputTemplate::parse("%(title|Unknown)s.%(ext)s").unwrap();
+    let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
+    assert_eq!(result, "Unknown.mp4");
+}
+
+/// Companion to the above: empty title with NO pipe-default falls
+/// through to the unconditional "NA" sentinel — also yt-dlp parity.
+#[test]
+fn test_render_empty_title_no_default_falls_to_na() {
+    let mut info = test_info();
+    info.title = String::new();
+    let t = OutputTemplate::parse("%(title)s.%(ext)s").unwrap();
+    let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
+    assert_eq!(result, "NA.mp4");
+}
+
+/// Whitespace-only string is also "missing" — yt-dlp's heuristic is
+/// stricter than just `len == 0`, but we match the practical case
+/// (titles like "   " from misconfigured extractors).
+#[test]
+fn test_render_whitespace_title_falls_to_default() {
+    let mut info = test_info();
+    info.title = "   ".to_string();
+    let t = OutputTemplate::parse("%(title|Unknown)s").unwrap();
+    let result = t.render(&info, &test_format(), "mp4", &test_ctx()).unwrap();
+    assert_eq!(result, "Unknown");
+}
+
 #[test]
 fn test_render_numeric_padding() {
     let t = OutputTemplate::parse("%(playlist_index)03d").unwrap();

--- a/crates/rdlp-api/src/orchestrator/tests/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/mod.rs
@@ -173,9 +173,13 @@ fn test_generate_output_path() {
     let format = create_test_format("720p", "720p", Some(1000000));
 
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
+    // Default template is `%(title|Unknown)s [%(id)s].%(ext)s` —
+    // see `Config::default` in `rdlp-types/src/config.rs`. The
+    // `[id]` suffix is always present so empty-title extracts
+    // (e.g. godresource) still land at distinguishable filenames.
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "Test Video.mp4"
+        "Test Video [test123].mp4"
     );
 }
 
@@ -194,7 +198,7 @@ fn test_generate_output_path_sanitizes_invalid_chars() {
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "Invalid_Characters_In_Title__.mp4.mp4"
+        "Invalid_Characters_In_Title__.mp4 [test123].mp4"
     );
 }
 
@@ -217,7 +221,7 @@ fn test_generate_output_path_hls_extension() {
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "HLS Test Video.mp4"
+        "HLS Test Video [test123].mp4"
     );
 
     // HLS with MPEG-TS segments (detected from segment metadata)
@@ -225,7 +229,7 @@ fn test_generate_output_path_hls_extension() {
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "HLS Test Video.ts"
+        "HLS Test Video [test123].ts"
     );
 
     // HLS with explicit container field
@@ -234,7 +238,7 @@ fn test_generate_output_path_hls_extension() {
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "HLS Test Video.mp4"
+        "HLS Test Video [test123].mp4"
     );
 
     // HLS with container suffix (e.g., "mp4_dash")
@@ -242,7 +246,7 @@ fn test_generate_output_path_hls_extension() {
     let path = orchestrator.generate_output_path(&info, &format).unwrap();
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "HLS Test Video.mp4"
+        "HLS Test Video [test123].mp4"
     );
 }
 

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -291,7 +291,7 @@ fn test_merge_config_defaults() {
     let config =
         merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
 
-    assert_eq!(config.output_template, "%(title)s.%(ext)s");
+    assert_eq!(config.output_template, "%(title|Unknown)s [%(id)s].%(ext)s");
     assert!(!config.quiet);
     assert!(!config.verbose);
 }
@@ -428,7 +428,7 @@ fn test_merge_config_stdout_does_not_set_output_template() {
         merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
 
     // output_template should remain the default, not "-"
-    assert_eq!(config.output_template, "%(title)s.%(ext)s");
+    assert_eq!(config.output_template, "%(title|Unknown)s [%(id)s].%(ext)s");
 }
 
 #[test]

--- a/crates/rdlp-desktop/src/components/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.test.tsx
@@ -32,9 +32,23 @@ describe("JobCard", () => {
         expect(screen.getByText("My Video")).toBeInTheDocument();
     });
 
-    it("falls back to URL when title is null", () => {
+    it("falls back to 'Unknown' placeholder when title is null", () => {
+        // Updated from URL fallback in Task 39 — godresource port
+        // surfaced the empty-title case (API returns null), and the
+        // standardised UX is "Unknown" everywhere rather than a mix
+        // of URL / 'Untitled' / blank space across views. URL is
+        // still visible elsewhere in the JobCard layout, so we
+        // don't lose the information.
         render(<JobCard job={makeJob({ title: null, url: "https://example.com/fallback" })} onCancel={noop} onRemove={noop} onRetry={noop} />);
-        expect(screen.getByText("https://example.com/fallback")).toBeInTheDocument();
+        expect(screen.getByText("Unknown")).toBeInTheDocument();
+    });
+
+    it("renders 'Unknown' when title is empty string (godresource case)", () => {
+        // Plugin's _real_extract sets `'title': ''` when API returns
+        // null; without empty-string handling the rendered text was
+        // a blank line.
+        render(<JobCard job={makeJob({ title: "", url: "https://x.com/y" })} onCancel={noop} onRemove={noop} onRetry={noop} />);
+        expect(screen.getByText("Unknown")).toBeInTheDocument();
     });
 
     it("renders status badge", () => {

--- a/crates/rdlp-desktop/src/components/JobCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { DownloadJob } from "../types";
-import { cn } from "@/lib/utils";
+import { cn, displayTitle as resolveTitle } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -43,7 +43,11 @@ function statusClasses(status: string): string {
 /** Displays a single download job with status, progress, and action buttons. */
 export function JobCard({ job, onCancel, onRemove, onRetry }: JobCardProps) {
     const [revealError, setRevealError] = useState<string | null>(null);
-    const displayTitle = job.title ?? job.url;
+    // Empty/null/whitespace titles render as the shared "Unknown"
+    // placeholder. Without the empty-string check, godresource-style
+    // jobs (API returned `title: null`) showed as a blank line next
+    // to the URL — see `lib/utils.ts:displayTitle`.
+    const displayTitle = resolveTitle(job.title);
     const isRunning = job.status === "running";
     const isFailed = job.status === "failed";
     const isTerminal =

--- a/crates/rdlp-desktop/src/components/JobMiniCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobMiniCard.tsx
@@ -2,7 +2,7 @@
 // Click switches to Queue view and selects the job.
 
 import { setView, setSelectedJob } from "@/stores/uiStore";
-import { cn } from "@/lib/utils";
+import { cn, displayTitle } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 interface JobMiniCardProps {
@@ -12,7 +12,7 @@ interface JobMiniCardProps {
 
 export function JobMiniCard({ job, className }: JobMiniCardProps) {
     const progress = job.progress ?? 0;
-    const title = job.title ?? job.url;
+    const title = displayTitle(job.title);
     const isRunning = job.status === "running";
     const isPending = job.status === "pending";
 

--- a/crates/rdlp-desktop/src/lib/utils.test.ts
+++ b/crates/rdlp-desktop/src/lib/utils.test.ts
@@ -2,7 +2,7 @@
 // Unit tests for lib/utils.ts — cn() and parseUploadTimestamp().
 
 import { describe, test, expect } from "vitest";
-import { cn, parseUploadTimestamp } from "./utils";
+import { cn, displayTitle, parseUploadTimestamp, TITLE_PLACEHOLDER } from "./utils";
 
 // ---------------------------------------------------------------------------
 // cn()
@@ -91,5 +91,42 @@ describe("parseUploadTimestamp", () => {
         const d = parseUploadTimestamp("  20230101  ");
         expect(d).not.toBeNull();
         expect(d!.getFullYear()).toBe(2023);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// displayTitle()
+// ---------------------------------------------------------------------------
+
+describe("displayTitle", () => {
+    test("returns trimmed title for non-empty input", () => {
+        expect(displayTitle("My Video")).toBe("My Video");
+        expect(displayTitle("  Padded  ")).toBe("Padded");
+    });
+
+    test("returns placeholder for null", () => {
+        expect(displayTitle(null)).toBe(TITLE_PLACEHOLDER);
+    });
+
+    test("returns placeholder for undefined", () => {
+        expect(displayTitle(undefined)).toBe(TITLE_PLACEHOLDER);
+    });
+
+    test("returns placeholder for empty string", () => {
+        // godresource regression: API returns title:null, plugin's
+        // _real_extract sets `'title': ''` — must surface as "Unknown".
+        expect(displayTitle("")).toBe(TITLE_PLACEHOLDER);
+    });
+
+    test("returns placeholder for whitespace-only string", () => {
+        expect(displayTitle("   ")).toBe(TITLE_PLACEHOLDER);
+        expect(displayTitle("\t\n")).toBe(TITLE_PLACEHOLDER);
+    });
+
+    test("placeholder text is 'Unknown'", () => {
+        // Locked in so a future rename of the constant doesn't silently
+        // change what users see; rename here too if you change the
+        // shared placeholder.
+        expect(TITLE_PLACEHOLDER).toBe("Unknown");
     });
 });

--- a/crates/rdlp-desktop/src/lib/utils.ts
+++ b/crates/rdlp-desktop/src/lib/utils.ts
@@ -40,3 +40,32 @@ export function parseUploadTimestamp(value: string): Date | null {
 
     return null;
 }
+
+
+/**
+ * Placeholder text rendered in the GUI when an extractor produces an
+ * empty/null/whitespace-only title. Single source of truth so JobCard,
+ * MediaHero, HistoryView etc. don't drift apart on labelling.
+ *
+ * Surfaced by the godresource port: API returned `title: null`, the
+ * shim's `_real_extract` wrote `'title': ''`, and the backend's
+ * template renderer (after the empty-string-as-missing fix) maps that
+ * to either the `|default` pipe or "NA". For the UI we use the same
+ * placeholder text everywhere so users see consistent language.
+ */
+export const TITLE_PLACEHOLDER = "Unknown";
+
+/**
+ * Normalise a title-like string for display. Returns `TITLE_PLACEHOLDER`
+ * when the input is null, undefined, empty, or whitespace-only —
+ * matching the backend's empty-string-as-missing semantics. Use at
+ * every render site that displays a video/playlist title.
+ *
+ * @param title - The raw title from an `InfoDict` / job state.
+ * @returns The trimmed title if non-blank, otherwise `TITLE_PLACEHOLDER`.
+ */
+export function displayTitle(title: string | null | undefined): string {
+    if (title == null) return TITLE_PLACEHOLDER;
+    const trimmed = title.trim();
+    return trimmed.length === 0 ? TITLE_PLACEHOLDER : trimmed;
+}

--- a/crates/rdlp-desktop/src/views/analyze/MediaHero.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/MediaHero.tsx
@@ -4,6 +4,7 @@
 import { Thumbnail } from "@/components/Thumbnail";
 import { StreamBadge } from "@/components/StreamBadge";
 import type { FormatListResponse, FormatInfo } from "@/types";
+import { displayTitle } from "@/lib/utils";
 
 interface MediaHeroProps {
     data: FormatListResponse;
@@ -50,7 +51,7 @@ export function MediaHero({ data, url }: MediaHeroProps) {
             <div className="w-20 h-[52px] shrink-0 rounded-[4px] overflow-hidden bg-[#0e0e1e]">
                 <Thumbnail
                     src={data.thumbnail_url}
-                    alt={isPlaylist ? (data.playlist?.title ?? data.title) : data.title}
+                    alt={isPlaylist ? displayTitle(data.playlist?.title) : displayTitle(data.title)}
                     className="w-full h-full object-cover"
                 />
             </div>
@@ -67,8 +68,8 @@ export function MediaHero({ data, url }: MediaHeroProps) {
                     }}
                 >
                     {isPlaylist
-                        ? (data.playlist?.title ?? "Untitled Playlist")
-                        : (data.title || "Untitled")}
+                        ? (data.playlist?.title?.trim() || "Unknown Playlist")
+                        : displayTitle(data.title)}
                 </h1>
 
                 <div className="flex items-center gap-2 flex-wrap mt-0.5">

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -298,7 +298,14 @@ impl Default for Config {
         Self {
             // Output options
             output_to_stdout: false,
-            output_template: "%(title)s.%(ext)s".to_string(),
+            // yt-dlp parity. The pipe-default + ID suffix protects
+            // against extractors that produce empty/null titles
+            // (e.g. godresource API returning `title: null`) — without
+            // the fallback, the filename is `.mp4` (sanitised to `mp4`)
+            // and downloads from the same extractor collide on stem.
+            // The bracketed `[id]` suffix is always present so even
+            // anonymous URLs land at distinguishable paths.
+            output_template: "%(title|Unknown)s [%(id)s].%(ext)s".to_string(),
             output_directory: PathBuf::from("."),
             restrict_filenames: false,
             overwrite: false,

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -7,7 +7,7 @@ use crate::container::ContainerFormat;
 #[test]
 fn test_default_config() {
     let config = Config::default();
-    assert_eq!(config.output_template, "%(title)s.%(ext)s");
+    assert_eq!(config.output_template, "%(title|Unknown)s [%(id)s].%(ext)s");
     assert!(config.format.is_none());
     assert!(config.continue_downloads);
     assert_eq!(config.concurrent_fragments, 4);


### PR DESCRIPTION
Closes Tasks 35 + 39. Coupled because the template change relies on the renderer fix to actually substitute its pipe-default.

## The bug

godresource port surfaced two paired defects on a single download flow:

1. **Backend renderer** treated empty strings as values, not as missing fields. `lookup_field` returned `Some("")` so the `|default` pipe-fallback never fired. Filename rendered as `.mp4` (sanitised to `mp4`), then HLS auto-remux flipped to `.mkv` → on-disk filename `mp4.mkv`.
2. **Frontend job views** rendered `job.title` directly — empty string → blank line, plus three different fallback strategies (URL / "Untitled" / nothing) across JobCard / MediaHero / JobMiniCard.

## Fix

### Backend
- `template/render.rs`: new module-private `is_missing(value)` helper; `lookup_field` now treats null + empty + whitespace-only as missing.
- `rdlp-types/src/config.rs`: default template `%(title)s.%(ext)s` → `%(title|Unknown)s [%(id)s].%(ext)s`. yt-dlp parity, and the `[id]` suffix means same-title or empty-title extracts land at distinguishable paths.

### Desktop
- New `displayTitle()` + `TITLE_PLACEHOLDER` in `lib/utils.ts`. Single source of truth.
- `JobCard`, `JobMiniCard`, `MediaHero` (single + playlist modes) all route through it. Standardises on "Unknown" everywhere.

## Tests

| Surface | Tests added | Tests updated |
|---|---|---|
| Backend `tests_render` | 3 (empty triggers pipe-default; empty no-default → NA; whitespace) | — |
| Backend `orchestrator/tests` | — | 4 (new default's `[id]` suffix) |
| Backend `config_tests` | — | 3 (default-template assertion) |
| Frontend `utils.test.ts` | 6 (non-empty, null, undefined, empty, whitespace, placeholder text locked) | — |
| Frontend `JobCard.test.tsx` | 1 (empty-string companion) | 1 (URL → "Unknown" fallback) |

## Verification

- `cargo test --workspace`: all green
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `npx tsc --noEmit`: clean
- Vitest: 131/131 pass

## Test plan

- [ ] CI Lint
- [ ] CI Build & Test (3 platforms)
- [ ] CI Run Golden Build (path filter — should skip; no WIT/shim changes)
- [ ] Manual: download a godresource video; confirm filename is `Unknown [<id>].mkv` (not `mp4.mkv`); confirm GUI Jobs row shows "Unknown" not blank.