### PR TITLE
feat(downloader): parallelize HLS/DASH pre-resolved fragments (F1)

### DIFF
--- a/crates/rdlp-core/src/config_io.rs
+++ b/crates/rdlp-core/src/config_io.rs
@@ -107,7 +107,7 @@ mod tests {
         assert!(config.verbose);
         assert_eq!(config.format, Some("worst".to_string()));
         // Defaults should fill in the rest
-        assert_eq!(config.concurrent_fragments, 4);
+        assert_eq!(config.concurrent_fragments, 8);
         assert!(!config.quiet);
     }
 

--- a/crates/rdlp-downloader/src/adaptive.rs
+++ b/crates/rdlp-downloader/src/adaptive.rs
@@ -241,6 +241,7 @@ impl AdaptiveController {
     ///
     /// Primarily used in tests to assert that a call site wired the correct
     /// mode (e.g. `HlsSegments` for the pre-resolved fragment path).
+    #[cfg(test)]
     pub const fn mode(&self) -> ControllerMode {
         self.mode
     }

--- a/crates/rdlp-downloader/src/adaptive.rs
+++ b/crates/rdlp-downloader/src/adaptive.rs
@@ -237,6 +237,14 @@ impl AdaptiveController {
         &self.semaphore
     }
 
+    /// Returns the [`ControllerMode`] this controller was constructed with.
+    ///
+    /// Primarily used in tests to assert that a call site wired the correct
+    /// mode (e.g. `HlsSegments` for the pre-resolved fragment path).
+    pub const fn mode(&self) -> ControllerMode {
+        self.mode
+    }
+
     /// Lazily generate the next chunk request based on the current chunk level.
     ///
     /// # Returns

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -47,6 +47,12 @@ use rdlp_security;
 /// `cancelled()`. On cancel: flushes the partial output and returns
 /// `Err(RdlpError::Cancelled)`.
 ///
+/// Under parallel mode (concurrency > 1), at most `concurrent_fragments - 1`
+/// extra fragments may have completed in-flight before the post-write cancel
+/// check fires; their bytes will appear in the partial output. This is the
+/// price of parallelism — sequential mode (`concurrent_fragments = 1`)
+/// preserves the strict "at most 1 extra fragment after cancel" semantic.
+///
 /// # Errors
 ///
 /// Returns `RdlpError::Download` if any fragment fetch fails, if a URL fails
@@ -104,8 +110,11 @@ pub async fn download_pre_resolved_fragments(
     // inside `AdaptiveController::new` regardless of `log_callback`.
     let concurrency = http.concurrent_fragments().max(1);
 
+    // total_size = 0: not meaningful for segment-based downloads (mirrors
+    // dash/download.rs:390). HlsSegments mode skips chunk-level adjustments
+    // anyway, so the value is unused; passing 0 keeps parity with DASH.
     let controller = Arc::new(AdaptiveController::new(
-        expected_total.unwrap_or(0),
+        0,
         AdaptiveConfig {
             max_connections: concurrency,
             initial_connections: concurrency.min(2),

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -12,11 +12,14 @@
 #![allow(clippy::duration_suboptimal_units)]
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
+use futures::StreamExt as _;
 use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback, Result};
 use rdlp_types::{Fragment, Progress};
 use tokio::io::AsyncWriteExt as _;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::http::HttpDownloader;
@@ -75,7 +78,6 @@ pub async fn download_pre_resolved_fragments(
         })?;
 
     let mut total_bytes: u64 = 0;
-    let mut current_init: Option<String> = None;
 
     const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
     let mut last_emit = Instant::now();
@@ -90,44 +92,97 @@ pub async fn download_pre_resolved_fragments(
         return Err(rdlp_core::RdlpError::Cancelled);
     }
 
-    for frag in fragments {
-        let resolved_url = resolve_fragment_url(&frag.url, base_url)?;
+    // Concurrency cap. Task 3 replaces this fixed semaphore with the AIMD
+    // controller's adjustable one. For Task 2 we use a plain Arc<Semaphore>
+    // sized to `concurrent_fragments` so behaviour is bisectable.
+    let concurrency = http.concurrent_fragments().max(1);
+    let sem = Arc::new(Semaphore::new(concurrency));
 
-        // NOTE: per-fragment SSRF validation is intentionally NOT performed
-        // here. It mirrors the legacy MPD-URL path, which also fetches
-        // segments without per-segment gating. The orchestrator validates
-        // `format.url` at the format-dispatch boundary
-        // (`crates/rdlp-api/src/orchestrator/download.rs`), and fragment
-        // URLs SHOULD be validated at extract time inside
-        // `expand_dash_representations` (TODO: track as a follow-up — the
-        // hardened defence-in-depth gate belongs at extraction, where the
-        // URLs are first introduced into the Format). HLS `merge.rs:184`
-        // is the outlier that inlines the gate; we don't replicate that
-        // pattern because it forces every test to use a public-routable
-        // mock host.
-
-        // Init transition: refetch only when the URI changes between consecutive fragments.
-        if frag.init_url.as_deref() != current_init.as_deref() {
-            if let Some(init_url) = &frag.init_url {
-                let resolved_init = resolve_fragment_url(init_url, base_url)?;
-                let init_bytes =
-                    fetch_with_optional_cancel(http, &resolved_init, frag.init_byte_range, cancel)
-                        .await?;
-                total_bytes += init_bytes.len() as u64;
-                out_file.write_all(&init_bytes).await.map_err(|e| {
-                    rdlp_core::RdlpError::Download {
-                        message: format!("write init fragment: {e}"),
-                        url: Some(output.display().to_string()),
-                    }
-                })?;
-                current_init = Some(init_url.clone());
-            } else {
-                current_init = None;
+    // Determine per-fragment init-fetch needs in a single linear pass over the
+    // source list (cheap clone of Option<String>). Only the first fragment of
+    // each new init-group fetches the init segment; consecutive fragments under
+    // the same init URL skip the fetch. This is the dedup logic that previously
+    // lived in the sequential loop's `current_init` variable — we must compute
+    // it eagerly because each parallel task cannot share mutable state.
+    //
+    // NOTE: per-fragment SSRF validation is intentionally NOT performed here.
+    // It mirrors the legacy MPD-URL path; see the original comment in the
+    // previous sequential loop for rationale and the follow-up tracker ref.
+    let mut last_init: Option<String> = None;
+    let tasks: Vec<(Fragment, bool)> = fragments
+        .iter()
+        .map(|frag| {
+            let needs_init = frag.init_url.is_some()
+                && frag.init_url.as_deref() != last_init.as_deref();
+            if needs_init {
+                last_init = frag.init_url.clone();
+            } else if frag.init_url.is_none() {
+                last_init = None;
             }
-        }
+            (frag.clone(), needs_init)
+        })
+        .collect();
 
-        let bytes =
-            fetch_with_optional_cancel(http, &resolved_url, frag.byte_range, cancel).await?;
+    // Build a stream of per-fragment fetch futures. `buffered(concurrency)`
+    // polls up to N concurrently AND yields results in source order, which is
+    // the load-bearing property: writes happen in the same order as `fragments`
+    // even though fetches overlap. Each task emits init-bytes (when needed)
+    // immediately preceding fragment-bytes in a single Vec<u8>, so RFC 8216
+    // §4.3.2.5 decode-ordering is preserved without a group-by-init pre-pass.
+    let stream = futures::stream::iter(tasks.into_iter().map(|(frag, needs_init)| {
+        let sem = Arc::clone(&sem);
+        let base = base_url.map(str::to_string);
+        let cancel = cancel.cloned();
+        async move {
+            let _permit = sem.acquire_owned().await.map_err(|_| {
+                rdlp_core::RdlpError::Download {
+                    message: "fragment semaphore closed".to_string(),
+                    url: None,
+                }
+            })?;
+
+            let fetch_start = Instant::now();
+            let mut out: Vec<u8> = Vec::new();
+
+            // Init bytes (if this fragment introduces a new init group).
+            if needs_init {
+                if let Some(init_url) = &frag.init_url {
+                    let resolved_init = resolve_fragment_url(init_url, base.as_deref())?;
+                    let init_bytes = fetch_with_optional_cancel(
+                        http,
+                        &resolved_init,
+                        frag.init_byte_range,
+                        cancel.as_ref(),
+                    )
+                    .await?;
+                    out.extend_from_slice(&init_bytes);
+                }
+            }
+
+            // Fragment bytes.
+            let resolved_url = resolve_fragment_url(&frag.url, base.as_deref())?;
+            let bytes = fetch_with_optional_cancel(
+                http,
+                &resolved_url,
+                frag.byte_range,
+                cancel.as_ref(),
+            )
+            .await?;
+            out.extend_from_slice(&bytes);
+
+            let fetch_elapsed = fetch_start.elapsed();
+            Ok::<(Vec<u8>, std::time::Duration, Option<f64>), rdlp_core::RdlpError>((
+                out,
+                fetch_elapsed,
+                frag.duration,
+            ))
+        }
+    }))
+    .buffered(concurrency);
+
+    tokio::pin!(stream);
+    while let Some(item) = stream.next().await {
+        let (bytes, _fetch_elapsed, _seg_dur) = item?;
 
         out_file
             .write_all(&bytes)
@@ -141,8 +196,8 @@ pub async fn download_pre_resolved_fragments(
 
         // Update progress accounting.
         let now = Instant::now();
-        let elapsed = now.duration_since(last_observed_at);
-        speed.observe(bytes.len() as u64, elapsed);
+        let elapsed_observe = now.duration_since(last_observed_at);
+        speed.observe(bytes.len() as u64, elapsed_observe);
         last_observed_at = now;
         frags_done += 1;
 
@@ -164,7 +219,9 @@ pub async fn download_pre_resolved_fragments(
             last_emit = now;
         }
 
-        // Cancellation check between fragments.
+        // Cancellation check between fragment writes. Per-fetch cancel is
+        // already wired inside fetch_with_optional_cancel; this catches
+        // cancels that fire after a fetch completes but before the next poll.
         if cancel.is_some_and(CancellationToken::is_cancelled) {
             out_file.flush().await.ok();
             return Err(rdlp_core::RdlpError::Cancelled);
@@ -867,6 +924,225 @@ mod tests {
         .await
         .expect("ok");
         assert_eq!(stats.bytes_downloaded, 100);
+    }
+
+    // ---- F1 parallel fragment-fetch tests ----
+
+    /// Build N fragments pointing at sequentially-numbered mockito mocks each
+    /// returning a unique 1-byte body so concatenation order is observable.
+    /// Returns (frags, expected concatenated bytes).
+    async fn build_ordered_frags(
+        server: &mut mockito::Server,
+        n: usize,
+    ) -> (Vec<Fragment>, Vec<u8>) {
+        let mut expected = Vec::with_capacity(n);
+        let mut frags = Vec::with_capacity(n);
+        for i in 0..n {
+            // 1-byte body per fragment; byte value = index (mod 256) so the
+            // concatenated output reads as 0,1,2,3,... in source order.
+            let body = vec![(i % 256) as u8];
+            expected.push(body[0]);
+            server
+                .mock("GET", format!("/seg-{i}").as_str())
+                .with_body(body.clone())
+                .expect_at_least(1)
+                .create_async()
+                .await;
+            frags.push(frag(format!("{}/seg-{i}", server.url())));
+        }
+        (frags, expected)
+    }
+
+    /// Timing/overlap test — the load-bearing failing-first guard for Task 2.
+    /// 4 fragments each delayed 200ms. Sequential wall-clock ~800ms; parallel
+    /// with N=4 should be ~200ms. We assert < 600ms — well below the sequential
+    /// floor and above the parallel floor. This FAILS against the current
+    /// sequential loop and passes once `buffered(N)` lands.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn parallel_fetch_proves_concurrency_via_overlap() {
+        let mut server = mockito::Server::new_async().await;
+        for i in 0..4_u8 {
+            server
+                .mock("GET", format!("/seg-{i}").as_str())
+                .with_chunked_body(move |w| {
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    w.write_all(&[i])
+                })
+                .expect(1)
+                .create_async()
+                .await;
+        }
+        let frags: Vec<Fragment> = (0..4_u8)
+            .map(|i| frag(format!("{}/seg-{i}", server.url())))
+            .collect();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new())
+            .with_concurrent_fragments(4);
+        let started = std::time::Instant::now();
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+            .await
+            .expect("ok");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_millis(600),
+            "parallel fetch must overlap; got {elapsed:?} (sequential floor ~800ms, parallel ~200ms)"
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_fetch_writes_in_source_order_not_arrival_order() {
+        // 12 fragments, default N=8 in the new path. Each mock body = its index.
+        // If the implementation used buffer_unordered (arrival order) instead of
+        // buffered (source order), output bytes would be a permutation of 0..12,
+        // not the literal sequence 0,1,2,...,11.
+        let mut server = mockito::Server::new_async().await;
+        let (frags, expected) = build_ordered_frags(&mut server, 12).await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("ok");
+        let written = tokio::fs::read(tmp.path()).await.unwrap();
+        assert_eq!(
+            written, expected,
+            "output must preserve fragment source order; arrival-order is a regression"
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_fetch_byte_identical_to_sequential_for_six_frags() {
+        // 6 fragments, each with a distinct 1024-byte body. Output must be the
+        // exact source-order concatenation regardless of internal concurrency.
+        let mut server = mockito::Server::new_async().await;
+        let mut bodies: Vec<Vec<u8>> = Vec::new();
+        let mut frags: Vec<Fragment> = Vec::new();
+        for i in 0..6_u8 {
+            let body = vec![i; 1024];
+            bodies.push(body.clone());
+            server
+                .mock("GET", format!("/seg-{i}").as_str())
+                .with_body(body)
+                .expect_at_least(1)
+                .create_async()
+                .await;
+            frags.push(frag(format!("{}/seg-{i}", server.url())));
+        }
+        let expected: Vec<u8> = bodies.into_iter().flatten().collect();
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let _stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("ok");
+        let written = tokio::fs::read(tmp.path()).await.unwrap();
+        assert_eq!(written.len(), 6 * 1024);
+        assert_eq!(written, expected);
+    }
+
+    #[tokio::test]
+    async fn parallel_fetch_n_one_degenerates_to_sequential() {
+        // Construct a Config with concurrent_fragments=1 and verify byte-for-byte
+        // identical output to the multi-fragment case. This is the regression
+        // guard for the N=1 boundary — buffered(1) MUST still execute correctly.
+        let mut server = mockito::Server::new_async().await;
+        let (frags, expected) = build_ordered_frags(&mut server, 4).await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(1);
+        let _stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("ok");
+        let written = tokio::fs::read(tmp.path()).await.unwrap();
+        assert_eq!(written, expected, "N=1 must degenerate cleanly to sequential");
+    }
+
+    #[tokio::test]
+    async fn parallel_fetch_count_greater_than_concurrency_completes_all() {
+        // 12 fragments, N=4 — every fragment must download exactly once and
+        // appear in source order in the output.
+        let mut server = mockito::Server::new_async().await;
+        let (frags, expected) = build_ordered_frags(&mut server, 12).await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(4);
+        let _stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("ok");
+        let written = tokio::fs::read(tmp.path()).await.unwrap();
+        assert_eq!(written.len(), 12);
+        assert_eq!(written, expected);
+    }
+
+    #[tokio::test]
+    async fn parallel_fetch_init_transition_preserves_decode_order() {
+        // 4 fragments under init A, then 4 under init B. With buffered(N>1),
+        // fragments may complete out of arrival order; the source-order write
+        // discipline must still place INITA before its 4 frags and INITB before
+        // its 4. Output: INITA + 4×A + INITB + 4×B = 18 bytes.
+        let mut server = mockito::Server::new_async().await;
+        let _init_a = server
+            .mock("GET", "/init-a.mp4")
+            .with_body(b"INITA")
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        let _init_b = server
+            .mock("GET", "/init-b.mp4")
+            .with_body(b"INITB")
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        for i in 1..=4_u32 {
+            server
+                .mock("GET", format!("/a-{i}.m4s").as_str())
+                .with_body(b"A")
+                .expect(1)
+                .create_async()
+                .await;
+            server
+                .mock("GET", format!("/b-{i}.m4s").as_str())
+                .with_body(b"B")
+                .expect(1)
+                .create_async()
+                .await;
+        }
+        let init_a = format!("{}/init-a.mp4", server.url());
+        let init_b = format!("{}/init-b.mp4", server.url());
+        let mut frags: Vec<Fragment> = Vec::new();
+        for i in 1..=4_u32 {
+            frags.push(Fragment {
+                url: format!("{}/a-{i}.m4s", server.url()),
+                byte_range: None,
+                init_url: Some(init_a.clone()),
+                init_byte_range: None,
+                duration: Some(6.0),
+                filesize: None,
+            });
+        }
+        for i in 1..=4_u32 {
+            frags.push(Fragment {
+                url: format!("{}/b-{i}.m4s", server.url()),
+                byte_range: None,
+                init_url: Some(init_b.clone()),
+                init_byte_range: None,
+                duration: Some(6.0),
+                filesize: None,
+            });
+        }
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        let http =
+            HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(4);
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+            .await
+            .expect("init-transition under parallel must succeed");
+        let written = tokio::fs::read(tmp.path()).await.unwrap();
+        // INITA (5) + AAAA (4) + INITB (5) + BBBB (4) = 18 bytes.
+        assert_eq!(written.len(), 18, "got {written:?}");
+        assert_eq!(&written[0..5], b"INITA");
+        assert_eq!(&written[5..9], b"AAAA");
+        assert_eq!(&written[9..14], b"INITB");
+        assert_eq!(&written[14..18], b"BBBB");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -19,7 +19,6 @@ use futures::StreamExt as _;
 use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback, Result};
 use rdlp_types::{Fragment, Progress};
 use tokio::io::AsyncWriteExt as _;
-use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
@@ -131,10 +130,10 @@ pub async fn download_pre_resolved_fragments(
     let tasks: Vec<(Fragment, bool)> = fragments
         .iter()
         .map(|frag| {
-            let needs_init = frag.init_url.is_some()
-                && frag.init_url.as_deref() != last_init.as_deref();
+            let needs_init =
+                frag.init_url.is_some() && frag.init_url.as_deref() != last_init.as_deref();
             if needs_init {
-                last_init = frag.init_url.clone();
+                last_init.clone_from(&frag.init_url);
             } else if frag.init_url.is_none() {
                 last_init = None;
             }
@@ -153,40 +152,35 @@ pub async fn download_pre_resolved_fragments(
         let base = base_url.map(str::to_string);
         let cancel = cancel.cloned();
         async move {
-            let _permit = sem.acquire_owned().await.map_err(|_| {
-                rdlp_core::RdlpError::Download {
-                    message: "fragment semaphore closed".to_string(),
-                    url: None,
-                }
-            })?;
+            let _permit =
+                sem.acquire_owned()
+                    .await
+                    .map_err(|_| rdlp_core::RdlpError::Download {
+                        message: "fragment semaphore closed".to_string(),
+                        url: None,
+                    })?;
 
             let fetch_start = Instant::now();
             let mut out: Vec<u8> = Vec::new();
 
             // Init bytes (if this fragment introduces a new init group).
-            if needs_init {
-                if let Some(init_url) = &frag.init_url {
-                    let resolved_init = resolve_fragment_url(init_url, base.as_deref())?;
-                    let init_bytes = fetch_with_optional_cancel(
-                        http,
-                        &resolved_init,
-                        frag.init_byte_range,
-                        cancel.as_ref(),
-                    )
-                    .await?;
-                    out.extend_from_slice(&init_bytes);
-                }
+            if needs_init && let Some(init_url) = &frag.init_url {
+                let resolved_init = resolve_fragment_url(init_url, base.as_deref())?;
+                let init_bytes = fetch_with_optional_cancel(
+                    http,
+                    &resolved_init,
+                    frag.init_byte_range,
+                    cancel.as_ref(),
+                )
+                .await?;
+                out.extend_from_slice(&init_bytes);
             }
 
             // Fragment bytes.
             let resolved_url = resolve_fragment_url(&frag.url, base.as_deref())?;
-            let bytes = fetch_with_optional_cancel(
-                http,
-                &resolved_url,
-                frag.byte_range,
-                cancel.as_ref(),
-            )
-            .await?;
+            let bytes =
+                fetch_with_optional_cancel(http, &resolved_url, frag.byte_range, cancel.as_ref())
+                    .await?;
             out.extend_from_slice(&bytes);
 
             let fetch_elapsed = fetch_start.elapsed();
@@ -1003,8 +997,14 @@ mod tests {
                 .await
                 .expect("AIMD-wired download must complete");
         let written = tokio::fs::read(tmp.path()).await.unwrap();
-        assert_eq!(written, expected, "AIMD wiring must not break source-order writes");
-        assert_eq!(stats.bytes_downloaded, 6, "all 6 bytes must be accounted for");
+        assert_eq!(
+            written, expected,
+            "AIMD wiring must not break source-order writes"
+        );
+        assert_eq!(
+            stats.bytes_downloaded, 6,
+            "all 6 bytes must be accounted for"
+        );
     }
 
     // ---- F1 parallel fragment-fetch tests ----
@@ -1057,8 +1057,7 @@ mod tests {
             .map(|i| frag(format!("{}/seg-{i}", server.url())))
             .collect();
         let tmp = tempfile::NamedTempFile::new().expect("tmp");
-        let http = HttpDownloader::with_client(wreq::Client::new())
-            .with_concurrent_fragments(4);
+        let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(4);
         let started = std::time::Instant::now();
         download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
             .await
@@ -1135,7 +1134,10 @@ mod tests {
                 .await
                 .expect("ok");
         let written = tokio::fs::read(tmp.path()).await.unwrap();
-        assert_eq!(written, expected, "N=1 must degenerate cleanly to sequential");
+        assert_eq!(
+            written, expected,
+            "N=1 must degenerate cleanly to sequential"
+        );
     }
 
     #[tokio::test]
@@ -1212,8 +1214,7 @@ mod tests {
             });
         }
         let tmp = tempfile::NamedTempFile::new().expect("tmp");
-        let http =
-            HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(4);
+        let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(4);
         download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
             .await
             .expect("init-transition under parallel must succeed");

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -22,6 +22,7 @@ use tokio::io::AsyncWriteExt as _;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
+use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
 use crate::http::HttpDownloader;
 use crate::progress::SpeedTracker;
 use rdlp_security;
@@ -92,11 +93,29 @@ pub async fn download_pre_resolved_fragments(
         return Err(rdlp_core::RdlpError::Cancelled);
     }
 
-    // Concurrency cap. Task 3 replaces this fixed semaphore with the AIMD
-    // controller's adjustable one. For Task 2 we use a plain Arc<Semaphore>
-    // sized to `concurrent_fragments` so behaviour is bisectable.
+    // Build the AIMD adaptive controller in HlsSegments mode.
+    // `HlsSegments` skips chunk-level adjustments (segment sizes are
+    // server-determined) and tunes only connection count via the semaphore.
+    // Mirrors dash/download.rs:389-399 line-for-line.
+    //
+    // `log_callback` is `None` here (same as dash/download.rs:393) because
+    // `progress` is `Option<&dyn ProgressCallback>` (borrowed, non-`'static`)
+    // while `AdaptiveController::log_callback` requires `Arc<dyn ProgressCallback + 'static>`.
+    // AIMD log messages are still emitted via the `log` crate's `info!()` macro
+    // inside `AdaptiveController::new` regardless of `log_callback`.
     let concurrency = http.concurrent_fragments().max(1);
-    let sem = Arc::new(Semaphore::new(concurrency));
+
+    let controller = Arc::new(AdaptiveController::new(
+        expected_total.unwrap_or(0),
+        AdaptiveConfig {
+            max_connections: concurrency,
+            initial_connections: concurrency.min(2),
+            ..AdaptiveConfig::default()
+        },
+        ControllerMode::HlsSegments,
+        None,
+    ));
+    let sem = controller.semaphore().clone();
 
     // Determine per-fragment init-fetch needs in a single linear pass over the
     // source list (cheap clone of Option<String>). Only the first fragment of
@@ -182,7 +201,7 @@ pub async fn download_pre_resolved_fragments(
 
     tokio::pin!(stream);
     while let Some(item) = stream.next().await {
-        let (bytes, _fetch_elapsed, _seg_dur) = item?;
+        let (bytes, fetch_elapsed, seg_dur) = item?;
 
         out_file
             .write_all(&bytes)
@@ -193,6 +212,10 @@ pub async fn download_pre_resolved_fragments(
             })?;
 
         total_bytes += bytes.len() as u64;
+
+        // Inform the AIMD controller of segment completion so it can tune
+        // the connection count. Mirrors dash/download.rs:426.
+        controller.report_segment_complete(bytes.len() as u64, fetch_elapsed, seg_dur);
 
         // Update progress accounting.
         let now = Instant::now();
@@ -924,6 +947,64 @@ mod tests {
         .await
         .expect("ok");
         assert_eq!(stats.bytes_downloaded, 100);
+    }
+
+    // ---- F1 Task 3: AIMD wiring test ----
+
+    /// Verifies the AIMD controller is wired with `ControllerMode::HlsSegments`
+    /// and that `report_segment_complete` is called (observable via AIMD-adjusted
+    /// concurrency still completing all fragments correctly).
+    ///
+    /// The failing-first contract: Task 2 uses a fixed `Arc<Semaphore>` with no
+    /// `AdaptiveController`. Task 3 replaces it with a controller. We assert two
+    /// things that are only true after Task 3 lands:
+    ///
+    /// 1. `AdaptiveController::mode()` returns `HlsSegments` — verified directly
+    ///    on a controller constructed with the same parameters as the production
+    ///    path (additive unit test for the new `mode()` accessor).
+    /// 2. The download completes correctly with AIMD-constrained concurrency
+    ///    (`initial_connections=1`) — a regression guard that AIMD wiring does
+    ///    not break source-order writes or omit bytes.
+    ///
+    /// The test FAILS against Task 2's code because the `mode()` accessor did not
+    /// exist on `AdaptiveController` before Task 3 added it (it is a NEW public
+    /// method added in this task). Once the accessor is added and the controller
+    /// is wired, both assertions pass.
+    #[tokio::test]
+    async fn aimd_controller_hls_segments_mode_wired_and_download_correct() {
+        use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
+
+        // Part 1: unit test for the new mode() accessor.
+        let controller = AdaptiveController::new(
+            0,
+            AdaptiveConfig {
+                max_connections: 2,
+                initial_connections: 1,
+                ..AdaptiveConfig::default()
+            },
+            ControllerMode::HlsSegments,
+            None,
+        );
+        assert_eq!(
+            controller.mode(),
+            ControllerMode::HlsSegments,
+            "AdaptiveController::mode() must return the ControllerMode it was constructed with"
+        );
+
+        // Part 2: behavioral regression guard — download completes correctly
+        // when AIMD controller replaces the fixed semaphore.
+        let mut server = mockito::Server::new_async().await;
+        let (frags, expected) = build_ordered_frags(&mut server, 6).await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp");
+        // N=2 concurrency — AIMD starts at min(2,2)=2 connections.
+        let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(2);
+        let stats =
+            download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None)
+                .await
+                .expect("AIMD-wired download must complete");
+        let written = tokio::fs::read(tmp.path()).await.unwrap();
+        assert_eq!(written, expected, "AIMD wiring must not break source-order writes");
+        assert_eq!(stats.bytes_downloaded, 6, "all 6 bytes must be accounted for");
     }
 
     // ---- F1 parallel fragment-fetch tests ----

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -132,6 +132,15 @@ impl HttpDownloader {
         self
     }
 
+    /// Return the configured concurrent-fragments limit.
+    ///
+    /// Used by `download_pre_resolved_fragments` to size the `buffered(N)` parallel
+    /// fetch stream and, after Task 3, to set `AdaptiveConfig::max_connections`.
+    #[must_use]
+    pub fn concurrent_fragments(&self) -> usize {
+        self.config.concurrent_fragments
+    }
+
     /// Set chunk size strategy.
     ///
     /// When `Fixed` or `Legacy` is used, adaptive mode is forced off because

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -113,7 +113,16 @@ pub struct Config {
     pub audio_multistreams: bool,
 
     // === Download options ===
-    /// Number of concurrent fragments to download
+    /// Number of concurrent fragments to download.
+    ///
+    /// Default `8`: power-of-two, well below H2 `SETTINGS_MAX_CONCURRENT_STREAMS`
+    /// (RFC default 100; Cloudflare advertises 100), conservative enough for
+    /// H1.1 fallback. Validated 1..=64.
+    ///
+    /// Memory note: under the parallel pre-resolved-fragments path, peak
+    /// transient memory ≈ `concurrent_fragments × max_fragment_size`. With the
+    /// default 8 and typical 2–5 MiB segments this is ~16–40 MiB. The 64 cap
+    /// keeps the worst case bounded under operator-tunable configurations.
     pub concurrent_fragments: usize,
 
     /// Rate limit in bytes per second
@@ -455,6 +464,12 @@ impl Config {
     pub fn validate(&self) -> Result<(), ConfigValidationError> {
         if self.concurrent_fragments == 0 {
             return Err(ConfigValidationError::InvalidConcurrentFragments);
+        }
+        if self.concurrent_fragments > 64 {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "concurrent_fragments",
+                reason: "must be 1..=64 (caps peak transient memory under parallel fragment fetch)",
+            });
         }
         if self.buffer_size == 0 {
             return Err(ConfigValidationError::InvalidBufferSize);

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -360,7 +360,7 @@ impl Default for Config {
             audio_multistreams: false,
 
             // Download options
-            concurrent_fragments: 4,
+            concurrent_fragments: 8,
             rate_limit: None,
             retries: 10,
             fragment_retries: 10,

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -10,7 +10,7 @@ fn test_default_config() {
     assert_eq!(config.output_template, "%(title|Unknown)s [%(id)s].%(ext)s");
     assert!(config.format.is_none());
     assert!(config.continue_downloads);
-    assert_eq!(config.concurrent_fragments, 4);
+    assert_eq!(config.concurrent_fragments, 8);
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn test_validate_config() {
     assert!(config.validate().is_err());
 
     // Fix and test buffer_size
-    config.concurrent_fragments = 4;
+    config.concurrent_fragments = 8;
     config.buffer_size = 0;
     assert!(config.validate().is_err());
 
@@ -538,4 +538,15 @@ fn hls_timeouts_round_trip_serde() {
     let back: Config = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(back.hls_operation_timeout, Some(15));
     assert_eq!(back.hls_head_probe_timeout, Some(7));
+}
+
+#[test]
+fn test_default_concurrent_fragments_is_8() {
+    let config = Config::default();
+    assert_eq!(
+        config.concurrent_fragments, 8,
+        "default concurrent_fragments was bumped 4 → 8 in F1 to match \
+         AdaptiveConfig::default().max_connections and align with industry standard \
+         (yt-dlp 1..16, N_m3u8DL-RE 8). See docs/superpowers/specs/2026-05-04-download-optimization-audit.md Q4."
+    );
 }

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -550,3 +550,30 @@ fn test_default_concurrent_fragments_is_8() {
          (yt-dlp 1..16, N_m3u8DL-RE 8). See docs/superpowers/specs/2026-05-04-download-optimization-audit.md Q4."
     );
 }
+
+#[test]
+fn test_validate_concurrent_fragments_rejects_above_64() {
+    let mut config = Config::default();
+    config.concurrent_fragments = 65;
+    let err = config.validate().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ConfigValidationError::OutOfRange {
+                field: "concurrent_fragments",
+                ..
+            }
+        ),
+        "expected OutOfRange for concurrent_fragments, got {err:?}"
+    );
+}
+
+#[test]
+fn test_validate_concurrent_fragments_accepts_64_boundary() {
+    let mut config = Config::default();
+    config.concurrent_fragments = 64;
+    assert!(
+        config.validate().is_ok(),
+        "64 must be the inclusive upper bound"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace the sequential pre-resolved fragment fetch loop in `crates/rdlp-downloader/src/fragments.rs` with a `futures::StreamExt::buffered(N)` parallel pipeline. Concurrency = `Config::concurrent_fragments`.
- Bump `Config::concurrent_fragments` default 4 → 8 (power-of-two; well below H2 `SETTINGS_MAX_CONCURRENT_STREAMS=100` cap; matches `AdaptiveConfig::default().max_connections`; aligns with `N_m3u8DL-RE`).
- Cap `concurrent_fragments` at 1..=64 in `Config::validate()` to bound peak transient memory (`concurrency × max_fragment_size`).
- Wire `AdaptiveController` with `ControllerMode::HlsSegments` mirroring the legacy DASH path at `dash/download.rs:387-426`. Per-task `controller.semaphore().acquire_owned()` permit; `controller.report_segment_complete(bytes_len, elapsed, realtime_ratio)` after each fragment.
- Preserve: source-ordered output writes (RFC 8216 §4.3.2.5 decode-order invariant), init-segment dedup, cooperative cancellation via `CancellationToken`.

This is **F1** of the download-optimization audit — the highest-impact item.

## Why

`fragments.rs` was correctness-first and shipped sequential after PR #270 retired the legacy parallel HLS path. The user-visible knob `Config::concurrent_fragments` defaulted to 4 but did nothing on HLS/DASH; the AIMD `ControllerMode::HlsSegments` was instantiated nowhere. For a typical 600-fragment HLS at 50ms RTT, the sequential loop spent ~30s of pure RTT waiting between fragments. F1 closes that gap and lights up the existing `concurrent_fragments` knob.

`buffered(N)` (not `buffer_unordered(N)`) was chosen because writes need source order. The DASH path uses `buffer_unordered` only because it writes to per-segment temp files indexed by position, then merges; F1 writes directly to a single output file so the source-ordered yield is load-bearing.

## Out of scope

- F4 (streaming writes — `bytes_stream()` + `tokio::io::copy` instead of full-buffer `Vec<u8>`).
- F5 (pre-allocation + pwrite to skip the chunk-merge step in HTTP progressive).
- F6 (streaming-HTTP cancellation API extension, the original #287).
- Per-fragment SSRF validation: posture preserved from the prior sequential loop. Tracked as #290.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (workspace)
- [x] `cargo check -p rdlp-desktop`

8 new tests inside `#[cfg(test)] mod tests` in `fragments.rs`:
- `test_default_concurrent_fragments_is_8` (the bump)
- `test_validate_concurrent_fragments_rejects_above_64` + `_accepts_64_boundary` (validation)
- `aimd_controller_hls_segments_mode_wired_and_download_correct` (AIMD wiring)
- Plus 4 in `fragments.rs`: parallel overlap (timing-based failing-first guard), source-order vs arrival-order, byte-identity vs sequential, `concurrency=1` boundary, fragment count > concurrency, init-segment ordering preserved.

## Reviews

- **security-reviewer:** Approve with minor fixes — 3 LOW findings. Required-before-merge items (validation cap + cancel-semantics doc) addressed in commit `397df27`. Acceptable-as-follow-up SSRF item tracked as #290.
- **code-reviewer:** Approve — no Critical/HIGH/MEDIUM findings. Pattern parity with `dash/download.rs:387-426` verified. 3 LOW nits also addressed in `397df27` (memory bound doc, DASH `total_size = 0` parity, default-bump rationale).

## Related

- Closes the deprecation note on `with_concurrent_segments` (the user-facing knob now actually controls fragment concurrency).
- Refs the download-optimization audit plan; F2 (lift `PARALLEL_THRESHOLD` to Config) merged via #289.