### PR TITLE
feat(hls): hoist expand_hls_in_place + migrate eporner to fragments parity

### DIFF
--- a/crates/rdlp-extractor/src/extractors/eporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/eporner/mod.rs
@@ -376,6 +376,12 @@ async fn build_info(
         xhr_formats
     };
 
+    // Pre-resolve any HLS variant playlists into per-variant Format rows so the
+    // downloader can take the Format.fragments fast path. Non-HLS rows pass
+    // through unchanged; expand failures keep the original row (graceful
+    // fallback to the legacy variant-URL path).
+    let formats = crate::hls::expand_hls_in_place(formats, ctx.http_client.clone()).await;
+
     let mut info = InfoDict::new(id, title, EPORNER_NAME, page_url);
     info.view_count = views;
     info.duration = duration_iso
@@ -502,6 +508,72 @@ mod tests {
             !meta.actors.is_empty(),
             "Expected at least one actor from live JSON-LD fixture"
         );
+    }
+
+    /// Regression guard for #258 — confirm `parse_xhr_formats` emits an
+    /// `M3u8Native` row when `sources.hls.src` is populated and that the
+    /// hoisted `expand_hls_in_place` helper resolves it into per-variant
+    /// fragments. Catches a wiring break where the helper call is removed
+    /// from `build_info` (rows would arrive at the downloader unexpanded).
+    #[tokio::test]
+    async fn xhr_hls_row_is_expanded_into_fragments() {
+        use rdlp_types::DownloadProtocol;
+
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/media.m3u8")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXTINF:6.0,\nseg-1.ts\n#EXTINF:6.0,\nseg-2.ts\n#EXT-X-ENDLIST\n",
+            )
+            .create_async()
+            .await;
+
+        let xhr_json = serde_json::json!({
+            "sources": {
+                "hls": { "src": format!("{}/media.m3u8", server.url()) },
+                "mp4": {}
+            }
+        });
+
+        let formats = parse_xhr_formats(&xhr_json);
+        assert_eq!(formats.len(), 1, "expect single HLS row");
+        assert!(matches!(formats[0].protocol, DownloadProtocol::M3u8Native));
+
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let expanded = crate::hls::expand_hls_in_place(formats, http).await;
+        assert_eq!(expanded.len(), 1);
+        assert!(
+            expanded[0].fragments.is_some(),
+            "HLS row must carry pre-resolved fragments after expand"
+        );
+        assert_eq!(expanded[0].fragments.as_ref().unwrap().len(), 2);
+    }
+
+    /// Non-HLS rows (the EPorner /dload/ MP4 fast path) MUST pass through
+    /// `expand_hls_in_place` unchanged. Guards against a regression where
+    /// the helper accidentally rewrites `Https` rows.
+    #[tokio::test]
+    async fn dload_mp4_rows_pass_through_unchanged() {
+        let formats = parse_dload_formats(
+            "https://www.eporner.com/video-svXh0Ne27Ig/harleysummers/",
+            PAGE_FIXTURE,
+        );
+        assert!(!formats.is_empty(), "fixture must yield /dload/ rows");
+        let count = formats.len();
+        let originals: Vec<(String, String)> = formats
+            .iter()
+            .map(|f| (f.format_id.clone(), f.url.clone()))
+            .collect();
+
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let expanded = crate::hls::expand_hls_in_place(formats, http).await;
+        assert_eq!(expanded.len(), count, "row count preserved");
+        for (i, f) in expanded.iter().enumerate() {
+            assert_eq!(f.format_id, originals[i].0);
+            assert_eq!(f.url, originals[i].1);
+            assert!(f.fragments.is_none(), "non-HLS row must not gain fragments");
+        }
     }
 
     /// Regression guard for issue #207 — EPorner thumbnail rendered empty

