### PR TITLE
fix(desktop): aria-label on JobCard Progress

### DIFF
--- a/crates/rdlp-desktop/src/components/JobCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobCard.tsx
@@ -80,6 +80,7 @@ export function JobCard({ job, onCancel, onRemove, onRetry }: JobCardProps) {
                 {isRunning && (
                     <div className="space-y-1.5">
                         <Progress
+                            aria-label="Download progress"
                             value={(job.progress ?? 0) * 100}
                             className="h-1"
                         />


### PR DESCRIPTION
## Summary

The `JobCard` component renders a React Aria \`ProgressBar\` (via \`@/components/ui/progress\`) without an \`aria-label\`. React Aria emits a runtime warning during Vitest runs:

> If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility

The warning fired on every test that renders JobCard with \`status: \"running\"\` (4 of the 18 cases). Adding \`aria-label=\"Download progress\"\` clears it.

## Test plan

- [x] \`cd crates/rdlp-desktop && npm test -- --run JobCard.test\` — 18 tests pass, no a11y stderr.
- [ ] Cypress E2E (\`npm run test:e2e\`) — unchanged contract; the new aria-label is descriptive of the existing visual.

## Scope

One-line addition. No styling change, no behaviour change, no export shape change.