### PR TITLE
feat(downloader): collapse HTTP probes into single GET (F3)

### DIFF
--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -73,7 +73,9 @@ pub trait Downloader: Send + Sync {
     ///
     /// # Returns
     /// Size in bytes, or `None` if size cannot be determined
-    async fn get_size(&self, url: &str) -> Result<Option<u64>>;
+    async fn get_size(&self, _url: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
 
     /// Download a [`rdlp_types::Format`] to a single output file.
     ///
@@ -543,9 +545,6 @@ mod tests {
             }
             fn supports(&self, _url: &str) -> bool {
                 false
-            }
-            async fn get_size(&self, _url: &str) -> Result<Option<u64>> {
-                Ok(None)
             }
         }
 

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -172,5 +172,4 @@ impl Downloader for DashDownloader {
         )
         .await
     }
-
 }

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -173,7 +173,4 @@ impl Downloader for DashDownloader {
         .await
     }
 
-    async fn get_size(&self, _url: &str) -> Result<Option<u64>> {
-        Ok(None)
-    }
 }

--- a/crates/rdlp-downloader/src/hls/mod.rs
+++ b/crates/rdlp-downloader/src/hls/mod.rs
@@ -157,10 +157,6 @@ impl Downloader for HlsDownloader {
             || url.contains(".m3u8?")
     }
 
-    async fn get_size(&self, _url: &str) -> Result<Option<u64>> {
-        Ok(None)
-    }
-
     async fn download_format(
         &self,
         format: &rdlp_types::Format,

--- a/crates/rdlp-downloader/src/http/config.rs
+++ b/crates/rdlp-downloader/src/http/config.rs
@@ -20,6 +20,18 @@ use std::time::Duration;
 /// `DownloaderConfig::default()` value.
 pub(super) const DEFAULT_PARALLEL_THRESHOLD_BYTES: u64 = 10 * 1024 * 1024;
 
+/// Size of the F3 initial range probe used to detect `Content-Length` and range support.
+/// The body is discarded; only headers are consulted.
+///
+/// Rationale (per docs/superpowers/specs/2026-05-21-f3-f6-download-optimization-design.md):
+/// - Matches `MIN_CHUNK_LEVEL=2` (256 KB) in `adaptive.rs` so the probe looks like a real
+///   chunk to bot-detecting origins.
+/// - Fits TCP slow-start delivery within ~3-4 RTTs from cwnd=10 (RFC 6928).
+/// - 4× the H2 default connection window (RFC 7540 §6.9, 64 KiB) — requires a few
+///   WINDOW_UPDATE frames but does not catastrophically starve concurrent streams.
+///   1 MiB (16× the window) would actively block parallel chunks.
+pub(crate) const PROBE_WINDOW_BYTES: u64 = 256 * 1024;
+
 /// Progress callback update interval
 pub(super) const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -90,5 +102,22 @@ impl Default for DownloaderConfig {
             merge_timeout: DEFAULT_MERGE_TIMEOUT,
             adaptive: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_window_is_256_kib() {
+        assert_eq!(PROBE_WINDOW_BYTES, 256 * 1024);
+    }
+
+    #[test]
+    fn probe_window_under_one_mib() {
+        // 1 MiB would be 16x the RFC 7540 default H2 connection window (64 KiB)
+        // and would starve parallel streams.
+        assert!(PROBE_WINDOW_BYTES < 1024 * 1024);
     }
 }

--- a/crates/rdlp-downloader/src/http/config.rs
+++ b/crates/rdlp-downloader/src/http/config.rs
@@ -28,7 +28,7 @@ pub(super) const DEFAULT_PARALLEL_THRESHOLD_BYTES: u64 = 10 * 1024 * 1024;
 ///   chunk to bot-detecting origins.
 /// - Fits TCP slow-start delivery within ~3-4 RTTs from cwnd=10 (RFC 6928).
 /// - 4× the H2 default connection window (RFC 7540 §6.9, 64 KiB) — requires a few
-///   WINDOW_UPDATE frames but does not catastrophically starve concurrent streams.
+///   `WINDOW_UPDATE` frames but does not catastrophically starve concurrent streams.
 ///   1 MiB (16× the window) would actively block parallel chunks.
 pub(crate) const PROBE_WINDOW_BYTES: u64 = 256 * 1024;
 
@@ -118,6 +118,6 @@ mod tests {
     fn probe_window_under_one_mib() {
         // 1 MiB would be 16x the RFC 7540 default H2 connection window (64 KiB)
         // and would starve parallel streams.
-        assert!(PROBE_WINDOW_BYTES < 1024 * 1024);
+        const { assert!(PROBE_WINDOW_BYTES < 1024 * 1024) };
     }
 }

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -286,7 +286,10 @@ impl HttpDownloader {
         })
         .await
         else {
-            return Ok(ProbeResult { size: None, supports_ranges: false });
+            return Ok(ProbeResult {
+                size: None,
+                supports_ranges: false,
+            });
         };
 
         match resp.status().as_u16() {
@@ -298,7 +301,10 @@ impl HttpDownloader {
                 size: resp.content_length(),
                 supports_ranges: false,
             }),