--- a/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
@@ -29,35 +29,6 @@ const SPANKBANG_NAME: &str = "SpankBang";
 const SPANKBANG_PRIORITY: i32 = 100;
 const FORMATS_API_URL: &str = "https://spankbang.com/api/videos/stream";
 
-/// Post-process a `Vec<Format>`, replacing M3u8 entries with the per-variant
-/// rows produced by [`crate::hls::expand_hls_url`]. On expand failure the
-/// original Format row is kept so the legacy variant-URL path still handles
-/// risky playlists (encrypted, live, byte-range init, multi-init, etc.).
-async fn expand_hls_in_place(
-    formats: Vec<rdlp_types::Format>,
-    http: std::sync::Arc<wreq::Client>,
-) -> Vec<rdlp_types::Format> {
-    use rdlp_types::DownloadProtocol;
-    let mut expanded = Vec::with_capacity(formats.len());
-    for f in formats {
-        if matches!(f.protocol, DownloadProtocol::M3u8) {
-            match crate::hls::expand_hls_url(&f, std::sync::Arc::clone(&http)).await {
-                Ok(rows) => expanded.extend(rows),
-                Err(e) => {
-                    log::warn!(
-                        "HLS expand failed for {} ({e}) — falling back to legacy variant-URL path",
-                        rdlp_security::sanitize_for_logging(&f.url)
-                    );
-                    expanded.push(f);
-                }
-            }
-        } else {
-            expanded.push(f);
-        }
-    }
-    expanded
-}
-
 /// SpankBang site extractor.
 #[derive(Default)]
 pub struct SpankBangExtractor;
@@ -167,7 +138,9 @@ impl InfoExtractor for SpankBangExtractor {
                 "[spankbang] inline stream_data produced {} formats",
                 formats.len()
             );
-            formats = expand_hls_in_place(formats, std::sync::Arc::clone(&ctx.http_client)).await;
+            formats =
+                crate::hls::expand_hls_in_place(formats, std::sync::Arc::clone(&ctx.http_client))
+                    .await;
         }
 
         if formats.is_empty() {
@@ -181,7 +154,9 @@ impl InfoExtractor for SpankBangExtractor {
             })?;
             let data = Self::fetch_formats_api(ctx, &key, &canonical).await?;
             formats = formats::build_formats(&data);
