### PR TITLE
chore(quality): dedup detection ratchet (sprint PR A)

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -1,0 +1,95 @@
+[[ignore]]
+fingerprint = "1f71fa7657f2f924"
+reason = "Acceptable test boilerplate; deduplication via test helper deferred (write_signed_plugin x3 in plugin golden tests)"
+
+[[ignore]]
+fingerprint = "8c6b8e22faf810b1"
+reason = "Acceptable test boilerplate (build_*_plugin x3 in plugin golden tests)"
+
+[[ignore]]
+fingerprint = "e79a123cf3c33161"
+reason = "Initiative #5: InfoExtractorExt — fetch_api/html_search_page shared across PornHub+RedTube (tracking issue)"
+
+[[ignore]]
+fingerprint = "0b7f365890f934cb"
+reason = "Initiative #5: InfoExtractorExt — XHamster+TNAFlix search_all_pages share pagination scaffold (tracking issue)"
+
+[[ignore]]
+fingerprint = "36dd26d02f5ee08b"
+reason = "Intentional single-call vs paginated twin (Orchestrator::search vs search_page; matches RdlpClient pair)"
+
+[[ignore]]
+fingerprint = "40ffb0ebfe965e24"
+reason = "Initiative #3: delegate_to_base! macro — EMPFlix+MovieFap search_all_pages clone the TNAFlix base (tracking issue)"
+
+[[ignore]]
+fingerprint = "43815788a5f74903"
+reason = "Intentional single-call vs paginated twin (RdlpClient::search vs search_page)"
+
+[[ignore]]
+fingerprint = "5f3484e2369caff5"
+reason = "Intentional domain separation; audio/video sample-format vs pixel-format helpers are incompatible (ffmpeg-the-third upstream split). Re-evaluate if a 3rd codec domain appears."
+
+[[ignore]]
+fingerprint = "611204904b3045f3"
+reason = "Intentional domain separation; preferred_audio_encoder vs preferred_video_encoder iterate distinct codec tables and availability checks (ffmpeg-the-third upstream split). Re-evaluate if a 3rd codec domain (subtitle codec preference) appears."
+
+[[ignore]]
+fingerprint = "6dbb2cbb33f171e5"
+reason = "Acceptable test redundancy; same 5xx-propagation assertion for API vs HTML fetch strategies"
+
+[[ignore]]
+fingerprint = "90a940b4af1cc624"
+reason = "Acceptable test redundancy; set_cookie attribute + Secure flag are deliberately separate assertions"
+
+[[ignore]]
+fingerprint = "c724f5103213d974"
+reason = "Same domain-separation rationale (resolve_audio_encoder vs resolve_encoder for video)"
+
+[[ignore]]
+fingerprint = "e12f9e5e11985162"
+reason = "Rule of Three pending: build_api_search_url is duplicated in PornHub+RedTube; extract when a 3rd extractor needs the same pattern (tracking issue)"
+
+[[ignore]]
+fingerprint = "f07ba850fd9c6f4d"
+reason = "Acceptable test redundancy; two distinct retry scenarios (exhausted vs non-retryable) share assertion shape"
+
+[[ignore]]
+fingerprint = "baa10f1d8b4a5471"
+reason = "False positive: download_to_file vs download_to_writer share timeout scaffold but diverge in probe+parallel dispatch vs sequential BrokenPipe handling"
+
+[[ignore]]
+fingerprint = "9b402eaf0837811d"
+reason = "False positive: HLS format-detection and DASH download closures share structural shape but operate on incompatible segment-type streams"
+
+[[ignore]]
+fingerprint = "c280dd2ab56d298f"
+reason = "Initiative #5: InfoExtractorExt — search_filter_descriptors duplicated across PornHub+RedTube (tracking issue)"
+
+[[ignore]]
+fingerprint = "3b98ca18011a1100"
+reason = "Same domain-separation rationale (list_available_audio_codecs vs list_available_codecs for video)"
+
+[[ignore]]
+fingerprint = "2171a47deb213f3b"
+reason = "Same domain-separation rationale (closures inside list_*_codecs helpers iterate distinct codec tables)"
+
+[[ignore]]
+fingerprint = "c779eff5aef82766"
+reason = "Initiative #5: InfoExtractorExt — XNXX+SpankBang SearchExtractor::search_page share pagination scaffold (tracking issue)"
+
+[[ignore]]
+fingerprint = "d1fae871b2e72790"
+reason = "Acceptable test redundancy; two related assertions on Orchestrator::select merge-selector behaviour (explicit vs derived merge selection)"
+
+[[ignore]]
+fingerprint = "9c27d6eddcbf2fa7"
+reason = "False positive: FFmpegRunner::merge and embed_thumbnail wrap the same FFmpeg session-spawn boilerplate but operate on disjoint stream maps (mux vs attached_pic remux)"
+
+[[ignore]]
+fingerprint = "40cd6e66253b577b"
+reason = "Acceptable test redundancy; round-trip pattern for two distinct serializable session-state shapes (playlist vs merge_plan)"
+
+[[ignore]]
+fingerprint = "b1f95f057f50ca9e"
+reason = "Initiative #5: InfoExtractorExt — category_values (PornHub) and tag_values (RedTube) share filter-value enumeration scaffold (tracking issue)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,9 @@ must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 
 # ── Dev profile: prioritize compile speed ──────────────────────────────
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,9 @@ mockito = "1.5"
 temp-env = "0.3"
 tempfile = "3.14"
 
