### PR TITLE
feat(postprocess,api): plumb CancellationToken through Pipeline::run

### DIFF
--- a/crates/rdlp-api/Cargo.toml
+++ b/crates/rdlp-api/Cargo.toml
@@ -25,7 +25,7 @@ rdlp-plugin = { path = "../rdlp-plugin" }
 
 dirs = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -5,8 +5,10 @@
 use super::{Orchestrator, Result};
 use crate::events::Event;
 use crate::handle::DownloadId;
+use crate::orchestrator::errors::OrchestratorError;
 use log::{debug, warn};
 use rdlp_core::{PostProcessCallback, PostProcessCallbackFactory};
+use rdlp_postprocess::pipeline::PipelineError;
 use rdlp_types::Progress;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -143,6 +145,7 @@ impl Orchestrator {
                 is_hls,
                 self.config.verbose,
                 callback_factory,
+                Some(self.cancel_token.clone()),
             )
             .await
         {
@@ -163,6 +166,15 @@ impl Orchestrator {
                 Ok(output_files)
             }
             Err(e) => {
+                // Cancellation MUST propagate as OrchestratorError::UserCancelled.
+                // Any non-cancel pipeline error keeps today's silent warn-and-fallback
+                // behaviour (returns the original input files; logs a warning).
+                if matches!(
+                    e.downcast_ref::<PipelineError>(),
+                    Some(PipelineError::Cancelled)
+                ) {
+                    return Err(OrchestratorError::UserCancelled);
+                }
                 warn!("Post-processing pipeline failed: {e}");
                 // Return original files on failure.
                 Ok(files)

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -12,7 +12,7 @@ rdlp-types = { path = "../rdlp-types" }
 rdlp-ffmpeg = { path = "../rdlp-ffmpeg" }
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -48,7 +48,7 @@
 //! let config = Arc::new(PostProcess::default());
 //! let files = vec![PathBuf::from("video.mp4")];
 //!
-//! let output = pipeline.run(info, files, config, "video".to_string(), false, false, None).await?;
+//! let output = pipeline.run(info, files, config, "video".to_string(), false, false, None, None).await?;
 //! println!("Output: {output:?}");
 //! # Ok(())
 //! # }

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use thiserror::Error;
 use tokio::sync::{Semaphore, mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 
 use rdlp_core::PostProcessCallbackFactory;
 use rdlp_types::InfoDict;
@@ -182,6 +183,7 @@ impl Pipeline {
         is_hls: bool,
         verbose: bool,
         callback_factory: Option<PostProcessCallbackFactory>,
+        cancel: Option<CancellationToken>,
     ) -> anyhow::Result<Vec<std::path::PathBuf>> {
         let _permit =
             self.concurrency.acquire().await.map_err(|_| {
@@ -205,37 +207,49 @@ impl Pipeline {
             encoding_tool: None,
         };
 
+        // `None` callers get a fresh token that nobody else holds — zero-cost.
+        // The isolation guarantee is load-bearing: a `None` caller can never
+        // observe a spurious cancel because the locally-created token is held
+        // exclusively by this function's scope (cloned only into the per-stage
+        // tasks below; never escapes outward via channels or shared state).
+        // A future refactor that hands the local token to a sibling supervisor
+        // task would silently break this property — keep it scope-local.
+        let token = cancel.unwrap_or_default();
+
         // Build channel chain: one mpsc(1) between consecutive stages.
         // first_tx → stage_0 → stage_1 → ... → stage_N → final_rx
-        let mut final_rx = self.spawn_chain(msg);
+        let mut final_rx = self.spawn_chain(msg, &token);
 
         // Await the final message.
-        match final_rx.recv().await {
-            Some(final_msg) => {
-                // FileTracker::cleanup performs N × std::fs::remove_file and
-                // std::fs::rename. These are blocking syscalls that can stall
-                // the async runtime on slow or network filesystems. Move the
-                // work to a blocking worker so the executor stays responsive
-                // for any concurrent pipeline runs.
-                let current_files = tokio::task::spawn_blocking(move || {
-                    let mut tracker = final_msg.tracker;
-                    tracker.cleanup();
-                    tracker.current_files
-                })
-                .await
-                .map_err(|e| anyhow::anyhow!("pipeline cleanup task join failed: {e}"))?;
-                Ok(current_files)
+        let Some(final_msg) = final_rx.recv().await else {
+            // If the cascade ended because the token was cancelled, surface that
+            // distinct from "pipeline terminated with no output" (which is a bug
+            // scenario — every stage cascaded None without error).
+            if token.is_cancelled() {
+                return Err(PipelineError::Cancelled.into());
             }
-            None => {
-                // Pipeline was interrupted — recover error from the oneshot.
-                match error_rx.await.ok() {
-                    Some(err) => Err(anyhow::anyhow!("{err}")),
-                    None => Err(anyhow::anyhow!(
-                        "pipeline terminated with no output and no error"
-                    )),
-                }
-            }
-        }
+            // Pipeline was interrupted — recover error from the oneshot.
+            return match error_rx.await.ok() {
+                Some(err) => Err(anyhow::anyhow!("{err}")),
+                None => Err(anyhow::anyhow!(
+                    "pipeline terminated with no output and no error"
+                )),
+            };
+        };
+
+        // FileTracker::cleanup performs N × std::fs::remove_file and
+        // std::fs::rename. These are blocking syscalls that can stall
+        // the async runtime on slow or network filesystems. Move the
+        // work to a blocking worker so the executor stays responsive
+        // for any concurrent pipeline runs.
+        let current_files = tokio::task::spawn_blocking(move || {
+            let mut tracker = final_msg.tracker;
+            tracker.cleanup();
+            tracker.current_files
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("pipeline cleanup task join failed: {e}"))?;
+        Ok(current_files)
     }
 
     /// Run the pipeline concurrently for multiple videos.
@@ -249,12 +263,14 @@ impl Pipeline {
         config: Arc<PostProcess>,
         verbose: bool,
         callback_factory: Option<PostProcessCallbackFactory>,
+        cancel: Option<CancellationToken>,
     ) -> Vec<anyhow::Result<Vec<std::path::PathBuf>>> {
         let mut handles = Vec::with_capacity(inputs.len());
         for input in inputs {
             let pipeline = Arc::clone(&self);
             let config = Arc::clone(&config);
             let factory = callback_factory.clone();
+            let cancel_clone = cancel.clone();
             let handle = tokio::spawn(async move {
                 pipeline
                     .run(
@@ -265,6 +281,7 @@ impl Pipeline {
                         input.is_hls,
                         verbose,
                         factory,
+                        cancel_clone,
                     )
                     .await
             });
@@ -288,7 +305,11 @@ impl Pipeline {
     /// Each stage task reads from `in_rx`, may process or pass-through,
     /// then sends to `out_tx`. When a fatal stage fails, it drops `out_tx`
     /// which cascades None through all downstream stages.
-    fn spawn_chain(&self, initial_msg: PipelineMessage) -> mpsc::Receiver<PipelineMessage> {
+    fn spawn_chain(
+        &self,
+        initial_msg: PipelineMessage,
+        token: &CancellationToken,
+    ) -> mpsc::Receiver<PipelineMessage> {
         if self.stages.is_empty() {
             // No stages — connect directly.
             let (tx, rx) = mpsc::channel::<PipelineMessage>(1);
@@ -325,11 +346,33 @@ impl Pipeline {
                 .expect("pipeline: rxs has stages+1 elements; iteration {i} must yield Some");
             let out_tx = txs[i + 1].clone();
             let stage_name = stage.name().to_owned();
+            let stage_token = token.clone();
 
             tokio::spawn(async move {
                 let mut in_rx = in_rx_i;
-                let Some(msg) = in_rx.recv().await else {
-                    return; // upstream cascade
+                // Cancellation granularity: this select! fires BETWEEN stages.
+                // A stage already executing inside `process()` (e.g. FFmpeg
+                // work in MergeStage / RecodeStage) will not observe the
+                // token until it returns — `spawn_blocking` workers cannot
+                // be interrupted, and FFmpeg's `AVIOInterruptCB` is IO-layer
+                // only (does not interrupt codec encode/decode loops). Mid-
+                // stage interruption is a separate, deferred follow-up.
+                //
+                // `biased;` ensures cancel observation wins ties — without
+                // it, tokio::select!'s pseudo-random arm selection could
+                // process one more message after the cancel fired. Same
+                // pattern used in `crates/rdlp-downloader/src/fragments.rs`
+                // for the per-fragment fetch race.
+                let msg = tokio::select! {
+                    biased;
+                    () = stage_token.cancelled() => {
+                        drop(out_tx); // cascade None downstream — mirrors fatal-error path
+                        return;
+                    }
+                    result = in_rx.recv() => match result {
+                        Some(m) => m,
+                        None => return, // upstream cascade (existing behavior)
+                    },
                 };
 
                 if !stage.should_run(&msg) {
@@ -394,6 +437,18 @@ pub struct BatchInput {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// 8-tuple returned by `run_args` for `Pipeline::run` calls in tests.
+    type RunArgs = (
+        InfoDict,
+        Vec<PathBuf>,
+        Arc<PostProcess>,
+        String,
+        bool,
+        bool,
+        Option<PostProcessCallbackFactory>,
+        Option<CancellationToken>,
+    );
 
     fn make_pipeline(stages: Vec<Arc<dyn PipelineStage>>) -> Pipeline {
         let reg = Arc::new(TempRegistry::new());
@@ -477,17 +532,7 @@ mod tests {
         }
     }
 
-    fn run_args(
-        files: Vec<PathBuf>,
-    ) -> (
-        InfoDict,
-        Vec<PathBuf>,
-        Arc<PostProcess>,
-        String,
-        bool,
-        bool,
-        Option<PostProcessCallbackFactory>,
-    ) {
+    fn run_args(files: Vec<PathBuf>) -> RunArgs {
         (
             make_info(),
             files,
@@ -496,16 +541,17 @@ mod tests {
             false,
             false,
             None,
+            None, // cancel — default to None for back-compat tests
         )
     }
 
     #[tokio::test]
     async fn test_pipeline_passthrough() {
         let pipeline = make_pipeline(vec![Arc::new(PassthroughStage)]);
-        let (info, files, config, stem, hls, verbose, cb) =
+        let (info, files, config, stem, hls, verbose, cb, cancel) =
             run_args(vec![PathBuf::from("/tmp/video.mp4")]);
         let result = pipeline
-            .run(info, files, config, stem, hls, verbose, cb)
+            .run(info, files, config, stem, hls, verbose, cb, cancel)
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), vec![PathBuf::from("/tmp/video.mp4")]);
@@ -514,10 +560,10 @@ mod tests {
     #[tokio::test]
     async fn test_pipeline_skip_stage() {
         let pipeline = make_pipeline(vec![Arc::new(SkipStage), Arc::new(PassthroughStage)]);
-        let (info, files, config, stem, hls, verbose, cb) =
+        let (info, files, config, stem, hls, verbose, cb, cancel) =
             run_args(vec![PathBuf::from("/tmp/video.mp4")]);
         let result = pipeline
-            .run(info, files, config, stem, hls, verbose, cb)
+            .run(info, files, config, stem, hls, verbose, cb, cancel)
             .await;
         assert!(result.is_ok());
     }
@@ -525,10 +571,10 @@ mod tests {
     #[tokio::test]
     async fn test_pipeline_fatal_error_cascades() {
         let pipeline = make_pipeline(vec![Arc::new(FailStage), Arc::new(PassthroughStage)]);
-        let (info, files, config, stem, hls, verbose, cb) =
+        let (info, files, config, stem, hls, verbose, cb, cancel) =
             run_args(vec![PathBuf::from("/tmp/video.mp4")]);
         let result = pipeline
-            .run(info, files, config, stem, hls, verbose, cb)
+            .run(info, files, config, stem, hls, verbose, cb, cancel)
             .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -541,10 +587,10 @@ mod tests {
             Arc::new(NonFatalFailStage),
             Arc::new(PassthroughStage),
         ]);
-        let (info, files, config, stem, hls, verbose, cb) =
+        let (info, files, config, stem, hls, verbose, cb, cancel) =
             run_args(vec![PathBuf::from("/tmp/video.mp4")]);
         let result = pipeline
-            .run(info, files, config, stem, hls, verbose, cb)
+            .run(info, files, config, stem, hls, verbose, cb, cancel)
             .await;
         assert!(result.is_ok());
     }
@@ -607,9 +653,9 @@ mod tests {
             }
         });
 
-        let (info, files, config, stem, hls, verbose, cb) = run_args(vec![video.clone()]);
+        let (info, files, config, stem, hls, verbose, cb, cancel) = run_args(vec![video.clone()]);
         let result = pipeline
-            .run(info, files, config, stem, hls, verbose, cb)
+            .run(info, files, config, stem, hls, verbose, cb, cancel)
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), vec![video]);
@@ -653,9 +699,10 @@ mod tests {
         for _ in 0..6 {
             let p = StdArc::clone(&pipeline);
             handles.push(tokio::spawn(async move {
-                let (info, files, config, stem, hls, verbose, cb) =
+                let (info, files, config, stem, hls, verbose, cb, cancel) =
                     run_args(vec![PathBuf::from("/tmp/v.mp4")]);
-                p.run(info, files, config, stem, hls, verbose, cb).await
+                p.run(info, files, config, stem, hls, verbose, cb, cancel)
+                    .await
             }));
         }
         for h in handles {
@@ -667,5 +714,241 @@ mod tests {
             "max concurrent was {}",
             MAX_SEEN.load(Ordering::SeqCst)
         );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::items_after_statements)]
+    async fn pipeline_run_returns_cancelled_when_token_pre_cancelled() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Counter-stage that increments every time `process` is called.
+        let count = Arc::new(AtomicUsize::new(0));
+
+        struct CountingStage(Arc<AtomicUsize>);
+        #[async_trait]
+        impl PipelineStage for CountingStage {
+            fn name(&self) -> &str {
+                "counting"
+            }
+            fn should_run(&self, _msg: &PipelineMessage) -> bool {
+                true
+            }
+            fn is_fatal(&self) -> bool {
+                false
+            }
+            async fn process(&self, msg: PipelineMessage) -> anyhow::Result<PipelineMessage> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(msg)
+            }
+        }
+
+        let pipeline = make_pipeline(vec![Arc::new(CountingStage(Arc::clone(&count)))]);
+        let (info, files, config, stem, hls, verbose, cb, _) =
+            run_args(vec![PathBuf::from("/tmp/video.mp4")]);
+
+        let token = CancellationToken::new();
+        token.cancel(); // pre-cancel BEFORE run
+
+        let result = pipeline
+            .run(info, files, config, stem, hls, verbose, cb, Some(token))
+            .await;
+
+        assert!(result.is_err(), "pre-cancelled token must surface as Err");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<PipelineError>(),
+                Some(PipelineError::Cancelled)
+            ),
+            "expected PipelineError::Cancelled, got: {err:?}"
+        );
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "stage MUST NOT execute when token is pre-cancelled"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::items_after_statements)]
+    async fn pipeline_run_cancels_mid_pipeline() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Stage 0: cancels the token at the end of `process`, returns Ok(msg).
+        // Stages 1, 2: increment a counter; assert they never run.
+        //
+        // Determinism: `process` calls `token.cancel()` BEFORE returning Ok,
+        // so the cancel atomic flag is set before the spawn_chain caller's
+        // `out_tx.send(msg)` runs. Downstream stages' `tokio::select!` is
+        // `biased;` — the cancel arm is checked before the recv arm. Per
+        // tokio docs, `biased;` is a hard ordering guarantee (not "usually"
+        // / "preferred"). So the count assertion is deterministic regardless
+        // of multi-thread scheduling: every downstream stage sees the cancel
+        // first when its task is polled, regardless of whether the message
+        // arrived in its mpsc channel before or after the wake.
+        let token = CancellationToken::new();
+        let token_for_stage = token.clone();
+        let downstream_count = Arc::new(AtomicUsize::new(0));
+
+        struct CancelOnExitStage {
+            token: CancellationToken,
+        }
+        #[async_trait]
+        impl PipelineStage for CancelOnExitStage {
+            fn name(&self) -> &str {
+                "cancel-on-exit"
+            }
+            fn should_run(&self, _msg: &PipelineMessage) -> bool {
+                true
+            }
+            fn is_fatal(&self) -> bool {
+                false
+            }
+            async fn process(&self, msg: PipelineMessage) -> anyhow::Result<PipelineMessage> {
+                // Process succeeds, then trigger cancel before returning.
+                self.token.cancel();
+                Ok(msg)
+            }
+        }
+
+        struct DownstreamCountingStage(Arc<AtomicUsize>);
+        #[async_trait]
+        impl PipelineStage for DownstreamCountingStage {
+            fn name(&self) -> &str {
+                "downstream-counting"
+            }
+            fn should_run(&self, _msg: &PipelineMessage) -> bool {
+                true
+            }
+            fn is_fatal(&self) -> bool {
+                false
+            }
+            async fn process(&self, msg: PipelineMessage) -> anyhow::Result<PipelineMessage> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(msg)
+            }
+        }
+
+        let pipeline = make_pipeline(vec![
+            Arc::new(CancelOnExitStage {
+                token: token_for_stage,
+            }),
+            Arc::new(DownstreamCountingStage(Arc::clone(&downstream_count))),
+            Arc::new(DownstreamCountingStage(Arc::clone(&downstream_count))),
+        ]);
+        let (info, files, config, stem, hls, verbose, cb, _) =
+            run_args(vec![PathBuf::from("/tmp/video.mp4")]);
+
+        let result = pipeline
+            .run(info, files, config, stem, hls, verbose, cb, Some(token))
+            .await;
+
+        assert!(result.is_err(), "mid-pipeline cancel must surface as Err");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<PipelineError>(),
+                Some(PipelineError::Cancelled)
+            ),
+            "expected PipelineError::Cancelled, got: {err:?}"
+        );
+        assert_eq!(
+            downstream_count.load(Ordering::SeqCst),
+            0,
+            "downstream stages MUST NOT run after stage 0 cancels the token"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_run_with_none_cancel_runs_to_completion() {
+        let pipeline = make_pipeline(vec![Arc::new(PassthroughStage)]);
+        let (info, files, config, stem, hls, verbose, cb, _) =
+            run_args(vec![PathBuf::from("/tmp/video.mp4")]);
+
+        let result = pipeline
+            .run(info, files, config, stem, hls, verbose, cb, None)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "None cancel arg MUST run to completion identically to the pre-token behaviour: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::items_after_statements)]
+    async fn run_batch_cancels_all_in_flight_items() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Verifies the shared-parent-token semantic: ONE token cancels ALL
+        // in-flight batch items. We pre-cancel the token so each item's
+        // first stage hits the select! cancel branch deterministically —
+        // this avoids racing the test against tokio's scheduler. The
+        // architectural property under test is "items share the token,"
+        // not "items observe the cancel within X ms."
+        let count = Arc::new(AtomicUsize::new(0));
+
+        struct CountingStage(Arc<AtomicUsize>);
+        #[async_trait]
+        impl PipelineStage for CountingStage {
+            fn name(&self) -> &str {
+                "counting"
+            }
+            fn should_run(&self, _msg: &PipelineMessage) -> bool {
+                true
+            }
+            fn is_fatal(&self) -> bool {
+                false
+            }
+            async fn process(&self, msg: PipelineMessage) -> anyhow::Result<PipelineMessage> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(msg)
+            }
+        }
+
+        let pipeline = std::sync::Arc::new(make_pipeline(vec![Arc::new(CountingStage(
+            Arc::clone(&count),
+        ))]));
+
+        let inputs: Vec<BatchInput> = (0..3)
+            .map(|i| BatchInput {
+                info: make_info(),
+                files: vec![PathBuf::from(format!("/tmp/video-{i}.mp4"))],
+                original_stem: format!("video-{i}"),
+                is_hls: false,
+            })
+            .collect();
+
+        let token = CancellationToken::new();
+        token.cancel(); // pre-cancel — all items see it on first poll
+
+        let results = pipeline
+            .run_batch(
+                inputs,
+                Arc::new(PostProcess::default()),
+                false,
+                None,
+                Some(token),
+            )
+            .await;
+
+        assert_eq!(results.len(), 3, "all 3 batch items must be returned");
+        for (i, result) in results.iter().enumerate() {
+            assert!(
+                result.is_err(),
+                "batch item {i}: shared-token cancel must surface as Err in every item"
+            );
+            let err = result.as_ref().unwrap_err();
+            assert!(
+                matches!(
+                    err.downcast_ref::<PipelineError>(),
+                    Some(PipelineError::Cancelled)
+                ),
+                "batch item {i}: expected PipelineError::Cancelled, got: {err:?}"
+            );
+        }
+        // Stage MAY have run on items that beat the cancel into recv — accept
+        // 0..=3 here (depending on scheduler). The load-bearing assertion is
+        // that every item's RESULT is Err(Cancelled), not the count.
     }
 }

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -54,6 +54,20 @@ pub enum PipelineError {
         /// Human-readable cause.
         cause: String,
     },
+    /// The pipeline was cancelled via its `CancellationToken`.
+    ///
+    /// Surfaced when `Pipeline::run`'s final receiver closes AND the token
+    /// has been cancelled — the cascade of dropped `out_tx`s in `spawn_chain`
+    /// stage tasks reaches the final receiver, and the post-loop check sees
+    /// `token.is_cancelled() == true`. Distinct from `StageFailure` because
+    /// no stage actually errored — the work was simply abandoned on user
+    /// cancel. Call sites (notably the orchestrator at
+    /// `crates/rdlp-api/src/orchestrator/postprocess.rs`) MUST distinguish
+    /// this from `StageFailure` via `anyhow::Error::downcast_ref` and
+    /// propagate cancellation as `OrchestratorError::UserCancelled` rather
+    /// than the silent warn-and-fallback path used for stage failures.
+    #[error("pipeline cancelled by token")]
+    Cancelled,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Plumbs \`tokio_util::sync::CancellationToken\` through \`Pipeline::run\` and \`Pipeline::run_batch\`. A user-cancelled download now stops the post-process pipeline at the next between-stage checkpoint, mirroring the canonical tokio cancellation pattern (closure capture per stage task + \`tokio::select!\` with \`biased;\` race in the recv loop).

Closes the post-process half of issue #287. HTTP-downloader half remains tracked separately under the same issue.

2 commits, 5 files, +348/-53.

## Why

\`crates/rdlp-postprocess/src/pipeline/mod.rs\` had zero \`CancellationToken\` references. The orchestrator at \`execution.rs:109-127\` raced the **download** future against \`cancel_token.cancelled()\`, but the post-process call at \`postprocess.rs:137\` ran in a separate \`await\` with no cancel race. Long-running stages (Recode minutes, Normalize minutes, Merge moderate) could not be interrupted.

## Architecture

- \`cancel: Option<CancellationToken>\` as the 8th positional arg on \`run\`/\`run_batch\`. \`None\` callers get a fresh standalone token nobody else holds — zero-cost back-compat.
- Inside \`spawn_chain\`, the token is taken by reference and cloned per stage task. Each task races \`tokio::select! { biased; () = stage_token.cancelled() => drop(out_tx); return; result = in_rx.recv() => ... }\` at the top of its loop. On cancel, drop \`out_tx\` cascades None downstream — same mechanism as fatal-error cascade.
- After \`final_rx.recv()\` returns None in \`Pipeline::run\`, check \`token.is_cancelled()\` and surface \`PipelineError::Cancelled\` (new unit variant).
- \`Pipeline::run_batch\` shares the SAME parent token across all in-flight batch items: user cancel stops everything.
- Orchestrator at \`postprocess.rs:137-179\` discriminates cancel vs. stage failure via \`matches!(e.downcast_ref::<PipelineError>(), Some(PipelineError::Cancelled))\`. Cancel propagates as \`OrchestratorError::UserCancelled\`; non-cancel errors keep today's silent warn-and-fallback behaviour.

## Granularity ceiling (documented in code at the select! site)

Cancellation fires **between stages**, not mid-FFmpeg. Long Recode/Normalize stages still run to completion before the cancel-observation point fires for the next stage. Mid-FFmpeg cancellation requires raw \`ffmpeg-sys-the-third\` FFI for \`AVIOInterruptCB\`, which is IO-layer only per FFmpeg's doxygen spec — codec loops have no interrupt mechanism. Deferred to a separate issue when operationally relevant.

## Out of scope

- Mid-FFmpeg interruption via \`AVIOInterruptCB\` (separate issue).
- Adding \`cancel_token\` field on \`PipelineMessage\` (rejected — anti-idiomatic per researcher report).
- Builder pattern for \`Pipeline::run\` (kept positional 8th arg as the lighter pragmatic move).
- HTTP-downloader cancellation gap (issue #287's other half — distinct architectural problem).

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo check\` (workspace)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` — 4 new unit tests in \`rdlp-postprocess::pipeline\`:
  - \`pipeline_run_returns_cancelled_when_token_pre_cancelled\` (positive)
  - \`pipeline_run_cancels_mid_pipeline\` (mid-pipeline cancel; deterministic via \`biased;\`)
  - \`pipeline_run_with_none_cancel_runs_to_completion\` (back-compat guard)
  - \`run_batch_cancels_all_in_flight_items\` (batch shared-token cancel via pre-cancel)
- [x] \`cargo check -p rdlp-desktop\`

## Reviews

- **security-reviewer:** PASS — no blocking findings. 2 LOW notes (unwrap_or_default isolation comment + test-determinism caveat) addressed inline before push via additional doc-comments.
- **code-reviewer:** Approve with minor fixes — pattern parity with \`fragments.rs::fetch_with_optional_cancel\` confirmed; CAS loop n/a; \`unwrap_or_default()\` justified; \`&CancellationToken\` lifetime sound; let-else refactor preserves all 3 outcomes; test coverage proportionate; doc-comment quality appropriate; \`#[allow(clippy::items_after_statements)]\` justified. Minor fix (granularity-ceiling code comment at select! site) applied inline before push.

## References

- Spec (gitignored, local): \`docs/superpowers/specs/2026-05-05-pipeline-cancellation-token-design.md\`.
- Plan (gitignored, local): \`docs/superpowers/plans/2026-05-05-pipeline-cancellation-token.md\`.
- Researcher: agentId a5a6b1ce6cbcd4411 (2026-05-05 21:10 UTC). Cited tokio docs, axum graceful-shutdown, sunshowers RustConf 2025 talk, FFmpeg doxygen on \`AVIOInterruptCB\`.
- Sibling pattern: \`crates/rdlp-downloader/src/fragments.rs::fetch_with_optional_cancel\` — closure-captured cancel token + \`tokio::select! { biased; ... }\` race.

## Closes

#287 (post-process half — HTTP-downloader half remains)