### PR TITLE
feat(hls): forward seed http_headers in expand_hls_url + wire 9anime

### DIFF
--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -249,6 +249,14 @@ pub(crate) async fn resolve_episode_formats(
         dub_subtitle_tracks
     };
 
+    // Pre-resolve HLS variant playlists into per-variant Format rows so the
+    // downloader can take the Format.fragments fast path. Non-HLS rows pass
+    // through unchanged; expand failures keep the original row (graceful
+    // fallback to the legacy variant-URL path). The seed Format's
+    // `http_headers` (Referer) is preserved on every expanded row via
+    // `seed.clone()` inside `expand_media_playlist`.
+    let all_formats = crate::hls::expand_hls_in_place(all_formats, ctx.http_client.clone()).await;
+
     Ok((all_formats, hls_flags, subtitle_tracks))
 }
 
@@ -459,5 +467,76 @@ mod tests {
     fn test_build_subtitle_map_empty() {
         let map = build_subtitle_map(&[]);
         assert!(map.is_empty());
+    }
+
+    /// Regression guard for #258 — confirm an `M3u8` HLS row produced by
+    /// `resolve_episode_formats` is expanded into per-variant fragments by
+    /// `expand_hls_in_place`, that the per-format `Referer` header is
+    /// preserved on every expanded row, and that non-HLS rows pass through
+    /// unchanged. Catches a wiring break where the helper call is removed
+    /// from `resolve_episode_formats` (the M3u8 row would arrive at the
+    /// downloader without pre-resolved fragments) AND a regression in
+    /// `expand_media_playlist`'s seed-clone behaviour that would drop the
+    /// Referer (Megacloud rejects HLS segment fetches without it).
+    #[tokio::test]
+    async fn hls_row_expanded_with_referer_preserved_and_https_pass_through() {
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/9a-master.m3u8")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXTINF:6.0,\nseg-1.ts\n#EXTINF:6.0,\nseg-2.ts\n#EXT-X-ENDLIST\n",
+            )
+            .create_async()
+            .await;
+
+        let hls_url = format!("{}/9a-master.m3u8", server.url());
+        let mut hls = Format::new("vidcloud-sub-0", &hls_url, "mp4", DownloadProtocol::M3u8);
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Referer".to_string(),
+            "https://megacloud.tv/embed-2/e-1/abc?k=1".to_string(),
+        );
+        hls.http_headers = Some(headers);
+        hls.format_note = Some("SUB (Vidcloud)".to_string());
+        hls.language = Some("SUB".to_string());
+
+        let mut mp4 = Format::new(
+            "douvideo-dub-0",
+            "https://cdn.example.com/v.mp4",
+            "mp4",
+            DownloadProtocol::Https,
+        );
+        mp4.format_note = Some("DUB (DouVideo)".to_string());
+        mp4.language = Some("DUB".to_string());
+
+        let formats = vec![hls, mp4];
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let expanded = crate::hls::expand_hls_in_place(formats, http).await;
+
+        assert_eq!(expanded.len(), 2);
+        assert!(
+            expanded[0].fragments.is_some(),
+            "M3u8 row must carry pre-resolved fragments after expand"
+        );
+        assert_eq!(expanded[0].fragments.as_ref().unwrap().len(), 2);
+        let preserved = expanded[0]
+            .http_headers
+            .as_ref()
+            .and_then(|h| h.get("Referer"))
+            .map(String::as_str);
+        assert_eq!(
+            preserved,
+            Some("https://megacloud.tv/embed-2/e-1/abc?k=1"),
+            "Referer header must survive expand (Megacloud rejects without it)"
+        );
+        assert_eq!(expanded[0].language.as_deref(), Some("SUB"));
+
+        assert!(
+            expanded[1].fragments.is_none(),
+            "Https MP4 row must pass through untouched"
+        );
+        assert_eq!(expanded[1].url, "https://cdn.example.com/v.mp4");
+        assert_eq!(expanded[1].language.as_deref(), Some("DUB"));
     }
 }

--- a/crates/rdlp-extractor/src/hls/expand.rs
+++ b/crates/rdlp-extractor/src/hls/expand.rs
@@ -1,7 +1,7 @@
 //! HLS master/media playlist expansion into pre-resolved `Format` entries
 //! with `Format.fragments` populated.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use rdlp_types::{Format, Fragment};
