### PR TITLE
feat(plugin,ytdlp-compat): wire _extract_mpd_formats_and_subtitles to expand_dash_representations

### DIFF
--- a/crates/rdlp-extractor/src/base/common/dash/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/mod.rs
@@ -4,10 +4,10 @@
 //!
 mod audio_sampling_rate;
 mod baseurl;
-mod errors;
+pub mod errors;
 mod expand;
 mod frame_rate;
 mod segments;
 
-pub(crate) use errors::DashExpandError;
-pub(crate) use expand::expand_dash_representations;
+pub use errors::DashExpandError;
+pub use expand::expand_dash_representations;

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -816,7 +816,7 @@ hi.m3u8\n";
 
     /// Happy-path: a valid static MPD with video and audio representations yields
     /// ≥2 formats (one video-only, one audio-only), each with non-empty fragments,
-    /// a fragment_base_url, manifest_url matching the fetch URL, and container "mp4_dash".
+    /// a `fragment_base_url`, `manifest_url` matching the fetch URL, and container `"mp4_dash"`.
     ///
     /// EXPECTED TO FAIL against the Task-4 stub (returns empty formats vec).
     #[tokio::test]
@@ -876,7 +876,7 @@ hi.m3u8\n";
         }
     }
 
-    /// Non-fatal path: when no FetchCtx is installed the fetch capability is absent.
+    /// Non-fatal path: when no `FetchCtx` is installed the fetch capability is absent.
     /// With fatal=false the error must be swallowed and an empty extraction returned.
     ///
     /// NOTE: This test MAY PASS coincidentally against the Task-4 stub, because the
@@ -884,7 +884,7 @@ hi.m3u8\n";
     /// of input — the same value this test asserts on. The coincidental pass does NOT
     /// indicate correctness; it merely means the stub and the intended behavior agree on
     /// the empty-output shape for this one case. The real non-fatal path requires the
-    /// implementation to check for a missing FetchCtx and swallow the error.
+    /// implementation to check for a missing `FetchCtx` and swallow the error.
     #[tokio::test]
     async fn extract_mpd_non_fatal_swallows_fetch_failure() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
@@ -903,7 +903,7 @@ hi.m3u8\n";
         assert!(r.subtitles.is_empty());
     }
 
-    /// Fatal path: when no FetchCtx is installed and fatal=true the error must propagate.
+    /// Fatal path: when no `FetchCtx` is installed and `fatal=true` the error must propagate.
     ///
     /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
     #[tokio::test]
@@ -957,8 +957,8 @@ hi.m3u8\n";
     /// A DRM-protected representation must be filtered out; non-DRM sibling representations
     /// must survive.
     ///
-    /// with_drm.mpd has DRM only on the video representation; the audio representation
-    /// has no ContentProtection. The extraction must drop the video and return only the audio.
+    /// `with_drm.mpd` has DRM only on the video representation; the audio representation
+    /// has no `ContentProtection`. The extraction must drop the video and return only the audio.
     #[tokio::test]
     async fn extract_mpd_drm_protected_reps_are_dropped() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
@@ -980,7 +980,7 @@ hi.m3u8\n";
             .await
             .expect("audio rep survives DRM filtering");
         assert_eq!(r.formats.len(), 1, "only the audio rep should survive");
-        let f = &r.formats[0];
+        let f = r.formats.first().expect("len asserted above");
         assert!(f.acodec.is_some(), "expected audio codec");
         assert!(f.vcodec.is_none(), "DRM video rep must be dropped");
     }
@@ -989,8 +989,8 @@ hi.m3u8\n";
     /// valid UTF-8 for parsing).
     ///
     /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
-    /// Note: FixtureResponse::ok accepts impl Into<Vec<u8>>, so raw bytes work directly —
-    /// no ok_bytes variant is needed.
+    /// Note: `FixtureResponse::ok` accepts impl `Into<Vec<u8>>`, so raw bytes work directly —
+    /// no `ok_bytes` variant is needed.
     #[tokio::test]
     async fn extract_mpd_invalid_utf8_returns_fetch_error() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -917,7 +917,8 @@ hi.m3u8\n";
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
             .expect_err("DRM-only MPD must error after representations dropped");
-        let _ = err;
+        let msg = format!("{err:?}");
+        assert!(!msg.is_empty(), "error must not be empty");
     }
 
     /// Non-UTF-8 bytes in the response body must cause an error (MPD is XML, must be
@@ -946,7 +947,8 @@ hi.m3u8\n";
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
             .expect_err("invalid utf-8 must error");
-        let _ = err;
+        let msg = format!("{err:?}");
+        assert!(!msg.is_empty(), "error must not be empty");
     }
 
     /// Well-formed XML that is not an MPD document must cause an error.
@@ -973,6 +975,7 @@ hi.m3u8\n";
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
             .expect_err("non-MPD XML must error");
-        let _ = err;
+        let msg = format!("{err:?}");
+        assert!(!msg.is_empty(), "error must not be empty");
     }
 }

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -736,4 +736,243 @@ hi.m3u8\n";
         assert_eq!(r.formats.len(), 0);
         assert_eq!(r.subtitles.len(), 0);
     }
