### PR TITLE
test: migrate env-var-mutating tests to temp-env crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5886,6 +5886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5921,6 +5922,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -7952,6 +7954,15 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ hex = "0.4"
 
 # Testing
 mockito = "1.5"
+temp-env = "0.3"
 tempfile = "3.14"
 
 [workspace.lints.clippy]

--- a/crates/rdlp-api/Cargo.toml
+++ b/crates/rdlp-api/Cargo.toml
@@ -45,6 +45,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+temp-env = { workspace = true }
 tempfile = { workspace = true }
 proptest = "1.4"
 mockito = "1.7"

--- a/crates/rdlp-api/tests/plugin_bootstrap_fail_soft.rs
+++ b/crates/rdlp-api/tests/plugin_bootstrap_fail_soft.rs
@@ -14,67 +14,72 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::disallowed_methods,
-    missing_docs,
-    unsafe_code, // integration test uses set_var to isolate XDG dirs from user config
+    missing_docs
 )]
 
 use rdlp_api::RdlpClient;
 use rdlp_types::Config;
 
-fn isolate_xdg(tempdir: &std::path::Path) {
-    // SAFETY: tests in this crate run with cargo's default scheduling.
-    // The env vars are scoped to the process and the tempdir outlives this
-    // function. We do this so the bootstrap doesn't write trust state into
-    // the user's real ~/.config/rdlp.
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", tempdir);
-        std::env::set_var("HOME", tempdir);
-    }
+/// Run `f` with XDG_CONFIG_HOME and HOME both pointing at a fresh tempdir.
+///
+/// This prevents the bootstrap from reading or writing trust state into the
+/// user's real `~/.config/rdlp`. temp-env's internal mutex serialises against
+/// any other test that reads or writes these vars. The tempdir is cleaned up
+/// when the closure returns.
+fn with_isolated_xdg<F: FnOnce(&std::path::Path)>(f: F) {
+    let tmp = tempfile::TempDir::new().expect("tempdir creation");
+    let path_str = tmp.path().to_str().expect("tempdir path is utf-8");
+    temp_env::with_vars(
+        [
+            ("XDG_CONFIG_HOME", Some(path_str)),
+            ("HOME", Some(path_str)),
+        ],
+        || f(tmp.path()),
+    );
 }
 
 #[test]
 fn malformed_plugin_toml_does_not_break_client() {
-    let tempdir = tempfile::tempdir().unwrap();
-    isolate_xdg(tempdir.path());
+    with_isolated_xdg(|tmpdir| {
+        // Drop a directory that *looks* like a plugin but has a syntactically
+        // invalid manifest. Bootstrap should warn-and-skip, not propagate.
+        let plug_dir = tmpdir.join("plugins").join("broken");
+        std::fs::create_dir_all(&plug_dir).unwrap();
+        std::fs::write(
+            plug_dir.join("plugin.toml"),
+            "this = is = not = valid = toml",
+        )
+        .unwrap();
+        std::fs::write(plug_dir.join("plugin.wasm"), b"not actual wasm").unwrap();
 
-    // Drop a directory that *looks* like a plugin but has a syntactically
-    // invalid manifest. Bootstrap should warn-and-skip, not propagate.
-    let plug_dir = tempdir.path().join("plugins").join("broken");
-    std::fs::create_dir_all(&plug_dir).unwrap();
-    std::fs::write(
-        plug_dir.join("plugin.toml"),
-        "this = is = not = valid = toml",
-    )
-    .unwrap();
-    std::fs::write(plug_dir.join("plugin.wasm"), b"not actual wasm").unwrap();
+        let config = Config {
+            progress: false,
+            plugin_directories: vec![tmpdir.join("plugins")],
+            ..Default::default()
+        };
 
-    let config = Config {
-        progress: false,
-        plugin_directories: vec![tempdir.path().join("plugins")],
-        ..Default::default()
-    };
-
-    let client = RdlpClient::new(config).expect("client must build despite broken plugin");
-    let names = client.list_extractors();
-    // Built-ins must be present and the broken plugin must not be.
-    assert!(names.contains(&"Generic"));
-    assert!(!names.contains(&"broken"));
+        let client = RdlpClient::new(config).expect("client must build despite broken plugin");
+        let names = client.list_extractors();
+        // Built-ins must be present and the broken plugin must not be.
+        assert!(names.contains(&"Generic"));
+        assert!(!names.contains(&"broken"));
+    });
 }
 
 #[test]
 fn missing_plugin_dir_does_not_break_client() {
-    let tempdir = tempfile::tempdir().unwrap();
-    isolate_xdg(tempdir.path());
-    let nonexistent = tempdir.path().join("does-not-exist");
+    with_isolated_xdg(|tmpdir| {
+        let nonexistent = tmpdir.join("does-not-exist");
 
-    let config = Config {
-        progress: false,
-        plugin_directories: vec![nonexistent],
-        ..Default::default()
-    };
+        let config = Config {
+            progress: false,
+            plugin_directories: vec![nonexistent],
+            ..Default::default()
+        };
 
-    let client = RdlpClient::new(config).expect("client must build with missing plugin dir");
-    assert!(client.list_extractors().contains(&"Generic"));
+        let client = RdlpClient::new(config).expect("client must build with missing plugin dir");
+        assert!(client.list_extractors().contains(&"Generic"));
+    });
 }
 
 #[test]
