### PR TITLE
Fragment-level progress + cooperative cancellation (#272)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6071,6 +6071,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml 0.9.12+spec-1.1.0",
  "url",
  "wreq",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6142,6 +6142,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "wreq",

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -209,6 +209,7 @@ impl From<RdlpError> for RdlpApiError {
             },
             RdlpError::Unsupported(msg) => Self::UnsupportedPlatform { feature: msg },
             RdlpError::Other(msg) => Self::Soft { message: msg },
+            RdlpError::Cancelled => Self::UserCancelled,
         }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -106,7 +106,13 @@ impl Orchestrator {
             )
         };
 
-        // Race between download and cancellation token
+        // Race between download and cancellation token. Belt-and-braces:
+        // the fragment-based downloaders (HLS, DASH per-Repr) check the
+        // token cooperatively between fragments and return
+        // RdlpError::Cancelled — that lands on the `result` arm. The
+        // streaming-HTTP path (download_to_file) has no in-loop cancel
+        // check yet, so the `cancelled()` arm covers it via future-drop.
+        // Both arms produce Ok(None); whichever fires is acceptable.
         let stats = tokio::select! {
             result = download_future => {
                 result.map_err(OrchestratorError::DownloadFailed)?

--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -98,7 +98,12 @@ impl Orchestrator {
                 progress_callback,
             )
         } else {
-            downloader.download_format(format, output_path, progress_callback)
+            downloader.download_format(
+                format,
+                output_path,
+                progress_callback,
+                Some(&self.cancel_token),
+            )
         };
 
         // Race between download and cancellation token

--- a/crates/rdlp-core/Cargo.toml
+++ b/crates/rdlp-core/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 rdlp-types = { path = "../rdlp-types" }
 async-trait = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 wreq = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rdlp-core/src/error.rs
+++ b/crates/rdlp-core/src/error.rs
@@ -98,6 +98,10 @@ pub enum RdlpError {
     /// Generic errors
     #[error("{0}")]
     Other(String),
+
+    /// User cancelled the operation. Cooperative-cancellation typed signal.
+    #[error("operation cancelled")]
+    Cancelled,
 }
 
 impl RdlpError {
@@ -223,5 +227,17 @@ mod tests {
         } else {
             panic!("wrong variant");
         }
+    }
+}
+
+#[cfg(test)]
+mod cancelled_tests {
+    use super::*;
+
+    #[test]
+    fn cancelled_variant_displays_lowercase() {
+        let e = RdlpError::Cancelled;
+        let s = format!("{e}");
+        assert!(s.to_lowercase().contains("cancelled"), "got: {s}");
     }
 }

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::path::Path;
 use std::time::Duration;
 use tokio::io::AsyncWrite;
+use tokio_util::sync::CancellationToken;
 
 use crate::Result;
 
@@ -95,7 +96,9 @@ pub trait Downloader: Send + Sync {
         format: &rdlp_types::Format,
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&CancellationToken>,
     ) -> Result<DownloadStats> {
+        let _ = cancel; // default impl: outer select! handles cancellation
         self.download_to_file(&format.url, path, progress).await
     }
 