+
+    // ---- DASH (extract_mpd) tests ----------------------------------------
+
+    const SEGMENT_TEMPLATE_MPD: &str = include_str!(
+        "../../../rdlp-downloader/tests/fixtures/dash/segment_template.mpd"
+    );
+    const DYNAMIC_MPD: &str = include_str!(
+        "../../../rdlp-downloader/tests/fixtures/dash/dynamic.mpd"
+    );
+    const WITH_DRM_MPD: &str = include_str!(
+        "../../../rdlp-downloader/tests/fixtures/dash/with_drm.mpd"
+    );
+
+    fn mpd_opts(fatal: bool) -> crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions {
+        crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions {
+            mpd_id: None,
+            fatal,
+        }
+    }
+
+    /// Happy-path: a valid static MPD with video and audio representations yields
+    /// ≥2 formats (one video-only, one audio-only), each with non-empty fragments,
+    /// a fragment_base_url, manifest_url matching the fetch URL, and container "mp4_dash".
+    ///
+    /// EXPECTED TO FAIL against the Task-4 stub (returns empty formats vec).
+    #[tokio::test]
+    async fn extract_mpd_returns_formats_via_fixture() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        c.fetch = Some(crate::host::fetch::FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new()
+                    .with(url, FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec())),
+            )),
+        });
+
+        let r = c
+            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true))
+            .await
+            .expect("extract_mpd");
+
+        assert!(
+            r.formats.len() >= 2,
+            "expected ≥2 formats, got {}",
+            r.formats.len()
+        );
+        assert!(
+            r.formats.iter().any(|f| f.vcodec.is_some() && f.acodec.is_none()),
+            "expected at least one video-only format"
+        );
+        assert!(
+            r.formats.iter().any(|f| f.acodec.is_some() && f.vcodec.is_none()),
+            "expected at least one audio-only format"
+        );
+        for f in &r.formats {
+            assert!(!f.fragments.is_empty(), "fragments must be non-empty for {}", f.format_id);
+            assert!(f.fragment_base_url.is_some(), "fragment_base_url must be set for {}", f.format_id);
+            assert_eq!(
+                f.manifest_url.as_deref(),
+                Some(url),
+                "manifest_url must match fetch URL for {}",
+                f.format_id
+            );
+            assert_eq!(
+                f.container.as_deref(),
+                Some("mp4_dash"),
+                "container must be mp4_dash for {}",
+                f.format_id
+            );
+        }
+    }
+
+    /// Non-fatal path: when no FetchCtx is installed the fetch capability is absent.
+    /// With fatal=false the error must be swallowed and an empty extraction returned.
+    ///
+    /// NOTE: This test MAY PASS coincidentally against the Task-4 stub, because the
+    /// stub returns `Ok(MpdExtraction { formats: vec![], subtitles: vec![] })` regardless
+    /// of input — the same value this test asserts on. The coincidental pass does NOT
+    /// indicate correctness; it merely means the stub and the intended behavior agree on
+    /// the empty-output shape for this one case. The real non-fatal path requires the
+    /// implementation to check for a missing FetchCtx and swallow the error.
+    #[tokio::test]
+    async fn extract_mpd_non_fatal_swallows_fetch_failure() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+
+        let mut c = ctx();
+        c.fetch = None;
+        let r = c
+            .extract_mpd(
+                "https://x/m.mpd".to_string(),
+                "v".to_string(),
+                mpd_opts(false),
+            )
+            .await
+            .expect("non-fatal returns Ok");
+        assert!(r.formats.is_empty());
+        assert!(r.subtitles.is_empty());
+    }
+
+    /// Fatal path: when no FetchCtx is installed and fatal=true the error must propagate.
+    ///
+    /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
+    #[tokio::test]
+    async fn extract_mpd_fatal_propagates_fetch_failure() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+
+        let mut c = ctx();
+        c.fetch = None;
+        let err = c
+            .extract_mpd(
+                "https://x/m.mpd".to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+            )
+            .await
+            .expect_err("fatal must propagate");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("fetch") || msg.contains("capability"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// A dynamic/live MPD must be refused with an error mentioning "dynamic".
+    ///
+    /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
+    #[tokio::test]
+    async fn extract_mpd_dynamic_mpd_returns_fetch_error() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://x/m.mpd";
+        let mut c = ctx();
+        c.fetch = Some(crate::host::fetch::FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new().with(url, FixtureResponse::ok(DYNAMIC_MPD.as_bytes().to_vec())),
+            )),
+        });
+        let err = c
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .await
+            .expect_err("dynamic MPD must error");
+        let msg = format!("{err:?}").to_lowercase();
+        assert!(msg.contains("dynamic"), "expected 'dynamic' in error: {msg}");
+    }
+
+    /// A DRM-only MPD must be refused (all representations drop out, leaving nothing
+    /// to download).
+    ///
+    /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
+    #[tokio::test]
+    async fn extract_mpd_drm_protected_returns_fetch_error() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://x/m.mpd";
+        let mut c = ctx();
+        c.fetch = Some(crate::host::fetch::FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new().with(url, FixtureResponse::ok(WITH_DRM_MPD.as_bytes().to_vec())),
+            )),
+        });
+        let err = c
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .await
+            .expect_err("DRM-only MPD must error after representations dropped");
+        let _ = err;
+    }
+
+    /// Non-UTF-8 bytes in the response body must cause an error (MPD is XML, must be
+    /// valid UTF-8 for parsing).
+    ///
+    /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
+    /// Note: FixtureResponse::ok accepts impl Into<Vec<u8>>, so raw bytes work directly —
+    /// no ok_bytes variant is needed.
+    #[tokio::test]
+    async fn extract_mpd_invalid_utf8_returns_fetch_error() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://x/m.mpd";
+        let mut c = ctx();
+        c.fetch = Some(crate::host::fetch::FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new().with(url, FixtureResponse::ok(vec![0xff_u8, 0xfe, 0xfd])),
+            )),
+        });
+        let err = c
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .await
+            .expect_err("invalid utf-8 must error");
+        let _ = err;
+    }
+
+    /// Well-formed XML that is not an MPD document must cause an error.
+    ///
+    /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
+    #[tokio::test]
+    async fn extract_mpd_unparseable_xml_returns_fetch_error() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://x/m.mpd";
+        let mut c = ctx();
+        c.fetch = Some(crate::host::fetch::FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new()
+                    .with(url, FixtureResponse::ok(b"<not-mpd></not-mpd>".to_vec())),
+            )),
+        });
+        let err = c
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .await
+            .expect_err("non-MPD XML must error");
+        let _ = err;
+    }
 }

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -294,6 +294,20 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         }
     }
 
+    async fn extract_mpd(
+        &mut self,
+        _url: String,
+        _video_id: String,
+        _opts: crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions,
+    ) -> Result<
+        crate::bindings::rdlp::plugin::host_extract_helpers::MpdExtraction,
+        crate::bindings::rdlp::plugin::host_fetch::FetchError,
+    > {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::MpdExtraction;
+        // Stub — real impl in Task 6.
+        Ok(MpdExtraction { formats: vec![], subtitles: vec![] })
+    }
+
     async fn extract_json_ld(
         &mut self,
         html: String,

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -900,6 +900,7 @@ hi.m3u8\n";
     #[tokio::test]
     async fn extract_mpd_drm_protected_returns_fetch_error() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::bindings::rdlp::plugin::host_fetch::FetchError;
         use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
         use std::sync::Arc;
 
@@ -917,8 +918,10 @@ hi.m3u8\n";
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
             .expect_err("DRM-only MPD must error after representations dropped");
-        let msg = format!("{err:?}");
-        assert!(!msg.is_empty(), "error must not be empty");
+        assert!(
+            matches!(err, FetchError::Network(_)),
+            "expected FetchError::Network, got {err:?}"
+        );
     }
 
     /// Non-UTF-8 bytes in the response body must cause an error (MPD is XML, must be
@@ -930,6 +933,7 @@ hi.m3u8\n";
     #[tokio::test]
     async fn extract_mpd_invalid_utf8_returns_fetch_error() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::bindings::rdlp::plugin::host_fetch::FetchError;
         use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
         use std::sync::Arc;
 
@@ -947,8 +951,10 @@ hi.m3u8\n";
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
             .expect_err("invalid utf-8 must error");
