### PR TITLE
feat(plugin,ytdlp-compat): plumb data/headers/query through host-extract-helpers (WIT @0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6234,6 +6234,7 @@ dependencies = [
  "hex",
  "html-escape",
  "log",
+ "percent-encoding",
  "psl",
  "rand 0.8.5",
  "rdlp-cookies",

--- a/crates/rdlp-plugin/Cargo.toml
+++ b/crates/rdlp-plugin/Cargo.toml
@@ -46,6 +46,7 @@ sha2 = "0.10"
 hex = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
+percent-encoding = "2"
 html-escape = "0.2.13"
 rdlp-extractor = { version = "0.1.0", path = "../rdlp-extractor" }
 

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -227,6 +227,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         url: String,
         _video_id: String,
         opts: crate::bindings::rdlp::plugin::host_extract_helpers::M3u8Options,
+        _fetch: crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions,
     ) -> Result<
         crate::bindings::rdlp::plugin::host_extract_helpers::M3u8Extraction,
         crate::bindings::rdlp::plugin::host_fetch::FetchError,
@@ -299,6 +300,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         url: String,
         _video_id: String,
         opts: crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions,
+        _fetch: crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions,
     ) -> Result<
         crate::bindings::rdlp::plugin::host_extract_helpers::MpdExtraction,
         crate::bindings::rdlp::plugin::host_fetch::FetchError,
@@ -767,6 +769,7 @@ hi.m3u8\n";
                 "https://x.com/master.m3u8".to_string(),
                 "vid".to_string(),
                 opts,
+                empty_fetch(),
             )
             .await
             .unwrap();
@@ -802,6 +805,7 @@ hi.m3u8\n";
                 "https://x.com/never-resolved.m3u8".to_string(),
                 "vid".to_string(),
                 opts,
+                empty_fetch(),
             )
             .await
             .unwrap();
@@ -822,6 +826,14 @@ hi.m3u8\n";
         crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions {
             mpd_id: None,
             fatal,
+        }
+    }
+
+    fn empty_fetch() -> crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+        crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+            headers: vec![],
+            query: vec![],
+            body: None,
         }
     }
 
@@ -849,7 +861,7 @@ hi.m3u8\n";
         });
 
         let r = c
-            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true))
+            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true), empty_fetch())
             .await
             .expect("extract_mpd");
 
@@ -919,6 +931,7 @@ hi.m3u8\n";
                 "https://x/m.mpd".to_string(),
                 "v".to_string(),
                 mpd_opts(false),
+                empty_fetch(),
             )
             .await
             .expect("non-fatal returns Ok");
@@ -940,6 +953,7 @@ hi.m3u8\n";
                 "https://x/m.mpd".to_string(),
                 "v".to_string(),
                 mpd_opts(true),
+                empty_fetch(),
             )
             .await
             .expect_err("fatal must propagate");
@@ -971,7 +985,7 @@ hi.m3u8\n";
             )),
         });
         let err = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
             .await
             .expect_err("dynamic MPD must error");
         let msg = format!("{err:?}").to_lowercase();
@@ -1004,7 +1018,7 @@ hi.m3u8\n";
             )),
         });
         let r = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
             .await
             .expect("audio rep survives DRM filtering");
         assert_eq!(r.formats.len(), 1, "only the audio rep should survive");
@@ -1037,7 +1051,7 @@ hi.m3u8\n";
             )),
         });
         let err = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
             .await
             .expect_err("invalid utf-8 must error");
         assert!(
@@ -1068,7 +1082,7 @@ hi.m3u8\n";
             )),
         });
         let err = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true))
+            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
             .await
             .expect_err("non-MPD XML must error");
         assert!(
@@ -1101,7 +1115,7 @@ hi.m3u8\n";
         });
 
         let r = c
-            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true))
+            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true), empty_fetch())
             .await
             .expect("extract_mpd");
 

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -1091,6 +1091,358 @@ hi.m3u8\n";
         );
     }
 
