### PR TITLE
feat(dash): MPEG-DASH protocol support (static VoD)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c6d128af408d8ebd08331f0331cf2cf20d19e6c44a7aec58791641ecc8c0b5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,7 +911,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -943,9 +949,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1560,12 +1566,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1584,11 +1590,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1609,13 +1614,42 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "dash-mpd"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99aa4f01bf47635af7d137707d14665af5603d65fb410a64da42ad949527069c"
+dependencies = [
+ "base64 0.22.1",
+ "base64-serde",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "edit-distance",
+ "futures-util",
+ "hxdmp",
+ "iso8601",
+ "lazy_static",
+ "num-traits",
+ "quick-xml 0.39.2",
+ "regex",
+ "serde",
+ "serde_path_to_error",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "webm-iterable",
+ "xattr",
 ]
 
 [[package]]
@@ -1937,6 +1971,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ebml-iterable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5173ac3752f08b526a6991509615e1a345b221ec3c58c7633433e8c9582312"
+dependencies = [
+ "ebml-iterable-specification",
+ "ebml-iterable-specification-derive",
+ "futures",
+]
+
+[[package]]
+name = "ebml-iterable-specification"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56467af159a98735d44231f53eaa505e919e6003266f103b99649a93f106784"
+
+[[package]]
+name = "ebml-iterable-specification-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b066b81018300fdce40f71c4db355a102699324af96fad28f25ab1b5f87de066"
+dependencies = [
+ "ebml-iterable-specification",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2037,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "edit-distance"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324d428080b707bac399325341bd61af5ded1b30f33b7c949792ca464733c2d5"
 
 [[package]]
 name = "ego-tree"
@@ -3136,6 +3205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hxdmp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b27f28a7466846baca75f0a5244e546e44178eb7f1c07a3820f413e91c6b0"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,6 +3564,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom 8.0.0",
+]
 
 [[package]]
 name = "itertools"
