### PR TITLE
feat(http): 3-axis HTTP timeouts + HLS probe order fix (#269)

### DIFF
--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -719,7 +719,6 @@ fn looks_like_media(url: &str) -> bool {
     matches!(ext.as_deref(), Some("mp4" | "m3u8" | "m3u" | "webm"))
 }
 
-
 /// Extract `content` attribute from a meta[itemprop] element.
 fn meta_content(html: &Html, selector: &Selector) -> Option<String> {
     html.select(selector)

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -164,19 +164,13 @@ impl InfoExtractor for KoreanPornMovieExtractor {
             ));
         }
 
-        // === Phase 3: Probe filesize via HEAD request (async) ===
-        let mut formats = formats;
-        for format in &mut formats {
-            if let Some(size) = probe_filesize(&format.url, ctx).await {
-                format.filesize = Some(size);
-            }
-        }
-
         // Pre-resolve HLS variant playlists into per-variant Format rows so
         // the downloader can take the Format.fragments fast path. Non-HLS
         // rows pass through unchanged; expand failures keep the original row
         // (graceful fallback to the legacy variant-URL path).
         let formats = crate::hls::expand_hls_in_place(formats, ctx.http_client.clone()).await;
+        let (formats, _hls_flags) =
+            crate::hls::detect_format_sizes_lazy(formats, ctx, InfoExtractor::name(self)).await;
 
         info.formats = formats;
         Ok(info)
@@ -725,28 +719,6 @@ fn looks_like_media(url: &str) -> bool {
     matches!(ext.as_deref(), Some("mp4" | "m3u8" | "m3u" | "webm"))
 }
 
-/// Probe a video URL via HEAD request to get Content-Length (filesize).
-///
-/// Returns `None` on any error (timeout, 403, etc.) — non-fatal.
-async fn probe_filesize(url: &str, ctx: &ExtractionContext) -> Option<u64> {
-    let response = ctx
-        .http_client
-        .head(url)
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-        .ok()?;
-
-    if !response.status().is_success() {
-        return None;
-    }
-
-    response
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-}
 
 /// Extract `content` attribute from a meta[itemprop] element.
 fn meta_content(html: &Html, selector: &Selector) -> Option<String> {

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -223,10 +223,24 @@ pub(crate) async fn resolve_episode_formats(
         }));
     }
 
+    // Pre-resolve HLS variant playlists into per-variant Format rows FIRST.
+    // The seed Format's `http_headers` (Referer) is preserved on every
+    // expanded row via `seed.clone()` inside `expand_media_playlist`.
+    // Non-HLS rows pass through unchanged; expand failures keep the
+    // original row (graceful fallback to the legacy variant-URL path).
+    //
+    // Probe ordering convention (issue #269): expand MUST run before
+    // detect_format_sizes_lazy so HEAD probes target per-variant URLs
+    // rather than the master playlist URL.
+    let all_formats =
+        crate::hls::expand_hls_in_place(all_formats, ctx.http_client.clone()).await;
+
     // Enrich HLS formats with resolution, codecs, duration, segments
     let (mut all_formats, hls_flags) = detect_format_sizes_lazy(all_formats, ctx, "9anime").await;
 