@@ -109,7 +109,16 @@ pub async fn expand_hls_url(
     seed: &Format,
     http: Arc<wreq::Client>,
 ) -> Result<Vec<Format>, HlsExpandError> {
-    let bytes = fetch_playlist_bytes(&http, &seed.url).await?;
+    let headers = seed.http_headers.as_ref();
+    // Seed origin (scheme + host + port) — used to gate cross-origin header
+    // forwarding on variant fetches. `Url::origin()` returns Opaque for URLs
+    // without a defined tuple origin (e.g. data:); Opaque values compare
+    // not-equal, so the cross-origin check defaults to the safe "drop headers"
+    // outcome when either side cannot be parsed.
+    let seed_origin = url::Url::parse(&seed.url).ok().map(|u| u.origin());
+
+    // Master fetch: always to seed.url — same origin by definition, headers safe.
+    let bytes = fetch_playlist_bytes(&http, &seed.url, headers).await?;
     let playlist = m3u8_rs::parse_playlist_res(&bytes)
         .map_err(|e| HlsExpandError::Parse(format!("playlist: {e:?}")))?;
 
@@ -137,7 +146,18 @@ pub async fn expand_hls_url(
                     .map_err(|e| HlsExpandError::Parse(format!("variant uri: {e}")))?
                     .to_string();
                 validate_resolved_url(&media_url)?;
-                let media_bytes = fetch_playlist_bytes(&http, &media_url).await?;
+                // Cross-origin header forwarding is suppressed: a malicious or
+                // compromised master playlist whose variant URI points to an
+                // attacker-controlled CDN must NOT receive Referer / Cookie /
+                // Authorization or any other operator-set header. Only forward
+                // when the variant's origin (scheme+host+port) matches the
+                // seed's origin.
+                let same_origin = match (&seed_origin, url::Url::parse(&media_url).ok()) {
+                    (Some(a), Some(b)) => *a == b.origin(),
+                    _ => false,
+                };
+                let variant_headers = if same_origin { headers } else { None };
+                let media_bytes = fetch_playlist_bytes(&http, &media_url, variant_headers).await?;
                 let f = expand_media_playlist(seed, &media_url, &media_bytes)?;
                 out.push(f);
             }
@@ -146,10 +166,25 @@ pub async fn expand_hls_url(
     }
 }
 
-async fn fetch_playlist_bytes(http: &wreq::Client, url: &str) -> Result<Vec<u8>, HlsExpandError> {
+/// Fetch a playlist body, forwarding the seed Format's `http_headers` (if any)
+/// on the GET request. This is what lets sites like 9anime/Megacloud (which
+/// require a `Referer` header on the master + variant playlist fetches)
+/// successfully reach the per-variant fragment fast path. Without forwarding,
+/// the fetch would 403 and `expand_hls_in_place` would silently fall back to
+/// the legacy variant-URL download path, defeating the optimization.
+async fn fetch_playlist_bytes(
+    http: &wreq::Client,
+    url: &str,
+    headers: Option<&HashMap<String, String>>,
+) -> Result<Vec<u8>, HlsExpandError> {
     let safe_url = rdlp_security::sanitize_for_logging(url);
-    let resp = http
-        .get(url)
+    let mut req = http.get(url);
+    if let Some(headers) = headers {
+        for (k, v) in headers {
+            req = req.header(k, v);
+        }
+    }
+    let resp = req
         .send()
         .await
         .map_err(|e| HlsExpandError::Network(format!("fetch {safe_url}: {e}")))?;
@@ -774,5 +809,169 @@ http://10.0.0.1/admin
             err,
             HlsExpandError::NoSegments | HlsExpandError::NoVariants | HlsExpandError::LiveStream
         ));
