### PR TITLE
refactor(extractor): drop Config::hls_operation_timeout (closes #292)

### DIFF
--- a/crates/rdlp-extractor/src/hls/detector.rs
+++ b/crates/rdlp-extractor/src/hls/detector.rs
@@ -79,7 +79,7 @@ impl HlsSizeDetector {
     /// #     std::sync::Arc::new(wreq::Client::new()),
     /// #     false
     /// # );
-    /// match detector.detect_size("https://example.com/playlist.m3u8", std::time::Duration::from_secs(10)).await {
+    /// match detector.detect_size("https://example.com/playlist.m3u8").await {
     ///     Ok(Some(size)) => println!("Size: {} MB", size / 1_000_000),
     ///     Ok(None) => println!("Size could not be determined"),
     ///     Err(e) => eprintln!("Error: {e}"),
@@ -93,14 +93,10 @@ impl HlsSizeDetector {
     /// Returns `Err` when:
     /// - URL security validation fails (SSRF protection) (`RdlpError::Security`)
     /// - Delegated `detect_info` call fails (`RdlpError::Network` or `RdlpError::Extraction`)
-    pub async fn detect_size(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<Option<u64>> {
+    pub async fn detect_size(&self, m3u8_url: &str) -> Result<Option<u64>> {
         // Use detect_info and extract just the size
         Ok(self
-            .detect_info(m3u8_url, timeout)
+            .detect_info(m3u8_url)
             .await?
             .and_then(|info| info.total_size))
     }
@@ -118,11 +114,7 @@ impl HlsSizeDetector {
     ///
     /// Returns `Err` when:
     /// - URL security validation fails (SSRF protection) (`RdlpError::Security`)
-    pub async fn count_segments(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<Option<usize>> {
+    pub async fn count_segments(&self, m3u8_url: &str) -> Result<Option<usize>> {
         // Validate the input URL for security (SSRF protection)
         BaseExtractor::validate_url_security(m3u8_url)?;
 
@@ -131,7 +123,7 @@ impl HlsSizeDetector {
         }
 
         // Parse playlist to extract segment URLs
-        match self.parse_playlist(m3u8_url, timeout).await {
+        match self.parse_playlist(m3u8_url).await {
             Ok(urls) => {
                 let count = urls.len();
                 if self.verbose {
@@ -166,11 +158,7 @@ impl HlsSizeDetector {
     /// Returns `Err` when:
     /// - URL security validation fails (SSRF protection) (`RdlpError::Security`)
     /// - Playlist URL parsing fails (`RdlpError::Extraction`)
-    pub async fn detect_info(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<Option<HlsInfo>> {
+    pub async fn detect_info(&self, m3u8_url: &str) -> Result<Option<HlsInfo>> {
         let start = std::time::Instant::now();
 
         // Validate the input URL for security (SSRF protection)
@@ -181,7 +169,7 @@ impl HlsSizeDetector {
         }
 
         // Step 1: Parse playlist to extract segment URLs
-        let segment_urls = match self.parse_playlist(m3u8_url, timeout).await {
+        let segment_urls = match self.parse_playlist(m3u8_url).await {
             Ok(urls) => urls,
             Err(e) => {
                 if self.verbose {
@@ -244,12 +232,8 @@ impl HlsSizeDetector {
     }
 
     /// Fetch M3U8 playlist text from a URL
-    pub(super) async fn fetch_playlist_text(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<String> {
-        let mut request = self.http_client.get(m3u8_url).timeout(timeout);
+    pub(super) async fn fetch_playlist_text(&self, m3u8_url: &str) -> Result<String> {
+        let mut request = self.http_client.get(m3u8_url);
         if let Some(headers) = &self.default_headers {
             request = request.headers(headers.clone());
         }
@@ -294,9 +278,8 @@ impl HlsSizeDetector {
     pub(super) async fn fetch_and_extract_media_info(
         &self,
         media_url: &str,
-        timeout: std::time::Duration,
     ) -> Result<Option<MediaPlaylistInfo>> {
-        let text = self.fetch_playlist_text(media_url, timeout).await?;
+        let text = self.fetch_playlist_text(media_url).await?;
         let playlist = m3u8_rs::parse_playlist_res(text.as_bytes()).map_err(|e| {
             if !text.trim().starts_with("#EXTM3U") {
                 let preview: String = text.chars().take(200).collect();

--- a/crates/rdlp-extractor/src/hls/format_detection.rs
+++ b/crates/rdlp-extractor/src/hls/format_detection.rs
@@ -9,24 +9,10 @@ use crate::base::common::BaseExtractor;
 use log::debug;
 use rdlp_types::Codec;
 
-/// Default cap on multi-step HLS probes when `Config::hls_operation_timeout`
-/// is unset. Matches the legacy hard-coded value before #277.
-const DEFAULT_HLS_OPERATION_TIMEOUT_SECS: u64 = 10;
-
 /// Default cap on the single-HEAD probe for non-HLS file size detection
 /// when `Config::hls_head_probe_timeout` is unset. Matches the legacy
 /// hard-coded value before #277.
 const DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS: u64 = 5;
-
-/// Resolve the wall-clock cap for HLS metadata / variant probes from `Config`,
-/// falling back to `DEFAULT_HLS_OPERATION_TIMEOUT_SECS` when unset.
-pub(crate) fn resolve_hls_operation_timeout(config: &rdlp_types::Config) -> std::time::Duration {
-    std::time::Duration::from_secs(
-        config
-            .hls_operation_timeout
-            .unwrap_or(DEFAULT_HLS_OPERATION_TIMEOUT_SECS),
-    )
-}
 
 /// Resolve the wall-clock cap for the non-HLS HEAD-probe from `Config`,
 /// falling back to `DEFAULT_HLS_HEAD_PROBE_TIMEOUT_SECS` when unset.
@@ -101,18 +87,11 @@ async fn enrich_single_hls_format(
     url: &str,
     extractor_name: &str,
     verbose: bool,
-    op_timeout: std::time::Duration,
 ) -> (Option<bool>, Option<bool>) {
-    use tokio::time::timeout;
-
-    let result = timeout(
-        op_timeout,
-        hls_detector.detect_hls_metadata(url, op_timeout),
-    )
-    .await;
+    let result = hls_detector.detect_hls_metadata(url).await;
 
     let hls_info = match result {
-        Ok(Ok(Some(info))) => info,
+        Ok(Some(info)) => info,
         _ => {
             if verbose {
                 debug!(
@@ -215,7 +194,6 @@ async fn detect_format_sizes_inner(
     use tokio::time::timeout;
 
     let verbose = ctx.config.verbose;
-    let op_timeout = resolve_hls_operation_timeout(&ctx.config);
     let head_timeout = resolve_hls_head_probe_timeout(&ctx.config);
     let mut hls_detector = HlsSizeDetector::new(ctx.http_client.clone(), verbose);
 
@@ -260,18 +238,14 @@ async fn detect_format_sizes_inner(
 
                 if is_hls {
                     // Try to expand master playlist into per-variant formats
-                    let result = timeout(
-                        op_timeout,
-                        hls_detector.detect_hls_variants(&url, op_timeout),
-                    )
-                    .await;
+                    let variants_res = hls_detector.detect_hls_variants(&url).await;
 
-                    let variants = match result {
+                    let variants = match variants_res {
                         // Expand when the master produced multiple variants,
                         // OR when any audio-only rendition is present (even
                         // if there's only one video-only variant paired with
                         // it — the XHamster AV1 case).
-                        Ok(Ok(v)) if v.len() > 1 || v.iter().any(|x| x.is_audio_only) => v,
+                        Ok(v) if v.len() > 1 || v.iter().any(|x| x.is_audio_only) => v,
                         _ => {
                             // Not a master playlist or detection failed — fall back to
                             // single-format enrichment via detect_hls_metadata
@@ -282,7 +256,6 @@ async fn detect_format_sizes_inner(
                                 &url,
                                 &extractor_name,
                                 verbose,
-                                op_timeout,
                             )
                             .await;
                             return vec![(format, is_live, has_enc)];
@@ -560,27 +533,9 @@ mod is_hls_tests {
 
 #[cfg(test)]
 mod resolve_timeout_tests {
-    use super::{resolve_hls_head_probe_timeout, resolve_hls_operation_timeout};
+    use super::resolve_hls_head_probe_timeout;
     use rdlp_types::Config;
     use std::time::Duration;
-
-    #[test]
-    fn op_timeout_uses_default_when_none() {
-        let c = Config {
-            hls_operation_timeout: None,
-            ..Config::default()
-        };
-        assert_eq!(resolve_hls_operation_timeout(&c), Duration::from_secs(10));
-    }
-
-    #[test]
-    fn op_timeout_uses_override_when_some() {
-        let c = Config {
-            hls_operation_timeout: Some(45),
-            ..Config::default()
-        };
-        assert_eq!(resolve_hls_operation_timeout(&c), Duration::from_secs(45));
-    }
 
     #[test]
     fn head_probe_timeout_uses_default_when_none() {

--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -28,7 +28,7 @@
 //! let detector = HlsSizeDetector::new(http_client, false);
 //!
 //! let m3u8_url = "https://example.com/playlist.m3u8";
-//! if let Some(size) = detector.detect_size(m3u8_url, std::time::Duration::from_secs(10)).await? {
+//! if let Some(size) = detector.detect_size(m3u8_url).await? {
 //!     println!("Total size: {} MB", size / 1_000_000);
 //! }
 //! # Ok(())

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -24,16 +24,12 @@ impl HlsSizeDetector {
     /// # Returns
     /// * `Ok(Vec<String>)` - List of segment URLs
     /// * `Err(_)` - Network error, parse error, or master playlist detected
-    pub(super) async fn parse_playlist(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<Vec<String>> {
+    pub(super) async fn parse_playlist(&self, m3u8_url: &str) -> Result<Vec<String>> {
         if self.verbose {
             debug!(url:? = m3u8_url; "HLS fetching playlist");
         }
 
-        let playlist_text = self.fetch_playlist_text(m3u8_url, timeout).await?;
+        let playlist_text = self.fetch_playlist_text(m3u8_url).await?;
 
         if self.verbose {
             debug!(bytes = playlist_text.len(); "HLS playlist size");
@@ -149,13 +145,10 @@ impl HlsSizeDetector {
                 // Validate the resolved media playlist URL (SSRF protection)
                 BaseExtractor::validate_url_security(&media_playlist_url)?;
 
-                // Recursively parse the media playlist. Each recursion level
-                // passes the FULL `timeout` to its own `RequestBuilder::timeout`
-                // (per-request budget, not per-tree). The wall-clock cap on
-                // the entire call tree is enforced by the outer
-                // `tokio::time::timeout` at the call site in
-                // `hls/format_detection.rs`, not here.
-                Box::pin(self.parse_playlist(&media_playlist_url, timeout)).await
+                // Recursively parse the media playlist. Each fetch is bounded
+                // by the wreq Client's connect_timeout / read_timeout
+                // (configured via Config::socket_timeout / Config::read_timeout).
+                Box::pin(self.parse_playlist(&media_playlist_url)).await
             }
         }
     }

--- a/crates/rdlp-extractor/src/hls/variants.rs
+++ b/crates/rdlp-extractor/src/hls/variants.rs
@@ -164,18 +164,14 @@ impl HlsSizeDetector {
     ///
     /// Panics if a master playlist has variants but none can be selected
     /// (programmer error — the filter + `or_else` fallback should always find one).
-    pub async fn detect_hls_metadata(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<Option<HlsInfo>> {
+    pub async fn detect_hls_metadata(&self, m3u8_url: &str) -> Result<Option<HlsInfo>> {
         BaseExtractor::validate_url_security(m3u8_url)?;
 
         if self.verbose {
             debug!(url:? = m3u8_url; "HLS detecting metadata");
         }
 
-        let playlist_text = match self.fetch_playlist_text(m3u8_url, timeout).await {
+        let playlist_text = match self.fetch_playlist_text(m3u8_url).await {
             Ok(text) => text,
             Err(e) => {
                 if self.verbose {
@@ -253,8 +249,7 @@ impl HlsSizeDetector {
 
                 BaseExtractor::validate_url_security(&media_url)?;
 
-                let media_info = match self.fetch_and_extract_media_info(&media_url, timeout).await
-                {
+                let media_info = match self.fetch_and_extract_media_info(&media_url).await {
                     Ok(Some(info)) => info,
                     Ok(None) | Err(_) => {
                         // Return what we have from the master playlist
@@ -341,14 +336,10 @@ impl HlsSizeDetector {
     ///
     /// Panics if a master playlist has non-I-frame variants but none can be selected
     /// (programmer error — the filter + `or_else` fallback should always find one).
-    pub async fn detect_hls_variants(
-        &self,
-        m3u8_url: &str,
-        timeout: std::time::Duration,
-    ) -> Result<Vec<HlsVariantInfo>> {
+    pub async fn detect_hls_variants(&self, m3u8_url: &str) -> Result<Vec<HlsVariantInfo>> {
         BaseExtractor::validate_url_security(m3u8_url)?;
 
-        let playlist_text = match self.fetch_playlist_text(m3u8_url, timeout).await {
+        let playlist_text = match self.fetch_playlist_text(m3u8_url).await {
             Ok(text) => text,
             Err(e) => {
                 if self.verbose {
@@ -409,10 +400,7 @@ impl HlsSizeDetector {
             })?
             .to_string();
 
-        if let Ok(Some(media_info)) = self
-            .fetch_and_extract_media_info(&best_media_url, timeout)
-            .await
-        {
+        if let Ok(Some(media_info)) = self.fetch_and_extract_media_info(&best_media_url).await {
             for v in &mut variants {
                 v.segment_count = media_info.segment_count;
                 v.total_duration = Some(media_info.total_duration);

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -180,18 +180,9 @@ pub struct Config {
     #[serde(default)]
     pub pool_idle_timeout: Option<u64>,
 
-    /// Wall-clock cap on multi-step HLS probes (master playlist fetch + parse,
-    /// per-format metadata refresh). Distinct from the socket-level
-    /// `read_timeout`: this is total elapsed time for the helper, regardless
-    /// of how many TCP reads it spans. Used by
-    /// `crates/rdlp-extractor/src/hls/format_detection.rs`.
-    /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
-    pub hls_operation_timeout: Option<u64>,
-
     /// Wall-clock cap on a single HEAD probe used to detect content-length on
-    /// non-HLS formats. Smaller than `hls_operation_timeout` because the
-    /// operation is a single HEAD request (with a Range-GET fallback), not a
-    /// multi-step playlist parse.
+    /// non-HLS formats. The operation is a single HEAD request with a
+    /// Range-GET fallback.
     /// Validated post-load by `Config::validate()`: must be 1..=300 seconds.
     pub hls_head_probe_timeout: Option<u64>,
 
@@ -391,7 +382,6 @@ impl Default for Config {
             socket_timeout: Some(30),
             read_timeout: None,
             pool_idle_timeout: None,
-            hls_operation_timeout: Some(10),
             hls_head_probe_timeout: Some(5),
             parallel_threshold: Some(10 * 1024 * 1024),
             source_address: None,
@@ -585,14 +575,6 @@ impl Config {
             return Err(ConfigValidationError::OutOfRange {
                 field: "pool_idle_timeout",
                 reason: "must be 0..=3600 seconds (0 = disabled)",
-            });
-        }
-        if let Some(t) = self.hls_operation_timeout
-            && !(1..=300).contains(&t)
-        {
-            return Err(ConfigValidationError::OutOfRange {
-                field: "hls_operation_timeout",
-                reason: "must be 1..=300 seconds",
             });
         }
         if let Some(t) = self.hls_head_probe_timeout

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -453,41 +453,9 @@ fn socket_timeout_rejects_above_300() {
 }
 
 #[test]
-fn hls_operation_timeout_default_is_some_10() {
-    let c = Config::default();
-    assert_eq!(c.hls_operation_timeout, Some(10));
-}
-
-#[test]
 fn hls_head_probe_timeout_default_is_some_5() {
     let c = Config::default();
     assert_eq!(c.hls_head_probe_timeout, Some(5));
-}
-
-#[test]
-fn hls_operation_timeout_zero_rejected() {
-    let c = Config {
-        hls_operation_timeout: Some(0),
-        ..Config::default()
-    };
-    let err = c.validate().expect_err("must reject");
-    assert!(format!("{err:#}").contains("hls_operation_timeout"));
-}
-
-#[test]
-fn hls_operation_timeout_above_max_rejected() {
-    let c = Config {
-        hls_operation_timeout: Some(301),
-        ..Config::default()
-    };
-    let err = c.validate().expect_err("must reject");
-    assert!(matches!(
-        err,
-        ConfigValidationError::OutOfRange {
-            field: "hls_operation_timeout",
-            ..
-        }
-    ));
 }
 
 #[test]
@@ -520,23 +488,20 @@ fn hls_head_probe_timeout_above_max_rejected() {
 fn hls_timeouts_partial_json_inherits_struct_default() {
     // Struct-level `#[serde(default)]` means an empty/partial JSON deserializes
     // to `Config::default()`-overlaid values. Pin the documented default
-    // (Some(10) / Some(5)) so a future refactor that strips struct-level
+    // (Some(5)) so a future refactor that strips struct-level
     // serde(default) and forgets to add per-field annotations gets caught.
     let c: Config = serde_json::from_str("{}").expect("partial config must deserialize");
-    assert_eq!(c.hls_operation_timeout, Some(10));
     assert_eq!(c.hls_head_probe_timeout, Some(5));
 }
 
 #[test]
 fn hls_timeouts_round_trip_serde() {
     let c = Config {
-        hls_operation_timeout: Some(15),
         hls_head_probe_timeout: Some(7),
         ..Config::default()
     };
     let json = serde_json::to_string(&c).expect("serialize");
     let back: Config = serde_json::from_str(&json).expect("deserialize");
-    assert_eq!(back.hls_operation_timeout, Some(15));
     assert_eq!(back.hls_head_probe_timeout, Some(7));
 }
 


### PR DESCRIPTION
## Summary

Closes #292.

Deletes `Config::hls_operation_timeout` and the wall-clock-cap machinery from HLS extraction. Match industry behavior — rely on the per-request socket timeout (`wreq::Client::connect_timeout` 30s / `read_timeout` 60s, configured via `Config::socket_timeout` / `Config::read_timeout`).

Single commit, 7 files changed, +32 / -166 lines (net -134).

## Why

Industry research (yt-dlp 20s `socket_timeout`, N_m3u8DL-RE 100s `--http-request-timeout`, streamlink 20s `--http-timeout`, FFmpeg's `libavformat/hls.c` inherits via `rw_timeout`) confirms:

1. **No mainstream HLS tool has a wall-clock cap on multi-step playlist expansion.** Every tool uses per-request socket timeouts only.
2. **rdlp's 10s default was tighter than every industry per-request default.** Could fire on slow-but-functional CDNs before the per-request timeout would.
3. **rdlp's "warn + drop format row" behavior on timeout was uniquely soft.** Every industry tool hard-fails. Silent drop risked zero-format extraction on slow CDNs.
4. **The original wire-up was incomplete.** `expand_hls_in_place` does the master-playlist fetch with no timeout wrapper, despite `Config::hls_operation_timeout`'s doc-comment claiming to cover it. #292 was filed to close that gap; this PR closes it by deleting the field instead of wiring it up.

## What changes

- `Config::hls_operation_timeout` field, default, validation, 3 unit tests — deleted.
- `format_detection.rs` `DEFAULT_HLS_OPERATION_TIMEOUT_SECS` const, `resolve_hls_operation_timeout` helper, 3 `tokio::time::timeout(op_timeout, ...)` wrappers + match-arm collapse, 2 unit tests — deleted.
- `timeout: Duration` parameter cascade through 8 methods (3 `pub` on `HlsSizeDetector`: `detect_size`, `count_segments`, `detect_info`; 5 `pub(super)`: `fetch_playlist_text`, `fetch_and_extract_media_info`, `parse_playlist`, `detect_hls_metadata`, `detect_hls_variants`) — dropped uniformly.
- `request.timeout(timeout)` on the HLS playlist-fetch GET (`detector.rs:252`) — dropped. Bounded now by wreq client-level timeouts.

## What does NOT change

- `Config::hls_head_probe_timeout` — independent semantics (single HEAD probe for content-type detection on opaque URLs). Untouched.
- `Config::read_timeout` and `Config::socket_timeout` — already wired via `rdlp-http::HttpClientFactory`, unchanged.
- Per-fragment SSRF gate at `expand_dash_representations` (PR #294) and the HLS expand path — unchanged.
- Soft-drop user-facing behavior — `wreq::is_timeout()` errors propagate the same way, format rows are kept and enrichment is skipped (verified by reviewer).

## Backwards compatibility

Not maintained. `rdlp-types` is `0.x` (pre-1.0); breaking changes are allowed. Solo workflow per machine-wide CLAUDE.md exception.

- **Programmatic users** constructing `Config { hls_operation_timeout: Some(N), .. }`: compile error; correct response is to delete the line.
- **TOML config files** with `hls_operation_timeout = N`: silently parse — `Config` is `#[serde(default)]` without `deny_unknown_fields`. Operator's intended cap is silently ineffective. Reflected in this PR body. A future hardening sprint may add `deny_unknown_fields` to surface field removals as TOML parse errors.
- **`HlsSizeDetector::{detect_size, count_segments, detect_info}`** are `pub` and lost their `timeout: Duration` parameter. Workspace grep returns zero callers (only a doc-comment).

## Slow-trickle hazard

Removing both (a) the wall-clock cap and (b) the per-request total-time cap on the playlist GET means the only remaining protection is `wreq::Client::read_timeout` — per-read inactivity, not per-request total. A server trickling 1 byte every 59 s makes the playlist fetch effectively unbounded.

This is **not a new hazard**: it applies to every other HTTP path in rdlp today (segment downloads, fragment fetches). Removing `hls_operation_timeout` brings HLS playlist fetch into consistency with the rest of the codebase, not regression below it. yt-dlp / streamlink share the same hazard for the same architectural reason.

If slow-trickle becomes operationally painful, the right fix is a uniform `Config::request_timeout: Option<u64>` field that adds `wreq::ClientBuilder::timeout(...)` (per-request total) — defends slow-trickle across all HTTP paths. Out of scope for this PR.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check` (workspace)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — net 5 tests removed (3 `rdlp-types`, 2 `rdlp-extractor`); all surviving tests pass; doctest at `hls/mod.rs` updated and compiles
- [x] `cargo check -p rdlp-desktop`

## Reviews

- **security-reviewer:** APPROVE — no blocking findings. 4 INFORMATIONAL notes (slow-trickle model change, TOML silent no-op, soft-drop equivalence verified, public-API break is internal-only). All deliberate per the spec.
- **code-reviewer:** APPROVE — match-arm collapses verified preserving drop-with-warn semantics; `tokio::time::timeout` import still live for surviving `head_timeout` site; doctest at `hls/mod.rs:31` compiles; `is_timeout()` branch correctly retained; zero stragglers.

## Closes

#292