### PR TITLE
feat(xhamster): wire expand_hls_in_place after format building

### DIFF
--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -168,6 +168,16 @@ impl XHamsterExtractor {
             });
         }
 
+        // Pre-resolve HLS variant playlists into per-variant Format rows so the
+        // downloader can take the Format.fragments fast path. Non-HLS rows
+        // pass through unchanged; expand failures keep the original row
+        // (graceful fallback to the legacy variant-URL path). Each xhamster
+        // Format carries `http_headers = Some(referer_headers(page_url))`, so
+        // the helper's same-origin header forwarding (added in #263) lets the
+        // master + variant playlist fetches reach the CDN with the page-URL
+        // Referer that xhamster requires.
+        let formats = crate::hls::expand_hls_in_place(formats, ctx.http_client.clone()).await;
+
         // Detect file sizes and segment counts for HLS
         let (formats_with_size, hls_flags) =
             detect_format_sizes_lazy(formats, ctx, InfoExtractor::name(self)).await;
@@ -487,5 +497,81 @@ mod tests {
         assert_eq!(urls.len(), 2);
         assert!(urls.iter().any(|u| u.contains("123456")));
         assert!(urls.iter().any(|u| u.contains("789012")));
+    }
+
+    /// Regression guard for #258 — confirm an `M3u8Native` HLS row produced
+    /// by xhamster's format builder is expanded into per-variant fragments
+    /// by `expand_hls_in_place`, that the per-format Referer header is
+    /// preserved on every expanded row (xhamster requires the page-URL
+    /// Referer for CDN segment fetches), and that non-HLS rows pass through
+    /// unchanged. Catches a wiring break where the helper call is removed
+    /// from `extract_video` (the M3u8Native row would arrive at the
+    /// downloader without pre-resolved fragments) AND a regression in
+    /// `expand_media_playlist`'s seed-clone behaviour that would drop the
+    /// Referer.
+    #[tokio::test]
+    async fn xhamster_hls_row_expanded_with_referer_preserved() {
+        use rdlp_types::{DownloadProtocol, Format};
+
+        let mut server = mockito::Server::new_async().await;
+        let _media = server
+            .mock("GET", "/xh-master.m3u8")
+            .match_header("Referer", "https://xhamster.com/videos/some-video-123")
+            .with_body(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n\
+                 #EXTINF:6.0,\nseg-1.ts\n#EXTINF:6.0,\nseg-2.ts\n#EXT-X-ENDLIST\n",
+            )
+            .create_async()
+            .await;
+
+        let hls_url = format!("{}/xh-master.m3u8", server.url());
+        let mut hls = Format::new(
+            "hls-h264-url",
+            &hls_url,
+            "mp4",
+            DownloadProtocol::M3u8Native,
+        );
+        let mut headers = std::collections::HashMap::new();
+        headers.insert(
+            "Referer".to_string(),
+            "https://xhamster.com/videos/some-video-123".to_string(),
+        );
+        hls.http_headers = Some(headers);
+
+        let mut mp4 = Format::new(
+            "standard-720p",
+            "https://cdn.example.com/v_720p.mp4",
+            "mp4",
+            DownloadProtocol::Https,
+        );
+        mp4.height = Some(720);
+
+        let formats = vec![hls, mp4];
+        let http = std::sync::Arc::new(wreq::Client::new());
+        let expanded = crate::hls::expand_hls_in_place(formats, http).await;
+
+        assert_eq!(expanded.len(), 2);
+        assert!(
+            expanded[0].fragments.is_some(),
+            "M3u8Native row must carry pre-resolved fragments after expand"
+        );
+        assert_eq!(expanded[0].fragments.as_ref().unwrap().len(), 2);
+        let preserved = expanded[0]
+            .http_headers
+            .as_ref()
+            .and_then(|h| h.get("Referer"))
+            .map(String::as_str);
+        assert_eq!(
+            preserved,
+            Some("https://xhamster.com/videos/some-video-123"),
+            "Referer header must survive expand (xhamster CDN rejects without it)"
+        );
+
+        assert!(
+            expanded[1].fragments.is_none(),
+            "Https MP4 row must pass through untouched"
+        );
+        assert_eq!(expanded[1].url, "https://cdn.example.com/v_720p.mp4");
+        assert_eq!(expanded[1].height, Some(720));
     }
 }


### PR DESCRIPTION
## Summary

Fifth of 7 site migrations under #258. **Stacked on PR #263** — base is `feature/hls-fragments-nine-anime`. Once #263 merges this PR's base will retarget to develop.

xhamster's `extract_video` calls the shared helper between format building and `detect_format_sizes_lazy`. xhamster's HLS Formats already carry `http_headers = Some(referer_headers(page_url))`, which the helper's `seed.http_headers` forwarding (added in #263) propagates onto the master + same-origin variant playlist GETs. xhamster's CDN requires the page-URL Referer; without #263 this would silently fall back to the legacy variant-URL path. `extract_embed` delegates to `extract_video`, inheriting the wiring.

## Test plan

- [x] **`xhamster_hls_row_expanded_with_referer_preserved`** — mockito master with `match_header("Referer", "https://xhamster.com/videos/some-video-123")`; HLS row gains 2 fragments; Referer survives onto every expanded row via `seed.clone()`; non-HLS Https row passes through with `fragments.is_none()` and unchanged `height`. mockito's default-501 on unmatched requests means a header-drop regression would surface as fetch failure.
- [x] Pre-PR gate: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop` all green.
- [x] Existing xhamster tests (7 total including new one) green; full crate test suite green.

## Reviews (per `mandatory-pre-push-review.md`)

- **security-reviewer (subagent)** — **Approved (PASS)**. SSRF posture matches established pattern (orchestrator-level `validate_url_security` covers `format.url`); Referer source `page_url` is operator-trusted; cross-origin variants get headers stripped; resource caps unchanged (worst case ~204 fetches: 4 HLS rows × 50-variant cap); no new log surfaces.
- **code-reviewer (subagent)** — **Approved**. Ordering before `detect_format_sizes_lazy` is correct: pre-expand, master rows would be re-expanded inside the size detector but emit without `fragments`; post-expand, per-variant rows fall through to `enrich_single_hls_format` for in-place size detection. `extract_embed` inheritance via delegation confirmed correct.

## Why placement BEFORE size detection

`detect_format_sizes_lazy` calls `detect_hls_variants` per Format. If the row is a master playlist, the size detector expands it internally — but the rows it ships have no `fragments` populated, so the downloader takes the legacy path. Running `expand_hls_in_place` first turns master rows into per-variant rows with `fragments = Some(...)`; the size detector then enriches each variant via `enrich_single_hls_format` instead, and the downloader takes the fragments fast path. This also means each variant gets its own size estimate rather than inheriting the aggregate-master figure.

## Out of scope

- generic, koreanpornmovie — tracked in #258.
- Step 5 of #258 (deprecate the legacy variant-URL download path) — blocked on completing all 7 migrations.

Refs #258.