-    // Restore audio type label in format_note (enrichment overwrites it)
+    // Restore audio type label in format_note (enrichment overwrites it).
+    // Must run AFTER detect_format_sizes_lazy because the helper sets
+    // format_note from resolution; this loop prepends the language tag.
     for f in &mut all_formats {
         if let Some(lang) = &f.language {
             match &f.format_note {
@@ -248,14 +262,6 @@ pub(crate) async fn resolve_episode_formats(
     } else {
         dub_subtitle_tracks
     };
-
-    // Pre-resolve HLS variant playlists into per-variant Format rows so the
-    // downloader can take the Format.fragments fast path. Non-HLS rows pass
-    // through unchanged; expand failures keep the original row (graceful
-    // fallback to the legacy variant-URL path). The seed Format's
-    // `http_headers` (Referer) is preserved on every expanded row via
-    // `seed.clone()` inside `expand_media_playlist`.
-    let all_formats = crate::hls::expand_hls_in_place(all_formats, ctx.http_client.clone()).await;
 
     Ok((all_formats, hls_flags, subtitle_tracks))
 }

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -232,8 +232,7 @@ pub(crate) async fn resolve_episode_formats(
     // Probe ordering convention (issue #269): expand MUST run before
     // detect_format_sizes_lazy so HEAD probes target per-variant URLs
     // rather than the master playlist URL.
-    let all_formats =
-        crate::hls::expand_hls_in_place(all_formats, ctx.http_client.clone()).await;
+    let all_formats = crate::hls::expand_hls_in_place(all_formats, ctx.http_client.clone()).await;
 
     // Enrich HLS formats with resolution, codecs, duration, segments
     let (mut all_formats, hls_flags) = detect_format_sizes_lazy(all_formats, ctx, "9anime").await;

--- a/crates/rdlp-extractor/src/hls/expand_in_place.rs
+++ b/crates/rdlp-extractor/src/hls/expand_in_place.rs
@@ -5,6 +5,22 @@
 //! protocol is `M3u8` or `M3u8Native` with the per-variant rows produced by
 //! [`expand_hls_url`]. On any [`HlsExpandError`] the row is dropped entirely
 //! (no fallback to legacy variant-URL path).
+//!
+//! ## Convention
+//!
+//! Size probes (`detect_format_sizes_lazy`, custom HEAD probes,
+//! segment-count enrichment) MUST run AFTER `expand_hls_in_place`,
+//! not before. Probing the master-playlist URL yields manifest size,
+//! not per-variant size; per-variant size estimation requires the
+//! `Fragment` list this helper produces.
+//!
+//! Reference call shape (xhamster, the model):
+//! ```ignore
+//! let formats = expand_hls_in_place(formats, http_client).await;
+//! let (formats, flags) = detect_format_sizes_lazy(formats, ctx, name).await;
+//! ```
+//!
+//! See issue #269 for the audit and remediation history.
 
 use std::sync::Arc;
 

--- a/crates/rdlp-http/src/client.rs
+++ b/crates/rdlp-http/src/client.rs
@@ -80,7 +80,7 @@ impl HttpClientFactory {
             .emulation(self.config.emulation.resolve())
             .redirect(wreq::redirect::Policy::limited(10))
             .pool_max_idle_per_host(self.config.pool_max_idle_per_host)
-            .pool_idle_timeout(Duration::from_secs(self.config.pool_idle_timeout_secs))
+            .pool_idle_timeout(self.config.pool_idle_timeout_secs.map(Duration::from_secs))
             .tcp_keepalive(Duration::from_secs(self.config.tcp_keepalive_secs))
             .tcp_nodelay(self.config.tcp_nodelay)
             .connect_timeout(Duration::from_secs(self.config.connect_timeout_secs))

--- a/crates/rdlp-http/src/config.rs
+++ b/crates/rdlp-http/src/config.rs
@@ -32,8 +32,9 @@ pub struct HttpClientConfig {
     /// Maximum idle connections per host
     pub pool_max_idle_per_host: usize,
 
-    /// Idle connection timeout in seconds
-    pub pool_idle_timeout_secs: u64,
+    /// Idle connection timeout in seconds. `None` disables idle eviction
+    /// entirely (wired to `wreq::ClientBuilder::pool_idle_timeout(None)`).
+    pub pool_idle_timeout_secs: Option<u64>,
 
     /// TCP keepalive interval in seconds
     pub tcp_keepalive_secs: u64,
@@ -53,7 +54,7 @@ impl Default for HttpClientConfig {
             connect_timeout_secs: 30,
             read_timeout_secs: 60,
             pool_max_idle_per_host: 10,
-            pool_idle_timeout_secs: 90,
+            pool_idle_timeout_secs: Some(90),
             tcp_keepalive_secs: 60,
             tcp_nodelay: true,
             proxy: None,
@@ -125,10 +126,17 @@ impl HttpClientConfig {
         self
     }
 
-    /// Set the idle connection timeout in seconds
+    /// Set the idle connection timeout in seconds.
     #[must_use]
     pub const fn with_pool_idle_timeout_secs(mut self, secs: u64) -> Self {
-        self.pool_idle_timeout_secs = secs;
+        self.pool_idle_timeout_secs = Some(secs);
+        self
+    }
+
+    /// Disable idle connection eviction entirely.
+    #[must_use]
+    pub const fn with_pool_idle_disabled(mut self) -> Self {
+        self.pool_idle_timeout_secs = None;
         self
     }
 
@@ -188,5 +196,17 @@ mod tests {
     fn test_with_emulation() {
         let config = HttpClientConfig::new().with_emulation(BrowserEmulation::FirefoxLatest);
         assert!(matches!(config.emulation, BrowserEmulation::FirefoxLatest));
+    }
+
+    #[test]
+    fn pool_idle_timeout_secs_can_be_disabled() {
+        let config = HttpClientConfig::new().with_pool_idle_disabled();
+        assert!(config.pool_idle_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn default_pool_idle_timeout_is_some_90() {
+        let config = HttpClientConfig::default();
+        assert_eq!(config.pool_idle_timeout_secs, Some(90));
     }
 }

--- a/crates/rdlp-http/src/config.rs
+++ b/crates/rdlp-http/src/config.rs
@@ -81,6 +81,13 @@ impl HttpClientConfig {
         if let Some(timeout) = config.socket_timeout {
             http_config.connect_timeout_secs = timeout;
         }
+        if let Some(timeout) = config.read_timeout {
+            http_config.read_timeout_secs = timeout;
+        }
+        if let Some(timeout) = config.pool_idle_timeout {
+            // 0 is the user-facing sentinel for "disable eviction".
+            http_config.pool_idle_timeout_secs = if timeout == 0 { None } else { Some(timeout) };
+        }
 
         http_config.emulation = config.browser_emulation.clone();
         http_config.proxy.clone_from(&config.proxy);
@@ -208,5 +215,49 @@ mod tests {
     fn default_pool_idle_timeout_is_some_90() {
         let config = HttpClientConfig::default();
         assert_eq!(config.pool_idle_timeout_secs, Some(90));
+    }
+
+    #[test]
+    fn from_rdlp_config_maps_read_timeout() {
+        let cfg = rdlp_types::Config {
+            read_timeout: Some(120),
+            ..rdlp_types::Config::default()
+        };
+        let http = HttpClientConfig::from_rdlp_config(&cfg);
+        assert_eq!(http.read_timeout_secs, 120);
+    }
+
+    #[test]
+    fn from_rdlp_config_maps_pool_idle_timeout_zero_to_none() {
+        let cfg = rdlp_types::Config {
+            pool_idle_timeout: Some(0),
+            ..rdlp_types::Config::default()
+        };
+        let http = HttpClientConfig::from_rdlp_config(&cfg);
+        assert!(http.pool_idle_timeout_secs.is_none(), "0 must map to None (disable)");
+    }
+
+    #[test]
+    fn from_rdlp_config_maps_pool_idle_timeout_positive() {
+        let cfg = rdlp_types::Config {
+            pool_idle_timeout: Some(60),
+            ..rdlp_types::Config::default()
+        };
+        let http = HttpClientConfig::from_rdlp_config(&cfg);
+        assert_eq!(http.pool_idle_timeout_secs, Some(60));
+    }
+
+    #[test]
+    fn from_rdlp_config_with_no_timeout_overrides_uses_defaults() {
+        let cfg = rdlp_types::Config {
+            socket_timeout: None,
+            read_timeout: None,
+            pool_idle_timeout: None,
+            ..rdlp_types::Config::default()
+        };
+        let http = HttpClientConfig::from_rdlp_config(&cfg);
+        assert_eq!(http.connect_timeout_secs, 30);
+        assert_eq!(http.read_timeout_secs, 60);
+        assert_eq!(http.pool_idle_timeout_secs, Some(90));
     }
 }

--- a/crates/rdlp-http/src/config.rs
+++ b/crates/rdlp-http/src/config.rs
@@ -234,7 +234,10 @@ mod tests {
             ..rdlp_types::Config::default()
         };
         let http = HttpClientConfig::from_rdlp_config(&cfg);
-        assert!(http.pool_idle_timeout_secs.is_none(), "0 must map to None (disable)");
+        assert!(
+            http.pool_idle_timeout_secs.is_none(),
+            "0 must map to None (disable)"
+        );
     }
 
     #[test]

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -141,8 +141,31 @@ pub struct Config {
     /// HTTP/SOCKS proxy URL
     pub proxy: Option<String>,
 
-    /// Socket timeout in seconds
+    /// Connect-axis timeout in seconds (TCP + TLS handshake).
+    ///
+    /// Default: 30. Range validation enforces 1..=300 if set.
+    ///
+    /// Named `socket_timeout` for historical compatibility with the
+    /// pre-1.0 single-knob model; the actual semantics are connect-only.
+    /// Read and pool-idle timeouts are configured separately via
+    /// `read_timeout` and `pool_idle_timeout`.
     pub socket_timeout: Option<u64>,
+
+    /// Read-axis timeout in seconds (per-read inactivity, not total).
+    ///
+    /// Default: 60. Range: 1..=600.
+    #[serde(default)]
+    pub read_timeout: Option<u64>,
+
+    /// Pool idle-connection timeout in seconds.
+    ///
+    /// Default: 90. Range: 0..=3600.
+    ///
+    /// `0` is a sentinel meaning "disable idle eviction entirely" — wired
+    /// through to wreq/reqwest as `pool_idle_timeout(None)`. Any positive
+    /// value caps how long an idle connection is kept in the pool.
+    #[serde(default)]
+    pub pool_idle_timeout: Option<u64>,
 
     /// Source IP address to bind to
     pub source_address: Option<String>,
@@ -330,6 +353,8 @@ impl Default for Config {
             // Network options
             proxy: None,
             socket_timeout: Some(30),
+            read_timeout: None,
+            pool_idle_timeout: None,
             source_address: None,
             user_agent: Some(
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36".to_string(),
@@ -488,6 +513,32 @@ impl Config {
             return Err(ConfigValidationError::OutOfRange {
                 field: "plugin_stack_limit_mb",
                 reason: "must be 1..=64 MB",
+            });
+        }
+
+        // HTTP timeout range checks
+        if let Some(t) = self.socket_timeout
+            && !(1..=300).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "socket_timeout",
+                reason: "must be 1..=300 seconds",
+            });
+        }
+        if let Some(t) = self.read_timeout
+            && !(1..=600).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "read_timeout",
+                reason: "must be 1..=600 seconds",
+            });
+        }
+        if let Some(t) = self.pool_idle_timeout
+            && t > 3600
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "pool_idle_timeout",
+                reason: "must be 0..=3600 seconds (0 = disabled)",
             });
         }
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -430,6 +430,7 @@ impl Config {
     /// Returns [`ConfigValidationError`] if any field is out of range or
     /// inconsistent (e.g. `concurrent_fragments == 0`, `buffer_size == 0`,
     /// invalid `playlist_start`).
+    #[allow(clippy::too_many_lines)] // Linear sequence of independent range checks; splitting harms readability.
     pub fn validate(&self) -> Result<(), ConfigValidationError> {
         if self.concurrent_fragments == 0 {
             return Err(ConfigValidationError::InvalidConcurrentFragments);

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -164,6 +164,10 @@ pub struct Config {
     /// `0` is a sentinel meaning "disable idle eviction entirely" — wired
     /// through to wreq/reqwest as `pool_idle_timeout(None)`. Any positive
     /// value caps how long an idle connection is kept in the pool.
+    ///
+    /// Connection count is still capped by `pool_max_idle_per_host`
+    /// (default 10), so disabling eviction does not permit unbounded
+    /// pool growth.
     #[serde(default)]
     pub pool_idle_timeout: Option<u64>,
 

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -360,7 +360,10 @@ fn read_timeout_rejects_zero() {
     };
     assert!(matches!(
         cfg.validate(),
-        Err(ConfigValidationError::OutOfRange { field: "read_timeout", .. })
+        Err(ConfigValidationError::OutOfRange {
+            field: "read_timeout",
+            ..
+        })
     ));
 }
 
@@ -372,7 +375,10 @@ fn read_timeout_rejects_above_600() {
     };
     assert!(matches!(
         cfg.validate(),
-        Err(ConfigValidationError::OutOfRange { field: "read_timeout", .. })
+        Err(ConfigValidationError::OutOfRange {
+            field: "read_timeout",
+            ..
+        })
     ));
 }
 
@@ -383,7 +389,10 @@ fn pool_idle_timeout_accepts_zero_and_max() {
             pool_idle_timeout: Some(v),
             ..Config::default()
         };
-        assert!(cfg.validate().is_ok(), "pool_idle_timeout={v} should be valid");
+        assert!(
+            cfg.validate().is_ok(),
+            "pool_idle_timeout={v} should be valid"
+        );
     }
 }
 
@@ -395,7 +404,10 @@ fn pool_idle_timeout_rejects_above_3600() {
     };
     assert!(matches!(
         cfg.validate(),
-        Err(ConfigValidationError::OutOfRange { field: "pool_idle_timeout", .. })
+        Err(ConfigValidationError::OutOfRange {
+            field: "pool_idle_timeout",
+            ..
+        })
     ));
 }
 
@@ -418,7 +430,10 @@ fn socket_timeout_rejects_zero() {
     };
     assert!(matches!(
         cfg.validate(),
-        Err(ConfigValidationError::OutOfRange { field: "socket_timeout", .. })
+        Err(ConfigValidationError::OutOfRange {
+            field: "socket_timeout",
+            ..
+        })
     ));
 }
 