-            _ => Ok(ProbeResult { size: None, supports_ranges: false }),
+            _ => Ok(ProbeResult {
+                size: None,
+                supports_ranges: false,
+            }),
         }
     }
 

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -266,7 +266,7 @@ impl HttpDownloader {
         let hdrs = self.headers();
         let range = format!("bytes=0-{}", PROBE_WINDOW_BYTES - 1);
 
-        let resp = match with_retry(&self.config.retry_config, "HTTP probe (F3)", || {
+        let Ok(resp) = with_retry(&self.config.retry_config, "HTTP probe (F3)", || {
             let client = client.clone();
             let url = url_string.clone();
             let hdrs = hdrs.clone();
@@ -285,9 +285,8 @@ impl HttpDownloader {
             }
         })
         .await
-        {
-            Ok(r) => r,
-            Err(_) => return Ok(ProbeResult { size: None, supports_ranges: false }),
+        else {
+            return Ok(ProbeResult { size: None, supports_ranges: false });
         };
 
         match resp.status().as_u16() {
@@ -301,37 +300,6 @@ impl HttpDownloader {
             }),
             _ => Ok(ProbeResult { size: None, supports_ranges: false }),
         }
-    }
-
-    /// Check if server supports range requests
-    async fn supports_ranges(&self, url: &str) -> Result<bool> {
-        let client = self.client.clone();
-        let url = url.to_string();
-        let hdrs = self.headers();
-
-        let response = with_retry(&self.config.retry_config, "HTTP HEAD (range check)", || {
-            let client = client.clone();
-            let url = url.clone();
-            let hdrs = hdrs.clone();
-            async move {
-                client
-                    .head(&url)
-                    .headers(hdrs)
-                    .send()
-                    .await
-                    .map_err(|e| RdlpError::Network {
-                        message: format!("HEAD request failed: {e}"),
-                        url: Some(url.clone()),
-                    })
-            }
-        })
-        .await?;
-
-        Ok(response
-            .headers()
-            .get("accept-ranges")
-            .and_then(|v| v.to_str().ok())
-            .is_some_and(|v| v != "none"))
     }
 
     /// Download a specific byte range with shared progress tracking
@@ -552,7 +520,7 @@ mod content_range_tests {
     #[test]
     fn parses_total_from_content_range_206() {
         let h = make_headers(Some("bytes 0-262143/1048576"));
-        assert_eq!(parse_content_range_total(&h), Some(1048576));
+        assert_eq!(parse_content_range_total(&h), Some(1_048_576));
     }
 
     #[test]

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -82,6 +82,18 @@ pub(crate) fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Op
         .and_then(|s| s.parse::<u64>().ok())
 }
 
+/// Result of the F3 single-GET probe in `HttpDownloader::probe`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProbeResult {
+    /// Total file size if the server reported it via Content-Range (206) or
+    /// Content-Length (200). `None` when neither header is parseable.
+    pub size: Option<u64>,
+    /// `true` if the server returned `206 Partial Content`, indicating it
+    /// honoured the Range request. RFC 7233 §4.1: 206 itself implies range
+    /// support; `Accept-Ranges` is not required.
+    pub supports_ranges: bool,
+}
+
 /// HTTP/HTTPS downloader
 ///
 /// **Clone performance:** O(1) - both client and config use Arc internally
@@ -231,6 +243,64 @@ impl HttpDownloader {
     #[must_use]
     pub fn headers(&self) -> HeaderMap {
         self.extra_headers.clone()
+    }
+
+    /// F3 single-GET probe: replaces the HEAD×2 + Range:bytes=0-0 sequence.
+    /// Sends `GET Range: bytes=0-{PROBE_WINDOW_BYTES-1}`, parses headers only,
+    /// discards body. Returns `ProbeResult` for the downstream parallel-vs-sequential
+    /// decision in `download_to_file`.
+    ///
+    /// Status handling:
+    /// - 206 → parse total from `Content-Range`, `supports_ranges = true`.
+    /// - 200 → server ignored Range; parse total from `Content-Length`,
+    ///   `supports_ranges = false`. The probe body is discarded (caller
+    ///   re-issues a plain GET via `download_sequential`).
+    /// - other (4xx/5xx after retry) → `ProbeResult { size: None,
+    ///   supports_ranges: false }`. Non-2xx is "no info", not an error;
+    ///   caller falls to sequential.
+    pub(crate) async fn probe(&self, url: &str) -> Result<ProbeResult> {
+        use config::PROBE_WINDOW_BYTES;
+
+        let client = self.client.clone();
+        let url_string = url.to_string();
+        let hdrs = self.headers();
+        let range = format!("bytes=0-{}", PROBE_WINDOW_BYTES - 1);
+
+        let resp = match with_retry(&self.config.retry_config, "HTTP probe (F3)", || {
+            let client = client.clone();
+            let url = url_string.clone();
+            let hdrs = hdrs.clone();
+            let range = range.clone();
+            async move {
+                client
+                    .get(&url)
+                    .headers(hdrs)
+                    .header("Range", range)
+                    .send()
+                    .await
+                    .map_err(|e| RdlpError::Network {
+                        message: format!("probe failed: {e}"),
+                        url: Some(url.clone()),
+                    })
+            }
+        })
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => return Ok(ProbeResult { size: None, supports_ranges: false }),
+        };
+
+        match resp.status().as_u16() {
+            206 => Ok(ProbeResult {
+                size: parse_content_range_total(resp.headers()),
+                supports_ranges: true,
+            }),
+            200 => Ok(ProbeResult {
+                size: resp.content_length(),
+                supports_ranges: false,
+            }),
+            _ => Ok(ProbeResult { size: None, supports_ranges: false }),
+        }
     }
 
     /// Check if server supports range requests

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -69,6 +69,19 @@ where
         .await
 }
 
