### PR TITLE
feat(downloader): cooperative cancellation in streaming-HTTP path (F6)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -107,12 +107,19 @@ impl Orchestrator {
         };
 
         // Race between download and cancellation token. Belt-and-braces:
-        // the fragment-based downloaders (HLS, DASH per-Repr) check the
-        // token cooperatively between fragments and return
-        // RdlpError::Cancelled — that lands on the `result` arm. The
-        // streaming-HTTP path (download_to_file) has no in-loop cancel
-        // check yet, so the `cancelled()` arm covers it via future-drop.
-        // Both arms produce Ok(None); whichever fires is acceptable.
+        // - Fragment downloaders (HLS, DASH per-Repr) check the token
+        //   cooperatively between fragments and return RdlpError::Cancelled.
+        // - Streaming-HTTP (HttpDownloader::download_format → download_sequential)
+        //   honours the token per `bytes_stream().next()` via
+        //   next_with_cancel_and_timeout, flushing BufWriter before returning
+        //   RdlpError::Cancelled. (F6, PR #287 follow-up.)
+        // - DashDownloader::download_format non-fragment branch delegates to
+        //   HttpDownloader::download_format and inherits the same.
+        // The outer `cancelled()` arm remains as a fallback for pre-start
+        // cancellation, the cancel-less trait methods (download_to_writer,
+        // download_with_resume), and third-party Downloader impls that
+        // ignore the cancel parameter. Both arms produce Ok(None);
+        // whichever fires is acceptable.
         let stats = tokio::select! {
             result = download_future => {
                 result.map_err(OrchestratorError::DownloadFailed)?

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -138,9 +138,12 @@ impl Downloader for DashDownloader {
             )
             .await
         } else {
-            // Non-fragment branch: cancellation owned by outer select! today.
-            // TODO(#287): cooperative cancellation for download_to_file path.
-            self.download_to_file(&format.url, output, progress).await
+            // F6: cooperative cancellation via HttpDownloader's cancel-aware paths.
+            // The legacy MPD-URL branch delegates to the inner HTTP downloader which
+            // honours `cancel` via its `download_format` override. Closes #287.
+            self.http_downloader
+                .download_format(format, output, progress, cancel)
+                .await
         }
     }
 

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -399,18 +399,31 @@ impl HttpDownloader {
         Ok(downloaded)
     }
 