-            formats = expand_hls_in_place(formats, std::sync::Arc::clone(&ctx.http_client)).await;
+            formats =
+                crate::hls::expand_hls_in_place(formats, std::sync::Arc::clone(&ctx.http_client))
+                    .await;
         }
 
         if formats.is_empty() {
@@ -240,94 +215,5 @@ mod tests {
     fn name_matches_constant() {
         let ext = SpankBangExtractor::new();
         assert_eq!(ext.name(), "SpankBang");
-    }
-
-    #[tokio::test]
-    async fn expand_hls_in_place_replaces_m3u8_rows_with_fragments() {
-        use rdlp_types::{DownloadProtocol, Format};
-
-        let mut server = mockito::Server::new_async().await;
-        let _media = server
-            .mock("GET", "/v.m3u8")
-            .with_body(
-                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
-                 #EXTINF:6.0,\nseg-1.ts\n#EXTINF:6.0,\nseg-2.ts\n#EXT-X-ENDLIST\n",
-            )
-            .create_async()
-            .await;
-
-        let url = format!("{}/v.m3u8", server.url());
-        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8);
-
-        let http = std::sync::Arc::new(wreq::Client::new());
-        let out = super::expand_hls_in_place(vec![f], http).await;
-        assert_eq!(out.len(), 1);
-        assert!(out[0].fragments.is_some());
-        assert_eq!(out[0].fragments.as_ref().unwrap().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn expand_hls_in_place_preserves_non_m3u8_rows() {
-        use rdlp_types::{DownloadProtocol, Format};
-
-        let mp4 = Format::new(
-            "1080p",
-            "https://h.com/x.mp4",
-            "mp4",
-            DownloadProtocol::Https,
-        );
-        let http = std::sync::Arc::new(wreq::Client::new());
-        let out = super::expand_hls_in_place(vec![mp4.clone()], http).await;
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].format_id, "1080p");
-        assert!(out[0].fragments.is_none(), "MP4 row untouched");
-    }
-
-    #[tokio::test]
-    async fn expand_hls_in_place_keeps_original_on_encrypted() {
-        use rdlp_types::{DownloadProtocol, Format};
-
-        let mut server = mockito::Server::new_async().await;
-        let _media = server
-            .mock("GET", "/enc.m3u8")
-            .with_body(
-                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
-                 #EXT-X-KEY:METHOD=AES-128,URI=\"https://h.com/key\"\n\
-                 #EXTINF:6.0,\nseg-1.ts\n#EXT-X-ENDLIST\n",
-            )
-            .create_async()
-            .await;
-
-        let url = format!("{}/enc.m3u8", server.url());
-        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8);
-
-        let http = std::sync::Arc::new(wreq::Client::new());
-        let out = super::expand_hls_in_place(vec![f.clone()], http).await;
-        assert_eq!(out.len(), 1, "graceful fallback keeps original");
-        assert_eq!(out[0].url, f.url);
-        assert!(out[0].fragments.is_none(), "no fragments on fallback");
-    }
-
-    #[tokio::test]
-    async fn expand_hls_in_place_keeps_original_on_live() {
-        use rdlp_types::{DownloadProtocol, Format};
-
-        let mut server = mockito::Server::new_async().await;
-        let _media = server
-            .mock("GET", "/live.m3u8")
-            .with_body(
-                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
-                 #EXTINF:6.0,\nseg-1.ts\n", // no #EXT-X-ENDLIST
-            )
-            .create_async()
-            .await;
-
-        let url = format!("{}/live.m3u8", server.url());
-        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8);
-
-        let http = std::sync::Arc::new(wreq::Client::new());
-        let out = super::expand_hls_in_place(vec![f.clone()], http).await;
-        assert_eq!(out.len(), 1);
-        assert!(out[0].fragments.is_none());
     }
 }

