### PR TITLE
fix(cli): hoist browser env-var test guard to module scope (Windows CI race)

### DIFF
--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -485,9 +485,22 @@ fn test_merge_config_normal_output_not_stdout() {
 }
 
 // === Browser emulation tests ===
+//
+// `merge_config` reads `RDLP_BROWSER_EMULATION` when `args.browser` is None.
+// `test_merge_config_browser_env_fallback` mutates that env var, so any other
+// test that reads it must take the same lock. The guard is module-scoped so
+// the racing tests can share it (a function-local static is unreachable from
+// other functions and was the source of the prior Windows-CI flake).
+static BROWSER_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
 fn test_merge_config_browser_default_is_chrome_latest() {
+    // Reads RDLP_BROWSER_EMULATION via merge_config; serialise against the
+    // env-fallback test that mutates the same var.
+    let _guard = BROWSER_ENV_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let args = default_args();
     let config =
         merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
@@ -529,19 +542,14 @@ fn test_merge_config_browser_cli_flag_pinned() {
 #[test]
 fn test_merge_config_browser_env_fallback() {
     // CLI flag absent; env var should drive the value.
-    // NOTE: this test mutates process-global env vars, so it must be
-    // serialised against any other test that reads RDLP_BROWSER_EMULATION.
-    // Guard with a local lock to avoid cross-test flakiness under
-    // `cargo test`'s default parallel runner.
-    use std::sync::Mutex;
-    static ENV_GUARD: Mutex<()> = Mutex::new(());
-    let _guard = ENV_GUARD
+    // Serialised against the default-value test that also reads this var.
+    let _guard = BROWSER_ENV_GUARD
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-    // SAFETY: `cargo test` runs tests in threads; we serialise env mutation
-    // via the Mutex above, and the other test that reads this var takes
-    // the same guard.
+    // SAFETY: `cargo test` runs tests in threads; the module-scoped
+    // BROWSER_ENV_GUARD serialises every test that reads or writes
+    // RDLP_BROWSER_EMULATION.
     unsafe {
         std::env::set_var("RDLP_BROWSER_EMULATION", "safari-latest");
     }


### PR DESCRIPTION
## Summary
- `test_merge_config_browser_env_fallback` declared its `Mutex` guard inside the function body. The static was therefore unreachable from sibling tests, so `test_merge_config_browser_default_is_chrome_latest` read `RDLP_BROWSER_EMULATION` via `merge_config` *without* taking the lock.
- On Windows, parallel scheduling let the default-test observe the env var mid-mutation and fail `assert!(matches!(_, ChromeLatest))` (saw `SafariLatest` instead). Reliably reproducible on develop CI, hidden on Linux/macOS by scheduling luck.
- Fix: hoist `BROWSER_ENV_GUARD` to module scope; both racing tests acquire it.

Caught when develop CI ran post-PR-#227 (run [25229552381](https://github.com/crippledgeek/rdlp/actions/runs/25229552381)) — failure was not introduced by #227, just exposed by the next push.

## Why module-scope Mutex (not serial_test / temp-env)
- Canonical Rust pattern per [rust-lang/rust#43155](https://github.com/rust-lang/rust/issues/43155).
- Function-local statics are unreachable from sibling functions — that *is* the bug here.
- `serial_test` / `temp-env` would solve it more rigorously but pull in new test deps; out of scope for this hotfix.

## No paired regression test
Race-condition fixes that depend on wall-clock thread scheduling are documented as exempt by the bug-fix-requires-failing-test rule. The original test (`test_merge_config_browser_default_is_chrome_latest`) IS the regression guard — once the guard is in place, it stops racing.

## Test plan
- [x] `cargo test -p rdlp-cli test_merge_config_browser` — all 4 tests pass locally
- [x] `cargo clippy -p rdlp-cli --all-targets -- -D warnings` clean
- [ ] Windows CI passes on this PR (the failing platform)