### PR TITLE
feat(downloader): wire Config::parallel_threshold into DownloaderRegistry (F1.5)

### DIFF
--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -364,11 +364,14 @@ impl DownloaderRegistry {
         let rate_limiter = config.rate_limit.map(|bps| Arc::new(RateLimiter::new(bps)));
 
         // Create HTTP downloader with optimized settings
-        let http_downloader = HttpDownloader::with_client(client)
+        let mut http_downloader = HttpDownloader::with_client(client)
             .with_buffer_size(config.buffer_size)
             .with_concurrent_fragments(config.concurrent_fragments)
             .with_rate_limiter(rate_limiter)
             .with_adaptive(config.adaptive_downloads);
+        if let Some(threshold) = config.parallel_threshold {
+            http_downloader = http_downloader.with_parallel_threshold(threshold);
+        }
 
         // Create HLS downloader. concurrent_segments/buffer_size were no-ops on the
         // legacy parallel path (deleted in #270); the pre-resolved fragments path
@@ -524,6 +527,34 @@ mod tests {
 
         let unknown = registry.find_downloader("rtmp://example.com/stream");
         assert!(unknown.is_none());
+    }
+
+    #[test]
+    fn registry_wires_parallel_threshold_from_config() {
+        let config = Config {
+            parallel_threshold: Some(5 * 1024 * 1024), // 5 MiB override
+            ..Default::default()
+        };
+        let registry = DownloaderRegistry::with_config(&config);
+        assert_eq!(
+            registry.http_base.config.parallel_threshold,
+            5 * 1024 * 1024,
+            "Config::parallel_threshold must reach HttpDownloader via build_registry"
+        );
+    }
+
+    #[test]
+    fn registry_uses_http_default_when_parallel_threshold_is_none() {
+        let config = Config {
+            parallel_threshold: None,
+            ..Default::default()
+        };
+        let registry = DownloaderRegistry::with_config(&config);
+        assert_eq!(
+            registry.http_base.config.parallel_threshold,
+            10 * 1024 * 1024,
+            "None must fall back to HttpDownloader's DEFAULT_PARALLEL_THRESHOLD_BYTES"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wire `Config::parallel_threshold` into `DownloaderRegistry::build_registry` so the user-visible field actually reaches `HttpDownloader`.
- Closes the orchestrator wire-up gap flagged by both F2 (#289) and F1 (#291) reviewers.
- 2 new tests verify the wire-up: positive (`Some(5 MiB)` reaches `http_base.config`) + negative (`None` falls back to 10 MiB default).

This is **F1.5** of the download-optimization audit's 3-PR plan (F2 → F1 → F1.5).

## Why

`Config::parallel_threshold` was added in F2 (#289) but only consumable through `HttpDownloader::with_parallel_threshold()` in test code. CLI and desktop surfaces had no path to override it. F1.5 closes that gap with the same pattern as `with_buffer_size`, `with_concurrent_fragments`, `with_rate_limiter`, and `with_adaptive` already use.

The conditional `if let Some(threshold) = config.parallel_threshold` form preserves `HttpDownloader`'s built-in `DEFAULT_PARALLEL_THRESHOLD_BYTES` (10 MiB) when the user hasn't overridden — avoids duplicating the constant into the registry per `no-hardcoded-magic-numbers.md`.

## Out of scope

- Sibling fields `hls_operation_timeout` / `hls_head_probe_timeout` have the same wire-up gap. Tracked separately (follow-up issue filed).
- CLI flag `--parallel-threshold "10MB"` (still deferred to a CLI sprint with `bytesize` dep).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (workspace)
- [x] `cargo check -p rdlp-desktop`

## Reviews

- **security-reviewer:** PASS — no findings. Validation path preserved (Config::validate enforces 1..=1 GiB upstream; with_parallel_threshold defence-in-depth `.max(1)`); None case correctly falls back; HLS/DASH unaffected by design.
- **code-reviewer:** Approve — pattern parity confirmed; conditional `if let Some` is the right choice for Option fields with default-routing semantics; tests cover both directions; no clippy/fmt debt.