-        let msg = format!("{err:?}");
-        assert!(!msg.is_empty(), "error must not be empty");
+        assert!(
+            matches!(err, FetchError::Network(_)),
+            "expected FetchError::Network, got {err:?}"
+        );
     }
 
     /// Well-formed XML that is not an MPD document must cause an error.
@@ -957,6 +963,7 @@ hi.m3u8\n";
     #[tokio::test]
     async fn extract_mpd_unparseable_xml_returns_fetch_error() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
+        use crate::bindings::rdlp::plugin::host_fetch::FetchError;
         use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
         use std::sync::Arc;
 
@@ -975,7 +982,9 @@ hi.m3u8\n";
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
             .expect_err("non-MPD XML must error");
-        let msg = format!("{err:?}");
-        assert!(!msg.is_empty(), "error must not be empty");
+        assert!(
+            matches!(err, FetchError::Network(_)),
+            "expected FetchError::Network, got {err:?}"
+        );
     }
 }

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -864,10 +864,13 @@ hi.m3u8\n";
                 "manifest_url must match fetch URL for {}",
                 f.format_id
             );
+            // expand_dash_representations sets container = "{ext}_dash"
+            let expected_container = format!("{}_dash", f.ext);
             assert_eq!(
                 f.container.as_deref(),
-                Some("mp4_dash"),
-                "container must be mp4_dash for {}",
+                Some(expected_container.as_str()),
+                "container must be {}_dash for {}",
+                f.ext,
                 f.format_id
             );
         }
@@ -951,14 +954,14 @@ hi.m3u8\n";
         assert!(msg.contains("dynamic"), "expected 'dynamic' in error: {msg}");
     }
 
-    /// A DRM-only MPD must be refused (all representations drop out, leaving nothing
-    /// to download).
+    /// A DRM-protected representation must be filtered out; non-DRM sibling representations
+    /// must survive.
     ///
-    /// EXPECTED TO FAIL against the Task-4 stub (stub returns Ok, not Err).
+    /// with_drm.mpd has DRM only on the video representation; the audio representation
+    /// has no ContentProtection. The extraction must drop the video and return only the audio.
     #[tokio::test]
-    async fn extract_mpd_drm_protected_returns_fetch_error() {
+    async fn extract_mpd_drm_protected_reps_are_dropped() {
         use crate::bindings::rdlp::plugin::host_extract_helpers::Host as _;
-        use crate::bindings::rdlp::plugin::host_fetch::FetchError;
         use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
         use std::sync::Arc;
 
@@ -972,14 +975,14 @@ hi.m3u8\n";
                 FetchFixtures::new().with(url, FixtureResponse::ok(WITH_DRM_MPD.as_bytes().to_vec())),
             )),
         });
-        let err = c
+        let r = c
             .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
             .await
-            .expect_err("DRM-only MPD must error after representations dropped");
-        assert!(
-            matches!(err, FetchError::Network(_)),
-            "expected FetchError::Network, got {err:?}"
-        );
+            .expect("audio rep survives DRM filtering");
+        assert_eq!(r.formats.len(), 1, "only the audio rep should survive");
+        let f = &r.formats[0];
+        assert!(f.acodec.is_some(), "expected audio codec");
+        assert!(f.vcodec.is_none(), "DRM video rep must be dropped");
     }
 
     /// Non-UTF-8 bytes in the response body must cause an error (MPD is XML, must be

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -321,8 +321,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             let resp = self.fetch(req).await?;
             let body =
                 String::from_utf8(resp.body).map_err(|e| FetchError::Network(e.to_string()))?;
-            let base =
-                Url::parse(&url).map_err(|e| FetchError::Network(e.to_string()))?;
+            let base = Url::parse(&url).map_err(|e| FetchError::Network(e.to_string()))?;
             let formats = expand_dash_representations(&body, &base)
                 .map_err(|e| FetchError::Network(format!("{e:#}")))?;
 
@@ -347,12 +346,18 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
                         .fragments
                         .unwrap_or_default()
                         .into_iter()
-                        .map(|fr| MpdFragment { url: fr.url, duration: fr.duration })
+                        .map(|fr| MpdFragment {
+                            url: fr.url,
+                            duration: fr.duration,
+                        })
                         .collect(),
                 })
                 .collect();
 
-            Ok(MpdExtraction { formats: mpd_formats, subtitles: vec![] })
+            Ok(MpdExtraction {
+                formats: mpd_formats,
+                subtitles: vec![],
+            })
         }
         .await;
 
@@ -797,15 +802,12 @@ hi.m3u8\n";
 
     // ---- DASH (extract_mpd) tests ----------------------------------------
 
-    const SEGMENT_TEMPLATE_MPD: &str = include_str!(
-        "../../../rdlp-downloader/tests/fixtures/dash/segment_template.mpd"
-    );
-    const DYNAMIC_MPD: &str = include_str!(
-        "../../../rdlp-downloader/tests/fixtures/dash/dynamic.mpd"
-    );
-    const WITH_DRM_MPD: &str = include_str!(
-        "../../../rdlp-downloader/tests/fixtures/dash/with_drm.mpd"
-    );
+    const SEGMENT_TEMPLATE_MPD: &str =
+        include_str!("../../../rdlp-downloader/tests/fixtures/dash/segment_template.mpd");
+    const DYNAMIC_MPD: &str =
+        include_str!("../../../rdlp-downloader/tests/fixtures/dash/dynamic.mpd");
+    const WITH_DRM_MPD: &str =
+        include_str!("../../../rdlp-downloader/tests/fixtures/dash/with_drm.mpd");
 
     fn mpd_opts(fatal: bool) -> crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions {
         crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions {
@@ -831,10 +833,10 @@ hi.m3u8\n";
             client: rdlp_http::wreq::Client::builder()
                 .build()
                 .expect("test client"),
-            fixtures: Some(Arc::new(
-                FetchFixtures::new()
-                    .with(url, FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec())),
-            )),
+            fixtures: Some(Arc::new(FetchFixtures::new().with(
+                url,
+                FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec()),
+            ))),
         });
 
         let r = c
