### PR TITLE
chore(ci): cache npm tarball directory to fix Windows install flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,27 @@ jobs:
       # --- Desktop frontend (must build before any Rust pass, because
       #     rdlp-desktop's tauri build script reads dist/ via tauri.conf.json) ---
 
+      # Cache npm's tarball cache. setup-node's built-in `cache: 'npm'`
+      # requires a tracked `package-lock.json` — the project doesn't track
+      # one (per the comment on the setup-node step above), so we cache the
+      # tarball directory directly via actions/cache@v5. Keys on the
+      # crates/rdlp-desktop/package.json hash; falls back to any
+      # platform-matched cache via restore-keys.
+      #
+      # Without this step, every CI run does a fresh `npm install` against
+      # the npm registry, which intermittently fails on Windows runners
+      # (registry redirect / DNS / antivirus scanning) — observed on
+      # PR #297 CI run 25398198158.
+      - name: Cache npm tarball cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.npm
+            ~\AppData\Local\npm-cache
+          key: ${{ runner.os }}-npm-${{ hashFiles('crates/rdlp-desktop/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Install frontend dependencies
         working-directory: crates/rdlp-desktop
         run: npm install


### PR DESCRIPTION
## Summary

Adds an \`actions/cache@v5\` step in \`.github/workflows/ci.yml\` targeting npm's tarball cache (\`~/.npm\` on Linux/macOS, \`~\AppData\Local\npm-cache\` on Windows). Cache key is the \`crates/rdlp-desktop/package.json\` hash.

Single-file YAML change. +21 lines.

## Why

\`setup-node@v5\`'s built-in \`cache: 'npm'\` requires a tracked \`package-lock.json\` — the project doesn't track one (per the comment on the existing \`setup-node\` step at lines 167-172). Every CI run did a fresh \`npm install\` against the npm registry, which intermittently failed on Windows runners. Observed on PR #297 CI run 25398198158 as \`Install frontend dependencies\` exit code 1.

The canonical alternative (per [actions/cache examples doc](https://github.com/actions/cache/blob/main/examples.md) and [actions/setup-node advanced-usage](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md)) is to cache \`~/.npm\` directly. On cache hit, \`npm install\` completes from the local tarball cache without hitting the registry — eliminating the transient flakiness entirely.

## What does NOT change

- The \`Install frontend dependencies\` step itself — \`npm install\` is unchanged.
- The \`Build frontend\` and \`Frontend type check and tests\` steps — untouched.
- No project-policy change (we still don't track \`package-lock.json\`; that's a separate decision).

## Caveat

PR #297's Windows failure root cause is **not** 100% confirmed to be registry flakiness — it could also be a genuine dep-resolution failure. If CI continues to fail on Windows after this lands, the next investigation step is to read the underlying \`npm install\` error from the failing log. The cache fix only helps if the cause is transient registry hiccups; if it's a dep-resolution issue, separate work is needed.

## Test plan

- [x] YAML sanity check via \`node -e\` (parsed without syntax error).
- [ ] First CI run on this PR will validate behavior (cold cache miss expected on first run; subsequent PRs benefit from the warm cache).
- [ ] Future Windows PR runs no longer fail at \`Install frontend dependencies\` — observed across the next 5+ PRs.

## Reviews

Pre-push review skipped per \`~/.claude/rules/mandatory-pre-push-review.md\` exception clause: trivial CI YAML change, no production code paths / external inputs / dependencies / error surfaces / security-sensitive code touched.

## References

- Researcher report: multi-source-research dispatched 2026-05-05; recommended option (i) (\`~/.npm\` via \`actions/cache@v5\`).
- [actions/cache examples — npm without lockfile](https://github.com/actions/cache/blob/main/examples.md)
- [actions/setup-node advanced-usage](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md)
- Related PRs today: #298 (replace wall-clock concurrency test), #297 (CODING_RULES tokio::fs flush rule), #296 (flush-before-Err structural fix).