### PR TITLE
feat: lift PARALLEL_THRESHOLD to Config (operator-tunable)

### DIFF
--- a/crates/rdlp-downloader/src/http/config.rs
+++ b/crates/rdlp-downloader/src/http/config.rs
@@ -15,8 +15,10 @@ use std::time::Duration;
 // Constants
 // =============================================================================
 
-/// Minimum file size to enable parallel downloads (10 MB)
-pub(super) const PARALLEL_THRESHOLD: u64 = 10 * 1024 * 1024;
+/// Default minimum file size to enable parallel downloads (10 MiB).
+/// Used when `Config::parallel_threshold` is `None` and as the
+/// `DownloaderConfig::default()` value.
+pub(super) const DEFAULT_PARALLEL_THRESHOLD_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Progress callback update interval
 pub(super) const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
@@ -51,6 +53,9 @@ pub struct DownloaderConfig {
     pub retry_config: RetryConfig,
     pub concurrent_fragments: usize,
     pub chunk_strategy: ChunkSizeStrategy,
+    /// Minimum file size at which `download_to_file` switches to parallel chunked
+    /// download. Defaults to `DEFAULT_PARALLEL_THRESHOLD_BYTES` (10 MiB).
+    pub parallel_threshold: u64,
     /// Per-read idle timeout (no data received for this long = abort)
     pub read_timeout: Duration,
     /// Total download timeout (entire operation must complete within this)
@@ -79,6 +84,7 @@ impl Default for DownloaderConfig {
             retry_config: RetryConfig::default_config(),
             concurrent_fragments,
             chunk_strategy: ChunkSizeStrategy::Auto,
+            parallel_threshold: DEFAULT_PARALLEL_THRESHOLD_BYTES,
             read_timeout: DEFAULT_READ_TIMEOUT,
             download_timeout: DEFAULT_DOWNLOAD_TIMEOUT,
             merge_timeout: DEFAULT_MERGE_TIMEOUT,

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -132,6 +132,15 @@ impl HttpDownloader {
         self
     }
 
+    /// Set the minimum file size in bytes at which the downloader switches
+    /// to parallel chunked mode. Below this, sequential I/O is used.
+    /// Default: `DEFAULT_PARALLEL_THRESHOLD_BYTES` (10 MiB).
+    #[must_use = "builder methods consume self and return a new instance"]
+    pub fn with_parallel_threshold(mut self, bytes: u64) -> Self {
+        Arc::make_mut(&mut self.config).parallel_threshold = bytes;
+        self
+    }
+
     /// Set chunk size strategy.
     ///
     /// When `Fixed` or `Legacy` is used, adaptive mode is forced off because

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -135,9 +135,13 @@ impl HttpDownloader {
     /// Set the minimum file size in bytes at which the downloader switches
     /// to parallel chunked mode. Below this, sequential I/O is used.
     /// Default: `DEFAULT_PARALLEL_THRESHOLD_BYTES` (10 MiB).
+    ///
+    /// `bytes` is clamped to a floor of 1 to mirror the `Config::validate()`
+    /// lower bound and prevent threshold = 0 from amplifying HEAD-probe
+    /// traffic on every download.
     #[must_use = "builder methods consume self and return a new instance"]
     pub fn with_parallel_threshold(mut self, bytes: u64) -> Self {
-        Arc::make_mut(&mut self.config).parallel_threshold = bytes;
+        Arc::make_mut(&mut self.config).parallel_threshold = bytes.max(1);
         self
     }
 

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -581,6 +581,15 @@ fn default_parallel_threshold_is_10_mib() {
     assert_eq!(downloader.config.parallel_threshold, 10 * 1024 * 1024);
 }
 
+#[test]
+fn with_parallel_threshold_clamps_zero_to_one() {
+    let downloader = HttpDownloader::new().with_parallel_threshold(0);
+    assert_eq!(
+        downloader.config.parallel_threshold, 1,
+        "threshold = 0 must be clamped to the validated floor of 1"
+    );
+}
+
 #[tokio::test]
 async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
     use mockito::Server;

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -613,7 +613,7 @@ async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
         .await;
 
     let downloader = HttpDownloader::new()
-        .with_parallel_threshold(1 * 1024 * 1024) // 1 MiB — below the 5 MiB file
+        .with_parallel_threshold(1024 * 1024) // 1 MiB — below the 5 MiB file
         .with_concurrent_fragments(2)
         .with_read_timeout(std::time::Duration::from_secs(5))
         .with_download_timeout(std::time::Duration::from_secs(10));

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -568,3 +568,58 @@ async fn test_parallel_resume() {
         "First resumed byte should be from chunk 0"
     );
 }
+
+#[test]
+fn with_parallel_threshold_sets_config_field() {
+    let downloader = HttpDownloader::new().with_parallel_threshold(5 * 1024 * 1024);
+    assert_eq!(downloader.config.parallel_threshold, 5 * 1024 * 1024);
+}
+
+#[test]
+fn default_parallel_threshold_is_10_mib() {
+    let downloader = HttpDownloader::new();
+    assert_eq!(downloader.config.parallel_threshold, 10 * 1024 * 1024);
+}
+
+#[tokio::test]
+async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
+    use mockito::Server;
+
+    let mut server = Server::new_async().await;
+    let body = vec![0u8; 5 * 1024 * 1024]; // 5 MiB
+
+    // HEAD returns content-length 5 MiB, supports ranges.
+    let _head = server
+        .mock("HEAD", "/file.bin")
+        .with_status(200)
+        .with_header("content-length", &body.len().to_string())
+        .with_header("accept-ranges", "bytes")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    // GET with Range header returns partial content. Multiple range requests
+    // means we took the parallel path; the mock asserts ≥2 invocations.
+    let _get_range = server
+        .mock("GET", "/file.bin")
+        .match_header("range", mockito::Matcher::Regex(r"^bytes=\d+-\d+$".to_string()))
+        .with_status(206)
+        .with_body(&body[..1024]) // any body; size mismatch is fine — we only assert call count
+        .expect_at_least(2)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new()
+        .with_parallel_threshold(1 * 1024 * 1024)  // 1 MiB — below the 5 MiB file
+        .with_concurrent_fragments(2)
+        .with_read_timeout(std::time::Duration::from_secs(5))
+        .with_download_timeout(std::time::Duration::from_secs(10));
+
+    let url = format!("{}/file.bin", server.url());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let _ = downloader.download_to_file(&url, tmp.path(), None).await;
+    // Assertions: the mock's `expect_at_least(2)` for range requests verifies
+    // the parallel path executed. Any download outcome (success, body-mismatch
+    // error) is acceptable — we're testing the dispatch decision, not the
+    // download correctness.
+}

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -602,7 +602,10 @@ async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
     // means we took the parallel path; the mock asserts ≥2 invocations.
     let _get_range = server
         .mock("GET", "/file.bin")
-        .match_header("range", mockito::Matcher::Regex(r"^bytes=\d+-\d+$".to_string()))
+        .match_header(
+            "range",
+            mockito::Matcher::Regex(r"^bytes=\d+-\d+$".to_string()),
+        )
         .with_status(206)
         .with_body(&body[..1024]) // any body; size mismatch is fine — we only assert call count
         .expect_at_least(2)
@@ -610,7 +613,7 @@ async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
         .await;
 
     let downloader = HttpDownloader::new()
-        .with_parallel_threshold(1 * 1024 * 1024)  // 1 MiB — below the 5 MiB file
+        .with_parallel_threshold(1 * 1024 * 1024) // 1 MiB — below the 5 MiB file
         .with_concurrent_fragments(2)
         .with_read_timeout(std::time::Duration::from_secs(5))
         .with_download_timeout(std::time::Duration::from_secs(10));

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -85,7 +85,7 @@ impl Downloader for HttpDownloader {
             };
 
             let parallel_size = match size {
-                Some(s) if s > super::config::PARALLEL_THRESHOLD => {
+                Some(s) if s > self.config.parallel_threshold => {
                     if self.config.concurrent_fragments > 1 && supports_ranges {
                         Some(s)
                     } else {
@@ -105,7 +105,7 @@ impl Downloader for HttpDownloader {
 
             let reason = match size {
                 None | Some(0) => "could not detect file size",
-                Some(s) if s <= super::config::PARALLEL_THRESHOLD => "file too small for parallel",
+                Some(s) if s <= self.config.parallel_threshold => "file too small for parallel",
                 Some(_) if self.config.concurrent_fragments <= 1 => "concurrent_fragments <= 1",
                 Some(_) if !supports_ranges => "server doesn't support ranges",
                 Some(_) => "unknown reason",
@@ -346,7 +346,7 @@ impl Downloader for HttpDownloader {
                     supports_ranges
                 );
 
-                let can_parallel = remaining_size > super::config::PARALLEL_THRESHOLD
+                let can_parallel = remaining_size > self.config.parallel_threshold
                     && self.config.concurrent_fragments > 1
                     && supports_ranges;
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -186,6 +186,14 @@ pub struct Config {
     /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
     pub hls_head_probe_timeout: Option<u64>,
 
+    /// Minimum file size in bytes at which the HTTP downloader switches from
+    /// sequential to parallel chunked download. Below this, parallel fan-out
+    /// overhead (HEAD probes, chunk-merge step) outweighs the throughput gain.
+    /// `None` falls back to the downloader's default
+    /// (`DEFAULT_PARALLEL_THRESHOLD_BYTES`, currently 10 MiB).
+    /// Validated post-load by `Config::validate()`: must be 1..=1_073_741_824 bytes (1 GiB).
+    pub parallel_threshold: Option<u64>,
+
     /// Source IP address to bind to
     pub source_address: Option<String>,
 
@@ -376,6 +384,7 @@ impl Default for Config {
             pool_idle_timeout: None,
             hls_operation_timeout: Some(10),
             hls_head_probe_timeout: Some(5),
+            parallel_threshold: Some(10 * 1024 * 1024),
             source_address: None,
             user_agent: Some(
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36".to_string(),
@@ -577,6 +586,14 @@ impl Config {
             return Err(ConfigValidationError::OutOfRange {
                 field: "hls_head_probe_timeout",
                 reason: "must be 1..=300 seconds",
+            });
+        }
+        if let Some(t) = self.parallel_threshold
+            && !(1..=1024 * 1024 * 1024).contains(&t)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "parallel_threshold",
+                reason: "must be 1..=1_073_741_824 bytes (1 GiB)",
             });
         }
 

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -191,7 +191,7 @@ pub struct Config {
     /// overhead (HEAD probes, chunk-merge step) outweighs the throughput gain.
     /// `None` falls back to the downloader's default
     /// (`DEFAULT_PARALLEL_THRESHOLD_BYTES`, currently 10 MiB).
-    /// Validated post-load by `Config::validate()`: must be 1..=1_073_741_824 bytes (1 GiB).
+    /// Validated post-load by `Config::validate()`: must be `1..=1_073_741_824` bytes (1 GiB).
     pub parallel_threshold: Option<u64>,
 
     /// Source IP address to bind to

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -539,3 +539,48 @@ fn hls_timeouts_round_trip_serde() {
     assert_eq!(back.hls_operation_timeout, Some(15));
     assert_eq!(back.hls_head_probe_timeout, Some(7));
 }
+
+#[test]
+fn test_default_parallel_threshold_is_10_mib() {
+    let config = Config::default();
+    assert_eq!(config.parallel_threshold, Some(10 * 1024 * 1024));
+}
+
+#[test]
+fn test_validate_parallel_threshold_rejects_zero() {
+    let mut config = Config::default();
+    config.parallel_threshold = Some(0);
+    let err = config.validate().unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigValidationError::OutOfRange { field: "parallel_threshold", .. }
+    ));
+}
+
+#[test]
+fn test_validate_parallel_threshold_rejects_above_1_gib() {
+    let mut config = Config::default();
+    config.parallel_threshold = Some(1024 * 1024 * 1024 + 1);
+    let err = config.validate().unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigValidationError::OutOfRange { field: "parallel_threshold", .. }
+    ));
+}
+
+#[test]
+fn test_validate_parallel_threshold_accepts_boundaries() {
+    let mut config = Config::default();
+    config.parallel_threshold = Some(1);
+    assert!(config.validate().is_ok(), "1 byte must be valid");
+
+    config.parallel_threshold = Some(1024 * 1024 * 1024);
+    assert!(config.validate().is_ok(), "1 GiB must be valid");
+}
+
+#[test]
+fn test_validate_parallel_threshold_none_is_valid() {
+    let mut config = Config::default();
+    config.parallel_threshold = None;
+    assert!(config.validate().is_ok(), "None must be valid (uses downloader default)");
+}

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -553,7 +553,10 @@ fn test_validate_parallel_threshold_rejects_zero() {
     let err = config.validate().unwrap_err();
     assert!(matches!(
         err,
-        ConfigValidationError::OutOfRange { field: "parallel_threshold", .. }
+        ConfigValidationError::OutOfRange {
+            field: "parallel_threshold",
+            ..
+        }
     ));
 }
 
@@ -564,7 +567,10 @@ fn test_validate_parallel_threshold_rejects_above_1_gib() {
     let err = config.validate().unwrap_err();
     assert!(matches!(
         err,
-        ConfigValidationError::OutOfRange { field: "parallel_threshold", .. }
+        ConfigValidationError::OutOfRange {
+            field: "parallel_threshold",
+            ..
+        }
     ));
 }
 
@@ -582,5 +588,8 @@ fn test_validate_parallel_threshold_accepts_boundaries() {
 fn test_validate_parallel_threshold_none_is_valid() {
     let mut config = Config::default();
     config.parallel_threshold = None;
-    assert!(config.validate().is_ok(), "None must be valid (uses downloader default)");
+    assert!(
+        config.validate().is_ok(),
+        "None must be valid (uses downloader default)"
+    );
 }


### PR DESCRIPTION
## Summary

- Add `Config::parallel_threshold: Option<u64>` (operator-tunable, default Some(10 MiB), validated 1..=1 GiB).
- Add `DownloaderConfig::parallel_threshold` + `HttpDownloader::with_parallel_threshold()` builder (clamps to floor of 1 to mirror `Config::validate()`).
- Replace the hardcoded `PARALLEL_THRESHOLD = 10 * 1024 * 1024` const usage in `trait_impl.rs` (3 call sites — initial dispatch, log line, resume path).

This is **F2** from the download-optimization audit. Pattern mirrors PR #283 (hls_operation_timeout / hls_head_probe_timeout).

## Why

Per `~/.claude/rules/no-hardcoded-magic-numbers.md`: a numeric literal that affects runtime behavior belongs on Config, not inline in the code path. The 10 MiB threshold is operator-relevant: on a 1 Gbit pipe the threshold could safely drop to 1 MiB; on a slow network the current value may already be too low.

## Out of scope

- End-to-end wire-up from `rdlp-api` orchestrator to `with_parallel_threshold()`. Same gap exists today for `with_concurrent_fragments` and `hls_head_probe_timeout` (only consumed by tests). Tracked as a follow-up wiring PR.
- CLI flag `--parallel-threshold "10MB"` and `bytesize` dependency. Separate CLI sprint.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check` (workspace)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 5 new tests in `rdlp-types` (default, rejects 0, rejects >1 GiB, accepts boundaries, accepts None) + 4 new tests in `rdlp-downloader` (builder sets field, default 10 MiB, clamp 0→1, mockito integration)
- [x] `cargo check -p rdlp-desktop`

## Reviews

- security-reviewer subagent: **Approve with minor fix** — 1 LOW finding (`with_parallel_threshold(0)` bypasses validation floor). Fixed in commit `0a4e10a` with `.max(1)` clamp + regression test.
- code-reviewer subagent: **Approve** — no Critical/HIGH/MEDIUM findings. Pattern parity with PR #283 verified. Naming consistency clean. 3rd call-site replacement (resume path) preserves semantics.

## Closes

(no issue — F2 is a sub-finding of an audit doc, not a tracking issue)