+[workspace.lints.rust]
+missing_docs = "warn"
+
 [workspace.lints.clippy]
 must_use_candidate = "warn"
 await_holding_lock = "deny"
@@ -157,6 +160,10 @@ disallowed_methods = "deny"
 match_same_arms = "warn"
 redundant_clone = "warn"
 collapsible_match = "warn"
+unwrap_used = "warn"
+expect_used = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
 
 # ── Dev profile: prioritize compile speed ──────────────────────────────
 [profile.dev]

--- a/crates/rdlp-api/Cargo.toml
+++ b/crates/rdlp-api/Cargo.toml
@@ -69,17 +69,14 @@ missing_docs = "warn"
 unsafe_code = "deny"
 
 [lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
-# Security-relevant lints applied to ALL targets.
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
-# `indexing_slicing`, `pedantic`, and `nursery` are lib-only via
-# `#![warn(...)]` in `src/lib.rs`. See plugin crate Cargo.toml for the
-# full rationale (test indexing is a guarded assertion pattern).

--- a/crates/rdlp-api/tests/api_integration.rs
+++ b/crates/rdlp-api/tests/api_integration.rs
@@ -141,11 +141,8 @@ async fn test_cancel_before_result() {
     // Either UserCancelled or extraction failure — both are acceptable
     // depending on race timing
     match &result {
-        Err(RdlpApiError::UserCancelled) => {
-            // Cancellation won the race — expected path
-        }
         Err(_) => {
-            // Extraction failure reached first — also acceptable
+            // Cancellation won the race or extraction failure reached first — both acceptable
         }
         Ok(_) => panic!("Should not succeed after cancel"),
     }

--- a/crates/rdlp-api/tests/plugin_dispatch_regression.rs
+++ b/crates/rdlp-api/tests/plugin_dispatch_regression.rs
@@ -111,7 +111,7 @@ signature = "PLACEHOLDER"
             let config = Config {
                 progress: false,
                 plugin_directories: vec![tempdir.path().to_path_buf()],
-                plugin_trusted_publishers: vec![identity.clone()],
+                plugin_trusted_publishers: vec![identity],
                 ..Default::default()
             };
 

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -52,28 +52,5 @@ async-trait = { workspace = true }
 regex = { workspace = true }
 rdlp-plugin-manifest = { path = "../rdlp-plugin-manifest" }
 
-# Per-crate lint config — extends workspace lints (which cannot be composed
-# with workspace = true once per-crate tables are added).
-# Workspace lint baselines replicated here:
-#   clippy::must_use_candidate = warn
-#   clippy::await_holding_lock = deny
-#   clippy::await_holding_refcell_ref = deny
-#   clippy::disallowed_methods = deny
-
-[lints.rust]
-missing_docs = "warn"
-
-[lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
-must_use_candidate = "warn"
-disallowed_methods = "deny"
-await_holding_lock = "deny"
-await_holding_refcell_ref = "deny"
-# Security-relevant lints applied to ALL targets.
-unwrap_used = "warn"
-expect_used = "warn"
-missing_errors_doc = "warn"
-missing_panics_doc = "warn"
-# `indexing_slicing`, `pedantic`, and `nursery` are binary-only via
-# `#![warn(...)]` in `src/main.rs` and `src/lib.rs`.
+[lints]
+workspace = true

--- a/crates/rdlp-cli/Cargo.toml
+++ b/crates/rdlp-cli/Cargo.toml
@@ -52,5 +52,8 @@ async-trait = { workspace = true }
 regex = { workspace = true }
 rdlp-plugin-manifest = { path = "../rdlp-plugin-manifest" }
 
+# `indexing_slicing`, `pedantic`, and `nursery` are applied binary-only
+# via `#![warn(...)]` in `src/main.rs` and `src/lib.rs` — do NOT lift
+# them to the workspace table.
 [lints]
 workspace = true

--- a/crates/rdlp-cli/tests/plugin_cmd.rs
+++ b/crates/rdlp-cli/tests/plugin_cmd.rs
@@ -106,7 +106,7 @@ fn run_uninstall_rejects_path_traversal_name() {
         std::fs::create_dir_all(&plugin_dir).unwrap();
         let config = Config {
             progress: false,
-            plugin_directories: vec![plugin_dir.clone()],
+            plugin_directories: vec![plugin_dir],
             ..Default::default()
         };
 

--- a/crates/rdlp-cookies/Cargo.toml
+++ b/crates/rdlp-cookies/Cargo.toml
@@ -26,5 +26,7 @@ windows-sys = { version = "0.59", features = ["Win32_Security_Cryptography", "Wi
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 
+# unsafe_code: intentionally NOT set to forbid — Windows DPAPI
+# CryptUnprotectData FFI requires unsafe blocks on the Windows target.
 [lints]
 workspace = true

--- a/crates/rdlp-cookies/Cargo.toml
+++ b/crates/rdlp-cookies/Cargo.toml
@@ -26,18 +26,5 @@ windows-sys = { version = "0.59", features = ["Win32_Security_Cryptography", "Wi
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 
-[lints.rust]
-missing_docs = "warn"
-# unsafe_code: Windows CryptUnprotectData FFI requires unsafe (DPAPI on Windows)
-
-[lints.clippy]
-# Workspace baseline
-must_use_candidate = "warn"
-await_holding_lock = "deny"
-await_holding_refcell_ref = "deny"
-disallowed_methods = "deny"
-# Security lints
-unwrap_used = "warn"
-expect_used = "warn"
-missing_errors_doc = "warn"
-missing_panics_doc = "warn"
+[lints]
+workspace = true

--- a/crates/rdlp-core/Cargo.toml
+++ b/crates/rdlp-core/Cargo.toml
@@ -30,12 +30,13 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-crypto/Cargo.toml
+++ b/crates/rdlp-crypto/Cargo.toml
@@ -20,12 +20,13 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-desktop/src-tauri/Cargo.toml
+++ b/crates/rdlp-desktop/src-tauri/Cargo.toml
@@ -44,31 +44,19 @@ tauri-build = { version = "2", features = [] }
 [dev-dependencies]
 mockito = { workspace = true }
 
-# Per-crate lint config — extends workspace lints (which cannot be composed
-# with workspace = true once per-crate tables are added).
-# Workspace lint baselines replicated here:
-#   clippy::must_use_candidate = warn
-#   clippy::await_holding_lock = deny
-#   clippy::await_holding_refcell_ref = deny
-#   clippy::disallowed_methods = deny
-
 [lints.rust]
 missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
-# Strict surface for the Tauri IPC layer.
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
-# `indexing_slicing`, `pedantic`, and `nursery` are lib-only via
-# `#![warn(...)]` in `src/lib.rs`. Test code inherits the
-# `allow-unwrap-in-tests` / `allow-expect-in-tests` exemptions from
-# `clippy.toml`.

--- a/crates/rdlp-downloader/Cargo.toml
+++ b/crates/rdlp-downloader/Cargo.toml
@@ -43,9 +43,12 @@ unsafe_code = "forbid"
 
 [lints.clippy]
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -37,18 +37,5 @@ mockito = { workspace = true }
 rdlp-http = { path = "../rdlp-http" }
 rdlp-cookies = { path = "../rdlp-cookies" }
 
-[lints.rust]
-missing_docs = "warn"
-
-[lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
-must_use_candidate = "warn"
-disallowed_methods = "deny"
-await_holding_lock = "deny"
-await_holding_refcell_ref = "deny"
-# Documentation completeness (applies to all targets).
-missing_errors_doc = "warn"
-missing_panics_doc = "warn"
-unwrap_used = "warn"
-expect_used = "warn"
+[lints]
+workspace = true

--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -37,5 +37,7 @@ mockito = { workspace = true }
 rdlp-http = { path = "../rdlp-http" }
 rdlp-cookies = { path = "../rdlp-cookies" }
 
+# Documentation-completeness rationale only — do NOT lift extractor-
+# specific `#![warn(...)]` lints (declared in `src/lib.rs`) to workspace.
 [lints]
 workspace = true

--- a/crates/rdlp-extractor/src/base/common/dash/expand.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/expand.rs
@@ -327,10 +327,8 @@ pub fn expand_dash_representations(
 /// Map a MIME type to a container file extension.
 fn mime_to_ext(mime: &str) -> &'static str {
     match mime {
-        "video/mp4" => "mp4",
-        "video/webm" => "webm",
+        "video/webm" | "audio/webm" => "webm",
         "audio/mp4" => "m4a",
-        "audio/webm" => "webm",
         _ => "mp4",
     }
 }
@@ -440,10 +438,8 @@ fn build_fragments(
 /// yt-dlp's convention.
 fn mime_to_sub_ext(mime: &str, codecs: &str) -> String {
     match mime {
-        "text/ttml" | "application/ttml+xml" => "ttml",
         "text/vtt" => "vtt",
         "application/mp4" => match codecs {
-            "stpp" | "ttml" | "dfxp" => "ttml",
             "wvtt" => "vtt",
             _ => "ttml",
         },

--- a/crates/rdlp-extractor/src/extractors/generic/html_sources.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/html_sources.rs
@@ -158,16 +158,14 @@ fn mime_to_ext(mime: &str) -> Option<String> {
     let mime = mime.to_lowercase();
     match mime.as_str() {
         "video/mp4" => Some("mp4".to_string()),
-        "video/webm" => Some("webm".to_string()),
-        "video/ogg" => Some("ogg".to_string()),
+        "video/webm" | "audio/webm" => Some("webm".to_string()),
+        "video/ogg" | "audio/ogg" => Some("ogg".to_string()),
         "video/x-flv" => Some("flv".to_string()),
         "video/x-matroska" => Some("mkv".to_string()),
         "video/quicktime" => Some("mov".to_string()),
         "video/mp2t" | "video/MP2T" => Some("ts".to_string()),
         "audio/mpeg" => Some("mp3".to_string()),
         "audio/mp4" => Some("m4a".to_string()),
-        "audio/ogg" => Some("ogg".to_string()),
-        "audio/webm" => Some("webm".to_string()),
         "audio/wav" => Some("wav".to_string()),
         "audio/flac" => Some("flac".to_string()),
         "application/vnd.apple.mpegurl" | "application/x-mpegurl" => Some("m3u8".to_string()),

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/cipher.rs
@@ -282,9 +282,9 @@ mod tests {
         let s2 = seed_shuffle(&chars, "test_key");
         assert_eq!(s1, s2);
         // Should be a permutation (same elements)
-        let mut sorted1 = s1.clone();
+        let mut sorted1 = s1;
         sorted1.sort();
-        let mut sorted_chars = chars.clone();
+        let mut sorted_chars = chars;
         sorted_chars.sort();
         assert_eq!(sorted1, sorted_chars);
     }

--- a/crates/rdlp-extractor/src/extractors/xnxx/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/mod.rs
@@ -152,7 +152,7 @@ impl InfoExtractor for XNXXExtractor {
 
         let thumbnail = inline.thumbnail_url.or_else(|| ld.thumbnail_url.clone());
 
-        let uploader = inline.uploader.clone();
+        let uploader = inline.uploader;
 
         let description = ld.description.clone();
         let duration = ld
@@ -160,7 +160,7 @@ impl InfoExtractor for XNXXExtractor {
             .as_deref()
             .and_then(BaseExtractor::parse_iso8601_duration);
         let view_count = ld.view_count;
-        let upload_date = ld.upload_date.clone();
+        let upload_date = ld.upload_date;
 
         // --- build InfoDict ---
         let mut info = InfoDict::new(&video_id, &title, XNXX_NAME, url);

--- a/crates/rdlp-extractor/src/hls/mod.rs
+++ b/crates/rdlp-extractor/src/hls/mod.rs
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn test_detector_creation() {
         let client = Arc::new(wreq::Client::new());
-        let detector = HlsSizeDetector::new(client.clone(), false);
+        let detector = HlsSizeDetector::new(client, false);
 
         assert_eq!(detector.concurrent_requests, 8);
         assert!(!detector.verbose);

--- a/crates/rdlp-ffmpeg/Cargo.toml
+++ b/crates/rdlp-ffmpeg/Cargo.toml
@@ -37,9 +37,12 @@ unsafe_op_in_unsafe_fn = "warn"
 
 [lints.clippy]
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-http/Cargo.toml
+++ b/crates/rdlp-http/Cargo.toml
@@ -35,29 +35,19 @@ openssl-sys = { version = "0.9", features = ["vendored"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
-# Per-crate lint config — extends workspace lints (which cannot be composed
-# with workspace = true once per-crate tables are added).
-# Workspace lint baselines replicated here:
-#   clippy::must_use_candidate = warn
-#   clippy::await_holding_lock = deny
-#   clippy::await_holding_refcell_ref = deny
-#   clippy::disallowed_methods = deny
-
 [lints.rust]
 missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
-# Security-relevant lints applied to ALL targets.
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
-# `indexing_slicing`, `pedantic`, and `nursery` are lib-only via
-# `#![warn(...)]` in `src/lib.rs`.

--- a/crates/rdlp-jsinterp/Cargo.toml
+++ b/crates/rdlp-jsinterp/Cargo.toml
@@ -21,12 +21,13 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-plugin-manifest/Cargo.toml
+++ b/crates/rdlp-plugin-manifest/Cargo.toml
@@ -6,14 +6,6 @@ authors.workspace = true
 license.workspace = true
 description = "Plugin manifest schema, parser, and canonical-bytes encoder for rdlp. Pure data; no wasmtime / sigstore / sled dependencies."
 
-# Per-crate lint config — extends workspace lints (which cannot be composed
-# with workspace = true once per-crate tables are added).
-# Workspace lint baselines replicated here:
-#   clippy::must_use_candidate = warn
-#   clippy::await_holding_lock = deny
-#   clippy::await_holding_refcell_ref = deny
-#   clippy::disallowed_methods = deny
-
 [lints]
 workspace = true
 # `indexing_slicing`, `pedantic`, and `nursery` are lib-only via

--- a/crates/rdlp-plugin-manifest/Cargo.toml
+++ b/crates/rdlp-plugin-manifest/Cargo.toml
@@ -14,21 +14,8 @@ description = "Plugin manifest schema, parser, and canonical-bytes encoder for r
 #   clippy::await_holding_refcell_ref = deny
 #   clippy::disallowed_methods = deny
 
-[lints.rust]
-missing_docs = "warn"
-
-[lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
-must_use_candidate = "warn"
-disallowed_methods = "deny"
-await_holding_lock = "deny"
-await_holding_refcell_ref = "deny"
-# Security-relevant lints applied to ALL targets.
-unwrap_used = "warn"
-expect_used = "warn"
-missing_errors_doc = "warn"
-missing_panics_doc = "warn"
+[lints]
+workspace = true
 # `indexing_slicing`, `pedantic`, and `nursery` are lib-only via
 # `#![warn(...)]` in `src/lib.rs`. See plugin crate Cargo.toml for the
 # full rationale (test indexing is a guarded assertion pattern).

--- a/crates/rdlp-plugin/Cargo.toml
+++ b/crates/rdlp-plugin/Cargo.toml
@@ -56,35 +56,19 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wat = "1"
 rand = "0.8.5"
 
-# Per-crate lint config — extends workspace lints (which cannot be composed
-# with workspace = true once per-crate tables are added).
-# Workspace lint baselines replicated here:
-#   clippy::must_use_candidate = warn
-#   clippy::await_holding_lock = deny
-#   clippy::await_holding_refcell_ref = deny
-#   clippy::disallowed_methods = deny
-
 [lints.rust]
-unsafe_code = "forbid"
 missing_docs = "warn"
+unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
 must_use_candidate = "warn"
-disallowed_methods = "deny"
-# Security-relevant lints applied to ALL targets (lib + integration tests +
-# benches): async-correctness, panic-on-failure, bounds-check skipping.
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
-# `indexing_slicing` and the style-polish families (`clippy::pedantic`,
-# `clippy::nursery`) are applied LIB-ONLY via `#![warn(...)]` inside
-# `src/lib.rs`. Integration tests under `tests/` are separate compilation
-# units; in tests, `vec[0]` guarded by a preceding `assert_eq!(len, …)` IS
-# the assertion form, so panicking-on-bad-index is intentional.
-# Wasmtime's "opt-in lints per target" guidance is the basis for this split:
-#   https://docs.wasmtime.dev/contributing-coding-guidelines.html

--- a/crates/rdlp-plugin/tests/adapter_trap_disable.rs
+++ b/crates/rdlp-plugin/tests/adapter_trap_disable.rs
@@ -65,7 +65,7 @@ signature = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         manifest,
         identity,
         component,
-        origin_dir: workspace_relative("tests/fixtures").to_path_buf(),
+        origin_dir: workspace_relative("tests/fixtures"),
     };
     Some(PluginExtractor::new(loaded, engine, HostResources::default()).expect("adapter"))
 }

--- a/crates/rdlp-plugin/tests/prompt.rs
+++ b/crates/rdlp-plugin/tests/prompt.rs
@@ -114,7 +114,11 @@ fn pre_trusted_identities_denies_capability_creep_unconditionally() {
 }
 
 #[test]
+#[allow(
+    clippy::redundant_clone,
+    reason = "Intentional: exercises Clone impl as a compile-time check"
+)]
 fn confirm_request_is_clone() {
     let r = first_install("x");
-    let _r2 = r.clone(); // compile-time check
+    let _r2 = r.clone();
 }

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -36,9 +36,12 @@ unsafe_op_in_unsafe_fn = "warn"
 
 [lints.clippy]
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-probe/Cargo.toml
+++ b/crates/rdlp-probe/Cargo.toml
@@ -20,29 +20,19 @@ serde_json = { workspace = true }
 scraper = { workspace = true }
 regex = { workspace = true }
 
-# Per-crate lint config — extends workspace lints (which cannot be composed
-# with workspace = true once per-crate tables are added).
-# Workspace lint baselines replicated here:
-#   clippy::must_use_candidate = warn
-#   clippy::await_holding_lock = deny
-#   clippy::await_holding_refcell_ref = deny
-#   clippy::disallowed_methods = deny
-
 [lints.rust]
 missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline (replicated — cannot use workspace = true alongside
-# per-crate tables).
 must_use_candidate = "warn"
-disallowed_methods = "deny"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
-# Security-relevant lints applied to ALL targets.
+disallowed_methods = "deny"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
-# `indexing_slicing`, `pedantic`, and `nursery` are binary-only via
-# `#![warn(...)]` in `src/main.rs`.

--- a/crates/rdlp-ratelimit/Cargo.toml
+++ b/crates/rdlp-ratelimit/Cargo.toml
@@ -17,12 +17,13 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-security/Cargo.toml
+++ b/crates/rdlp-security/Cargo.toml
@@ -17,12 +17,13 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-table/Cargo.toml
+++ b/crates/rdlp-table/Cargo.toml
@@ -16,12 +16,13 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"

--- a/crates/rdlp-types/Cargo.toml
+++ b/crates/rdlp-types/Cargo.toml
@@ -24,13 +24,14 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Workspace baseline
 must_use_candidate = "warn"
 await_holding_lock = "deny"
 await_holding_refcell_ref = "deny"
 disallowed_methods = "deny"
-# Security lints
 unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
+match_same_arms = "warn"
+redundant_clone = "warn"
+collapsible_match = "warn"

--- a/scripts/check-dedup.sh
+++ b/scripts/check-dedup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Local pre-push dedup detection gate. See
+# docs/superpowers/specs/2026-05-21-code-quality-sprint-design.md (PR A).
+#
+# Two stages:
+#   1. cargo dupes check (--exclude-tests --min-lines 20) — the GATE.
+#      AST-shape detector with a per-fingerprint allowlist
+#      (.dupes-ignore.toml) for intentional similarity. Fails on any
+#      NEW duplicate not in the allowlist.
+#   2. similarity-rs (--threshold 0.99 --skip-test) — ADVISORY.
+#      Function-pair detector with no allowlist mechanism; reports
+#      structural copy-paste for human review but does not gate
+#      because the same intentional pairs would be reported forever.
+#
+# Clippy lints (match_same_arms, redundant_clone, collapsible_match)
+# are enforced by the surrounding pre-PR clippy gate (`-D warnings`),
+# not here.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> cargo dupes check --exclude-tests --min-lines 20 -p crates/"
+cargo dupes check --exclude-tests --min-lines 20 -p crates/
+echo "    OK"
+
+echo "==> similarity-rs --threshold 0.99 --skip-test crates/  (advisory)"
+sim_count=$(
+  similarity-rs --threshold 0.99 --skip-test crates/ 2>&1 \
+    | grep -cE "^  Similarity: " \
+    || true
+)
+echo "    advisory: $sim_count function-pair(s) at >=99% similarity (no allowlist; review manually if count grows beyond known intentional pairs)"
+
+echo "Dedup gate: PASS"


### PR DESCRIPTION
## Summary

Installs structural and lint-based duplicate detection as a local pre-push gate. PR A of the 2026-05-21 code-quality sprint (A → B → C).

- Extends `[workspace.lints.clippy]` with 3 new lints (`match_same_arms`, `redundant_clone`, `collapsible_match`) and consolidates 4 previously-replicated security lints (`unwrap_used`, `expect_used`, `missing_errors_doc`, `missing_panics_doc`) from per-crate tables into the workspace.
- Adds `[workspace.lints.rust]` carrying `missing_docs = "warn"`.
- 4 crates with no `unsafe_code` override fully inherit via `[lints] workspace = true`; 15 crates with `unsafe_code` divergences keep explicit `[lints.rust]` / `[lints.clippy]` blocks (Cargo refuses to mix `workspace = true` with per-crate `[lints.rust]` subtables — empirically verified).
- Fixes 6 `match_same_arms` violations (MIME-dispatch tables in DASH expansion + generic HTML source detection + one API integration test) using `|` arm patterns or default-arm fallthrough.
- Fixes 9 `redundant_clone` violations surfaced by the new lint (7 `.clone()` removals on last-use sites, 1 redundant `.to_path_buf()` on an already-owned `PathBuf`, 1 `#[allow(...)]` for a `confirm_request_is_clone` test that intentionally exercises the Clone impl).
- Adds `scripts/check-dedup.sh`: cargo-dupes check (gate, allowlist-driven) + similarity-rs (advisory; no native allowlist mechanism so reported as informational).
- Grandfathers 24 cargo-dupes fingerprints in `.dupes-ignore.toml` with documented `--reason` strings covering: Initiative #3 / #5 tracking pointers, intentional audio/video domain separation in `rdlp-ffmpeg`, single-call-vs-paginated twins (`search` / `search_page`), acceptable test redundancy + scaffold-shape false positives.
- Files 2 tracking issues for deferred Rule-of-Three / 3rd-codec-domain refactors (#309, #310).
- Restores DPAPI rationale + per-crate scope rationale comments lost in the consolidation (post-review minor fixes).

## Spec / Plan (gitignored — local only)

- Spec: `docs/superpowers/specs/2026-05-21-code-quality-sprint-design.md` (PR A section)
- Plan: `docs/superpowers/plans/2026-05-21-pr-a-dedup-ratchet.md`

## Reviews

- **security-reviewer**: APPROVE. One LOW finding (lost DPAPI rationale on `rdlp-cookies`) — fixed in commit `2a49bd2`. No other findings.
- **code-reviewer** (`pr-review-toolkit:code-reviewer`): APPROVE. Two minor housekeeping observations (stale comment in `plugin-manifest`; lost rationale in `rdlp-cli` + `rdlp-extractor`) — fixed in commit `aa0f0c0`.
- Local gate: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && bash scripts/check-dedup.sh` — all ✅.

## Plan defects detected during execution (for future sprint planning)

- Plan's Task 1 audit `grep '^\[lints\]'` was too narrow — it missed 18 crates' pre-existing `[lints.rust]` / `[lints.clippy]` subtables. Surfaced and resolved.
- Plan's `for d in crates/*/` loop pattern is wrong for `rdlp-desktop` (real member is `crates/rdlp-desktop/src-tauri/`). Surfaced and resolved.
- Cargo does NOT permit `[lints] workspace = true` alongside per-crate `[lints.rust]` subtables (RFC 3389 ambiguity in plan). Resolved by hybrid pattern (inherit-or-replicate).
- `redundant_clone` surfaced 9 in-tree violations not anticipated in the plan; fixed inline.

Closes the per-crate-drift hazard that made the original audit miss existing duplication.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (no `match_same_arms`, `redundant_clone`, `collapsible_match`, or pre-existing-lint warnings)
- [x] `cargo test --workspace` all green
- [x] `cargo check -p rdlp-desktop` clean
- [x] `bash scripts/check-dedup.sh` exits 0 (cargo-dupes ✅, similarity-rs advisory at 14 known intentional pairs)
- [x] `cargo dupes ignored` lists 24 fingerprints, each with a non-empty `--reason` string

## Notes

- GitHub Actions are disabled on this repo; the dedup gate is enforced locally only via the pre-PR gate in `CLAUDE.md` (locally updated; file is gitignored so the change does not appear in this PR).
- Next: PR B (method naming standards), then PR C (parameter naming standards).