@@ -82,32 +87,32 @@ fn corrupted_disabled_list_blocks_bootstrap() {
     // Inverse of fail-soft: a corrupted disabled-plugins TOML MUST be
     // surfaced loudly. Silently treating it as empty would silently
     // re-enable any previously-blocked plugin (security regression).
-    let tempdir = tempfile::tempdir().unwrap();
-    isolate_xdg(tempdir.path());
-    let rdlp_dir = tempdir.path().join("rdlp");
-    std::fs::create_dir_all(&rdlp_dir).unwrap();
-    std::fs::write(
-        rdlp_dir.join("plugin-disabled.toml"),
-        "this = is = not = valid",
-    )
-    .unwrap();
+    with_isolated_xdg(|tmpdir| {
+        let rdlp_dir = tmpdir.join("rdlp");
+        std::fs::create_dir_all(&rdlp_dir).unwrap();
+        std::fs::write(
+            rdlp_dir.join("plugin-disabled.toml"),
+            "this = is = not = valid",
+        )
+        .unwrap();
 
-    let plug_dir = tempdir.path().join("plugins");
-    std::fs::create_dir_all(&plug_dir).unwrap();
+        let plug_dir = tmpdir.join("plugins");
+        std::fs::create_dir_all(&plug_dir).unwrap();
 
-    let config = Config {
-        progress: false,
-        plugin_directories: vec![plug_dir],
-        ..Default::default()
-    };
+        let config = Config {
+            progress: false,
+            plugin_directories: vec![plug_dir],
+            ..Default::default()
+        };
 
-    // RdlpClient::new currently returns Ok with an empty plugin set when
-    // bootstrap fails (fail-soft at the top level), but the inner
-    // `bootstrap_plugins` returns Err for this case so the WARN log fires.
-    // We assert client construction succeeds AND the broken disabled list
-    // does NOT silently let plugins through. With no plugin dirs to load
-    // here, the test only confirms the corrupted-disabled-list path
-    // doesn't panic and still builds the client with built-ins.
-    let client = RdlpClient::new(config).expect("client builds (fail-soft top-level)");
-    assert!(client.list_extractors().contains(&"Generic"));
+        // RdlpClient::new currently returns Ok with an empty plugin set when
+        // bootstrap fails (fail-soft at the top level), but the inner
+        // `bootstrap_plugins` returns Err for this case so the WARN log fires.
+        // We assert client construction succeeds AND the broken disabled list
+        // does NOT silently let plugins through. With no plugin dirs to load
+        // here, the test only confirms the corrupted-disabled-list path
+        // doesn't panic and still builds the client with built-ins.
+        let client = RdlpClient::new(config).expect("client builds (fail-soft top-level)");
+        assert!(client.list_extractors().contains(&"Generic"));
+    });
 }

--- a/crates/rdlp-api/tests/plugin_dispatch_regression.rs
+++ b/crates/rdlp-api/tests/plugin_dispatch_regression.rs
@@ -6,8 +6,7 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::disallowed_methods,
-    missing_docs,
-    unsafe_code, // integration test uses set_var to isolate XDG dirs from user config
+    missing_docs
 )]
 
 //! Regression test for the plugin dispatch wiring bug.
@@ -51,27 +50,31 @@ fn list_extractors_includes_loaded_plugin() {
     }
 
     let tempdir = tempfile::tempdir().expect("tempdir");
+    let path_str = tempdir.path().to_str().expect("tempdir path is utf-8");
+
     // Isolate the trust store from any pre-existing global state. The bootstrap
     // resolves the trust store via dirs::config_dir() → XDG_CONFIG_HOME → HOME.
     // Pointing all three at the tempdir guarantees a clean slate.