@@ -4021,7 +4105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03cd3335fb5f2447755d45cda9c70f76013626a9db44374973791b0926a86c3"
 dependencies = [
  "chrono",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4266,6 +4350,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5272,7 +5365,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -5637,6 +5730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6021,6 +6124,7 @@ dependencies = [
  "backon",
  "bytes",
  "chrono",
+ "dash-mpd",
  "futures",
  "indicatif",
  "log",
@@ -6028,6 +6132,7 @@ dependencies = [
  "mockito",
  "proptest",
  "rdlp-core",
+ "rdlp-ffmpeg",
  "rdlp-http",
  "rdlp-ratelimit",
  "rdlp-security",
@@ -6035,6 +6140,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -6984,9 +7090,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7003,11 +7109,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -9415,6 +9521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webm-iterable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fbf173b4b38f2f8bbb0082a0d4cb21f263a70811f5fccb1663c421c66d9f9"
+dependencies = [
+ "ebml-iterable",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10228,6 +10343,16 @@ dependencies = [
  "signature",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ scraper = "0.25"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 m3u8-rs = "6.0"  # HLS playlist parser
+dash-mpd = { version = "0.20", default-features = false }  # DASH MPD parser
 
 # Error handling
 anyhow = "1.0"

--- a/crates/rdlp-downloader/Cargo.toml
+++ b/crates/rdlp-downloader/Cargo.toml
@@ -12,6 +12,7 @@ rdlp-http = { path = "../rdlp-http" }
 rdlp-ratelimit = { path = "../rdlp-ratelimit" }
 rdlp-security = { path = "../rdlp-security" }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 wreq = { workspace = true }
@@ -26,6 +27,8 @@ url = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
+dash-mpd = { workspace = true }
+rdlp-ffmpeg = { path = "../rdlp-ffmpeg" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -1,0 +1,1 @@
+//! Parallel segment download + mux. Implementation lands in Tasks 4 and 5.

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -428,7 +428,7 @@ async fn download_representation(
             Ok::<(usize, u64), RdlpError>((i, len))
         }
     }))
-    .buffer_unordered(concurrent);
+    .buffer_unordered(concurrent * 2);
 
     let mut completed_since_save: usize = 0;
     let mut stream_err: Option<RdlpError> = None;

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -1,9 +1,14 @@
 //! DASH download orchestration: MPD fetch + parallel segment fetch + concat
 //! + FFmpeg stream-copy mux into a single output container.
+//!
+//! Resume model: per-segment temp files under `<output>.<suffix>.parts/`,
+//! with init markers and completed-index tracking persisted to
+//! `<output>.dash_state.json`. State is path-only-URL-keyed (CDN-tolerant),
+//! saved every 16 successful segment fetches, and deleted on full mux
+//! success.
 
 #![allow(clippy::doc_markdown)]
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -18,19 +23,26 @@ use rdlp_core::{
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::sync::Mutex;
 use url::Url;
 
 use crate::dash::errors::DashError;
 use crate::dash::manifest;
 use crate::dash::segments::SegmentPlan;
+use crate::dash::state::DashDownloadState;
 use crate::http::HttpDownloader;
+
+/// Number of successful segment fetches between state-save flushes.
+const STATE_SAVE_BATCH: usize = 16;
 
 /// Run a DASH download for `mpd_url` into `output_path`.
 ///
 /// Internally produces `<output>.video.m4s` and (when an audio repr exists)
 /// `<output>.audio.m4s`, then muxes them via FFmpeg stream-copy into
 /// `output_path`. Intermediates are deleted on success and retained on
-/// mux failure for diagnosis.
+/// mux failure for diagnosis. Resume state is tracked under
+/// `<output>.dash_state.json` and pruned on successful mux.
+#[allow(clippy::too_many_lines, clippy::similar_names)]
 pub async fn run(
     http_downloader: &HttpDownloader,
     retry_config: Arc<RetryConfig>,
@@ -73,6 +85,33 @@ pub async fn run(
     let started = Instant::now();
     let bytes_total = Arc::new(AtomicU64::new(0));
 
+    // Resolve all paths up-front.
+    let video_final = intermediate_path(output_path, "video");
+    let audio_final = intermediate_path(output_path, "audio");
+    let video_parts = parts_dir(output_path, "video");
+    let audio_parts = parts_dir(output_path, "audio");
+    let state_file = state_path(output_path);
+
+    let video_repr_id = parsed.video.id.clone();
+    let audio_repr_id = parsed.audio.as_ref().map(|a| a.id.clone());
+
+    // Load matching state, or start fresh.
+    let loaded_state = DashDownloadState::load_matching(
+        &state_file,
+        &mpd_url_parsed,
+        &video_repr_id,
+        audio_repr_id.as_deref(),
+    )
+    .await;
+    let initial_state = loaded_state.unwrap_or_else(|| {
+        DashDownloadState::new(
+            &mpd_url_parsed,
+            video_repr_id.clone(),
+            audio_repr_id.clone(),
+        )
+    });
+    let state_arc = Arc::new(Mutex::new(initial_state));
+
     // Video (always present after parse).
     let video_ts = period_duration_ts(parsed.period_duration, &parsed.video.plan);
     let video_init = parsed.video.plan.init_url(&parsed.video.base_urls);
@@ -86,34 +125,56 @@ pub async fn run(
             url: Some(mpd_url.to_string()),
         });
     }
-    let video_path = intermediate_path(output_path, "video");
     let video_bytes = download_representation(
         http_downloader,
         &retry_config,
         concurrent_segments,
         buffer_size,
-        &parsed.video.id,
+        &video_repr_id,
         video_init,
         video_seg_urls,
-        &video_path,
+        &video_final,
+        &video_parts,
+        Arc::clone(&state_arc),
+        &state_file,
+        true,
         Arc::clone(&bytes_total),
     )
     .await?;
 
     // Audio (optional).
     let has_audio = parsed.audio.is_some();
-    let audio_bytes = download_audio_if_present(
-        http_downloader,
-        &retry_config,
-        concurrent_segments,
-        buffer_size,
-        &parsed,
-        output_path,
-        mpd_url,
-        Arc::clone(&bytes_total),
-    )
-    .await?;
-    let audio_path = intermediate_path(output_path, "audio");
+    let audio_bytes = if let Some(audio_repr) = parsed.audio.as_ref() {
+        let audio_ts = period_duration_ts(parsed.period_duration, &audio_repr.plan);
+        let audio_init = audio_repr.plan.init_url(&audio_repr.base_urls);
+        let audio_seg_urls = audio_repr
+            .plan
+            .segment_urls(&audio_repr.base_urls, audio_ts);
+        if audio_seg_urls.is_empty() {
+            return Err(RdlpError::Download {
+                message: "DASH: no audio segments resolved".into(),
+                url: Some(mpd_url.to_string()),
+            });
+        }
+        download_representation(
+            http_downloader,
+            &retry_config,
+            concurrent_segments,
+            buffer_size,
+            &audio_repr.id,
+            audio_init,
+            audio_seg_urls,
+            &audio_final,
+            &audio_parts,
+            Arc::clone(&state_arc),
+            &state_file,
+            false,
+            Arc::clone(&bytes_total),
+        )
+        .await?
+    } else {
+        0
+    };
 
     // ----- Mux video + audio into the single output container -----
     //
@@ -121,7 +182,15 @@ pub async fn run(
     // output) is preserved by performing the mux here, before returning.
     // Intermediates are deleted on success and retained on failure for
     // diagnosis.
-    mux_outputs(&video_path, has_audio.then_some(&audio_path), output_path).await?;
+    mux_outputs(&video_final, has_audio.then_some(&audio_final), output_path).await?;
+
+    // Mux succeeded → wipe resume state.
+    if let Err(e) = fs::remove_file(&state_file).await {
+        debug!(
+            "DASH state cleanup: failed to remove {} ({e})",
+            state_file.display()
+        );
+    }
 
     let elapsed = started.elapsed();
     let bytes = video_bytes + audio_bytes;
@@ -156,46 +225,6 @@ pub async fn run(
     Ok(stats)
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn download_audio_if_present(
-    http: &HttpDownloader,
-    retry: &Arc<RetryConfig>,
-    concurrent: usize,
-    buffer_size: usize,
-    parsed: &manifest::ParsedManifest,
-    output_path: &Path,
-    mpd_url: &str,
-    bytes_counter: Arc<AtomicU64>,
-) -> Result<u64> {
-    let Some(audio_repr) = parsed.audio.as_ref() else {
-        return Ok(0);
-    };
-    let audio_ts = period_duration_ts(parsed.period_duration, &audio_repr.plan);
-    let audio_init = audio_repr.plan.init_url(&audio_repr.base_urls);
-    let audio_seg_urls = audio_repr
-        .plan
-        .segment_urls(&audio_repr.base_urls, audio_ts);
-    if audio_seg_urls.is_empty() {
-        return Err(RdlpError::Download {
-            message: "DASH: no audio segments resolved".into(),
-            url: Some(mpd_url.to_string()),
-        });
-    }
-    let audio_path = intermediate_path(output_path, "audio");
-    download_representation(
-        http,
-        retry,
-        concurrent,
-        buffer_size,
-        &audio_repr.id,
-        audio_init,
-        audio_seg_urls,
-        &audio_path,
-        bytes_counter,
-    )
-    .await
-}
-
 fn period_duration_ts(period_duration: Duration, plan: &SegmentPlan) -> u64 {
     let timescale = match plan {
         SegmentPlan::Template(t) => t.timescale,
@@ -226,7 +255,32 @@ fn intermediate_path(output: &Path, suffix: &str) -> PathBuf {
     parent.join(name)
 }
 
-#[allow(clippy::too_many_arguments)]
+fn parts_dir(output: &Path, suffix: &str) -> PathBuf {
+    let stem = output
+        .file_stem()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_default();
+    let parent = output
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let mut name = stem.into_string().unwrap_or_default();
+    name.push('.');
+    name.push_str(suffix);
+    name.push_str(".parts");
+    parent.join(name)
+}
+
+fn state_path(output: &Path) -> PathBuf {
+    let mut p = output.to_path_buf().into_os_string();
+    p.push(".dash_state.json");
+    PathBuf::from(p)
+}
+
+fn segment_filename(idx: usize) -> String {
+    format!("{idx:04}.m4s")
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn download_representation(
     http: &HttpDownloader,
     retry: &Arc<RetryConfig>,
@@ -235,61 +289,185 @@ async fn download_representation(
     repr_id: &str,
     init_url: Option<Url>,
     seg_urls: Vec<Url>,
-    output: &Path,
+    final_path: &Path,
+    parts_dir: &Path,
+    state_arc: Arc<Mutex<DashDownloadState>>,
+    state_path: &Path,
+    is_video: bool,
     bytes_counter: Arc<AtomicU64>,
 ) -> Result<u64> {
-    if let Some(parent) = output.parent()
+    if let Some(parent) = final_path.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent).await?;
     }
+    fs::create_dir_all(parts_dir).await?;
 
+    let mut total: u64 = 0;
+
+    // ----- Init segment -----
+    let init_part_path = parts_dir.join("init.m4s");
+    if let Some(u) = init_url {
+        let init_done = {
+            let s = state_arc.lock().await;
+            if is_video {
+                s.init_video_done
+            } else {
+                s.init_audio_done
+            }
+        };
+        let on_disk = fs::metadata(&init_part_path)
+            .await
+            .is_ok_and(|m| m.len() > 0);
+        if init_done && on_disk {
+            // Resume — count existing bytes toward total.
+            let len = fs::metadata(&init_part_path).await?.len();
+            bytes_counter.fetch_add(len, Ordering::Relaxed);
+            total += len;
+            debug!("DASH repr {repr_id}: init resumed ({len} bytes)");
+        } else {
+            let bytes = download_one(http, retry, &u).await?;
+            let len = bytes.len() as u64;
+            fs::write(&init_part_path, &bytes).await?;
+            bytes_counter.fetch_add(len, Ordering::Relaxed);
+            total += len;
+            {
+                let mut s = state_arc.lock().await;
+                if is_video {
+                    s.init_video_done = true;
+                } else {
+                    s.init_audio_done = true;
+                }
+                if let Err(e) = s.save(state_path).await {
+                    warn!("DASH state save failed (init): {e}");
+                }
+            }
+            debug!("DASH repr {repr_id}: init {len} bytes");
+        }
+    }
+
+    // ----- Segments -----
+    //
+    // Partition into "already-done on disk" (skip + count bytes) vs
+    // "needs fetch" (enqueue).
+    let total_segments = seg_urls.len();
+    let mut to_fetch: Vec<(usize, Url)> = Vec::new();
+    {
+        let mut s = state_arc.lock().await;
+        for (i, u) in seg_urls.into_iter().enumerate() {
+            let part_path = parts_dir.join(segment_filename(i));
+            let recorded_done = s.is_segment_done(repr_id, i as u64);
+            let on_disk_len = fs::metadata(&part_path).await.map_or(0, |m| m.len());
+            if recorded_done && on_disk_len > 0 {
+                bytes_counter.fetch_add(on_disk_len, Ordering::Relaxed);
+                total += on_disk_len;
+            } else {
+                // If state said done but file is missing or zero-length, drop
+                // the bookkeeping so we re-fetch.
+                if recorded_done
+                    && let Some(v) = s.completed_segments.get_mut(repr_id)
+                {
+                    v.retain(|x| *x != i as u64);
+                }
+                to_fetch.push((i, u));
+            }
+        }
+    }
+
+    let concurrent = concurrent.max(1);
+
+    let mut stream =
+        futures::stream::iter(to_fetch.into_iter().map(|(i, u)| {
+            let http = http.clone();
+            let retry = Arc::clone(retry);
+            let parts_dir = parts_dir.to_path_buf();
+            async move {
+                let bytes = download_one(&http, &retry, &u).await?;
+                let part_path = parts_dir.join(segment_filename(i));
+                fs::write(&part_path, &bytes)
+                    .await
+                    .map_err(RdlpError::Io)?;
+                Ok::<(usize, u64), RdlpError>((i, bytes.len() as u64))
+            }
+        }))
+        .buffer_unordered(concurrent);
+
+    let mut completed_since_save: usize = 0;
+    let mut stream_err: Option<RdlpError> = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok((i, len)) => {
+                bytes_counter.fetch_add(len, Ordering::Relaxed);
+                total += len;
+                let mut s = state_arc.lock().await;
+                s.record_segment(repr_id, i as u64);
+                completed_since_save += 1;
+                if completed_since_save >= STATE_SAVE_BATCH {
+                    if let Err(e) = s.save(state_path).await {
+                        warn!("DASH state save failed (batch): {e}");
+                    }
+                    completed_since_save = 0;
+                }
+            }
+            Err(e) => {
+                // Don't return immediately — drain remaining in-flight
+                // results so their bookkeeping is recorded and persisted
+                // before we propagate the error.
+                if stream_err.is_none() {
+                    stream_err = Some(e);
+                }
+            }
+        }
+    }
+
+    // Always flush state once the stream has drained — covers both the
+    // success path and the error path (so the next run can resume from
+    // whatever did complete before the failure).
+    {
+        let mut s = state_arc.lock().await;
+        if let Err(e) = s.save(state_path).await {
+            warn!("DASH state save failed (final): {e}");
+        }
+    }
+    if let Some(e) = stream_err {
+        return Err(e);
+    }
+    let _ = completed_since_save;
+
+    // ----- Concat init + sorted segments → final_path -----
     let file = OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
-        .open(output)
+        .open(final_path)
         .await?;
     let mut writer = BufWriter::with_capacity(buffer_size, file);
 
-    let mut total: u64 = 0;
-
-    if let Some(u) = init_url {
-        let bytes = download_one(http, retry, &u).await?;
-        let len = bytes.len() as u64;
-        writer.write_all(&bytes).await?;
-        bytes_counter.fetch_add(len, Ordering::Relaxed);
-        total += len;
-        log::debug!("DASH repr {repr_id}: init {len} bytes");
+    if init_url_was_present(&init_part_path).await {
+        let init_bytes = fs::read(&init_part_path).await?;
+        writer.write_all(&init_bytes).await?;
     }
-
-    let concurrent = concurrent.max(1);
-    let mut results: BTreeMap<usize, Vec<u8>> = BTreeMap::new();
-
-    let mut stream = futures::stream::iter(seg_urls.into_iter().enumerate().map(|(i, u)| {
-        let http = http.clone();
-        let retry = Arc::clone(retry);
-        async move {
-            let bytes = download_one(&http, &retry, &u).await?;
-            Ok::<(usize, Vec<u8>), RdlpError>((i, bytes))
-        }
-    }))
-    .buffer_unordered(concurrent);
-
-    while let Some(item) = stream.next().await {
-        let (i, bytes) = item?;
-        let len = bytes.len() as u64;
-        bytes_counter.fetch_add(len, Ordering::Relaxed);
-        total += len;
-        results.insert(i, bytes);
-    }
-
-    for (_, bytes) in results {
-        writer.write_all(&bytes).await?;
+    for i in 0..total_segments {
+        let part_path = parts_dir.join(segment_filename(i));
+        let seg_bytes = fs::read(&part_path).await?;
+        writer.write_all(&seg_bytes).await?;
     }
     writer.flush().await?;
 
+    // Best-effort cleanup of parts dir — successful concat means we don't
+    // need them anymore. Keep them on error so the next run can resume.
+    if let Err(e) = fs::remove_dir_all(parts_dir).await {
+        debug!(
+            "DASH parts cleanup: failed to remove {} ({e})",
+            parts_dir.display()
+        );
+    }
+
     Ok(total)
+}
+
+async fn init_url_was_present(init_part_path: &Path) -> bool {
+    fs::metadata(init_part_path).await.is_ok()
 }
 
 /// Mux video (+ optional audio) intermediates into `output_path` via
@@ -298,7 +476,11 @@ async fn download_representation(
 ///
 /// When `audio_path` is `None`, the video intermediate is moved (renamed,
 /// or copy+remove on cross-mount failure) into the final output path.
-async fn mux_outputs(video_path: &Path, audio_path: Option<&Path>, output_path: &Path) -> Result<()> {
+async fn mux_outputs(
+    video_path: &Path,
+    audio_path: Option<&Path>,
+    output_path: &Path,
+) -> Result<()> {
     if let Some(audio_path) = audio_path {
         let runner = FFmpegRunner::new().map_err(|e| {
             RdlpError::from(DashError::Mux(format!("FFmpegRunner init failed: {e}")))
@@ -344,7 +526,9 @@ async fn mux_outputs(video_path: &Path, audio_path: Option<&Path>, output_path: 
             debug!(
                 "DASH video-only rename failed ({rename_err}); falling back to copy+remove"
             );
-            fs::copy(video_path, output_path).await.map_err(RdlpError::Io)?;
+            fs::copy(video_path, output_path)
+                .await
+                .map_err(RdlpError::Io)?;
             if let Err(e) = fs::remove_file(video_path).await {
                 debug!(
                     "DASH cleanup: failed to remove {} ({e})",

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -1,1 +1,327 @@
-//! Parallel segment download + mux. Implementation lands in Tasks 4 and 5.
+//! DASH download orchestration: MPD fetch + parallel segment fetch + concat.
+//!
+//! Mux to a single output container is performed by Task 5; this module
+//! produces `<output>.video.m4s` and (optionally) `<output>.audio.m4s`.
+
+#![allow(clippy::doc_markdown)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use backon::Retryable;
+use futures::StreamExt;
+use log::{info, warn};
+use rdlp_core::{
+    DownloadStats, ProgressCallback, RdlpError, Result, RetryConfig, is_retryable_error,
+};
+use tokio::fs::{self, OpenOptions};
+use tokio::io::{AsyncWriteExt, BufWriter};
+use url::Url;
+
+use crate::dash::manifest;
+use crate::dash::segments::SegmentPlan;
+use crate::http::HttpDownloader;
+
+/// Run a DASH download for `mpd_url` into `output_path`.
+///
+/// Produces sibling intermediates `<output>.video.m4s` and (when an audio
+/// repr exists) `<output>.audio.m4s`. The actual `output_path` is NOT
+/// written by this function — Task 5 will mux the intermediates into it.
+pub async fn run(
+    http_downloader: &HttpDownloader,
+    retry_config: Arc<RetryConfig>,
+    concurrent_segments: usize,
+    buffer_size: usize,
+    mpd_url: &str,
+    output_path: &Path,
+    progress: Option<Box<dyn ProgressCallback>>,
+) -> Result<DownloadStats> {
+    let mpd_url_parsed = Url::parse(mpd_url).map_err(|e| RdlpError::Extraction {
+        message: format!("invalid MPD URL: {e}"),
+        url: Some(mpd_url.to_string()),
+    })?;
+
+    // Fetch MPD body.
+    let client = http_downloader.client().clone();
+    let response = client
+        .get(mpd_url)
+        .headers(http_downloader.headers())
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| RdlpError::Network {
+            message: format!("MPD fetch failed: {e}"),
+            url: Some(mpd_url.to_string()),
+        })?;
+    if !response.status().is_success() {
+        return Err(RdlpError::Http {
+            status: response.status().as_u16(),
+            reason: format!("MPD returned HTTP {}", response.status()),
+        });
+    }
+    let body = response.text().await.map_err(|e| RdlpError::Network {
+        message: format!("MPD read error: {e}"),
+        url: Some(mpd_url.to_string()),
+    })?;
+
+    let parsed = manifest::parse_mpd(&body, &mpd_url_parsed).map_err(RdlpError::from)?;
+
+    let started = Instant::now();
+    let bytes_total = Arc::new(AtomicU64::new(0));
+
+    // Video (always present after parse).
+    let video_ts = period_duration_ts(parsed.period_duration, &parsed.video.plan);
+    let video_init = parsed.video.plan.init_url(&parsed.video.base_urls);
+    let video_seg_urls = parsed
+        .video
+        .plan
+        .segment_urls(&parsed.video.base_urls, video_ts);
+    if video_seg_urls.is_empty() {
+        return Err(RdlpError::Download {
+            message: "DASH: no video segments resolved".into(),
+            url: Some(mpd_url.to_string()),
+        });
+    }
+    let video_path = intermediate_path(output_path, "video");
+    let video_bytes = download_representation(
+        http_downloader,
+        &retry_config,
+        concurrent_segments,
+        buffer_size,
+        &parsed.video.id,
+        video_init,
+        video_seg_urls,
+        &video_path,
+        Arc::clone(&bytes_total),
+    )
+    .await?;
+
+    // Audio (optional).
+    let audio_bytes = download_audio_if_present(
+        http_downloader,
+        &retry_config,
+        concurrent_segments,
+        buffer_size,
+        &parsed,
+        output_path,
+        mpd_url,
+        Arc::clone(&bytes_total),
+    )
+    .await?;
+
+    let elapsed = started.elapsed();
+    let bytes = video_bytes + audio_bytes;
+    #[allow(clippy::cast_precision_loss)]
+    let avg = if elapsed.as_secs_f64() > 0.0 {
+        bytes as f64 / elapsed.as_secs_f64()
+    } else {
+        0.0
+    };
+    let stats = DownloadStats {
+        bytes_downloaded: bytes,
+        duration: elapsed,
+        average_speed: avg,
+        retries: 0,
+        fragments: None,
+    };
+
+    info!(
+        "DASH download complete: {} bytes in {:.1}s",
+        bytes,
+        elapsed.as_secs_f64()
+    );
+    if let Some(cb) = progress {
+        cb.on_log(&format!(
+            "DASH download complete: {} bytes in {:.1}s",
+            bytes,
+            elapsed.as_secs_f64()
+        ));
+        cb.on_complete(&stats);
+    }
+
+    Ok(stats)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn download_audio_if_present(
+    http: &HttpDownloader,
+    retry: &Arc<RetryConfig>,
+    concurrent: usize,
+    buffer_size: usize,
+    parsed: &manifest::ParsedManifest,
+    output_path: &Path,
+    mpd_url: &str,
+    bytes_counter: Arc<AtomicU64>,
+) -> Result<u64> {
+    let Some(audio_repr) = parsed.audio.as_ref() else {
+        return Ok(0);
+    };
+    let audio_ts = period_duration_ts(parsed.period_duration, &audio_repr.plan);
+    let audio_init = audio_repr.plan.init_url(&audio_repr.base_urls);
+    let audio_seg_urls = audio_repr
+        .plan
+        .segment_urls(&audio_repr.base_urls, audio_ts);
+    if audio_seg_urls.is_empty() {
+        return Err(RdlpError::Download {
+            message: "DASH: no audio segments resolved".into(),
+            url: Some(mpd_url.to_string()),
+        });
+    }
+    let audio_path = intermediate_path(output_path, "audio");
+    download_representation(
+        http,
+        retry,
+        concurrent,
+        buffer_size,
+        &audio_repr.id,
+        audio_init,
+        audio_seg_urls,
+        &audio_path,
+        bytes_counter,
+    )
+    .await
+}
+
+fn period_duration_ts(period_duration: Duration, plan: &SegmentPlan) -> u64 {
+    let timescale = match plan {
+        SegmentPlan::Template(t) => t.timescale,
+        SegmentPlan::Timeline(t) => t.timescale,
+        SegmentPlan::List(_) => 1,
+    };
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    let ts = (period_duration.as_secs_f64() * timescale as f64).round() as u64;
+    ts
+}
+
+fn intermediate_path(output: &Path, suffix: &str) -> PathBuf {
+    let stem = output
+        .file_stem()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_default();
+    let parent = output
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let mut name = stem.into_string().unwrap_or_default();
+    name.push('.');
+    name.push_str(suffix);
+    name.push_str(".m4s");
+    parent.join(name)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn download_representation(
+    http: &HttpDownloader,
+    retry: &Arc<RetryConfig>,
+    concurrent: usize,
+    buffer_size: usize,
+    repr_id: &str,
+    init_url: Option<Url>,
+    seg_urls: Vec<Url>,
+    output: &Path,
+    bytes_counter: Arc<AtomicU64>,
+) -> Result<u64> {
+    if let Some(parent) = output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).await?;
+    }
+
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(output)
+        .await?;
+    let mut writer = BufWriter::with_capacity(buffer_size, file);
+
+    let mut total: u64 = 0;
+
+    if let Some(u) = init_url {
+        let bytes = download_one(http, retry, &u).await?;
+        let len = bytes.len() as u64;
+        writer.write_all(&bytes).await?;
+        bytes_counter.fetch_add(len, Ordering::Relaxed);
+        total += len;
+        log::debug!("DASH repr {repr_id}: init {len} bytes");
+    }
+
+    let concurrent = concurrent.max(1);
+    let mut results: BTreeMap<usize, Vec<u8>> = BTreeMap::new();
+
+    let mut stream = futures::stream::iter(seg_urls.into_iter().enumerate().map(|(i, u)| {
+        let http = http.clone();
+        let retry = Arc::clone(retry);
+        async move {
+            let bytes = download_one(&http, &retry, &u).await?;
+            Ok::<(usize, Vec<u8>), RdlpError>((i, bytes))
+        }
+    }))
+    .buffer_unordered(concurrent);
+
+    while let Some(item) = stream.next().await {
+        let (i, bytes) = item?;
+        let len = bytes.len() as u64;
+        bytes_counter.fetch_add(len, Ordering::Relaxed);
+        total += len;
+        results.insert(i, bytes);
+    }
+
+    for (_, bytes) in results {
+        writer.write_all(&bytes).await?;
+    }
+    writer.flush().await?;
+
+    Ok(total)
+}
+
+async fn download_one(
+    http: &HttpDownloader,
+    retry: &Arc<RetryConfig>,
+    url: &Url,
+) -> Result<Vec<u8>> {
+    let client = http.client().clone();
+    let headers = http.headers();
+    let backoff = retry.to_backoff();
+    let url_str = url.to_string();
+    (|| {
+        let client = client.clone();
+        let headers = headers.clone();
+        let url_str = url_str.clone();
+        async move {
+            let resp = client
+                .get(&url_str)
+                .headers(headers)
+                .timeout(Duration::from_secs(60))
+                .send()
+                .await
+                .map_err(|e| RdlpError::Network {
+                    message: format!("DASH segment fetch failed: {e}"),
+                    url: Some(url_str.clone()),
+                })?;
+            if !resp.status().is_success() {
+                return Err(RdlpError::Http {
+                    status: resp.status().as_u16(),
+                    reason: format!("DASH segment HTTP {}", resp.status()),
+                });
+            }
+            let bytes = resp.bytes().await.map_err(|e| RdlpError::Network {
+                message: format!("DASH segment read error: {e}"),
+                url: Some(url_str.clone()),
+            })?;
+            Ok(bytes.to_vec())
+        }
+    })
+    .retry(backoff)
+    .when(is_retryable_error)
+    .notify(|err, dur| {
+        warn!("DASH segment fetch retry after {dur:?}: {err}");
+    })
+    .await
+}

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -303,15 +303,8 @@ async fn mux_outputs(video_path: &Path, audio_path: Option<&Path>, output_path: 
         let runner = FFmpegRunner::new().map_err(|e| {
             RdlpError::from(DashError::Mux(format!("FFmpegRunner init failed: {e}")))
         })?;
-        // Mirror `encoding_tool_tag("dash")` from rdlp-ffmpeg. The helper
-        // is not re-exported, but the `encoding_tool` format-level metadata
-        // shape is `rdlp/{version} ({component})` and both crates share
-        // the workspace version.
         let opts = RemuxOptions {
-            encoding_tool_override: Some(format!(
-                "rdlp/{} (dash)",
-                env!("CARGO_PKG_VERSION")
-            )),
+            encoding_tool_override: Some(rdlp_ffmpeg::encoding_tool_tag("dash")),
             ..Default::default()
         };
         match runner

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -26,6 +26,7 @@ use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::Mutex;
 use url::Url;
 
+use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
 use crate::dash::errors::DashError;
 use crate::dash::manifest;
 use crate::dash::segments::SegmentPlan;
@@ -85,6 +86,11 @@ pub async fn run(
     let started = Instant::now();
     let bytes_total = Arc::new(AtomicU64::new(0));
 
+    // Wrap the progress callback in Arc so it can be shared with the per-
+    // representation adaptive controllers without cloning the Box.
+    let progress_arc: Option<Arc<dyn ProgressCallback>> =
+        progress.map(|cb| Arc::from(cb) as Arc<dyn ProgressCallback>);
+
     // Resolve all paths up-front.
     let video_final = intermediate_path(output_path, "video");
     let audio_final = intermediate_path(output_path, "audio");
@@ -139,6 +145,7 @@ pub async fn run(
         &state_file,
         true,
         Arc::clone(&bytes_total),
+        progress_arc.clone(),
     )
     .await?;
 
@@ -170,6 +177,7 @@ pub async fn run(
             &state_file,
             false,
             Arc::clone(&bytes_total),
+            progress_arc.clone(),
         )
         .await?
     } else {
@@ -213,7 +221,7 @@ pub async fn run(
         bytes,
         elapsed.as_secs_f64()
     );
-    if let Some(cb) = progress {
+    if let Some(ref cb) = progress_arc {
         cb.on_log(&format!(
             "DASH download complete: {} bytes in {:.1}s",
             bytes,
@@ -295,6 +303,7 @@ async fn download_representation(
     state_path: &Path,
     is_video: bool,
     bytes_counter: Arc<AtomicU64>,
+    log_callback: Option<Arc<dyn ProgressCallback>>,
 ) -> Result<u64> {
     if let Some(parent) = final_path.parent()
         && !parent.as_os_str().is_empty()
@@ -364,9 +373,7 @@ async fn download_representation(
             } else {
                 // If state said done but file is missing or zero-length, drop
                 // the bookkeeping so we re-fetch.
-                if recorded_done
-                    && let Some(v) = s.completed_segments.get_mut(repr_id)
-                {
+                if recorded_done && let Some(v) = s.completed_segments.get_mut(repr_id) {
                     v.retain(|x| *x != i as u64);
                 }
                 to_fetch.push((i, u));
@@ -376,21 +383,52 @@ async fn download_representation(
 
     let concurrent = concurrent.max(1);
 
-    let mut stream =
-        futures::stream::iter(to_fetch.into_iter().map(|(i, u)| {
-            let http = http.clone();
-            let retry = Arc::clone(retry);
-            let parts_dir = parts_dir.to_path_buf();
-            async move {
-                let bytes = download_one(&http, &retry, &u).await?;
-                let part_path = parts_dir.join(segment_filename(i));
-                fs::write(&part_path, &bytes)
-                    .await
-                    .map_err(RdlpError::Io)?;
-                Ok::<(usize, u64), RdlpError>((i, bytes.len() as u64))
-            }
-        }))
-        .buffer_unordered(concurrent);
+    // Build an AIMD adaptive controller for this representation.
+    // `HlsSegments` mode skips chunk-level adjustments (segment sizes are
+    // server-determined), matching the HLS downloader's pattern exactly.
+    let controller = Arc::new(AdaptiveController::new(
+        0, // total_size not meaningful for segment-based downloads
+        AdaptiveConfig {
+            max_connections: concurrent,
+            initial_connections: concurrent.min(2),
+            ..AdaptiveConfig::default()
+        },
+        ControllerMode::HlsSegments,
+        log_callback,
+    ));
+    let sem = controller.semaphore().clone();
+
+    let mut stream = futures::stream::iter(to_fetch.into_iter().map(|(i, u)| {
+        let http = http.clone();
+        let retry = Arc::clone(retry);
+        let parts_dir = parts_dir.to_path_buf();
+        let sem = sem.clone();
+        let controller = Arc::clone(&controller);
+        async move {
+            // Acquire a semaphore permit so the adaptive controller governs
+            // actual concurrency (mirrors the HLS pattern in merge.rs).
+            let _permit = sem.acquire_owned().await.map_err(|_| RdlpError::Download {
+                message: "DASH adaptive semaphore closed".to_string(),
+                url: None,
+            })?;
+
+            let fetch_start = Instant::now();
+            let bytes = download_one(&http, &retry, &u).await?;
+            let len = bytes.len() as u64;
+            let elapsed = fetch_start.elapsed();
+
+            let part_path = parts_dir.join(segment_filename(i));
+            fs::write(&part_path, &bytes).await.map_err(RdlpError::Io)?;
+
+            // Report to the adaptive controller so AIMD can tune connection
+            // count based on observed throughput.  Permit is still held here;
+            // it drops at the end of this async block.
+            controller.report_segment_complete(len, elapsed, None);
+
+            Ok::<(usize, u64), RdlpError>((i, len))
+        }
+    }))
+    .buffer_unordered(concurrent);
 
     let mut completed_since_save: usize = 0;
     let mut stream_err: Option<RdlpError> = None;
@@ -523,9 +561,7 @@ async fn mux_outputs(
         // Video-only: move intermediate into place. Try rename first; fall
         // back to copy+remove on cross-mount failures.
         if let Err(rename_err) = fs::rename(video_path, output_path).await {
-            debug!(
-                "DASH video-only rename failed ({rename_err}); falling back to copy+remove"
-            );
+            debug!("DASH video-only rename failed ({rename_err}); falling back to copy+remove");
             fs::copy(video_path, output_path)
                 .await
                 .map_err(RdlpError::Io)?;

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -1,7 +1,5 @@
-//! DASH download orchestration: MPD fetch + parallel segment fetch + concat.
-//!
-//! Mux to a single output container is performed by Task 5; this module
-//! produces `<output>.video.m4s` and (optionally) `<output>.audio.m4s`.
+//! DASH download orchestration: MPD fetch + parallel segment fetch + concat
+//! + FFmpeg stream-copy mux into a single output container.
 
 #![allow(clippy::doc_markdown)]
 
@@ -13,23 +11,26 @@ use std::time::{Duration, Instant};
 
 use backon::Retryable;
 use futures::StreamExt;
-use log::{info, warn};
+use log::{debug, info, warn};
 use rdlp_core::{
     DownloadStats, ProgressCallback, RdlpError, Result, RetryConfig, is_retryable_error,
 };
+use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncWriteExt, BufWriter};
 use url::Url;
 
+use crate::dash::errors::DashError;
 use crate::dash::manifest;
 use crate::dash::segments::SegmentPlan;
 use crate::http::HttpDownloader;
 
 /// Run a DASH download for `mpd_url` into `output_path`.
 ///
-/// Produces sibling intermediates `<output>.video.m4s` and (when an audio
-/// repr exists) `<output>.audio.m4s`. The actual `output_path` is NOT
-/// written by this function — Task 5 will mux the intermediates into it.
+/// Internally produces `<output>.video.m4s` and (when an audio repr exists)
+/// `<output>.audio.m4s`, then muxes them via FFmpeg stream-copy into
+/// `output_path`. Intermediates are deleted on success and retained on
+/// mux failure for diagnosis.
 pub async fn run(
     http_downloader: &HttpDownloader,
     retry_config: Arc<RetryConfig>,
@@ -100,6 +101,7 @@ pub async fn run(
     .await?;
 
     // Audio (optional).
+    let has_audio = parsed.audio.is_some();
     let audio_bytes = download_audio_if_present(
         http_downloader,
         &retry_config,
@@ -111,6 +113,15 @@ pub async fn run(
         Arc::clone(&bytes_total),
     )
     .await?;
+    let audio_path = intermediate_path(output_path, "audio");
+
+    // ----- Mux video + audio into the single output container -----
+    //
+    // The trait's single-file contract (`download_to_file` writes one
+    // output) is preserved by performing the mux here, before returning.
+    // Intermediates are deleted on success and retained on failure for
+    // diagnosis.
+    mux_outputs(&video_path, has_audio.then_some(&audio_path), output_path).await?;
 
     let elapsed = started.elapsed();
     let bytes = video_bytes + audio_bytes;
@@ -279,6 +290,77 @@ async fn download_representation(
     writer.flush().await?;
 
     Ok(total)
+}
+
+/// Mux video (+ optional audio) intermediates into `output_path` via
+/// FFmpeg stream-copy. On success, intermediates are deleted (best-effort).
+/// On failure they are retained for diagnosis and the error is propagated.
+///
+/// When `audio_path` is `None`, the video intermediate is moved (renamed,
+/// or copy+remove on cross-mount failure) into the final output path.
+async fn mux_outputs(video_path: &Path, audio_path: Option<&Path>, output_path: &Path) -> Result<()> {
+    if let Some(audio_path) = audio_path {
+        let runner = FFmpegRunner::new().map_err(|e| {
+            RdlpError::from(DashError::Mux(format!("FFmpegRunner init failed: {e}")))
+        })?;
+        // Mirror `encoding_tool_tag("dash")` from rdlp-ffmpeg. The helper
+        // is not re-exported, but the `encoding_tool` format-level metadata
+        // shape is `rdlp/{version} ({component})` and both crates share
+        // the workspace version.
+        let opts = RemuxOptions {
+            encoding_tool_override: Some(format!(
+                "rdlp/{} (dash)",
+                env!("CARGO_PKG_VERSION")
+            )),
+            ..Default::default()
+        };
+        match runner
+            .merge(video_path, audio_path, output_path, &opts, None)
+            .await
+        {
+            Ok(()) => {
+                if let Err(e) = fs::remove_file(video_path).await {
+                    debug!(
+                        "DASH cleanup: failed to remove {} ({e})",
+                        video_path.display()
+                    );
+                }
+                if let Err(e) = fs::remove_file(audio_path).await {
+                    debug!(
+                        "DASH cleanup: failed to remove {} ({e})",
+                        audio_path.display()
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                warn!(
+                    "DASH mux failed; intermediates retained: {} {}",
+                    video_path.display(),
+                    audio_path.display()
+                );
+                Err(RdlpError::from(DashError::Mux(format!(
+                    "FFmpeg merge failed: {e}"
+                ))))
+            }
+        }
+    } else {
+        // Video-only: move intermediate into place. Try rename first; fall
+        // back to copy+remove on cross-mount failures.
+        if let Err(rename_err) = fs::rename(video_path, output_path).await {
+            debug!(
+                "DASH video-only rename failed ({rename_err}); falling back to copy+remove"
+            );
+            fs::copy(video_path, output_path).await.map_err(RdlpError::Io)?;
+            if let Err(e) = fs::remove_file(video_path).await {
+                debug!(
+                    "DASH cleanup: failed to remove {} ({e})",
+                    video_path.display()
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 async fn download_one(

--- a/crates/rdlp-downloader/src/dash/errors.rs
+++ b/crates/rdlp-downloader/src/dash/errors.rs
@@ -11,7 +11,7 @@ pub enum DashError {
     /// MPD declares dynamic / live presentation; not yet supported.
     #[error("Dynamic/live MPD is not yet supported")]
     DynamicMpd,
-    /// MPD contains DRM protection (ContentProtection elements).
+    /// MPD contains DRM protection (`ContentProtection` elements).
     #[error("DRM-protected MPD is not supported")]
     DrmProtected,
     /// No video representation usable by this downloader was found.
@@ -23,7 +23,7 @@ pub enum DashError {
     /// A segment HTTP fetch failed past the retry budget.
     #[error("Segment fetch failed: {0}")]
     SegmentFetch(String),
-    /// FFmpeg mux of the resolved video + audio streams failed.
+    /// `FFmpeg` mux of the resolved video + audio streams failed.
     #[error("Mux failed: {0}")]
     Mux(String),
 }
@@ -34,12 +34,12 @@ impl From<DashError> for RdlpError {
             DashError::DynamicMpd
             | DashError::DrmProtected
             | DashError::NoVideoRepresentation
-            | DashError::NoAudioRepresentation => RdlpError::Extraction {
+            | DashError::NoAudioRepresentation => Self::Extraction {
                 message: e.to_string(),
                 url: None,
             },
             DashError::Parse(_) | DashError::SegmentFetch(_) | DashError::Mux(_) => {
-                RdlpError::Download {
+                Self::Download {
                     message: e.to_string(),
                     url: None,
                 }

--- a/crates/rdlp-downloader/src/dash/errors.rs
+++ b/crates/rdlp-downloader/src/dash/errors.rs
@@ -1,0 +1,49 @@
+//! Typed errors for the DASH downloader.
+
+use rdlp_core::RdlpError;
+
+/// Errors raised during DASH manifest parsing, segment fetch, and mux.
+#[derive(Debug, thiserror::Error)]
+pub enum DashError {
+    /// MPD XML failed to parse or violated structural expectations.
+    #[error("Failed to parse MPD: {0}")]
+    Parse(String),
+    /// MPD declares dynamic / live presentation; not yet supported.
+    #[error("Dynamic/live MPD is not yet supported")]
+    DynamicMpd,
+    /// MPD contains DRM protection (ContentProtection elements).
+    #[error("DRM-protected MPD is not supported")]
+    DrmProtected,
+    /// No video representation usable by this downloader was found.
+    #[error("MPD has no usable video representation")]
+    NoVideoRepresentation,
+    /// No audio representation usable by this downloader was found.
+    #[error("MPD has no usable audio representation")]
+    NoAudioRepresentation,
+    /// A segment HTTP fetch failed past the retry budget.
+    #[error("Segment fetch failed: {0}")]
+    SegmentFetch(String),
+    /// FFmpeg mux of the resolved video + audio streams failed.
+    #[error("Mux failed: {0}")]
+    Mux(String),
+}
+
+impl From<DashError> for RdlpError {
+    fn from(e: DashError) -> Self {
+        match e {
+            DashError::DynamicMpd
+            | DashError::DrmProtected
+            | DashError::NoVideoRepresentation
+            | DashError::NoAudioRepresentation => RdlpError::Extraction {
+                message: e.to_string(),
+                url: None,
+            },
+            DashError::Parse(_) | DashError::SegmentFetch(_) | DashError::Mux(_) => {
+                RdlpError::Download {
+                    message: e.to_string(),
+                    url: None,
+                }
+            }
+        }
+    }
+}

--- a/crates/rdlp-downloader/src/dash/manifest.rs
+++ b/crates/rdlp-downloader/src/dash/manifest.rs
@@ -1,1 +1,296 @@
-//! MPD parser. Implementation lands in Task 2.
+//! MPD parser. Wraps `dash_mpd::parse` and projects the relevant subset
+//! into rdlp-internal types.
+//!
+//! Refuses live (`@type="dynamic"`) and DRM-protected MPDs. Multi-period
+//! MPDs parse with a warning; only the first period is consumed (Task 3+
+//! may revisit). The actual `SegmentPlan` is attached in Task 3 — this
+//! module only resolves representation selection and BaseURL chains.
+
+// DASH proper nouns (MPD, AdaptationSet, Representation, BaseURL, Period)
+// appear extensively in doc-comments. The pedantic doc_markdown lint flags
+// them as bare CamelCase identifiers, which is noise for a module whose
+// vocabulary is fixed by an external spec.
+#![allow(clippy::doc_markdown)]
+
+use std::time::Duration;
+
+use url::Url;
+
+use crate::dash::errors::DashError;
+
+/// Result of parsing an MPD manifest. Owns enough state to drive segment
+/// downloads in a later task — the actual `SegmentPlan` is attached in Task 3.
+#[derive(Debug)]
+pub struct ParsedManifest {
+    /// Effective duration of the (first) period. Falls back to
+    /// `mpd@mediaPresentationDuration`, then to `Duration::ZERO`.
+    pub period_duration: Duration,
+    /// Selected video representation (highest bandwidth in the first period).
+    pub video: RepresentationInfo,
+    /// Optional audio representation (None if no audio AdaptationSet exists).
+    pub audio: Option<RepresentationInfo>,
+    /// MPD-level resolved BaseURL chain. Always non-empty: at minimum it
+    /// contains the URL the MPD was fetched from.
+    pub mpd_base_urls: Vec<Url>,
+    /// Total number of `<Period>` elements in the source MPD (>=1).
+    pub period_count: usize,
+}
+
+/// Resolved metadata for a single Representation chosen from an AdaptationSet.
+#[derive(Debug)]
+pub struct RepresentationInfo {
+    /// `Representation@id` from the source MPD. Never empty (synthesised if
+    /// the source omitted it).
+    pub id: String,
+    /// Declared average bandwidth in bits per second; `0` when missing.
+    pub bandwidth: u64,
+    /// RFC 6381 codec string, e.g. `"avc1.640028"`. Inherited from
+    /// AdaptationSet when not present on the Representation.
+    pub codecs: Option<String>,
+    /// MIME type, e.g. `"video/mp4"`. Inherited from AdaptationSet when not
+    /// present on the Representation.
+    pub mime_type: Option<String>,
+    /// Declared frame width in pixels.
+    pub width: Option<u32>,
+    /// Declared frame height in pixels.
+    pub height: Option<u32>,
+    /// RFC 5646 language tag for the AdaptationSet.
+    pub lang: Option<String>,
+    /// Resolved BaseURL chain for this Representation:
+    /// MPD BaseURL ▸ Period BaseURL ▸ AdaptationSet BaseURL ▸ Representation BaseURL.
+    /// Always non-empty.
+    pub base_urls: Vec<Url>,
+    // Task 3 will add: pub plan: SegmentPlan,
+}
+
+/// Parse an MPD body and select the highest-bandwidth video representation
+/// (and matching audio, when any) from the first period.
+///
+/// `base_url` is the URL the MPD itself was fetched from; it acts as the
+/// root for resolving relative `<BaseURL>` elements.
+///
+/// # Errors
+///
+/// Returns [`DashError::Parse`] on malformed XML or missing `<Period>`,
+/// [`DashError::DynamicMpd`] for live MPDs, [`DashError::DrmProtected`] when
+/// any `ContentProtection` element is present, and
+/// [`DashError::NoVideoRepresentation`] when no video AdaptationSet is found.
+pub fn parse_mpd(body: &str, base_url: &Url) -> Result<ParsedManifest, DashError> {
+    let mpd = dash_mpd::parse(body).map_err(|e| DashError::Parse(e.to_string()))?;
+
+    if mpd.mpdtype.as_deref() == Some("dynamic") {
+        return Err(DashError::DynamicMpd);
+    }
+
+    // DRM gate. Refuse before representation selection so DRM beats
+    // "no video repr" in error precedence.
+    if mpd_has_drm(&mpd) {
+        return Err(DashError::DrmProtected);
+    }
+
+    let period_count = mpd.periods.len();
+    if period_count > 1 {
+        log::warn!(
+            "MPD has {period_count} periods; only the first is consumed (multi-period support deferred)"
+        );
+    }
+
+    let period = mpd
+        .periods
+        .first()
+        .ok_or_else(|| DashError::Parse("no <Period>".into()))?;
+
+    let mpd_base_urls = resolve_base_urls(&mpd.base_url, base_url);
+    let period_base_urls = resolve_period_base_urls(period, &mpd_base_urls);
+
+    let period_duration = period
+        .duration
+        .or(mpd.mediaPresentationDuration)
+        .unwrap_or_default();
+
+    let video = pick_video(period, &period_base_urls)?;
+    let audio = match pick_audio(period, &period_base_urls) {
+        Ok(info) => Some(info),
+        Err(DashError::NoAudioRepresentation) => None,
+        Err(e) => return Err(e),
+    };
+
+    Ok(ParsedManifest {
+        period_duration,
+        video,
+        audio,
+        mpd_base_urls,
+        period_count,
+    })
+}
+
+/// Returns true if any `ContentProtection` element appears at MPD, Period,
+/// AdaptationSet, or Representation scope.
+fn mpd_has_drm(mpd: &dash_mpd::MPD) -> bool {
+    if !mpd.ContentProtection.is_empty() {
+        return true;
+    }
+    for period in &mpd.periods {
+        if !period.ContentProtection.is_empty() {
+            return true;
+        }
+        for aset in &period.adaptations {
+            if !aset.ContentProtection.is_empty() {
+                return true;
+            }
+            for repr in &aset.representations {
+                if !repr.ContentProtection.is_empty() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Resolve a list of `<BaseURL>` elements against a parent URL. When the
+/// list is empty, returns `[parent]` so the chain is always non-empty.
+/// Entries that fail to parse against the parent are dropped with a warning.
+fn resolve_base_urls(base_urls: &[dash_mpd::BaseURL], parent: &Url) -> Vec<Url> {
+    if base_urls.is_empty() {
+        return vec![parent.clone()];
+    }
+    let mut out = Vec::with_capacity(base_urls.len());
+    for b in base_urls {
+        match parent.join(&b.base) {
+            Ok(u) => out.push(u),
+            Err(e) => log::warn!("failed to resolve BaseURL {:?}: {e}", b.base),
+        }
+    }
+    if out.is_empty() {
+        // All entries failed — fall back to parent so the chain stays non-empty.
+        out.push(parent.clone());
+    }
+    out
+}
+
+/// Build the Period-scoped BaseURL chain by resolving Period BaseURLs
+/// against the MPD-level chain (using the first MPD BaseURL as the parent).
+fn resolve_period_base_urls(period: &dash_mpd::Period, mpd_base_urls: &[Url]) -> Vec<Url> {
+    // resolve_base_urls always returns a non-empty Vec, so .first() should
+    // not fail here; the unwrap_or_else is defensive only.
+    let parent = mpd_base_urls.first().cloned().unwrap_or_else(|| {
+        #[allow(clippy::unwrap_used)]
+        Url::parse("about:blank").unwrap()
+    });
+    resolve_base_urls(&period.BaseURL, &parent)
+}
+
+/// Build the AdaptationSet-scoped BaseURL chain by resolving the AS's
+/// BaseURLs against the period chain.
+fn resolve_aset_base_urls(aset: &dash_mpd::AdaptationSet, period_base_urls: &[Url]) -> Vec<Url> {
+    let parent = period_base_urls.first().cloned().unwrap_or_else(|| {
+        #[allow(clippy::unwrap_used)]
+        Url::parse("about:blank").unwrap()
+    });
+    resolve_base_urls(&aset.BaseURL, &parent)
+}
+
+/// Build the Representation-scoped BaseURL chain by resolving the
+/// Representation's BaseURLs against the AdaptationSet chain.
+fn resolve_repr_base_urls(repr: &dash_mpd::Representation, aset_base_urls: &[Url]) -> Vec<Url> {
+    let parent = aset_base_urls.first().cloned().unwrap_or_else(|| {
+        #[allow(clippy::unwrap_used)]
+        Url::parse("about:blank").unwrap()
+    });
+    resolve_base_urls(&repr.BaseURL, &parent)
+}
+
+/// Returns true if the AdaptationSet describes video content. Trusts
+/// `@contentType` first, falls back to `@mimeType` prefix.
+fn is_video_aset(aset: &dash_mpd::AdaptationSet) -> bool {
+    if let Some(ct) = aset.contentType.as_deref() {
+        return ct.eq_ignore_ascii_case("video");
+    }
+    aset.mimeType
+        .as_deref()
+        .is_some_and(|m| m.to_ascii_lowercase().starts_with("video/"))
+}
+
+/// Returns true if the AdaptationSet describes audio content. Trusts
+/// `@contentType` first, falls back to `@mimeType` prefix.
+fn is_audio_aset(aset: &dash_mpd::AdaptationSet) -> bool {
+    if let Some(ct) = aset.contentType.as_deref() {
+        return ct.eq_ignore_ascii_case("audio");
+    }
+    aset.mimeType
+        .as_deref()
+        .is_some_and(|m| m.to_ascii_lowercase().starts_with("audio/"))
+}
+
+/// Pick the highest-bandwidth video Representation across all video
+/// AdaptationSets in the period.
+fn pick_video(
+    period: &dash_mpd::Period,
+    period_base_urls: &[Url],
+) -> Result<RepresentationInfo, DashError> {
+    pick_representation(period, period_base_urls, is_video_aset)
+        .ok_or(DashError::NoVideoRepresentation)
+}
+
+/// Pick the highest-bandwidth audio Representation across all audio
+/// AdaptationSets in the period.
+fn pick_audio(
+    period: &dash_mpd::Period,
+    period_base_urls: &[Url],
+) -> Result<RepresentationInfo, DashError> {
+    pick_representation(period, period_base_urls, is_audio_aset)
+        .ok_or(DashError::NoAudioRepresentation)
+}
+
+/// Generic Representation picker: filter AdaptationSets by `match_aset`,
+/// then pick the highest-bandwidth Representation from the union.
+fn pick_representation(
+    period: &dash_mpd::Period,
+    period_base_urls: &[Url],
+    match_aset: fn(&dash_mpd::AdaptationSet) -> bool,
+) -> Option<RepresentationInfo> {
+    let mut best: Option<(u64, &dash_mpd::AdaptationSet, &dash_mpd::Representation)> = None;
+
+    for aset in &period.adaptations {
+        if !match_aset(aset) {
+            continue;
+        }
+        for repr in &aset.representations {
+            let bw = repr.bandwidth.unwrap_or(0);
+            match best {
+                Some((b, _, _)) if b >= bw => {}
+                _ => best = Some((bw, aset, repr)),
+            }
+        }
+    }
+
+    let (bandwidth, aset, repr) = best?;
+    let aset_base_urls = resolve_aset_base_urls(aset, period_base_urls);
+    let base_urls = resolve_repr_base_urls(repr, &aset_base_urls);
+
+    let id = repr
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("repr-{bandwidth}"));
+
+    let codecs = repr.codecs.clone().or_else(|| aset.codecs.clone());
+    let mime_type = repr.mimeType.clone().or_else(|| aset.mimeType.clone());
+
+    Some(RepresentationInfo {
+        id,
+        bandwidth,
+        codecs,
+        mime_type,
+        width: repr
+            .width
+            .or(aset.width)
+            .and_then(|w| u32::try_from(w).ok()),
+        height: repr
+            .height
+            .or(aset.height)
+            .and_then(|h| u32::try_from(h).ok()),
+        lang: aset.lang.clone(),
+        base_urls,
+    })
+}

--- a/crates/rdlp-downloader/src/dash/manifest.rs
+++ b/crates/rdlp-downloader/src/dash/manifest.rs
@@ -1,0 +1,1 @@
+//! MPD parser. Implementation lands in Task 2.

--- a/crates/rdlp-downloader/src/dash/manifest.rs
+++ b/crates/rdlp-downloader/src/dash/manifest.rs
@@ -17,6 +17,9 @@ use std::time::Duration;
 use url::Url;
 
 use crate::dash::errors::DashError;
+use crate::dash::segments::{
+    SegmentListPlan, SegmentPlan, SegmentTemplatePlan, SegmentTimelinePlan, TimelineEntry,
+};
 
 /// Result of parsing an MPD manifest. Owns enough state to drive segment
 /// downloads in a later task — the actual `SegmentPlan` is attached in Task 3.
@@ -60,7 +63,9 @@ pub struct RepresentationInfo {
     /// MPD BaseURL ▸ Period BaseURL ▸ AdaptationSet BaseURL ▸ Representation BaseURL.
     /// Always non-empty.
     pub base_urls: Vec<Url>,
-    // Task 3 will add: pub plan: SegmentPlan,
+    /// Segment plan. Populated by [`parse_mpd`]. Drives URL enumeration
+    /// during download.
+    pub plan: SegmentPlan,
 }
 
 /// Parse an MPD body and select the highest-bandwidth video representation
@@ -108,8 +113,8 @@ pub fn parse_mpd(body: &str, base_url: &Url) -> Result<ParsedManifest, DashError
         .or(mpd.mediaPresentationDuration)
         .unwrap_or_default();
 
-    let video = pick_video(period, &period_base_urls)?;
-    let audio = match pick_audio(period, &period_base_urls) {
+    let video = pick_video(period, &period_base_urls, period_duration)?;
+    let audio = match pick_audio(period, &period_base_urls, period_duration) {
         Ok(info) => Some(info),
         Err(DashError::NoAudioRepresentation) => None,
         Err(e) => return Err(e),
@@ -228,9 +233,13 @@ fn is_audio_aset(aset: &dash_mpd::AdaptationSet) -> bool {
 fn pick_video(
     period: &dash_mpd::Period,
     period_base_urls: &[Url],
+    period_duration: Duration,
 ) -> Result<RepresentationInfo, DashError> {
-    pick_representation(period, period_base_urls, is_video_aset)
-        .ok_or(DashError::NoVideoRepresentation)
+    match pick_representation(period, period_base_urls, period_duration, is_video_aset) {
+        Ok(Some(info)) => Ok(info),
+        Ok(None) => Err(DashError::NoVideoRepresentation),
+        Err(e) => Err(e),
+    }
 }
 
 /// Pick the highest-bandwidth audio Representation across all audio
@@ -238,18 +247,27 @@ fn pick_video(
 fn pick_audio(
     period: &dash_mpd::Period,
     period_base_urls: &[Url],
+    period_duration: Duration,
 ) -> Result<RepresentationInfo, DashError> {
-    pick_representation(period, period_base_urls, is_audio_aset)
-        .ok_or(DashError::NoAudioRepresentation)
+    match pick_representation(period, period_base_urls, period_duration, is_audio_aset) {
+        Ok(Some(info)) => Ok(info),
+        Ok(None) => Err(DashError::NoAudioRepresentation),
+        Err(e) => Err(e),
+    }
 }
 
 /// Generic Representation picker: filter AdaptationSets by `match_aset`,
 /// then pick the highest-bandwidth Representation from the union.
+///
+/// Returns `Ok(None)` when no Representation matched the filter; returns
+/// `Err` when a Representation was selected but its segment plan could not
+/// be built (no SegmentTemplate / SegmentList found, missing required attrs).
 fn pick_representation(
     period: &dash_mpd::Period,
     period_base_urls: &[Url],
+    period_duration: Duration,
     match_aset: fn(&dash_mpd::AdaptationSet) -> bool,
-) -> Option<RepresentationInfo> {
+) -> Result<Option<RepresentationInfo>, DashError> {
     let mut best: Option<(u64, &dash_mpd::AdaptationSet, &dash_mpd::Representation)> = None;
 
     for aset in &period.adaptations {
@@ -265,7 +283,10 @@ fn pick_representation(
         }
     }
 
-    let (bandwidth, aset, repr) = best?;
+    let Some((bandwidth, aset, repr)) = best else {
+        return Ok(None);
+    };
+
     let aset_base_urls = resolve_aset_base_urls(aset, period_base_urls);
     let base_urls = resolve_repr_base_urls(repr, &aset_base_urls);
 
@@ -277,7 +298,9 @@ fn pick_representation(
     let codecs = repr.codecs.clone().or_else(|| aset.codecs.clone());
     let mime_type = repr.mimeType.clone().or_else(|| aset.mimeType.clone());
 
-    Some(RepresentationInfo {
+    let plan = build_segment_plan(aset, repr, period_duration, &id, bandwidth)?;
+
+    Ok(Some(RepresentationInfo {
         id,
         bandwidth,
         codecs,
@@ -292,5 +315,110 @@ fn pick_representation(
             .and_then(|h| u32::try_from(h).ok()),
         lang: aset.lang.clone(),
         base_urls,
-    })
+        plan,
+    }))
+}
+
+/// Build a `SegmentPlan` for the chosen Representation, applying DASH
+/// inheritance: prefer Representation-level over AdaptationSet-level for
+/// both `<SegmentTemplate>` and `<SegmentList>`.
+fn build_segment_plan(
+    aset: &dash_mpd::AdaptationSet,
+    repr: &dash_mpd::Representation,
+    period_duration: Duration,
+    representation_id: &str,
+    bandwidth: u64,
+) -> Result<SegmentPlan, DashError> {
+    if let Some(st) = repr.SegmentTemplate.as_ref().or(aset.SegmentTemplate.as_ref()) {
+        return build_template_plan(st, period_duration, representation_id, bandwidth);
+    }
+    if let Some(sl) = repr.SegmentList.as_ref().or(aset.SegmentList.as_ref()) {
+        return Ok(build_list_plan(sl));
+    }
+    Err(DashError::Parse(format!(
+        "Representation {representation_id} has no SegmentTemplate or SegmentList"
+    )))
+}
+
+fn build_template_plan(
+    st: &dash_mpd::SegmentTemplate,
+    period_duration: Duration,
+    representation_id: &str,
+    bandwidth: u64,
+) -> Result<SegmentPlan, DashError> {
+    let media = st.media.clone().ok_or_else(|| {
+        DashError::Parse(format!(
+            "Representation {representation_id} SegmentTemplate has no @media"
+        ))
+    })?;
+    let init = st.initialization.clone();
+    let start_number = st.startNumber.unwrap_or(1);
+    let timescale = st.timescale.unwrap_or(1).max(1);
+
+    if let Some(timeline) = st.SegmentTimeline.as_ref() {
+        let entries: Vec<TimelineEntry> = timeline
+            .segments
+            .iter()
+            .map(|s| TimelineEntry {
+                t: s.t,
+                d: s.d,
+                r: s.r,
+            })
+            .collect();
+        return Ok(SegmentPlan::Timeline(SegmentTimelinePlan {
+            init,
+            media,
+            start_number,
+            timescale,
+            entries,
+            representation_id: representation_id.to_string(),
+            bandwidth,
+        }));
+    }
+
+    // Plain SegmentTemplate@duration mode.
+    let seg_dur_f64 = st.duration.ok_or_else(|| {
+        DashError::Parse(format!(
+            "Representation {representation_id} SegmentTemplate has no @duration and no SegmentTimeline"
+        ))
+    })?;
+    if !seg_dur_f64.is_finite() || seg_dur_f64 <= 0.0 {
+        return Err(DashError::Parse(format!(
+            "Representation {representation_id} SegmentTemplate @duration is non-positive: {seg_dur_f64}"
+        )));
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let segment_duration_ts = seg_dur_f64.round() as u64;
+    let segment_duration_ts = segment_duration_ts.max(1);
+
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let total_segments = {
+        let period_secs = period_duration.as_secs_f64();
+        let total_ts = period_secs * timescale as f64;
+        (total_ts / seg_dur_f64).ceil() as u64
+    };
+
+    Ok(SegmentPlan::Template(SegmentTemplatePlan {
+        init,
+        media,
+        start_number,
+        timescale,
+        segment_duration_ts,
+        total_segments,
+        representation_id: representation_id.to_string(),
+        bandwidth,
+    }))
+}
+
+fn build_list_plan(sl: &dash_mpd::SegmentList) -> SegmentPlan {
+    let init = sl
+        .Initialization
+        .as_ref()
+        .and_then(|i| i.sourceURL.clone());
+    let urls = sl
+        .segment_urls
+        .iter()
+        .filter_map(|u| u.media.clone())
+        .collect();
+    SegmentPlan::List(SegmentListPlan { init, urls })
 }

--- a/crates/rdlp-downloader/src/dash/manifest.rs
+++ b/crates/rdlp-downloader/src/dash/manifest.rs
@@ -329,7 +329,11 @@ fn build_segment_plan(
     representation_id: &str,
     bandwidth: u64,
 ) -> Result<SegmentPlan, DashError> {
-    if let Some(st) = repr.SegmentTemplate.as_ref().or(aset.SegmentTemplate.as_ref()) {
+    if let Some(st) = repr
+        .SegmentTemplate
+        .as_ref()
+        .or(aset.SegmentTemplate.as_ref())
+    {
         return build_template_plan(st, period_duration, representation_id, bandwidth);
     }
     if let Some(sl) = repr.SegmentList.as_ref().or(aset.SegmentList.as_ref()) {
@@ -391,7 +395,11 @@ fn build_template_plan(
     let segment_duration_ts = seg_dur_f64.round() as u64;
     let segment_duration_ts = segment_duration_ts.max(1);
 
-    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
     let total_segments = {
         let period_secs = period_duration.as_secs_f64();
         let total_ts = period_secs * timescale as f64;
@@ -411,10 +419,7 @@ fn build_template_plan(
 }
 
 fn build_list_plan(sl: &dash_mpd::SegmentList) -> SegmentPlan {
-    let init = sl
-        .Initialization
-        .as_ref()
-        .and_then(|i| i.sourceURL.clone());
+    let init = sl.Initialization.as_ref().and_then(|i| i.sourceURL.clone());
     let urls = sl
         .segment_urls
         .iter()

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -3,6 +3,10 @@
 //! Static (VoD) MPDs only; live/DRM/multi-period beyond the first period are
 //! refused at parse time. See `docs/planning/2026-05-02-dash-protocol-support-design.md`.
 
+// `Duration::from_mins` / `from_hours` (lint's suggested replacements) need Rust 1.95;
+// workspace MSRV is 1.85.
+#![allow(clippy::duration_suboptimal_units)]
+
 pub mod errors;
 pub mod manifest;
 pub mod segments;
@@ -20,9 +24,11 @@ use rdlp_core::{Downloader, DownloadStats, ProgressCallback, Result, RetryConfig
 
 use crate::http::HttpDownloader;
 
-/// DASH downloader. Resolves the highest-bandwidth video + audio reprs
-/// from the supplied MPD URL, downloads segments in parallel, and muxes
-/// the result into a single output container via FFmpeg stream-copy.
+/// DASH downloader.
+///
+/// Resolves the highest-bandwidth video + audio reprs from the supplied
+/// MPD URL, downloads segments in parallel, and muxes the result into a
+/// single output container via `FFmpeg` stream-copy.
 #[derive(Clone)]
 pub struct DashDownloader {
     #[allow(dead_code)]
@@ -54,8 +60,8 @@ impl DashDownloader {
             buffer_size: 2 * 1024 * 1024,
             retry_config: Arc::new(RetryConfig::default_config()),
             expected_size: None,
-            download_timeout: Duration::from_secs(3600),
-            merge_timeout: Duration::from_secs(1800),
+            download_timeout: Duration::from_secs(3600), // 1 hour
+            merge_timeout: Duration::from_secs(1800),    // 30 min
             max_segment_failures: 3,
         }
     }
@@ -77,7 +83,7 @@ impl DashDownloader {
 
     /// Set the file write buffer size (bytes).
     #[must_use = "builder methods consume self and return a new instance"]
-    pub fn with_buffer_size(mut self, size: usize) -> Self {
+    pub const fn with_buffer_size(mut self, size: usize) -> Self {
         self.buffer_size = size;
         self
     }
@@ -96,10 +102,14 @@ impl Downloader for DashDownloader {
     }
 
     fn supports(&self, url: &str) -> bool {
-        let lower = url.to_ascii_lowercase();
-        // Path ends with .mpd, or query string suggests MPD.
-        lower.split('?').next().is_some_and(|p| p.ends_with(".mpd"))
-            || lower.contains(".mpd?")
+        // Path ends with .mpd, or query string suggests MPD. Both checks
+        // are case-insensitive — the URL is lowercased first.
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        {
+            let lower = url.to_ascii_lowercase();
+            let path = lower.split('?').next().unwrap_or("");
+            path.ends_with(".mpd") || lower.contains(".mpd?")
+        }
     }
 
     async fn download_to_file(

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -11,7 +11,7 @@ pub mod errors;
 pub mod manifest;
 pub mod segments;
 mod download;
-mod state;
+pub mod state;
 
 pub use errors::DashError;
 
@@ -81,6 +81,15 @@ impl DashDownloader {
     #[must_use = "builder methods consume self and return a new instance"]
     pub const fn with_buffer_size(mut self, size: usize) -> Self {
         self.buffer_size = size;
+        self
+    }
+
+    /// Replace the retry policy used for MPD and segment fetches. Tests
+    /// override this with a tight policy to avoid burning multi-minute
+    /// backoff cycles on synthetic 503s.
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
+        self.retry_config = Arc::new(config);
         self
     }
 }

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -1,0 +1,121 @@
+//! DASH (Dynamic Adaptive Streaming over HTTP) downloader module.
+//!
+//! Static (VoD) MPDs only; live/DRM/multi-period beyond the first period are
+//! refused at parse time. See `docs/planning/2026-05-02-dash-protocol-support-design.md`.
+
+pub mod errors;
+pub mod manifest;
+pub mod segments;
+mod download;
+mod state;
+
+pub use errors::DashError;
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rdlp_core::{Downloader, DownloadStats, ProgressCallback, Result, RetryConfig};
+
+use crate::http::HttpDownloader;
+
+/// DASH downloader. Resolves the highest-bandwidth video + audio reprs
+/// from the supplied MPD URL, downloads segments in parallel, and muxes
+/// the result into a single output container via FFmpeg stream-copy.
+#[derive(Clone)]
+pub struct DashDownloader {
+    #[allow(dead_code)]
+    http_downloader: HttpDownloader,
+    #[allow(dead_code)]
+    concurrent_segments: usize,
+    #[allow(dead_code)]
+    buffer_size: usize,
+    #[allow(dead_code)]
+    retry_config: Arc<RetryConfig>,
+    #[allow(dead_code)]
+    expected_size: Option<u64>,
+    #[allow(dead_code)]
+    download_timeout: Duration,
+    #[allow(dead_code)]
+    merge_timeout: Duration,
+    #[allow(dead_code)]
+    max_segment_failures: usize,
+}
+
+impl DashDownloader {
+    /// Construct a new `DashDownloader` with default settings (8 concurrent
+    /// segments, 2 MiB buffer, 1 h download timeout, 30 min mux timeout).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            http_downloader: HttpDownloader::new(),
+            concurrent_segments: 8,
+            buffer_size: 2 * 1024 * 1024,
+            retry_config: Arc::new(RetryConfig::default_config()),
+            expected_size: None,
+            download_timeout: Duration::from_secs(3600),
+            merge_timeout: Duration::from_secs(1800),
+            max_segment_failures: 3,
+        }
+    }
+
+    /// Replace the inner HTTP downloader (used by the registry to share a
+    /// single client / cookie jar across downloaders).
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_http_downloader(mut self, http: HttpDownloader) -> Self {
+        self.http_downloader = http;
+        self
+    }
+
+    /// Set the number of segments fetched in parallel. Floored to 1.
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_concurrent_segments(mut self, count: usize) -> Self {
+        self.concurrent_segments = count.max(1);
+        self
+    }
+
+    /// Set the file write buffer size (bytes).
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_buffer_size(mut self, size: usize) -> Self {
+        self.buffer_size = size;
+        self
+    }
+}
+
+impl Default for DashDownloader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Downloader for DashDownloader {
+    fn protocol(&self) -> &'static str {
+        "dash"
+    }
+
+    fn supports(&self, url: &str) -> bool {
+        let lower = url.to_ascii_lowercase();
+        // Path ends with .mpd, or query string suggests MPD.
+        lower.split('?').next().is_some_and(|p| p.ends_with(".mpd"))
+            || lower.contains(".mpd?")
+    }
+
+    async fn download_to_file(
+        &self,
+        _url: &str,
+        _path: &Path,
+        _progress: Option<Box<dyn ProgressCallback>>,
+    ) -> Result<DownloadStats> {
+        // Implemented in Task 5 (download.rs::run).
+        Err(rdlp_core::RdlpError::Download {
+            message: "DashDownloader::download_to_file not yet implemented".to_string(),
+            url: None,
+        })
+    }
+
+    async fn get_size(&self, _url: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
+}

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -31,13 +31,9 @@ use crate::http::HttpDownloader;
 /// single output container via `FFmpeg` stream-copy.
 #[derive(Clone)]
 pub struct DashDownloader {
-    #[allow(dead_code)]
     http_downloader: HttpDownloader,
-    #[allow(dead_code)]
     concurrent_segments: usize,
-    #[allow(dead_code)]
     buffer_size: usize,
-    #[allow(dead_code)]
     retry_config: Arc<RetryConfig>,
     #[allow(dead_code)]
     expected_size: Option<u64>,
@@ -114,15 +110,20 @@ impl Downloader for DashDownloader {
 
     async fn download_to_file(
         &self,
-        _url: &str,
-        _path: &Path,
-        _progress: Option<Box<dyn ProgressCallback>>,
+        url: &str,
+        path: &Path,
+        progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
-        // Implemented in Task 5 (download.rs::run).
-        Err(rdlp_core::RdlpError::Download {
-            message: "DashDownloader::download_to_file not yet implemented".to_string(),
-            url: None,
-        })
+        download::run(
+            &self.http_downloader,
+            Arc::clone(&self.retry_config),
+            self.concurrent_segments,
+            self.buffer_size,
+            url,
+            path,
+            progress,
+        )
+        .await
     }
 
     async fn get_size(&self, _url: &str) -> Result<Option<u64>> {

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -7,10 +7,10 @@
 // workspace MSRV is 1.85.
 #![allow(clippy::duration_suboptimal_units)]
 
+mod download;
 pub mod errors;
 pub mod manifest;
 pub mod segments;
-mod download;
 pub mod state;
 
 pub use errors::DashError;
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use rdlp_core::{Downloader, DownloadStats, ProgressCallback, Result, RetryConfig};
+use rdlp_core::{DownloadStats, Downloader, ProgressCallback, Result, RetryConfig};
 
 use crate::http::HttpDownloader;
 

--- a/crates/rdlp-downloader/src/dash/segments.rs
+++ b/crates/rdlp-downloader/src/dash/segments.rs
@@ -115,9 +115,7 @@ impl SegmentPlan {
     pub fn total_duration(&self) -> Duration {
         match self {
             Self::Template(t) => Duration::from_secs(
-                t.total_segments
-                    .saturating_mul(t.segment_duration_ts)
-                    / t.timescale.max(1),
+                t.total_segments.saturating_mul(t.segment_duration_ts) / t.timescale.max(1),
             ),
             Self::Timeline(t) => {
                 let total_ts: u64 = t.entries.iter().map(timeline_entry_ts).sum();

--- a/crates/rdlp-downloader/src/dash/segments.rs
+++ b/crates/rdlp-downloader/src/dash/segments.rs
@@ -1,1 +1,210 @@
-//! Segment URL resolution. Implementation lands in Task 3.
+//! Segment-URL resolution for the three DASH listing modes.
+//!
+//! `SegmentPlan` encodes the durable subset of a `<SegmentTemplate>`,
+//! `<SegmentList>`, or `<SegmentTimeline>` so we can enumerate segment URLs
+//! without holding onto the parsed dash-mpd tree.
+
+#![allow(clippy::doc_markdown)]
+
+use std::time::Duration;
+use url::Url;
+
+/// One of the three DASH segment-listing modes.
+#[derive(Debug, Clone)]
+pub enum SegmentPlan {
+    /// `<SegmentTemplate>` with `@duration` (no SegmentTimeline child).
+    Template(SegmentTemplatePlan),
+    /// `<SegmentTemplate>` containing a `<SegmentTimeline>`.
+    Timeline(SegmentTimelinePlan),
+    /// Explicit `<SegmentList>` with per-segment URLs.
+    List(SegmentListPlan),
+}
+
+/// `<SegmentTemplate>` with `@duration` (no SegmentTimeline child).
+#[derive(Debug, Clone)]
+pub struct SegmentTemplatePlan {
+    /// Initialisation segment URL template (relative to the BaseURL chain).
+    pub init: Option<String>,
+    /// Media template string e.g. `"video/seg-$Number$.m4s"`.
+    pub media: String,
+    /// First segment number (DASH `@startNumber`, defaults to 1).
+    pub start_number: u64,
+    /// Timescale for `@duration` and `$Time$` substitutions.
+    pub timescale: u64,
+    /// Default segment duration in `timescale` units.
+    pub segment_duration_ts: u64,
+    /// Computed total segment count: `ceil(period_duration_ts / segment_duration_ts)`.
+    pub total_segments: u64,
+    /// `Representation@id` used for `$RepresentationID$` substitution.
+    pub representation_id: String,
+    /// `Representation@bandwidth` used for `$Bandwidth$` substitution.
+    pub bandwidth: u64,
+}
+
+/// `<SegmentTemplate>` containing a `<SegmentTimeline>`.
+#[derive(Debug, Clone)]
+pub struct SegmentTimelinePlan {
+    /// Initialisation segment URL template.
+    pub init: Option<String>,
+    /// Media template string.
+    pub media: String,
+    /// First segment number.
+    pub start_number: u64,
+    /// Timescale for `$Time$` substitutions.
+    pub timescale: u64,
+    /// Ordered list of `<S>` entries describing segment durations.
+    pub entries: Vec<TimelineEntry>,
+    /// `Representation@id`.
+    pub representation_id: String,
+    /// `Representation@bandwidth`.
+    pub bandwidth: u64,
+}
+
+/// One `<S>` inside a `<SegmentTimeline>`.
+#[derive(Debug, Clone)]
+pub struct TimelineEntry {
+    /// Optional explicit start time (`@t`). When `None`, the entry continues
+    /// from the previous entry's end.
+    pub t: Option<u64>,
+    /// Required `@d` — segment duration in timescale units.
+    pub d: u64,
+    /// `@r` — None or 0 means "no repeat" (emit one segment), positive means
+    /// "emit 1 + r segments", negative means "repeat to end of period".
+    pub r: Option<i64>,
+}
+
+/// `<SegmentList>` — explicit per-segment URL listing.
+#[derive(Debug, Clone)]
+pub struct SegmentListPlan {
+    /// Initialisation segment URL (relative).
+    pub init: Option<String>,
+    /// Per-segment relative URLs in playback order.
+    pub urls: Vec<String>,
+}
+
+impl SegmentPlan {
+    /// Resolve the initialisation segment URL against the supplied BaseURL chain.
+    /// Returns `None` when no init is declared.
+    #[must_use]
+    pub fn init_url(&self, base: &[Url]) -> Option<Url> {
+        let init = match self {
+            Self::Template(t) => t.init.as_deref(),
+            Self::Timeline(t) => t.init.as_deref(),
+            Self::List(t) => t.init.as_deref(),
+        }?;
+        join(base, init).ok()
+    }
+
+    /// Enumerate every media-segment URL.
+    ///
+    /// `period_duration_ts` is only consulted by the Timeline branch (to
+    /// expand entries with negative `r`); Template and List ignore it.
+    #[must_use]
+    pub fn segment_urls(&self, base: &[Url], period_duration_ts: u64) -> Vec<Url> {
+        match self {
+            Self::Template(t) => template_urls(t, base),
+            Self::Timeline(t) => timeline_urls(t, base, period_duration_ts),
+            Self::List(t) => t.urls.iter().filter_map(|u| join(base, u).ok()).collect(),
+        }
+    }
+
+    /// Total media duration covered by this plan, derived from segment counts.
+    /// Useful for diagnostic logging — the canonical period duration comes
+    /// from the manifest.
+    #[must_use]
+    pub fn total_duration(&self) -> Duration {
+        match self {
+            Self::Template(t) => Duration::from_secs(
+                t.total_segments
+                    .saturating_mul(t.segment_duration_ts)
+                    / t.timescale.max(1),
+            ),
+            Self::Timeline(t) => {
+                let total_ts: u64 = t.entries.iter().map(timeline_entry_ts).sum();
+                Duration::from_secs(total_ts / t.timescale.max(1))
+            }
+            Self::List(_) => Duration::from_secs(0),
+        }
+    }
+}
+
+fn timeline_entry_ts(entry: &TimelineEntry) -> u64 {
+    let repeats = match entry.r {
+        None | Some(0) => 0u64,
+        Some(k) if k > 0 => u64::try_from(k).unwrap_or(0),
+        Some(_neg) => 0, // diagnostic only — true value depends on period duration
+    };
+    entry.d.saturating_mul(repeats.saturating_add(1))
+}
+
+fn template_urls(t: &SegmentTemplatePlan, base: &[Url]) -> Vec<Url> {
+    (0..t.total_segments)
+        .filter_map(|i| {
+            let n = t.start_number + i;
+            let raw = substitute(
+                &t.media,
+                &t.representation_id,
+                n,
+                n.saturating_mul(t.segment_duration_ts),
+                t.bandwidth,
+            );
+            join(base, &raw).ok()
+        })
+        .collect()
+}
+
+fn timeline_urls(t: &SegmentTimelinePlan, base: &[Url], period_duration_ts: u64) -> Vec<Url> {
+    let mut out = Vec::new();
+    let mut n = t.start_number;
+    let mut ts: u64 = 0;
+    for entry in &t.entries {
+        if let Some(explicit_t) = entry.t {
+            ts = explicit_t;
+        }
+        // DASH SegmentTimeline @r:
+        //   None or Some(0) → emit one segment (no repeats)
+        //   Some(k>0) → emit 1 + k segments
+        //   Some(neg) → repeat until end of period
+        let repeats: u64 = match entry.r {
+            None | Some(0) => 0,
+            Some(k) if k > 0 => u64::try_from(k).unwrap_or(0),
+            Some(_neg) => {
+                let remaining = period_duration_ts.saturating_sub(ts);
+                remaining
+                    .checked_div(entry.d)
+                    .map_or(0, |q| q.saturating_sub(1))
+            }
+        };
+        for _ in 0..=repeats {
+            let raw = substitute(&t.media, &t.representation_id, n, ts, t.bandwidth);
+            if let Ok(u) = join(base, &raw) {
+                out.push(u);
+            }
+            n += 1;
+            ts = ts.saturating_add(entry.d);
+        }
+    }
+    out
+}
+
+fn substitute(template: &str, rep_id: &str, number: u64, time: u64, bw: u64) -> String {
+    template
+        .replace("$RepresentationID$", rep_id)
+        .replace("$Number$", &number.to_string())
+        .replace("$Time$", &time.to_string())
+        .replace("$Bandwidth$", &bw.to_string())
+}
+
+/// Resolve `rel` against the supplied BaseURL chain. The chain is walked in
+/// order: each successive entry resolves against the previous resolution.
+/// The chain is always non-empty (manifest::resolve_base_urls guarantees this).
+fn join(base: &[Url], rel: &str) -> Result<Url, url::ParseError> {
+    let mut current = base
+        .first()
+        .cloned()
+        .ok_or(url::ParseError::RelativeUrlWithoutBase)?;
+    for b in base.iter().skip(1) {
+        current = current.join(b.as_str())?;
+    }
+    current.join(rel)
+}

--- a/crates/rdlp-downloader/src/dash/segments.rs
+++ b/crates/rdlp-downloader/src/dash/segments.rs
@@ -1,0 +1,1 @@
+//! Segment URL resolution. Implementation lands in Task 3.

--- a/crates/rdlp-downloader/src/dash/state.rs
+++ b/crates/rdlp-downloader/src/dash/state.rs
@@ -1,0 +1,1 @@
+//! Resume state. Implementation lands in Task 6.

--- a/crates/rdlp-downloader/src/dash/state.rs
+++ b/crates/rdlp-downloader/src/dash/state.rs
@@ -1,1 +1,116 @@
-//! Resume state. Implementation lands in Task 6.
+//! Resume state for DASH downloads.
+//!
+//! State is persisted to `<output>.dash_state.json` and loaded on retry.
+//! URL match is path-only — CDN host swaps don't break resume.
+//!
+//! Load/save are async (`tokio::fs`) because the workspace clippy config
+//! bans blocking `std::fs` in async contexts. The file is tiny.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use url::Url;
+
+/// Current schema version. Bump on incompatible field changes.
+pub const STATE_VERSION: u32 = 1;
+
+/// Persisted state of an in-progress DASH download.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashDownloadState {
+    /// Schema version. Mismatches force a fresh start.
+    pub state_version: u32,
+    /// Path component of the MPD URL (path-only — CDN-tolerant).
+    pub mpd_path: String,
+    /// `id` of the chosen video representation.
+    pub video_repr_id: String,
+    /// `id` of the chosen audio representation, when one is present.
+    pub audio_repr_id: Option<String>,
+    /// `true` once the video init segment has been written to disk.
+    pub init_video_done: bool,
+    /// `true` once the audio init segment has been written to disk.
+    pub init_audio_done: bool,
+    /// `repr_id -> sorted indices of completed segments`.
+    pub completed_segments: HashMap<String, Vec<u64>>,
+    /// Unix epoch seconds — for stale-state diagnosis.
+    pub updated_at: u64,
+}
+
+impl DashDownloadState {
+    /// Construct a fresh state for the given MPD + representation pair.
+    #[must_use]
+    pub fn new(mpd_url: &Url, video_repr_id: String, audio_repr_id: Option<String>) -> Self {
+        Self {
+            state_version: STATE_VERSION,
+            mpd_path: mpd_url.path().to_string(),
+            video_repr_id,
+            audio_repr_id,
+            init_video_done: false,
+            init_audio_done: false,
+            completed_segments: HashMap::new(),
+            updated_at: now_secs(),
+        }
+    }
+
+    /// Load state if present and matching the requested MPD URL (path-only).
+    /// Returns `None` for: missing file, parse failure, version mismatch,
+    /// path mismatch, or repr-id mismatch.
+    #[must_use]
+    pub async fn load_matching(
+        path: &Path,
+        mpd_url: &Url,
+        video_repr_id: &str,
+        audio_repr_id: Option<&str>,
+    ) -> Option<Self> {
+        let body = fs::read_to_string(path).await.ok()?;
+        let s: Self = serde_json::from_str(&body).ok()?;
+        if s.state_version != STATE_VERSION
+            || s.mpd_path != mpd_url.path()
+            || s.video_repr_id != video_repr_id
+            || s.audio_repr_id.as_deref() != audio_repr_id
+        {
+            return None;
+        }
+        Some(s)
+    }
+
+    /// Persist state to `path`, updating the `updated_at` stamp.
+    ///
+    /// # Errors
+    /// Returns the underlying I/O error from the file write, or a JSON
+    /// serialization error wrapped as `io::Error::other`.
+    pub async fn save(&mut self, path: &Path) -> std::io::Result<()> {
+        self.updated_at = now_secs();
+        let body = serde_json::to_string(self).map_err(std::io::Error::other)?;
+        fs::write(path, body).await
+    }
+
+    /// Mark segment `idx` of representation `repr_id` as completed.
+    /// Sorted-insert; idempotent for duplicates.
+    pub fn record_segment(&mut self, repr_id: &str, idx: u64) {
+        let entry = self
+            .completed_segments
+            .entry(repr_id.to_string())
+            .or_default();
+        if !entry.contains(&idx) {
+            entry.push(idx);
+            entry.sort_unstable();
+        }
+    }
+
+    /// Returns `true` if segment `idx` of `repr_id` has been recorded.
+    #[must_use]
+    pub fn is_segment_done(&self, repr_id: &str, idx: u64) -> bool {
+        self.completed_segments
+            .get(repr_id)
+            .is_some_and(|v| v.binary_search(&idx).is_ok())
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -273,21 +273,21 @@
 pub(crate) mod adaptive;
 /// Intelligent chunk size calculation for optimal download performance
 pub mod chunking;
+/// DASH (Dynamic Adaptive Streaming over HTTP) downloader for static VoD MPDs
+pub mod dash;
 /// HLS (HTTP Live Streaming) downloader with parallel segment downloads
 pub mod hls;
 /// HLS download state persistence for resume support
 pub mod hls_state;
 /// HTTP/HTTPS downloader with parallel chunk support
 pub mod http;
-/// DASH (Dynamic Adaptive Streaming over HTTP) downloader for static VoD MPDs
-pub mod dash;
 /// Shared progress reporting infrastructure
 pub mod progress;
 
 pub use chunking::{ChunkSizeStrategy, calculate_chunks, chunk_size_for_file};
+pub use dash::DashDownloader;
 pub use hls::HlsDownloader;
 pub use http::HttpDownloader;
-pub use dash::DashDownloader;
 pub use progress::{
     ProgressGuard, ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter,
 };

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate provides downloaders for various streaming protocols:
 //! - **HTTP/HTTPS**: Power-of-two chunking with fine-grained parallelism
 //! - **HLS (m3u8)**: Parallel segment downloads with automatic playlist parsing
-//! - **DASH**: Coming soon
+//! - **DASH**: Supported (static VoD only)
 //!
 //! ## Overview
 //!
@@ -279,12 +279,15 @@ pub mod hls;
 pub mod hls_state;
 /// HTTP/HTTPS downloader with parallel chunk support
 pub mod http;
+/// DASH (Dynamic Adaptive Streaming over HTTP) downloader for static VoD MPDs
+pub mod dash;
 /// Shared progress reporting infrastructure
 pub mod progress;
 
 pub use chunking::{ChunkSizeStrategy, calculate_chunks, chunk_size_for_file};
 pub use hls::HlsDownloader;
 pub use http::HttpDownloader;
+pub use dash::DashDownloader;
 pub use progress::{
     ProgressGuard, ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter,
 };
@@ -366,16 +369,27 @@ impl DownloaderRegistry {
             .with_concurrent_segments(config.concurrent_fragments)
             .with_buffer_size(config.buffer_size);
 
+        // Create DASH downloader
+        let dash_downloader = DashDownloader::new()
+            .with_http_downloader(http_downloader.clone())
+            .with_concurrent_segments(config.concurrent_fragments)
+            .with_buffer_size(config.buffer_size);
+
         let mut registry = Self {
             downloaders: Vec::new(),
             http_base: http_downloader.clone(),
             hls_base: hls_downloader.clone(),
         };
 
-        // Register HLS downloader FIRST (more specific matcher for .m3u8 URLs)
+        // Register HLS downloader FIRST (specific matcher for .m3u8 URLs)
         registry.register(Arc::new(hls_downloader));
 
-        // Register HTTP downloader SECOND (fallback for generic HTTP/HTTPS URLs)
+        // Register DASH downloader SECOND (specific matcher for .mpd URLs;
+        // MUST come before HTTP because HTTP's supports() matches every
+        // https URL and would eat .mpd otherwise)
+        registry.register(Arc::new(dash_downloader));
+
+        // Register HTTP downloader LAST (fallback for generic HTTP/HTTPS URLs)
         registry.register(Arc::new(http_downloader));
 
         registry

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate provides downloaders for various streaming protocols:
 //! - **HTTP/HTTPS**: Power-of-two chunking with fine-grained parallelism
 //! - **HLS (m3u8)**: Parallel segment downloads with automatic playlist parsing
-//! - **DASH**: Supported (static VoD only)
+//! - **DASH**: Supported (static `VoD` only)
 //!
 //! ## Overview
 //!
@@ -527,6 +527,7 @@ mod tests {
 
         assert!(downloaders.contains(&"http"));
         assert!(downloaders.contains(&"hls"));
-        assert_eq!(downloaders.len(), 2);
+        assert!(downloaders.contains(&"dash"));
+        assert_eq!(downloaders.len(), 3);
     }
 }

--- a/crates/rdlp-downloader/tests/dash_adaptive.rs
+++ b/crates/rdlp-downloader/tests/dash_adaptive.rs
@@ -1,0 +1,195 @@
+//! Smoke test: `AdaptiveController` integration for DASH segment fetching.
+//!
+//! Verifies that `DashDownloader::download_to_file` routes segment fetching
+//! through the AIMD adaptive controller rather than a fixed-concurrency
+//! `buffer_unordered`.  The signal used is the controller's startup log
+//! message ("Adaptive controller:") forwarded via `ProgressCallback::on_log`
+//! — if the controller is not wired, no such message is produced.
+
+#![allow(clippy::disallowed_methods, clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use rdlp_core::Downloader;
+use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback};
+use rdlp_downloader::DashDownloader;
+use tempfile::TempDir;
+
+// ─── Capturing progress callback ─────────────────────────────────────────────
+
+/// `ProgressCallback` that captures every `on_log` message for inspection.
+struct LogCapture {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl LogCapture {
+    fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let cap = Self {
+            messages: Arc::clone(&messages),
+        };
+        (cap, messages)
+    }
+}
+
+impl ProgressCallback for LogCapture {
+    fn on_progress(&self, _info: &DownloadProgress) {}
+    fn on_complete(&self, _stats: &DownloadStats) {}
+    fn on_error(&self, _error: &str) {}
+    fn on_log(&self, message: &str) {
+        self.messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(message.to_string());
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Build a minimal `SegmentTemplate` MPD with `count` segments per
+/// representation, served from `base_url`.
+fn make_mpd(base_url: &str, seg_count: u32) -> String {
+    // Each segment covers 2 seconds → total duration = seg_count × 2 s.
+    let duration_secs = seg_count * 2;
+    let period_dur = format!("PT{duration_secs}S");
+    let seg_dur_ts: u64 = 2000; // timescale = 1000 ms, duration = 2000 ts
+
+    format!(
+        r#"<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="{period_dur}" minBufferTime="PT4S">
+  <Period duration="{period_dur}">
+    <BaseURL>{base_url}/</BaseURL>
+    <AdaptationSet contentType="video">
+      <Representation id="v1" bandwidth="800000" mimeType="video/mp4">
+        <SegmentTemplate timescale="1000" duration="{seg_dur_ts}" startNumber="1"
+          initialization="vinit.mp4" media="vseg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" lang="en">
+      <Representation id="a1" bandwidth="64000" mimeType="audio/mp4">
+        <SegmentTemplate timescale="1000" duration="{seg_dur_ts}" startNumber="1"
+          initialization="ainit.mp4" media="aseg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>"#
+    )
+}
+
+// ─── Smoke test ───────────────────────────────────────────────────────────────
+
+/// Smoke test: adaptive controller governs a DASH download of 24 video + 24
+/// audio segments.
+///
+/// The test asserts:
+///   1. `download_to_file` returns an error **only** on the FFmpeg mux step
+///      (placeholder bytes are not valid fMP4 — identical to the `dash_e2e`
+///      test contract).  All segment fetches succeed.
+///   2. All segment endpoints are called exactly once (the controller did not
+///      skip or double-fetch any segment).
+///   3. At least one "Adaptive controller:" log message was forwarded via
+///      `ProgressCallback::on_log`, proving the `AdaptiveController` was
+///      constructed and its log path was exercised.
+///
+/// Assertion 3 fails before the adaptive wiring is in place (the controller
+/// is never instantiated, so its startup message is never produced).
+#[tokio::test]
+async fn smoke_adaptive_controller_governs_dash_segments() {
+    const SEG_COUNT: u32 = 24;
+
+    let mut server = mockito::Server::new_async().await;
+    let base = server.url();
+
+    let mpd_body = make_mpd(&base, SEG_COUNT);
+
+    let _mpd = server
+        .mock("GET", "/manifest.mpd")
+        .with_body(&mpd_body)
+        .create_async()
+        .await;
+
+    // Init segments.
+    let _vi = server
+        .mock("GET", "/vinit.mp4")
+        .with_body(b"VINIT")
+        .create_async()
+        .await;
+    let _ai = server
+        .mock("GET", "/ainit.mp4")
+        .with_body(b"AINIT")
+        .create_async()
+        .await;
+
+    // Register all 24 video segments.
+    let mut video_mocks = Vec::new();
+    for n in 1..=SEG_COUNT {
+        let path = format!("/vseg-{n}.m4s");
+        let body = format!("V{n}");
+        let m = server
+            .mock("GET", path.as_str())
+            .with_body(body.as_bytes())
+            .expect(1)
+            .create_async()
+            .await;
+        video_mocks.push(m);
+    }
+
+    // Register all 24 audio segments.
+    let mut audio_mocks = Vec::new();
+    for n in 1..=SEG_COUNT {
+        let path = format!("/aseg-{n}.m4s");
+        let body = format!("A{n}");
+        let m = server
+            .mock("GET", path.as_str())
+            .with_body(body.as_bytes())
+            .expect(1)
+            .create_async()
+            .await;
+        audio_mocks.push(m);
+    }
+
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("out.mp4");
+    let url = format!("{base}/manifest.mpd");
+
+    let (cb, log_messages) = LogCapture::new();
+
+    let downloader = DashDownloader::new();
+    let result = downloader
+        .download_to_file(&url, &out, Some(Box::new(cb)))
+        .await;
+
+    // Assertion 1 — download should fail only at the mux step (placeholder
+    // bytes are not valid fMP4).
+    let err = result.expect_err("mux must fail on non-fMP4 placeholder bytes");
+    let err_str = format!("{err}").to_lowercase();
+    assert!(
+        err_str.contains("mux") || err_str.contains("ffmpeg") || err_str.contains("invalid"),
+        "expected mux/ffmpeg failure, got: {err_str}"
+    );
+
+    // Assertion 2 — every segment mock must have been called exactly once.
+    for m in video_mocks {
+        m.assert_async().await;
+    }
+    for m in audio_mocks {
+        m.assert_async().await;
+    }
+
+    // Assertion 3 — adaptive controller log forwarded via on_log.
+    let msgs = log_messages
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let adaptive_msg_count = msgs
+        .iter()
+        .filter(|m| m.to_lowercase().contains("adaptive"))
+        .count();
+    assert!(
+        adaptive_msg_count > 0,
+        "expected at least one 'Adaptive controller:' log message forwarded via \
+         on_log (got 0); this signals AdaptiveController was not wired into DASH \
+         segment fetching.\n\nAll captured log messages:\n{}",
+        msgs.join("\n")
+    );
+}

--- a/crates/rdlp-downloader/tests/dash_e2e.rs
+++ b/crates/rdlp-downloader/tests/dash_e2e.rs
@@ -1,0 +1,96 @@
+//! End-to-end DASH download test (mockito): MPD fetch → parse → init+segment
+//! fetch → concat to `<output>.video.m4s` + `<output>.audio.m4s`.
+//!
+//! Mux into a single container is Task 5; this test asserts only that the
+//! intermediates are produced and that the muxed output does NOT yet exist.
+
+use rdlp_core::Downloader;
+use rdlp_downloader::DashDownloader;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn downloads_segment_template_video_and_audio() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mpd_body = format!(
+        r#"<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="PT12S" minBufferTime="PT2S">
+  <Period duration="PT12S">
+    <BaseURL>{}/</BaseURL>
+    <AdaptationSet contentType="video">
+      <Representation id="v1" bandwidth="500000" mimeType="video/mp4">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+          initialization="vinit.mp4" media="vseg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" lang="en">
+      <Representation id="a1" bandwidth="64000" mimeType="audio/mp4">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+          initialization="ainit.mp4" media="aseg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>"#,
+        server.url()
+    );
+
+    let _mpd = server
+        .mock("GET", "/manifest.mpd")
+        .with_body(&mpd_body)
+        .create_async()
+        .await;
+    let _vi = server
+        .mock("GET", "/vinit.mp4")
+        .with_body(b"VINIT")
+        .create_async()
+        .await;
+    let _v1 = server
+        .mock("GET", "/vseg-1.m4s")
+        .with_body(b"V1")
+        .create_async()
+        .await;
+    let _v2 = server
+        .mock("GET", "/vseg-2.m4s")
+        .with_body(b"V2")
+        .create_async()
+        .await;
+    let _ai = server
+        .mock("GET", "/ainit.mp4")
+        .with_body(b"AINIT")
+        .create_async()
+        .await;
+    let _a1 = server
+        .mock("GET", "/aseg-1.m4s")
+        .with_body(b"A1")
+        .create_async()
+        .await;
+    let _a2 = server
+        .mock("GET", "/aseg-2.m4s")
+        .with_body(b"A2")
+        .create_async()
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("out.mp4");
+    let url = format!("{}/manifest.mpd", server.url());
+
+    let downloader = DashDownloader::new();
+    let stats = downloader
+        .download_to_file(&url, &out, None)
+        .await
+        .expect("download succeeds");
+
+    let video = dir.path().join("out.video.m4s");
+    let audio = dir.path().join("out.audio.m4s");
+    assert!(video.exists(), "video file written");
+    assert!(audio.exists(), "audio file written");
+    assert_eq!(tokio::fs::read(&video).await.unwrap(), b"VINITV1V2");
+    assert_eq!(tokio::fs::read(&audio).await.unwrap(), b"AINITA1A2");
+    // Mux is Task 5 — out.mp4 itself does NOT exist yet.
+    assert!(
+        !out.exists(),
+        "muxed output is Task 5; should not exist after Task 4"
+    );
+    assert!(stats.bytes_downloaded > 0);
+}

--- a/crates/rdlp-downloader/tests/dash_e2e.rs
+++ b/crates/rdlp-downloader/tests/dash_e2e.rs
@@ -97,14 +97,8 @@ async fn fake_segments_fail_mux_with_intermediates_retained() {
     // Intermediates retained for diagnosis.
     let video = dir.path().join("out.video.m4s");
     let audio = dir.path().join("out.audio.m4s");
-    assert!(
-        video.exists(),
-        "video intermediate retained on mux failure"
-    );
-    assert!(
-        audio.exists(),
-        "audio intermediate retained on mux failure"
-    );
+    assert!(video.exists(), "video intermediate retained on mux failure");
+    assert!(audio.exists(), "audio intermediate retained on mux failure");
     assert_eq!(tokio::fs::read(&video).await.unwrap(), b"VINITV1V2");
     assert_eq!(tokio::fs::read(&audio).await.unwrap(), b"AINITA1A2");
     assert!(!out.exists(), "no output produced on mux failure");

--- a/crates/rdlp-downloader/tests/dash_e2e.rs
+++ b/crates/rdlp-downloader/tests/dash_e2e.rs
@@ -1,15 +1,24 @@
 //! End-to-end DASH download test (mockito): MPD fetch → parse → init+segment
-//! fetch → concat to `<output>.video.m4s` + `<output>.audio.m4s`.
+//! fetch → concat → FFmpeg stream-copy mux.
 //!
-//! Mux into a single container is Task 5; this test asserts only that the
-//! intermediates are produced and that the muxed output does NOT yet exist.
+//! The fixture serves placeholder bytes (`b"VINIT"`, `b"V1"`, etc.) — these
+//! are NOT valid fMP4 boxes, so FFmpeg correctly refuses to mux them. The
+//! test exercises the full pipeline up to and including the mux call, and
+//! asserts that:
+//!   1. download + concat succeed (intermediates exist mid-flight)
+//!   2. mux fails deterministically (FFmpeg rejects the garbage)
+//!   3. intermediates are RETAINED on mux failure for diagnosis
+//!   4. no output file is produced
+//!
+//! A separate `#[ignore]` test exercises the success path against real
+//! fMP4 fixtures (not committed; see test body for generation steps).
 
 use rdlp_core::Downloader;
 use rdlp_downloader::DashDownloader;
 use tempfile::TempDir;
 
 #[tokio::test]
-async fn downloads_segment_template_video_and_audio() {
+async fn fake_segments_fail_mux_with_intermediates_retained() {
     let mut server = mockito::Server::new_async().await;
 
     let mpd_body = format!(
@@ -76,21 +85,53 @@ async fn downloads_segment_template_video_and_audio() {
     let url = format!("{}/manifest.mpd", server.url());
 
     let downloader = DashDownloader::new();
-    let stats = downloader
-        .download_to_file(&url, &out, None)
-        .await
-        .expect("download succeeds");
+    let result = downloader.download_to_file(&url, &out, None).await;
 
+    let err = result.expect_err("mux must fail on non-fMP4 bytes");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("mux") || msg.contains("ffmpeg") || msg.contains("invalid"),
+        "expected mux/ffmpeg failure, got: {msg}"
+    );
+
+    // Intermediates retained for diagnosis.
     let video = dir.path().join("out.video.m4s");
     let audio = dir.path().join("out.audio.m4s");
-    assert!(video.exists(), "video file written");
-    assert!(audio.exists(), "audio file written");
+    assert!(
+        video.exists(),
+        "video intermediate retained on mux failure"
+    );
+    assert!(
+        audio.exists(),
+        "audio intermediate retained on mux failure"
+    );
     assert_eq!(tokio::fs::read(&video).await.unwrap(), b"VINITV1V2");
     assert_eq!(tokio::fs::read(&audio).await.unwrap(), b"AINITA1A2");
-    // Mux is Task 5 — out.mp4 itself does NOT exist yet.
-    assert!(
-        !out.exists(),
-        "muxed output is Task 5; should not exist after Task 4"
-    );
-    assert!(stats.bytes_downloaded > 0);
+    assert!(!out.exists(), "no output produced on mux failure");
+}
+
+/// Real fMP4 success-path test. Skipped by default — requires committed
+/// fMP4 fixtures.
+///
+/// To generate fixtures locally:
+///
+/// ```bash
+/// ffmpeg -y -f lavfi -i 'testsrc=size=160x120:duration=2' \
+///   -f lavfi -i 'sine=frequency=1000:duration=2' \
+///   -map 0:v -c:v libx264 -tune zerolatency -profile:v baseline -level 3.0 \
+///   -map 1:a -c:a aac -b:a 64k \
+///   -f dash -seg_duration 1 -use_template 1 -use_timeline 0 \
+///   -init_seg_name 'init-$RepresentationID$.mp4' \
+///   -media_seg_name 'seg-$RepresentationID$-$Number$.m4s' \
+///   /tmp/dash/manifest.mpd
+/// ```
+///
+/// Then commit `init-0.mp4` (video), `init-1.mp4` (audio), and one segment
+/// each under `crates/rdlp-downloader/tests/fixtures/dash/segments/`.
+#[tokio::test]
+#[ignore = "requires real fMP4 fixtures; see test docstring for generation steps"]
+async fn real_fmp4_fixtures_mux_to_single_output() {
+    // Wire up a mockito server that serves real fMP4 init + segment bytes
+    // from disk fixtures, run download_to_file, assert out.mp4 exists and
+    // is non-empty, intermediates are cleaned up.
 }

--- a/crates/rdlp-downloader/tests/dash_parse.rs
+++ b/crates/rdlp-downloader/tests/dash_parse.rs
@@ -1,10 +1,6 @@
 //! Integration tests for `rdlp_downloader::dash::manifest::parse_mpd`.
 
-#![allow(
-    clippy::disallowed_methods,
-    clippy::unwrap_used,
-    clippy::expect_used
-)]
+#![allow(clippy::disallowed_methods, clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::PathBuf;
 use url::Url;

--- a/crates/rdlp-downloader/tests/dash_parse.rs
+++ b/crates/rdlp-downloader/tests/dash_parse.rs
@@ -66,3 +66,39 @@ fn multi_period_warns_and_returns_first_period() {
     let m = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
     assert!(m.period_count >= 2);
 }
+
+#[test]
+fn segment_template_fixture_produces_template_plan() {
+    let body = fixture("segment_template.mpd");
+    let m = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+    match &m.video.plan {
+        rdlp_downloader::dash::segments::SegmentPlan::Template(t) => {
+            assert_eq!(t.start_number, 1);
+            assert_eq!(t.timescale, 1000);
+            // 30s @ 6000-tick segments / 1000 timescale → 5 segments.
+            assert_eq!(t.total_segments, 5);
+            assert_eq!(t.representation_id, "v1");
+        }
+        other => panic!("expected Template plan, got {other:?}"),
+    }
+}
+
+#[test]
+fn segment_timeline_fixture_produces_timeline_plan() {
+    let body = fixture("segment_timeline.mpd");
+    let m = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+    assert!(matches!(
+        m.video.plan,
+        rdlp_downloader::dash::segments::SegmentPlan::Timeline(_)
+    ));
+}
+
+#[test]
+fn segment_list_fixture_produces_list_plan() {
+    let body = fixture("segment_list.mpd");
+    let m = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+    assert!(matches!(
+        m.video.plan,
+        rdlp_downloader::dash::segments::SegmentPlan::List(_)
+    ));
+}

--- a/crates/rdlp-downloader/tests/dash_parse.rs
+++ b/crates/rdlp-downloader/tests/dash_parse.rs
@@ -1,0 +1,68 @@
+//! Integration tests for `rdlp_downloader::dash::manifest::parse_mpd`.
+
+#![allow(
+    clippy::disallowed_methods,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+use std::path::PathBuf;
+use url::Url;
+
+fn fixture(name: &str) -> String {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/dash");
+    p.push(name);
+    std::fs::read_to_string(&p).expect("fixture exists")
+}
+
+fn base() -> Url {
+    Url::parse("https://example.test/dash/manifest.mpd").unwrap()
+}
+
+#[test]
+fn segment_template_picks_highest_bandwidth_video_and_audio() {
+    let body = fixture("segment_template.mpd");
+    let m = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+    assert_eq!(m.video.id, "v1");
+    assert_eq!(m.video.bandwidth, 1_000_000);
+    assert_eq!(m.audio.as_ref().unwrap().id, "a1");
+    assert_eq!(m.video.width, Some(1920));
+    assert_eq!(m.video.height, Some(1080));
+}
+
+#[test]
+fn segment_timeline_parses() {
+    let body = fixture("segment_timeline.mpd");
+    rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+}
+
+#[test]
+fn segment_list_parses() {
+    let body = fixture("segment_list.mpd");
+    rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+}
+
+#[test]
+fn dynamic_mpd_refused() {
+    let body = fixture("dynamic.mpd");
+    let err = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap_err();
+    assert!(matches!(err, rdlp_downloader::dash::DashError::DynamicMpd));
+}
+
+#[test]
+fn drm_mpd_refused() {
+    let body = fixture("with_drm.mpd");
+    let err = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap_err();
+    assert!(matches!(
+        err,
+        rdlp_downloader::dash::DashError::DrmProtected
+    ));
+}
+
+#[test]
+fn multi_period_warns_and_returns_first_period() {
+    let body = fixture("multi_period.mpd");
+    let m = rdlp_downloader::dash::manifest::parse_mpd(&body, &base()).unwrap();
+    assert!(m.period_count >= 2);
+}

--- a/crates/rdlp-downloader/tests/dash_resume.rs
+++ b/crates/rdlp-downloader/tests/dash_resume.rs
@@ -1,0 +1,168 @@
+//! DASH resume test (mockito): partial first run leaves state + per-segment
+//! parts on disk; second run skips already-fetched segments.
+
+use std::time::Duration;
+
+use mockito::Server;
+use rdlp_core::{Downloader, RetryConfig};
+use rdlp_downloader::DashDownloader;
+use tempfile::TempDir;
+
+/// Tight retry policy so tests don't burn 60s per 503.
+fn fast_retry() -> RetryConfig {
+    RetryConfig::new(2, Duration::from_millis(10), Duration::from_millis(50), 2.0)
+        .with_jitter(false)
+}
+
+fn fast_dl() -> DashDownloader {
+    DashDownloader::new().with_retry_config(fast_retry())
+}
+
+fn mpd_body(server_url: &str) -> String {
+    format!(
+        r#"<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="PT12S" minBufferTime="PT2S">
+  <Period duration="PT12S">
+    <BaseURL>{server_url}/</BaseURL>
+    <AdaptationSet contentType="video">
+      <Representation id="v1" bandwidth="500000" mimeType="video/mp4">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+          initialization="vinit.mp4" media="vseg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>"#
+    )
+}
+
+#[tokio::test]
+async fn resume_skips_already_downloaded_segments() {
+    // Phase 1: succeed init + seg 1, fail seg 2 with 503. State should
+    // record seg 0 (0-based) as done.
+    let mut server = Server::new_async().await;
+    let _mpd = server
+        .mock("GET", "/manifest.mpd")
+        .with_body(mpd_body(&server.url()))
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let _vi = server
+        .mock("GET", "/vinit.mp4")
+        .with_body(b"VINIT")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let v1_first = server
+        .mock("GET", "/vseg-1.m4s")
+        .with_body(b"V1")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let v2_fail = server
+        .mock("GET", "/vseg-2.m4s")
+        .with_status(503)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("out.mp4");
+    let url = format!("{}/manifest.mpd", server.url());
+    let downloader = fast_dl();
+
+    // First run: must error because seg 2 fails (503 burns through retries).
+    let _err = downloader
+        .download_to_file(&url, &out, None)
+        .await
+        .expect_err("seg 2 503 → fail");
+
+    // State file should exist; init + seg-0 part on disk.
+    let state_file = dir.path().join("out.mp4.dash_state.json");
+    assert!(state_file.exists(), "state persisted");
+    let parts = dir.path().join("out.video.parts");
+    let init_part = parts.join("init.m4s");
+    let part0 = parts.join("0000.m4s");
+    assert!(init_part.exists(), "init part written");
+    assert!(part0.exists(), "seg 0 part written");
+
+    // State JSON should record seg 0 as done.
+    let body = tokio::fs::read_to_string(&state_file).await.unwrap();
+    assert!(
+        body.contains("\"v1\":[0]") || body.contains("\"v1\": [0]"),
+        "state should record seg 0 done; got: {body}"
+    );
+
+    // Phase 2: drop the failing mock, replace with success. Wire a NEW
+    // vseg-1 mock with expect(0) — it MUST NOT be hit again.
+    drop(v2_fail);
+    drop(v1_first);
+
+    let v1_replay = server
+        .mock("GET", "/vseg-1.m4s")
+        .expect(0)
+        .with_body(b"V1")
+        .create_async()
+        .await;
+    let _v2_ok = server
+        .mock("GET", "/vseg-2.m4s")
+        .with_body(b"V2")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    // Second run: outcome may be Ok or Err depending on whether the
+    // fake-byte mux works (it doesn't, FFmpeg rejects). We only care that
+    // vseg-1 was NOT re-fetched.
+    let _ = downloader.download_to_file(&url, &out, None).await;
+
+    v1_replay.assert_async().await;
+}
+
+/// State file path is `<output>.dash_state.json` — i.e. the FULL output
+/// filename plus suffix, not the stem.
+#[tokio::test]
+async fn state_path_uses_full_output_filename() {
+    let mut server = Server::new_async().await;
+    let _mpd = server
+        .mock("GET", "/manifest.mpd")
+        .with_body(mpd_body(&server.url()))
+        .create_async()
+        .await;
+    // Init succeeds, then segment 1 fails so we get partial state written.
+    let _vi = server
+        .mock("GET", "/vinit.mp4")
+        .with_body(b"VINIT")
+        .create_async()
+        .await;
+    let _v1 = server
+        .mock("GET", "/vseg-1.m4s")
+        .with_status(503)
+        .create_async()
+        .await;
+    let _v2 = server
+        .mock("GET", "/vseg-2.m4s")
+        .with_status(503)
+        .create_async()
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("out.mp4");
+    let url = format!("{}/manifest.mpd", server.url());
+
+    let _err = fast_dl()
+        .download_to_file(&url, &out, None)
+        .await
+        .expect_err("segs 503 must fail");
+
+    // The correct path includes the full output filename.
+    assert!(
+        dir.path().join("out.mp4.dash_state.json").exists(),
+        "state path must be <output>.dash_state.json"
+    );
+    // The wrong (stem-only) path must NOT exist.
+    assert!(
+        !dir.path().join("out.dash_state.json").exists(),
+        "state path must include the .mp4 suffix, not just the stem"
+    );
+}

--- a/crates/rdlp-downloader/tests/dash_segments.rs
+++ b/crates/rdlp-downloader/tests/dash_segments.rs
@@ -1,10 +1,6 @@
 //! Unit tests for `rdlp_downloader::dash::segments::SegmentPlan`.
 
-#![allow(
-    clippy::disallowed_methods,
-    clippy::unwrap_used,
-    clippy::expect_used
-)]
+#![allow(clippy::disallowed_methods, clippy::unwrap_used, clippy::expect_used)]
 
 use rdlp_downloader::dash::segments::{
     SegmentListPlan, SegmentPlan, SegmentTemplatePlan, SegmentTimelinePlan, TimelineEntry,

--- a/crates/rdlp-downloader/tests/dash_segments.rs
+++ b/crates/rdlp-downloader/tests/dash_segments.rs
@@ -1,0 +1,128 @@
+//! Unit tests for `rdlp_downloader::dash::segments::SegmentPlan`.
+
+#![allow(
+    clippy::disallowed_methods,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+use rdlp_downloader::dash::segments::{
+    SegmentListPlan, SegmentPlan, SegmentTemplatePlan, SegmentTimelinePlan, TimelineEntry,
+};
+use url::Url;
+
+fn base() -> Vec<Url> {
+    vec![Url::parse("https://example.test/dash/").unwrap()]
+}
+
+#[test]
+fn template_substitutes_number_and_bandwidth() {
+    let plan = SegmentPlan::Template(SegmentTemplatePlan {
+        init: Some("video/init.mp4".into()),
+        media: "video/$RepresentationID$/$Number$-$Bandwidth$.m4s".into(),
+        start_number: 1,
+        timescale: 1000,
+        segment_duration_ts: 6000,
+        total_segments: 3,
+        representation_id: "v1".into(),
+        bandwidth: 1_000_000,
+    });
+    let urls = plan.segment_urls(&base(), 18_000);
+    assert_eq!(urls.len(), 3);
+    assert_eq!(
+        urls[0].as_str(),
+        "https://example.test/dash/video/v1/1-1000000.m4s"
+    );
+    assert_eq!(
+        urls[2].as_str(),
+        "https://example.test/dash/video/v1/3-1000000.m4s"
+    );
+}
+
+#[test]
+fn timeline_expands_positive_repeats() {
+    let plan = SegmentPlan::Timeline(SegmentTimelinePlan {
+        init: None,
+        media: "seg-$Number$.m4s".into(),
+        start_number: 1,
+        timescale: 1000,
+        entries: vec![TimelineEntry {
+            t: Some(0),
+            d: 6000,
+            r: Some(4),
+        }], // 5 segments
+        representation_id: "v1".into(),
+        bandwidth: 1_000_000,
+    });
+    let urls = plan.segment_urls(&base(), 30_000);
+    assert_eq!(urls.len(), 5);
+    assert_eq!(urls[0].as_str(), "https://example.test/dash/seg-1.m4s");
+    assert_eq!(urls[4].as_str(), "https://example.test/dash/seg-5.m4s");
+}
+
+#[test]
+fn timeline_expands_negative_r_to_period_end() {
+    // Period = 30s @ 1000 timescale = 30_000 ts. Each segment 6000 ts → 5 segments.
+    let plan = SegmentPlan::Timeline(SegmentTimelinePlan {
+        init: None,
+        media: "seg-$Number$.m4s".into(),
+        start_number: 1,
+        timescale: 1000,
+        entries: vec![TimelineEntry {
+            t: Some(0),
+            d: 6000,
+            r: Some(-1),
+        }],
+        representation_id: "v1".into(),
+        bandwidth: 1,
+    });
+    let urls = plan.segment_urls(&base(), 30_000);
+    assert_eq!(urls.len(), 5);
+}
+
+#[test]
+fn timeline_no_repeat_emits_single_segment() {
+    let plan = SegmentPlan::Timeline(SegmentTimelinePlan {
+        init: None,
+        media: "seg-$Number$.m4s".into(),
+        start_number: 1,
+        timescale: 1000,
+        entries: vec![TimelineEntry {
+            t: Some(0),
+            d: 6000,
+            r: None,
+        }],
+        representation_id: "v1".into(),
+        bandwidth: 1,
+    });
+    assert_eq!(plan.segment_urls(&base(), 30_000).len(), 1);
+}
+
+#[test]
+fn list_resolves_relative_urls() {
+    let plan = SegmentPlan::List(SegmentListPlan {
+        init: Some("init.mp4".into()),
+        urls: vec!["s1.m4s".into(), "s2.m4s".into()],
+    });
+    let urls = plan.segment_urls(&base(), 0);
+    assert_eq!(urls.len(), 2);
+    assert_eq!(urls[0].as_str(), "https://example.test/dash/s1.m4s");
+}
+
+#[test]
+fn init_url_resolves() {
+    let plan = SegmentPlan::Template(SegmentTemplatePlan {
+        init: Some("init.mp4".into()),
+        media: "seg-$Number$.m4s".into(),
+        start_number: 1,
+        timescale: 1000,
+        segment_duration_ts: 6000,
+        total_segments: 1,
+        representation_id: "v1".into(),
+        bandwidth: 1,
+    });
+    assert_eq!(
+        plan.init_url(&base()).unwrap().as_str(),
+        "https://example.test/dash/init.mp4"
+    );
+}

--- a/crates/rdlp-downloader/tests/fixtures/dash/dynamic.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/dynamic.mpd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="dynamic"
+     availabilityStartTime="2024-01-01T00:00:00Z"
+     minimumUpdatePeriod="PT5S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="0" start="PT0S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="video/init.mp4"
+            media="video/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-downloader/tests/fixtures/dash/multi_period.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/multi_period.mpd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="static"
+     mediaPresentationDuration="PT30S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0" duration="PT15S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="video/init.mp4"
+            media="video/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="audio/mp4" contentType="audio" lang="en" segmentAlignment="true">
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="audio/init.mp4"
+            media="audio/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="1" duration="PT15S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v_p2" bandwidth="500000" codecs="avc1.640028" width="1280" height="720">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="video2/init.mp4"
+            media="video2/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-downloader/tests/fixtures/dash/segment_list.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/segment_list.mpd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="static"
+     mediaPresentationDuration="PT30S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0" duration="PT30S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentList timescale="1000" duration="6000">
+          <Initialization sourceURL="video/init.mp4"/>
+          <SegmentURL media="video/seg-1.m4s"/>
+          <SegmentURL media="video/seg-2.m4s"/>
+          <SegmentURL media="video/seg-3.m4s"/>
+          <SegmentURL media="video/seg-4.m4s"/>
+          <SegmentURL media="video/seg-5.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="audio/mp4" contentType="audio" lang="en" segmentAlignment="true">
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentList timescale="1000" duration="6000">
+          <Initialization sourceURL="audio/init.mp4"/>
+          <SegmentURL media="audio/seg-1.m4s"/>
+          <SegmentURL media="audio/seg-2.m4s"/>
+          <SegmentURL media="audio/seg-3.m4s"/>
+          <SegmentURL media="audio/seg-4.m4s"/>
+          <SegmentURL media="audio/seg-5.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-downloader/tests/fixtures/dash/segment_template.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/segment_template.mpd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="static"
+     mediaPresentationDuration="PT30S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0" duration="PT30S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="video/init.mp4"
+            media="video/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="audio/mp4" contentType="audio" lang="en" segmentAlignment="true">
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="audio/init.mp4"
+            media="audio/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-downloader/tests/fixtures/dash/segment_timeline.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/segment_timeline.mpd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="static"
+     mediaPresentationDuration="PT30S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0" duration="PT30S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentTemplate timescale="1000" startNumber="1"
+            initialization="video/init.mp4"
+            media="video/seg-$Number$.m4s">
+          <SegmentTimeline>
+            <S t="0" d="6000" r="4"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="audio/mp4" contentType="audio" lang="en" segmentAlignment="true">
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentTemplate timescale="1000" startNumber="1"
+            initialization="audio/init.mp4"
+            media="audio/seg-$Number$.m4s">
+          <SegmentTimeline>
+            <S t="0" d="6000" r="4"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-downloader/tests/fixtures/dash/with_drm.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/with_drm.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="static"
+     mediaPresentationDuration="PT30S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0" duration="PT30S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="video/init.mp4"
+            media="video/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="audio/mp4" contentType="audio" lang="en" segmentAlignment="true">
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentTemplate timescale="1000" duration="6000" startNumber="1"
+            initialization="audio/init.mp4"
+            media="audio/seg-$Number$.m4s"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-extractor/src/extractors/generic/direct.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/direct.rs
@@ -31,6 +31,13 @@ impl PrefetchResponse {
             .is_some_and(|ct| patterns::is_media_content_type(ct))
     }
 
+    /// Check if Content-Type indicates a DASH manifest.
+    pub fn is_dash_content_type(&self) -> bool {
+        self.content_type
+            .as_ref()
+            .is_some_and(|ct| ct.to_lowercase().contains("dash+xml"))
+    }
+
     /// Check if Content-Type indicates HTML.
     pub fn is_html_content_type(&self) -> bool {
         self.content_type
@@ -44,7 +51,6 @@ impl PrefetchResponse {
     }
 
     /// Check if prefetched bytes look like an MPD manifest.
-    #[allow(dead_code)]
     pub fn is_mpd_manifest(&self) -> bool {
         let text = String::from_utf8_lossy(&self.bytes);
         let trimmed = text.trim_start();

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -192,6 +192,18 @@ impl InfoExtractor for GenericExtractor {
 
 /// Try to handle a direct media URL from the prefetch response.
 fn try_direct_media(url: &str, pf: &PrefetchResponse) -> Result<Option<InfoDict>> {
+    // Check for DASH manifest before the generic media content-type branch, since
+    // `application/dash+xml` satisfies `is_media_content_type` and would otherwise
+    // produce a wrong generic-direct format instead of `HttpDashSegments`.
+    if pf.is_dash_content_type() || pf.is_mpd_manifest() {
+        let title = title_from_url(url);
+        let video_id = generate_video_id(url);
+        let mut info = InfoDict::new(&video_id, &title, "Generic", url);
+        let format = Format::new("dash", url, "mpd", DownloadProtocol::HttpDashSegments);
+        info.formats = vec![format];
+        return Ok(Some(info));
+    }
+
     if pf.is_media_content_type() && !pf.is_html_content_type() {
         let title = title_from_url(url);
         let ext = ext_from_url(url).or_else(|| {
@@ -426,5 +438,47 @@ mod tests {
         };
         let result = try_direct_media("https://example.com/page", &pf).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn direct_mpd_emits_dash_format() {
+        // Content-Type: application/dash+xml — should emit HttpDashSegments, not generic direct
+        let pf_ct = PrefetchResponse {
+            content_type: Some("application/dash+xml".to_string()),
+            bytes: b"<?xml version=\"1.0\"?><MPD xmlns=\"urn:mpeg:dash:schema\">".to_vec(),
+            content_length: None,
+        };
+        let result = try_direct_media("https://cdn.example.com/manifest.mpd", &pf_ct).unwrap();
+        assert!(
+            result.is_some(),
+            "expected Some(InfoDict) for MPD via Content-Type"
+        );
+        let info = result.unwrap();
+        assert_eq!(info.formats.len(), 1);
+        assert_eq!(
+            info.formats[0].protocol,
+            DownloadProtocol::HttpDashSegments,
+            "format must use HttpDashSegments protocol"
+        );
+        assert_eq!(info.formats[0].ext, "mpd");
+
+        // Body sniff: <MPD start with no application/dash+xml Content-Type
+        let pf_sniff = PrefetchResponse {
+            content_type: Some("application/octet-stream".to_string()),
+            bytes: b"<MPD xmlns=\"urn:mpeg:dash:schema\" type=\"static\">".to_vec(),
+            content_length: None,
+        };
+        let result2 = try_direct_media("https://cdn.example.com/stream.mpd", &pf_sniff).unwrap();
+        assert!(
+            result2.is_some(),
+            "expected Some(InfoDict) for MPD via body sniff"
+        );
+        let info2 = result2.unwrap();
+        assert_eq!(info2.formats.len(), 1);
+        assert_eq!(
+            info2.formats[0].protocol,
+            DownloadProtocol::HttpDashSegments,
+            "body-sniffed MPD must also use HttpDashSegments protocol"
+        );
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
@@ -21,6 +21,7 @@ use std::ffi::CString;
 /// encoding_tool_tag("libx264 + libfdk_aac")  // → "rdlp/0.1.0 (libx264 + libfdk_aac)"
 /// encoding_tool_tag("remux")                  // → "rdlp/0.1.0 (remux)"
 /// ```
+#[must_use]
 pub fn encoding_tool_tag(components: &str) -> String {
     format!("rdlp/{} ({components})", env!("CARGO_PKG_VERSION"))
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -42,6 +42,7 @@
 mod audio_codecs;
 pub mod audio_encoder_registry;
 mod encoding_tag;
+pub use encoding_tag::encoding_tool_tag;
 mod ffi_helpers;
 pub mod fixup;
 pub mod log_capture;

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -54,5 +54,5 @@ pub use ffmpeg::{
     AudioCodecInfo, AudioEncoderInfo, AudioExtractOptions, AudioNormMode, ChapterEntry,
     FFmpegRunner, FfmpegLogBridge, LogForwarderGuard, LoudnormMeasurements, LoudnormPreset,
     MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo, VideoCodecInfo,
-    VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs, set_verbose,
+    VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs, encoding_tool_tag, set_verbose,
 };


### PR DESCRIPTION
## Summary

Implements `HttpDashSegments` end-to-end in `rdlp-downloader`. Static VoD MPDs now download, mux, and post-process through the existing pipeline. Per the design doc at `docs/planning/2026-05-02-dash-protocol-support-design.md`.

- New `DashDownloader` under `crates/rdlp-downloader/src/dash/` mirroring HLS layout (manifest parser, segment plan, parallel fetch, in-downloader FFmpeg stream-copy mux to a single output, `.dash_state.json` resume).
- New dep `dash-mpd 0.20` with `default-features = false` (parse-only — no transitive reqwest).
- New edge `rdlp-downloader → rdlp-ffmpeg` for stream-copy mux (precedent: `rdlp-postprocess → rdlp-ffmpeg`).
- AIMD adaptive controller wired (HlsSegments mode, one per Representation) — same controller HLS uses, no new controller code.
- Generic extractor emits `Format { protocol: HttpDashSegments }` on `application/dash+xml` Content-Type or `<MPD` body sniff, so the branch is exercisable end-to-end on merge (not dead code).

## Out of scope (refused with typed errors or warnings)

- Dynamic / live MPDs (`@type=\"dynamic\"`) — refused.
- DRM / ContentProtection — refused.
- Multi-period MPDs — first period only, warning logged.
- LL-DASH (chunked CMAF).
- yt-dlp shim wiring of `_extract_mpd_formats_and_subtitles` — Slice 2.5 task.
- Per-Representation Format emission for selector DSL — current branch picks max-bandwidth video + audio.

## Test plan

- [x] \`cargo check\` passes.
- [x] \`cargo clippy -- -D warnings\` passes.
- [x] \`cargo test\` passes (DASH: 8 negative regression-guard tests + 2 positive resolution tests + e2e + resume + adaptive smoke).
- [x] \`cargo fmt --check\` passes.
- [x] Generic extractor regression: \`cargo test -p rdlp-extractor\` 887 → 888 (+1 new \`direct_mpd_emits_dash_format\`, 0 regressions).
- [ ] Manual end-to-end against a real DASH-only site once an extractor producer lands beyond Generic (deferred — not in this branch's scope).
- [ ] \`cargo check -p rdlp-desktop\` — fails in this worktree because frontend \`dist/\` is not built; passes on a clean checkout where the frontend has been built.

## Per-task review trail

Tasks 7–9 (the final phase, prior to this) were reviewed under the per-task review cycle in \`superpowers-skill-ordering.md\`:

- Task 7 (\`14dd511\`): spec compliance PASS, code quality PASS-WITH-NITS. The substantive nit (\`buffer_unordered\` headroom defeating AIMD upper end) is fixed in \`accac55\`.
- Task 8 (\`9ae77e9\`): spec compliance PASS, code quality PASS-WITH-NITS (cosmetic only).

Earlier tasks (1–6) were reviewed inline during implementation.