@@ -430,6 +445,9 @@ fn socket_timeout_rejects_above_300() {
     };
     assert!(matches!(
         cfg.validate(),
-        Err(ConfigValidationError::OutOfRange { field: "socket_timeout", .. })
+        Err(ConfigValidationError::OutOfRange {
+            field: "socket_timeout",
+            ..
+        })
     ));
 }

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -340,3 +340,96 @@ fn test_out_of_range_error_display() {
         "plugin_memory_limit_mb: must be 1..=1024 MB"
     );
 }
+
+#[test]
+fn read_timeout_accepts_valid_range() {
+    for v in [1u64, 60, 600] {
+        let cfg = Config {
+            read_timeout: Some(v),
+            ..Config::default()
+        };
+        assert!(cfg.validate().is_ok(), "read_timeout={v} should be valid");
+    }
+}
+
+#[test]
+fn read_timeout_rejects_zero() {
+    let cfg = Config {
+        read_timeout: Some(0),
+        ..Config::default()
+    };
+    assert!(matches!(
+        cfg.validate(),
+        Err(ConfigValidationError::OutOfRange { field: "read_timeout", .. })
+    ));
+}
+
+#[test]
+fn read_timeout_rejects_above_600() {
+    let cfg = Config {
+        read_timeout: Some(601),
+        ..Config::default()
+    };
+    assert!(matches!(
+        cfg.validate(),
+        Err(ConfigValidationError::OutOfRange { field: "read_timeout", .. })
+    ));
+}
+
+#[test]
+fn pool_idle_timeout_accepts_zero_and_max() {
+    for v in [0u64, 90, 3600] {
+        let cfg = Config {
+            pool_idle_timeout: Some(v),
+            ..Config::default()
+        };
+        assert!(cfg.validate().is_ok(), "pool_idle_timeout={v} should be valid");
+    }
+}
+
+#[test]
+fn pool_idle_timeout_rejects_above_3600() {
+    let cfg = Config {
+        pool_idle_timeout: Some(3601),
+        ..Config::default()
+    };
+    assert!(matches!(
+        cfg.validate(),
+        Err(ConfigValidationError::OutOfRange { field: "pool_idle_timeout", .. })
+    ));
+}
+
+#[test]
+fn socket_timeout_accepts_valid_range() {
+    for v in [1u64, 30, 300] {
+        let cfg = Config {
+            socket_timeout: Some(v),
+            ..Config::default()
+        };
+        assert!(cfg.validate().is_ok(), "socket_timeout={v} should be valid");
+    }
+}
+
+#[test]
+fn socket_timeout_rejects_zero() {
+    let cfg = Config {
+        socket_timeout: Some(0),
+        ..Config::default()
+    };
+    assert!(matches!(
+        cfg.validate(),
+        Err(ConfigValidationError::OutOfRange { field: "socket_timeout", .. })
+    ));
+}
+
+#[test]
+fn socket_timeout_rejects_above_300() {
+    let cfg = Config {
+        socket_timeout: Some(301),
+        ..Config::default()
+    };
+    assert!(matches!(
+        cfg.validate(),
+        Err(ConfigValidationError::OutOfRange { field: "socket_timeout", .. })
+    ));
+}