-    // SAFETY: tests run with --test-threads=1 in this crate by default; the env
-    // vars are scoped to this process and tempdir lives until the test exits.
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", tempdir.path());
-        std::env::set_var("HOME", tempdir.path());
-    }
-    let plugin_dir = tempdir.path().join("example");
-    std::fs::create_dir_all(&plugin_dir).unwrap();
+    // temp-env's internal mutex serialises this against any other test that
+    // reads or writes these vars.
+    temp_env::with_vars(
+        [
+            ("XDG_CONFIG_HOME", Some(path_str)),
+            ("HOME", Some(path_str)),
+        ],
+        || {
+            let plugin_dir = tempdir.path().join("example");
+            std::fs::create_dir_all(&plugin_dir).unwrap();
 
-    let wasm_bytes = std::fs::read(&wasm_src).expect("read example wasm");
-    std::fs::write(plugin_dir.join("plugin.wasm"), &wasm_bytes).unwrap();
+            let wasm_bytes = std::fs::read(&wasm_src).expect("read example wasm");
+            std::fs::write(plugin_dir.join("plugin.wasm"), &wasm_bytes).unwrap();
 
-    let signing_key: SigningKey = SigningKey::generate(&mut OsRng);
-    let pubkey_b64 =
-        base64::engine::general_purpose::STANDARD.encode(signing_key.verifying_key().as_bytes());
+            let signing_key: SigningKey = SigningKey::generate(&mut OsRng);
+            let pubkey_b64 = base64::engine::general_purpose::STANDARD
+                .encode(signing_key.verifying_key().as_bytes());
 
-    let template = format!(
-        r#"name = "example"
+            let template = format!(
+                r#"name = "example"
 version = "0.1.0"
 wit_version = "0.1.0"
 matches = ["https://example.com/video/*"]
@@ -86,36 +89,38 @@ type = "ed25519"
 pubkey = "{pubkey_b64}"
 signature = "PLACEHOLDER"
 "#
-    );
+            );
 
-    let manifest = parse_manifest_str(&template.replace("PLACEHOLDER", "AAAA")).unwrap();
-    let mut to_sign = canonical_bytes(&manifest);
-    to_sign.extend_from_slice(&wasm_bytes);
-    let sig = signing_key.sign(&to_sign);
-    let sig_b64 = base64::engine::general_purpose::STANDARD.encode(sig.to_bytes());
-    let final_toml = template.replace("PLACEHOLDER", &sig_b64);
+            let manifest = parse_manifest_str(&template.replace("PLACEHOLDER", "AAAA")).unwrap();
+            let mut to_sign = canonical_bytes(&manifest);
+            to_sign.extend_from_slice(&wasm_bytes);
+            let sig = signing_key.sign(&to_sign);
+            let sig_b64 = base64::engine::general_purpose::STANDARD.encode(sig.to_bytes());
+            let final_toml = template.replace("PLACEHOLDER", &sig_b64);
 
-    std::fs::write(plugin_dir.join("plugin.toml"), final_toml).unwrap();
+            std::fs::write(plugin_dir.join("plugin.toml"), final_toml).unwrap();
 
-    // Pre-trust the publisher so the loader's prompter approves the plugin
-    // without interactive input. Identity must match
-    // `Signature::identity_string()` exactly, which is `ed25519:<hex of full
-    // SHA-256 over the base64-encoded pubkey>` post-MVP-hardening.
-    use sha2::{Digest, Sha256};
-    let pub_hash_hex = hex::encode(Sha256::digest(pubkey_b64.as_bytes()));
-    let identity = format!("ed25519:{pub_hash_hex}");
+            // Pre-trust the publisher so the loader's prompter approves the plugin
+            // without interactive input. Identity must match
+            // `Signature::identity_string()` exactly, which is `ed25519:<hex of full
+            // SHA-256 over the base64-encoded pubkey>` post-MVP-hardening.
+            use sha2::{Digest, Sha256};
+            let pub_hash_hex = hex::encode(Sha256::digest(pubkey_b64.as_bytes()));
+            let identity = format!("ed25519:{pub_hash_hex}");
 
-    let config = Config {
-        progress: false,
-        plugin_directories: vec![tempdir.path().to_path_buf()],
-        plugin_trusted_publishers: vec![identity.clone()],
-        ..Default::default()
-    };
+            let config = Config {
+                progress: false,
+                plugin_directories: vec![tempdir.path().to_path_buf()],
+                plugin_trusted_publishers: vec![identity.clone()],
+                ..Default::default()
+            };
 
-    let client = RdlpClient::new(config).expect("client");
-    let extractors = client.list_extractors();
-    assert!(
-        extractors.contains(&"example"),
-        "expected `example` plugin in list_extractors() output, got: {extractors:?}"
+            let client = RdlpClient::new(config).expect("client");
+            let extractors = client.list_extractors();
+            assert!(
+                extractors.contains(&"example"),
+                "expected `example` plugin in list_extractors() output, got: {extractors:?}"
+            );
+        },
     );
 }

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -44,6 +44,7 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.4"
+temp-env = { workspace = true }
 tempfile = "3.24"
 mockito = "1.7"
 wiremock = "0.6"
