### PR TITLE
fix(downloader): flush partial output before propagating fragment Err

### DIFF
--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -211,15 +211,31 @@ pub async fn download_pre_resolved_fragments(
 
     tokio::pin!(stream);
     while let Some(item) = stream.next().await {
-        let (bytes, fetch_elapsed, seg_dur) = item?;
+        // Flush before propagating any per-fragment Err. `tokio::fs::File`'s
+        // `write_all` schedules the actual write on a blocking thread and
+        // returns before the bytes reach the kernel; without an explicit
+        // flush, returning Err drops `out_file` synchronously and abandons
+        // the in-flight spawn_blocking handle — so previously-written
+        // fragment bytes can disappear from the partial output. The success
+        // path already flushes after the loop (see end of function); the
+        // cancellation path already flushes before its own return.
+        // See tokio::fs module docs ("calls to write will return before the
+        // write has finished; flush will wait for the write to finish").
+        let (bytes, fetch_elapsed, seg_dur) = match item {
+            Ok(v) => v,
+            Err(e) => {
+                out_file.flush().await.ok();
+                return Err(e);
+            }
+        };
 
-        out_file
-            .write_all(&bytes)
-            .await
-            .map_err(|e| rdlp_core::RdlpError::Download {
+        if let Err(e) = out_file.write_all(&bytes).await {
+            out_file.flush().await.ok();
+            return Err(rdlp_core::RdlpError::Download {
                 message: format!("write fragment: {e}"),
                 url: Some(output.display().to_string()),
-            })?;
+            });
+        }
 
         total_bytes += bytes.len() as u64;
 


### PR DESCRIPTION
## Summary

Adds explicit `out_file.flush().await.ok()` before the two error-propagation points in `download_pre_resolved_fragments`'s consumer loop. Mirrors the cancellation-path flush already at line 259.

## Root cause

`tokio::fs::File::write_all().await` returns BEFORE the bytes reach the kernel — the actual write is dispatched to a `spawn_blocking` task whose completion is only awaited by `flush().await`. When the consumer loop short-circuits on a per-fragment Err, `out_file` drops synchronously on function return, abandoning the in-flight `spawn_blocking` handle. Previously-written fragment bytes can disappear from the partial output file.

> "calls to write will return before the write has finished; flush will wait for the write to finish"
> — https://docs.rs/tokio/latest/tokio/fs/index.html

Linux passed deterministically by scheduler luck; macOS GitHub Actions runners surface the race intermittently. Observed on PR #295's CI as `fragment_progress_mid_stream_failure_returns_error_partial_file` asserting `written == 100` but seeing `written = 0`.

## Why structural fix, not test-side workaround

An earlier draft forced `with_concurrent_fragments(1)` on the failing test. That would have masked the bug — every other multi-fragment Err path (one segment 503s mid-stream in a real download) would still lose bytes silently on macOS. The structural fix recovers the bytes for ALL callers, deterministically. Researched via multi-source-research (Context7 + WebSearch + tokio docs + tokio issue #4296) before fixing.

## Verification

- 20/20 stress passes locally on the affected test post-fix.
- Full pre-PR gate green: fmt / clippy `-D warnings` / workspace test / desktop check.

## Reviews

- **security-reviewer:** PASS — no blocking findings.
- **code-reviewer:** Approve — pattern parity with cancellation-path flush confirmed; error shape and message preserved bit-for-bit; full-function audit found no other unflushed Err exits.