+    }
+
+    /// Regression guard for #258 — `expand_hls_url` MUST forward the seed
+    /// Format's `http_headers` (e.g. `Referer`) on BOTH the master and
+    /// variant playlist GETs. Without this, sites like 9anime/Megacloud
+    /// reject the master fetch with 403 and `expand_hls_in_place` silently
+    /// falls back to the legacy variant-URL path, defeating the optimization.
+    /// The mockito matcher rejects requests missing the header, turning
+    /// "header dropped" into a Network error in this test.
+    #[tokio::test]
+    async fn expand_forwards_seed_http_headers_on_master_and_variant_fetches() {
+        use mockito::Matcher;
+
+        let mut server = mockito::Server::new_async().await;
+
+        let _master = server
+            .mock("GET", "/master.m3u8")
+            .match_header("Referer", "https://megacloud.tv/embed-2/e-1/abc?k=1")
+            .with_body(MASTER_ONE_VARIANT)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let _variant = server
+            .mock("GET", "/v720.m3u8")
+            .match_header("Referer", "https://megacloud.tv/embed-2/e-1/abc?k=1")
+            .with_body(MEDIA_PLAIN)
+            .expect(1)
+            .create_async()
+            .await;
+
+        // A "missed" mock fires a 501 if mockito sees a request that doesn't
+        // match the headers above — turning a regression into a fetch error.
+        let _master_unmatched = server
+            .mock("GET", Matcher::Any)
+            .with_status(501)
+            .create_async()
+            .await;
+
+        let mut s = seed();
+        s.url = format!("{}/master.m3u8", server.url());
+        let mut h = HashMap::new();
+        h.insert(
+            "Referer".to_string(),
+            "https://megacloud.tv/embed-2/e-1/abc?k=1".to_string(),
+        );
+        s.http_headers = Some(h);
+
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let out = expand_hls_url(&s, http)
+            .await
+            .expect("expand must succeed when Referer is forwarded");
+        assert_eq!(out.len(), 1);
+        assert!(out[0].fragments.is_some());
+        // Seed header survives onto the expanded row via seed.clone().
+        assert_eq!(
+            out[0]
+                .http_headers
+                .as_ref()
+                .and_then(|h| h.get("Referer"))
+                .map(String::as_str),
+            Some("https://megacloud.tv/embed-2/e-1/abc?k=1")
+        );
+    }
+
+    /// Security regression guard for #258 — cross-host variant fetches MUST
+    /// NOT receive the seed's `http_headers`. A malicious master playlist
+    /// whose variant URI points to an attacker CDN should not exfiltrate
+    /// the operator's Referer/Cookie/Authorization. The mockito matcher
+    /// here expects the variant fetch to arrive WITHOUT a Referer header.
+    /// If header forwarding to cross-host variants regresses, the matcher
+    /// misses and the catch-all 501 fires, surfacing as Network error.
+    #[tokio::test]
+    async fn expand_does_not_forward_seed_headers_to_cross_host_variant() {
+        use mockito::Matcher;
+
+        // Master server — accepts the Referer header (same host as seed).
+        let mut master_server = mockito::Server::new_async().await;
+        // Variant server — different host (loopback but different port =
+        // different origin). The matcher REJECTS any request carrying a
+        // Referer header by requiring its absence.
+        let mut variant_server = mockito::Server::new_async().await;
+
+        // Body of the master playlist points the variant at the OTHER server
+        // (cross-host). Note: build the absolute URL pointing at variant_server.
+        let variant_abs_url = format!("{}/v720.m3u8", variant_server.url());
+        let master_body = format!(
+            "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000,RESOLUTION=720x480\n{variant_abs_url}\n"
+        );
+
+        let _master = master_server
+            .mock("GET", "/master.m3u8")
+            .match_header("Referer", "https://operator.example.com/page")
+            .with_body(master_body)
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Cross-host variant: must NOT see Referer.
+        let _variant = variant_server
+            .mock("GET", "/v720.m3u8")
+            .match_header("Referer", Matcher::Missing)
+            .with_body(MEDIA_PLAIN)
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Catch-all on variant_server: 501 if Referer DID arrive.
+        let _variant_unmatched = variant_server
+            .mock("GET", Matcher::Any)
+            .with_status(501)
+            .create_async()
+            .await;
+
+        let mut s = seed();
+        s.url = format!("{}/master.m3u8", master_server.url());
+        let mut h = HashMap::new();
+        h.insert(
+            "Referer".to_string(),
+            "https://operator.example.com/page".to_string(),
+        );
+        s.http_headers = Some(h);
+
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let out = expand_hls_url(&s, http).await.expect(
+            "expand must succeed: master sees Referer, variant on different host sees nothing",
+        );
+        assert_eq!(out.len(), 1);
+        assert!(out[0].fragments.is_some());
+    }
+
+    /// Negative companion to the test above — proves the test infrastructure
+    /// is real: when the seed has NO `http_headers`, the master fetch hits
+    /// the unmatched-mock 501 path and `expand_hls_url` returns Network err.
+    #[tokio::test]
+    async fn expand_without_seed_headers_fails_when_server_requires_them() {
+        use mockito::Matcher;
+
+        let mut server = mockito::Server::new_async().await;
+
+        // Master mock requires Referer.
+        let _master = server
+            .mock("GET", "/master.m3u8")
+            .match_header("Referer", Matcher::Regex(r"^https://".to_string()))
+            .with_body(MASTER_ONE_VARIANT)
+            .create_async()
+            .await;
+
+        // Catch-all returns 501 when Referer is absent.
+        let _unmatched = server
+            .mock("GET", Matcher::Any)
+            .with_status(501)
+            .create_async()
+            .await;
+
+        let mut s = seed();
+        s.url = format!("{}/master.m3u8", server.url());
+        s.http_headers = None;
+
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let err = expand_hls_url(&s, http)
+            .await
+            .expect_err("master fetch must fail without Referer");
+        assert!(matches!(err, HlsExpandError::Network(_)));
     }
 }


