### PR TITLE
Lift HLS operation + HEAD-probe timeouts to Config (#277)

### DIFF
--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -555,6 +555,11 @@ mod detect_file_size_timeout_tests {
 
     /// Black-hole TCP listener: accepts connections, then sleeps without
     /// responding. Forces the client to time out instead of completing.
+    ///
+    /// The spawned task is intentionally not joined; it lives for the rest
+    /// of the test process. Each invocation leaks one tokio task plus one
+    /// open TCP listener socket. Acceptable for a handful of tests; revisit
+    /// if the helper sees heavier reuse.
     async fn spawn_blackhole() -> u16 {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -30,7 +30,7 @@
 //! let id = BaseExtractor::extract_id_from_url(url, &MY_URL_PATTERN, "id");
 //!
 //! // Detect file size with fallback strategies
-//! let size = BaseExtractor::detect_file_size(&video_url, &ctx.http_client, None).await;
+//! let size = BaseExtractor::detect_file_size(&video_url, &ctx.http_client, None, std::time::Duration::from_secs(5)).await;
 //! ```
 
 pub mod dash;
@@ -373,16 +373,18 @@ impl BaseExtractor {
     /// # Example
     ///
     /// ```rust,ignore
-    /// let size = BaseExtractor::detect_file_size(&url, &ctx.http_client, None).await;
-    /// let size = BaseExtractor::detect_file_size(&url, &client, Some("HLS")).await;
+    /// use std::time::Duration;
+    /// let size = BaseExtractor::detect_file_size(&url, &ctx.http_client, None, Duration::from_secs(5)).await;
+    /// let size = BaseExtractor::detect_file_size(&url, &client, Some("HLS"), Duration::from_secs(5)).await;
     /// ```
     pub(crate) async fn detect_file_size(
         url: &str,
         http_client: &wreq::Client,
         log_prefix: Option<&str>,
+        timeout: std::time::Duration,
     ) -> Option<u64> {
         // Strategy 1: HEAD request
-        if let Ok(response) = http_client.head(url).send().await
+        if let Ok(response) = http_client.head(url).timeout(timeout).send().await
             && let Some(size) = response.content_length().filter(|&s| s > 0)
         {
             if let Some(prefix) = log_prefix {
@@ -395,6 +397,7 @@ impl BaseExtractor {
         if let Ok(response) = http_client
             .get(url)
             .header("Range", "bytes=0-0")
+            .timeout(timeout)
             .send()
             .await
             && let Some(size) = Self::parse_content_range_total(response.headers())

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -547,3 +547,64 @@ impl BaseExtractor {
         }
     }
 }
+
+#[cfg(test)]
+mod detect_file_size_timeout_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    /// Black-hole TCP listener: accepts connections, then sleeps without
+    /// responding. Forces the client to time out instead of completing.
+    async fn spawn_blackhole() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        tokio::spawn(async move {
+            loop {
+                if let Ok((stream, _)) = listener.accept().await {
+                    // Hold the connection open without writing a response.
+                    // The 60s sleep is deliberately longer than any test's
+                    // configured timeout — the inner timeout fires first.
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    drop(stream);
+                }
+            }
+        });
+        port
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn detect_file_size_respects_configured_timeout() {
+        let port = spawn_blackhole().await;
+        let url = format!("http://127.0.0.1:{port}/probe");
+        let client = wreq::Client::new();
+        let configured = Duration::from_secs(1);
+
+        let started = Instant::now();
+        let result = BaseExtractor::detect_file_size(&url, &client, None, configured).await;
+        let elapsed = started.elapsed();
+
+        // detect_file_size returns None on inner-timeout (both inner requests
+        // time out, falling through to the final `None`).
+        assert_eq!(result, None);
+
+        // Wall-clock must be roughly the configured timeout, with a generous
+        // tolerance for CI scheduling jitter. detect_file_size makes TWO
+        // sequential inner requests (HEAD then Range-GET fallback), each
+        // bounded by the configured timeout. Worst-case is therefore
+        // 2 * configured. Pin upper bound at 2 * configured + 500ms.
+        let upper_bound = configured * 2 + Duration::from_millis(500);
+        assert!(
+            elapsed < upper_bound,
+            "expected elapsed < {upper_bound:?}, got {elapsed:?} (configured: {configured:?})",
+        );
+
+        // Also assert lower bound: must not return faster than the configured
+        // timeout (otherwise we know it didn't actually wait).
+        assert!(
+            elapsed >= configured,
+            "expected elapsed >= {configured:?}, got {elapsed:?}",
+        );
+    }
+}

--- a/crates/rdlp-extractor/src/base/mod.rs
+++ b/crates/rdlp-extractor/src/base/mod.rs
@@ -33,7 +33,7 @@
 //! // Generic utilities (all extractors)
 //! let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 //! let title = BaseExtractor::extract_title_multi_strategy(&html);
-//! let size = BaseExtractor::detect_file_size(&video_url, &ctx.http_client, None).await;
+//! let size = BaseExtractor::detect_file_size(&video_url, &ctx.http_client, None, std::time::Duration::from_secs(5)).await;
 //!
 //! // Network-specific utilities (TNAFlix family only)
 //! let base = TnaFlixNetworkBase::new();

--- a/crates/rdlp-extractor/src/hls/detector.rs
+++ b/crates/rdlp-extractor/src/hls/detector.rs
@@ -79,7 +79,7 @@ impl HlsSizeDetector {
     /// #     std::sync::Arc::new(wreq::Client::new()),
     /// #     false
     /// # );
-    /// match detector.detect_size("https://example.com/playlist.m3u8").await {
+    /// match detector.detect_size("https://example.com/playlist.m3u8", std::time::Duration::from_secs(10)).await {
     ///     Ok(Some(size)) => println!("Size: {} MB", size / 1_000_000),
     ///     Ok(None) => println!("Size could not be determined"),
     ///     Err(e) => eprintln!("Error: {e}"),
@@ -93,10 +93,14 @@ impl HlsSizeDetector {
     /// Returns `Err` when:
     /// - URL security validation fails (SSRF protection) (`RdlpError::Security`)
     /// - Delegated `detect_info` call fails (`RdlpError::Network` or `RdlpError::Extraction`)
-    pub async fn detect_size(&self, m3u8_url: &str) -> Result<Option<u64>> {
+    pub async fn detect_size(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Option<u64>> {
         // Use detect_info and extract just the size
         Ok(self
-            .detect_info(m3u8_url)
+            .detect_info(m3u8_url, timeout)
             .await?
             .and_then(|info| info.total_size))
     }
@@ -114,7 +118,11 @@ impl HlsSizeDetector {
     ///
     /// Returns `Err` when:
     /// - URL security validation fails (SSRF protection) (`RdlpError::Security`)
-    pub async fn count_segments(&self, m3u8_url: &str) -> Result<Option<usize>> {
+    pub async fn count_segments(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Option<usize>> {
         // Validate the input URL for security (SSRF protection)
         BaseExtractor::validate_url_security(m3u8_url)?;
 
@@ -123,7 +131,7 @@ impl HlsSizeDetector {
         }
 
         // Parse playlist to extract segment URLs
-        match self.parse_playlist(m3u8_url).await {
+        match self.parse_playlist(m3u8_url, timeout).await {
             Ok(urls) => {
                 let count = urls.len();
                 if self.verbose {
@@ -158,7 +166,11 @@ impl HlsSizeDetector {
     /// Returns `Err` when:
     /// - URL security validation fails (SSRF protection) (`RdlpError::Security`)
     /// - Playlist URL parsing fails (`RdlpError::Extraction`)
-    pub async fn detect_info(&self, m3u8_url: &str) -> Result<Option<HlsInfo>> {
+    pub async fn detect_info(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Option<HlsInfo>> {
         let start = std::time::Instant::now();
 
         // Validate the input URL for security (SSRF protection)
@@ -169,7 +181,7 @@ impl HlsSizeDetector {
         }
 
         // Step 1: Parse playlist to extract segment URLs
-        let segment_urls = match self.parse_playlist(m3u8_url).await {
+        let segment_urls = match self.parse_playlist(m3u8_url, timeout).await {
             Ok(urls) => urls,
             Err(e) => {
                 if self.verbose {
@@ -232,8 +244,12 @@ impl HlsSizeDetector {
     }
 
     /// Fetch M3U8 playlist text from a URL
-    pub(super) async fn fetch_playlist_text(&self, m3u8_url: &str) -> Result<String> {
-        let mut request = self.http_client.get(m3u8_url);
+    pub(super) async fn fetch_playlist_text(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<String> {
+        let mut request = self.http_client.get(m3u8_url).timeout(timeout);
         if let Some(headers) = &self.default_headers {
             request = request.headers(headers.clone());
         }
@@ -278,8 +294,9 @@ impl HlsSizeDetector {
     pub(super) async fn fetch_and_extract_media_info(
         &self,
         media_url: &str,
+        timeout: std::time::Duration,
     ) -> Result<Option<MediaPlaylistInfo>> {
-        let text = self.fetch_playlist_text(media_url).await?;
+        let text = self.fetch_playlist_text(media_url, timeout).await?;
         let playlist = m3u8_rs::parse_playlist_res(text.as_bytes()).map_err(|e| {
             if !text.trim().starts_with("#EXTM3U") {
                 let preview: String = text.chars().take(200).collect();

--- a/crates/rdlp-extractor/src/hls/format_detection.rs
+++ b/crates/rdlp-extractor/src/hls/format_detection.rs
@@ -9,6 +9,37 @@ use crate::base::common::BaseExtractor;
 use log::debug;
 use rdlp_types::Codec;
 
+/// Default cap on multi-step HLS probes when `Config::hls_operation_timeout`
+/// is unset. Matches the legacy hard-coded value before #277.
+const DEFAULT_HLS_OPERATION_TIMEOUT_SECS: u64 = 10;
+
+/// Default cap on the single-HEAD probe for non-HLS file size detection
+/// when `Config::hls_head_probe_timeout` is unset. Matches the legacy
+/// hard-coded value before #277.
+const DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS: u64 = 5;
+
+/// Resolve the wall-clock cap for HLS metadata / variant probes from `Config`,
+/// falling back to `DEFAULT_HLS_OPERATION_TIMEOUT_SECS` when unset.
+#[allow(dead_code)] // wired in Tasks 3-5 of #277
+pub(crate) fn resolve_hls_operation_timeout(config: &rdlp_types::Config) -> std::time::Duration {
+    std::time::Duration::from_secs(
+        config
+            .hls_operation_timeout
+            .unwrap_or(DEFAULT_HLS_OPERATION_TIMEOUT_SECS),
+    )
+}
+
+/// Resolve the wall-clock cap for the non-HLS HEAD-probe from `Config`,
+/// falling back to `DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS` when unset.
+#[allow(dead_code)] // wired in Tasks 3-5 of #277
+pub(crate) fn resolve_hls_head_probe_timeout(config: &rdlp_types::Config) -> std::time::Duration {
+    std::time::Duration::from_secs(
+        config
+            .hls_head_probe_timeout
+            .unwrap_or(DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS),
+    )
+}
+
 /// Slugify a rendition tag (`LANGUAGE` / `GROUP-ID` / `NAME`) into a
 /// format-id-safe token: lowercase ASCII alphanumerics with `-` for
 /// any other character, collapsed and trimmed. Keeps audio-only format
@@ -524,5 +555,48 @@ mod is_hls_tests {
             "hls",
             "https://cdn.example.com/no-extension/abc123"
         ));
+    }
+}
+
+#[cfg(test)]
+mod resolve_timeout_tests {
+    use super::{resolve_hls_head_probe_timeout, resolve_hls_operation_timeout};
+    use rdlp_types::Config;
+    use std::time::Duration;
+
+    #[test]
+    fn op_timeout_uses_default_when_none() {
+        let c = Config {
+            hls_operation_timeout: None,
+            ..Config::default()
+        };
+        assert_eq!(resolve_hls_operation_timeout(&c), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn op_timeout_uses_override_when_some() {
+        let c = Config {
+            hls_operation_timeout: Some(45),
+            ..Config::default()
+        };
+        assert_eq!(resolve_hls_operation_timeout(&c), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn head_probe_timeout_uses_default_when_none() {
+        let c = Config {
+            hls_head_probe_timeout: None,
+            ..Config::default()
+        };
+        assert_eq!(resolve_hls_head_probe_timeout(&c), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn head_probe_timeout_uses_override_when_some() {
+        let c = Config {
+            hls_head_probe_timeout: Some(2),
+            ..Config::default()
+        };
+        assert_eq!(resolve_hls_head_probe_timeout(&c), Duration::from_secs(2));
     }
 }

--- a/crates/rdlp-extractor/src/hls/format_detection.rs
+++ b/crates/rdlp-extractor/src/hls/format_detection.rs
@@ -20,7 +20,6 @@ const DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS: u64 = 5;
 
 /// Resolve the wall-clock cap for HLS metadata / variant probes from `Config`,
 /// falling back to `DEFAULT_HLS_OPERATION_TIMEOUT_SECS` when unset.
-#[allow(dead_code)] // wired in Tasks 3-5 of #277
 pub(crate) fn resolve_hls_operation_timeout(config: &rdlp_types::Config) -> std::time::Duration {
     std::time::Duration::from_secs(
         config
@@ -31,7 +30,6 @@ pub(crate) fn resolve_hls_operation_timeout(config: &rdlp_types::Config) -> std:
 
 /// Resolve the wall-clock cap for the non-HLS HEAD-probe from `Config`,
 /// falling back to `DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS` when unset.
-#[allow(dead_code)] // wired in Tasks 3-5 of #277
 pub(crate) fn resolve_hls_head_probe_timeout(config: &rdlp_types::Config) -> std::time::Duration {
     std::time::Duration::from_secs(
         config
@@ -103,13 +101,13 @@ async fn enrich_single_hls_format(
     url: &str,
     extractor_name: &str,
     verbose: bool,
+    op_timeout: std::time::Duration,
 ) -> (Option<bool>, Option<bool>) {
-    use std::time::Duration;
     use tokio::time::timeout;
 
     let result = timeout(
-        Duration::from_secs(10),
-        hls_detector.detect_hls_metadata(url),
+        op_timeout,
+        hls_detector.detect_hls_metadata(url, op_timeout),
     )
     .await;
 
@@ -214,10 +212,11 @@ async fn detect_format_sizes_inner(
     detect_sizes: bool,
 ) -> (Vec<rdlp_types::Format>, HlsStreamFlags) {
     use futures::future::join_all;
-    use std::time::Duration;
     use tokio::time::timeout;
 
     let verbose = ctx.config.verbose;
+    let op_timeout = resolve_hls_operation_timeout(&ctx.config);
+    let head_timeout = resolve_hls_head_probe_timeout(&ctx.config);
     let mut hls_detector = HlsSizeDetector::new(ctx.http_client.clone(), verbose);
 
     // Propagate HTTP headers from formats (e.g., Referer) to the HLS detector.
@@ -262,8 +261,8 @@ async fn detect_format_sizes_inner(
                 if is_hls {
                     // Try to expand master playlist into per-variant formats
                     let result = timeout(
-                        Duration::from_secs(10),
-                        hls_detector.detect_hls_variants(&url),
+                        op_timeout,
+                        hls_detector.detect_hls_variants(&url, op_timeout),
                     )
                     .await;
 
@@ -283,6 +282,7 @@ async fn detect_format_sizes_inner(
                                 &url,
                                 &extractor_name,
                                 verbose,
+                                op_timeout,
                             )
                             .await;
                             return vec![(format, is_live, has_enc)];
@@ -420,8 +420,8 @@ async fn detect_format_sizes_inner(
                     let mut format = format;
                     if detect_sizes {
                         let result = timeout(
-                            Duration::from_secs(5),
-                            BaseExtractor::detect_file_size(&url, &http_client, None),
+                            head_timeout,
+                            BaseExtractor::detect_file_size(&url, &http_client, None, head_timeout),
                         )
                         .await;
 

--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -28,7 +28,7 @@
 //! let detector = HlsSizeDetector::new(http_client, false);
 //!
 //! let m3u8_url = "https://example.com/playlist.m3u8";
-//! if let Some(size) = detector.detect_size(m3u8_url).await? {
+//! if let Some(size) = detector.detect_size(m3u8_url, std::time::Duration::from_secs(10)).await? {
 //!     println!("Total size: {} MB", size / 1_000_000);
 //! }
 //! # Ok(())

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -149,7 +149,12 @@ impl HlsSizeDetector {
                 // Validate the resolved media playlist URL (SSRF protection)
                 BaseExtractor::validate_url_security(&media_playlist_url)?;
 
-                // Recursively parse the media playlist
+                // Recursively parse the media playlist. Each recursion level
+                // passes the FULL `timeout` to its own `RequestBuilder::timeout`
+                // (per-request budget, not per-tree). The wall-clock cap on
+                // the entire call tree is enforced by the outer
+                // `tokio::time::timeout` at the call site in
+                // `hls/format_detection.rs`, not here.
                 Box::pin(self.parse_playlist(&media_playlist_url, timeout)).await
             }
         }

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -24,12 +24,16 @@ impl HlsSizeDetector {
     /// # Returns
     /// * `Ok(Vec<String>)` - List of segment URLs
     /// * `Err(_)` - Network error, parse error, or master playlist detected
-    pub(super) async fn parse_playlist(&self, m3u8_url: &str) -> Result<Vec<String>> {
+    pub(super) async fn parse_playlist(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Vec<String>> {
         if self.verbose {
             debug!(url:? = m3u8_url; "HLS fetching playlist");
         }
 
-        let playlist_text = self.fetch_playlist_text(m3u8_url).await?;
+        let playlist_text = self.fetch_playlist_text(m3u8_url, timeout).await?;
 
         if self.verbose {
             debug!(bytes = playlist_text.len(); "HLS playlist size");
@@ -146,7 +150,7 @@ impl HlsSizeDetector {
                 BaseExtractor::validate_url_security(&media_playlist_url)?;
 
                 // Recursively parse the media playlist
-                Box::pin(self.parse_playlist(&media_playlist_url)).await
+                Box::pin(self.parse_playlist(&media_playlist_url, timeout)).await
             }
         }
     }

--- a/crates/rdlp-extractor/src/hls/variants.rs
+++ b/crates/rdlp-extractor/src/hls/variants.rs
@@ -164,14 +164,18 @@ impl HlsSizeDetector {
     ///
     /// Panics if a master playlist has variants but none can be selected
     /// (programmer error — the filter + `or_else` fallback should always find one).
-    pub async fn detect_hls_metadata(&self, m3u8_url: &str) -> Result<Option<HlsInfo>> {
+    pub async fn detect_hls_metadata(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Option<HlsInfo>> {
         BaseExtractor::validate_url_security(m3u8_url)?;
 
         if self.verbose {
             debug!(url:? = m3u8_url; "HLS detecting metadata");
         }
 
-        let playlist_text = match self.fetch_playlist_text(m3u8_url).await {
+        let playlist_text = match self.fetch_playlist_text(m3u8_url, timeout).await {
             Ok(text) => text,
             Err(e) => {
                 if self.verbose {
@@ -249,7 +253,8 @@ impl HlsSizeDetector {
 
                 BaseExtractor::validate_url_security(&media_url)?;
 
-                let media_info = match self.fetch_and_extract_media_info(&media_url).await {
+                let media_info = match self.fetch_and_extract_media_info(&media_url, timeout).await
+                {
                     Ok(Some(info)) => info,
                     Ok(None) | Err(_) => {
                         // Return what we have from the master playlist
@@ -336,10 +341,14 @@ impl HlsSizeDetector {
     ///
     /// Panics if a master playlist has non-I-frame variants but none can be selected
     /// (programmer error — the filter + `or_else` fallback should always find one).
-    pub async fn detect_hls_variants(&self, m3u8_url: &str) -> Result<Vec<HlsVariantInfo>> {
+    pub async fn detect_hls_variants(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Vec<HlsVariantInfo>> {
         BaseExtractor::validate_url_security(m3u8_url)?;
 
-        let playlist_text = match self.fetch_playlist_text(m3u8_url).await {
+        let playlist_text = match self.fetch_playlist_text(m3u8_url, timeout).await {
             Ok(text) => text,
             Err(e) => {
                 if self.verbose {
@@ -400,7 +409,10 @@ impl HlsSizeDetector {
             })?
             .to_string();
 
-        if let Ok(Some(media_info)) = self.fetch_and_extract_media_info(&best_media_url).await {
+        if let Ok(Some(media_info)) = self
+            .fetch_and_extract_media_info(&best_media_url, timeout)
+            .await
+        {
             for v in &mut variants {
                 v.segment_count = media_info.segment_count;
                 v.total_duration = Some(media_info.total_duration);

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -171,6 +171,21 @@ pub struct Config {
     #[serde(default)]
     pub pool_idle_timeout: Option<u64>,
 
+    /// Wall-clock cap on multi-step HLS probes (master playlist fetch + parse,
+    /// per-format metadata refresh). Distinct from the socket-level
+    /// `read_timeout`: this is total elapsed time for the helper, regardless
+    /// of how many TCP reads it spans. Used by
+    /// `crates/rdlp-extractor/src/hls/format_detection.rs`.
+    /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
+    pub hls_operation_timeout: Option<u64>,
+
+    /// Wall-clock cap on a single HEAD probe used to detect content-length on
+    /// non-HLS formats. Smaller than `hls_operation_timeout` because the
+    /// operation is a single HEAD request (with a Range-GET fallback), not a
+    /// multi-step playlist parse.
+    /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
+    pub hls_head_probe_timeout: Option<u64>,
+
     /// Source IP address to bind to
     pub source_address: Option<String>,
 
@@ -359,6 +374,8 @@ impl Default for Config {
             socket_timeout: Some(30),
             read_timeout: None,
             pool_idle_timeout: None,
+            hls_operation_timeout: Some(10),
+            hls_head_probe_timeout: Some(5),
             source_address: None,
             user_agent: Some(
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36".to_string(),
@@ -544,6 +561,22 @@ impl Config {
             return Err(ConfigValidationError::OutOfRange {
                 field: "pool_idle_timeout",
                 reason: "must be 0..=3600 seconds (0 = disabled)",
+            });
+        }
+        if let Some(t) = self.hls_operation_timeout
+            && !(1..=300).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "hls_operation_timeout",
+                reason: "must be 1..=300 seconds",
+            });
+        }
+        if let Some(t) = self.hls_head_probe_timeout
+            && !(1..=300).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "hls_head_probe_timeout",
+                reason: "must be 1..=300 seconds",
             });
         }
 

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -480,7 +480,14 @@ fn hls_operation_timeout_above_max_rejected() {
         hls_operation_timeout: Some(301),
         ..Config::default()
     };
-    assert!(c.validate().is_err());
+    let err = c.validate().expect_err("must reject");
+    assert!(matches!(
+        err,
+        ConfigValidationError::OutOfRange {
+            field: "hls_operation_timeout",
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -499,7 +506,25 @@ fn hls_head_probe_timeout_above_max_rejected() {
         hls_head_probe_timeout: Some(301),
         ..Config::default()
     };
-    assert!(c.validate().is_err());
+    let err = c.validate().expect_err("must reject");
+    assert!(matches!(
+        err,
+        ConfigValidationError::OutOfRange {
+            field: "hls_head_probe_timeout",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn hls_timeouts_partial_json_inherits_struct_default() {
+    // Struct-level `#[serde(default)]` means an empty/partial JSON deserializes
+    // to `Config::default()`-overlaid values. Pin the documented default
+    // (Some(10) / Some(5)) so a future refactor that strips struct-level
+    // serde(default) and forgets to add per-field annotations gets caught.
+    let c: Config = serde_json::from_str("{}").expect("partial config must deserialize");
+    assert_eq!(c.hls_operation_timeout, Some(10));
+    assert_eq!(c.hls_head_probe_timeout, Some(5));
 }
 
 #[test]

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -451,3 +451,66 @@ fn socket_timeout_rejects_above_300() {
         })
     ));
 }
+
+#[test]
+fn hls_operation_timeout_default_is_some_10() {
+    let c = Config::default();
+    assert_eq!(c.hls_operation_timeout, Some(10));
+}
+
+#[test]
+fn hls_head_probe_timeout_default_is_some_5() {
+    let c = Config::default();
+    assert_eq!(c.hls_head_probe_timeout, Some(5));
+}
+
+#[test]
+fn hls_operation_timeout_zero_rejected() {
+    let c = Config {
+        hls_operation_timeout: Some(0),
+        ..Config::default()
+    };
+    let err = c.validate().expect_err("must reject");
+    assert!(format!("{err:#}").contains("hls_operation_timeout"));
+}
+
+#[test]
+fn hls_operation_timeout_above_max_rejected() {
+    let c = Config {
+        hls_operation_timeout: Some(301),
+        ..Config::default()
+    };
+    assert!(c.validate().is_err());
+}
+
+#[test]
+fn hls_head_probe_timeout_zero_rejected() {
+    let c = Config {
+        hls_head_probe_timeout: Some(0),
+        ..Config::default()
+    };
+    let err = c.validate().expect_err("must reject");
+    assert!(format!("{err:#}").contains("hls_head_probe_timeout"));
+}
+
+#[test]
+fn hls_head_probe_timeout_above_max_rejected() {
+    let c = Config {
+        hls_head_probe_timeout: Some(301),
+        ..Config::default()
+    };
+    assert!(c.validate().is_err());
+}
+
+#[test]
+fn hls_timeouts_round_trip_serde() {
+    let c = Config {
+        hls_operation_timeout: Some(15),
+        hls_head_probe_timeout: Some(7),
+        ..Config::default()
+    };
+    let json = serde_json::to_string(&c).expect("serialize");
+    let back: Config = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.hls_operation_timeout, Some(15));
+    assert_eq!(back.hls_head_probe_timeout, Some(7));
+}

--- a/docs/superpowers/plans/2026-05-04-hls-operation-timeouts-configurable.md
+++ b/docs/superpowers/plans/2026-05-04-hls-operation-timeouts-configurable.md
@@ -1,0 +1,813 @@
+# HLS Operation Timeouts — Configurable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the 3 hard-coded `Duration::from_secs(N)` timeouts in `crates/rdlp-extractor/src/hls/format_detection.rs` to two new `Config` fields (`hls_operation_timeout`, `hls_head_probe_timeout`), and push the same durations into `wreq::RequestBuilder::timeout(D)` on the inner HTTP requests for defense-in-depth.
+
+**Architecture:** Two `Option<u64>` fields on `rdlp_types::Config` mirror the existing `socket_timeout` shape. `format_detection.rs` resolves them via small helpers (`resolve_hls_operation_timeout` / `resolve_hls_head_probe_timeout`) and threads `Duration` arguments down to (1) `enrich_single_hls_format`, (2) `HlsSizeDetector::fetch_playlist_text` (chokepoint for `detect_hls_metadata` + `detect_hls_variants`), (3) `BaseExtractor::detect_file_size` (gains 4th param, applies to both inner HEAD + Range-GET requests).
+
+**Tech Stack:** Rust 1.85, `wreq` (TLS-impersonating reqwest fork — `RequestBuilder::timeout(Duration)` verified at `rdlp-api/src/orchestrator/subtitle_pipeline/mod.rs:93`), `tokio::time::timeout`, `mockito` for one end-to-end test.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-hls-operation-timeouts-configurable-design.md`
+
+**Branch:** `feature/hls-operation-timeouts-configurable` (already created from `develop`).
+
+**Issue:** [#277](https://github.com/crippledgeek/rdlp/issues/277). Closes on merge.
+
+---
+
+## Verified call-site shapes (from research pass)
+
+| Site | File:line | Current | New plumbing |
+|---|---|---|---|
+| 1. `enrich_single_hls_format` | `crates/rdlp-extractor/src/hls/format_detection.rs:79-82` | `timeout(Duration::from_secs(10), hls_detector.detect_hls_metadata(url))` | New `op_timeout: Duration` param on the function; caller passes `resolve_hls_operation_timeout(&ctx.config)`. |
+| 2. `detect_format_sizes_inner` HLS branch | `crates/rdlp-extractor/src/hls/format_detection.rs:233-237` | `timeout(Duration::from_secs(10), hls_detector.detect_hls_variants(&url))` | Replace literal with `resolve_hls_operation_timeout(&ctx.config)`. |
+| 3. `detect_format_sizes_inner` non-HLS branch | `crates/rdlp-extractor/src/hls/format_detection.rs:391-395` | `timeout(Duration::from_secs(5), BaseExtractor::detect_file_size(&url, &http_client, None))` | Replace literal with `resolve_hls_head_probe_timeout(&ctx.config)`; pass that same Duration as the new 4th arg to `detect_file_size`. |
+
+`fetch_playlist_text` (the chokepoint inside `HlsSizeDetector` for sites 1 + 2) gains a `timeout: Duration` parameter and applies `.timeout(timeout)` to its `RequestBuilder` at `crates/rdlp-extractor/src/hls/detector.rs:236`.
+
+`detect_file_size` at `crates/rdlp-extractor/src/base/common/mod.rs:379` (signature `(url, http_client, log_prefix)`) gains `timeout: Duration` as the 4th param and applies `.timeout(timeout)` to BOTH the HEAD call (line ~386) AND the Range-GET fallback (line ~395-399).
+
+---
+
+## Task 1 — Add `Config` fields + validation + tests
+
+**Files:**
+- Modify: `crates/rdlp-types/src/config.rs`
+- Test: `crates/rdlp-types/src/config_tests.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `crates/rdlp-types/src/config_tests.rs`. Look for an existing test like `socket_timeout_zero_rejected` to mirror the exact import / call shape. Then add:
+
+```rust
+#[test]
+fn hls_operation_timeout_default_is_some_10() {
+    let c = Config::default();
+    assert_eq!(c.hls_operation_timeout, Some(10));
+}
+
+#[test]
+fn hls_head_probe_timeout_default_is_some_5() {
+    let c = Config::default();
+    assert_eq!(c.hls_head_probe_timeout, Some(5));
+}
+
+#[test]
+fn hls_operation_timeout_zero_rejected() {
+    let c = Config {
+        hls_operation_timeout: Some(0),
+        ..Config::default()
+    };
+    let err = c.validate().expect_err("must reject");
+    assert!(format!("{err:#}").contains("hls_operation_timeout"));
+}
+
+#[test]
+fn hls_operation_timeout_above_max_rejected() {
+    let c = Config {
+        hls_operation_timeout: Some(301),
+        ..Config::default()
+    };
+    assert!(c.validate().is_err());
+}
+
+#[test]
+fn hls_head_probe_timeout_zero_rejected() {
+    let c = Config {
+        hls_head_probe_timeout: Some(0),
+        ..Config::default()
+    };
+    let err = c.validate().expect_err("must reject");
+    assert!(format!("{err:#}").contains("hls_head_probe_timeout"));
+}
+
+#[test]
+fn hls_head_probe_timeout_above_max_rejected() {
+    let c = Config {
+        hls_head_probe_timeout: Some(301),
+        ..Config::default()
+    };
+    assert!(c.validate().is_err());
+}
+
+#[test]
+fn hls_timeouts_round_trip_serde() {
+    let c = Config {
+        hls_operation_timeout: Some(15),
+        hls_head_probe_timeout: Some(7),
+        ..Config::default()
+    };
+    let json = serde_json::to_string(&c).expect("serialize");
+    let back: Config = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.hls_operation_timeout, Some(15));
+    assert_eq!(back.hls_head_probe_timeout, Some(7));
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `cargo test -p rdlp-types hls_operation_timeout hls_head_probe_timeout hls_timeouts_round_trip_serde`
+Expected: compile error (fields don't exist).
+
+- [ ] **Step 3: Add the two fields**
+
+In `crates/rdlp-types/src/config.rs`, locate the existing HTTP timeout field block (around lines 148-172 — `socket_timeout`, `read_timeout`, `pool_idle_timeout`). Add IMMEDIATELY AFTER `pool_idle_timeout`:
+
+```rust
+    /// Wall-clock cap on multi-step HLS probes (master playlist fetch + parse,
+    /// per-format metadata refresh). Distinct from the socket-level
+    /// `read_timeout`: this is total elapsed time for the helper, regardless
+    /// of how many TCP reads it spans. Used by
+    /// `crates/rdlp-extractor/src/hls/format_detection.rs`.
+    /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
+    pub hls_operation_timeout: Option<u64>,
+
+    /// Wall-clock cap on a single HEAD probe used to detect content-length on
+    /// non-HLS formats. Smaller than `hls_operation_timeout` because the
+    /// operation is a single HEAD request (with a Range-GET fallback), not a
+    /// multi-step playlist parse.
+    /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
+    pub hls_head_probe_timeout: Option<u64>,
+```
+
+In `impl Default for Config { fn default() -> Self { Self { ... } } }` (around line 359 — read it to confirm exact position), add to the field initializer list (alongside the other timeout defaults):
+
+```rust
+            hls_operation_timeout: Some(10),
+            hls_head_probe_timeout: Some(5),
+```
+
+In `Config::validate()` (around lines 524-548 — the existing HTTP timeout validation block), add IMMEDIATELY AFTER the `pool_idle_timeout` validation:
+
+```rust
+        if let Some(t) = self.hls_operation_timeout
+            && !(1..=300).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "hls_operation_timeout",
+                reason: "must be 1..=300 seconds",
+            });
+        }
+        if let Some(t) = self.hls_head_probe_timeout
+            && !(1..=300).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "hls_head_probe_timeout",
+                reason: "must be 1..=300 seconds",
+            });
+        }
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `cargo test -p rdlp-types hls_`
+Expected: all 7 PASS.
+
+Run full crate: `cargo test -p rdlp-types`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add crates/rdlp-types/src/config.rs crates/rdlp-types/src/config_tests.rs
+git commit -m "feat(types): add hls_operation_timeout and hls_head_probe_timeout to Config (#277)"
+```
+
+---
+
+## Task 2 — Add resolver helpers in `format_detection.rs`
+
+**Files:**
+- Modify: `crates/rdlp-extractor/src/hls/format_detection.rs`
+
+These are tiny pure functions that read from `Config` and return `Duration`. They exist to give us a structural test seam (per spec test plan) and to centralize the default values so the call sites stay tidy.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the existing `#[cfg(test)] mod tests { ... }` block in `crates/rdlp-extractor/src/hls/format_detection.rs` (read the file first to confirm the test module location and pattern). If there's no existing test module in this file, create one at the end of the file:
+
+```rust
+#[cfg(test)]
+mod resolve_timeout_tests {
+    use super::{resolve_hls_head_probe_timeout, resolve_hls_operation_timeout};
+    use rdlp_types::Config;
+    use std::time::Duration;
+
+    #[test]
+    fn op_timeout_uses_default_when_none() {
+        let c = Config {
+            hls_operation_timeout: None,
+            ..Config::default()
+        };
+        // Note: Config::default() pre-populates Some(10), so we assert against
+        // the explicit-None case to prove the fallback. We override with None
+        // after Config::default() so the helper's None branch is exercised.
+        // (Also covers the "field stripped from settings.toml" path.)
+        let mut c = c;
+        c.hls_operation_timeout = None;
+        assert_eq!(resolve_hls_operation_timeout(&c), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn op_timeout_uses_override_when_some() {
+        let mut c = Config::default();
+        c.hls_operation_timeout = Some(45);
+        assert_eq!(resolve_hls_operation_timeout(&c), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn head_probe_timeout_uses_default_when_none() {
+        let mut c = Config::default();
+        c.hls_head_probe_timeout = None;
+        assert_eq!(resolve_hls_head_probe_timeout(&c), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn head_probe_timeout_uses_override_when_some() {
+        let mut c = Config::default();
+        c.hls_head_probe_timeout = Some(2);
+        assert_eq!(resolve_hls_head_probe_timeout(&c), Duration::from_secs(2));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+`cargo test -p rdlp-extractor resolve_timeout_tests`
+Expected: compile error (helpers don't exist).
+
+- [ ] **Step 3: Add the helpers**
+
+In `crates/rdlp-extractor/src/hls/format_detection.rs`, near the top of the module (after `use` statements, before the first `pub fn`), add:
+
+```rust
+/// Default cap on multi-step HLS probes when `Config::hls_operation_timeout`
+/// is unset. Matches the legacy hard-coded value before #277.
+const DEFAULT_HLS_OPERATION_TIMEOUT_SECS: u64 = 10;
+
+/// Default cap on the single-HEAD probe for non-HLS file size detection
+/// when `Config::hls_head_probe_timeout` is unset. Matches the legacy
+/// hard-coded value before #277.
+const DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS: u64 = 5;
+
+/// Resolve the wall-clock cap for HLS metadata / variant probes from `Config`,
+/// falling back to `DEFAULT_HLS_OPERATION_TIMEOUT_SECS` when unset.
+pub(crate) fn resolve_hls_operation_timeout(config: &rdlp_types::Config) -> std::time::Duration {
+    std::time::Duration::from_secs(
+        config
+            .hls_operation_timeout
+            .unwrap_or(DEFAULT_HLS_OPERATION_TIMEOUT_SECS),
+    )
+}
+
+/// Resolve the wall-clock cap for the non-HLS HEAD-probe from `Config`,
+/// falling back to `DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS` when unset.
+pub(crate) fn resolve_hls_head_probe_timeout(config: &rdlp_types::Config) -> std::time::Duration {
+    std::time::Duration::from_secs(
+        config
+            .hls_head_probe_timeout
+            .unwrap_or(DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS),
+    )
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+`cargo test -p rdlp-extractor resolve_timeout_tests`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add crates/rdlp-extractor/src/hls/format_detection.rs
+git commit -m "feat(extractor): add resolve_hls_operation_timeout / resolve_hls_head_probe_timeout helpers (#277)"
+```
+
+---
+
+## Task 3 — Thread `Duration` into `fetch_playlist_text` + `RequestBuilder::timeout`
+
+**Files:**
+- Modify: `crates/rdlp-extractor/src/hls/detector.rs`
+- Modify: `crates/rdlp-extractor/src/hls/variants.rs`
+
+`fetch_playlist_text` is `pub(super)` per `crates/rdlp-extractor/src/hls/detector.rs:235`. It's called from `detect_hls_metadata` (`hls/variants.rs:174`) and `detect_hls_variants` (`hls/variants.rs:343`).
+
+- [ ] **Step 1: Read the current shapes**
+
+Read:
+- `crates/rdlp-extractor/src/hls/detector.rs` lines 230-275 (full `fetch_playlist_text` body).
+- `crates/rdlp-extractor/src/hls/variants.rs` lines 167-185 (`detect_hls_metadata` start).
+- `crates/rdlp-extractor/src/hls/variants.rs` lines 335-355 (`detect_hls_variants` start).
+
+Confirm there are exactly two callers of `fetch_playlist_text`. (Search: `grep -n "fetch_playlist_text" crates/rdlp-extractor/src/hls/`.)
+
+- [ ] **Step 2: Update `fetch_playlist_text` signature**
+
+In `crates/rdlp-extractor/src/hls/detector.rs:235`, change:
+
+```rust
+    pub(super) async fn fetch_playlist_text(&self, m3u8_url: &str) -> Result<String> {
+        let mut request = self.http_client.get(m3u8_url);
+        if let Some(headers) = &self.default_headers {
+            request = request.headers(headers.clone());
+        }
+        let response = request.send().await.map_err(|e| {
+```
+
+to:
+
+```rust
+    pub(super) async fn fetch_playlist_text(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<String> {
+        let mut request = self.http_client.get(m3u8_url).timeout(timeout);
+        if let Some(headers) = &self.default_headers {
+            request = request.headers(headers.clone());
+        }
+        let response = request.send().await.map_err(|e| {
+```
+
+(The `.timeout(timeout)` chains immediately after `.get(m3u8_url)` so it applies to the request even if `default_headers` add more state.)
+
+- [ ] **Step 3: Update both callers in `variants.rs`**
+
+In `crates/rdlp-extractor/src/hls/variants.rs:167`, change `detect_hls_metadata`'s signature:
+
+```rust
+    pub async fn detect_hls_metadata(&self, m3u8_url: &str) -> Result<Option<HlsInfo>> {
+```
+
+to:
+
+```rust
+    pub async fn detect_hls_metadata(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Option<HlsInfo>> {
+```
+
+And update the inner call (around line 174) from `self.fetch_playlist_text(m3u8_url).await` to `self.fetch_playlist_text(m3u8_url, timeout).await`.
+
+In `crates/rdlp-extractor/src/hls/variants.rs:339`, mirror the change for `detect_hls_variants`:
+
+```rust
+    pub async fn detect_hls_variants(
+        &self,
+        m3u8_url: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Vec<HlsVariantInfo>> {
+```
+
+And update its inner call (around line 343) the same way.
+
+- [ ] **Step 4: Verify the new compilation surface — expect callers in `format_detection.rs` to break**
+
+Run: `cargo check -p rdlp-extractor 2>&1 | head -40`
+Expected: errors at the call sites in `format_detection.rs` lines 81, 235 (the outer `tokio::time::timeout` arms that now invoke `detect_hls_metadata` / `detect_hls_variants` with the OLD signature). These are fixed in Task 4.
+
+If there are other callers of `detect_hls_metadata` or `detect_hls_variants` outside `format_detection.rs`, the call sites need updating now. Find them:
+
+```bash
+grep -rn "detect_hls_metadata\|detect_hls_variants" crates/ | grep -v test | grep -v fetch_playlist_text
+```
+
+If extras exist, update them too with `Duration::from_secs(10)` literal (a follow-up commit can plumb their proper Config later). Note this in the commit body so it's discoverable.
+
+- [ ] **Step 5: Commit (compilation will fail at this stage — that's expected; Task 4 fixes it)**
+
+DO NOT commit at the end of Task 3. Continue directly to Task 4 in a single batch — committing a broken build mid-branch violates the per-commit-green discipline.
+
+If you absolutely must split, mark the Task 3 commit as a WIP-style intermediate and ensure Task 4 lands in the same PR. Better: defer the commit until Task 4 completes.
+
+---
+
+## Task 4 — Update call sites in `format_detection.rs`
+
+**Files:**
+- Modify: `crates/rdlp-extractor/src/hls/format_detection.rs`
+
+- [ ] **Step 1: Update the three call sites**
+
+In `crates/rdlp-extractor/src/hls/format_detection.rs`:
+
+**Site 1** — `enrich_single_hls_format` (around lines 69-100). Read the current function signature (you'll see it does NOT take `ctx` — only `hls_detector, url, extractor_name, verbose`). Add a new parameter `op_timeout: std::time::Duration`. The call site inside (around line 79-82):
+
+```rust
+    let result = timeout(
+        Duration::from_secs(10),
+        hls_detector.detect_hls_metadata(url),
+    )
+```
+
+becomes:
+
+```rust
+    let result = timeout(
+        op_timeout,
+        hls_detector.detect_hls_metadata(url, op_timeout),
+    )
+```
+
+(The same `op_timeout` is used for both the outer `tokio::time::timeout` and the inner `RequestBuilder::timeout` propagation through `fetch_playlist_text`. This is the defense-in-depth pattern.)
+
+**Site 2** — `detect_format_sizes_inner` HLS branch (around lines 233-237):
+
+```rust
+                    let result = timeout(
+                        Duration::from_secs(10),
+                        hls_detector.detect_hls_variants(&url),
+                    )
+```
+
+becomes:
+
+```rust
+                    let op_timeout = resolve_hls_operation_timeout(&ctx.config);
+                    let result = timeout(
+                        op_timeout,
+                        hls_detector.detect_hls_variants(&url, op_timeout),
+                    )
+```
+
+(Resolve once into a local so both the outer and inner timeouts get the same value.)
+
+**Site 3** — `detect_format_sizes_inner` non-HLS branch (around lines 391-395):
+
+```rust
+                        let result = timeout(
+                            Duration::from_secs(5),
+                            BaseExtractor::detect_file_size(&url, &http_client, None),
+                        )
+```
+
+becomes:
+
+```rust
+                        let head_timeout = resolve_hls_head_probe_timeout(&ctx.config);
+                        let result = timeout(
+                            head_timeout,
+                            BaseExtractor::detect_file_size(&url, &http_client, None, head_timeout),
+                        )
+```
+
+(`detect_file_size` gains a 4th `Duration` arg in Task 5. This site call must match.)
+
+- [ ] **Step 2: Update the caller of `enrich_single_hls_format`**
+
+Find where `enrich_single_hls_format` is called from (almost certainly `detect_format_sizes_inner`). Resolve the duration from `ctx.config` once and pass it down:
+
+```rust
+let op_timeout = resolve_hls_operation_timeout(&ctx.config);
+// ... call enrich_single_hls_format(..., op_timeout)
+```
+
+Reuse the same `op_timeout` local from Site 2 if the function structure permits (no double-resolution).
+
+- [ ] **Step 3: Verify partial compile — expect Task 5 break only**
+
+Run: `cargo check -p rdlp-extractor 2>&1 | tail -10`
+Expected: only the call to `detect_file_size(&url, &http_client, None, head_timeout)` errors because `detect_file_size` doesn't yet have the 4th param. (Task 5.)
+
+- [ ] **Step 4: Don't commit yet — proceed directly to Task 5.**
+
+---
+
+## Task 5 — Add `timeout: Duration` to `detect_file_size`
+
+**Files:**
+- Modify: `crates/rdlp-extractor/src/base/common/mod.rs`
+
+- [ ] **Step 1: Update the signature**
+
+In `crates/rdlp-extractor/src/base/common/mod.rs:379-410`, change:
+
+```rust
+    pub(crate) async fn detect_file_size(
+        url: &str,
+        http_client: &wreq::Client,
+        log_prefix: Option<&str>,
+    ) -> Option<u64> {
+        // Strategy 1: HEAD request
+        if let Ok(response) = http_client.head(url).send().await
+            && let Some(size) = response.content_length().filter(|&s| s > 0)
+        {
+```
+
+to:
+
+```rust
+    pub(crate) async fn detect_file_size(
+        url: &str,
+        http_client: &wreq::Client,
+        log_prefix: Option<&str>,
+        timeout: std::time::Duration,
+    ) -> Option<u64> {
+        // Strategy 1: HEAD request
+        if let Ok(response) = http_client.head(url).timeout(timeout).send().await
+            && let Some(size) = response.content_length().filter(|&s| s > 0)
+        {
+```
+
+And in the Range-GET fallback (around line 395):
+
+```rust
+        // Strategy 2: Range request fallback
+        if let Ok(response) = http_client
+            .get(url)
+            .header("Range", "bytes=0-0")
+            .send()
+            .await
+```
+
+becomes:
+
+```rust
+        // Strategy 2: Range request fallback
+        if let Ok(response) = http_client
+            .get(url)
+            .header("Range", "bytes=0-0")
+            .timeout(timeout)
+            .send()
+            .await
+```
+
+- [ ] **Step 2: Update doc-example in the rustdoc**
+
+Lines 374-376 of the same file have:
+
+```rust
+    /// let size = BaseExtractor::detect_file_size(&url, &ctx.http_client, None).await;
+    /// let size = BaseExtractor::detect_file_size(&url, &client, Some("HLS")).await;
+```
+
+Update to:
+
+```rust
+    /// let size = BaseExtractor::detect_file_size(&url, &ctx.http_client, None, Duration::from_secs(5)).await;
+    /// let size = BaseExtractor::detect_file_size(&url, &client, Some("HLS"), Duration::from_secs(5)).await;
+```
+
+- [ ] **Step 3: Update other callers of `detect_file_size`**
+
+Find them:
+
+```bash
+grep -rn "detect_file_size" crates/ | grep -v "fn detect_file_size" | grep -v test
+```
+
+For each call site, add a `Duration::from_secs(5)` 4th argument (mirroring the previous outer `tokio::time::timeout` cap). If a site has its own custom cap or no `tokio::time::timeout` wrapper today, use `Duration::from_secs(30)` as a defensive default; document the choice in the commit body.
+
+- [ ] **Step 4: Verify full compile**
+
+```
+cargo fmt
+cargo check --workspace
+```
+Expected: clean.
+
+- [ ] **Step 5: Run all extractor tests + types tests**
+
+```
+cargo test -p rdlp-types
+cargo test -p rdlp-extractor
+```
+Expected: all green (the existing tests should not be affected by adding the 4th arg + timeout chaining).
+
+- [ ] **Step 6: Commit (Tasks 3 + 4 + 5 batched)**
+
+```bash
+cargo fmt
+git add crates/rdlp-extractor/src/hls/detector.rs \
+        crates/rdlp-extractor/src/hls/variants.rs \
+        crates/rdlp-extractor/src/hls/format_detection.rs \
+        crates/rdlp-extractor/src/base/common/mod.rs
+git commit -m "feat(extractor): make HLS operation + HEAD probe timeouts configurable (#277)
+
+Threads Duration through fetch_playlist_text, detect_hls_metadata,
+detect_hls_variants, detect_file_size. Pushes RequestBuilder::timeout(D)
+on inner HTTP requests for defense in depth. Replaces hard-coded 10s/5s
+in format_detection.rs with resolve_hls_operation_timeout /
+resolve_hls_head_probe_timeout helpers reading from Config."
+```
+
+---
+
+## Task 6 — End-to-end mockito test (single, slowest path)
+
+**Files:**
+- Test: `crates/rdlp-extractor/src/hls/format_detection.rs` (or `tests/` if integration-test-style)
+
+Per spec test plan, structural helper tests in Task 2 are the workhorse; one end-to-end mockito test pins the timeout-firing behavior on the slowest path.
+
+- [ ] **Step 1: Find the in-repo mockito pattern**
+
+Read an existing mockito-driven test in this crate. Examples:
+- `crates/rdlp-extractor/src/xhamster/mod.rs:512` (mod.rs unit-test pattern)
+- `crates/rdlp-extractor/src/koreanpornmovie/mod.rs:896`
+
+The CLAUDE.md note explicitly says: "HLS tests use unit tests, not integration tests" because of the loopback bypass at `crates/rdlp-extractor/src/hls/expand.rs:92-107`. This test must therefore live in `#[cfg(test)] mod` inside `src/`, not in `tests/`.
+
+- [ ] **Step 2: Write the test**
+
+Append to the existing `#[cfg(test)] mod` inside `crates/rdlp-extractor/src/hls/format_detection.rs` (or create the module if absent):
+
+```rust
+#[cfg(test)]
+mod end_to_end_timeout_tests {
+    use super::*;
+    use mockito::Server;
+    use std::time::{Duration, Instant};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn detect_file_size_respects_head_probe_timeout() {
+        // Arrange: mockito server that delays HEAD by 5s. Configure 1s
+        // timeout. Expect the call to return None within ~1.5s wall-clock.
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("HEAD", "/slow")
+            .with_status(200)
+            .with_chunked_body(|_| Ok(()))
+            // Real-time delay simulating a slow CDN.
+            .expect_at_most(1)
+            .create_async()
+            .await;
+
+        // mockito doesn't expose a direct "delay" hook for HEAD; instead,
+        // configure the mock to NEVER respond and rely on the timeout firing.
+        // (Adjust if a future mockito version exposes a per-mock delay.)
+        // For now: use mockito::Server::host_with_port() against a black-hole
+        // path that the mock-server holds open. If this test pattern
+        // doesn't work cleanly with mockito 1.x, fall back to a hand-rolled
+        // tokio::net::TcpListener that accepts the connection then sleeps
+        // for 5s before responding.
+
+        let url = format!("{}/slow", server.url());
+        let client = wreq::Client::new();
+
+        let start = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            BaseExtractor::detect_file_size(
+                &url,
+                &client,
+                None,
+                Duration::from_secs(1),
+            ),
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        // The outer tokio::time::timeout fires at ~1s; OR the inner
+        // RequestBuilder::timeout fires at ~1s. Either way, the call
+        // returns within a small tolerance.
+        assert!(
+            elapsed < Duration::from_millis(2000),
+            "expected timeout within ~1s, got {elapsed:?}"
+        );
+
+        // The inner detect_file_size returns Option<u64>. When timed out
+        // by the inner RequestBuilder, both inner requests fail and the
+        // function returns None. When timed out by the outer wrapper,
+        // result is Err(Elapsed).
+        match result {
+            Ok(None) => {} // inner-timeout path — function returned None
+            Err(_) => {}   // outer-timeout path — Elapsed
+            Ok(Some(_)) => panic!("should not have detected a size"),
+        }
+    }
+}
+```
+
+If `mockito 1.x` does not support per-mock real-time delay, swap the approach to a hand-rolled `tokio::net::TcpListener` that accepts then sleeps:
+
+```rust
+// Alternative: hand-rolled black-hole listener
+let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+let port = listener.local_addr().unwrap().port();
+tokio::spawn(async move {
+    if let Ok((stream, _)) = listener.accept().await {
+        // Hold the connection open without responding for 5s.
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        drop(stream);
+    }
+});
+let url = format!("http://127.0.0.1:{port}/slow");
+// ... rest unchanged.
+```
+
+This bypasses mockito entirely and is the simplest reliable form for "block the request from completing." Confirm `validate_url_security` allows loopback IPs in test mode (it should — see the `#[cfg(test)]` bypass at `crates/rdlp-extractor/src/hls/expand.rs:92-107`).
+
+- [ ] **Step 3: Run the test**
+
+```
+cargo test -p rdlp-extractor end_to_end_timeout_tests::detect_file_size_respects_head_probe_timeout -- --nocapture
+```
+Expected: PASS (within ~1.5s wall-clock).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt
+git add crates/rdlp-extractor/src/hls/format_detection.rs
+git commit -m "test(extractor): end-to-end timeout test for detect_file_size HEAD probe (#277)"
+```
+
+---
+
+## Task 7 — Full verification gate + pre-push reviews
+
+**No code changes — verification + review.**
+
+- [ ] **Step 1: Verification gate**
+
+```bash
+cargo fmt --check
+cargo check --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+Every command must exit 0.
+
+- [ ] **Step 2: Dispatch security-reviewer**
+
+Pass: `BASE..HEAD` diff. Threat model focus:
+
+- DoS via misconfiguration (too-long timeout × too many extractors → resource accumulation)
+- Bypass scenarios (does the inner `RequestBuilder::timeout` actually fire on socket dead-end, or only on body bytes?)
+- Validation bypass (can a hand-edited `~/.config/rdlp/config.toml` set `hls_operation_timeout = 999999`?)
+- Per the rule at `~/.claude/rules/mandatory-pre-push-review.md`: HIGH/Critical findings MUST be fixed BEFORE push, not after.
+
+- [ ] **Step 3: Dispatch pr-review-toolkit:code-reviewer**
+
+Pass: `BASE..HEAD` diff. Project standards: `CODING_RULES.md`, `~/.claude/rules/no-hardcoded-magic-numbers.md` (this is the rule that motivated the work — verify the implementation actually conforms), `~/.claude/rules/bug-fix-requires-failing-test.md`.
+
+- [ ] **Step 4: Apply review fixes (if any) and re-verify**
+
+If reviewers flag HIGH/Critical or Important issues, fix in a follow-up commit on this branch and re-run the gate + reviews.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin feature/hls-operation-timeouts-configurable
+gh pr create --base develop \
+  --title "Lift HLS operation + HEAD-probe timeouts to Config (#277)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes #277.
+
+Lifts three hard-coded `Duration::from_secs(N)` values in
+`crates/rdlp-extractor/src/hls/format_detection.rs` to two new `Config`
+fields: `hls_operation_timeout` (default 10s, validated 1..=300) covering the
+two multi-step HLS probes, and `hls_head_probe_timeout` (default 5s, same range)
+covering the single-HEAD non-HLS file-size probe. Pushes the same `Duration`
+through `wreq::RequestBuilder::timeout(D)` on the inner HTTP requests for
+defense-in-depth.
+
+This is the first instance of the new global rule
+`~/.claude/rules/no-hardcoded-magic-numbers.md` being applied to a follow-up
+issue.
+
+## Test plan
+
+- [x] `cargo fmt --check` clean
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [x] `cargo test --workspace` — 0 failures
+- [x] 7 new validation tests + 4 helper-resolver tests + 1 end-to-end mockito test
+- [x] Pre-push security-reviewer ✅
+- [x] Pre-push code-reviewer ✅
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Two `Config` fields → Task 1 ✓
+- Validation 1..=300 → Task 1 ✓
+- Default values 10s/5s → Task 1 ✓
+- Resolver helpers → Task 2 ✓
+- 3 call-site rewires → Task 4 ✓
+- `RequestBuilder::timeout` defense in depth → Task 3 (`fetch_playlist_text`) + Task 5 (`detect_file_size`) ✓
+- Two-knob model preserved (multi-step vs single-HEAD) → Tasks 1+4 ✓
+- Tests: structural helper tests + 1 end-to-end → Task 2 + Task 6 ✓
+
+**Placeholder scan:** none.
+
+**Type consistency:**
+- `hls_operation_timeout: Option<u64>` everywhere it appears.
+- `Duration` parameters propagated as `std::time::Duration` (no `Duration::from_secs(u64)` ambiguity).
+- Resolver helpers consistently `pub(crate) fn ... -> Duration`.
+
+**Scope:** single PR; touches 5 files (`config.rs`, `config_tests.rs`, `format_detection.rs`, `detector.rs`, `variants.rs`, `base/common/mod.rs` — actually 6, all small targeted changes). One coherent diff.
+
+**Cross-task ordering note:** Tasks 3, 4, 5 must batch in a single commit (intermediate states fail to compile). Task 1, 2, 6, and 7 each commit independently.

--- a/docs/superpowers/specs/2026-05-04-hls-operation-timeouts-configurable-design.md
+++ b/docs/superpowers/specs/2026-05-04-hls-operation-timeouts-configurable-design.md
@@ -48,20 +48,20 @@ Per `~/.claude/rules/no-hardcoded-magic-numbers.md`, every numeric literal that 
 /// `read_timeout`: this is total elapsed time for the helper, regardless of
 /// how many TCP reads it spans.
 /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
-pub hls_operation_timeout_secs: Option<u64>,
+pub hls_operation_timeout: Option<u64>,
 
 /// Wall-clock cap on a single HEAD probe used to detect content-length on
-/// non-HLS formats. Smaller than `hls_operation_timeout_secs` because the
+/// non-HLS formats. Smaller than `hls_operation_timeout` because the
 /// operation is a single HEAD request, not a multi-step playlist parse.
 /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
-pub hls_head_probe_timeout_secs: Option<u64>,
+pub hls_head_probe_timeout: Option<u64>,
 ```
 
 Defaults match current constants:
 
 ```rust
-hls_operation_timeout_secs: Some(10),
-hls_head_probe_timeout_secs: Some(5),
+hls_operation_timeout: Some(10),
+hls_head_probe_timeout: Some(5),
 ```
 
 ### Validation (extend `Config::validate()`)
@@ -69,19 +69,19 @@ hls_head_probe_timeout_secs: Some(5),
 Mirror the existing 3-axis HTTP timeout pattern at `crates/rdlp-types/src/config.rs:524-548`:
 
 ```rust
-if let Some(t) = self.hls_operation_timeout_secs
+if let Some(t) = self.hls_operation_timeout
     && !(1..=300).contains(&t)
 {
     return Err(ConfigValidationError::OutOfRange {
-        field: "hls_operation_timeout_secs",
+        field: "hls_operation_timeout",
         reason: "must be 1..=300 seconds",
     });
 }
-if let Some(t) = self.hls_head_probe_timeout_secs
+if let Some(t) = self.hls_head_probe_timeout
     && !(1..=300).contains(&t)
 {
     return Err(ConfigValidationError::OutOfRange {
-        field: "hls_head_probe_timeout_secs",
+        field: "hls_head_probe_timeout",
         reason: "must be 1..=300 seconds",
     });
 }
@@ -89,16 +89,19 @@ if let Some(t) = self.hls_head_probe_timeout_secs
 
 ### Call-site rewiring
 
-`crates/rdlp-extractor/src/hls/format_detection.rs` reads the durations from `ctx.config` (or whatever the extractor context exposes — to be confirmed during implementation). Each call site replaces its hard-coded `Duration::from_secs(N)` with the configured value.
+Verified in research pass:
 
-**Defense in depth:** in addition to the outer `tokio::time::timeout` wrapper, the inner `wreq::RequestBuilder` for each HTTP request inside `HlsSizeDetector::detect_hls_metadata` / `detect_hls_variants` and inside `BaseExtractor::detect_file_size` MUST receive `.timeout(<same duration>)`. The outer `tokio::time::timeout` remains the hard cancellation wall; the inner `RequestBuilder::timeout` triggers `wreq`'s typed timeout error (better diagnostics, cleaner socket teardown).
+- `detect_format_sizes_inner` receives `ctx: &rdlp_core::ExtractionContext`; `ctx.config` is `Arc<Config>`. Auto-deref through `Arc` already works in the file (e.g. `ctx.config.verbose` at line 189). Reading `ctx.config.hls_operation_timeout` works the same way.
+- `enrich_single_hls_format` does NOT receive `ctx` — its current signature is `(hls_detector, url, extractor_name, verbose)`. The caller (`detect_format_sizes_inner`) MUST resolve the duration from `ctx.config` and pass it down as a new `Duration` parameter.
+- `HlsSizeDetector::detect_hls_metadata` (`hls/variants.rs:167`) and `detect_hls_variants` (`hls/variants.rs:339`) both build their `wreq::RequestBuilder` via `self.fetch_playlist_text` (`hls/detector.rs:235`). To push `.timeout(D)` to the inner request, `fetch_playlist_text` MUST accept a `timeout: Duration` parameter (or each public method does). Pick the chokepoint: `fetch_playlist_text` is the lower-cost change.
+- `BaseExtractor::detect_file_size` (`base/common/mod.rs:379`) signature today: `(url, http_client, log_prefix: Option<&str>)`. Note the third arg is a logging label, NOT a headers map. The function executes TWO HTTP requests internally (HEAD first, then a `bytes=0-0` Range-GET fallback). Add a fourth `timeout: Duration` parameter and apply `.timeout(D)` to BOTH inner requests.
 
-If pushing the duration through to `detect_file_size` requires extending its signature (currently `(&url, &http_client, None)`), do so — the third argument already exists for "an optional something"; if it is currently a header-map, add a fourth `Duration` parameter or wrap both into a struct.
+**Defense in depth:** the outer `tokio::time::timeout` remains the hard cancellation wall; the inner `wreq::RequestBuilder::timeout(D)` triggers `wreq`'s typed timeout error (better diagnostics, cleaner socket teardown). `wreq::RequestBuilder::timeout(Duration)` is verified in production use at `rdlp-api/src/orchestrator/subtitle_pipeline/mod.rs:93` and `rdlp-downloader/src/dash/download.rs:66`.
 
 ### Naming rationale
 
-- `hls_operation_timeout_secs` — the *operation* qualifier names the SLA boundary explicitly (vs `read_timeout` which is per-byte idle).
-- `hls_head_probe_timeout_secs` — names both the protocol verb and the purpose, making the smaller default value self-explaining.
+- `hls_operation_timeout` — the *operation* qualifier names the SLA boundary explicitly (vs `read_timeout` which is per-byte idle).
+- `hls_head_probe_timeout` — names both the protocol verb and the purpose, making the smaller default value self-explaining.
 - `_secs` suffix matches existing `Config` convention (`socket_timeout`, `read_timeout`, `pool_idle_timeout` use the bare name; the `rdlp-http` `HttpClientConfig` uses `_secs`. The naming inconsistency in the existing code is out of scope to fix here — match whichever the surrounding `Config` block uses for the timeout family. Verify during implementation).
 
 **Decision (locked):** match the bare-name convention used by the existing timeout fields in `rdlp-types::Config`. Field names will be `hls_operation_timeout` and `hls_head_probe_timeout` (without `_secs` suffix). Documentation cites the unit explicitly.
@@ -118,12 +121,16 @@ Per `~/.claude/rules/bug-fix-requires-failing-test.md`:
 
 ### Unit tests in `format_detection.rs`
 
-Use `tokio::time::pause` + a fixture `HlsSizeDetector` that sleeps longer than the configured timeout:
+`tokio::time::pause` is NOT used elsewhere in this codebase (researcher confirmed zero hits). Two viable test patterns:
 
-1. **Positive — `detect_format_sizes_inner` HLS branch respects override.** Configure `hls_operation_timeout = Some(2)`, fixture sleeps 5s, assert the call returns within ~2s.
-2. **Positive — `enrich_single_hls_format` respects override.** Same shape, different call site.
-3. **Positive — `detect_file_size` HEAD probe respects override.** Configure `hls_head_probe_timeout = Some(1)`, fixture sleeps 3s, assert the call returns within ~1s.
-4. **Default still 10s/5s when unset.** Configure both as `None`, assert the duration passed to `tokio::time::timeout` matches the documented defaults (this is a structural test — may require exposing a helper that returns the resolved duration, or a logging assertion).
+- **Structural (preferred for the resolve-from-config check):** expose (or factor) a small helper `resolve_hls_operation_timeout(&Config) -> Duration` and `resolve_hls_head_probe_timeout(&Config) -> Duration` that the call sites use. Test the helpers directly with various `Config` values. This proves the config plumbing without needing time-based assertions.
+- **Real-time mockito (preferred for end-to-end timeout firing):** use a mockito server endpoint that delays its response longer than the configured timeout, run the extractor against it, assert the wall-clock elapsed time is within `[configured_timeout, configured_timeout + tolerance]`. Tolerance ~500ms is appropriate for CI.
+
+Tests:
+
+1. **Positive — `resolve_hls_operation_timeout` returns 10s default when `None`, returns the override when `Some(N)`.** Pure helper test.
+2. **Positive — `resolve_hls_head_probe_timeout` returns 5s default when `None`, returns the override when `Some(N)`.** Pure helper test.
+3. **End-to-end — `detect_file_size` against a mockito 60s-delay endpoint with `hls_head_probe_timeout = Some(1)` returns within ~1.5s.** Single mockito test exercising the slowest path is sufficient; the helper tests above cover the other two call sites structurally.
 
 ### Validation tests in `config_tests.rs`
 
@@ -145,9 +152,10 @@ Use `tokio::time::pause` + a fixture `HlsSizeDetector` that sleeps longer than t
 |------|--------|
 | `crates/rdlp-types/src/config.rs` | Add 2 fields, defaults, validation. |
 | `crates/rdlp-types/src/config_tests.rs` | 4-6 new tests. |
-| `crates/rdlp-extractor/src/hls/format_detection.rs` | Read from config, plumb to 3 call sites. Pass duration to `RequestBuilder::timeout` on inner requests. |
-| `crates/rdlp-extractor/src/base/common/file_size.rs` (or wherever `detect_file_size` lives) | Extend signature to accept duration; pass to `RequestBuilder::timeout`. |
-| `crates/rdlp-extractor/src/hls/detector.rs` (or wherever `HlsSizeDetector` lives) | Pass duration to `RequestBuilder::timeout` on its inner HTTP calls. |
+| `crates/rdlp-extractor/src/hls/format_detection.rs` | Read from `ctx.config`, plumb to 3 call sites. Pass duration into `enrich_single_hls_format` as a new param. |
+| `crates/rdlp-extractor/src/base/common/mod.rs` | `detect_file_size` gains 4th `timeout: Duration` parameter. Apply to both inner requests (HEAD + Range-GET fallback). |
+| `crates/rdlp-extractor/src/hls/detector.rs` | `fetch_playlist_text` gains a `timeout: Duration` param; apply to inner `RequestBuilder::timeout(D)`. |
+| `crates/rdlp-extractor/src/hls/variants.rs` | `detect_hls_metadata` + `detect_hls_variants` accept and forward the timeout to `fetch_playlist_text`. |
 
 ## Open questions (resolved)
 

--- a/docs/superpowers/specs/2026-05-04-hls-operation-timeouts-configurable-design.md
+++ b/docs/superpowers/specs/2026-05-04-hls-operation-timeouts-configurable-design.md
@@ -1,0 +1,169 @@
+# HLS Operation Timeouts — Configurable Design
+
+**Issue:** [#277](https://github.com/crippledgeek/rdlp/issues/277)
+**Date:** 2026-05-04
+**Status:** Draft (pending review)
+
+## Summary
+
+`crates/rdlp-extractor/src/hls/format_detection.rs` has three `tokio::time::timeout` call sites with hard-coded `Duration::from_secs(N)` values: two at 10s wrapping HLS metadata / variant probes, and one at 5s wrapping a HEAD-request probe for non-HLS file size. These are wall-clock operation deadlines — semantically distinct from the socket-level `socket_timeout` / `read_timeout` / `pool_idle_timeout` axes already exposed.
+
+Per `~/.claude/rules/no-hardcoded-magic-numbers.md`, every numeric literal that affects runtime behavior must live in `Config` (preferred) or a documented module-level `const`. This spec lifts the three values into two new `Config` fields and adds defense-in-depth at the HTTP layer via `RequestBuilder::timeout`.
+
+## Non-goals
+
+- No new CLI flag or Settings UI. These are low-frequency operator knobs; TOML-only is the right surface for now.
+- No removal of the existing `tokio::time::timeout` wrappers — they remain as the hard cancellation wall.
+- No change to the underlying `HlsSizeDetector` / `BaseExtractor::detect_file_size` APIs beyond passing a `Duration` parameter.
+
+## Background
+
+### Current state — three magic numbers
+
+`crates/rdlp-extractor/src/hls/format_detection.rs`:
+
+| Line | Site | Current cap | Wraps |
+|------|------|-------------|-------|
+| 79   | `enrich_single_hls_format` | `Duration::from_secs(10)` | `hls_detector.detect_hls_metadata(url)` (per-format metadata refresh) |
+| 233  | `detect_format_sizes_inner` (HLS branch) | `Duration::from_secs(10)` | `hls_detector.detect_hls_variants(&url)` (master playlist fetch + parse) |
+| 391  | `detect_format_sizes_inner` (non-HLS branch) | `Duration::from_secs(5)` | `BaseExtractor::detect_file_size(&url, &http_client, None)` (single HEAD request) |
+
+### Researcher findings (cited in PR brainstorm)
+
+- `tokio::time::timeout(D, future)` is the idiomatic Rust pattern for operation-level wall-clock caps. Cancellation drops the wrapped future at the next `.await` yield — for network I/O this is reliable.
+- `reqwest::RequestBuilder::timeout(D)` is the direct analog of OkHttp `callTimeout` and covers connect-through-body. `wreq` inherits this API.
+- Reusing `read_timeout` (per-read idle) as an operation cap is semantically wrong — a CDN that drips bytes within the read budget can keep a request alive for `unbounded_read_count × read_timeout`.
+- No widely-distributed Rust HLS/DASH extractor crate exposes a configurable operation-level timeout with its own named field — this project is setting precedent.
+- Two-knob design (multi-step vs single-HEAD) preserves the SLA distinction the original constants encoded. One-knob design loses it.
+
+## Design
+
+### New `Config` fields
+
+`crates/rdlp-types/src/config.rs`:
+
+```rust
+/// Wall-clock cap on multi-step HLS probes (master playlist fetch + parse,
+/// per-format metadata refresh). Distinct from the socket-level
+/// `read_timeout`: this is total elapsed time for the helper, regardless of
+/// how many TCP reads it spans.
+/// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
+pub hls_operation_timeout_secs: Option<u64>,
+
+/// Wall-clock cap on a single HEAD probe used to detect content-length on
+/// non-HLS formats. Smaller than `hls_operation_timeout_secs` because the
+/// operation is a single HEAD request, not a multi-step playlist parse.
+/// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
+pub hls_head_probe_timeout_secs: Option<u64>,
+```
+
+Defaults match current constants:
+
+```rust
+hls_operation_timeout_secs: Some(10),
+hls_head_probe_timeout_secs: Some(5),
+```
+
+### Validation (extend `Config::validate()`)
+
+Mirror the existing 3-axis HTTP timeout pattern at `crates/rdlp-types/src/config.rs:524-548`:
+
+```rust
+if let Some(t) = self.hls_operation_timeout_secs
+    && !(1..=300).contains(&t)
+{
+    return Err(ConfigValidationError::OutOfRange {
+        field: "hls_operation_timeout_secs",
+        reason: "must be 1..=300 seconds",
+    });
+}
+if let Some(t) = self.hls_head_probe_timeout_secs
+    && !(1..=300).contains(&t)
+{
+    return Err(ConfigValidationError::OutOfRange {
+        field: "hls_head_probe_timeout_secs",
+        reason: "must be 1..=300 seconds",
+    });
+}
+```
+
+### Call-site rewiring
+
+`crates/rdlp-extractor/src/hls/format_detection.rs` reads the durations from `ctx.config` (or whatever the extractor context exposes — to be confirmed during implementation). Each call site replaces its hard-coded `Duration::from_secs(N)` with the configured value.
+
+**Defense in depth:** in addition to the outer `tokio::time::timeout` wrapper, the inner `wreq::RequestBuilder` for each HTTP request inside `HlsSizeDetector::detect_hls_metadata` / `detect_hls_variants` and inside `BaseExtractor::detect_file_size` MUST receive `.timeout(<same duration>)`. The outer `tokio::time::timeout` remains the hard cancellation wall; the inner `RequestBuilder::timeout` triggers `wreq`'s typed timeout error (better diagnostics, cleaner socket teardown).
+
+If pushing the duration through to `detect_file_size` requires extending its signature (currently `(&url, &http_client, None)`), do so — the third argument already exists for "an optional something"; if it is currently a header-map, add a fourth `Duration` parameter or wrap both into a struct.
+
+### Naming rationale
+
+- `hls_operation_timeout_secs` — the *operation* qualifier names the SLA boundary explicitly (vs `read_timeout` which is per-byte idle).
+- `hls_head_probe_timeout_secs` — names both the protocol verb and the purpose, making the smaller default value self-explaining.
+- `_secs` suffix matches existing `Config` convention (`socket_timeout`, `read_timeout`, `pool_idle_timeout` use the bare name; the `rdlp-http` `HttpClientConfig` uses `_secs`. The naming inconsistency in the existing code is out of scope to fix here — match whichever the surrounding `Config` block uses for the timeout family. Verify during implementation).
+
+**Decision (locked):** match the bare-name convention used by the existing timeout fields in `rdlp-types::Config`. Field names will be `hls_operation_timeout` and `hls_head_probe_timeout` (without `_secs` suffix). Documentation cites the unit explicitly.
+
+## Failure modes & error mapping
+
+When a `tokio::time::timeout` fires:
+
+- Currently: returns `Err(_)` from the wrapped future, which is mapped by the call site into a generic extraction error.
+- After: same behavior. The new `RequestBuilder::timeout` triggers `wreq::Error::is_timeout() == true` BEFORE the outer wrapper fires, surfacing a typed timeout. Either path leaves the format with `filesize: None` (existing behavior); the surrounding code is already lazy-tolerant.
+
+No changes to the public error types.
+
+## Testing
+
+Per `~/.claude/rules/bug-fix-requires-failing-test.md`:
+
+### Unit tests in `format_detection.rs`
+
+Use `tokio::time::pause` + a fixture `HlsSizeDetector` that sleeps longer than the configured timeout:
+
+1. **Positive — `detect_format_sizes_inner` HLS branch respects override.** Configure `hls_operation_timeout = Some(2)`, fixture sleeps 5s, assert the call returns within ~2s.
+2. **Positive — `enrich_single_hls_format` respects override.** Same shape, different call site.
+3. **Positive — `detect_file_size` HEAD probe respects override.** Configure `hls_head_probe_timeout = Some(1)`, fixture sleeps 3s, assert the call returns within ~1s.
+4. **Default still 10s/5s when unset.** Configure both as `None`, assert the duration passed to `tokio::time::timeout` matches the documented defaults (this is a structural test — may require exposing a helper that returns the resolved duration, or a logging assertion).
+
+### Validation tests in `config_tests.rs`
+
+5. `hls_operation_timeout = Some(0)` → `Config::validate()` returns `OutOfRange { field: "hls_operation_timeout", .. }`.
+6. `hls_operation_timeout = Some(301)` → same.
+7. `hls_head_probe_timeout = Some(301)` → `OutOfRange { field: "hls_head_probe_timeout", .. }`.
+8. Both fields default to `Some(10)` / `Some(5)` after `Config::default()`.
+9. Both fields round-trip through serde.
+10. Legacy TOML without the keys deserializes cleanly with the documented defaults (forward-compat).
+
+### Integration / regression
+
+11. `cargo test -p rdlp-extractor` — full suite green, no regressions.
+12. `cargo test -p rdlp-types` — full suite green.
+
+## Files touched
+
+| File | Reason |
+|------|--------|
+| `crates/rdlp-types/src/config.rs` | Add 2 fields, defaults, validation. |
+| `crates/rdlp-types/src/config_tests.rs` | 4-6 new tests. |
+| `crates/rdlp-extractor/src/hls/format_detection.rs` | Read from config, plumb to 3 call sites. Pass duration to `RequestBuilder::timeout` on inner requests. |
+| `crates/rdlp-extractor/src/base/common/file_size.rs` (or wherever `detect_file_size` lives) | Extend signature to accept duration; pass to `RequestBuilder::timeout`. |
+| `crates/rdlp-extractor/src/hls/detector.rs` (or wherever `HlsSizeDetector` lives) | Pass duration to `RequestBuilder::timeout` on its inner HTTP calls. |
+
+## Open questions (resolved)
+
+| Question | Resolution |
+|---|---|
+| One knob vs two? | Two — semantically distinct operations. |
+| `_secs` suffix? | No — match existing `Config` bare-name convention. |
+| CLI flag / Settings UI? | Out of scope — TOML-only. |
+| Push duration to `RequestBuilder::timeout`? | Yes — defense in depth. |
+| Extend `detect_file_size` signature? | Yes if needed. |
+
+## References
+
+- Issue [#277](https://github.com/crippledgeek/rdlp/issues/277)
+- PR #282 (closed #278; established the timeout-field naming and validation pattern this spec mirrors)
+- [tokio::time::timeout docs](https://docs.rs/tokio/latest/tokio/time/fn.timeout.html)
+- [reqwest RequestBuilder::timeout docs](https://docs.rs/reqwest/latest/reqwest/struct.RequestBuilder.html)
+- [Oxide RFD 400 — Cancel Safety in Async Rust](https://rfd.shared.oxide.computer/rfd/0400)
+- `~/.claude/rules/no-hardcoded-magic-numbers.md` — governance rule that motivated this work


### PR DESCRIPTION
## Summary

Closes #277.

Lifts three hardcoded \`Duration::from_secs(N)\` values in \`crates/rdlp-extractor/src/hls/format_detection.rs\` to two new validated \`Config\` fields:

- **\`hls_operation_timeout\`** (default 10s, validated 1..=300) — wall-clock cap on multi-step HLS probes (\`detect_hls_metadata\`, \`detect_hls_variants\`).
- **\`hls_head_probe_timeout\`** (default 5s, validated 1..=300) — wall-clock cap on the single-HEAD probe for non-HLS file-size detection (with Range-GET fallback).

\`Duration\` is threaded through the helper chain (\`fetch_playlist_text\`, \`detect_hls_metadata\`, \`detect_hls_variants\`, \`parse_playlist\`, \`fetch_and_extract_media_info\`, \`count_segments\`, \`detect_size\`, \`detect_info\`, \`enrich_single_hls_format\`, \`detect_file_size\`) and pushed into \`wreq::RequestBuilder::timeout(D)\` on inner HTTP requests for defense-in-depth.

This is the first application of the new global rule \`~/.claude/rules/no-hardcoded-magic-numbers.md\`.

## Layered diff

| Layer | Change |
|---|---|
| \`rdlp-types::Config\` | + 2 \`Option<u64>\` fields, defaults \`Some(10)\` / \`Some(5)\`, validation 1..=300. |
| \`rdlp-extractor::hls::format_detection\` | + \`resolve_hls_operation_timeout\` / \`resolve_hls_head_probe_timeout\` helpers. |
| \`rdlp-extractor::hls::detector\` | \`fetch_playlist_text\` + 4 sibling methods accept \`Duration\`; \`.timeout(D)\` on inner request. |
| \`rdlp-extractor::hls::variants\` | \`detect_hls_metadata\` + \`detect_hls_variants\` accept \`Duration\`. |
| \`rdlp-extractor::hls::segments\` | \`parse_playlist\` accepts \`Duration\`; recursive call documents per-request vs per-tree budget. |
| \`rdlp-extractor::base::common\` | \`detect_file_size\` gains 4th param; \`.timeout(D)\` on BOTH HEAD and Range-GET fallback. |

## Reviews

- Per-task spec compliance: ✅ all 4 tasks (1, 2, 3+4+5 batched, 6).
- Per-task code quality: ✅ all 4 tasks (Important findings on Task 1 negative-test rigor + Task 2 dead-code allow + Task 6 fixture leak doc fixed inline).
- Pre-push code review (whole diff): ✅ approve, no Critical/Important.
- Pre-push security review: ✅ approve. 1 LOW finding — Desktop \`AppSettings\` doesn't mirror the new \`Config\` fields (operator-confusion gap, not a security issue). Filed as known follow-up; not in scope.

## Known follow-ups (post-merge issues to file)

- Desktop \`AppSettings\` mirror for \`hls_operation_timeout\` / \`hls_head_probe_timeout\` so users can tune from the Settings UI.
- Pre-existing posture items (out of scope, surfaced during review): \`fetch_segment_size\` lacks explicit timeout; \`fetch_playlist_text\` body read has no streaming size cap.
- Defaults duplication: \`Config::default()\` and \`format_detection.rs\` consts both encode 10/5 — consider a shared const.
- API surface audit: \`HlsSizeDetector\` methods are \`pub\` but workspace-internal-only; consider downgrade to \`pub(crate)\`.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` — 0 failures (including 7 new validation tests + 4 helper tests + 1 end-to-end timeout regression test)
- [x] End-to-end test (\`detect_file_size_respects_configured_timeout\`) uses \`tokio::net::TcpListener\` black-hole; observed elapsed 2.01s for configured 1s, well within \`[1s, 2.5s]\` bounds.

## Commits

1. \`dbbe83f\` feat(types): Config fields + validation + 7 tests
2. \`8258096\` fix(types): tighten negative-test assertions + partial-JSON pin
3. \`35baa2a\` feat(extractor): resolver helpers + 4 tests
4. \`08791e4\` feat(extractor): thread Duration end-to-end (largest commit, 7 files)
5. \`ee610eb\` docs(extractor): clarify recursion budget semantics
6. \`16b18bf\` test(extractor): end-to-end timeout regression test
7. \`b289b8b\` docs(test): document spawn_blackhole task leak rationale