+    // ---- fetch-options threading tests (Task 3 — expected 8 fail / 2 pass) ---
+
+    fn m3u8_opts(fatal: bool) -> crate::bindings::rdlp::plugin::host_extract_helpers::M3u8Options {
+        crate::bindings::rdlp::plugin::host_extract_helpers::M3u8Options {
+            ext: None,
+            protocol: None,
+            m3u8_id: None,
+            fatal,
+        }
+    }
+
+    fn fetch_with_headers(
+        headers: Vec<(String, String)>,
+    ) -> crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+        crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+            headers,
+            query: vec![],
+            body: None,
+        }
+    }
+
+    fn fetch_with_query(
+        query: Vec<(String, String)>,
+    ) -> crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+        crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+            headers: vec![],
+            query,
+            body: None,
+        }
+    }
+
+    fn fetch_with_body(
+        body: Vec<u8>,
+    ) -> crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+        crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions {
+            headers: vec![],
+            query: vec![],
+            body: Some(body),
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_m3u8_threads_headers_into_request() {
+        use crate::host::fetch::{FetchCtx};
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://example.com/playlist.m3u8";
+        let mut c = ctx();
+        let fixtures = Arc::new(
+            FetchFixtures::new()
+                .with(url, FixtureResponse::ok(b"#EXTM3U\n".to_vec())),
+        );
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+
+        let _ = c
+            .extract_m3u8(
+                url.to_string(),
+                "v".to_string(),
+                m3u8_opts(true),
+                fetch_with_headers(vec![("Authorization".into(), "Bearer abc".into())]),
+            )
+            .await;
+
+        let recorded = fixtures.last_request().expect("request recorded");
+        assert!(
+            recorded.headers.iter().any(|(k, v)| k == "Authorization" && v == "Bearer abc"),
+            "headers missing Authorization: {:?}",
+            recorded.headers
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_m3u8_appends_query_params_to_url() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::{FetchFixtures};
+        use std::sync::Arc;
+
+        let url = "https://example.com/playlist.m3u8";
+        let mut c = ctx();
+        let fixtures = Arc::new(FetchFixtures::new());
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+
+        let _ = c
+            .extract_m3u8(
+                url.to_string(),
+                "v".to_string(),
+                m3u8_opts(false),
+                fetch_with_query(vec![("token".into(), "abc".into())]),
+            )
+            .await;
+
+        let recorded = fixtures.last_request().expect("request recorded");
+        assert!(
+            recorded.url.contains("?token=abc"),
+            "url missing query: {}",
+            recorded.url
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_m3u8_post_with_body() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::FetchFixtures;
+        use std::sync::Arc;
+
+        let url = "https://example.com/playlist.m3u8";
+        let mut c = ctx();
+        let fixtures = Arc::new(FetchFixtures::new());
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+
+        let _ = c
+            .extract_m3u8(
+                url.to_string(),
+                "v".to_string(),
+                m3u8_opts(false),
+                fetch_with_body(b"x".to_vec()),
+            )
+            .await;
+
+        let recorded = fixtures.last_request().expect("request recorded");
+        assert_eq!(
+            recorded.method, "POST",
+            "method should be POST when body present"
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_m3u8_empty_fetch_options_unchanged() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://example.com/playlist.m3u8";
+        let mut c = ctx();
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new().with(url, FixtureResponse::ok(b"#EXTM3U\n".to_vec())),
+            )),
+        });
+        let _ = c
+            .extract_m3u8(
+                url.to_string(),
+                "v".to_string(),
+                m3u8_opts(false),
+                empty_fetch(),
+            )
+            .await
+            .expect("extract_m3u8 with empty fetch options");
+    }
+
+    #[tokio::test]
+    async fn extract_mpd_threads_headers_into_request() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        let fixtures = Arc::new(
+            FetchFixtures::new()
+                .with(url, FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec())),
+        );
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+        let _ = c
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+                fetch_with_headers(vec![("X-CDN-Token".into(), "xyz".into())]),
+            )
+            .await;
+        let recorded = fixtures.last_request().expect("recorded");
+        assert!(
+            recorded.headers.iter().any(|(k, v)| k == "X-CDN-Token" && v == "xyz"),
+            "headers: {:?}",
+            recorded.headers
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_mpd_appends_query_params_to_url() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::FetchFixtures;
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        let fixtures = Arc::new(FetchFixtures::new());
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+        let _ = c
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(false),
+                fetch_with_query(vec![("k".into(), "v".into())]),
+            )
+            .await;
+        let recorded = fixtures.last_request().expect("recorded");
+        assert!(
+            recorded.url.contains("?k=v"),
+            "url: {}",
+            recorded.url
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_mpd_post_with_body() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::FetchFixtures;
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        let fixtures = Arc::new(FetchFixtures::new());
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+        let _ = c
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(false),
+                fetch_with_body(b"data".to_vec()),
+            )
+            .await;
+        let recorded = fixtures.last_request().expect("recorded");
+        assert_eq!(recorded.method, "POST");
+    }
+
+    #[tokio::test]
+    async fn extract_mpd_empty_fetch_options_unchanged() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::new(
+                FetchFixtures::new()
+                    .with(url, FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec())),
+            )),
+        });
+        let _ = c
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn query_param_with_special_chars_is_url_encoded() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::FetchFixtures;
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd";
+        let mut c = ctx();
+        let fixtures = Arc::new(FetchFixtures::new());
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+        let _ = c
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(false),
+                fetch_with_query(vec![("k".into(), "a b&c".into())]),
+            )
+            .await;
+        let recorded = fixtures.last_request().expect("recorded");
+        // Space → %20, ampersand → %26
+        assert!(
+            recorded.url.contains("k=a%20b%26c"),
+            "url: {}",
+            recorded.url
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_query_string_in_url_uses_ampersand_separator() {
+        use crate::host::fetch::FetchCtx;
+        use crate::host::fetch_fixtures::FetchFixtures;
+        use std::sync::Arc;
+
+        let url = "https://example.com/manifest.mpd?x=1";
+        let mut c = ctx();
+        let fixtures = Arc::new(FetchFixtures::new());
+        c.fetch = Some(FetchCtx {
+            client: rdlp_http::wreq::Client::builder()
+                .build()
+                .expect("test client"),
+            fixtures: Some(Arc::clone(&fixtures)),
+        });
+        let _ = c
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(false),
+                fetch_with_query(vec![("y".into(), "2".into())]),
+            )
+            .await;
+        let recorded = fixtures.last_request().expect("recorded");
+        // The new param joins with & not ?
+        assert!(
+            recorded.url.contains("x=1&y=2") || recorded.url.contains("y=2&x=1"),
+            "url: {}",
+            recorded.url
+        );
+    }
+
     const WITH_TEXT_TRACKS_MPD: &str =
         include_str!("../../../rdlp-downloader/tests/fixtures/dash/with_text_tracks.mpd");
 

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -261,7 +261,11 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             let url = build_url_with_query(url, &fetch.query);
             let req = Request {
                 url: url.clone(),
-                method: if fetch.body.is_some() { "POST".into() } else { "GET".into() },
+                method: if fetch.body.is_some() {
+                    "POST".into()
+                } else {
+                    "GET".into()
+                },
                 headers: fetch.headers.clone(),
                 body: fetch.body.clone(),
                 timeout_ms: Some(30_000),
@@ -337,7 +341,11 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             let url = build_url_with_query(url, &fetch.query);
             let req = Request {
                 url: url.clone(),
-                method: if fetch.body.is_some() { "POST".into() } else { "GET".into() },
+                method: if fetch.body.is_some() {
+                    "POST".into()
+                } else {
+                    "GET".into()
+                },
                 headers: fetch.headers.clone(),
                 body: fetch.body.clone(),
                 timeout_ms: Some(30_000),
@@ -883,7 +891,12 @@ hi.m3u8\n";
         });
 
         let r = c
-            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true), empty_fetch())
+            .extract_mpd(
+                url.to_string(),
+                "vid".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
             .await
             .expect("extract_mpd");
 
@@ -1007,7 +1020,12 @@ hi.m3u8\n";
             )),
         });
         let err = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
             .await
             .expect_err("dynamic MPD must error");
         let msg = format!("{err:?}").to_lowercase();
@@ -1040,7 +1058,12 @@ hi.m3u8\n";
             )),
         });
         let r = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
             .await
             .expect("audio rep survives DRM filtering");
         assert_eq!(r.formats.len(), 1, "only the audio rep should survive");
@@ -1073,7 +1096,12 @@ hi.m3u8\n";
             )),
         });
         let err = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
             .await
             .expect_err("invalid utf-8 must error");
         assert!(
@@ -1104,7 +1132,12 @@ hi.m3u8\n";
             )),
         });
         let err = c