### PR DESCRIPTION
## Summary

Fourth of 7 site migrations under #258. Two coupled changes — the helper extension is what makes the 9anime wiring useful in production rather than a no-op via graceful fallback.

### Helper change (`expand.rs`)

`expand_hls_url` now forwards `seed.http_headers` (e.g. `Referer`) on the master playlist GET, and on per-variant playlist GETs **only when the variant URI's origin (scheme+host+port) matches the seed's origin**. Without forwarding, sites that gate playlist access on a header — most notably 9anime via Megacloud, which 403s any master.m3u8 fetch missing `Referer` — would fall through to the legacy variant-URL download path and never benefit from `Format.fragments` pre-resolution.

Cross-origin restriction is a security boundary added during pre-push review. A malicious or compromised master playlist whose variant URI points to an attacker-controlled CDN MUST NOT receive operator-set headers (Referer, and a fortiori Cookie/Authorization if a future extractor sets them). Origin equality uses `url::Url::origin()` per RFC 6454; `Origin::Opaque` compares not-equal so the check fails-closed on parse failure.

`fetch_playlist_bytes` gains `headers: Option<&HashMap<String, String>>` and walks the map applying each pair on the GET builder. The `seed.clone()` inside `expand_media_playlist` already preserves headers onto output rows so segment fetches downstream still carry them.

### 9anime wiring (`extractors/nine_anime/mod.rs`)

`resolve_episode_formats` calls `expand_hls_in_place` after size-detection + format_note enrichment. 9anime's Format rows already carry `Referer = source.embed_url`. With the helper change, that Referer now flows on the master + same-origin variant playlist fetches inside `expand_hls_url`, so 9anime exercises the fragments fast path.

## Test plan

- [x] **`expand_forwards_seed_http_headers_on_master_and_variant_fetches`** — same-origin master + variant both required to see Referer; catch-all 501 turns "header dropped" into Network error.
- [x] **`expand_does_not_forward_seed_headers_to_cross_host_variant`** — master accepts Referer, variant on a different mockito server (different port = different origin per RFC 6454) MUST NOT see it (`Matcher::Missing`); catch-all 501 enforces rejection.
- [x] **`expand_without_seed_headers_fails_when_server_requires_them`** — negative companion proving test infra is real.
- [x] **`hls_row_expanded_with_referer_preserved_and_https_pass_through`** — 9anime-side: HLS row gains 2 fragments, Referer survives onto expanded rows (Megacloud rejects without it), language tag preserved, Https MP4 row passes through.
- [x] Pre-PR gate: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop` all green. 31 expand tests + 6 nine_anime tests + full suite pass.

## Reviews (per `mandatory-pre-push-review.md`)

- **security-reviewer (subagent)** — first pass flagged a MEDIUM cross-origin header leakage; **fixed in this commit** with the origin-equality check + `Matcher::Missing` regression test. Re-review **Approved** (PASS). Verified: `url::Url::origin()` correctly distinguishes ports, IDN/case-canonicalization eliminates host-bypass paths, `Origin::Opaque` fails-closed, hyper rejects CRLF in header values at insert time, SSRF gate / body cap / segment cap unchanged. Test infrastructure exercises real failure modes (mockito mock ordering verified).
- **code-reviewer (subagent)** — **Approved**. Master fetch is always same-origin by construction (master URL IS seed URL). `match`-on-`Option`-tuple idiom is the right form for joint Option inspection (fails-closed on None). Test asserting both Referer preservation AND language tag is load-bearing (covers the `seed.clone()` contract for 9anime's SUB/DUB UI distinction).

## Out of scope

- Migrating xhamster, generic, koreanpornmovie — tracked in #258. xhamster will benefit from the helper change in this PR (cookie/auth header forwarding works the same way).
- Step 5 of #258 (deprecate the legacy variant-URL download path) — blocked on completing all 7 migrations.

Refs #258.