### PR TITLE
chore(downloader/hls): deprecate no-op builder methods

### DIFF
--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -81,6 +81,9 @@ impl HlsDownloader {
 
     /// Set number of concurrent segment downloads
     #[must_use = "builder methods consume self and return a new instance"]
+    #[deprecated(
+        note = "no-op since #270; legacy parallel path removed; pre-resolved fragments path doesn't use this knob"
+    )]
     pub fn with_concurrent_segments(mut self, count: usize) -> Self {
         self.concurrent_segments = count.max(1);
         self
@@ -88,6 +91,9 @@ impl HlsDownloader {
 
     /// Set buffer size for segment merging
     #[must_use = "builder methods consume self and return a new instance"]
+    #[deprecated(
+        note = "no-op since #270; legacy parallel path removed; pre-resolved fragments path doesn't use this knob"
+    )]
     pub const fn with_buffer_size(mut self, size: usize) -> Self {
         self.buffer_size = size;
         self
@@ -102,6 +108,9 @@ impl HlsDownloader {
 
     /// Set merge operation timeout
     #[must_use = "builder methods consume self and return a new instance"]
+    #[deprecated(
+        note = "no-op since #270; legacy parallel path removed; pre-resolved fragments path doesn't use this knob"
+    )]
     pub const fn with_merge_timeout(mut self, timeout: Duration) -> Self {
         self.merge_timeout = timeout;
         self
@@ -109,6 +118,9 @@ impl HlsDownloader {
 
     /// Set maximum number of segment failures before aborting
     #[must_use = "builder methods consume self and return a new instance"]
+    #[deprecated(
+        note = "no-op since #270; legacy parallel path removed; pre-resolved fragments path doesn't use this knob"
+    )]
     pub const fn with_max_segment_failures(mut self, max: usize) -> Self {
         self.max_segment_failures = max;
         self
@@ -211,6 +223,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // exercising deprecated builder methods to verify they still compile
     fn test_hls_downloader_builder() {
         let downloader = HlsDownloader::new()
             .with_concurrent_segments(16)
@@ -231,6 +244,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // exercising deprecated builder method to verify clamp behavior
     fn test_concurrent_segments_minimum() {
         let downloader = HlsDownloader::new().with_concurrent_segments(0);
         // Should be clamped to minimum of 1

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -370,11 +370,10 @@ impl DownloaderRegistry {
             .with_rate_limiter(rate_limiter)
             .with_adaptive(config.adaptive_downloads);
 
-        // Create HLS downloader
-        let hls_downloader = HlsDownloader::new()
-            .with_http_downloader(http_downloader.clone())
-            .with_concurrent_segments(config.concurrent_fragments)
-            .with_buffer_size(config.buffer_size);
+        // Create HLS downloader. concurrent_segments/buffer_size were no-ops on the
+        // legacy parallel path (deleted in #270); the pre-resolved fragments path
+        // doesn't use them. See issue #271.
+        let hls_downloader = HlsDownloader::new().with_http_downloader(http_downloader.clone());
 
         // Create DASH downloader
         let dash_downloader = DashDownloader::new()


### PR DESCRIPTION
## Summary

- Marks four `HlsDownloader` builder methods as `#[deprecated]` — they accept input that is silently ignored after #270's legacy parallel-segment path was deleted:
  - `with_concurrent_segments`
  - `with_buffer_size`
  - `with_max_segment_failures`
  - `with_merge_timeout`
- Drops the internal callers in `DownloaderRegistry::build_registry` (already no-ops); leaves the equivalent calls on `DashDownloader` untouched (out of scope — DASH still uses those).
- Adds `#[allow(deprecated)]` to the two HLS test cases that exercise the deprecated builders to verify clamp / build behavior still compiles.

Removal would be a SemVer-major break; deprecation gives downstream callers a compiler hint now without breaking them.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check` (workspace)
- [x] `cargo clippy --all-targets -- -D warnings` (workspace)
- [x] `cargo test -p rdlp-downloader --lib` (60 passed)

Closes #271. Refs #270.