+/// Parse the `Content-Range` header's total-bytes field.
+///
+/// Accepts `bytes 0-N/TOTAL` (returns `Some(TOTAL)`) and returns `None` for
+/// `bytes 0-N/*` (server signalled unknown total per RFC 7233 §4.2), any
+/// missing header, or any unparseable total.
+pub(crate) fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Option<u64> {
+    headers
+        .get("content-range")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split('/').nth(1))
+        .and_then(|s| s.parse::<u64>().ok())
+}
+
 /// HTTP/HTTPS downloader
 ///
 /// **Clone performance:** O(1) - both client and config use Arc internally
@@ -450,5 +463,49 @@ impl HttpDownloader {
 impl Default for HttpDownloader {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod content_range_tests {
+    use super::*;
+    use wreq::header::HeaderMap;
+
+    fn make_headers(content_range: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(cr) = content_range {
+            h.insert("content-range", cr.parse().unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn parses_total_from_content_range_206() {
+        let h = make_headers(Some("bytes 0-262143/1048576"));
+        assert_eq!(parse_content_range_total(&h), Some(1048576));
+    }
+
+    #[test]
+    fn returns_none_when_header_missing() {
+        let h = make_headers(None);
+        assert_eq!(parse_content_range_total(&h), None);
+    }
+
+    #[test]
+    fn returns_none_when_header_malformed_no_slash() {
+        let h = make_headers(Some("bytes 0-262143"));
+        assert_eq!(parse_content_range_total(&h), None);
+    }
+
+    #[test]
+    fn returns_none_when_total_is_star() {
+        let h = make_headers(Some("bytes 0-262143/*"));
+        assert_eq!(parse_content_range_total(&h), None);
+    }
+
+    #[test]
+    fn returns_none_when_total_unparseable() {
+        let h = make_headers(Some("bytes 0-262143/notanumber"));
+        assert_eq!(parse_content_range_total(&h), None);
     }
 }

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -741,3 +741,50 @@ async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
     // error) is acceptable — we're testing the dispatch decision, not the
     // download correctness.
 }
+
+#[tokio::test]
+async fn download_to_file_no_head_under_normal_flow() {
+    use mockito::Matcher;
+
+    let mut server = mockito::Server::new_async().await;
+    let body = vec![0xAA; 524288];
+
+    // Probe responds with 206; total = 524288 (below 10 MiB threshold -> sequential).
+    let _probe = server
+        .mock("GET", "/file")
+        .match_header("range", "bytes=0-262143")
+        .with_status(206)
+        .with_header("content-range", "bytes 0-262143/524288")
+        .with_body(vec![0u8; 262144])
+        .create_async()
+        .await;
+
+    // Sequential download re-fetches the full file (no Range header).
+    let _seq = server
+        .mock("GET", "/file")
+        .match_header("range", Matcher::Missing)
+        .with_status(200)
+        .with_body(body.clone())
+        .create_async()
+        .await;
+
+    // HEAD must NEVER be issued.
+    let head_guard = server
+        .mock("HEAD", "/file")
+        .expect(0)
+        .create_async()
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.bin");
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let stats = downloader
+        .download_to_file(&url, &out, None)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.bytes_downloaded, 524288);
+    head_guard.assert_async().await;
+}

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -676,12 +676,13 @@ async fn probe_206_malformed_content_range_keeps_supports_ranges_true() {
     use mockito::Server;
 
     let mut server = Server::new_async().await;
-    let _mock = server
+    let mock = server
         .mock("GET", "/file")
         .match_header("range", "bytes=0-262143")
         .with_status(206)
         .with_header("content-range", "invalid-garbage")
         .with_body(vec![0u8; 262144])
+        .expect(1)
         .create_async()
         .await;
 
@@ -692,6 +693,7 @@ async fn probe_206_malformed_content_range_keeps_supports_ranges_true() {
 
     assert_eq!(result.size, None);
     assert!(result.supports_ranges);
+    mock.assert_async().await;
 }
 
 #[tokio::test]

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -591,6 +591,110 @@ fn with_parallel_threshold_clamps_zero_to_one() {
 }
 
 #[tokio::test]
+async fn probe_206_returns_size_from_content_range() {
+    use mockito::Server;
+
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/file")
+        .match_header("range", "bytes=0-262143")
+        .with_status(206)
+        .with_header("content-range", "bytes 0-262143/1048576")
+        .with_body(vec![0u8; 262144])
+        .expect(1)
+        .create_async()
+        .await;
+
+    let head_guard = server
+        .mock("HEAD", "/file")
+        .expect(0)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let result = downloader.probe(&url).await.unwrap();
+
+    assert_eq!(result.size, Some(1048576));
+    assert!(result.supports_ranges);
+    mock.assert_async().await;
+    head_guard.assert_async().await;
+}
+
+#[tokio::test]
+async fn probe_200_returns_content_length_no_ranges() {
+    use mockito::Server;
+
+    let mut server = Server::new_async().await;
+    let body = vec![0u8; 524288];
+    let mock = server
+        .mock("GET", "/file")
+        .match_header("range", "bytes=0-262143")
+        .with_status(200)
+        .with_header("content-length", "524288")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let result = downloader.probe(&url).await.unwrap();
+
+    assert_eq!(result.size, Some(524288));
+    assert!(!result.supports_ranges);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn probe_416_returns_none_falls_to_sequential() {
+    use mockito::Server;
+
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/file")
+        .match_header("range", "bytes=0-262143")
+        .with_status(416)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let result = downloader.probe(&url).await.unwrap();
+
+    assert_eq!(result.size, None);
+    assert!(!result.supports_ranges);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn probe_206_malformed_content_range_keeps_supports_ranges_true() {
+    use mockito::Server;
+
+    let mut server = Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/file")
+        .match_header("range", "bytes=0-262143")
+        .with_status(206)
+        .with_header("content-range", "invalid-garbage")
+        .with_body(vec![0u8; 262144])
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let result = downloader.probe(&url).await.unwrap();
+
+    assert_eq!(result.size, None);
+    assert!(result.supports_ranges);
+}
+
+#[tokio::test]
 async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
     use mockito::Server;
 

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -593,11 +593,7 @@ async fn probe_206_returns_size_from_content_range() {
         .create_async()
         .await;
 
-    let head_guard = server
-        .mock("HEAD", "/file")
-        .expect(0)
-        .create_async()
-        .await;
+    let head_guard = server.mock("HEAD", "/file").expect(0).create_async().await;
 
     let downloader = HttpDownloader::new();
     let url = format!("{}/file", server.url());
@@ -758,21 +754,14 @@ async fn download_to_file_no_head_under_normal_flow() {
         .await;
 
     // HEAD must NEVER be issued.
-    let head_guard = server
-        .mock("HEAD", "/file")
-        .expect(0)
-        .create_async()
-        .await;
+    let head_guard = server.mock("HEAD", "/file").expect(0).create_async().await;
 
     let dir = tempfile::tempdir().unwrap();
     let out = dir.path().join("out.bin");
     let downloader = HttpDownloader::new();
     let url = format!("{}/file", server.url());
 
-    let stats = downloader
-        .download_to_file(&url, &out, None)
-        .await
-        .unwrap();
+    let stats = downloader.download_to_file(&url, &out, None).await.unwrap();
 
     assert_eq!(stats.bytes_downloaded, 524288);
     head_guard.assert_async().await;

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -109,23 +109,14 @@ async fn test_parallel_download_error_propagation() {
     let total_size = 20 * 1024 * 1024; // 20 MB total
     let test_content = vec![0u8; chunk_size];
 
-    // Mock HEAD request for size detection (allow multiple calls)
-    let mock_head = server
-        .mock("HEAD", "/test-video.mp4")
-        .with_status(200)
-        .with_header("Accept-Ranges", "bytes")
-        .with_header("Content-Length", &total_size.to_string())
-        .expect_at_least(1)
-        .create_async()
-        .await;
-
-    // Mock Range request for size fallback detection
-    let _mock_size_check = server
+    // Mock F3 probe: Range: bytes=0-262143 returns 206 with total size in Content-Range
+    let _probe = server
         .mock("GET", "/test-video.mp4")
-        .match_header("range", "bytes=0-0")
+        .match_header("range", "bytes=0-262143")
         .with_status(206)
-        .with_header("Content-Range", &format!("bytes 0-0/{total_size}"))
-        .expect_at_most(1)
+        .with_header("content-range", &format!("bytes 0-262143/{total_size}"))
+        .with_body(vec![0u8; 262144])
+        .expect(1)
         .create_async()
         .await;
 
@@ -199,9 +190,6 @@ async fn test_parallel_download_error_propagation() {
         matches!(err, RdlpError::Http { .. } | RdlpError::Network { .. }),
         "Should be an HTTP or network error, got: {err:?}"
     );
-
-    // Verify mocks were called appropriately
-    mock_head.assert_async().await;
 
     // Chunks 0 and 1 should have been called (they succeed)
     // Note: The exact order depends on async scheduling, but try_join_all
@@ -703,18 +691,19 @@ async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
     let mut server = Server::new_async().await;
     let body = vec![0u8; 5 * 1024 * 1024]; // 5 MiB
 
-    // HEAD returns content-length 5 MiB, supports ranges.
-    let _head = server
-        .mock("HEAD", "/file.bin")
-        .with_status(200)
-        .with_header("content-length", &body.len().to_string())
-        .with_header("accept-ranges", "bytes")
-        .expect_at_least(1)
+    // F3 probe: Range: bytes=0-262143 returns total size via content-range.
+    let _probe = server
+        .mock("GET", "/file.bin")
+        .match_header("range", "bytes=0-262143")
+        .with_status(206)
+        .with_header("content-range", &format!("bytes 0-262143/{}", body.len()))
+        .with_body(vec![0u8; 262144])
+        .expect(1)
         .create_async()
         .await;
 
-    // GET with Range header returns partial content. Multiple range requests
-    // means we took the parallel path; the mock asserts ≥2 invocations.
+    // Parallel chunk requests: multiple range requests verify we took the parallel
+    // path. The mock asserts ≥2 invocations; any download outcome is acceptable.
     let _get_range = server
         .mock("GET", "/file.bin")
         .match_header(

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -210,32 +210,6 @@ impl Downloader for HttpDownloader {
         url.starts_with("http://") || url.starts_with("https://")
     }
 
-    async fn get_size(&self, url: &str) -> Result<Option<u64>> {
-        let client = self.client.clone();
-        let url = url.to_string();
-        let hdrs = self.headers();
-
-        let response = with_retry(&self.config.retry_config, "HTTP HEAD", || {
-            let client = client.clone();
-            let url = url.clone();
-            let hdrs = hdrs.clone();
-            async move {
-                client
-                    .head(&url)
-                    .headers(hdrs)
-                    .send()
-                    .await
-                    .map_err(|e| RdlpError::Network {
-                        message: format!("HEAD request failed: {e}"),
-                        url: Some(url.clone()),
-                    })
-            }
-        })
-        .await?;
-
-        Ok(response.content_length())
-    }
-
     async fn download_with_resume(
         &self,
         url: &str,

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -66,12 +66,7 @@ impl Downloader for HttpDownloader {
                 })
                 .await
                 {
-                    Ok(response) => response
-                        .headers()
-                        .get("content-range")
-                        .and_then(|v| v.to_str().ok())
-                        .and_then(|s| s.split('/').nth(1))
-                        .and_then(|s| s.parse::<u64>().ok())
+                    Ok(response) => crate::http::parse_content_range_total(response.headers())
                         .inspect(|size| {
                             debug!(
                                 "Detected size from Range: {} MB",
@@ -318,12 +313,7 @@ impl Downloader for HttpDownloader {
             })
             .await?;
 
-            let total_size = response
-                .headers()
-                .get("content-range")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.split('/').nth(1))
-                .and_then(|s| s.parse::<u64>().ok())
+            let total_size = crate::http::parse_content_range_total(response.headers())
                 .or_else(|| response.content_length().map(|size| size + resume_from));
 
             // Check for parallel resume

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -33,51 +33,18 @@ impl Downloader for HttpDownloader {
     ) -> Result<DownloadStats> {
         let timeout = self.config.download_timeout;
         tokio::time::timeout(timeout, async {
-            let size = self.get_size(url).await.ok().flatten();
-            let supports_ranges = self.supports_ranges(url).await.unwrap_or(false);
+            // F3: single GET probe replaces HEAD x2 + Range:bytes=0-0 sequence.
+            // See docs/superpowers/specs/2026-05-21-f3-f6-download-optimization-design.md
+            let probe = self.probe(url).await?;
+            let size = probe.size;
+            let supports_ranges = probe.supports_ranges;
 
             debug!(
-                "Download analysis: size={} MB, concurrent={}, ranges={}",
+                "Probe result: size={} MB, concurrent={}, ranges={}",
                 size.map_or(0, |s| s / 1024 / 1024),
                 self.config.concurrent_fragments,
                 supports_ranges
             );
-
-            // Try Range request if HEAD didn't return size
-            let size = if (size.is_none() || size == Some(0)) && supports_ranges {
-                debug!("HEAD didn't return valid size, trying Range request...");
-                let client = self.client.clone();
-                let url_string = url.to_string();
-                let hdrs = self.headers();
-
-                match with_retry(&self.config.retry_config, "HTTP GET (size check)", || {
-                    let client = client.clone();
-                    let url = url_string.clone();
-                    let hdrs = hdrs.clone();
-                    async move {
-                        client
-                            .get(&url)
-                            .headers(hdrs)
-                            .header("Range", "bytes=0-0")
-                            .send()
-                            .await
-                            .map_err(|e| RdlpError::Network { message: format!("Size check failed: {e}"), url: Some(url.clone()) })
-                    }
-                })
-                .await
-                {
-                    Ok(response) => crate::http::parse_content_range_total(response.headers())
-                        .inspect(|size| {
-                            debug!(
-                                "Detected size from Range: {} MB",
-                                size / 1024 / 1024
-                            );
-                        }),
-                    Err(_) => None,
-                }
-            } else {
-                size
-            };
 
             let parallel_size = match size {
                 Some(s) if s > self.config.parallel_threshold => {


### PR DESCRIPTION
## Summary

- Replaces `HEAD × 2` + `Range: bytes=0-0` probe in `HttpDownloader::download_to_file` with a single `GET Range: bytes=0-262143`.
- Saves **2 RTT** on every HTTP download (industry-standard pattern: yt-dlp, aria2, curl, wget).
- Adds `HttpDownloader::probe()` returning `ProbeResult { size, supports_ranges }`; extracts `parse_content_range_total(&HeaderMap)` helper.
- Deletes now-unused `HttpDownloader::get_size` override and private `supports_ranges` method; adds default `Ok(None)` body to `Downloader::get_size` trait; removes redundant `Ok(None)` overrides on `DashDownloader` / `HlsDownloader` / test `StubDownloader`.

Closes the F3 portion of \`docs/superpowers/specs/2026-05-04-download-optimization-audit.md\`.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-05-21-f3-f6-download-optimization-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-21-f3-f6-download-optimization.md\`

(Both gitignored; local-only.)

## Probe semantics

| Status | Action |
|---|---|
| 206 | parse \`Content-Range\` total → \`size\`; \`supports_ranges = true\`; body discarded |
| 200 | server ignored Range → \`size = Content-Length\`; \`supports_ranges = false\`; body discarded (sequential re-fetches) |
| other (after retry) | \`size: None, supports_ranges: false\` → falls to sequential |

Probe is informational only — never errors. \`check_http_response\` is not called.

## Reviews

- security-reviewer: ✅ **Approve** (Info-only findings; net posture improvement over HEAD × 2)
- code-reviewer: ✅ **Approve** (nits non-blocking)
- \`cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test\`: ✅

## Test plan

- [x] \`probe_206_returns_size_from_content_range\` — happy path
- [x] \`probe_200_returns_content_length_no_ranges\` — server ignored Range
- [x] \`probe_416_returns_none_falls_to_sequential\` — non-2xx → no info
- [x] \`probe_206_malformed_content_range_keeps_supports_ranges_true\` — RFC 7233 §4.1 invariant
- [x] \`download_to_file_no_head_under_normal_flow\` — HEAD never issued (\`expect(0)\` + \`assert_async\`)
- [x] \`parse_content_range_total\` 5 unit tests (happy / missing / no-slash / star / unparseable)
- [ ] Manual smoke: download a single video from two CDN families.

## Known deferrals

- Extractor-side \`detect_file_size\` (\`crates/rdlp-extractor/src/base/common/mod.rs:355-412\`) still issues HEAD + \`Range: bytes=0-0\`. Tracked as consolidation follow-up.