-            .extract_mpd(url.to_string(), "v".to_string(), mpd_opts(true), empty_fetch())
+            .extract_mpd(
+                url.to_string(),
+                "v".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
             .await
             .expect_err("non-MPD XML must error");
         assert!(
@@ -1156,16 +1189,14 @@ hi.m3u8\n";
 
     #[tokio::test]
     async fn extract_m3u8_threads_headers_into_request() {
-        use crate::host::fetch::{FetchCtx};
+        use crate::host::fetch::FetchCtx;
         use crate::host::fetch_fixtures::{FetchFixtures, FixtureResponse};
         use std::sync::Arc;
 
         let url = "https://example.com/playlist.m3u8";
         let mut c = ctx();
-        let fixtures = Arc::new(
-            FetchFixtures::new()
-                .with(url, FixtureResponse::ok(b"#EXTM3U\n".to_vec())),
-        );
+        let fixtures =
+            Arc::new(FetchFixtures::new().with(url, FixtureResponse::ok(b"#EXTM3U\n".to_vec())));
         c.fetch = Some(FetchCtx {
             client: rdlp_http::wreq::Client::builder()
                 .build()
@@ -1184,7 +1215,10 @@ hi.m3u8\n";
 
         let recorded = fixtures.last_request().expect("request recorded");
         assert!(
-            recorded.headers.iter().any(|(k, v)| k == "Authorization" && v == "Bearer abc"),
+            recorded
+                .headers
+                .iter()
+                .any(|(k, v)| k == "Authorization" && v == "Bearer abc"),
             "headers missing Authorization: {:?}",
             recorded.headers
         );
@@ -1193,7 +1227,7 @@ hi.m3u8\n";
     #[tokio::test]
     async fn extract_m3u8_appends_query_params_to_url() {
         use crate::host::fetch::FetchCtx;
-        use crate::host::fetch_fixtures::{FetchFixtures};
+        use crate::host::fetch_fixtures::FetchFixtures;
         use std::sync::Arc;
 
         let url = "https://example.com/playlist.m3u8";
@@ -1290,10 +1324,10 @@ hi.m3u8\n";
 
         let url = "https://example.com/manifest.mpd";
         let mut c = ctx();
-        let fixtures = Arc::new(
-            FetchFixtures::new()
-                .with(url, FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec())),
-        );
+        let fixtures = Arc::new(FetchFixtures::new().with(
+            url,
+            FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec()),
+        ));
         c.fetch = Some(FetchCtx {
             client: rdlp_http::wreq::Client::builder()
                 .build()
@@ -1310,7 +1344,10 @@ hi.m3u8\n";
             .await;
         let recorded = fixtures.last_request().expect("recorded");
         assert!(
-            recorded.headers.iter().any(|(k, v)| k == "X-CDN-Token" && v == "xyz"),
+            recorded
+                .headers
+                .iter()
+                .any(|(k, v)| k == "X-CDN-Token" && v == "xyz"),
             "headers: {:?}",
             recorded.headers
         );
@@ -1340,11 +1377,7 @@ hi.m3u8\n";
             )
             .await;
         let recorded = fixtures.last_request().expect("recorded");
-        assert!(
-            recorded.url.contains("?k=v"),
-            "url: {}",
-            recorded.url
-        );
+        assert!(recorded.url.contains("?k=v"), "url: {}", recorded.url);
     }
 
     #[tokio::test]
@@ -1386,10 +1419,10 @@ hi.m3u8\n";
             client: rdlp_http::wreq::Client::builder()
                 .build()
                 .expect("test client"),
-            fixtures: Some(Arc::new(
-                FetchFixtures::new()
-                    .with(url, FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec())),
-            )),
+            fixtures: Some(Arc::new(FetchFixtures::new().with(
+                url,
+                FixtureResponse::ok(SEGMENT_TEMPLATE_MPD.as_bytes().to_vec()),
+            ))),
         });
         let _ = c
             .extract_mpd(
@@ -1489,7 +1522,12 @@ hi.m3u8\n";
         });
 
         let r = c
-            .extract_mpd(url.to_string(), "vid".to_string(), mpd_opts(true), empty_fetch())
+            .extract_mpd(
+                url.to_string(),
+                "vid".to_string(),
+                mpd_opts(true),
+                empty_fetch(),
+            )
             .await
             .expect("extract_mpd");
 

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -32,6 +32,26 @@ static RE_P: LazyLock<regex::Regex> =
 static RE_TAGS: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"<.*?>").expect("valid tag-strip pattern"));
 