@@ -848,16 +850,28 @@ hi.m3u8\n";
             r.formats.len()
         );
         assert!(
-            r.formats.iter().any(|f| f.vcodec.is_some() && f.acodec.is_none()),
+            r.formats
+                .iter()
+                .any(|f| f.vcodec.is_some() && f.acodec.is_none()),
             "expected at least one video-only format"
         );
         assert!(
-            r.formats.iter().any(|f| f.acodec.is_some() && f.vcodec.is_none()),
+            r.formats
+                .iter()
+                .any(|f| f.acodec.is_some() && f.vcodec.is_none()),
             "expected at least one audio-only format"
         );
         for f in &r.formats {
-            assert!(!f.fragments.is_empty(), "fragments must be non-empty for {}", f.format_id);
-            assert!(f.fragment_base_url.is_some(), "fragment_base_url must be set for {}", f.format_id);
+            assert!(
+                !f.fragments.is_empty(),
+                "fragments must be non-empty for {}",
+                f.format_id
+            );
+            assert!(
+                f.fragment_base_url.is_some(),
+                "fragment_base_url must be set for {}",
+                f.format_id
+            );
             assert_eq!(
                 f.manifest_url.as_deref(),
                 Some(url),
@@ -943,7 +957,8 @@ hi.m3u8\n";
                 .build()
                 .expect("test client"),
             fixtures: Some(Arc::new(
-                FetchFixtures::new().with(url, FixtureResponse::ok(DYNAMIC_MPD.as_bytes().to_vec())),
+                FetchFixtures::new()
+                    .with(url, FixtureResponse::ok(DYNAMIC_MPD.as_bytes().to_vec())),
             )),
         });
         let err = c
@@ -951,7 +966,10 @@ hi.m3u8\n";
             .await
             .expect_err("dynamic MPD must error");
         let msg = format!("{err:?}").to_lowercase();
-        assert!(msg.contains("dynamic"), "expected 'dynamic' in error: {msg}");
+        assert!(
+            msg.contains("dynamic"),
+            "expected 'dynamic' in error: {msg}"
+        );
     }
 
     /// A DRM-protected representation must be filtered out; non-DRM sibling representations