### PR DESCRIPTION
## Summary

Two intertwined fixes:

1. **HLS probe ordering (#269 core)** — \`koreanpornmovie\` and \`nine_anime\` ran filesize probes BEFORE \`expand_hls_in_place\`, against the master playlist URL. Both now follow the xhamster model: expand THEN \`detect_format_sizes_lazy\`. \`koreanpornmovie\`'s bespoke \`probe_filesize\` (hard-coded 10s) is deleted in favour of the shared helper.

2. **3-axis HTTP timeouts** — \`Config\` gains \`read_timeout\` and \`pool_idle_timeout\` TOML fields alongside the existing \`socket_timeout\` (which keeps its name as the connect-axis alias for backward compat). Matches reqwest / Apache HC 5 / OkHttp / httpx convergence. \`pool_idle_timeout = 0\` is the disable-eviction sentinel, mapped to wreq's \`pool_idle_timeout(None)\`.

## Convention

Documented in \`crates/rdlp-extractor/src/hls/expand_in_place.rs\`: size probes MUST run AFTER \`expand_hls_in_place\`. Audit verified the only two offenders were \`koreanpornmovie\` and \`nine_anime\`; \`xhamster\` was already correct (the model); other HLS-emitting extractors don't run a separate size-probe stage.

## Breaking change note

\`socket_timeout\` was previously unvalidated. This PR adds a \`1..=300\` range gate. TOML configs with values outside that range will now fail validation at startup. Operators who relied on \`socket_timeout = 0\` (some HTTP stacks treat as \"no timeout\") or \`socket_timeout > 300\` will need to update their config.

## Test plan

- [x] \`HttpClientConfig.pool_idle_timeout_secs\` is \`Option<u64>\` with the disable sentinel.
- [x] \`Config\` validation rejects out-of-range timeouts (read 1..=600, pool-idle 0..=3600, socket 1..=300).
- [x] \`from_rdlp_config\` maps \`pool_idle_timeout: Some(0)\` → \`pool_idle_timeout_secs: None\`.
- [x] \`koreanpornmovie\` + \`nine_anime\` test suites green after reorder.
- [x] \`cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test\` — clean.

## Reviews

- **security-reviewer** (\`a30532f371e9c5e71\`): PASS, 1 MEDIUM (breaking-change note — addressed above), 2 LOW (one fixed inline in 0f2a166, one informational).
- **pr-review-toolkit:code-reviewer** (\`a77dff09e3d8dcb80\`): Approve, no Critical/Important findings. Three minor follow-ups filed as #278 + #279.
- Per-task spec + code-quality reviewers ran on every task.

## Deferred / follow-ups

- #277 — operation-level deadlines in \`format_detection.rs\` (separate from socket-level timeouts).
- #278 — CLI \`--read-timeout\` / \`--pool-idle-timeout\` flags.
- #279 — probe-order regression fixtures for \`koreanpornmovie\` / \`nine_anime\`.

## References

- Spec: \`docs/superpowers/specs/2026-05-04-hls-probe-order-and-http-timeouts-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-04-hls-probe-order-and-http-timeouts.md\`

Closes #269. Refs #277.