### PR TITLE
chore(generic): DASH cleanup nits from PR #233 review

### DIFF
--- a/crates/rdlp-extractor/src/extractors/generic/direct.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/direct.rs
@@ -33,9 +33,11 @@ impl PrefetchResponse {
 
     /// Check if Content-Type indicates a DASH manifest.
     pub fn is_dash_content_type(&self) -> bool {
-        self.content_type
-            .as_ref()
-            .is_some_and(|ct| ct.as_bytes().windows(8).any(|w| w.eq_ignore_ascii_case(b"dash+xml")))
+        self.content_type.as_ref().is_some_and(|ct| {
+            ct.as_bytes()
+                .windows(8)
+                .any(|w| w.eq_ignore_ascii_case(b"dash+xml"))
+        })
     }
 
     /// Check if Content-Type indicates HTML.

--- a/crates/rdlp-extractor/src/extractors/generic/direct.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/direct.rs
@@ -35,7 +35,7 @@ impl PrefetchResponse {
     pub fn is_dash_content_type(&self) -> bool {
         self.content_type
             .as_ref()
-            .is_some_and(|ct| ct.to_lowercase().contains("dash+xml"))
+            .is_some_and(|ct| ct.as_bytes().windows(8).any(|w| w.eq_ignore_ascii_case(b"dash+xml")))
     }
 
     /// Check if Content-Type indicates HTML.

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -460,6 +460,7 @@ mod tests {
             DownloadProtocol::HttpDashSegments,
             "format must use HttpDashSegments protocol"
         );
+        assert_eq!(info.formats[0].format_id, "dash");
         assert_eq!(info.formats[0].ext, "mpd");
 
         // Body sniff: <MPD start with no application/dash+xml Content-Type
@@ -480,5 +481,7 @@ mod tests {
             DownloadProtocol::HttpDashSegments,
             "body-sniffed MPD must also use HttpDashSegments protocol"
         );
+        assert_eq!(info2.formats[0].format_id, "dash");
+        assert_eq!(info2.formats[0].ext, "mpd");
     }
 }


### PR DESCRIPTION
## Summary

Addresses the two non-blocking nits from the code-quality review of PR #233:

- `direct.rs`: replace `to_lowercase().contains("dash+xml")` allocation in `is_dash_content_type` with a windowed `eq_ignore_ascii_case` scan. No allocation, ASCII-equivalent.
- `mod.rs`: assert `format_id == "dash"` and `ext == "mpd"` on the body-sniff branch of `direct_mpd_emits_dash_format` for symmetry with the Content-Type branch.

## Test plan

- [x] `cargo test -p rdlp-extractor direct_mpd_emits_dash_format` — passes.
- [x] `cargo clippy -p rdlp-extractor -- -D warnings` — clean.