--- a/crates/rdlp-extractor/src/hls/expand_in_place.rs
+++ b/crates/rdlp-extractor/src/hls/expand_in_place.rs
@@ -1,0 +1,152 @@
+//! Shared `expand_hls_in_place` post-processing helper.
+//!
+//! Hoisted from the spankbang extractor in PR #258 so every HLS-emitting
+//! extractor can call the same code path. Replaces every `Format` row whose
+//! protocol is `M3u8` or `M3u8Native` with the per-variant rows produced by
+//! [`expand_hls_url`]. On any [`HlsExpandError`] the original row is kept so
+//! the legacy variant-URL download path still handles risky playlists
+//! (encrypted, live, byte-range init, multi-init, etc.).
+
+use std::sync::Arc;
+
+use rdlp_types::{DownloadProtocol, Format};
+
+use super::expand::expand_hls_url;
+
+/// Replace every M3u8 / M3u8Native row in `formats` with its per-variant
+/// expansion. Non-HLS rows pass through unchanged. Expand failures keep the
+/// original row (graceful fallback to the legacy variant-URL path).
+pub async fn expand_hls_in_place(formats: Vec<Format>, http: Arc<wreq::Client>) -> Vec<Format> {
+    let mut expanded = Vec::with_capacity(formats.len());
+    for f in formats {
+        if matches!(
+            f.protocol,
+            DownloadProtocol::M3u8 | DownloadProtocol::M3u8Native
+        ) {
+            match expand_hls_url(&f, Arc::clone(&http)).await {
+                Ok(rows) => expanded.extend(rows),
+                Err(e) => {
+                    log::warn!(
+                        "HLS expand failed for {} ({e}) — falling back to legacy variant-URL path",
+                        rdlp_security::sanitize_for_logging(&f.url)
+                    );
+                    expanded.push(f);
+                }
+            }
+        } else {
+            expanded.push(f);
+        }
+    }
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn replaces_m3u8_rows_with_fragments() {
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/v.m3u8")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXTINF:6.0,\nseg-1.ts\n#EXTINF:6.0,\nseg-2.ts\n#EXT-X-ENDLIST\n",
+            )
+            .create_async()
+            .await;
+
+        let url = format!("{}/v.m3u8", server.url());
+        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8);
+
+        let http = Arc::new(wreq::Client::new());
+        let out = expand_hls_in_place(vec![f], http).await;
+        assert_eq!(out.len(), 1);
+        assert!(out[0].fragments.is_some());
+        assert_eq!(out[0].fragments.as_ref().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn replaces_m3u8_native_rows_with_fragments() {
+        // Regression guard: pre-hoist version only matched DownloadProtocol::M3u8
+        // and silently passed M3u8Native rows through without expansion. Eporner
+        // and several other extractors emit M3u8Native, not M3u8.
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/native.m3u8")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXTINF:6.0,\nseg-1.ts\n#EXTINF:6.0,\nseg-2.ts\n#EXT-X-ENDLIST\n",
+            )
+            .create_async()
+            .await;
+
+        let url = format!("{}/native.m3u8", server.url());
+        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8Native);
+
+        let http = Arc::new(wreq::Client::new());
+        let out = expand_hls_in_place(vec![f], http).await;
+        assert_eq!(out.len(), 1, "M3u8Native must expand identically to M3u8");
+        assert!(out[0].fragments.is_some());
+        assert_eq!(out[0].fragments.as_ref().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn preserves_non_hls_rows() {
+        let mp4 = Format::new(
+            "1080p",
+            "https://h.com/x.mp4",
+            "mp4",
+            DownloadProtocol::Https,
+        );
+        let http = Arc::new(wreq::Client::new());
+        let out = expand_hls_in_place(vec![mp4.clone()], http).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].format_id, "1080p");
+        assert!(out[0].fragments.is_none(), "MP4 row untouched");
+    }
+
+    #[tokio::test]
+    async fn keeps_original_on_encrypted() {
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/enc.m3u8")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXT-X-KEY:METHOD=AES-128,URI=\"https://h.com/key\"\n\
+                 #EXTINF:6.0,\nseg-1.ts\n#EXT-X-ENDLIST\n",
+            )
+            .create_async()
+            .await;
+
+        let url = format!("{}/enc.m3u8", server.url());
+        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8);
+
+        let http = Arc::new(wreq::Client::new());
+        let out = expand_hls_in_place(vec![f.clone()], http).await;
+        assert_eq!(out.len(), 1, "graceful fallback keeps original");
+        assert_eq!(out[0].url, f.url);
+        assert!(out[0].fragments.is_none(), "no fragments on fallback");
+    }
+
+    #[tokio::test]
+    async fn keeps_original_on_live() {
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/live.m3u8")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXTINF:6.0,\nseg-1.ts\n", // no #EXT-X-ENDLIST
+            )
+            .create_async()
+            .await;
+
+        let url = format!("{}/live.m3u8", server.url());
+        let f = Format::new("hls", &url, "m3u8", DownloadProtocol::M3u8);
+
+        let http = Arc::new(wreq::Client::new());
+        let out = expand_hls_in_place(vec![f.clone()], http).await;
+        assert_eq!(out.len(), 1);
+        assert!(out[0].fragments.is_none());
+    }
+}

--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -37,6 +37,7 @@
 
 mod detector;
 mod expand;
+mod expand_in_place;
 mod format_detection;
 mod segments;
 mod types;
@@ -45,6 +46,7 @@ mod variants;
 // Re-export public API unchanged
 pub use detector::HlsSizeDetector;
 pub use expand::{HlsExpandError, expand_hls_url};
