### PR TITLE
chore(ci): fix Windows npm cache via npm config get cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,12 +215,21 @@ jobs:
       # the npm registry, which intermittently fails on Windows runners
       # (registry redirect / DNS / antivirus scanning) — observed on
       # PR #297 CI run 25398198158.
+      #
+      # The cache path is queried via `npm config get cache` to avoid the
+      # earlier-PR-#299 Windows mistake (hardcoded `~\AppData\Local\npm-cache`
+      # is wrong — Windows default is `%APPDATA%\npm-cache` at
+      # `~\AppData\Roaming\npm-cache`, not Local). `npm config get cache` is
+      # authoritative across platforms and respects any project `.npmrc`.
+      - name: Resolve npm cache path
+        id: npm-cache-path
+        shell: bash
+        run: echo "path=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
       - name: Cache npm tarball cache
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.npm
-            ~\AppData\Local\npm-cache
+          path: ${{ steps.npm-cache-path.outputs.path }}
           key: ${{ runner.os }}-npm-${{ hashFiles('crates/rdlp-desktop/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-


### PR DESCRIPTION
## Summary

PR #299 hardcoded \`~\AppData\Local\npm-cache\` for the Windows cache path. That's the wrong location — Windows default is \`%APPDATA%\npm-cache\` (i.e. \`~\AppData\Roaming\npm-cache\`), NOT \`%LOCALAPPDATA%\`. Result: Windows runner did a fresh \`npm install\` against the registry on every CI run; only Linux + macOS got the cache benefit.

Replaces the hardcoded multi-line path with a \`npm config get cache\` pre-step that exports the platform's actual cache path. This is the canonical pattern flagged in PR #299's researcher report as the authoritative alternative to hardcoded paths.

## Evidence (from PR #300 CI run 25404241267)

| Platform | Result |
|---|---|
| ubuntu-22.04 | ✅ \`Cache hit for: Linux-npm-fd100eb...\` |
| macos-latest | ✅ \`Cache hit for: macOS-npm-fd100eb...\` |
| windows-latest | ❌ \`Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.\` |

After this fix, all three platforms hit the cache when \`crates/rdlp-desktop/package.json\` hash matches.

## What changes

- One YAML hunk in \`.github/workflows/ci.yml\` (+12/-3).
- New \`Resolve npm cache path\` step runs \`npm config get cache\` via bash (Git Bash is preinstalled on windows-latest GHA runners).
- \`Cache npm tarball cache\` step's \`path\` becomes \`\${{ steps.npm-cache-path.outputs.path }}\` instead of the hardcoded multi-line list.

## Side benefits

- Respects any future project \`.npmrc\` \`cache=\` override.
- Single path per platform — simpler than the previous multi-line \`~/.npm\` + Windows path.
- One source of truth (\`npm\` itself) — no platform-specific YAML conditionals.

## Reviews

Pre-push review skipped per \`~/.claude/rules/mandatory-pre-push-review.md\` exception clause: trivial CI YAML change, no production code paths / external inputs / dependencies / error surfaces / security-sensitive code touched. The change is a fix-forward for an observed CI behavior bug; the structural risk profile is identical to PR #299's.