--- a/crates/rdlp-downloader/Cargo.toml
+++ b/crates/rdlp-downloader/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 wreq = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -139,7 +139,7 @@ impl Downloader for DashDownloader {
             .await
         } else {
             // Non-fragment branch: cancellation owned by outer select! today.
-            // TODO(#NNN): cooperative cancellation for download_to_file path.
+            // TODO(#287): cooperative cancellation for download_to_file path.
             self.download_to_file(&format.url, output, progress).await
         }
     }

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -123,6 +123,7 @@ impl Downloader for DashDownloader {
         format: &Format,
         output: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<DownloadStats> {
         if let Some(fragments) = format.fragments.as_deref() {
             let base = format.fragment_base_url.as_deref();
@@ -130,10 +131,15 @@ impl Downloader for DashDownloader {
                 &self.http_downloader,
                 fragments,
                 base,
+                format.filesize,
+                progress.as_deref(),
                 output,
+                cancel,
             )
             .await
         } else {
+            // Non-fragment branch: cancellation owned by outer select! today.
+            // TODO(#NNN): cooperative cancellation for download_to_file path.
             self.download_to_file(&format.url, output, progress).await
         }
     }

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -543,7 +543,14 @@ mod tests {
             .expect("at least one")
             .progress
             .expect("set");
-        assert!(final_p.fraction() < 1.0);
+        // Pin the exact ratio: 100 / 1000 = 0.1. A regression that drops the
+        // numerator (e.g. emits with `bytes_downloaded = 0`) would still pass
+        // a bare `< 1.0` assertion — this catches it.
+        assert!(
+            (final_p.fraction() - 0.1).abs() < 0.01,
+            "expected ~0.1, got {}",
+            final_p.fraction()
+        );
     }
 
     #[tokio::test]
@@ -609,12 +616,20 @@ mod tests {
         let res =
             download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
                 .await;
-        assert!(res.is_err());
-        let written = tokio::fs::metadata(tmp.path()).await.expect("exists").len();
+        // Pin the typed error: a regression that reshapes the failure into
+        // Cancelled / Network / Other would silently pass a bare is_err().
+        let err = res.expect_err("must error on f2 500");
         assert!(
-            written >= 100,
-            "first fragment should be on disk; got {written}"
+            matches!(
+                err,
+                rdlp_core::RdlpError::Download { .. } | rdlp_core::RdlpError::Http { .. }
+            ),
+            "unexpected err shape: {err:?}"
         );
+        let written = tokio::fs::metadata(tmp.path()).await.expect("exists").len();
+        // First fragment was written + flushed before f2 attempted; f2 errors
+        // before any of its bytes reach the file.
+        assert_eq!(written, 100, "exact first-fragment bytes; got {written}");
     }
 
     #[tokio::test]

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -33,6 +33,7 @@ use rdlp_security;
 ///
 /// Returns `RdlpError::Download` if any fragment fetch fails, if a URL fails
 /// to resolve against the base URL, or if the output file cannot be created.
+#[allow(clippy::too_many_lines)]
 pub async fn download_pre_resolved_fragments(
     http: &HttpDownloader,
     fragments: &[Fragment],
@@ -92,7 +93,8 @@ pub async fn download_pre_resolved_fragments(
             if let Some(init_url) = &frag.init_url {
                 let resolved_init = resolve_fragment_url(init_url, base_url)?;
                 let init_bytes =
-                    fetch_with_optional_range(http, &resolved_init, frag.init_byte_range).await?;
+                    fetch_with_optional_cancel(http, &resolved_init, frag.init_byte_range, cancel)
+                        .await?;
                 total_bytes += init_bytes.len() as u64;
                 out_file.write_all(&init_bytes).await.map_err(|e| {
                     rdlp_core::RdlpError::Download {
@@ -106,7 +108,8 @@ pub async fn download_pre_resolved_fragments(
             }
         }
 
-        let bytes = fetch_with_optional_range(http, &resolved_url, frag.byte_range).await?;
+        let bytes =
+            fetch_with_optional_cancel(http, &resolved_url, frag.byte_range, cancel).await?;
 
         out_file
             .write_all(&bytes)
@@ -198,6 +201,29 @@ pub(crate) fn resolve_fragment_url(fragment_url: &str, base_url: Option<&str>) -
             Ok(resolved.to_string())
         }
         None => Ok(fragment_url.to_string()),
+    }
+}
+
+/// Fetch a fragment with cooperative cancellation.
+///
+/// Wraps `fetch_with_optional_range` in `tokio::select!` against the optional
+/// cancellation token. Without this, a hung connection (TCP accepted but body
+/// never arrives) would block indefinitely between cooperative cancel points
+/// — `fetch_with_optional_range` itself has no per-read timeout, and the
+/// helper's only `is_cancelled()` checks are between fragments.
+async fn fetch_with_optional_cancel(
+    http: &HttpDownloader,
+    url: &str,
+    byte_range: Option<(u64, u64)>,
+    cancel: Option<&CancellationToken>,
+) -> Result<Vec<u8>> {
+    match cancel {
+        Some(token) => tokio::select! {
+            biased;
+            () = token.cancelled() => Err(rdlp_core::RdlpError::Cancelled),
+            res = fetch_with_optional_range(http, url, byte_range) => res,
+        },
+        None => fetch_with_optional_range(http, url, byte_range).await,
     }
 }
 
@@ -674,5 +700,191 @@ mod tests {
         let written = tokio::fs::read(tmp.path()).await.unwrap();
         // 4 (INIT) + 10 × 1 (D) = 14 bytes.
         assert_eq!(written.len(), 14);
+    }
+
+    // ---- Cancellation regression tests (issue #272) ----
+
+    /// Black-hole TCP listener: accepts connections, then sleeps without
+    /// responding. Forces the client to hang until cancellation fires.
+    ///
+    /// The spawned task is intentionally not joined; it lives for the rest
+    /// of the test process. Each invocation leaks one tokio task plus one
+    /// open TCP listener socket. Acceptable for a handful of tests.
+    ///
+    /// Mirror of `crates/rdlp-extractor/src/base/common/mod.rs:563`'s helper,
+    /// which is module-private to that crate.
+    async fn spawn_blackhole() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        tokio::spawn(async move {
+            loop {
+                if let Ok((stream, _)) = listener.accept().await {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    drop(stream);
+                }
+            }
+        });
+        port
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fragment_cancel_before_first_returns_immediately() {
+        let port = spawn_blackhole().await;
+        let frags = vec![frag(format!("http://127.0.0.1:{port}/f1"))];
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel(); // pre-cancel
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let started = std::time::Instant::now();
+        let res = download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            None,
+            None,
+            tmp.path(),
+            Some(&token),
+        )
+        .await;
+        let elapsed = started.elapsed();
+        assert!(matches!(res, Err(rdlp_core::RdlpError::Cancelled)));
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "should return fast; got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fragment_cancel_mid_stream_returns_cancelled_partial_file() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let port = spawn_blackhole().await;
+        let frags = vec![
+            frag(format!("{}/f1", server.url())),
+            frag(format!("http://127.0.0.1:{port}/f2")),
+        ];
+        let token = tokio_util::sync::CancellationToken::new();
+        let token_clone = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            token_clone.cancel();
+        });
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let res = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            download_pre_resolved_fragments(
+                &http,
+                &frags,
+                None,
+                None,
+                None,
+                tmp.path(),
+                Some(&token),
+            ),
+        )
+        .await
+        .expect("test timeout");
+        assert!(matches!(res, Err(rdlp_core::RdlpError::Cancelled)));
+        let written = tokio::fs::metadata(tmp.path()).await.expect("exists").len();
+        // First fragment fully written + flushed; second hung in the black-hole
+        // until token.cancel() fired between fragments. Output has exactly the
+        // first fragment's bytes.
+        assert_eq!(
+            written, 100,
+            "first fragment should be flushed; got {written}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fragment_cancel_none_runs_to_completion() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("ok");
+        assert_eq!(stats.bytes_downloaded, 100);
+    }
+
+    #[tokio::test]
+    async fn fragment_cancel_never_fired_runs_to_completion() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let token = tokio_util::sync::CancellationToken::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let stats = download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            None,
+            None,
+            tmp.path(),
+            Some(&token),
+        )
+        .await
+        .expect("ok");
+        assert_eq!(stats.bytes_downloaded, 100);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fragment_cancel_does_not_delete_partial_file() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let port = spawn_blackhole().await;
+        let frags = vec![
+            frag(format!("{}/f1", server.url())),
+            frag(format!("http://127.0.0.1:{port}/f2")),
+        ];
+        let token = tokio_util::sync::CancellationToken::new();
+        let token_clone = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            token_clone.cancel();
+        });
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            download_pre_resolved_fragments(
+                &http,
+                &frags,
+                None,
+                None,
+                None,
+                tmp.path(),
+                Some(&token),
+            ),
+        )
+        .await;
+        assert!(
+            tmp.path().exists(),
+            "partial file should be preserved for resume"
+        );
+        let written = tokio::fs::metadata(tmp.path()).await.expect("exists").len();
+        assert!(written > 0);
     }
 }

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -14,11 +14,13 @@
 use std::path::Path;
 use std::time::Instant;
 
