### PR TITLE
feat(extractor/base): protocol_for_url path-extension classifier (#268)

### DIFF
--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -51,8 +51,8 @@ use rdlp_types::Format;
 use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
-pub(crate) use selectors::*;
 pub(crate) use protocol::protocol_for_url;
+pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks
 /// Re-exported from rdlp-security for backward compatibility

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -37,6 +37,7 @@ pub mod dash;
 pub mod json_ld;
 mod metadata;
 mod parsing;
+pub(crate) mod protocol;
 pub mod selector_macro;
 mod selectors;
 mod string_utils;
@@ -51,6 +52,7 @@ use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use selectors::*;
+pub(crate) use protocol::protocol_for_url;
 
 /// Maximum URL length to prevent memory exhaustion attacks
 /// Re-exported from rdlp-security for backward compatibility

--- a/crates/rdlp-extractor/src/base/common/protocol.rs
+++ b/crates/rdlp-extractor/src/base/common/protocol.rs
@@ -1,0 +1,146 @@
+//! URL → `DownloadProtocol` classifier based on path-segment extension.
+//!
+//! Mirrors the heuristic used by FFmpeg (`libavformat/hls.c`), VLC
+//! (`modules/demux/playlist/m3u.c`), mpv (`demux/demux_lavf.c`), and yt-dlp
+//! (`utils/_utils.py::determine_ext`): query and fragment are ignored.
+//!
+//! Callers that already have out-of-band knowledge of the protocol (e.g. a
+//! JS field literally named `setVideoHLS(...)`) MUST set the protocol
+//! directly; this helper is the fallback for pure URL strings.
+
+use rdlp_types::DownloadProtocol;
+use url::Url;
+
+/// Classify a URL into a [`DownloadProtocol`] by inspecting the last path
+/// segment's extension. Query and fragment are ignored.
+///
+/// Returns:
+/// - [`DownloadProtocol::M3u8`] for `.m3u8` / `.m3u` (case-insensitive)
+/// - [`DownloadProtocol::Https`] / [`DownloadProtocol::Http`] for the matching scheme
+/// - [`DownloadProtocol::Other`] for any other scheme (e.g. `data:`, `javascript:`)
+#[must_use]
+pub(crate) fn protocol_for_url(url: &Url) -> DownloadProtocol {
+    let ext = url
+        .path()
+        .rsplit('/')
+        .next()
+        .and_then(|seg| seg.rsplit_once('.').map(|(_, ext)| ext))
+        .unwrap_or("");
+
+    if ext.eq_ignore_ascii_case("m3u8") || ext.eq_ignore_ascii_case("m3u") {
+        return DownloadProtocol::M3u8;
+    }
+
+    match url.scheme() {
+        "https" => DownloadProtocol::Https,
+        "http" => DownloadProtocol::Http,
+        s => DownloadProtocol::Other(s.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn m3u8_path_extension_classifies_as_hls() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/master.m3u8")),
+            DownloadProtocol::M3u8
+        ));
+    }
+
+    #[test]
+    fn m3u8_with_query_and_fragment_classifies_as_hls() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/path/master.m3u8?token=abc#frag")),
+            DownloadProtocol::M3u8
+        ));
+    }
+
+    #[test]
+    fn m3u8_uppercase_classifies_as_hls() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/PLAYLIST.M3U8")),
+            DownloadProtocol::M3u8
+        ));
+    }
+
+    #[test]
+    fn m3u_path_extension_classifies_as_hls() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/playlist.m3u")),
+            DownloadProtocol::M3u8
+        ));
+    }
+
+    #[test]
+    fn mp4_with_m3u8_in_query_classifies_as_https() {
+        // Issue #268 reference case.
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/clip.mp4?ref=foo.m3u8")),
+            DownloadProtocol::Https
+        ));
+    }
+
+    #[test]
+    fn mp4_with_m3u8_in_fragment_classifies_as_https() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/clip.mp4#foo.m3u8")),
+            DownloadProtocol::Https
+        ));
+    }
+
+    #[test]
+    fn webm_classifies_as_https() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/video.webm")),
+            DownloadProtocol::Https
+        ));
+    }
+
+    #[test]
+    fn mkv_classifies_as_https() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/video.mkv")),
+            DownloadProtocol::Https
+        ));
+    }
+
+    #[test]
+    fn http_scheme_classifies_as_http() {
+        assert!(matches!(
+            protocol_for_url(&parse("http://host/video.mp4")),
+            DownloadProtocol::Http
+        ));
+    }
+
+    #[test]
+    fn no_extension_classifies_as_https() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/no-extension/abc123")),
+            DownloadProtocol::Https
+        ));
+    }
+
+    #[test]
+    fn trailing_slash_classifies_as_https() {
+        assert!(matches!(
+            protocol_for_url(&parse("https://host/path/")),
+            DownloadProtocol::Https
+        ));
+    }
+
+    #[test]
+    fn data_scheme_classifies_as_other() {
+        let p = protocol_for_url(&parse("data:text/plain,foo"));
+        match p {
+            DownloadProtocol::Other(s) => assert_eq!(s, "data"),
+            _ => panic!("expected Other(\"data\"), got {p:?}"),
+        }
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -620,7 +620,10 @@ mod tests {
         // Regression: issue #268. A URL with `.m3u8` in the query but
         // `.mp4` path-extension must classify as Https.
         let p = protocol_from_url("https://host/clip.mp4?ref=foo.m3u8", None);
-        assert!(matches!(p, rdlp_types::DownloadProtocol::Https), "got {p:?}");
+        assert!(
+            matches!(p, rdlp_types::DownloadProtocol::Https),
+            "got {p:?}"
+        );
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -337,12 +337,20 @@ fn detected_to_format(df: DetectedFormat) -> Format {
 
 /// Infer the download protocol from a URL and optional extension.
 fn protocol_from_url(url: &str, ext: Option<&str>) -> DownloadProtocol {
-    match ext {
-        Some("m3u8") => DownloadProtocol::M3u8,
-        _ if url.starts_with("https://") => DownloadProtocol::Https,
-        _ if url.starts_with("http://") => DownloadProtocol::Http,
-        _ => DownloadProtocol::Https,
+    if matches!(ext, Some("m3u8" | "m3u")) {
+        return DownloadProtocol::M3u8;
     }
+    url::Url::parse(url)
+        .map(|u| crate::base::common::protocol_for_url(&u))
+        .unwrap_or_else(|_| {
+            if url.starts_with("https://") {
+                DownloadProtocol::Https
+            } else if url.starts_with("http://") {
+                DownloadProtocol::Http
+            } else {
+                DownloadProtocol::Https
+            }
+        })
 }
 
 /// Map Content-Type to a file extension.
@@ -605,5 +613,26 @@ mod tests {
             "Https MP4 row must pass through untouched"
         );
         assert_eq!(expanded[1].url, "https://cdn.example.com/v.mp4");
+    }
+
+    #[test]
+    fn protocol_from_url_rejects_m3u8_in_query() {
+        // Regression: issue #268. A URL with `.m3u8` in the query but
+        // `.mp4` path-extension must classify as Https.
+        let p = protocol_from_url("https://host/clip.mp4?ref=foo.m3u8", None);
+        assert!(matches!(p, rdlp_types::DownloadProtocol::Https), "got {p:?}");
+    }
+
+    #[test]
+    fn protocol_from_url_honours_explicit_ext_arg() {
+        // Caller-supplied ext takes precedence over URL parsing.
+        let p = protocol_from_url("https://host/no-ext", Some("m3u8"));
+        assert!(matches!(p, rdlp_types::DownloadProtocol::M3u8), "got {p:?}");
+    }
+
+    #[test]
+    fn protocol_from_url_classifies_m3u8_path() {
+        let p = protocol_from_url("https://host/master.m3u8", None);
+        assert!(matches!(p, rdlp_types::DownloadProtocol::M3u8), "got {p:?}");
     }
 }

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -627,11 +627,9 @@ fn extract_formats_from_html(html: &Html, _page_url: &str) -> Vec<Format> {
 
 /// Create a Format with video codec markers set so the UI shows it as video, not audio-only.
 fn make_video_format(format_id: &str, url: &str) -> Format {
-    let protocol = if url.contains(".m3u8") {
-        DownloadProtocol::M3u8
-    } else {
-        DownloadProtocol::Https
-    };
+    let protocol = url::Url::parse(url)
+        .map(|u| crate::base::common::protocol_for_url(&u))
+        .unwrap_or(DownloadProtocol::Https);
     let ext = url
         .split('.')
         .next_back()
@@ -895,5 +893,27 @@ mod tests {
             "Https MP4 row must pass through untouched"
         );
         assert_eq!(expanded[1].url, "https://koreanporn.stream/Movie.mp4");
+    }
+
+    #[test]
+    fn make_video_format_rejects_m3u8_substring_in_query() {
+        // Regression: issue #268. A crafted MP4 URL with `.m3u8` in the
+        // query parameter must NOT classify as HLS.
+        let f = make_video_format("test", "https://host/clip.mp4?ref=foo.m3u8");
+        assert!(
+            matches!(f.protocol, rdlp_types::DownloadProtocol::Https),
+            "expected Https, got {:?}",
+            f.protocol
+        );
+    }
+
+    #[test]
+    fn make_video_format_classifies_m3u8_path_as_hls() {
+        let f = make_video_format("test", "https://host/master.m3u8");
+        assert!(
+            matches!(f.protocol, rdlp_types::DownloadProtocol::M3u8),
+            "expected M3u8, got {:?}",
+            f.protocol
+        );
     }
 }

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -695,18 +695,31 @@ fn extract_urls_from_decoded_tag(tag_html: &str) -> Vec<String> {
         .captures_iter(tag_html)
         .filter_map(|caps| {
             let url = caps.get(1)?.as_str();
-            // Only return actual media URLs, not embed pages
-            if url.contains(".mp4")
-                || url.contains(".m3u8")
-                || url.contains(".webm")
-                || url.contains("koreanporn.stream")
-            {
-                Some(url.to_string())
-            } else {
-                None
-            }
+            looks_like_media(url).then(|| url.to_string())
         })
         .collect()
+}
+
+/// Allow-list filter for media URLs found in decoded player iframes.
+///
+/// Matches by parsed path-segment extension (NOT substring). The
+/// `koreanporn.stream` host carve-out is preserved because some embeds
+/// link to opaque embed pages on that host that resolve to media at
+/// load time.
+fn looks_like_media(url: &str) -> bool {
+    if url.contains("koreanporn.stream") {
+        return true;
+    }
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    let ext = parsed
+        .path()
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.rsplit_once('.').map(|(_, e)| e))
+        .map(str::to_ascii_lowercase);
+    matches!(ext.as_deref(), Some("mp4" | "m3u8" | "m3u" | "webm"))
 }
 
 /// Probe a video URL via HEAD request to get Content-Length (filesize).
@@ -800,6 +813,35 @@ mod tests {
         let tag = r#"<iframe src="https://www.pornhub.com/embed/ph123"></iframe>"#;
         let urls = extract_urls_from_decoded_tag(tag);
         assert!(urls.is_empty()); // PornHub embed is not a direct media URL
+    }
+
+    #[test]
+    fn extract_urls_from_decoded_tag_rejects_substring_in_query() {
+        // Regression: substring matching admitted non-media URLs whose
+        // query/fragment contained a media extension.
+        let html = r#"<iframe src="https://host/page?embed=video.mp4"></iframe>"#;
+        let urls = extract_urls_from_decoded_tag(html);
+        assert!(
+            urls.is_empty(),
+            "expected empty (non-media URL), got {urls:?}"
+        );
+    }
+
+    #[test]
+    fn extract_urls_from_decoded_tag_accepts_media_extensions() {
+        let html =
+            r#"<source src="https://host/video.mp4"><source src="https://host/master.m3u8">"#;
+        let urls = extract_urls_from_decoded_tag(html);
+        assert_eq!(urls.len(), 2);
+        assert!(urls.iter().any(|u| u.ends_with(".mp4")));
+        assert!(urls.iter().any(|u| u.ends_with(".m3u8")));
+    }
+
+    #[test]
+    fn extract_urls_from_decoded_tag_accepts_koreanporn_stream_host() {
+        let html = r#"<source src="https://koreanporn.stream/embed/abc123">"#;
+        let urls = extract_urls_from_decoded_tag(html);
+        assert_eq!(urls.len(), 1);
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -707,12 +707,15 @@ fn extract_urls_from_decoded_tag(tag_html: &str) -> Vec<String> {
 /// link to opaque embed pages on that host that resolve to media at
 /// load time.
 fn looks_like_media(url: &str) -> bool {
-    if url.contains("koreanporn.stream") {
-        return true;
-    }
     let Ok(parsed) = url::Url::parse(url) else {
         return false;
     };
+    if parsed
+        .host_str()
+        .is_some_and(|h| h == "koreanporn.stream" || h.ends_with(".koreanporn.stream"))
+    {
+        return true;
+    }
     let ext = parsed
         .path()
         .rsplit('/')
@@ -842,6 +845,26 @@ mod tests {
         let html = r#"<source src="https://koreanporn.stream/embed/abc123">"#;
         let urls = extract_urls_from_decoded_tag(html);
         assert_eq!(urls.len(), 1);
+    }
+
+    #[test]
+    fn extract_urls_from_decoded_tag_rejects_subdomain_squatting() {
+        // Security: a hostile domain that contains "koreanporn.stream" as a
+        // substring (e.g. `koreanporn.stream.evil.com`, or any URL whose
+        // query references it) MUST NOT bypass the path-extension
+        // allow-list via the host carve-out.
+        let html = r#"<source src="https://koreanporn.stream.evil.com/page">"#;
+        assert!(extract_urls_from_decoded_tag(html).is_empty());
+
+        let html = r#"<source src="https://attacker.com/page?ref=koreanporn.stream">"#;
+        assert!(extract_urls_from_decoded_tag(html).is_empty());
+    }
+
+    #[test]
+    fn extract_urls_from_decoded_tag_accepts_koreanporn_stream_subdomain() {
+        // Legitimate subdomains (e.g. cdn.koreanporn.stream) remain allowed.
+        let html = r#"<source src="https://cdn.koreanporn.stream/embed/abc">"#;
+        assert_eq!(extract_urls_from_decoded_tag(html).len(), 1);
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/hls/format_detection.rs
+++ b/crates/rdlp-extractor/src/hls/format_detection.rs
@@ -520,6 +520,9 @@ mod is_hls_tests {
         // (e.g. RedTube's KVS-style API output, formats.rs:240) set
         // `format.ext = "hls"`. The short-circuit MUST treat that as HLS
         // regardless of URL shape.
-        assert!(is_hls_decision("hls", "https://cdn.example.com/no-extension/abc123"));
+        assert!(is_hls_decision(
+            "hls",
+            "https://cdn.example.com/no-extension/abc123"
+        ));
     }
 }

--- a/crates/rdlp-extractor/src/hls/format_detection.rs
+++ b/crates/rdlp-extractor/src/hls/format_detection.rs
@@ -218,7 +218,15 @@ async fn detect_format_sizes_inner(
 
             async move {
                 let url = format.url.clone();
-                let is_hls = format.ext == "hls" || url.contains(".m3u8") || url.contains("/hls/");
+                let is_hls = format.ext == "hls"
+                    || url::Url::parse(&url)
+                        .map(|u| {
+                            matches!(
+                                crate::base::common::protocol_for_url(&u),
+                                rdlp_types::DownloadProtocol::M3u8,
+                            )
+                        })
+                        .unwrap_or(false);
 
                 if is_hls {
                     // Try to expand master playlist into per-variant formats
@@ -463,4 +471,55 @@ async fn detect_format_sizes_inner(
     }
 
     (formats, flags)
+}
+
+#[cfg(test)]
+mod is_hls_tests {
+    use crate::base::common::protocol_for_url;
+    use rdlp_types::DownloadProtocol;
+    use url::Url;
+
+    /// Mirror of the post-migration `is_hls` decision used inside the
+    /// detection futures combinator at line ~221. Kept as a free function
+    /// so the test surface matches the production predicate exactly.
+    fn is_hls_decision(ext: &str, url: &str) -> bool {
+        ext == "hls"
+            || Url::parse(url)
+                .map(|u| matches!(protocol_for_url(&u), DownloadProtocol::M3u8))
+                .unwrap_or(false)
+    }
+
+    fn url_is_hls(url: &str) -> bool {
+        is_hls_decision("mp4", url)
+    }
+
+    #[test]
+    fn rejects_mp4_url_with_m3u8_in_query() {
+        // Regression: issue #268. The pre-migration check
+        // `url.contains(".m3u8")` returned true here.
+        assert!(!url_is_hls("https://host/clip.mp4?ref=foo.m3u8"));
+    }
+
+    #[test]
+    fn rejects_mp4_url_with_hls_substring_in_path() {
+        // Regression: pre-migration check `url.contains("/hls/")` returned
+        // true. The CDN-style `/hls/` substring is no longer treated as
+        // HLS — extractors that need HLS treatment must set
+        // `format.ext = "hls"` explicitly.
+        assert!(!url_is_hls("https://cdn/hls/abc123.mp4"));
+    }
+
+    #[test]
+    fn accepts_m3u8_path() {
+        assert!(url_is_hls("https://host/master.m3u8"));
+    }
+
+    #[test]
+    fn ext_hls_short_circuits_when_url_has_no_extension() {
+        // Contract: extractors that emit HLS without an `.m3u8` URL
+        // (e.g. RedTube's KVS-style API output, formats.rs:240) set
+        // `format.ext = "hls"`. The short-circuit MUST treat that as HLS
+        // regardless of URL shape.
+        assert!(is_hls_decision("hls", "https://cdn.example.com/no-extension/abc123"));
+    }
 }


### PR DESCRIPTION
## Summary

Replaces `url.contains(\".m3u8\")` substring classifiers with a new `protocol_for_url(&Url) -> DownloadProtocol` helper that inspects only the URL's last path-segment extension. Aligns rdlp's URL-protocol classification with the heuristic used by FFmpeg (`libavformat/hls.c`), VLC (`modules/demux/playlist/m3u.c`), mpv (`demux/demux_lavf.c`), and yt-dlp (`utils/_utils.py::determine_ext`).

The bug: a crafted MP4 URL containing `.m3u8` in a query parameter (`https://host/clip.mp4?ref=foo.m3u8`) was mis-classified as HLS and routed through `expand_hls_in_place`. Now correctly classified as Https.

## Migrations

- `koreanpornmovie::make_video_format` — protocol classifier
- `koreanpornmovie::extract_urls_from_decoded_tag` — media URL allow-list filter
- `koreanpornmovie::looks_like_media` — host carve-out tightened to parsed-host match (security: `koreanporn.stream.evil.com` no longer admitted)
- `hls/format_detection.rs::is_hls` — drops the non-standard `/hls/` CDN-path substring fallback
- `generic::protocol_from_url` — delegates to the new helper, adds `.m3u`

xnxx / xvideos use a `setVideoHLS(...)` regex capture (JS-context-known HLS) and assign `M3u8` directly — no migration needed (matches yt-dlp's extractor-first design).

## Test plan

- [x] 12 unit tests for `protocol_for_url` (positive, negative, scheme variants)
- [x] Per-extractor regression tests for each migrated call site
- [x] Security regression tests for `koreanporn.stream` subdomain-squatting
- [x] Each negative test fails against the unpatched code; passes after migration
- [x] \`cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test\` — all clean

## Reviews

- **security-reviewer** (\`add617d6735c42c8f\`): PASS with one LOW finding (`koreanporn.stream` substring host bypass) — fixed in commit 5008a9e
- **pr-review-toolkit:code-reviewer** (\`a0714889f1a69779b\`): Approve, no Critical/Important issues
- Per-task spec + code-quality reviewers ran on every task

## References

- Spec: `docs/superpowers/specs/2026-05-04-protocol-for-url-helper-design.md`
- Plan: `docs/superpowers/plans/2026-05-04-protocol-for-url-helper.md`

Closes #268.