+pub use expand_in_place::expand_hls_in_place;
 pub use format_detection::{detect_format_sizes, detect_format_sizes_lazy};
 pub use types::{HlsInfo, HlsStreamFlags, HlsVariantInfo};
 


### PR DESCRIPTION
## Summary

First of 7 site migrations under #258 (HLS Format.fragments parity follow-ups to #245 / #257).

- Hoists `expand_hls_in_place` from a private spankbang helper into a shared `crate::hls` module.
- Broadens the protocol match from `DownloadProtocol::M3u8` only to `M3u8 | M3u8Native` so `M3u8Native`-emitting sites (eporner, etc.) also get the pre-resolved-fragments fast path.
- Wires eporner to call the helper after format building.
- Spankbang's two call sites switch to the shared helper. Spankbang's 4 duplicate tests are deleted (covered verbatim by the 5 hoisted-module tests, including a new `M3u8Native` regression guard).

## Test plan

- [x] 5 unit tests in `crates/rdlp-extractor/src/hls/expand_in_place.rs`:
  - `replaces_m3u8_rows_with_fragments` — mockito-served master, asserts 2 fragments.
  - `replaces_m3u8_native_rows_with_fragments` — **new regression guard**, identical to M3u8 test but seeds `M3u8Native` protocol; would have failed against the pre-hoist single-arm match.
  - `preserves_non_hls_rows` — `Https`/MP4 row passes through untouched.
  - `keeps_original_on_encrypted` — `#EXT-X-KEY:METHOD=AES-128` triggers graceful fallback (legacy variant-URL path).
  - `keeps_original_on_live` — missing `#EXT-X-ENDLIST` triggers graceful fallback.
- [x] 2 integration tests in `crates/rdlp-extractor/src/extractors/eporner/mod.rs`:
  - `xhr_hls_row_is_expanded_into_fragments` — chains `parse_xhr_formats` → `expand_hls_in_place` against a mockito master; locks in that the eporner call site is wired (catches removal from `build_info`).
  - `dload_mp4_rows_pass_through_unchanged` — snapshots `(format_id, url)` from real `/dload/` fixture pre-expand, asserts unchanged post-expand with `fragments.is_none()`; locks in that non-HLS rows are not accidentally rewritten.
- [x] Pre-PR gate: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop` all green.
- [x] Existing DASH + HLS regression suites unchanged and green.

## Reviews (per `mandatory-pre-push-review.md`)

- **security-reviewer (subagent)** — **Approved**. Verified the broadened protocol match doesn't bypass the SSRF gate (`validate_resolved_url`) or the body cap (`MAX_PLAYLIST_BYTES = 8 MiB`) inside `expand_hls_url`; both fire on every variant URI / segment URI regardless of which arm matched. Log hygiene parity confirmed (`rdlp_security::sanitize_for_logging` on `f.url` before warn). Spankbang call-site semantic equivalence confirmed. One LOW (pre-existing, deferred): `parse_dload_formats` in eporner constructs absolute URLs from page-supplied paths without an extract-side SSRF gate — orchestrator-level `validate_url_security` already covers this at dispatch; not worsened by this PR.
- **code-reviewer (subagent)** — **Approved**. Confirmed the broadened match arm is the value-add (literal copy-move would have silently no-op'd on every eporner HLS row); the `M3u8Native` regression guard would have failed against the pre-hoist code; deleted spankbang tests used only generic data and are fully covered by the hoisted module's tests; no `unwrap_used`/`expect_used` lints triggered (test-block usage only).

## Out of scope

- Migrating xnxx, xvideos, nine_anime, xhamster, generic, koreanpornmovie — tracked in #258. Each will be its own PR.
- Step 5 of #258 (deprecate the legacy `M3u8` / `M3u8Native` variant-URL download path) — blocked on completing all 7 migrations.
- The `HlsExpandError` message-style polish carried forward from PR #257's punch list — separate PR.

Refs #258.