### PR TITLE
feat(dash,plugin,ytdlp-compat): emit DASH text AdaptationSet sidecar subtitles

### DIFF
--- a/crates/rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd
+++ b/crates/rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="static"
+     mediaPresentationDuration="PT60S"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT60S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentTemplate timescale="1000" duration="4000" media="v1/$Number$.m4s" initialization="v1/init.m4s" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="audio/mp4" contentType="audio" lang="en" segmentAlignment="true">
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentTemplate timescale="48000" duration="192000" media="a1/$Number$.m4s" initialization="a1/init.m4s" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="2" mimeType="text/ttml" contentType="text" lang="en">
+      <Representation id="t1" bandwidth="1000">
+        <BaseURL>subs/en.ttml</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="3" mimeType="application/mp4" contentType="text" lang="sv">
+      <Representation id="t2" bandwidth="1500" codecs="wvtt">
+        <BaseURL>subs/sv.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="4" mimeType="text/vtt" contentType="text">
+      <Representation id="t3" bandwidth="800">
+        <BaseURL>subs/und.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/crates/rdlp-extractor/src/base/common/dash/expand.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/expand.rs
@@ -140,8 +140,7 @@ pub fn expand_dash_representations(
                 // Sidecar VoD: BaseURL chain resolves to a single .ttml / .vtt file.
                 // Fragmented text tracks (SegmentTemplate) are deferred — log-warn + skip.
                 let synth_id = format!("sub_{adapt_idx}_{repr_idx}");
-                let plan =
-                    build_fragments(adapt, repr, &synth_id, 0, period_duration_seconds);
+                let plan = build_fragments(adapt, repr, &synth_id, 0, period_duration_seconds);
                 if plan.is_empty() {
                     let ext = mime_to_sub_ext(mime, codecs_str);
                     subtitles.push(DashSubtitle {
@@ -152,7 +151,8 @@ pub fn expand_dash_representations(
                 } else {
                     log::warn!(
                         "DASH: skipping fragmented text track at adapt={} repr={} (SegmentTemplate subs not yet supported)",
-                        adapt_idx, repr_idx,
+                        adapt_idx,
+                        repr_idx,
                     );
                 }
                 continue;
@@ -394,7 +394,10 @@ mod tests {
     fn segment_template_three_video_two_audio() {
         let xml = load_fixture("segment_template.mpd");
         let base = Url::parse("https://cdn.example.com/manifest.mpd").unwrap();
-        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&xml, &base).unwrap();
+        let DashExpansion {
+            formats,
+            subtitles: _,
+        } = expand_dash_representations(&xml, &base).unwrap();
 
         // Fixture defines at least one video Repr + one audio Repr.
         assert!(
@@ -437,7 +440,10 @@ mod tests {
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
         let result = expand_dash_representations(&xml, &base);
         match result {
-            Ok(DashExpansion { formats, subtitles: _ }) => {
+            Ok(DashExpansion {
+                formats,
+                subtitles: _,
+            }) => {
                 // None of the returned Formats should be DRM-encumbered.
                 // We can't introspect ContentProtection from a Format, but we
                 // can assert that every returned Format passed the filter.
@@ -454,7 +460,10 @@ mod tests {
     fn multi_period_first_only() {
         let xml = load_fixture("multi_period.mpd");
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
-        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&xml, &base).unwrap();
+        let DashExpansion {
+            formats,
+            subtitles: _,
+        } = expand_dash_representations(&xml, &base).unwrap();
         // Multi-period fixture has Reps in each period; we only emit period-1's.
         // Asserting non-empty is sufficient — a non-failing parse with at least
         // one Format proves the multi-period warn-and-skip path succeeded.
@@ -465,7 +474,10 @@ mod tests {
     fn mega_rep_cap_at_50() {
         let xml = load_fixture("mega_reps.mpd");
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
-        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&xml, &base).unwrap();
+        let DashExpansion {
+            formats,
+            subtitles: _,
+        } = expand_dash_representations(&xml, &base).unwrap();
         assert_eq!(formats.len(), 50, "60-Rep MPD should cap at 50");
         // The 50 retained should be the highest-bandwidth Reps (v11..v60).
         // Bandwidth formula: 100000 + i * 10000 → v11 = 210000, v60 = 700000.
@@ -494,16 +506,18 @@ mod tests {
   </Period>
 </MPD>"#;
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
-        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(xml, &base).unwrap();
+        let DashExpansion {
+            formats,
+            subtitles: _,
+        } = expand_dash_representations(xml, &base).unwrap();
         assert_eq!(formats.len(), 1);
         assert_eq!(formats[0].format_id, "dash_v_0_0");
     }
 
     // ---- DASH text-AdaptationSet expansion tests ------------------------------
 
-    const WITH_TEXT_TRACKS_MPD: &str = include_str!(
-        "../../../../../rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd"
-    );
+    const WITH_TEXT_TRACKS_MPD: &str =
+        include_str!("../../../../../rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd");
 
     /// Inline MPD: one fragmented text track (SegmentTemplate-driven). Used
     /// to verify the expansion logs a warning and skips it instead of emitting
@@ -554,7 +568,10 @@ mod tests {
         let langs: Vec<Option<&str>> = r.subtitles.iter().map(|s| s.language.as_deref()).collect();
         assert!(langs.contains(&Some("en")), "en sub present: {langs:?}");
         assert!(langs.contains(&Some("sv")), "sv sub present: {langs:?}");
-        assert!(langs.contains(&None), "lang-less sub present (None): {langs:?}");
+        assert!(
+            langs.contains(&None),
+            "lang-less sub present (None): {langs:?}"
+        );
 
         let exts: Vec<&str> = r.subtitles.iter().map(|s| s.ext.as_str()).collect();
         assert!(exts.contains(&"ttml"), "ttml ext present: {exts:?}");
@@ -564,9 +581,16 @@ mod tests {
     #[test]
     fn expand_assigns_none_when_lang_attr_missing() {
         let r = expand_dash_representations(WITH_TEXT_TRACKS_MPD, &text_test_base_url()).unwrap();
-        let lang_less = r.subtitles.iter().find(|s| s.language.is_none())
+        let lang_less = r
+            .subtitles
+            .iter()
+            .find(|s| s.language.is_none())
             .expect("lang-less sub");
-        assert!(lang_less.url.ends_with("subs/und.vtt"), "url: {}", lang_less.url);
+        assert!(
+            lang_less.url.ends_with("subs/und.vtt"),
+            "url: {}",
+            lang_less.url
+        );
         assert_eq!(lang_less.ext, "vtt");
     }
 
@@ -574,7 +598,11 @@ mod tests {
     fn expand_skips_fragmented_text_template() {
         let r = expand_dash_representations(FRAGMENTED_TEXT_MPD, &text_test_base_url()).unwrap();
         assert_eq!(r.formats.len(), 1, "video survives");
-        assert_eq!(r.subtitles.len(), 0, "fragmented text track must be skipped");
+        assert_eq!(
+            r.subtitles.len(),
+            0,
+            "fragmented text track must be skipped"
+        );
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/base/common/dash/expand.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/expand.rs
@@ -89,7 +89,7 @@ pub fn expand_dash_representations(
 
     let mut drm_dropped = 0usize;
     let mut formats: Vec<Format> = Vec::new();
-    let subtitles: Vec<DashSubtitle> = Vec::new();
+    let mut subtitles: Vec<DashSubtitle> = Vec::new();
 
     for (adapt_idx, adapt) in period.adaptations.iter().enumerate() {
         if !adapt.ContentProtection.is_empty() {
@@ -122,9 +122,39 @@ pub fn expand_dash_representations(
                 .as_deref()
                 .or(adapt.mimeType.as_deref())
                 .unwrap_or("");
+            let codecs_str = repr
+                .codecs
+                .as_deref()
+                .or(adapt.codecs.as_deref())
+                .unwrap_or("");
             let is_video = mime.starts_with("video/");
             let is_audio = mime.starts_with("audio/");
-            if !is_video && !is_audio {
+            let is_text = mime.starts_with("text/")
+                || (mime == "application/mp4"
+                    && matches!(codecs_str, "stpp" | "wvtt" | "ttml" | "dfxp"));
+            if !is_video && !is_audio && !is_text {
+                continue;
+            }
+
+            if is_text {
+                // Sidecar VoD: BaseURL chain resolves to a single .ttml / .vtt file.
+                // Fragmented text tracks (SegmentTemplate) are deferred — log-warn + skip.
+                let synth_id = format!("sub_{adapt_idx}_{repr_idx}");
+                let plan =
+                    build_fragments(adapt, repr, &synth_id, 0, period_duration_seconds);
+                if plan.is_empty() {
+                    let ext = mime_to_sub_ext(mime, codecs_str);
+                    subtitles.push(DashSubtitle {
+                        language: adapt_lang.clone(),
+                        url: final_base.to_string(),
+                        ext,
+                    });
+                } else {
+                    log::warn!(
+                        "DASH: skipping fragmented text track at adapt={} repr={} (SegmentTemplate subs not yet supported)",
+                        adapt_idx, repr_idx,
+                    );
+                }
                 continue;
             }
 
@@ -205,7 +235,7 @@ pub fn expand_dash_representations(
         log::warn!("DASH: capped representations at {MAX_REPS_PER_MPD} (dropped {dropped})");
     }
 
-    if formats.is_empty() {
+    if formats.is_empty() && subtitles.is_empty() {
         return Err(DashExpandError::NoUsableReps);
     }
     Ok(DashExpansion { formats, subtitles })
@@ -320,11 +350,23 @@ fn build_fragments(
     Vec::new()
 }
 
-#[cfg(test)]
-fn mime_to_sub_ext(_mime: &str, _codecs: &str) -> String {
-    // Stub: real implementation lands in Task 4 of the DASH-text-subtitle plan.
-    // Returning "ttml" lets Task 3's failing tests compile.
-    "ttml".to_owned()
+/// Derive a yt-dlp-style subtitle ext from an MPD text Representation's
+/// `mimeType` and (for `application/mp4` containers) `codecs`.
+///
+/// Defaults to `"ttml"` for unknown text mime types — defensive, matching
+/// yt-dlp's convention.
+fn mime_to_sub_ext(mime: &str, codecs: &str) -> String {
+    match mime {
+        "text/ttml" | "application/ttml+xml" => "ttml",
+        "text/vtt" => "vtt",
+        "application/mp4" => match codecs {
+            "stpp" | "ttml" | "dfxp" => "ttml",
+            "wvtt" => "vtt",
+            _ => "ttml",
+        },
+        _ => "ttml",
+    }
+    .to_owned()
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/base/common/dash/expand.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/expand.rs
@@ -19,6 +19,33 @@ use super::segments::{
 /// Hard cap on representations per MPD. Task 11 exercises the truncation logic.
 pub(crate) const MAX_REPS_PER_MPD: usize = 50;
 
+/// One DASH text AdaptationSet representation, projected to a sidecar subtitle.
+///
+/// `language` is `None` when the source AdaptationSet has no `@lang` attribute.
+/// Downstream consumers map `None` → `"und"` per yt-dlp convention.
+#[derive(Debug, Clone)]
+pub struct DashSubtitle {
+    /// BCP-47 language tag, or `None` when the source AdaptationSet has no `@lang`.
+    pub language: Option<String>,
+    /// Direct URL to the subtitle sidecar file.
+    pub url: String,
+    /// File extension derived from the MIME type (e.g. `"vtt"`, `"ttml"`).
+    pub ext: String,
+}
+
+/// Combined output of [`expand_dash_representations`].
+///
+/// `formats` contains video + audio Representations (one per Repr). `subtitles`
+/// contains text AdaptationSet sidecar tracks (single-URL per Repr; fragmented
+/// text tracks are skipped with a warn log — see plan task 4).
+#[derive(Debug, Clone)]
+pub struct DashExpansion {
+    /// Video and audio Representations, one [`Format`] per usable Representation.
+    pub formats: Vec<Format>,
+    /// Text AdaptationSet sidecar tracks. Empty until Task 4 adds detection.
+    pub subtitles: Vec<DashSubtitle>,
+}
+
 /// Parse the MPD body and project each Representation to a [`Format`].
 ///
 /// `mpd_xml` is the response body. `base_url` is the URL the MPD was fetched
@@ -35,7 +62,7 @@ pub(crate) const MAX_REPS_PER_MPD: usize = 50;
 pub fn expand_dash_representations(
     mpd_xml: &str,
     base_url: &Url,
-) -> Result<Vec<Format>, DashExpandError> {
+) -> Result<DashExpansion, DashExpandError> {
     let mpd = dash_mpd::parse(mpd_xml).map_err(|e| DashExpandError::Parse(e.to_string()))?;
 
     if mpd.mpdtype.as_deref() == Some("dynamic") {
@@ -62,6 +89,7 @@ pub fn expand_dash_representations(
 
     let mut drm_dropped = 0usize;
     let mut formats: Vec<Format> = Vec::new();
+    let subtitles: Vec<DashSubtitle> = Vec::new();
 
     for (adapt_idx, adapt) in period.adaptations.iter().enumerate() {
         if !adapt.ContentProtection.is_empty() {
@@ -180,7 +208,7 @@ pub fn expand_dash_representations(
     if formats.is_empty() {
         return Err(DashExpandError::NoUsableReps);
     }
-    Ok(formats)
+    Ok(DashExpansion { formats, subtitles })
 }
 
 /// Map a MIME type to a container file extension.
@@ -317,7 +345,7 @@ mod tests {
     fn segment_template_three_video_two_audio() {
         let xml = load_fixture("segment_template.mpd");
         let base = Url::parse("https://cdn.example.com/manifest.mpd").unwrap();
-        let formats = expand_dash_representations(&xml, &base).unwrap();
+        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&xml, &base).unwrap();
 
         // Fixture defines at least one video Repr + one audio Repr.
         assert!(
@@ -360,7 +388,7 @@ mod tests {
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
         let result = expand_dash_representations(&xml, &base);
         match result {
-            Ok(formats) => {
+            Ok(DashExpansion { formats, subtitles: _ }) => {
                 // None of the returned Formats should be DRM-encumbered.
                 // We can't introspect ContentProtection from a Format, but we
                 // can assert that every returned Format passed the filter.
@@ -377,7 +405,7 @@ mod tests {
     fn multi_period_first_only() {
         let xml = load_fixture("multi_period.mpd");
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
-        let formats = expand_dash_representations(&xml, &base).unwrap();
+        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&xml, &base).unwrap();
         // Multi-period fixture has Reps in each period; we only emit period-1's.
         // Asserting non-empty is sufficient — a non-failing parse with at least
         // one Format proves the multi-period warn-and-skip path succeeded.
@@ -388,7 +416,7 @@ mod tests {
     fn mega_rep_cap_at_50() {
         let xml = load_fixture("mega_reps.mpd");
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
-        let formats = expand_dash_representations(&xml, &base).unwrap();
+        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&xml, &base).unwrap();
         assert_eq!(formats.len(), 50, "60-Rep MPD should cap at 50");
         // The 50 retained should be the highest-bandwidth Reps (v11..v60).
         // Bandwidth formula: 100000 + i * 10000 → v11 = 210000, v60 = 700000.
@@ -417,7 +445,7 @@ mod tests {
   </Period>
 </MPD>"#;
         let base = Url::parse("https://cdn.example.com/m.mpd").unwrap();
-        let formats = expand_dash_representations(xml, &base).unwrap();
+        let DashExpansion { formats, subtitles: _ } = expand_dash_representations(xml, &base).unwrap();
         assert_eq!(formats.len(), 1);
         assert_eq!(formats[0].format_id, "dash_v_0_0");
     }

--- a/crates/rdlp-extractor/src/base/common/dash/expand.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/expand.rs
@@ -321,6 +321,13 @@ fn build_fragments(
 }
 
 #[cfg(test)]
+fn mime_to_sub_ext(_mime: &str, _codecs: &str) -> String {
+    // Stub: real implementation lands in Task 4 of the DASH-text-subtitle plan.
+    // Returning "ttml" lets Task 3's failing tests compile.
+    "ttml".to_owned()
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use rdlp_types::DownloadProtocol;
@@ -448,5 +455,128 @@ mod tests {
         let DashExpansion { formats, subtitles: _ } = expand_dash_representations(xml, &base).unwrap();
         assert_eq!(formats.len(), 1);
         assert_eq!(formats[0].format_id, "dash_v_0_0");
+    }
+
+    // ---- DASH text-AdaptationSet expansion tests ------------------------------
+
+    const WITH_TEXT_TRACKS_MPD: &str = include_str!(
+        "../../../../../rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd"
+    );
+
+    /// Inline MPD: one fragmented text track (SegmentTemplate-driven). Used
+    /// to verify the expansion logs a warning and skips it instead of emitting
+    /// a partial entry.
+    const FRAGMENTED_TEXT_MPD: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="PT60S" minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT60S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video">
+      <Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1920" height="1080">
+        <SegmentTemplate timescale="1000" duration="4000" media="v1/$Number$.m4s" initialization="v1/init.m4s" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" mimeType="application/mp4" contentType="text" lang="en">
+      <Representation id="t1" bandwidth="1500" codecs="wvtt">
+        <SegmentTemplate timescale="1000" duration="4000" media="subs/en/$Number$.m4s" initialization="subs/en/init.m4s" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>"#;
+
+    /// Inline MPD: text-only manifest (no video / audio AdaptationSets).
+    const TEXT_ONLY_MPD: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="PT60S" minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT60S">
+    <AdaptationSet id="0" mimeType="text/ttml" contentType="text" lang="en">
+      <Representation id="t1" bandwidth="1000">
+        <BaseURL>subs/en.ttml</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>"#;
+
+    fn text_test_base_url() -> Url {
+        Url::parse("https://example.com/manifest.mpd").expect("base url")
+    }
+
+    #[test]
+    fn expand_yields_text_subtitles_from_sidecar_mpd() {
+        let r = expand_dash_representations(WITH_TEXT_TRACKS_MPD, &text_test_base_url())
+            .expect("expansion succeeds");
+        assert_eq!(r.formats.len(), 2, "video + audio");
+        assert_eq!(r.subtitles.len(), 3, "three text reps in fixture");
+
+        let langs: Vec<Option<&str>> = r.subtitles.iter().map(|s| s.language.as_deref()).collect();
+        assert!(langs.contains(&Some("en")), "en sub present: {langs:?}");
+        assert!(langs.contains(&Some("sv")), "sv sub present: {langs:?}");
+        assert!(langs.contains(&None), "lang-less sub present (None): {langs:?}");
+
+        let exts: Vec<&str> = r.subtitles.iter().map(|s| s.ext.as_str()).collect();
+        assert!(exts.contains(&"ttml"), "ttml ext present: {exts:?}");
+        assert!(exts.contains(&"vtt"), "vtt ext present (twice): {exts:?}");
+    }
+
+    #[test]
+    fn expand_assigns_none_when_lang_attr_missing() {
+        let r = expand_dash_representations(WITH_TEXT_TRACKS_MPD, &text_test_base_url()).unwrap();
+        let lang_less = r.subtitles.iter().find(|s| s.language.is_none())
+            .expect("lang-less sub");
+        assert!(lang_less.url.ends_with("subs/und.vtt"), "url: {}", lang_less.url);
+        assert_eq!(lang_less.ext, "vtt");
+    }
+
+    #[test]
+    fn expand_skips_fragmented_text_template() {
+        let r = expand_dash_representations(FRAGMENTED_TEXT_MPD, &text_test_base_url()).unwrap();
+        assert_eq!(r.formats.len(), 1, "video survives");
+        assert_eq!(r.subtitles.len(), 0, "fragmented text track must be skipped");
+    }
+
+    #[test]
+    fn expand_returns_no_usable_reps_when_video_audio_and_text_all_empty() {
+        let empty = r#"<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="PT60S" minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT60S"></Period>
+</MPD>"#;
+        let err = expand_dash_representations(empty, &text_test_base_url())
+            .expect_err("empty MPD must error");
+        assert!(matches!(err, DashExpandError::NoUsableReps), "got {err:?}");
+    }
+
+    #[test]
+    fn expand_returns_ok_with_text_only_mpd() {
+        let r = expand_dash_representations(TEXT_ONLY_MPD, &text_test_base_url()).unwrap();
+        assert!(r.formats.is_empty(), "no AV formats");
+        assert_eq!(r.subtitles.len(), 1, "one text sub");
+        assert_eq!(r.subtitles[0].language.as_deref(), Some("en"));
+        assert_eq!(r.subtitles[0].ext, "ttml");
+    }
+
+    #[test]
+    fn mime_to_sub_ext_text_ttml() {
+        assert_eq!(mime_to_sub_ext("text/ttml", ""), "ttml");
+        assert_eq!(mime_to_sub_ext("application/ttml+xml", ""), "ttml");
+    }
+
+    #[test]
+    fn mime_to_sub_ext_text_vtt() {
+        assert_eq!(mime_to_sub_ext("text/vtt", ""), "vtt");
+    }
+
+    #[test]
+    fn mime_to_sub_ext_mp4_stpp() {
+        assert_eq!(mime_to_sub_ext("application/mp4", "stpp"), "ttml");
+        assert_eq!(mime_to_sub_ext("application/mp4", "ttml"), "ttml");
+        assert_eq!(mime_to_sub_ext("application/mp4", "dfxp"), "ttml");
+    }
+
+    #[test]
+    fn mime_to_sub_ext_mp4_wvtt() {
+        assert_eq!(mime_to_sub_ext("application/mp4", "wvtt"), "vtt");
     }
 }

--- a/crates/rdlp-extractor/src/base/common/dash/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/mod.rs
@@ -10,4 +10,4 @@ mod frame_rate;
 mod segments;
 
 pub use errors::DashExpandError;
-pub use expand::expand_dash_representations;
+pub use expand::{expand_dash_representations, DashExpansion, DashSubtitle};

--- a/crates/rdlp-extractor/src/base/common/dash/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/mod.rs
@@ -10,4 +10,4 @@ mod frame_rate;
 mod segments;
 
 pub use errors::DashExpandError;
-pub use expand::{expand_dash_representations, DashExpansion, DashSubtitle};
+pub use expand::{DashExpansion, DashSubtitle, expand_dash_representations};

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -213,7 +213,10 @@ fn try_direct_media(url: &str, pf: &PrefetchResponse) -> Result<Option<InfoDict>
         };
 
         match crate::base::common::dash::expand_dash_representations(body_str, &mpd_url) {
-            Ok(crate::base::common::dash::DashExpansion { formats, subtitles: _ }) => {
+            Ok(crate::base::common::dash::DashExpansion {
+                formats,
+                subtitles: _,
+            }) => {
                 // Subtitles deliberately dropped here — InfoDict has no subtitles field today.
                 // Tracking issue (to be filed) for orchestrator-level propagation.
                 let mut info = InfoDict::new(&video_id, &title, "Generic", url);

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -213,7 +213,9 @@ fn try_direct_media(url: &str, pf: &PrefetchResponse) -> Result<Option<InfoDict>
         };
 
         match crate::base::common::dash::expand_dash_representations(body_str, &mpd_url) {
-            Ok(formats) => {
+            Ok(crate::base::common::dash::DashExpansion { formats, subtitles: _ }) => {
+                // Subtitles deliberately dropped here — InfoDict has no subtitles field today.
+                // Tracking issue (to be filed) for orchestrator-level propagation.
                 let mut info = InfoDict::new(&video_id, &title, "Generic", url);
                 info.formats = formats;
                 return Ok(Some(info));

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -307,7 +307,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             ExtractHelpersSubtitle, MpdExtraction, MpdFormat, MpdFragment,
         };
         use crate::bindings::rdlp::plugin::host_fetch::{FetchError, Host as FetchHost, Request};
-        use rdlp_extractor::base::common::dash::{expand_dash_representations, DashExpansion};
+        use rdlp_extractor::base::common::dash::{DashExpansion, expand_dash_representations};
         use url::Url;
 
         let result: Result<MpdExtraction, FetchError> = async {
@@ -1110,8 +1110,11 @@ hi.m3u8\n";
 
         // Build a lookup by language. Lang-less sub maps to empty string at the WIT layer
         // (Python shim handles the und fallback).
-        let by_lang: std::collections::HashMap<&str, &ExtractHelpersSubtitle> =
-            r.subtitles.iter().map(|s| (s.language.as_str(), s)).collect();
+        let by_lang: std::collections::HashMap<&str, &ExtractHelpersSubtitle> = r
+            .subtitles
+            .iter()
+            .map(|s| (s.language.as_str(), s))
+            .collect();
         assert!(
             by_lang.contains_key("en"),
             "en sub present: {:?}",
@@ -1137,7 +1140,11 @@ hi.m3u8\n";
             Some("vtt")
         );
         assert_eq!(
-            by_lang.get("").expect("lang-less sub present").ext.as_deref(),
+            by_lang
+                .get("")
+                .expect("lang-less sub present")
+                .ext
+                .as_deref(),
             Some("vtt")
         );
     }

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -307,7 +307,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             MpdExtraction, MpdFormat, MpdFragment,
         };
         use crate::bindings::rdlp::plugin::host_fetch::{FetchError, Host as FetchHost, Request};
-        use rdlp_extractor::base::common::dash::expand_dash_representations;
+        use rdlp_extractor::base::common::dash::{expand_dash_representations, DashExpansion};
         use url::Url;
 
         let result: Result<MpdExtraction, FetchError> = async {
@@ -322,7 +322,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             let body =
                 String::from_utf8(resp.body).map_err(|e| FetchError::Network(e.to_string()))?;
             let base = Url::parse(&url).map_err(|e| FetchError::Network(e.to_string()))?;
-            let formats = expand_dash_representations(&body, &base)
+            let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&body, &base)
                 .map_err(|e| FetchError::Network(format!("{e:#}")))?;
 
             let mpd_formats: Vec<MpdFormat> = formats

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -304,7 +304,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         crate::bindings::rdlp::plugin::host_fetch::FetchError,
     > {
         use crate::bindings::rdlp::plugin::host_extract_helpers::{
-            MpdExtraction, MpdFormat, MpdFragment,
+            ExtractHelpersSubtitle, MpdExtraction, MpdFormat, MpdFragment,
         };
         use crate::bindings::rdlp::plugin::host_fetch::{FetchError, Host as FetchHost, Request};
         use rdlp_extractor::base::common::dash::{expand_dash_representations, DashExpansion};
@@ -322,7 +322,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             let body =
                 String::from_utf8(resp.body).map_err(|e| FetchError::Network(e.to_string()))?;
             let base = Url::parse(&url).map_err(|e| FetchError::Network(e.to_string()))?;
-            let DashExpansion { formats, subtitles: _ } = expand_dash_representations(&body, &base)
+            let DashExpansion { formats, subtitles } = expand_dash_representations(&body, &base)
                 .map_err(|e| FetchError::Network(format!("{e:#}")))?;
 
             let mpd_formats: Vec<MpdFormat> = formats
@@ -354,9 +354,18 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
                 })
                 .collect();
 
+            let mpd_subtitles: Vec<ExtractHelpersSubtitle> = subtitles
+                .into_iter()
+                .map(|s| ExtractHelpersSubtitle {
+                    language: s.language.unwrap_or_default(),
+                    url: s.url,
+                    ext: Some(s.ext),
+                })
+                .collect();
+
             Ok(MpdExtraction {
                 formats: mpd_formats,
-                subtitles: vec![],
+                subtitles: mpd_subtitles,
             })
         }
         .await;
@@ -1065,6 +1074,71 @@ hi.m3u8\n";
         assert!(
             matches!(err, FetchError::Network(_)),
             "expected FetchError::Network, got {err:?}"
+        );
+    }
+
+    const WITH_TEXT_TRACKS_MPD: &str =
+        include_str!("../../../rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd");
+
+    #[tokio::test]
+    async fn extract_mpd_returns_subtitles_via_fixture() {
+        use crate::bindings::rdlp::plugin::host_extract_helpers::{
+            ExtractHelpersSubtitle, Host as _,
+        };
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        c.fetch = Some(crate::host::fetch::FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(FetchFixtures::new().with(
+                url,
+                FixtureResponse::ok(WITH_TEXT_TRACKS_MPD.as_bytes().to_vec()),
+            ))),
+        });
+
+        let r = c
+            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true))
+            .await
+            .expect("extract_mpd");
+
+        assert_eq!(r.formats.len(), 2, "video + audio formats");
+        assert_eq!(r.subtitles.len(), 3, "three subtitle reps");
+
+        // Build a lookup by language. Lang-less sub maps to empty string at the WIT layer
+        // (Python shim handles the und fallback).
+        let by_lang: std::collections::HashMap<&str, &ExtractHelpersSubtitle> =
+            r.subtitles.iter().map(|s| (s.language.as_str(), s)).collect();
+        assert!(
+            by_lang.contains_key("en"),
+            "en sub present: {:?}",
+            by_lang.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            by_lang.contains_key("sv"),
+            "sv sub present: {:?}",
+            by_lang.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            by_lang.contains_key(""),
+            "lang-less sub present as empty string: {:?}",
+            by_lang.keys().collect::<Vec<_>>()
+        );
+
+        assert_eq!(
+            by_lang.get("en").expect("en sub present").ext.as_deref(),
+            Some("ttml")
+        );
+        assert_eq!(
+            by_lang.get("sv").expect("sv sub present").ext.as_deref(),
+            Some("vtt")
+        );
+        assert_eq!(
+            by_lang.get("").expect("lang-less sub present").ext.as_deref(),
+            Some("vtt")
         );
     }
 }

--- a/tools/ytdlp-compat/README.md
+++ b/tools/ytdlp-compat/README.md
@@ -89,7 +89,7 @@ build time resolves all upstream relative imports.
 - `search-regex`, `html-search-regex`, `html-search-meta` — regex / OG / meta primitives
 - `og-search-property` — OG property + entity unescape
 - `extract-m3u8` — HLS master playlist parsing (lossless dict round-trip)
-- `extract-mpd` — DASH MPD manifest parsing with segment extraction
+- `extract-mpd` — DASH MPD manifest parsing with segment extraction; subtitles slot now populated from text AdaptationSet sidecar tracks (fragmented text tracks deferred — log-warn + skip)
 - `extract-json-ld` — typed JSON-LD video extraction backed by rdlp's existing parser
 - `rta-search` — adult-content age-marker scan
 - `search-json` — brace-balanced JSON extraction (Next.js / urqlState)

--- a/tools/ytdlp-compat/rdlp_ytdlp_compat/info_extractor.py
+++ b/tools/ytdlp-compat/rdlp_ytdlp_compat/info_extractor.py
@@ -1293,7 +1293,14 @@ class InfoExtractor:
             if fatal:
                 raise
             return [], {}
-        return [_mpd_format_to_dict(f, mpd_url) for f in result.formats], {}
+        subtitles = {}
+        for s in result.subtitles:
+            entry = {'url': s.url}
+            if s.ext is not None:
+                entry['ext'] = s.ext
+            lang = s.language or 'und'
+            subtitles.setdefault(lang, []).append(entry)
+        return [_mpd_format_to_dict(f, mpd_url) for f in result.formats], subtitles
 
     def _search_json_ld(self, html, video_id, expected_type=None, *, fatal=True, default=NO_DEFAULT):
         """Slice-2.5 passthrough to host-extract-helpers.extract-json-ld.

--- a/tools/ytdlp-compat/tests/test_passthroughs.py
+++ b/tools/ytdlp-compat/tests/test_passthroughs.py
@@ -359,6 +359,74 @@ def test_extract_mpd_fragment_duration_optional_passthrough(monkeypatch):
     assert "duration" not in fmts[0]["fragments"][1]
 
 
+def test_extract_mpd_subtitles_grouped_by_language(monkeypatch):
+    """#11 (positive) — subtitles dict groups entries by language."""
+    from rdlp_ytdlp_compat import _host
+
+    @dataclass
+    class FakeSub:
+        language: str
+        url: str
+        ext: Optional[str]
+
+    fake = FakeMpdExtraction(
+        formats=[FakeMpdFormat(fragments=[FakeMpdFragment(url="seg-0.m4s")])],
+        subtitles=[
+            FakeSub(language="en", url="https://x/en.ttml", ext="ttml"),
+            FakeSub(language="sv", url="https://x/sv.vtt", ext="vtt"),
+        ],
+    )
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    _, subs = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert subs == {
+        "en": [{"url": "https://x/en.ttml", "ext": "ttml"}],
+        "sv": [{"url": "https://x/sv.vtt", "ext": "vtt"}],
+    }
+
+
+def test_extract_mpd_subtitles_use_und_fallback_when_lang_missing(monkeypatch):
+    """#12 — empty-string language at WIT layer maps to 'und' in Python dict."""
+    from rdlp_ytdlp_compat import _host
+
+    @dataclass
+    class FakeSub:
+        language: str
+        url: str
+        ext: Optional[str]
+
+    fake = FakeMpdExtraction(
+        formats=[FakeMpdFormat(fragments=[FakeMpdFragment(url="seg-0.m4s")])],
+        subtitles=[
+            FakeSub(language="", url="https://x/und.vtt", ext="vtt"),
+        ],
+    )
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    _, subs = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert "und" in subs
+    assert subs["und"] == [{"url": "https://x/und.vtt", "ext": "vtt"}]
+
+
+def test_extract_mpd_subtitles_omit_ext_when_none(monkeypatch):
+    """#13 — sub with ext=None must not put 'ext' key in the entry."""
+    from rdlp_ytdlp_compat import _host
+
+    @dataclass
+    class FakeSub:
+        language: str
+        url: str
+        ext: Optional[str]
+
+    fake = FakeMpdExtraction(
+        formats=[FakeMpdFormat(fragments=[FakeMpdFragment(url="seg-0.m4s")])],
+        subtitles=[
+            FakeSub(language="en", url="https://x/en.unknown", ext=None),
+        ],
+    )
+    monkeypatch.setattr(_host, "extract_mpd", lambda *a, **k: fake)
+    _, subs = _ie()._extract_mpd_formats_and_subtitles("https://x/m.mpd", "v")
+    assert subs == {"en": [{"url": "https://x/en.unknown"}]}
+
+
 def test_extract_mpd_subtitles_returned_as_empty_dict_in_v1(monkeypatch):
     """#19 — subtitles return slot is a dict (empty in v1).
 


### PR DESCRIPTION
## Summary
- `expand_dash_representations` now returns `DashExpansion { formats, subtitles }` (breaking signature change, all 3 call sites in-workspace).
- New `mime_to_sub_ext` helper derives ext from mime + codecs (TTML / VTT / wvtt / stpp).
- Text-track branch in the per-Repr loop emits sidecar text reps; fragmented (SegmentTemplate) text tracks log-warn + skip.
- `NoUsableReps` guard updated so text-only MPDs don't error.
- Plugin host helper projects DashSubtitle → `ExtractHelpersSubtitle` (existing WIT record, no contract change).
- Python shim builds the yt-dlp `{lang: [{url, ext}]}` dict from `result.subtitles`.
- Closes #251.

## Test plan
- [x] 9 Rust expansion tests (positive sidecar fixture + lang-fallback + fragmented-skip + text-only-MPD + 4 mime_to_sub_ext branches).
- [x] 1 Rust host helper test (extract_mpd_returns_subtitles_via_fixture).
- [x] 3 Python shim tests (grouped-by-lang + und-fallback + ext-omit).
- [x] `cargo check && cargo clippy --all-targets -- -D warnings && cargo test` — clean.
- [x] `pytest` in `tools/ytdlp-compat` — all green (411 passed).
- [x] `cargo fmt --check` — clean (verified before push).
- [x] `scripts/check-wit-drift.sh` — clean (no WIT changes in this PR).

## Out of scope (follow-ups)
- Fragmented (SegmentTemplate-driven) text track emission.
- `InfoDict.subtitles` propagation through the orchestrator (generic-extractor path silently drops; plugin-host path is fully wired).