-    /// Sequential download (original method)
-    async fn download_sequential(
+    /// Sequential download with optional cooperative cancellation.
+    ///
+    /// `cancel` — when `Some`, each chunk poll races the token; the first arm
+    /// that fires wins.  On cancellation the `BufWriter` is flushed before
+    /// returning `RdlpError::Cancelled` so partial bytes already buffered reach
+    /// disk.
+    pub(crate) async fn download_sequential(
         &self,
         url: &str,
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<DownloadStats> {
         let progress: Option<Arc<dyn ProgressCallback>> = progress.map(Arc::from);
         let start_time = Instant::now();
         let client = self.client.clone();
         let url_string: Arc<str> = Arc::from(url);
         let hdrs = self.headers();
+
+        // Check for pre-cancelled token before issuing the network request.
+        if let Some(token) = cancel
+            && token.is_cancelled()
+        {
+            return Err(RdlpError::Cancelled);
+        }
 
         let response = with_retry(&self.config.retry_config, "HTTP GET", || {
             let client = client.clone();
@@ -439,19 +452,32 @@ impl HttpDownloader {
         })?;
         let mut writer = BufWriter::with_capacity(self.config.buffer_size, file);
 
-        let mut stream = response.bytes_stream();
+        let stream = response.bytes_stream();
+        tokio::pin!(stream);
         let mut downloaded: u64 = 0;
         let mut last_update = Instant::now();
         let update_interval = PROGRESS_UPDATE_INTERVAL;
         let read_timeout = self.config.read_timeout;
 
-        while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
+        loop {
+            let next = match next_with_cancel_and_timeout(
+                stream.as_mut(),
+                cancel,
+                read_timeout,
+                &url_string,
+            )
             .await
-            .map_err(|_| RdlpError::Network {
-                message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
-                url: Some(url_string.to_string()),
-            })?
-        {
+            {
+                Ok(item) => item,
+                Err(RdlpError::Cancelled) => {
+                    // Flush partial bytes already in BufWriter to disk.
+                    writer.flush().await.ok();
+                    return Err(RdlpError::Cancelled);
+                }
+                Err(e) => return Err(e),
+            };
+
+            let Some(chunk_result) = next else { break };
             let chunk = chunk_result.map_err(|e| RdlpError::Network {
                 message: format!("Failed to read response body from {url_string}: {e}"),
                 url: Some(url_string.to_string()),
@@ -526,7 +552,6 @@ impl Default for HttpDownloader {
 /// ready, otherwise tokio's PRNG branch selection can starve the cancel arm
 /// under load. A static test in `tests.rs` (Task 12) will assert the
 /// `biased;` keyword is present in this select.
-#[allow(dead_code)] // wired to callers in Task 8+
 pub(crate) async fn next_with_cancel_and_timeout<S, E>(
     mut stream: std::pin::Pin<&mut S>,
     cancel: Option<&tokio_util::sync::CancellationToken>,

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -510,6 +510,53 @@ impl Default for HttpDownloader {
     }
 }
 
+/// Race a `bytes_stream()` poll against (a) the per-read timeout and (b) an
+/// optional cancellation token.
+///
+/// Returns:
+/// - `Ok(Some(Ok(bytes)))` — chunk delivered.
+/// - `Ok(Some(Err(stream_err)))` — stream-level error from the body; caller
+///   decides how to surface it.
+/// - `Ok(None)` — stream ended cleanly.
+/// - `Err(RdlpError::Cancelled)` — cancel arm fired; caller MUST flush its
+///   writer before returning.
+/// - `Err(RdlpError::Network { .. })` — read timed out.
+///
+/// `biased;` is required: the cancel arm must take priority when both are
+/// ready, otherwise tokio's PRNG branch selection can starve the cancel arm
+/// under load. A static test in `tests.rs` (Task 12) will assert the
+/// `biased;` keyword is present in this select.
+#[allow(dead_code)] // wired to callers in Task 8+
+pub(crate) async fn next_with_cancel_and_timeout<S, E>(
+    mut stream: std::pin::Pin<&mut S>,
+    cancel: Option<&tokio_util::sync::CancellationToken>,
+    read_timeout: std::time::Duration,
+    url: &str,
+) -> Result<Option<std::result::Result<bytes::Bytes, E>>>
+where
+    S: futures::Stream<Item = std::result::Result<bytes::Bytes, E>>,
+{
+    use futures::StreamExt;
+    let timeout_err = || RdlpError::Network {
+        message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
+        url: Some(url.to_string()),
+    };
+    match cancel {
+        Some(token) => {
+            tokio::select! {
+                biased;
+                () = token.cancelled() => Err(RdlpError::Cancelled),
+                r = tokio::time::timeout(read_timeout, stream.next()) => {
+                    r.map_or_else(|_| Err(timeout_err()), Ok)
+                },
+            }
+        }
+        None => tokio::time::timeout(read_timeout, stream.next())
+            .await
+            .map_or_else(|_| Err(timeout_err()), Ok),
+    }
+}
+
 #[cfg(test)]
 mod content_range_tests {
     use super::*;
@@ -551,5 +598,70 @@ mod content_range_tests {
     fn returns_none_when_total_unparseable() {
         let h = make_headers(Some("bytes 0-262143/notanumber"));
         assert_eq!(parse_content_range_total(&h), None);
+    }
+}
+
+#[cfg(test)]
+mod cancel_helper_tests {
+    use super::*;
+    use bytes::Bytes;
+    use futures::stream;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn returns_item_when_stream_ready_no_cancel() {
+        let s = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from("hello"))]);
+        tokio::pin!(s);
+        let timeout = Duration::from_secs(1);
+
+        let res = next_with_cancel_and_timeout(s.as_mut(), None, timeout, "test").await;
+
+        let item = res.unwrap();
+        assert!(matches!(item, Some(Ok(b)) if b == "hello"));
+    }
+
+    #[tokio::test]
+    async fn returns_none_at_stream_end() {
+        let s = stream::iter::<Vec<std::result::Result<Bytes, std::io::Error>>>(vec![]);
+        tokio::pin!(s);
+        let timeout = Duration::from_secs(1);
+
+        let res = next_with_cancel_and_timeout(s.as_mut(), None, timeout, "test").await;
+
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn cancel_fires_returns_cancelled_error() {
+        let s = stream::pending::<std::result::Result<Bytes, std::io::Error>>();
+        tokio::pin!(s);
+        let timeout = Duration::from_secs(10);
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let res = next_with_cancel_and_timeout(s.as_mut(), Some(&token), timeout, "test").await;
+
+        assert!(matches!(res, Err(RdlpError::Cancelled)));
+    }
+
+    #[tokio::test]
+    async fn read_timeout_fires_returns_network_error() {
+        let s = stream::pending::<std::result::Result<Bytes, std::io::Error>>();
+        tokio::pin!(s);
+        let timeout = Duration::from_millis(50);
+
+        let res = next_with_cancel_and_timeout(s.as_mut(), None, timeout, "http://test").await;
+
+        match res {
+            Err(RdlpError::Network { message, url }) => {
+                assert!(
+                    message.to_lowercase().contains("timed out"),
+                    "got: {message}"
+                );
+                assert_eq!(url.as_deref(), Some("http://test"));
+            }
+            other => panic!("expected Network timeout, got {other:?}"),
+        }
     }
 }

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -872,6 +872,61 @@ async fn download_format_propagates_cancel_to_sequential() {
     assert!(matches!(res, Err(RdlpError::Cancelled)));
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn download_with_resume_with_cancel_aborts_on_cancel() {
+    use std::net::TcpListener;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    // Blackhole that accepts a connection and sends a 206 header but then
+    // never sends body bytes. Forces the future to park at stream.next().
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        use std::io::Write;
+        if let Ok((mut stream, _)) = listener.accept() {
+            // Read request bytes (drop them)
+            let _ = stream.set_read_timeout(Some(Duration::from_millis(100)));
+            let mut buf = [0u8; 1024];
+            let _ = std::io::Read::read(&mut stream, &mut buf);
+
+            // Send 206 partial-content headers with a content-range that says total is 10MB
+            let _ = stream.write_all(
+                b"HTTP/1.1 206 Partial Content\r\n\
+                  Content-Range: bytes 0-10485759/10485760\r\n\
+                  Content-Length: 10485760\r\n\
+                  Content-Type: application/octet-stream\r\n\
+                  \r\n",
+            );
+            let _ = stream.flush();
+            // Hold the connection open so wreq waits for body data.
+            #[allow(clippy::duration_suboptimal_units)] // from_mins needs Rust 1.95; MSRV 1.85
+            std::thread::sleep(Duration::from_secs(60));
+        }
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.bin");
+    // Pre-create a 0-byte file to satisfy resume preconditions if any.
+    tokio::fs::write(&out, b"").await.unwrap();
+
+    let downloader = HttpDownloader::new();
+    let url = format!("http://127.0.0.1:{port}/blackhole");
+
+    let token = CancellationToken::new();
+    let token2 = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        token2.cancel();
+    });
+
+    let res = downloader
+        .download_with_resume_with_cancel(&url, &out, 0, None, Some(&token))
+        .await;
+
+    assert!(matches!(res, Err(RdlpError::Cancelled)));
+}
+
 #[tokio::test]
 async fn download_to_file_no_head_under_normal_flow() {
     use mockito::Matcher;

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -966,3 +966,59 @@ async fn download_to_file_no_head_under_normal_flow() {
     assert_eq!(stats.bytes_downloaded, 524288);
     head_guard.assert_async().await;
 }
+
+#[test]
+fn next_with_cancel_helper_uses_biased_select() {
+    // Static guard: the cancel select in next_with_cancel_and_timeout MUST
+    // include `biased;` so cancel-priority is deterministic. Without biased,
+    // tokio's PRNG branch selection can starve the cancel arm under load.
+    //
+    // Mirrors the static probe-order guard at
+    // crates/rdlp-extractor/src/hls/expand_in_place.rs:247
+    // (`test_extractor_call_order_expand_before_detect`).
+    let source = include_str!("mod.rs");
+
+    // Restrict to the helper's function body to avoid false positives from
+    // other select! invocations elsewhere in the file.
+    let start = source
+        .find("pub(crate) async fn next_with_cancel_and_timeout")
+        .expect("next_with_cancel_and_timeout not found in http/mod.rs");
+
+    // End at the next top-level `fn` definition or the `#[cfg(test)]` block,
+    // whichever comes first.
+    let after_start = &source[start..];
+    let cfg_test_end = after_start.find("\n#[cfg(test)]");
+    let next_fn_end = after_start[1..]
+        .find("\nfn ")
+        .or_else(|| after_start[1..].find("\nasync fn "))
+        .or_else(|| after_start[1..].find("\npub fn "))
+        .or_else(|| after_start[1..].find("\npub(crate) fn "))
+        .or_else(|| after_start[1..].find("\npub(crate) async fn "))
+        .map(|i| i + 1);
+    let end = match (cfg_test_end, next_fn_end) {
+        (Some(a), Some(b)) => a.min(b),
+        (Some(a), None) => a,
+        (None, Some(b)) => b,
+        (None, None) => after_start.len(),
+    };
+    let body = &after_start[..end];
+
+    let select_idx = body
+        .find("tokio::select!")
+        .expect("next_with_cancel_and_timeout must contain a tokio::select!");
+    let after_select = &body[select_idx..];
+
+    // `biased;` must appear before the first arm (which uses `=>`).
+    let first_arm = after_select
+        .find("=>")
+        .expect("tokio::select! must have at least one arm");
+    let header = &after_select[..first_arm];
+
+    assert!(
+        header.contains("biased;"),
+        "tokio::select! in next_with_cancel_and_timeout MUST use `biased;` \
+         to deterministically prioritize the cancel arm. Without it, tokio's \
+         PRNG branch selection can starve cancel under load. \
+         Found header: {header:?}"
+    );
+}

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -834,6 +834,44 @@ async fn download_sequential_cancel_none_passes_existing_behavior() {
     assert_eq!(tokio::fs::read(&out).await.unwrap(), body);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn download_format_propagates_cancel_to_sequential() {
+    use rdlp_types::{DownloadProtocol, Format};
+    use std::net::TcpListener;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        let _ = listener.accept();
+        // Hold connection open without sending any response — the probe
+        // will block waiting for a response, and the cancel fires first.
+        // `Duration::from_mins` needs Rust 1.95; workspace MSRV is 1.85.
+        #[allow(clippy::duration_suboptimal_units)]
+        std::thread::sleep(Duration::from_secs(60));
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.bin");
+    let downloader = HttpDownloader::new();
+    let url = format!("http://127.0.0.1:{port}/blackhole");
+    let format = Format::new("test", &url, "bin", DownloadProtocol::Https);
+
+    let token = CancellationToken::new();
+    let token2 = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        token2.cancel();
+    });
+
+    let res = downloader
+        .download_format(&format, &out, None, Some(&token))
+        .await;
+
+    assert!(matches!(res, Err(RdlpError::Cancelled)));
+}
+
 #[tokio::test]
 async fn download_to_file_no_head_under_normal_flow() {
     use mockito::Matcher;

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -780,7 +780,10 @@ async fn download_sequential_cancel_mid_stream_returns_cancelled() {
             );
             let _ = stream.flush();
             // Hold the connection open so wreq waits for the next chunk.
-            std::thread::sleep(Duration::from_mins(1));
+            // `Duration::from_mins` (clippy suggestion) needs Rust 1.95;
+            // workspace MSRV is 1.85.
+            #[allow(clippy::duration_suboptimal_units)]
+            std::thread::sleep(Duration::from_secs(60));
         }
     });
 

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -727,6 +727,110 @@ async fn parallel_threshold_override_takes_parallel_path_for_5mib_file() {
     // download correctness.
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn download_sequential_cancel_before_start_returns_cancelled() {
+    use tokio_util::sync::CancellationToken;
+
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/file")
+        .with_status(200)
+        .with_body(vec![0u8; 1024])
+        .create_async()
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.bin");
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let res = downloader
+        .download_sequential(&url, &out, None, Some(&token))
+        .await;
+
+    assert!(matches!(res, Err(RdlpError::Cancelled)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn download_sequential_cancel_mid_stream_returns_cancelled() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    // A server that sends HTTP 200 headers + chunked transfer-encoding preamble
+    // but never sends actual body chunks. This parks the wreq body stream at
+    // its next() poll, which is where the cancel arm races.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            // Read and discard the request.
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            // Send HTTP 200 with chunked encoding but no body chunks.
+            let _ = stream.write_all(
+                b"HTTP/1.1 200 OK\r\n\
+                  Transfer-Encoding: chunked\r\n\
+                  Content-Type: application/octet-stream\r\n\
+                  \r\n",
+            );
+            let _ = stream.flush();
+            // Hold the connection open so wreq waits for the next chunk.
+            std::thread::sleep(Duration::from_mins(1));
+        }
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.bin");
+    let downloader = HttpDownloader::new();
+    let url = format!("http://127.0.0.1:{port}/slow-body");
+
+    let token = CancellationToken::new();
+    let token2 = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        token2.cancel();
+    });
+
+    let res = downloader
+        .download_sequential(&url, &out, None, Some(&token))
+        .await;
+
+    assert!(
+        matches!(res, Err(RdlpError::Cancelled)),
+        "expected Cancelled, got: {res:?}"
+    );
+}
+
+#[tokio::test]
+async fn download_sequential_cancel_none_passes_existing_behavior() {
+    let mut server = mockito::Server::new_async().await;
+    let body = vec![0xCC; 4096];
+    let _mock = server
+        .mock("GET", "/file")
+        .with_status(200)
+        .with_body(body.clone())
+        .create_async()
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.bin");
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    let stats = downloader
+        .download_sequential(&url, &out, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.bytes_downloaded, 4096);
+    assert_eq!(tokio::fs::read(&out).await.unwrap(), body);
+}
+
 #[tokio::test]
 async fn download_to_file_no_head_under_normal_flow() {
     use mockito::Matcher;

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -10,10 +10,12 @@ use rdlp_core::{
     DownloadProgress, DownloadStats, Downloader, ProgressCallback, RdlpError, Result,
     check_http_response,
 };
+use rdlp_types::Format;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio_util::sync::CancellationToken;
 
 use super::config::PROGRESS_UPDATE_INTERVAL;
 use super::{HttpDownloader, with_retry};
@@ -23,6 +25,80 @@ use super::{HttpDownloader, with_retry};
 impl Downloader for HttpDownloader {
     fn protocol(&self) -> &'static str {
         "http"
+    }
+
+    /// F6: Override `download_format` to thread `cancel` into the download path.
+    ///
+    /// The trait's default impl discards `cancel`. This override re-implements
+    /// the `download_to_file` body inline — probe, then parallel-or-sequential
+    /// dispatch — and passes `cancel` to `download_sequential`. The probe itself
+    /// is wrapped in a `tokio::select!` so cancellation fires even before the
+    /// first byte arrives.
+    ///
+    /// Note: `download_parallel` does not yet take `cancel`; the outer
+    /// orchestrator `select!` provides cancellation for the parallel path.
+    async fn download_format(
+        &self,
+        format: &Format,
+        path: &Path,
+        progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<DownloadStats> {
+        let url = &format.url;
+        let timeout = self.config.download_timeout;
+
+        let download_fut = async {
+            let probe = self.probe(url).await?;
+            let size = probe.size;
+            let supports_ranges = probe.supports_ranges;
+
+            debug!(
+                "Probe result: size={} MB, concurrent={}, ranges={}",
+                size.map_or(0, |s| s / 1024 / 1024),
+                self.config.concurrent_fragments,
+                supports_ranges
+            );
+
+            let parallel_size = match size {
+                Some(s) if s > self.config.parallel_threshold => {
+                    if self.config.concurrent_fragments > 1 && supports_ranges {
+                        Some(s)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            if let Some(ps) = parallel_size {
+                // Parallel-path cooperative cancel is pre-existing AIMD work,
+                // out of scope for F6; outer select! at the orchestrator covers it.
+                return self.download_parallel(url, path, ps, progress).await;
+            }
+
+            self.download_sequential(url, path, progress, cancel).await
+        };
+
+        let timed = tokio::time::timeout(timeout, download_fut);
+
+        match cancel {
+            Some(token) => {
+                tokio::select! {
+                    biased;
+                    () = token.cancelled() => Err(RdlpError::Cancelled),
+                    result = timed => {
+                        result.map_err(|_| RdlpError::Download {
+                            message: format!("Download timed out after {}s", timeout.as_secs()),
+                            url: Some(url.clone()),
+                        })?
+                    }
+                }
+            }
+            None => timed.await.map_err(|_| RdlpError::Download {
+                message: format!("Download timed out after {}s", timeout.as_secs()),
+                url: Some(url.clone()),
+            })?,
+        }
     }
 
     async fn download_to_file(

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -314,6 +314,14 @@ impl HttpDownloader {
         progress: Option<Box<dyn ProgressCallback>>,
         cancel: Option<&CancellationToken>,
     ) -> Result<DownloadStats> {
+        // F6: pre-cancel guard. Mirrors download_sequential — avoids issuing
+        // a network round-trip when the caller has already cancelled.
+        if let Some(token) = cancel
+            && token.is_cancelled()
+        {
+            return Err(RdlpError::Cancelled);
+        }
+
         let timeout = self.config.download_timeout;
         tokio::time::timeout(timeout, async {
             let start_time = Instant::now();

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -293,6 +293,27 @@ impl Downloader for HttpDownloader {
         resume_from: u64,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
+        // Trait method discards cancel (outer select! covers it). For cooperative
+        // cancel, callers use `download_with_resume_with_cancel` directly.
+        // TODO(#287): trait method itself may take cancel in a future BC-break.
+        self.download_with_resume_with_cancel(url, path, resume_from, progress, None)
+            .await
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+impl HttpDownloader {
+    /// F6: cooperative-cancel-aware variant of `download_with_resume`.
+    /// The trait method `download_with_resume` delegates here with `cancel: None`.
+    /// Direct callers (e.g. tests) can pass a `CancellationToken` for mid-stream cancellation.
+    pub(crate) async fn download_with_resume_with_cancel(
+        &self,
+        url: &str,
+        path: &Path,
+        resume_from: u64,
+        progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<DownloadStats> {
         let timeout = self.config.download_timeout;
         tokio::time::timeout(timeout, async {
             let start_time = Instant::now();
@@ -388,19 +409,32 @@ impl Downloader for HttpDownloader {
                 ))?;
             let mut writer = BufWriter::with_capacity(self.config.buffer_size, file);
 
-            let mut stream = response.bytes_stream();
+            let stream = response.bytes_stream();
+            tokio::pin!(stream);
             let mut downloaded = resume_from;
             let mut last_update = Instant::now();
             let update_interval = PROGRESS_UPDATE_INTERVAL;
             let read_timeout = self.config.read_timeout;
 
-            while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
+            loop {
+                let next = match crate::http::next_with_cancel_and_timeout(
+                    stream.as_mut(),
+                    cancel,
+                    read_timeout,
+                    &url_string,
+                )
                 .await
-                .map_err(|_| RdlpError::Network {
-                    message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
-                    url: Some(url_string.to_string()),
-                })?
-            {
+                {
+                    Ok(item) => item,
+                    Err(RdlpError::Cancelled) => {
+                        // Flush partial bytes already in BufWriter to disk.
+                        writer.flush().await.ok();
+                        return Err(RdlpError::Cancelled);
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                let Some(chunk_result) = next else { break };
                 let chunk = chunk_result
                     .map_err(|e| RdlpError::Network { message: format!("Failed to read resume response body from {url_string}: {e}"), url: Some(url_string.to_string()) })?;
 

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -78,7 +78,7 @@ impl Downloader for HttpDownloader {
                 self.config.concurrent_fragments
             );
 
-            self.download_sequential(url, path, progress).await
+            self.download_sequential(url, path, progress, None).await
         })
         .await
         .map_err(|_| RdlpError::Download {


### PR DESCRIPTION
## Summary

- Adds \`next_with_cancel_and_timeout\` helper in \`http/mod.rs\` that races \`bytes_stream().next()\` against the per-read timeout and an optional \`CancellationToken\` via \`tokio::select! { biased; ... }\`.
- \`HttpDownloader::download_sequential\` and \`download_with_resume_with_cancel\` accept \`cancel: Option<&CancellationToken>\` and use the helper.
- \`HttpDownloader::download_format\` is overridden (the trait default discarded \`cancel\`) to thread the token down to \`download_sequential\`. Inlines probe + dispatch to avoid double-probe.
- New inherent \`download_with_resume_with_cancel\` on \`HttpDownloader\`; trait method \`download_with_resume\` is now a one-line delegate (\`Downloader\` trait signature unchanged).
- \`DashDownloader\` non-fragment branch delegates to \`HttpDownloader::download_format\`, closing \`TODO(#287)\`.
- \`BufWriter::flush().await.ok()\` before returning \`Err(RdlpError::Cancelled)\` ensures partial data hits disk (BufWriter Drop discards the buffer).
- Pre-cancel guards on \`download_sequential\` and \`download_with_resume_with_cancel\` short-circuit already-cancelled tokens before any network I/O.
- Static guard test asserts \`biased;\` presence in the helper's \`select!\` (mirrors \`hls/expand_in_place.rs:247\` pattern).
- Orchestrator outer-\`select!\` comment at \`execution.rs:109-125\` updated to reflect F6's cooperative coverage.

Closes #287. Refs F6 in \`docs/superpowers/specs/2026-05-04-download-optimization-audit.md\`.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-05-21-f3-f6-download-optimization-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-21-f3-f6-download-optimization.md\`

(Both gitignored; local-only.)

## Trait surface

NO changes to \`Downloader\` trait method signatures. Cancel threads through the existing \`Downloader::download_format(..., cancel)\` parameter via overrides on \`HttpDownloader\` (and \`DashDownloader\` via delegation).

## Reviews

- security-reviewer: ✅ **Approve with fixes** — 1 Medium (pre-cancel guard in \`download_with_resume_with_cancel\`) addressed in fix-up commit \`eab41cb\`. 1 Medium (URL in debug log) was not applicable — the debug log doesn't log \`format.url\`. Low findings (test thread linger, guard fragility) deferred to follow-up.
- code-reviewer: ✅ **Approved with nits** (non-blocking)
- \`cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test\`: ✅

## Test plan

- [x] \`download_sequential_cancel_before_start_returns_cancelled\` — pre-cancelled token returns \`Err(Cancelled)\` immediately
- [x] \`download_sequential_cancel_mid_stream_returns_cancelled\` — blackhole TCP listener, cancel mid-stream
- [x] \`download_sequential_cancel_none_passes_existing_behavior\` — regression: \`cancel: None\` unchanged
- [x] \`download_format_propagates_cancel_to_sequential\` — \`download_format\` override threads cancel
- [x] \`download_with_resume_with_cancel_aborts_on_cancel\` — resume cancel mid-stream
- [x] \`next_with_cancel_helper_uses_biased_select\` — static \`biased;\` guard
- [x] 4 unit tests for the helper itself (ready / end / cancel / timeout)
- [ ] Manual smoke: Ctrl+C a real HTTP download mid-stream; confirm partial file matches in-memory state.

## Out-of-scope deferrals (filed as follow-ups)

- Parallel-path (\`download_parallel_adaptive\`) cooperative cancel — outer \`select!\` only; semaphore-stuck chunks delay cancel ack by ≤1 chunk-RTT.
- \`Downloader::download_with_resume\` trait signature stays without \`cancel\`; private \`download_with_resume_with_cancel\` covers the cancellable path. Orchestrator's resume branch still relies on outer \`select!\`.
- \`download_to_writer\` (stdout sink) cooperative cancel — outer \`select!\` only.
- Test helper for blackhole-listener pattern (deduplication across 3 tests).