### PR TITLE
refactor(types): rename Format::get_filesize -> resolved_filesize (closes #312)

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/commands/formats/mod.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/formats/mod.rs
@@ -121,7 +121,7 @@ pub async fn formats(
             tbr: f.tbr,
             vcodec: f.vcodec.as_str().map(str::to_string),
             acodec: f.acodec.as_str().map(str::to_string),
-            filesize: f.get_filesize(),
+            filesize: f.resolved_filesize(),
             vbr: f.vbr,
             abr: f.abr,
             asr: f.asr,

--- a/crates/rdlp-types/src/format/mod.rs
+++ b/crates/rdlp-types/src/format/mod.rs
@@ -297,8 +297,9 @@ impl Format {
         }
     }
 
-    /// Get file size (exact or approximate)
-    pub fn get_filesize(&self) -> Option<u64> {
+    /// Resolved file size: prefers the exact `filesize` when known, falls
+    /// back to `filesize_approx` otherwise.
+    pub fn resolved_filesize(&self) -> Option<u64> {
         self.filesize.or(self.filesize_approx)
     }
 

--- a/scripts/check-dedup.sh
+++ b/scripts/check-dedup.sh
@@ -43,10 +43,6 @@ echo "==> M1 ratchet: no new \`fn get_<name>(&self...)\` accessors"
 #     with a key parameter (M1 exception).
 #   - host/cookie_jar.rs::get_cookies: WIT-generated trait impl
 #     (cannot rename without breaking the WIT contract).
-#   - format/mod.rs::get_filesize: rename pending design decision
-#     (would collide with field `filesize`; method has fallback logic
-#     to filesize_approx — needs a new name like `resolved_filesize`).
-#     Tracked in a follow-up GitHub issue.
 #   - host/store_kv.rs::get_blocking: HashMap-style K/V lookup
 #     (CODING_RULES.md M1 exception, also referenced in rdlp-plugin
 #     module docs).
@@ -56,7 +52,6 @@ m1_violations=$(
     | grep -vF 'crates/rdlp-desktop/src-tauri/src/state/download_queue.rs' \
     | grep -vF 'crates/rdlp-plugin/src/host/cookie_jar.rs' \
     | grep -vF 'crates/rdlp-plugin/src/host/store_kv.rs' \
-    | grep -vF 'crates/rdlp-types/src/format/mod.rs:301' \
     || true
 )
 if [ -n "$m1_violations" ]; then


### PR DESCRIPTION
Closes #312. Pure semantic-preserving rename of `Format::get_filesize` -> `resolved_filesize`, plus updated caller in `rdlp-desktop` and corresponding entry removed from `scripts/check-dedup.sh` M1 ratchet exception list. Reviews: security-reviewer ✅ APPROVE (3-file pure rename, no surface change); code-reviewer skipped per the trivial-rename exception in `mandatory-pre-push-review.md` (no new code paths/inputs/log surface/security-sensitive code).