@@ -972,7 +990,8 @@ hi.m3u8\n";
                 .build()
                 .expect("test client"),
             fixtures: Some(Arc::new(
-                FetchFixtures::new().with(url, FixtureResponse::ok(WITH_DRM_MPD.as_bytes().to_vec())),
+                FetchFixtures::new()
+                    .with(url, FixtureResponse::ok(WITH_DRM_MPD.as_bytes().to_vec())),
             )),
         });
         let r = c

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -296,16 +296,74 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
 
     async fn extract_mpd(
         &mut self,
-        _url: String,
+        url: String,
         _video_id: String,
-        _opts: crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions,
+        opts: crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions,
     ) -> Result<
         crate::bindings::rdlp::plugin::host_extract_helpers::MpdExtraction,
         crate::bindings::rdlp::plugin::host_fetch::FetchError,
     > {
-        use crate::bindings::rdlp::plugin::host_extract_helpers::MpdExtraction;
-        // Stub — real impl in Task 6.
-        Ok(MpdExtraction { formats: vec![], subtitles: vec![] })
+        use crate::bindings::rdlp::plugin::host_extract_helpers::{
+            MpdExtraction, MpdFormat, MpdFragment,
+        };
+        use crate::bindings::rdlp::plugin::host_fetch::{FetchError, Host as FetchHost, Request};
+        use rdlp_extractor::base::common::dash::expand_dash_representations;
+        use url::Url;
+
+        let result: Result<MpdExtraction, FetchError> = async {
+            let req = Request {
+                url: url.clone(),
+                method: "GET".to_string(),
+                headers: vec![],
+                body: None,
+                timeout_ms: Some(30_000),
+            };
+            let resp = self.fetch(req).await?;
+            let body =
+                String::from_utf8(resp.body).map_err(|e| FetchError::Network(e.to_string()))?;
+            let base =
+                Url::parse(&url).map_err(|e| FetchError::Network(e.to_string()))?;
+            let formats = expand_dash_representations(&body, &base)
+                .map_err(|e| FetchError::Network(format!("{e:#}")))?;
+
+            let mpd_formats: Vec<MpdFormat> = formats
+                .into_iter()
+                .map(|f| MpdFormat {
+                    format_id: f.format_id,
+                    url: f.url,
+                    ext: f.ext.clone(),
+                    vcodec: f.vcodec.as_str().map(str::to_owned),
+                    acodec: f.acodec.as_str().map(str::to_owned),
+                    tbr: f.tbr.map(|v| v as f32),
+                    width: f.width,
+                    height: f.height,
+                    fps: f.fps.map(|v| v as f32),
+                    asr: f.asr,
+                    language: f.language,
+                    container: f.container,
+                    manifest_url: Some(url.clone()),
+                    fragment_base_url: f.fragment_base_url,
+                    fragments: f
+                        .fragments
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|fr| MpdFragment { url: fr.url, duration: fr.duration })
+                        .collect(),
+                })
+                .collect();
+
+            Ok(MpdExtraction { formats: mpd_formats, subtitles: vec![] })
+        }
+        .await;
+
+        match (result, opts.fatal) {
+            (Ok(x), _) => Ok(x),
+            (Err(e), true) => Err(e),
+            (Err(_), false) => Ok(MpdExtraction {
+                formats: vec![],
+                subtitles: vec![],
+            }),
+        }
     }
 
     async fn extract_json_ld(

--- a/crates/rdlp-plugin/wit/host.wit
+++ b/crates/rdlp-plugin/wit/host.wit
@@ -156,4 +156,40 @@ interface host-extract-helpers {
                     -> result<m3u8-extraction, fetch-error>;
 
     extract-json-ld: func(html: string) -> option<json-ld-video>;
+
+    record mpd-options {
+        mpd-id: option<string>,
+        fatal: bool,
+    }
+
+    record mpd-fragment {
+        url: string,
+        duration: option<f64>,
+    }
+
+    record mpd-format {
+        format-id: string,
+        url: string,
+        ext: string,
+        vcodec: option<string>,
+        acodec: option<string>,
+        tbr: option<f32>,
+        width: option<u32>,
+        height: option<u32>,
+        fps: option<f32>,
+        asr: option<u32>,
+        language: option<string>,
+        container: option<string>,
+        manifest-url: option<string>,
+        fragment-base-url: option<string>,
+        fragments: list<mpd-fragment>,
+    }
+
+    record mpd-extraction {
+        formats: list<mpd-format>,
+        subtitles: list<extract-helpers-subtitle>,
+    }
+
+    extract-mpd: func(url: string, video-id: string, opts: mpd-options)
+                    -> result<mpd-extraction, fetch-error>;
 }

--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/host.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/host.wit
@@ -156,4 +156,40 @@ interface host-extract-helpers {
                     -> result<m3u8-extraction, fetch-error>;
 
     extract-json-ld: func(html: string) -> option<json-ld-video>;
+
+    record mpd-options {
+        mpd-id: option<string>,
+        fatal: bool,
+    }
+
+    record mpd-fragment {
+        url: string,
+        duration: option<f64>,
+    }
+
+    record mpd-format {
+        format-id: string,
+        url: string,
+        ext: string,
+        vcodec: option<string>,
+        acodec: option<string>,
+        tbr: option<f32>,
+        width: option<u32>,
+        height: option<u32>,
+        fps: option<f32>,
+        asr: option<u32>,
+        language: option<string>,
+        container: option<string>,
+        manifest-url: option<string>,
+        fragment-base-url: option<string>,
+        fragments: list<mpd-fragment>,
+    }
+
+    record mpd-extraction {
+        formats: list<mpd-format>,
+        subtitles: list<extract-helpers-subtitle>,
+    }
+
+    extract-mpd: func(url: string, video-id: string, opts: mpd-options)
+                    -> result<mpd-extraction, fetch-error>;
 }

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/host.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/host.wit
@@ -156,4 +156,40 @@ interface host-extract-helpers {
                     -> result<m3u8-extraction, fetch-error>;
 
     extract-json-ld: func(html: string) -> option<json-ld-video>;
+
+    record mpd-options {
+        mpd-id: option<string>,
+        fatal: bool,
+    }
+
+    record mpd-fragment {
+        url: string,
+        duration: option<f64>,
+    }
+
+    record mpd-format {
+        format-id: string,
+        url: string,
+        ext: string,
+        vcodec: option<string>,
+        acodec: option<string>,
+        tbr: option<f32>,
+        width: option<u32>,
+        height: option<u32>,
+        fps: option<f32>,
+        asr: option<u32>,
+        language: option<string>,
+        container: option<string>,
+        manifest-url: option<string>,
+        fragment-base-url: option<string>,
+        fragments: list<mpd-fragment>,
+    }
+
+    record mpd-extraction {
+        formats: list<mpd-format>,
+        subtitles: list<extract-helpers-subtitle>,
+    }
+
+    extract-mpd: func(url: string, video-id: string, opts: mpd-options)
+                    -> result<mpd-extraction, fetch-error>;
 }

--- a/tools/ytdlp-compat/README.md
+++ b/tools/ytdlp-compat/README.md
@@ -34,7 +34,7 @@ Helper additions verified against yt-dlp tag `2026.03.17`:
 
 - **Utility helpers** (`_utils.py`): `determine_ext`, `dict_get` (with `skip_false_values=`), `require`, `variadic`. Plus `RequiredError` exception subclass for `traverse_obj` propagation.
 - **`traverse_obj` rewrite** (`info_extractor.py`): now supports `{type}` / `{type, type, ...}` / `{callable}` set-syntax segments, `(branch_a, branch_b)` tuple sub-paths, two-arg `lambda k, v: ...` predicates, and `any` / `all` / `filter` builtin terminators. Drops upstream support for `re.Match`, `xml.etree`, `http.cookies.Morsel`, `slice`, and `traverse_string` — none exercised by SVT or any plausible Slice-2 plugin. Add when a port needs them.
-- **`InfoExtractor` methods**: `_match_valid_url`, `_match_id`, `suitable`, `ie_key` (classmethods); `url_result`, `playlist_result` (statics); `_og_search_title`, `_og_search_thumbnail`, `_og_search_property`; `_search_json` (regex + brace-balanced + parse_json), `_search_nextjs_data`; `_merge_subtitles` (+ `_merge_subtitle_items` dedupe); `_download_json`; `geo_verification_headers` (returns `{}` since shim has no YoutubeDL params surface). `_extract_f4m_formats` and `_extract_mpd_formats_and_subtitles` are stubs (F4M is dead; DASH unimplemented in rdlp-downloader — see `project_dash-protocol-missing` memory).
+- **`InfoExtractor` methods**: `_match_valid_url`, `_match_id`, `suitable`, `ie_key` (classmethods); `url_result`, `playlist_result` (statics); `_og_search_title`, `_og_search_thumbnail`, `_og_search_property`; `_search_json` (regex + brace-balanced + parse_json), `_search_nextjs_data`; `_merge_subtitles` (+ `_merge_subtitle_items` dedupe); `_download_json`; `geo_verification_headers` (returns `{}` since shim has no YoutubeDL params surface). `_extract_f4m_formats` is a stub (F4M is dead).
 - **Multi-class plugin support** (`_dispatch.py`): `discover_ie_classes` + `dispatch_url` honour SVT-style sibling `suitable()` overrides. Build-from-ytdlp's `extract_valid_urls` (Rust) captures every `_VALID_URL` (single + triple-quoted), skips docstring examples, and emits a deduped match-pattern union into the manifest.
 
 ## Limitations (deferred to Slice 2.5)
@@ -42,7 +42,6 @@ Helper additions verified against yt-dlp tag `2026.03.17`:
 - Pure-data helpers (`traverse_obj`, `dict_get`, `int_or_none`, …) MUST stay Python — they take Python callables / type objects which can't cross the WIT boundary. Slice 2.5 will move I/O helpers (`_extract_m3u8_formats_and_subtitles`, `_search_regex`, etc.) host-side via a v0.2 WIT bump. See memory `project_ytdlp-shim-slice2_5-host-helpers`.
 - `_parse_json` filters yt-dlp's `LenientJSONDecoder`-only kwargs (`ignore_extra` / `strict` / `lenient`) before forwarding to stdlib `json.loads`. Lenient parsing semantics (trailing data, control chars) are NOT supported. SVT's payloads are well-formed.
 - The Next.js / `urqlState` extraction path needs a hydrated HTML fixture to test (the SSR snapshot lacks `urqlState`). The svt:short-form test URL exercises everything else end-to-end.
-- DASH (`_extract_mpd_formats_and_subtitles`) is a stub returning `([], {})` — the rdlp downloader has no DASH segment downloader yet (`DownloadProtocol::HttpDashSegments` exists as a type-level variant only).
 
 ## Regenerating requirements-dev.txt
 
@@ -90,6 +89,7 @@ build time resolves all upstream relative imports.
 - `search-regex`, `html-search-regex`, `html-search-meta` — regex / OG / meta primitives
 - `og-search-property` — OG property + entity unescape
 - `extract-m3u8` — HLS master playlist parsing (lossless dict round-trip)
+- `extract-mpd` — DASH MPD manifest parsing with segment extraction
 - `extract-json-ld` — typed JSON-LD video extraction backed by rdlp's existing parser
 - `rta-search` — adult-content age-marker scan
 - `search-json` — brace-balanced JSON extraction (Next.js / urqlState)

--- a/tools/ytdlp-compat/rdlp_ytdlp_compat/_host.py
+++ b/tools/ytdlp-compat/rdlp_ytdlp_compat/_host.py
@@ -216,6 +216,18 @@ def extract_m3u8(url, video_id, *, ext=None, protocol=None, m3u8_id=None, fatal=
     return _hxh.extract_m3u8(url, video_id, opts)
 
 
+def extract_mpd(url, video_id, *, mpd_id=None, fatal=True):
+    """Parse a DASH MPD via the host helper. Returns MpdExtraction.
+
+    Stub during Task 1 of the DASH-host-helper plan; replaced with the real
+    passthrough in Task 7. Raises so accidental real calls fail loudly.
+    """
+    raise NotImplementedError(
+        "_host.extract_mpd: implementation pending; see "
+        "docs/superpowers/plans/2026-05-03-dash-host-helper.md task 7"
+    )
+
+
 def extract_json_ld(html):
     """Extract structured data from JSON-LD ``<script>`` blocks in `html`."""
     if not _HXH_AVAILABLE:

--- a/tools/ytdlp-compat/rdlp_ytdlp_compat/_host.py
+++ b/tools/ytdlp-compat/rdlp_ytdlp_compat/_host.py
@@ -217,15 +217,13 @@ def extract_m3u8(url, video_id, *, ext=None, protocol=None, m3u8_id=None, fatal=
 
 
 def extract_mpd(url, video_id, *, mpd_id=None, fatal=True):
-    """Parse a DASH MPD via the host helper. Returns MpdExtraction.
-
-    Stub during Task 1 of the DASH-host-helper plan; replaced with the real
-    passthrough in Task 7. Raises so accidental real calls fail loudly.
-    """
-    raise NotImplementedError(
-        "_host.extract_mpd: implementation pending; see "
-        "docs/superpowers/plans/2026-05-03-dash-host-helper.md task 7"
-    )
+    """Parse a DASH MPD via the host helper. Returns MpdExtraction."""
+    if not _HXH_AVAILABLE:
+        raise RuntimeError(
+            "_host.extract_mpd called outside componentize-py runtime"
+        )
+    opts = _hxh.MpdOptions(mpd_id=mpd_id, fatal=fatal)
+    return _hxh.extract_mpd(url, video_id, opts)
 
 
 def extract_json_ld(html):

--- a/tools/ytdlp-compat/rdlp_ytdlp_compat/info_extractor.py
+++ b/tools/ytdlp-compat/rdlp_ytdlp_compat/info_extractor.py
@@ -538,6 +538,41 @@ def _format_to_dict(f):
     return out
 
 
+def _location_key(url):
+    """yt-dlp convention: 'url' for absolute, 'path' for relative fragments."""
+    return 'url' if url.startswith(('http://', 'https://')) else 'path'
+
+
+def _mpd_fragment_to_dict(frag):
+    out = {_location_key(frag.url): frag.url}
+    if frag.duration is not None:
+        out['duration'] = frag.duration
+    return out
+
+
+def _mpd_format_to_dict(f, manifest_url):
+    d = {
+        'format_id': f.format_id,
+        'url': f.url,
+        'manifest_url': f.manifest_url or manifest_url,
+        'ext': f.ext,
+        'protocol': 'http_dash_segments',
+        'fragments': [_mpd_fragment_to_dict(x) for x in f.fragments],
+    }
+    if f.fragment_base_url is not None:
+        d['fragment_base_url'] = f.fragment_base_url
+    if f.container is not None:
+        d['container'] = f.container
+    for k, v in (
+        ('vcodec', f.vcodec), ('acodec', f.acodec), ('tbr', f.tbr),
+        ('width', f.width), ('height', f.height), ('fps', f.fps),
+        ('asr', f.asr), ('language', f.language),
+    ):
+        if v is not None:
+            d[k] = v
+    return d
+
+
 def _legacy_search_regex(pattern, string, name, default, fatal, flags, group):
     """Multi-group / named-group / no-host calls keep going through the
     local Python `re` module — the host helper returns a single string."""
@@ -1229,16 +1264,36 @@ class InfoExtractor:
         _host.log('debug', 'F4M format requested; not supported, returning []')
         return []
 
-    def _extract_mpd_formats_and_subtitles(self, *args, **kwargs):
-        """DASH/MPD is unimplemented in rdlp-downloader (see the
-        `project_dash-protocol-missing` memory). Stub returns
-        `([], {})` — extractors using DASH-only sources will surface a
-        `NoFormatsError` downstream rather than crash here."""
-        _host.log(
-            'debug',
-            'MPD/DASH format requested; not yet supported in rdlp, returning empty pair',
-        )
-        return [], {}
+    def _extract_mpd_formats(self, *args, **kwargs):
+        """yt-dlp's _extract_mpd_formats. Returns formats only (drops subs)."""
+        formats, _subs = self._extract_mpd_formats_and_subtitles(*args, **kwargs)
+        return formats
+
+    def _extract_mpd_formats_and_subtitles(
+        self, mpd_url, video_id, *,
+        mpd_id=None, fatal=True,
+        data=None, headers=None, query=None,
+        note=None, errnote=None,
+    ):
+        """Slice-2.5+ passthrough to host-extract-helpers.extract-mpd."""
+        if data is not None or headers is not None or query is not None:
+            raise NotImplementedError(
+                '_extract_mpd_formats_and_subtitles: data/headers/query are not '
+                'yet plumbed through WIT; track in Slice 2.5+'
+            )
+        if note is not None:
+            _host.log('info', f'{note}: {mpd_url}')
+        try:
+            result = _host.extract_mpd(
+                mpd_url, video_id, mpd_id=mpd_id, fatal=fatal,
+            )
+        except RuntimeError as e:
+            label = errnote or f'failed to extract DASH manifest {mpd_url}'
+            _host.log('warn', f'{label}: {e}')
+            if fatal:
+                raise
+            return [], {}
+        return [_mpd_format_to_dict(f, mpd_url) for f in result.formats], {}
 
     def _search_json_ld(self, html, video_id, expected_type=None, *, fatal=True, default=NO_DEFAULT):
         """Slice-2.5 passthrough to host-extract-helpers.extract-json-ld.

--- a/tools/ytdlp-compat/tests/test_fixture_plugin_dash.py
+++ b/tools/ytdlp-compat/tests/test_fixture_plugin_dash.py
@@ -1,0 +1,122 @@
+"""Issue #240 acceptance bullet: a Python plugin extracts DASH formats from
+a fixture-shaped MpdExtraction payload via _extract_mpd_formats_and_subtitles.
+
+The MpdExtraction payload below mirrors what the Rust host produces against
+crates/rdlp-downloader/tests/fixtures/dash/segment_template.mpd. The Rust host
+test in crates/rdlp-plugin/src/host/extract_helpers.rs is the authoritative
+check that the Rust side actually produces this payload from the real MPD.
+This test is the Python-plugin-level check that the shim consumes such a
+payload correctly.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from rdlp_ytdlp_compat.info_extractor import InfoExtractor
+from rdlp_ytdlp_compat import _host
+
+
+@dataclass
+class FakeMpdFragment:
+    url: str
+    duration: Optional[float] = None
+
+
+@dataclass
+class FakeMpdFormat:
+    format_id: str = "dash_v_0_0"
+    url: str = "https://example.com/manifest.mpd"
+    ext: str = "mp4"
+    vcodec: Optional[str] = "avc1.4d401f"
+    acodec: Optional[str] = None
+    tbr: Optional[float] = 1500.0
+    width: Optional[int] = 1280
+    height: Optional[int] = 720
+    fps: Optional[float] = 25.0
+    asr: Optional[int] = None
+    language: Optional[str] = None
+    container: Optional[str] = "mp4_dash"
+    manifest_url: Optional[str] = "https://example.com/manifest.mpd"
+    fragment_base_url: Optional[str] = "https://cdn.example.com/v720/"
+    fragments: list = field(default_factory=list)
+
+
+@dataclass
+class FakeMpdExtraction:
+    formats: list = field(default_factory=list)
+    subtitles: list = field(default_factory=list)
+
+
+class FixtureExtractor(InfoExtractor):
+    """Minimal Python plugin under test."""
+
+    _VALID_URL = r'.*'
+
+    def extract_dash(self, mpd_url, video_id):
+        return self._extract_mpd_formats_and_subtitles(mpd_url, video_id)
+
+
+def _segment_template_payload(manifest_url):
+    """Mirrors expand_dash_representations(segment_template.mpd, manifest_url).
+
+    Values approximate what the real Rust expansion produces — Rust test
+    `extract_mpd_returns_formats_via_fixture` is the authoritative check that
+    the real expansion shape matches what the Python conversion expects.
+    """
+    base = "https://cdn.example.com/v720/"
+    return FakeMpdExtraction(formats=[
+        FakeMpdFormat(
+            format_id="dash_v_0_0",
+            url=manifest_url,
+            ext="mp4",
+            vcodec="avc1.4d401f",
+            acodec=None,
+            tbr=1500.0,
+            width=1280,
+            height=720,
+            fps=25.0,
+            container="mp4_dash",
+            manifest_url=manifest_url,
+            fragment_base_url=base,
+            fragments=[FakeMpdFragment(url="seg-0.m4s", duration=4.0)],
+        ),
+        FakeMpdFormat(
+            format_id="dash_a_0_0",
+            url=manifest_url,
+            ext="m4a",
+            vcodec=None,
+            acodec="mp4a.40.2",
+            tbr=128.0,
+            asr=48000,
+            container="m4a_dash",
+            manifest_url=manifest_url,
+            fragment_base_url=base,
+            fragments=[FakeMpdFragment(url="seg-0.m4s", duration=4.0)],
+        ),
+    ])
+
+
+def test_fixture_plugin_extracts_dash_formats(monkeypatch):
+    manifest_url = "https://example.com/manifest.mpd"
+    monkeypatch.setattr(
+        _host, "extract_mpd",
+        lambda *a, **k: _segment_template_payload(manifest_url),
+    )
+
+    ie = FixtureExtractor()
+    fmts, subs = ie.extract_dash(manifest_url, "v123")
+
+    # Structural invariants — issue #240 acceptance.
+    assert len(fmts) >= 2, fmts
+    video_fmts = [f for f in fmts if f.get("vcodec") and not f.get("acodec")]
+    audio_fmts = [f for f in fmts if f.get("acodec") and not f.get("vcodec")]
+    assert len(video_fmts) >= 1, fmts
+    assert len(audio_fmts) >= 1, fmts
+
+    for f in fmts:
+        assert f["protocol"] == "http_dash_segments"
+        assert f["fragments"], f
+        assert f["fragment_base_url"]
+        assert f["manifest_url"] == manifest_url
+        assert f["container"] in ("mp4_dash", "m4a_dash")
+    assert subs == {}

--- a/tools/ytdlp-compat/tests/test_passthroughs.py
+++ b/tools/ytdlp-compat/tests/test_passthroughs.py
@@ -1,6 +1,8 @@
 """Verify Python InfoExtractor methods correctly delegate to _host."""
 
 import pytest
+from dataclasses import dataclass, field
+from typing import Optional
 
 from rdlp_ytdlp_compat import InfoExtractor
 
@@ -167,4 +169,208 @@ def test_extract_m3u8_calls_host(monkeypatch, ie):
     assert len(fmts) == 1
     assert fmts[0]['url'] == 'https://x/hi.m3u8'
     assert fmts[0]['width'] == 1920
+    assert subs == {}
+
+
+# ---- DASH (extract_mpd) fakes & tests --------------------------------
+
+
+@dataclass
+class FakeMpdFragment:
+    url: str
+    duration: Optional[float] = None
+
+
+@dataclass
+class FakeMpdFormat:
+    format_id: str = "dash_v_0_0"
+    url: str = "https://example.com/manifest.mpd"
+    ext: str = "mp4"
+    vcodec: Optional[str] = "avc1.4d401f"
+    acodec: Optional[str] = None
+    tbr: Optional[float] = 1500.0
+    width: Optional[int] = 1280
+    height: Optional[int] = 720
+    fps: Optional[float] = 25.0
+    asr: Optional[int] = None
+    language: Optional[str] = None
+    container: Optional[str] = "mp4_dash"
+    manifest_url: Optional[str] = "https://example.com/manifest.mpd"
+    fragment_base_url: Optional[str] = "https://cdn.example.com/v720/"
+    fragments: list = field(default_factory=list)
+
+
+@dataclass
+class FakeMpdExtraction:
+    formats: list = field(default_factory=list)
+    subtitles: list = field(default_factory=list)
+
+
+def _ie():
+    """Construct a bare InfoExtractor for shim-method exercise."""
+    from rdlp_ytdlp_compat.info_extractor import InfoExtractor
+
+    class _Concrete(InfoExtractor):
+        _VALID_URL = r'.*'
+
+    return _Concrete()
+
+
+def test_extract_mpd_calls_host(monkeypatch):
+    """#8 (positive) — shim invokes _host.extract_mpd and returns converted dicts."""
+    from rdlp_ytdlp_compat import _host
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[FakeMpdFragment(url="seg-0.m4s", duration=4.0)]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    fmts, subs = _ie()._extract_mpd_formats_and_subtitles(
+        "https://example.com/manifest.mpd", "v123",
+    )
+    assert len(fmts) == 1
+    assert fmts[0]["format_id"] == "dash_v_0_0"
+    assert fmts[0]["url"] == "https://example.com/manifest.mpd"
+    assert fmts[0]["manifest_url"] == "https://example.com/manifest.mpd"
+
+
+def test_extract_mpd_relative_fragment_uses_path_key(monkeypatch):
+    """#9 — relative fragment URLs use 'path', per yt-dlp location_key."""
+    from rdlp_ytdlp_compat import _host
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[FakeMpdFragment(url="seg-0.m4s", duration=4.0)]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    fmts, _ = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert fmts[0]["fragments"][0] == {"path": "seg-0.m4s", "duration": 4.0}
+    assert "url" not in fmts[0]["fragments"][0]
+
+
+def test_extract_mpd_absolute_fragment_uses_url_key(monkeypatch):
+    """#10 — absolute fragment URLs use 'url'."""
+    from rdlp_ytdlp_compat import _host
+    abs_url = "https://cdn.example.com/seg-0.m4s"
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[FakeMpdFragment(url=abs_url, duration=4.0)]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    fmts, _ = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert fmts[0]["fragments"][0] == {"url": abs_url, "duration": 4.0}
+    assert "path" not in fmts[0]["fragments"][0]
+
+
+def test_extract_mpd_protocol_is_http_dash_segments(monkeypatch):
+    """#11 — every emitted format dict carries protocol='http_dash_segments'."""
+    from rdlp_ytdlp_compat import _host
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[FakeMpdFragment(url="a.m4s")]),
+        FakeMpdFormat(format_id="dash_a_0_0", vcodec=None, acodec="mp4a.40.2",
+                      fragments=[FakeMpdFragment(url="b.m4s")]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    fmts, _ = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert len(fmts) == 2  # stub returns [] so this guards against vacuous all()
+    assert all(f["protocol"] == "http_dash_segments" for f in fmts)
+
+
+def test_extract_mpd_drops_unsupported_kwargs_data():
+    """#12 — data= kwarg raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="data/headers/query"):
+        _ie()._extract_mpd_formats_and_subtitles(
+            "https://x/m.mpd", "v", data=b"x",
+        )
+
+
+def test_extract_mpd_drops_unsupported_kwargs_headers():
+    """#13 — headers= kwarg raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="data/headers/query"):
+        _ie()._extract_mpd_formats_and_subtitles(
+            "https://x/m.mpd", "v", headers={"X": "y"},
+        )
+
+
+def test_extract_mpd_drops_unsupported_kwargs_query():
+    """#14 — query= kwarg raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="data/headers/query"):
+        _ie()._extract_mpd_formats_and_subtitles(
+            "https://x/m.mpd", "v", query={"k": "v"},
+        )
+
+
+def test_extract_mpd_fatal_false_returns_empty_on_runtime_error(monkeypatch):
+    """#15 — fatal=False swallows RuntimeError and returns ([], {}).
+
+    The guard `called` ensures the host was actually invoked (not bypassed by
+    the stub), so the test fails against the current no-op stub.
+    """
+    from rdlp_ytdlp_compat import _host
+
+    called = []
+
+    def boom(*a, **k):
+        called.append(True)
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_host, "extract_mpd", boom)
+    fmts, subs = _ie()._extract_mpd_formats_and_subtitles(
+        "https://x/m.mpd", "v", fatal=False,
+    )
+    assert called, "_host.extract_mpd was never invoked — stub bypassed the host"
+    assert fmts == []
+    assert subs == {}
+
+
+def test_extract_mpd_fatal_true_propagates_runtime_error(monkeypatch):
+    """#16 — fatal=True re-raises RuntimeError."""
+    from rdlp_ytdlp_compat import _host
+
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_host, "extract_mpd", boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        _ie()._extract_mpd_formats_and_subtitles(
+            "https://x/m.mpd", "v", fatal=True,
+        )
+
+
+def test_extract_mpd_formats_drops_subtitles(monkeypatch):
+    """#17 — _extract_mpd_formats returns list, not tuple."""
+    from rdlp_ytdlp_compat import _host
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[FakeMpdFragment(url="a.m4s")]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    result = _ie()._extract_mpd_formats("https://x/m.mpd", "v")
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+
+def test_extract_mpd_fragment_duration_optional_passthrough(monkeypatch):
+    """#18 — fragment.duration None is omitted; non-None is passed through."""
+    from rdlp_ytdlp_compat import _host
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[
+            FakeMpdFragment(url="a.m4s", duration=4.5),
+            FakeMpdFragment(url="b.m4s", duration=None),
+        ]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    fmts, _ = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert fmts[0]["fragments"][0]["duration"] == 4.5
+    assert "duration" not in fmts[0]["fragments"][1]
+
+
+def test_extract_mpd_subtitles_returned_as_empty_dict_in_v1(monkeypatch):
+    """#19 — subtitles return slot is a dict (empty in v1).
+
+    Also asserts formats came back non-empty so the stub (which never calls
+    the host) fails this test — format conversion is a prerequisite.
+    """
+    from rdlp_ytdlp_compat import _host
+    fake = FakeMpdExtraction(formats=[
+        FakeMpdFormat(fragments=[FakeMpdFragment(url="a.m4s")]),
+    ])
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    fmts, subs = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert len(fmts) == 1  # host must have been called and conversion must work
+    assert isinstance(subs, dict)
     assert subs == {}


### PR DESCRIPTION
## Summary
- New WIT host helper `extract-mpd` mirroring `extract-m3u8` for DASH/MPD manifests.
- Rust impl wraps `expand_dash_representations` (PR #233) and projects per-Repr `Format`s to `MpdFormat` records.
- Python shim's `_extract_mpd_formats_and_subtitles` and `_extract_mpd_formats` are now real passthroughs (no longer `([], {})` stubs).
- Closes #240.

## Implementation
- WIT records `mpd-options`, `mpd-fragment`, `mpd-format`, `mpd-extraction` added to `host-extract-helpers` (no package version bump — add-only within v0.2).
- Rust host fetches MPD body, calls `expand_dash_representations`, projects `Format` → `MpdFormat`, with three-arm fatal/non-fatal dispatch matching the m3u8 precedent.
- Python `_mpd_format_to_dict` + `_location_key` apply yt-dlp's relative-vs-absolute fragment URL convention (`path` vs `url` key).
- `subtitles` slot in `mpd-extraction` reserved for a follow-up that will expand DASH text AdaptationSets — currently always empty (verified safe for SVT, BBC iPlayer, France TV which all source subs out-of-band).

## Test plan
- [x] Rust host fixture test (`extract_mpd_returns_formats_via_fixture`) passes.
- [x] Six Rust negative tests (fatal/non-fatal × dynamic/DRM/utf8/unparseable) — all assert `FetchError::Network` variant.
- [x] Twelve Python passthrough negative tests (location_key, kwargs guards, fatal flag, optional fields, subtitle slot shape).
- [x] Fixture-plugin acceptance test (`test_fixture_plugin_extracts_dash_formats`) — Python plugin extracts DASH formats from a payload structurally identical to the Rust expansion.
- [x] `cargo check && cargo clippy --all-targets -- -D warnings && cargo test` — 2717 passed, 0 failed.
- [x] `pytest` in `tools/ytdlp-compat` — 408 passed.

## Out of scope (follow-ups)
- DASH text/subtitle AdaptationSet expansion (slot reserved in `mpd-extraction.subtitles`).
- `data` / `headers` / `query` kwargs (raises `NotImplementedError` mirroring the m3u8 helper).
- Python → componentize-py → WASM round-trip integration test.