@@ -61,8 +62,6 @@ rdlp-plugin-manifest = { path = "../rdlp-plugin-manifest" }
 
 [lints.rust]
 missing_docs = "warn"
-# config_tests.rs uses std::env::set_var in a test (with SAFETY comment and
-# mutex serialisation). unsafe_code is not forbidden here.
 
 [lints.clippy]
 # Workspace baseline (replicated — cannot use workspace = true alongside

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -487,28 +487,23 @@ fn test_merge_config_normal_output_not_stdout() {
 // === Browser emulation tests ===
 //
 // `merge_config` reads `RDLP_BROWSER_EMULATION` when `args.browser` is None.
-// `test_merge_config_browser_env_fallback` mutates that env var, so any other
-// test that reads it must take the same lock. The guard is module-scoped so
-// the racing tests can share it (a function-local static is unreachable from
-// other functions and was the source of the prior Windows-CI flake).
-static BROWSER_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+// temp-env's singleton mutex serialises all tests that read or write this var;
+// no per-module guard is needed.
 
 #[test]
 fn test_merge_config_browser_default_is_chrome_latest() {
-    // Reads RDLP_BROWSER_EMULATION via merge_config; serialise against the
-    // env-fallback test that mutates the same var.
-    let _guard = BROWSER_ENV_GUARD
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-    let args = default_args();
-    let config =
-        merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
-
-    assert!(matches!(
-        config.browser_emulation,
-        rdlp_api::BrowserEmulation::ChromeLatest
-    ));
+    // temp-env's singleton mutex serialises against any other test that
+    // reads or writes RDLP_BROWSER_EMULATION; the var is unset for the
+    // duration of the closure.
+    temp_env::with_var_unset("RDLP_BROWSER_EMULATION", || {
+        let args = default_args();
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+        assert!(matches!(
+            config.browser_emulation,
+            rdlp_api::BrowserEmulation::ChromeLatest
+        ));
+    });
 }
 
 #[test]
@@ -541,29 +536,17 @@ fn test_merge_config_browser_cli_flag_pinned() {
 
 #[test]
 fn test_merge_config_browser_env_fallback() {
-    // CLI flag absent; env var should drive the value.
-    // Serialised against the default-value test that also reads this var.
-    let _guard = BROWSER_ENV_GUARD
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-    // SAFETY: `cargo test` runs tests in threads; the module-scoped
-    // BROWSER_ENV_GUARD serialises every test that reads or writes
-    // RDLP_BROWSER_EMULATION.
-    unsafe {
-        std::env::set_var("RDLP_BROWSER_EMULATION", "safari-latest");
-    }
-    let args = default_args();
-    let config =
-        merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
-    unsafe {
-        std::env::remove_var("RDLP_BROWSER_EMULATION");
-    }
-
-    assert!(matches!(
-        config.browser_emulation,
-        rdlp_api::BrowserEmulation::SafariLatest
-    ));
+    // CLI flag absent; env var should drive the value. temp-env's
+    // singleton mutex serialises against the default-test reader.
+    temp_env::with_var("RDLP_BROWSER_EMULATION", Some("safari-latest"), || {
+        let args = default_args();
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+        assert!(matches!(
+            config.browser_emulation,
+            rdlp_api::BrowserEmulation::SafariLatest
+        ));
+    });
 }
 
 // === Proxy hard-fail negatives ===

--- a/crates/rdlp-cli/tests/plugin_cmd.rs
+++ b/crates/rdlp-cli/tests/plugin_cmd.rs
@@ -18,25 +18,22 @@
 use rdlp_plugin::disabled_list::read_disabled_list;
 use rdlp_plugin::manifest::validate_plugin_name;
 use rdlp_types::Config;
-use std::sync::{Mutex, MutexGuard, OnceLock};
 
-/// Shared lock — XDG_CONFIG_HOME is process-global, so tests that set it
-/// must serialize. The lock is also held across the test body so a
-/// concurrent test can't yank the env var out from under us.
-fn xdg_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-}
-
-fn isolate_xdg(tempdir: &std::path::Path) {
-    // SAFETY: caller holds `xdg_lock` for the test body; tempdir outlives
-    // the test.
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", tempdir);
-        std::env::set_var("HOME", tempdir);
-    }
+/// Run `f` with XDG_CONFIG_HOME and HOME both pointing at a fresh tempdir,
+/// then pass the tempdir path into the closure.
+///
+/// temp-env's internal mutex serialises against any other test that reads or
+/// writes these vars — no per-test `OnceLock<Mutex<()>>` guard is needed.
+fn with_isolated_xdg<F: FnOnce(&std::path::Path)>(f: F) {
+    let tmp = tempfile::TempDir::new().expect("tempdir creation");
+    let path_str = tmp.path().to_str().expect("tempdir path is utf-8");
+    temp_env::with_vars(
+        [
+            ("XDG_CONFIG_HOME", Some(path_str)),
+            ("HOME", Some(path_str)),
+        ],
+        || f(tmp.path()),
+    );
 }
 
 #[test]
@@ -83,60 +80,59 @@ fn validate_plugin_name_rejects_empty_and_oversize() {
 
 #[test]
 fn disable_then_enable_round_trips() {
-    let _guard = xdg_lock();
-    let tempdir = tempfile::tempdir().unwrap();
-    isolate_xdg(tempdir.path());
+    with_isolated_xdg(|tmpdir| {
+        // Each test sets its own tempdir and observes only its own state — no
+        // cross-test dependency on the env var value.
+        let _ = tmpdir; // XDG vars already set by with_isolated_xdg
 
-    rdlp_cli::plugin_cmd::run_disable("plugin-a").unwrap();
-    rdlp_cli::plugin_cmd::run_disable("plugin-b").unwrap();
-    let path = rdlp_cli::plugin_cmd::disabled_list_path().unwrap();
-    let list = read_disabled_list(&path).expect("read disabled list");
-    assert!(list.contains(&"plugin-a".to_string()));
-    assert!(list.contains(&"plugin-b".to_string()));
+        rdlp_cli::plugin_cmd::run_disable("plugin-a").unwrap();
+        rdlp_cli::plugin_cmd::run_disable("plugin-b").unwrap();
+        let path = rdlp_cli::plugin_cmd::disabled_list_path().unwrap();
+        let list = read_disabled_list(&path).expect("read disabled list");
+        assert!(list.contains(&"plugin-a".to_string()));
+        assert!(list.contains(&"plugin-b".to_string()));
 
-    rdlp_cli::plugin_cmd::run_enable("plugin-a").unwrap();
-    let list = read_disabled_list(&path).expect("read disabled list");
-    assert!(!list.contains(&"plugin-a".to_string()));
-    assert!(list.contains(&"plugin-b".to_string()));
+        rdlp_cli::plugin_cmd::run_enable("plugin-a").unwrap();
+        let list = read_disabled_list(&path).expect("read disabled list");
+        assert!(!list.contains(&"plugin-a".to_string()));
+        assert!(list.contains(&"plugin-b".to_string()));
+    });
 }
 
 #[test]
 fn run_uninstall_rejects_path_traversal_name() {
-    let _guard = xdg_lock();
-    let tempdir = tempfile::tempdir().unwrap();
-    isolate_xdg(tempdir.path());
-    let plugin_dir = tempdir.path().join("plugins");
-    std::fs::create_dir_all(&plugin_dir).unwrap();
-    let config = Config {
-        progress: false,
-        plugin_directories: vec![plugin_dir.clone()],
-        ..Default::default()
-    };
+    with_isolated_xdg(|tmpdir| {
+        let plugin_dir = tmpdir.join("plugins");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let config = Config {
+            progress: false,
+            plugin_directories: vec![plugin_dir.clone()],
+            ..Default::default()
+        };
 
-    // Marker file we will assert is NOT touched by a malicious name.
-    let canary = tempdir.path().join("canary.txt");
-    std::fs::write(&canary, "must survive").unwrap();
+        // Marker file we will assert is NOT touched by a malicious name.
+        let canary = tmpdir.join("canary.txt");
+        std::fs::write(&canary, "must survive").unwrap();
 
-    let err = rdlp_cli::plugin_cmd::run_uninstall("../canary.txt", &config)
-        .expect_err("uninstall must reject traversal name");
-    let msg = format!("{err:#}");
-    assert!(
-        msg.contains("invalid plugin name"),
-        "expected name-validation error, got: {msg}"
-    );
-    assert!(canary.exists(), "canary file MUST NOT be deleted");
+        let err = rdlp_cli::plugin_cmd::run_uninstall("../canary.txt", &config)
+            .expect_err("uninstall must reject traversal name");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("invalid plugin name"),
+            "expected name-validation error, got: {msg}"
+        );
+        assert!(canary.exists(), "canary file MUST NOT be deleted");
+    });
 }
 
 #[test]
 fn run_disable_rejects_invalid_name() {
-    let _guard = xdg_lock();
-    let tempdir = tempfile::tempdir().unwrap();
-    isolate_xdg(tempdir.path());
-
-    for bad in ["..", "/abs", "Capital", "a b"] {
-        let err = rdlp_cli::plugin_cmd::run_disable(bad)
-            .expect_err(&format!("disable must reject {bad:?}"));
-        let msg = format!("{err:#}");
-        assert!(msg.contains("invalid plugin name"));
-    }
+    with_isolated_xdg(|_tmpdir| {
+        for bad in ["..", "/abs", "Capital", "a b"] {
+            let err = rdlp_cli::plugin_cmd::run_disable(bad)
+                .expect_err(&format!("disable must reject {bad:?}"));
+            let msg = format!("{err:#}");
+            assert!(msg.contains("invalid plugin name"));
+        }
+    });
 }


### PR DESCRIPTION
## Summary

Replaces 4 separate raw `unsafe { std::env::set_var/remove_var }` sites across 3 crates with `temp_env::with_var` / `with_vars` closures.

Also delivers the audit promised in the static-selector follow-up tracker (project task #17): no test was depending on the racing behaviour.

## Why

- **Single mutex covers everything.** `temp_env`'s internal `parking_lot::Mutex` serialises every test that wraps its work in a `temp_env::with_var*` closure. No more per-binary module-static guards (PR #228's hotfix — now removed).
- **RAII auto-restore on panic.** Closure exit always restores the env, even if the test panics. No `remove_var` orphans.
- **Safe public API.** `temp_env`'s closure form is not `unsafe` — the `unsafe { set_var }` is encapsulated inside the crate. The `unsafe_code` lint exceptions for these integration tests are removed.

## Sites migrated

- `crates/rdlp-cli/src/config_tests.rs` — RDLP_BROWSER_EMULATION (drops the `BROWSER_ENV_GUARD` module-Mutex from PR #228).
- `crates/rdlp-api/tests/plugin_bootstrap_fail_soft.rs` — XDG_CONFIG_HOME + HOME via `with_isolated_xdg(|path| { ... })` callback helper.
- `crates/rdlp-api/tests/plugin_dispatch_regression.rs` — same closure form.
- `crates/rdlp-cli/tests/plugin_cmd.rs` — same callback helper, dropping the `OnceLock<Mutex<()>>` xdg_lock.

## Audit (project task #17)

Per file, every test that set XDG vars used its own fresh `tempfile::TempDir` and only operated on its own path. The old manual `OnceLock<Mutex<()>> + isolate_xdg` pattern was guard-then-mutate, but the guard correctly serialised the tests — no test ever read another test's tempdir. The new closure form is strictly better: each invocation gets its own temp dir, vars are set + restored atomically, and the tempdir is deleted when the closure exits.

## Test plan

- [x] `grep -rn "set_var\|remove_var" --include="*.rs" crates/ | grep -v temp_env` → empty (no remaining raw env mutation in the workspace)
- [x] `cargo test --workspace` — all test result lines `0 failed`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Stress run: `for i in 1 2 3 4 5; do cargo test -p rdlp-cli test_merge_config_browser; done` — 5/5 clean (4 tests each)

## References

- Closes the env-var follow-up from PR #228 (Mutex hotfix → temp-env structural fix).
- [temp-env docs](https://docs.rs/temp-env/latest/temp_env/)
- [std::env::set_var safety](https://doc.rust-lang.org/std/env/fn.set_var.html) — `unsafe` since Rust 1.85
- [rust-lang/rust#43155](https://github.com/rust-lang/rust/issues/43155) — Mutex serialisation pattern