+fn build_url_with_query(base_url: String, query: &[(String, String)]) -> String {
+    use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+    if query.is_empty() {
+        return base_url;
+    }
+    let qs: String = query
+        .iter()
+        .map(|(k, v)| {
+            format!(
+                "{}={}",
+                utf8_percent_encode(k, NON_ALPHANUMERIC),
+                utf8_percent_encode(v, NON_ALPHANUMERIC)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    let sep = if base_url.contains('?') { '&' } else { '?' };
+    format!("{base_url}{sep}{qs}")
+}
+
 fn build_regex(
     pattern: &str,
     flags: crate::bindings::rdlp::plugin::host_extract_helpers::RegexFlags,
@@ -227,7 +247,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         url: String,
         _video_id: String,
         opts: crate::bindings::rdlp::plugin::host_extract_helpers::M3u8Options,
-        _fetch: crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions,
+        fetch: crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions,
     ) -> Result<
         crate::bindings::rdlp::plugin::host_extract_helpers::M3u8Extraction,
         crate::bindings::rdlp::plugin::host_fetch::FetchError,
@@ -238,11 +258,12 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         use crate::bindings::rdlp::plugin::host_fetch::{FetchError, Host as FetchHost, Request};
 
         let result: Result<M3u8Extraction, FetchError> = async {
+            let url = build_url_with_query(url, &fetch.query);
             let req = Request {
                 url: url.clone(),
-                method: "GET".to_string(),
-                headers: vec![],
-                body: None,
+                method: if fetch.body.is_some() { "POST".into() } else { "GET".into() },
+                headers: fetch.headers.clone(),
+                body: fetch.body.clone(),
                 timeout_ms: Some(30_000),
             };
             let resp = self.fetch(req).await?;
@@ -300,7 +321,7 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         url: String,
         _video_id: String,
         opts: crate::bindings::rdlp::plugin::host_extract_helpers::MpdOptions,
-        _fetch: crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions,
+        fetch: crate::bindings::rdlp::plugin::host_extract_helpers::FetchOptions,
     ) -> Result<
         crate::bindings::rdlp::plugin::host_extract_helpers::MpdExtraction,
         crate::bindings::rdlp::plugin::host_fetch::FetchError,
@@ -313,11 +334,12 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
         use url::Url;
 
         let result: Result<MpdExtraction, FetchError> = async {
+            let url = build_url_with_query(url, &fetch.query);
             let req = Request {
                 url: url.clone(),
-                method: "GET".to_string(),
-                headers: vec![],
-                body: None,
+                method: if fetch.body.is_some() { "POST".into() } else { "GET".into() },
+                headers: fetch.headers.clone(),
+                body: fetch.body.clone(),
                 timeout_ms: Some(30_000),
             };
             let resp = self.fetch(req).await?;

--- a/crates/rdlp-plugin/src/host/fetch.rs
+++ b/crates/rdlp-plugin/src/host/fetch.rs
@@ -82,15 +82,23 @@ impl crate::bindings::rdlp::plugin::host_fetch::Host for PluginStoreData {
         // check on the hot path. We deliberately bypass
         // `validate_url_security` for fixture matches because tests
         // routinely use private-network or loopback URLs.
-        if let Some(fixtures) = ctx.fixtures.as_ref()
-            && let Some(canned) = fixtures.get(&req.url)
-        {
-            return Ok(Response {
-                status: canned.status,
-                headers: canned.headers.clone(),
-                body: canned.body.clone(),
-                final_url: req.url.clone(),
+        if let Some(fixtures) = ctx.fixtures.as_ref() {
+            // Record every inbound request regardless of fixture hit/miss,
+            // so tests can assert on url, method, headers, body after the call.
+            fixtures.record(crate::host::fetch_fixtures::RecordedRequest {
+                url: req.url.clone(),
+                method: req.method.clone(),
+                headers: req.headers.clone(),
+                body: req.body.clone(),
             });
+            if let Some(canned) = fixtures.get(&req.url) {
+                return Ok(Response {
+                    status: canned.status,
+                    headers: canned.headers.clone(),
+                    body: canned.body.clone(),
+                    final_url: req.url.clone(),
+                });
+            }
         }
 
         if let Err(e) = validate_url_security(&req.url) {

--- a/crates/rdlp-plugin/src/host/fetch_fixtures.rs
+++ b/crates/rdlp-plugin/src/host/fetch_fixtures.rs
@@ -60,6 +60,7 @@ impl FixtureResponse {
 }
 
 /// A minimal recording of the `Request` the host fetch dispatch received.
+///
 /// Avoids a dependency on the WIT-generated `Request` type from the
 /// `host_fetch` binding (which may not implement `Clone` in all
 /// configurations). Used exclusively by the test harness to assert on
@@ -137,7 +138,7 @@ impl FetchFixtures {
     pub fn record(&self, req: RecordedRequest) {
         self.recorded
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(req);
     }
 
@@ -147,7 +148,7 @@ impl FetchFixtures {
     pub fn last_request(&self) -> Option<RecordedRequest> {
         self.recorded
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .last()
             .cloned()
     }

--- a/crates/rdlp-plugin/src/host/fetch_fixtures.rs
+++ b/crates/rdlp-plugin/src/host/fetch_fixtures.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::doc_markdown)]
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// A canned HTTP response served when an inbound URL matches a fixture.
 #[derive(Clone, Debug)]
@@ -59,10 +59,41 @@ impl FixtureResponse {
     }
 }
 
+/// A minimal recording of the `Request` the host fetch dispatch received.
+/// Avoids a dependency on the WIT-generated `Request` type from the
+/// `host_fetch` binding (which may not implement `Clone` in all
+/// configurations). Used exclusively by the test harness to assert on
+/// what headers / method / URL the implementation passed to `host:fetch`.
+#[derive(Clone, Debug, Default)]
+pub struct RecordedRequest {
+    /// The URL that was dispatched (after any query-param appending).
+    pub url: String,
+    /// HTTP method string (`"GET"`, `"POST"`, …).
+    pub method: String,
+    /// Request headers as `(name, value)` pairs.
+    pub headers: Vec<(String, String)>,
+    /// Request body bytes, if any.
+    pub body: Option<Vec<u8>>,
+}
+
 /// URL → canned-response map. Lookup is exact-string match.
-#[derive(Clone, Default, Debug)]
+///
+/// Also records every inbound `Request` so tests can assert on headers,
+/// method, query params, etc. (see [`FetchFixtures::last_request`]).
+#[derive(Clone, Debug)]
 pub struct FetchFixtures {
     map: HashMap<String, FixtureResponse>,
+    /// All requests dispatched through this fixture set, in arrival order.
+    recorded: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+impl Default for FetchFixtures {
+    fn default() -> Self {
+        Self {
+            map: HashMap::new(),
+            recorded: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
 }
 
 impl FetchFixtures {
@@ -97,6 +128,28 @@ impl FetchFixtures {
     #[must_use]
     pub fn get(&self, url: &str) -> Option<&FixtureResponse> {
         self.map.get(url)
+    }
+
+    /// Record an inbound request. Called by `host:fetch` dispatch before
+    /// serving a canned response or forwarding to the live client.
+    /// Test-only — production callers never set `fixtures`, so this path
+    /// is unreachable outside the test harness.
+    pub fn record(&self, req: RecordedRequest) {
+        self.recorded
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(req);
+    }
+
+    /// Return the most recently recorded request, or `None` if no request
+    /// has been dispatched through this fixture set yet.
+    #[must_use]
+    pub fn last_request(&self) -> Option<RecordedRequest> {
+        self.recorded
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .last()
+            .cloned()
     }
 
     /// Number of fixtures registered. Tests that want to confirm "every

--- a/crates/rdlp-plugin/wit/extractor.wit
+++ b/crates/rdlp-plugin/wit/extractor.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 world extractor-plugin {
     import host-fetch;

--- a/crates/rdlp-plugin/wit/host.wit
+++ b/crates/rdlp-plugin/wit/host.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 interface host-fetch {
     record request {
@@ -112,6 +112,15 @@ interface host-extract-helpers {
         ext: option<string>,
     }
 
+    /// Caller-supplied HTTP options threaded into the underlying fetch.
+    /// `headers` and `query` are key-value lists — duplicate keys are
+    /// preserved verbatim. `body`, when present, switches the method to POST.
+    record fetch-options {
+        headers: list<tuple<string, string>>,
+        query: list<tuple<string, string>>,
+        body: option<list<u8>>,
+    }
+
     record m3u8-extraction {
         formats: list<m3u8-format>,
         subtitles: list<extract-helpers-subtitle>,
@@ -152,8 +161,12 @@ interface host-extract-helpers {
     search-json: func(start-pattern: string, end-pattern: string,
                       haystack: string) -> option<string>;
 
-    extract-m3u8: func(url: string, video-id: string, opts: m3u8-options)
-                    -> result<m3u8-extraction, fetch-error>;
+    extract-m3u8: func(
+        url: string,
+        video-id: string,
+        opts: m3u8-options,
+        fetch: fetch-options,
+    ) -> result<m3u8-extraction, fetch-error>;
 
     extract-json-ld: func(html: string) -> option<json-ld-video>;
 
@@ -190,6 +203,10 @@ interface host-extract-helpers {
         subtitles: list<extract-helpers-subtitle>,
     }
 
-    extract-mpd: func(url: string, video-id: string, opts: mpd-options)
-                    -> result<mpd-extraction, fetch-error>;
+    extract-mpd: func(
+        url: string,
+        video-id: string,
+        opts: mpd-options,
+        fetch: fetch-options,
+    ) -> result<mpd-extraction, fetch-error>;
 }

--- a/crates/rdlp-plugin/wit/types.wit
+++ b/crates/rdlp-plugin/wit/types.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 interface types {
     record plugin-info {

--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/extractor.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/extractor.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 world extractor-plugin {
     import host-fetch;

--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/host.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/host.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 interface host-fetch {
     record request {
@@ -112,6 +112,15 @@ interface host-extract-helpers {
         ext: option<string>,
     }
 
+    /// Caller-supplied HTTP options threaded into the underlying fetch.
+    /// `headers` and `query` are key-value lists — duplicate keys are
+    /// preserved verbatim. `body`, when present, switches the method to POST.
+    record fetch-options {
+        headers: list<tuple<string, string>>,
+        query: list<tuple<string, string>>,
+        body: option<list<u8>>,
+    }
+
     record m3u8-extraction {
         formats: list<m3u8-format>,
         subtitles: list<extract-helpers-subtitle>,
@@ -152,8 +161,12 @@ interface host-extract-helpers {
     search-json: func(start-pattern: string, end-pattern: string,
                       haystack: string) -> option<string>;
 
-    extract-m3u8: func(url: string, video-id: string, opts: m3u8-options)
-                    -> result<m3u8-extraction, fetch-error>;
+    extract-m3u8: func(
+        url: string,
+        video-id: string,
+        opts: m3u8-options,
+        fetch: fetch-options,
+    ) -> result<m3u8-extraction, fetch-error>;
 
     extract-json-ld: func(html: string) -> option<json-ld-video>;
 
@@ -190,6 +203,10 @@ interface host-extract-helpers {
         subtitles: list<extract-helpers-subtitle>,
     }
 
-    extract-mpd: func(url: string, video-id: string, opts: mpd-options)
-                    -> result<mpd-extraction, fetch-error>;
+    extract-mpd: func(
+        url: string,
+        video-id: string,
+        opts: mpd-options,
+        fetch: fetch-options,
+    ) -> result<mpd-extraction, fetch-error>;
 }

--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/types.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/types.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 interface types {
     record plugin-info {

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/extractor.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/extractor.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 world extractor-plugin {
     import host-fetch;

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/host.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/host.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 interface host-fetch {
     record request {
@@ -112,6 +112,15 @@ interface host-extract-helpers {
         ext: option<string>,
     }
 
+    /// Caller-supplied HTTP options threaded into the underlying fetch.
+    /// `headers` and `query` are key-value lists — duplicate keys are
+    /// preserved verbatim. `body`, when present, switches the method to POST.
+    record fetch-options {
+        headers: list<tuple<string, string>>,
+        query: list<tuple<string, string>>,
+        body: option<list<u8>>,
+    }
+
     record m3u8-extraction {
         formats: list<m3u8-format>,
         subtitles: list<extract-helpers-subtitle>,
@@ -152,8 +161,12 @@ interface host-extract-helpers {
     search-json: func(start-pattern: string, end-pattern: string,
                       haystack: string) -> option<string>;
 
-    extract-m3u8: func(url: string, video-id: string, opts: m3u8-options)
-                    -> result<m3u8-extraction, fetch-error>;
+    extract-m3u8: func(
+        url: string,
+        video-id: string,
+        opts: m3u8-options,
+        fetch: fetch-options,
+    ) -> result<m3u8-extraction, fetch-error>;
 
     extract-json-ld: func(html: string) -> option<json-ld-video>;
 
@@ -190,6 +203,10 @@ interface host-extract-helpers {
         subtitles: list<extract-helpers-subtitle>,
     }
 
-    extract-mpd: func(url: string, video-id: string, opts: mpd-options)
-                    -> result<mpd-extraction, fetch-error>;
+    extract-mpd: func(
+        url: string,
+        video-id: string,
+        opts: mpd-options,
+        fetch: fetch-options,
+    ) -> result<mpd-extraction, fetch-error>;
 }

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/types.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/types.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.2.0;
+package rdlp:plugin@0.3.0;
 
 interface types {
     record plugin-info {

--- a/examples/plugins/ytdlp-hello-world/wit/world.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/world.wit
@@ -1,5 +1,5 @@
 package local:hello@0.1.0;
 
 world hello-extractor {
-    include rdlp:plugin/extractor-plugin@0.2.0;
+    include rdlp:plugin/extractor-plugin@0.3.0;
 }

--- a/tools/ytdlp-compat/README.md
+++ b/tools/ytdlp-compat/README.md
@@ -39,7 +39,7 @@ Helper additions verified against yt-dlp tag `2026.03.17`:
 
 ## Limitations (deferred to Slice 2.5)
 
-- Pure-data helpers (`traverse_obj`, `dict_get`, `int_or_none`, …) MUST stay Python — they take Python callables / type objects which can't cross the WIT boundary. Slice 2.5 will move I/O helpers (`_extract_m3u8_formats_and_subtitles`, `_search_regex`, etc.) host-side via a v0.2 WIT bump. See memory `project_ytdlp-shim-slice2_5-host-helpers`.
+- Pure-data helpers (`traverse_obj`, `dict_get`, `int_or_none`, …) MUST stay Python — they take Python callables / type objects which can't cross the WIT boundary.
 - `_parse_json` filters yt-dlp's `LenientJSONDecoder`-only kwargs (`ignore_extra` / `strict` / `lenient`) before forwarding to stdlib `json.loads`. Lenient parsing semantics (trailing data, control chars) are NOT supported. SVT's payloads are well-formed.
 - The Next.js / `urqlState` extraction path needs a hydrated HTML fixture to test (the SSR snapshot lacks `urqlState`). The svt:short-form test URL exercises everything else end-to-end.
 
@@ -66,11 +66,12 @@ After regeneration:
 
 ## Slice-2.5 surface (host-side I/O helpers — 2026-04-30)
 
-Helpers moved host-side in v0.2 of the WIT contract. Plugin authors see
-no change in method signatures — `InfoExtractor` method bodies became
-2-line passthroughs over the new `host:extract-helpers` capability.
-The wasm artefact shrinks because the regex/HTML/m3u8 parsing libraries
-no longer ship per plugin.
+Helpers moved host-side in v0.2 of the WIT contract (bumped to v0.3 in
+#252 to add fetch-options plumbing). Plugin authors see no change in
+method signatures — `InfoExtractor` method bodies became 2-line
+passthroughs over the `host:extract-helpers` capability. The wasm
+artefact shrinks because the regex/HTML/m3u8 parsing libraries no longer
+ship per plugin.
 
 **Drop-in workflow (post Slice 2.5):**
 
@@ -84,12 +85,13 @@ cp foo/plugin.wasm plugin.toml ~/.config/rdlp/plugins/foo/
 No source edits to `foo.py`. The fake `yt_dlp/` package staged at
 build time resolves all upstream relative imports.
 
-**WIT v0.2 host helpers:**
+**WIT v0.3 host helpers:**
 
 - `search-regex`, `html-search-regex`, `html-search-meta` — regex / OG / meta primitives
 - `og-search-property` — OG property + entity unescape
 - `extract-m3u8` — HLS master playlist parsing (lossless dict round-trip)
 - `extract-mpd` — DASH MPD manifest parsing with segment extraction; subtitles slot now populated from text AdaptationSet sidecar tracks (fragmented text tracks deferred — log-warn + skip)
+- `fetch-options { headers, query, body }` record shared by `extract-m3u8` and `extract-mpd`; Python kwargs (`headers`, `query`, `data`) are mapped via `_make_fetch_options()` in `_host.py`
 - `extract-json-ld` — typed JSON-LD video extraction backed by rdlp's existing parser
 - `rta-search` — adult-content age-marker scan
 - `search-json` — brace-balanced JSON extraction (Next.js / urqlState)

--- a/tools/ytdlp-compat/rdlp_ytdlp_compat/_host.py
+++ b/tools/ytdlp-compat/rdlp_ytdlp_compat/_host.py
@@ -208,22 +208,67 @@ def search_json(start_pattern, end_pattern, string):
     return _hxh.search_json(start_pattern, end_pattern, string)
 
 
-def extract_m3u8(url, video_id, *, ext=None, protocol=None, m3u8_id=None, fatal=True):
-    """Parse an M3U8 playlist and return a list of Format dicts."""
+def _make_fetch_options(*, headers=None, query=None, data=None):
+    """Build a WIT ``FetchOptions`` value from yt-dlp-style kwargs.
+
+    `headers` — dict[str, str] or None
+    `query`   — dict[str, str] or None
+    `data`    — bytes or None (triggers POST when set)
+    """
+    header_list = list((headers or {}).items())
+    query_list = list((query or {}).items())
+    body = list(data) if data is not None else None
+    return _hxh.FetchOptions(headers=header_list, query=query_list, body=body)
+
+
+def extract_m3u8(
+    url,
+    video_id,
+    *,
+    ext=None,
+    protocol=None,
+    m3u8_id=None,
+    fatal=True,
+    headers=None,
+    query=None,
+    data=None,
+):
+    """Parse an M3U8 playlist and return a list of Format dicts.
+
+    `headers` — dict of extra HTTP request headers forwarded to the manifest fetch.
+    `query`   — dict of extra URL query parameters forwarded to the manifest fetch.
+    `data`    — bytes body; when set switches the manifest fetch to POST.
+    """
     if not _HXH_AVAILABLE:
         raise RuntimeError('_host.extract_m3u8 called outside componentize-py runtime')
     opts = _hxh.M3u8Options(ext=ext, protocol=protocol, m3u8_id=m3u8_id, fatal=fatal)
-    return _hxh.extract_m3u8(url, video_id, opts)
+    fetch = _make_fetch_options(headers=headers, query=query, data=data)
+    return _hxh.extract_m3u8(url, video_id, opts, fetch)
 
 
-def extract_mpd(url, video_id, *, mpd_id=None, fatal=True):
-    """Parse a DASH MPD via the host helper. Returns MpdExtraction."""
+def extract_mpd(
+    url,
+    video_id,
+    *,
+    mpd_id=None,
+    fatal=True,
+    headers=None,
+    query=None,
+    data=None,
+):
+    """Parse a DASH MPD via the host helper. Returns MpdExtraction.
+
+    `headers` — dict of extra HTTP request headers forwarded to the manifest fetch.
+    `query`   — dict of extra URL query parameters forwarded to the manifest fetch.
+    `data`    — bytes body; when set switches the manifest fetch to POST.
+    """
     if not _HXH_AVAILABLE:
         raise RuntimeError(
             "_host.extract_mpd called outside componentize-py runtime"
         )
     opts = _hxh.MpdOptions(mpd_id=mpd_id, fatal=fatal)
-    return _hxh.extract_mpd(url, video_id, opts)
+    fetch = _make_fetch_options(headers=headers, query=query, data=data)
+    return _hxh.extract_mpd(url, video_id, opts, fetch)
 
 
 def extract_json_ld(html):

--- a/tools/ytdlp-compat/rdlp_ytdlp_compat/info_extractor.py
+++ b/tools/ytdlp-compat/rdlp_ytdlp_compat/info_extractor.py
@@ -900,19 +900,13 @@ class InfoExtractor:
         headers=None,
         query=None,
     ):
-        """Slice-2.5 passthrough to host-extract-helpers.extract-m3u8.
+        """WIT @0.3.0 passthrough to host-extract-helpers.extract-m3u8.
 
-        WIT v0.1.0 limitation: the host signature does not yet accept
-        `data` / `headers` / `query`, so passing any of these would silently
-        fetch the manifest unauthenticated. Until WIT v0.2 lifts this, we
-        fail loud rather than silently dropping per-request credentials.
-        `live=True` is accepted but processed identically to on-demand.
+        `data` / `headers` / `query` are now plumbed through WIT @0.3.0 via
+        the `fetch-options` record. `live=True` is accepted but processed
+        identically to on-demand (live segment-window handling is not yet
+        implemented).
         """
-        if data is not None or headers is not None or query is not None:
-            raise NotImplementedError(
-                '_extract_m3u8_formats_and_subtitles: data/headers/query are not '
-                'yet plumbed through WIT v0.1.0; track in Slice 2.5'
-            )
         if live:
             _host.log(
                 'warn',
@@ -930,6 +924,9 @@ class InfoExtractor:
                 protocol=entry_protocol,
                 m3u8_id=m3u8_id,
                 fatal=fatal,
+                headers=headers,
+                query=query,
+                data=data,
             )
         except RuntimeError as e:
             # Outside componentize-py runtime or fetch failure.
@@ -1275,17 +1272,17 @@ class InfoExtractor:
         data=None, headers=None, query=None,
         note=None, errnote=None,
     ):
-        """Slice-2.5+ passthrough to host-extract-helpers.extract-mpd."""
-        if data is not None or headers is not None or query is not None:
-            raise NotImplementedError(
-                '_extract_mpd_formats_and_subtitles: data/headers/query are not '
-                'yet plumbed through WIT; track in Slice 2.5+'
-            )
+        """WIT @0.3.0 passthrough to host-extract-helpers.extract-mpd.
+
+        `data` / `headers` / `query` are now plumbed through WIT @0.3.0 via
+        the `fetch-options` record.
+        """
         if note is not None:
             _host.log('info', f'{note}: {mpd_url}')
         try:
             result = _host.extract_mpd(
                 mpd_url, video_id, mpd_id=mpd_id, fatal=fatal,
+                headers=headers, query=query, data=data,
             )
         except RuntimeError as e:
             label = errnote or f'failed to extract DASH manifest {mpd_url}'

--- a/tools/ytdlp-compat/tests/test_bug_fixes_h7_h8_h9.py
+++ b/tools/ytdlp-compat/tests/test_bug_fixes_h7_h8_h9.py
@@ -187,41 +187,97 @@ class TestUnifiedTimestampH8DateFormats:
 
 
 # =============================================================================
-# H7 — _extract_m3u8_formats_and_subtitles fails loud on unsupported params
+# H7 — _extract_m3u8_formats_and_subtitles forwards data/headers/query via WIT @0.3.0
 # =============================================================================
 
 
-class TestExtractM3u8H7UnsupportedParams:
-    """H7: passing data/headers/query must raise NotImplementedError (loud
-    failure) rather than silently fetching unauthenticated."""
+class TestExtractM3u8H7FetchOptionsPlumbing:
+    """H7 (updated for WIT @0.3.0): data/headers/query are now forwarded to
+    the host via fetch-options rather than raising NotImplementedError.
 
-    def test_headers_raises_not_implemented(self):
-        # NEGATIVE: before fix, headers= was silently ignored and the host
-        # was called without authentication.
+    The original H7 bug was "silent drop" — headers were ignored and the
+    manifest was fetched unauthenticated. The WIT @0.2.0 fix raised loud
+    NotImplementedError. WIT @0.3.0 completes the fix by actually forwarding
+    them through the fetch-options record.
+    """
+
+    def test_headers_forwarded_to_host(self, monkeypatch):
+        """POSITIVE: headers= is now forwarded to _host.extract_m3u8, NOT raised."""
+        from rdlp_ytdlp_compat import _host
+
+        captured = {}
+        def fake_extract_m3u8(url, video_id, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError('no runtime')  # outside componentize-py
+
+        monkeypatch.setattr(_host, 'extract_m3u8', fake_extract_m3u8)
+
         ie = InfoExtractor()
-        with pytest.raises(NotImplementedError, match='headers'):
+        formats, subs = ie._extract_m3u8_formats_and_subtitles(
+            'https://example.com/master.m3u8',
+            'vid',
+            headers={'Authorization': 'Bearer token123'},
+            fatal=False,
+        )
+        assert formats == []
+        assert subs == {}
+        assert captured.get('headers') == {'Authorization': 'Bearer token123'}, (
+            'headers must be forwarded to _host.extract_m3u8'
+        )
+
+    def test_query_forwarded_to_host(self, monkeypatch):
+        """query= is forwarded to _host.extract_m3u8."""
+        from rdlp_ytdlp_compat import _host
+
+        captured = {}
+        def fake_extract_m3u8(url, video_id, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError('no runtime')
+
+        monkeypatch.setattr(_host, 'extract_m3u8', fake_extract_m3u8)
+
+        ie = InfoExtractor()
+        ie._extract_m3u8_formats_and_subtitles(
+            'https://example.com/master.m3u8',
+            'vid',
+            query={'token': 'abc'},
+            fatal=False,
+        )
+        assert captured.get('query') == {'token': 'abc'}, (
+            'query must be forwarded to _host.extract_m3u8'
+        )
+
+    def test_data_forwarded_to_host(self, monkeypatch):
+        """data= is forwarded to _host.extract_m3u8."""
+        from rdlp_ytdlp_compat import _host
+
+        captured = {}
+        def fake_extract_m3u8(url, video_id, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError('no runtime')
+
+        monkeypatch.setattr(_host, 'extract_m3u8', fake_extract_m3u8)
+
+        ie = InfoExtractor()
+        ie._extract_m3u8_formats_and_subtitles(
+            'https://example.com/master.m3u8',
+            'vid',
+            data=b'body=payload',
+            fatal=False,
+        )
+        assert captured.get('data') == b'body=payload', (
+            'data must be forwarded to _host.extract_m3u8'
+        )
+
+    def test_no_extra_params_still_calls_host(self):
+        """Baseline: calling without data/headers/query still reaches the host
+        call (which raises RuntimeError outside the componentize-py runtime)."""
+        ie = InfoExtractor()
+        with pytest.raises(RuntimeError):
+            # fatal=True (default) so RuntimeError from no-runtime propagates.
             ie._extract_m3u8_formats_and_subtitles(
                 'https://example.com/master.m3u8',
                 'vid',
-                headers={'Authorization': 'Bearer token123'},
-            )
-
-    def test_data_raises_not_implemented(self):
-        ie = InfoExtractor()
-        with pytest.raises(NotImplementedError, match='data'):
-            ie._extract_m3u8_formats_and_subtitles(
-                'https://example.com/master.m3u8',
-                'vid',
-                data=b'body=payload',
-            )
-
-    def test_query_raises_not_implemented(self):
-        ie = InfoExtractor()
-        with pytest.raises(NotImplementedError, match='query'):
-            ie._extract_m3u8_formats_and_subtitles(
-                'https://example.com/master.m3u8',
-                'vid',
-                query={'token': 'abc'},
             )
 
     def test_live_logs_warning_proceeds_not_raises(self, caplog):
@@ -245,45 +301,3 @@ class TestExtractM3u8H7UnsupportedParams:
         assert any('live' in r.message.lower() for r in caplog.records), (
             'Expected a warning about live=True, got: ' + str([r.message for r in caplog.records])
         )
-
-    def test_no_extra_params_still_calls_host(self):
-        """Baseline: calling without data/headers/query must NOT raise
-        NotImplementedError — it proceeds to the host call (which raises
-        RuntimeError outside the runtime)."""
-        ie = InfoExtractor()
-        with pytest.raises(RuntimeError):
-            # fatal=True (default) so RuntimeError from no-runtime propagates.
-            ie._extract_m3u8_formats_and_subtitles(
-                'https://example.com/master.m3u8',
-                'vid',
-            )
-
-    def test_headers_error_message_mentions_wit(self):
-        """Error message must reference WIT/Slice 2.5 so plugin authors know
-        what to do."""
-        ie = InfoExtractor()
-        with pytest.raises(NotImplementedError) as exc_info:
-            ie._extract_m3u8_formats_and_subtitles(
-                'https://example.com/master.m3u8',
-                'vid',
-                headers={'X-Token': 'y'},
-            )
-        msg = str(exc_info.value)
-        assert 'WIT' in msg or 'Slice 2.5' in msg or 'v0.1.0' in msg
-
-    def test_headers_raised_before_host_call(self, monkeypatch):
-        """The NotImplementedError must be raised before ANY host call —
-        not after a potentially-unauthenticated fetch attempt."""
-        from rdlp_ytdlp_compat import _host
-
-        called = []
-        monkeypatch.setattr(_host, 'extract_m3u8', lambda *a, **kw: called.append(1))
-
-        ie = InfoExtractor()
-        with pytest.raises(NotImplementedError):
-            ie._extract_m3u8_formats_and_subtitles(
-                'https://example.com/master.m3u8',
-                'vid',
-                headers={'Authorization': 'Bearer token123'},
-            )
-        assert called == [], 'Host must NOT be called when headers are passed'

--- a/tools/ytdlp-compat/tests/test_passthroughs.py
+++ b/tools/ytdlp-compat/tests/test_passthroughs.py
@@ -271,28 +271,55 @@ def test_extract_mpd_protocol_is_http_dash_segments(monkeypatch):
     assert all(f["protocol"] == "http_dash_segments" for f in fmts)
 
 
-def test_extract_mpd_drops_unsupported_kwargs_data():
-    """#12 — data= kwarg raises NotImplementedError."""
-    with pytest.raises(NotImplementedError, match="data/headers/query"):
-        _ie()._extract_mpd_formats_and_subtitles(
-            "https://x/m.mpd", "v", data=b"x",
-        )
+def test_extract_mpd_forwards_kwargs_data(monkeypatch):
+    """#12 (WIT @0.3.0) — data= is forwarded to _host.extract_mpd via fetch-options."""
+    from rdlp_ytdlp_compat import _host
+
+    captured = {}
+
+    def fake(*a, **k):
+        captured.update(k)
+        raise RuntimeError("no runtime")
+
+    monkeypatch.setattr(_host, "extract_mpd", fake)
+    _ie()._extract_mpd_formats_and_subtitles(
+        "https://x/m.mpd", "v", data=b"x", fatal=False,
+    )
+    assert captured.get("data") == b"x", "data must be forwarded to _host.extract_mpd"
 
 
-def test_extract_mpd_drops_unsupported_kwargs_headers():
-    """#13 — headers= kwarg raises NotImplementedError."""
-    with pytest.raises(NotImplementedError, match="data/headers/query"):
-        _ie()._extract_mpd_formats_and_subtitles(
-            "https://x/m.mpd", "v", headers={"X": "y"},
-        )
+def test_extract_mpd_forwards_kwargs_headers(monkeypatch):
+    """#13 (WIT @0.3.0) — headers= is forwarded to _host.extract_mpd via fetch-options."""
+    from rdlp_ytdlp_compat import _host
+
+    captured = {}
+
+    def fake(*a, **k):
+        captured.update(k)
+        raise RuntimeError("no runtime")
+
+    monkeypatch.setattr(_host, "extract_mpd", fake)
+    _ie()._extract_mpd_formats_and_subtitles(
+        "https://x/m.mpd", "v", headers={"X": "y"}, fatal=False,
+    )
+    assert captured.get("headers") == {"X": "y"}, "headers must be forwarded to _host.extract_mpd"
 
 
-def test_extract_mpd_drops_unsupported_kwargs_query():
-    """#14 — query= kwarg raises NotImplementedError."""
-    with pytest.raises(NotImplementedError, match="data/headers/query"):
-        _ie()._extract_mpd_formats_and_subtitles(
-            "https://x/m.mpd", "v", query={"k": "v"},
-        )
+def test_extract_mpd_forwards_kwargs_query(monkeypatch):
+    """#14 (WIT @0.3.0) — query= is forwarded to _host.extract_mpd via fetch-options."""
+    from rdlp_ytdlp_compat import _host
+
+    captured = {}
+
+    def fake(*a, **k):
+        captured.update(k)
+        raise RuntimeError("no runtime")
+
+    monkeypatch.setattr(_host, "extract_mpd", fake)
+    _ie()._extract_mpd_formats_and_subtitles(
+        "https://x/m.mpd", "v", query={"k": "v"}, fatal=False,
+    )
+    assert captured.get("query") == {"k": "v"}, "query must be forwarded to _host.extract_mpd"
 
 
 def test_extract_mpd_fatal_false_returns_empty_on_runtime_error(monkeypatch):


### PR DESCRIPTION
## Summary
- WIT package bumped @0.2.0 → @0.3.0 (hard breaking — records have no optional fields).
- New shared `fetch-options { headers, query, body }` record used by `extract-m3u8` and `extract-mpd`.
- Rust host threads headers, percent-encoded query string, body, and method (POST when body, GET otherwise) into the underlying `Request`.
- Python `_host.py` passthroughs gain `headers` / `query` / `data` kwargs (mapped to `_make_fetch_options(...)`).
- Python shim `_extract_m3u8_formats_and_subtitles` and `_extract_mpd_formats_and_subtitles` no longer raise `NotImplementedError` — they forward kwargs to the host.
- All four golden plugins (svt, xxxymovies, ytdlp_golden, python_plugin_smoke) rebuilt and validated against @0.3.0.
- Closes #252.

## Test plan
- [x] 10 Rust host tests (header threading, query serialization with special chars and existing-query, POST inference, empty-options sanity, MPD parity).
- [x] 8 Python shim tests (forwarding for both helpers + no-longer-raises behaviour).
- [x] Obsolete `*_drops_unsupported_kwargs_*` test class rewritten as `*_FetchOptionsPlumbing`.
- [x] Golden plugin tests pass with `--ignored` against @0.3.0.
- [x] `cargo check && cargo clippy --all-targets -- -D warnings && cargo test` clean.
- [x] `pytest` in `tools/ytdlp-compat` clean (409 tests).
- [x] `cargo fmt --check` clean.
- [x] `scripts/check-wit-drift.sh` clean.

## Breaking change notice
All `.wasm` plugins compiled against WIT @0.2.0 will fail at component-link time when loaded by this @0.3.0 host. The four in-tree golden plugins rebuild transparently via `cargo run -p rdlp-cli -- plugin build-from-ytdlp`. External plugins (none today) require rebuild.

## Out of scope (follow-ups)
- Plumb `fetch-options` into other host-fetch helpers (most don't fetch today).
- Repeated header / query support in Python (currently `dict.items()` collapses duplicates).
- Generic `method` override (PUT/DELETE/PATCH).