-use rdlp_core::{DownloadStats, Result};
-use rdlp_types::Fragment;
+use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback, Result};
+use rdlp_types::{Fragment, Progress};
 use tokio::io::AsyncWriteExt as _;
+use tokio_util::sync::CancellationToken;
 
 use crate::http::HttpDownloader;
+use crate::progress::SpeedTracker;
 use rdlp_security;
 
 /// Fetch a pre-resolved list of fragment URLs and concatenate them into
@@ -35,7 +37,10 @@ pub async fn download_pre_resolved_fragments(
     http: &HttpDownloader,
     fragments: &[Fragment],
     base_url: Option<&str>,
+    expected_total: Option<u64>,
+    progress: Option<&dyn ProgressCallback>,
     output: &Path,
+    cancel: Option<&CancellationToken>,
 ) -> Result<DownloadStats> {
     let started = Instant::now();
 
@@ -52,6 +57,19 @@ pub async fn download_pre_resolved_fragments(
 
     let mut total_bytes: u64 = 0;
     let mut current_init: Option<String> = None;
+
+    const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+    let mut last_emit = Instant::now();
+    let mut last_observed_at = Instant::now();
+    let mut frags_done: u64 = 0;
+    let total_frags = fragments.len() as u64;
+    let mut speed = SpeedTracker::new();
+
+    // Pre-loop cancellation check.
+    if cancel.is_some_and(CancellationToken::is_cancelled) {
+        out_file.flush().await.ok();
+        return Err(rdlp_core::RdlpError::Cancelled);
+    }
 
     for frag in fragments {
         let resolved_url = resolve_fragment_url(&frag.url, base_url)?;
@@ -99,6 +117,37 @@ pub async fn download_pre_resolved_fragments(
             })?;
 
         total_bytes += bytes.len() as u64;
+
+        // Update progress accounting.
+        let now = Instant::now();
+        let elapsed = now.duration_since(last_observed_at);
+        speed.observe(bytes.len() as u64, elapsed);
+        last_observed_at = now;
+        frags_done += 1;
+
+        // Emit progress (100ms throttle OR fragment-N boundary).
+        if let Some(cb) = progress
+            && (now.duration_since(last_emit) >= PROGRESS_INTERVAL || frags_done == total_frags)
+        {
+            cb.on_progress(&DownloadProgress {
+                bytes_downloaded: total_bytes,
+                total_bytes: expected_total,
+                progress: expected_total.map(|t| Progress::from_ratio(total_bytes, t)),
+                segments_downloaded: Some(frags_done),
+                total_segments: Some(total_frags),
+                speed: speed.bytes_per_sec(),
+                eta: speed.eta(expected_total.map(|t| t.saturating_sub(total_bytes))),
+                duration_downloaded: None,
+                total_duration: None,
+            });
+            last_emit = now;
+        }
+
+        // Cancellation check between fragments.
+        if cancel.is_some_and(CancellationToken::is_cancelled) {
+            out_file.flush().await.ok();
+            return Err(rdlp_core::RdlpError::Cancelled);
+        }
     }
 
     out_file
@@ -239,7 +288,7 @@ mod tests {
 
         let http = HttpDownloader::with_client(wreq::Client::new());
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        download_pre_resolved_fragments(&http, &frags, None, tmp.path())
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
             .await
             .expect("download must succeed with Range header");
     }
@@ -294,7 +343,7 @@ mod tests {
 
         let http = HttpDownloader::with_client(wreq::Client::new());
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        download_pre_resolved_fragments(&http, &frags, None, tmp.path())
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
             .await
             .expect("multi-init download must succeed");
 
@@ -343,7 +392,7 @@ mod tests {
 
         let http = HttpDownloader::with_client(wreq::Client::new());
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        download_pre_resolved_fragments(&http, &frags, None, tmp.path())
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
             .await
             .expect("single-init download must succeed");
 

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -357,6 +357,266 @@ mod tests {
         assert_eq!(&written[18..22], b"DATA");
     }
 
+    // ---- Progress capture mock + tests (issue #272) ----
+
+    use std::sync::Mutex;
+
+    struct CaptureCallback {
+        events: Mutex<Vec<DownloadProgress>>,
+    }
+
+    impl CaptureCallback {
+        fn new() -> Self {
+            Self {
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<DownloadProgress> {
+            self.events.lock().expect("lock").clone()
+        }
+    }
+
+    impl ProgressCallback for CaptureCallback {
+        fn on_progress(&self, p: &DownloadProgress) {
+            self.events.lock().expect("lock").push(p.clone());
+        }
+        fn on_complete(&self, _stats: &DownloadStats) {}
+        fn on_error(&self, _msg: &str) {}
+    }
+
+    fn frag(url: String) -> Fragment {
+        Fragment {
+            url,
+            byte_range: None,
+            init_url: None,
+            init_byte_range: None,
+            duration: None,
+            filesize: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_final_boundary_emit_covers_all_frags() {
+        // N=2 fragments. The 100ms throttle suppresses intermediate emits when
+        // fragments arrive quickly, but the final-fragment boundary rule
+        // (`frags_done == total_frags`) guarantees at least one event with
+        // segments_downloaded == total_segments and bytes_downloaded == total.
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let _f2 = server
+            .mock("GET", "/f2")
+            .with_body(vec![0u8; 200])
+            .create_async()
+            .await;
+        let frags = vec![
+            frag(format!("{}/f1", server.url())),
+            frag(format!("{}/f2", server.url())),
+        ];
+        let cb = CaptureCallback::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _stats = download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            Some(300),
+            Some(&cb),
+            tmp.path(),
+            None,
+        )
+        .await
+        .expect("ok");
+        let evs = cb.events();
+        assert!(!evs.is_empty(), "boundary emit must fire at least once");
+        let last = evs.last().expect("at least one");
+        assert_eq!(last.segments_downloaded, Some(2));
+        assert_eq!(last.total_segments, Some(2));
+        assert_eq!(last.bytes_downloaded, 300);
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_none_callback_runs_to_completion() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("ok");
+        assert_eq!(stats.bytes_downloaded, 100);
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_expected_total_none_emits_none_total() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let cb = CaptureCallback::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _ =
+            download_pre_resolved_fragments(&http, &frags, None, None, Some(&cb), tmp.path(), None)
+                .await
+                .expect("ok");
+        let evs = cb.events();
+        assert!(!evs.is_empty());
+        assert!(
+            evs.iter()
+                .all(|e| e.total_bytes.is_none() && e.progress.is_none())
+        );
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_cdn_overrun_saturates_at_one() {
+        // expected_total smaller than actual bytes — Progress::from_ratio saturates.
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 200])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let cb = CaptureCallback::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _ = download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            Some(100),
+            Some(&cb),
+            tmp.path(),
+            None,
+        )
+        .await
+        .expect("ok");
+        let final_p = cb
+            .events()
+            .last()
+            .expect("at least one")
+            .progress
+            .expect("set");
+        assert!((final_p.fraction() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_expected_total_larger_completes_under_one() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let cb = CaptureCallback::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _ = download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            Some(1_000),
+            Some(&cb),
+            tmp.path(),
+            None,
+        )
+        .await
+        .expect("ok");
+        let final_p = cb
+            .events()
+            .last()
+            .expect("at least one")
+            .progress
+            .expect("set");
+        assert!(final_p.fraction() < 1.0);
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_zero_fragments_no_emit() {
+        let frags: Vec<Fragment> = vec![];
+        let cb = CaptureCallback::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, Some(&cb), tmp.path(), None)
+                .await
+                .expect("ok");
+        assert_eq!(stats.bytes_downloaded, 0);
+        assert_eq!(cb.events().len(), 0);
+        assert!(tmp.path().exists());
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_n_one_emits_exactly_once() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let frags = vec![frag(format!("{}/f1", server.url()))];
+        let cb = CaptureCallback::new();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _ = download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            Some(100),
+            Some(&cb),
+            tmp.path(),
+            None,
+        )
+        .await
+        .expect("ok");
+        assert_eq!(cb.events().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fragment_progress_mid_stream_failure_returns_error_partial_file() {
+        let mut server = mockito::Server::new_async().await;
+        let _f1 = server
+            .mock("GET", "/f1")
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+        let _f2 = server
+            .mock("GET", "/f2")
+            .with_status(500)
+            .create_async()
+            .await;
+        let frags = vec![
+            frag(format!("{}/f1", server.url())),
+            frag(format!("{}/f2", server.url())),
+        ];
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let res =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await;
+        assert!(res.is_err());
+        let written = tokio::fs::metadata(tmp.path()).await.expect("exists").len();
+        assert!(
+            written >= 100,
+            "first fragment should be on disk; got {written}"
+        );
+    }
+
     #[tokio::test]
     async fn single_init_fetched_once() {
         let mut server = mockito::Server::new_async().await;

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -29,10 +29,28 @@ use rdlp_security;
 /// Each URL is resolved against the optional `base_url`. Fragments are written
 /// sequentially — no intermediate files or `FFmpeg` mux step is required.
 ///
+/// # Progress
+///
+/// When `progress` is `Some`, emits `DownloadProgress` events on a 100ms
+/// throttle plus a forced emit at the final-fragment boundary. When
+/// `expected_total` is `None`, emitted events carry `total_bytes = None`
+/// and `progress = None`; consumers see fragment-count progress only
+/// (`segments_downloaded` / `total_segments`).
+///
+/// # Cancellation
+///
+/// When `cancel` is `Some`, the helper checks `is_cancelled()` pre-loop
+/// and after each fragment write, and races each fragment fetch against
+/// `cancelled()`. On cancel: flushes the partial output and returns
+/// `Err(RdlpError::Cancelled)`.
+///
 /// # Errors
 ///
 /// Returns `RdlpError::Download` if any fragment fetch fails, if a URL fails
 /// to resolve against the base URL, or if the output file cannot be created.
+/// Returns `RdlpError::Cancelled` if `cancel` fires.
+// 102/100 lines after the cancellation wrapper additions; splitting would
+// obscure the loop's bookkeeping flow.
 #[allow(clippy::too_many_lines)]
 pub async fn download_pre_resolved_fragments(
     http: &HttpDownloader,

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -772,7 +772,12 @@ mod tests {
         let token = tokio_util::sync::CancellationToken::new();
         let token_clone = token.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            // 500ms gives the helper time to fully fetch + write + flush f1
+            // (mockito serves instantly; the budget covers tokio scheduling
+            // jitter on loaded CI runners). Lower budgets risk firing cancel
+            // before f1 lands on disk, which would break the partial-file
+            // assertion below.
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             token_clone.cancel();
         });
         let tmp = tempfile::NamedTempFile::new().expect("tmp");
@@ -862,7 +867,12 @@ mod tests {
         let token = tokio_util::sync::CancellationToken::new();
         let token_clone = token.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            // 500ms gives the helper time to fully fetch + write + flush f1
+            // (mockito serves instantly; the budget covers tokio scheduling
+            // jitter on loaded CI runners). Lower budgets risk firing cancel
+            // before f1 lands on disk, which would break the partial-file
+            // assertion below.
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             token_clone.cancel();
         });
         let tmp = tempfile::NamedTempFile::new().expect("tmp");

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -165,7 +165,8 @@ impl Downloader for HlsDownloader {
         &self,
         format: &rdlp_types::Format,
         output: &Path,
-        _progress: Option<Box<dyn ProgressCallback>>,
+        progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<DownloadStats> {
         // After #267, every M3u8 / M3u8Native row reaching the downloader has
         // Format.fragments populated by expand_hls_in_place. A row without
@@ -187,7 +188,10 @@ impl Downloader for HlsDownloader {
             &self.http_downloader,
             fragments,
             format.fragment_base_url.as_deref(),
+            format.filesize,
+            progress.as_deref(),
             output,
+            cancel,
         )
         .await
     }

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -392,11 +392,12 @@ mod speed_tracker_tests {
     }
 
     #[test]
-    fn speed_tracker_zero_delta_secs_does_not_panic() {
+    fn speed_tracker_zero_delta_secs_is_a_noop() {
         let mut st = SpeedTracker::new();
         st.observe(0, Duration::ZERO);
-        // Either returns 0.0 or skips the update; must not panic or NaN.
-        assert!(st.bytes_per_sec().is_finite());
+        // Zero-delta observation MUST be a no-op against the initial state
+        // — not just "doesn't panic", but pinned to 0.0.
+        assert!(st.bytes_per_sec().abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -29,6 +29,70 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+/// EWMA speed tracker for sequential-download contexts.
+///
+/// Encapsulates the same `alpha=0.3` exponentially-weighted moving average
+/// pattern used inline in `spawn_progress_reporter`, but surfaced as a
+/// `pub(crate)` struct so callers that don't run a spawned reporter task
+/// (e.g. `download_pre_resolved_fragments`) can reuse it.
+///
+/// Usage: call `observe(bytes_delta, time_delta)` after each fragment
+/// completes; read `bytes_per_sec()` for the smoothed speed; read
+/// `eta(remaining)` for the projected time to completion.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)] // wired into download_pre_resolved_fragments in the next batch (issue #272)
+pub(crate) struct SpeedTracker {
+    smooth_speed: f64,
+    has_observation: bool,
+}
+
+#[allow(dead_code)] // wired into download_pre_resolved_fragments in the next batch (issue #272)
+impl SpeedTracker {
+    /// EWMA alpha — matches the inline value in `spawn_progress_reporter`.
+    const ALPHA: f64 = 0.3;
+
+    pub(crate) const fn new() -> Self {
+        Self {
+            smooth_speed: 0.0,
+            has_observation: false,
+        }
+    }
+
+    /// Record `bytes` transferred over `elapsed` since the previous
+    /// observation. Zero or near-zero `elapsed` is ignored to avoid
+    /// divide-by-zero / spike.
+    pub(crate) fn observe(&mut self, bytes: u64, elapsed: std::time::Duration) {
+        let secs = elapsed.as_secs_f64();
+        if secs <= 0.0 {
+            return;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let raw = (bytes as f64) / secs;
+        self.smooth_speed = if self.has_observation {
+            Self::ALPHA.mul_add(raw, (1.0 - Self::ALPHA) * self.smooth_speed)
+        } else {
+            raw
+        };
+        self.has_observation = true;
+    }
+
+    pub(crate) const fn bytes_per_sec(&self) -> f64 {
+        self.smooth_speed
+    }
+
+    /// Projected ETA given a known `remaining_bytes`. Returns `None` if the
+    /// speed is zero (no progress yet) or if `remaining_bytes` is `None`.
+    pub(crate) fn eta(&self, remaining_bytes: Option<u64>) -> Option<std::time::Duration> {
+        let r = remaining_bytes?;
+        if self.smooth_speed <= 0.0 {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let secs = (r as f64) / self.smooth_speed;
+        Some(std::time::Duration::from_secs_f64(secs))
+    }
+}
+
 /// RAII guard for progress reporter tasks.
 ///
 /// Ensures the progress reporter task is aborted when the guard goes out of scope,
@@ -292,5 +356,68 @@ mod tests {
         assert!(config.total_size.is_none());
         assert_eq!(config.total_segments, Some(100));
         assert_eq!(config.total_duration, Some(600.0));
+    }
+}
+
+#[cfg(test)]
+mod speed_tracker_tests {
+    use super::SpeedTracker;
+    use std::time::Duration;
+
+    #[test]
+    fn speed_tracker_zero_at_start() {
+        let st = SpeedTracker::new();
+        assert!(st.bytes_per_sec().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn speed_tracker_first_observation_initializes_smooth_speed() {
+        let mut st = SpeedTracker::new();
+        st.observe(1_000, Duration::from_millis(100));
+        // 1000 bytes / 0.1s = 10_000 B/s; first observation skips EWMA blend.
+        assert!(
+            (st.bytes_per_sec() - 10_000.0).abs() < 0.01,
+            "got {}",
+            st.bytes_per_sec()
+        );
+    }
+
+    #[test]
+    fn speed_tracker_subsequent_observations_blend_via_ewma() {
+        let mut st = SpeedTracker::new();
+        st.observe(1_000, Duration::from_millis(100)); // raw 10_000
+        st.observe(1_000, Duration::from_millis(100)); // raw 10_000, EWMA stable
+        let v = st.bytes_per_sec();
+        assert!((v - 10_000.0).abs() < 0.01, "stable rate, got {v}");
+    }
+
+    #[test]
+    fn speed_tracker_zero_delta_secs_does_not_panic() {
+        let mut st = SpeedTracker::new();
+        st.observe(0, Duration::ZERO);
+        // Either returns 0.0 or skips the update; must not panic or NaN.
+        assert!(st.bytes_per_sec().is_finite());
+    }
+
+    #[test]
+    fn speed_tracker_eta_with_speed() {
+        let mut st = SpeedTracker::new();
+        st.observe(1_000, Duration::from_secs(1)); // 1000 B/s
+        let eta = st.eta(Some(2_000));
+        // 2000 / 1000 = 2s
+        assert!(matches!(eta, Some(d) if (d.as_secs_f64() - 2.0).abs() < 0.01));
+    }
+
+    #[test]
+    fn speed_tracker_eta_returns_none_when_speed_is_zero() {
+        let st = SpeedTracker::new();
+        assert!(st.eta(Some(1_000)).is_none());
+    }
+
+    #[test]
+    fn speed_tracker_eta_returns_none_when_remaining_is_unknown() {
+        let mut st = SpeedTracker::new();
+        st.observe(1_000, Duration::from_secs(1));
+        assert!(st.eta(None).is_none());
     }
 }

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -40,13 +40,11 @@ use std::time::{Duration, Instant};
 /// completes; read `bytes_per_sec()` for the smoothed speed; read
 /// `eta(remaining)` for the projected time to completion.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // wired into download_pre_resolved_fragments in the next batch (issue #272)
 pub(crate) struct SpeedTracker {
     smooth_speed: f64,
     has_observation: bool,
 }
 
-#[allow(dead_code)] // wired into download_pre_resolved_fragments in the next batch (issue #272)
 impl SpeedTracker {
     /// EWMA alpha — matches the inline value in `spawn_progress_reporter`.
     const ALPHA: f64 = 0.3;

--- a/crates/rdlp-downloader/tests/dash_pre_resolved.rs
+++ b/crates/rdlp-downloader/tests/dash_pre_resolved.rs
@@ -97,7 +97,7 @@ async fn pre_resolved_fragments_skip_mpd_fetch() {
 
     let downloader = DashDownloader::new();
     let stats = downloader
-        .download_format(&format, &output, None)
+        .download_format(&format, &output, None, None)
         .await
         .expect("download should succeed");
 

--- a/crates/rdlp-downloader/tests/hls_pre_resolved.rs
+++ b/crates/rdlp-downloader/tests/hls_pre_resolved.rs
@@ -23,7 +23,7 @@ async fn fragments_none_returns_typed_download_error() {
     let output = tmp.path().join("video.ts");
 
     let result = HlsDownloader::new()
-        .download_format(&format, &output, None)
+        .download_format(&format, &output, None, None)
         .await;
 
     assert!(
@@ -140,7 +140,7 @@ async fn pre_resolved_fragments_skip_playlist_fetch() {
     let output = tmp.path().join("video.m4s");
 
     let stats = HlsDownloader::new()
-        .download_format(&format, &output, None)
+        .download_format(&format, &output, None, None)
         .await
         .expect("pre-resolved download must succeed");
 
@@ -199,7 +199,7 @@ async fn fragment_404_propagates_as_error() {
     let output = tmp.path().join("video.ts");
 
     let result = HlsDownloader::new()
-        .download_format(&format, &output, None)
+        .download_format(&format, &output, None, None)
         .await;
     assert!(result.is_err(), "404 must propagate");
 }
@@ -218,7 +218,7 @@ async fn empty_fragments_vec_writes_empty_file() {
     let output = tmp.path().join("video.ts");
 
     let stats = HlsDownloader::new()
-        .download_format(&format, &output, None)
+        .download_format(&format, &output, None, None)
         .await
         .expect("empty vec writes empty file");
     // Documented no-op: the shared helper writes zero bytes when fragments


### PR DESCRIPTION
## Summary

Closes #272.

Wires fragment-level progress events into `download_pre_resolved_fragments` and adds cooperative cancellation through the same code path. UX regression on every HLS download since PR #270 (deleted the legacy HLS path with its own counter+reporter task) + pre-existing UX gap on DASH per-Repr from PR #235 — both now report fragment-level progress, AND can be cancelled cleanly mid-fragment with the partial output flushed for resume.

## Layered diff

| Layer | Change |
|---|---|
| `rdlp-core::RdlpError` | + `Cancelled` unit variant for cooperative-cancellation typed signal. |
| `rdlp-api::From<RdlpError>` | + `Cancelled => Self::UserCancelled` arm (exhaustive match required to compile). |
| `rdlp-core::Downloader::download_format` | + `cancel: Option<&CancellationToken>` 4th param (additive; default impl ignores). |
| `rdlp-downloader::SpeedTracker` | New `pub(crate)` EWMA helper alongside existing `spawn_progress_reporter`. `alpha=0.3`. |
| `rdlp-downloader::download_pre_resolved_fragments` | + 3 new params (`expected_total`, `progress`, `cancel`). Emits `DownloadProgress` on 100ms throttle or fragment-N boundary. Pre-loop + between-fragments cancel checks. |
| `rdlp-downloader::fetch_with_optional_cancel` | New wrapper races `fetch_with_optional_range` against `token.cancelled()` so a black-holed connection inside a fragment fetch can be cancelled mid-flight. |
| `rdlp-downloader::dash::download_format` + `hls::download_format` | Thread the new params through to the helper. Non-fragment branches carry `// TODO(#287)` for streaming-HTTP cancellation follow-up. |
| `rdlp-api::orchestrator::execution` | Pass `Some(&self.cancel_token)` to `download_format`; outer `tokio::select!` preserved as belt-and-braces (commented). |

## Reviews

- Per-batch spec compliance + code quality: ✅ all 6 batches (Important findings on Batch 7 typed-error pin + Batch 8 timer slack fixed inline).
- Pre-push security review: **PASS**, 2 LOW notes (silent flush-error discard on cancel — UX, not security; `spawn_blackhole` test fixture leak — bounded by test process).
- Pre-push code review: **APPROVE**, 2 minor doc improvements applied inline.

## Known follow-up (filed as #287)

Cooperative cancellation for the streaming-HTTP single-request paths (`download_to_file`, `download_with_resume`, `download_to_writer`). The orchestrator's outer `tokio::select!` continues to handle them via future-drop in the meantime.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 0 failures
- [x] 21 new tests: 7 `SpeedTracker` unit + 8 progress (positive + negative) + 5 cancellation regression + 1 `RdlpError::Cancelled` Display
- [x] Pre-push security ✅ + code ✅