### PR TITLE
ci: speed up Run Golden Build (drop windows wait + cache wasm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,21 @@ jobs:
 
   ytdlp-plugin-golden:
     name: Run Golden Build
-    needs: [build-and-test, golden-filter]
+    needs: [golden-filter]
+    # `build-and-test` was previously a `needs:` dependency to gate Golden
+    # behind cross-platform compile success. We dropped it because:
+    #
+    # 1. Golden runs on ubuntu-22.04. Linux compile failures surface as
+    #    Golden failures directly — the matrix dependency added no signal
+    #    on top of that.
+    # 2. Windows is the slowest matrix shard (~11m). Golden waited the
+    #    extra ~7m for Windows after ubuntu/macos finished, every push,
+    #    even when Windows had nothing to do with the change. That's a
+    #    Golden-side cost paid for cross-platform parity that Golden
+    #    doesn't exercise.
+    # 3. Windows-only or macOS-only build failures are still caught
+    #    independently by the matrix's own status check.
+    #
     # Always run on push (merges into develop) and on workflow_dispatch
     # (manual reruns must exercise the golden — that's the one case where
     # you most want it). On PR, run only when the filter caught a relevant
@@ -373,6 +387,35 @@ jobs:
         with:
           shared-key: rust-ubuntu-22.04
 
+      # Cache componentize-py wasm artifacts produced by each `*_golden.rs`
+      # test's `build_*_plugin()` helper. Each plugin's wasm is a function
+      # of:
+      #   - the plugin's `.py` source (per-plugin),
+      #   - componentize-py version (pinned via requirements-dev.txt),
+      #   - the WIT contract,
+      #   - the rdlp-side compat shim and build-from-ytdlp wrapper.
+      # If any of those change, the cache key flips and we rebuild every
+      # plugin. Otherwise we restore the prior wasm and skip the
+      # ~30s componentize-py compile per plugin (3 ytdlp-goldens + svt +
+      # xxxymovies = 5 plugins ≈ 150s saved on cache hit).
+      #
+      # The test-side helpers (svt_golden::build_svt_plugin etc.) honour
+      # the `RDLP_TEST_USE_CACHED_WASM=1` env var: when set AND the wasm
+      # exists, they skip the rebuild and return the cached path. Local
+      # `cargo test` runs never set this env var, so the rebuild path
+      # remains the default — correctness over speed by default.
+      - name: Cache golden wasm artefacts
+        id: golden-wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            examples/plugins/svt/svt
+            examples/plugins/xxxymovies/xxxymovies
+            examples/plugins/ytdlp-golden/simple-html
+            examples/plugins/ytdlp-golden/json-traversal
+            examples/plugins/ytdlp-golden/m3u8-with-fallback
+          key: golden-wasm-${{ runner.os }}-${{ hashFiles('tools/ytdlp-compat/requirements-dev.txt', 'tools/ytdlp-compat/rdlp_ytdlp_compat/**/*.py', 'crates/rdlp-cli/src/plugin_cmd/build_from_ytdlp.rs', 'crates/rdlp-plugin/wit/**/*.wit', 'examples/plugins/svt/svt.py', 'examples/plugins/xxxymovies/xxxymovies.py', 'examples/plugins/ytdlp-golden/*.py') }}
+
       - name: Run all goldens
         # Iterates every `crates/rdlp-plugin/tests/*_golden.rs` file —
         # each new ported plugin (Slice 2.5+) auto-runs without CI
@@ -381,7 +424,13 @@ jobs:
         # pass --ignored. Sequential execution (one cargo test
         # invocation per file) avoids parallel wasm builds saturating
         # disk + CPU on the runner.
+        #
+        # `RDLP_TEST_USE_CACHED_WASM=1` opts the test helpers into the
+        # cache short-circuit — only takes effect on a cache hit, since
+        # the helpers re-check `wasm.exists()` before honouring the env.
         timeout-minutes: 30
+        env:
+          RDLP_TEST_USE_CACHED_WASM: "1"
         run: |
           set -euo pipefail
           shopt -s nullglob

--- a/crates/rdlp-plugin/tests/svt_golden.rs
+++ b/crates/rdlp-plugin/tests/svt_golden.rs
@@ -89,6 +89,13 @@ fn fixture_path(name: &str) -> PathBuf {
 
 /// Build the SVT plugin via `cargo run -p rdlp-cli -- plugin
 /// build-from-ytdlp ...`. Returns the path to the produced `plugin.wasm`.
+///
+/// CI may set `RDLP_TEST_USE_CACHED_WASM=1` after restoring a `plugin.wasm`
+/// from the actions/cache step keyed on plugin source + componentize-py
+/// version + WIT contract. When the env var is present AND the wasm exists,
+/// the rebuild is skipped — saving ~30s of componentize-py per plugin.
+/// Local runs never set this; the rebuild path remains the default for
+/// correctness.
 fn build_svt_plugin() -> PathBuf {
     let root = workspace_root();
     let py = root.join("examples/plugins/svt/svt.py");
@@ -96,9 +103,19 @@ fn build_svt_plugin() -> PathBuf {
 
     // build-from-ytdlp normalises filenames to kebab-case plugin names
     // and emits into <output_dir>/<name>/. For svt.py the output dir
-    // ends up at examples/plugins/svt/svt/plugin.wasm. Clean any prior
-    // build so a stale wasm doesn't mask a build failure.
+    // ends up at examples/plugins/svt/svt/plugin.wasm.
     let plugin_dir = py.parent().unwrap().join("svt");
+    let wasm = plugin_dir.join("plugin.wasm");
+
+    if std::env::var("RDLP_TEST_USE_CACHED_WASM").is_ok() && wasm.exists() {
+        eprintln!(
+            "[cache] svt: reusing cached plugin.wasm ({} bytes) — skipping build",
+            std::fs::metadata(&wasm).unwrap().len()
+        );
+        return wasm;
+    }
+
+    // Clean any prior build so a stale wasm doesn't mask a build failure.
     let _ = std::fs::remove_dir_all(&plugin_dir);
 
     let status = std::process::Command::new("cargo")
@@ -117,7 +134,6 @@ fn build_svt_plugin() -> PathBuf {
         .expect("invoke rdlp build-from-ytdlp");
     assert!(status.success(), "build-from-ytdlp failed");
 
-    let wasm = plugin_dir.join("plugin.wasm");
     assert!(wasm.exists(), "wasm missing at {wasm:?}");
     wasm
 }

--- a/crates/rdlp-plugin/tests/xxxymovies_golden.rs
+++ b/crates/rdlp-plugin/tests/xxxymovies_golden.rs
@@ -75,6 +75,17 @@ fn build_xxxymovies_plugin() -> PathBuf {
     assert!(py.exists(), "source missing: {py:?}");
 
     let plugin_dir = py.parent().unwrap().join("xxxymovies");
+    let wasm = plugin_dir.join("plugin.wasm");
+
+    // CI cache short-circuit (see svt_golden.rs::build_svt_plugin doc).
+    if std::env::var("RDLP_TEST_USE_CACHED_WASM").is_ok() && wasm.exists() {
+        eprintln!(
+            "[cache] xxxymovies: reusing cached plugin.wasm ({} bytes)",
+            std::fs::metadata(&wasm).unwrap().len()
+        );
+        return wasm;
+    }
+
     let _ = std::fs::remove_dir_all(&plugin_dir);
 
     let status = std::process::Command::new("cargo")
@@ -93,7 +104,6 @@ fn build_xxxymovies_plugin() -> PathBuf {
         .expect("invoke rdlp build-from-ytdlp");
     assert!(status.success(), "build-from-ytdlp failed");
 
-    let wasm = plugin_dir.join("plugin.wasm");
     assert!(wasm.exists(), "wasm missing at {wasm:?}");
     wasm
 }

--- a/crates/rdlp-plugin/tests/ytdlp_golden.rs
+++ b/crates/rdlp-plugin/tests/ytdlp_golden.rs
@@ -37,6 +37,7 @@ fn workspace_root() -> PathBuf {
 #[allow(clippy::disallowed_methods)] // test fixture — sync I/O is acceptable per clippy.toml
 fn ytdlp_goldens_build_and_emit_artefacts() {
     let root = workspace_root();
+    let use_cache = std::env::var("RDLP_TEST_USE_CACHED_WASM").is_ok();
     for name in GOLDENS {
         let py = root.join(format!("examples/plugins/ytdlp-golden/{name}.py"));
         assert!(py.exists(), "source missing: {py:?}");
@@ -46,27 +47,36 @@ fn ytdlp_goldens_build_and_emit_artefacts() {
         // therefore uses the normalised stem, not the raw filename.
         let normalised = name.to_ascii_lowercase().replace('_', "-");
         let plugin_dir = py.parent().unwrap().join(&normalised);
-        // Clean any prior build output
-        let _ = std::fs::remove_dir_all(&plugin_dir);
-
-        let status = Command::new("cargo")
-            .args([
-                "run",
-                "--quiet",
-                "-p",
-                "rdlp-cli",
-                "--",
-                "plugin",
-                "build-from-ytdlp",
-            ])
-            .arg(&py)
-            .current_dir(&root)
-            .status()
-            .expect("invoke rdlp build-from-ytdlp");
-        assert!(status.success(), "build-from-ytdlp failed for {name}");
-
         let wasm = plugin_dir.join("plugin.wasm");
         let toml = plugin_dir.join("plugin.toml.template");
+
+        // CI cache short-circuit (see svt_golden.rs::build_svt_plugin doc).
+        if use_cache && wasm.exists() && toml.exists() {
+            eprintln!(
+                "[cache] ytdlp-golden/{name}: reusing cached plugin.wasm ({} bytes)",
+                std::fs::metadata(&wasm).unwrap().len()
+            );
+        } else {
+            // Clean any prior build output
+            let _ = std::fs::remove_dir_all(&plugin_dir);
+
+            let status = Command::new("cargo")
+                .args([
+                    "run",
+                    "--quiet",
+                    "-p",
+                    "rdlp-cli",
+                    "--",
+                    "plugin",
+                    "build-from-ytdlp",
+                ])
+                .arg(&py)
+                .current_dir(&root)
+                .status()
+                .expect("invoke rdlp build-from-ytdlp");
+            assert!(status.success(), "build-from-ytdlp failed for {name}");
+        }
+
         assert!(wasm.exists(), "wasm missing for {name}: {wasm:?}");
         assert!(toml.exists(), "manifest missing for {name}: {toml:?}");
 


### PR DESCRIPTION
## Summary

Two changes that shorten the Golden job's wall time on every push to develop, while preserving correctness gates.

### A. Drop `build-and-test` from Golden's `needs:`

Golden runs on \`ubuntu-22.04\`. Previously it waited for ALL three matrix shards (ubuntu / windows / macos) to finish — meaning Golden was gated by the slowest shard (windows, ~11m) even though only ubuntu's compile is relevant to it. The dependency added no signal:

- ubuntu compile failures surface as Golden failures directly.
- windows-only / macos-only build failures are still caught independently by the matrix's own status check.

**Saves ~7m wall time per push** (the gap between ubuntu finishing at ~5m and windows finishing at ~11m).

### B. Cache componentize-py wasm artifacts

Each golden test (\`svt_golden.rs\`, \`xxxymovies_golden.rs\`, \`ytdlp_golden.rs\`) calls \`cargo run -p rdlp-cli plugin build-from-ytdlp\` to compile a Python plugin to wasm via componentize-py — ~30s per plugin × 5 plugins ≈ 150s of compile time, every push.

Added an \`actions/cache@v4\` step keyed on:

- plugin \`.py\` source files
- componentize-py version pin (\`tools/ytdlp-compat/requirements-dev.txt\`)
- WIT contract files
- rdlp-side compat shim Python sources
- \`build-from-ytdlp.rs\` wrapper

When any of those change, the cache key flips and we rebuild every plugin. Otherwise the wasm restores from cache and the test helpers skip the rebuild.

The test-side opt-in is \`RDLP_TEST_USE_CACHED_WASM=1\` (set only in CI). Local \`cargo test\` runs never set the env var, so the rebuild path stays the default — **correctness over speed by default**.

**Saves ~150s wall time on cache hit.**

### Combined impact (cache hit + B): ~510s shorter Golden runtime per push.

## Test plan

- [x] \`cargo check -p rdlp-plugin --tests\` clean
- [x] \`cargo clippy -p rdlp-plugin --tests -- -D warnings\` clean
- [ ] First push triggers a cache miss — Golden runs the same as today (correctness gate verified before any speedup is realised).
- [ ] Subsequent pushes against develop should land with the cache hit logic exercised.