### PR TITLE
feat(downloader): F6 cooperative cancellation completion (closes #307 #308)

### DIFF
--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio_util::sync::CancellationToken;
 
 /// Maximum number of retry attempts for a single chunk download.
 ///
@@ -155,6 +156,7 @@ impl HttpDownloader {
                 0,
                 "part",
                 progress.clone(),
+                None,
             )
             .await?
         } else {
@@ -252,6 +254,7 @@ impl HttpDownloader {
                 resume_from,
                 "resume",
                 progress.clone(),
+                None,
             )
             .await
         } else {
@@ -307,6 +310,9 @@ impl HttpDownloader {
     ///
     /// Returns `(chunk_paths_in_order, total_bytes_downloaded)`.
     /// `byte_offset` is added to every chunk's start position (for resume).
+    ///
+    /// `cancel` is `Option<CancellationToken>` (owned, not a reference) so it can be
+    /// cloned into the `try_unfold` closure. `CancellationToken` is cheaply cloneable.
     #[allow(clippy::too_many_arguments)]
     async fn download_parallel_adaptive(
         &self,
@@ -319,6 +325,7 @@ impl HttpDownloader {
         byte_offset: u64,
         suffix: &str,
         log_callback: Option<Arc<dyn ProgressCallback>>,
+        cancel: Option<CancellationToken>,
     ) -> Result<(Vec<PathBuf>, u64)> {
         let controller = Arc::new(AdaptiveController::new(
             size_to_download,
@@ -347,6 +354,8 @@ impl HttpDownloader {
             let temp_dir_owned = temp_dir.to_path_buf();
             let filename_owned = filename.to_string();
             let suffix_owned = suffix.to_string();
+            // Clone once outside the closure; each iteration re-clones from this.
+            let cancel_outer = cancel.clone();
 
             stream::try_unfold((controller.clone(), 0u64), move |(ctrl, chunk_id)| {
                 let sem = sem.clone();
@@ -358,18 +367,40 @@ impl HttpDownloader {
                     "{filename_owned}.{download_id}.{suffix_owned}{chunk_id}"
                 ));
                 let ctrl_next = ctrl.clone();
+                let cancel_for_unfold = cancel_outer.clone();
 
                 async move {
                     let Some(chunk) = ctrl.next_chunk() else {
                         return Ok(None);
                     };
 
+                    // F6 (#308): pre-dispatch cancel guard before semaphore acquisition.
+                    if let Some(ref token) = cancel_for_unfold
+                        && token.is_cancelled()
+                    {
+                        return Err(RdlpError::Cancelled);
+                    }
+
+                    let cancel_for_chunk = cancel_for_unfold.clone();
+
                     let download_fut = async move {
-                        let _permit =
+                        // F6 (#308): race semaphore acquisition against cancel so
+                        // a pending permit-wait unblocks immediately on cancellation.
+                        let _permit = if let Some(ref token) = cancel_for_chunk {
+                            tokio::select! {
+                                biased;
+                                () = token.cancelled() => return Err(RdlpError::Cancelled),
+                                p = sem.acquire_owned() => p.map_err(|_| RdlpError::Download {
+                                    message: "Semaphore closed".to_string(),
+                                    url: Some(url.to_string()),
+                                })?,
+                            }
+                        } else {
                             sem.acquire_owned().await.map_err(|_| RdlpError::Download {
                                 message: "Semaphore closed".to_string(),
                                 url: Some(url.to_string()),
-                            })?;
+                            })?
+                        };
                         let start_time = Instant::now();
                         let abs_start = byte_offset + chunk.start;
                         // end is exclusive in ChunkRequest, but HTTP Range is inclusive

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -1022,3 +1022,145 @@ fn next_with_cancel_helper_uses_biased_select() {
          Found header: {header:?}"
     );
 }
+
+// ── #307: download_to_writer cooperative cancellation ──────────────────────
+
+#[tokio::test]
+async fn download_to_writer_cancel_before_start_returns_cancelled() {
+    use tokio_util::sync::CancellationToken;
+
+    // Token cancelled before call — pre-cancel guard must short-circuit
+    // before any network activity.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let downloader = HttpDownloader::new();
+    // URL is deliberately unreachable; no connection should be attempted.
+    let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(tokio::io::sink());
+
+    let res = downloader
+        .download_to_writer_with_cancel(
+            "http://127.0.0.1:1/unreachable",
+            writer,
+            None,
+            Some(&token),
+        )
+        .await;
+
+    assert!(
+        matches!(res, Err(RdlpError::Cancelled)),
+        "expected Cancelled before any network attempt, got: {res:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn download_to_writer_cancel_mid_stream_returns_cancelled() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    // Server sends headers + chunked encoding preamble but holds the
+    // connection open without delivering body chunks, parking wreq's body
+    // stream at its next() poll — same pattern as
+    // download_sequential_cancel_mid_stream_returns_cancelled.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(
+                b"HTTP/1.1 200 OK\r\n\
+                  Transfer-Encoding: chunked\r\n\
+                  Content-Type: application/octet-stream\r\n\
+                  \r\n",
+            );
+            let _ = stream.flush();
+            #[allow(clippy::duration_suboptimal_units)]
+            std::thread::sleep(Duration::from_secs(60));
+        }
+    });
+
+    let downloader = HttpDownloader::new();
+    let url = format!("http://127.0.0.1:{port}/slow-body");
+    let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(tokio::io::sink());
+
+    let token = CancellationToken::new();
+    let token2 = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        token2.cancel();
+    });
+
+    let res = downloader
+        .download_to_writer_with_cancel(&url, writer, None, Some(&token))
+        .await;
+
+    assert!(
+        matches!(res, Err(RdlpError::Cancelled)),
+        "expected Cancelled mid-stream, got: {res:?}"
+    );
+}
+
+#[tokio::test]
+async fn download_to_writer_cancel_none_passes_existing_behavior() {
+    let mut server = mockito::Server::new_async().await;
+    let body = vec![0xAB; 4096];
+    let _mock = server
+        .mock("GET", "/file")
+        .with_status(200)
+        .with_body(body.clone())
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new();
+    let url = format!("{}/file", server.url());
+
+    // Use sink() to avoid the `'static` lifetime constraint on the boxed writer.
+    let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(tokio::io::sink());
+
+    let stats = downloader
+        .download_to_writer_with_cancel(&url, writer, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.bytes_downloaded, 4096);
+}
+
+// ── #308: AIMD parallel-path static biased-select guard ────────────────────
+
+#[test]
+fn parallel_adaptive_cancel_uses_biased_select() {
+    // Static guard: download_parallel_adaptive's semaphore-acquire select!
+    // MUST include `biased;` so cancel-priority is deterministic.
+    // Mirrors next_with_cancel_helper_uses_biased_select (Task 12, PR #303).
+    let source = include_str!("parallel.rs");
+
+    let start = source
+        .find("async fn download_parallel_adaptive")
+        .expect("download_parallel_adaptive not found in parallel.rs");
+
+    let after_start = &source[start..];
+    // End at the next top-level fn definition.
+    let end = after_start[1..]
+        .find("\n    async fn ")
+        .map_or(after_start.len(), |i| i + 1);
+    let body = &after_start[..end];
+
+    let select_idx = body
+        .find("tokio::select!")
+        .expect("download_parallel_adaptive must contain a tokio::select! for cancel");
+    let after_select = &body[select_idx..];
+    let first_arm = after_select
+        .find("=>")
+        .expect("tokio::select! must have at least one arm");
+    let header = &after_select[..first_arm];
+
+    assert!(
+        header.contains("biased;"),
+        "tokio::select! in download_parallel_adaptive MUST use `biased;` \
+         to deterministically prioritize the cancel arm. \
+         Found header: {header:?}"
+    );
+}

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -4,7 +4,6 @@
 //! `download_to_writer`, `supports`, `file_size`, and `download_with_resume`.
 
 use async_trait::async_trait;
-use futures::StreamExt;
 use log::debug;
 use rdlp_core::{
     DownloadProgress, DownloadStats, Downloader, ProgressCallback, RdlpError, Result,
@@ -168,12 +167,59 @@ impl Downloader for HttpDownloader {
     /// Unlike `download_to_file`, this always uses sequential I/O (no parallel
     /// chunks) because the destination is not seekable. On `BrokenPipe` the
     /// download stops gracefully and returns the bytes written so far.
+    ///
+    /// Delegates to `download_to_writer_with_cancel` with `cancel: None`.
+    /// For cooperative cancellation callers use that inherent method directly.
     async fn download_to_writer(
         &self,
         url: &str,
         writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
+        // Trait method discards cancel (outer select! covers it). For cooperative
+        // cancel, callers use `download_to_writer_with_cancel` directly.
+        self.download_to_writer_with_cancel(url, writer, progress, None)
+            .await
+    }
+
+    fn supports(&self, url: &str) -> bool {
+        url.starts_with("http://") || url.starts_with("https://")
+    }
+
+    async fn download_with_resume(
+        &self,
+        url: &str,
+        path: &Path,
+        resume_from: u64,
+        progress: Option<Box<dyn ProgressCallback>>,
+    ) -> Result<DownloadStats> {
+        // Trait method discards cancel (outer select! covers it). For cooperative
+        // cancel, callers use `download_with_resume_with_cancel` directly.
+        // TODO(#287): trait method itself may take cancel in a future BC-break.
+        self.download_with_resume_with_cancel(url, path, resume_from, progress, None)
+            .await
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+impl HttpDownloader {
+    /// F6 (#307): cooperative-cancel-aware variant of `download_to_writer`.
+    /// The trait method `download_to_writer` delegates here with `cancel: None`.
+    /// Direct callers can pass a `CancellationToken` for mid-stream cancellation.
+    pub(crate) async fn download_to_writer_with_cancel(
+        &self,
+        url: &str,
+        writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+        progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<DownloadStats> {
+        // F6: pre-cancel guard. Short-circuits before any network round-trip.
+        if let Some(token) = cancel
+            && token.is_cancelled()
+        {
+            return Err(RdlpError::Cancelled);
+        }
+
         let timeout = self.config.download_timeout;
         tokio::time::timeout(timeout, async {
             let start_time = Instant::now();
@@ -202,51 +248,61 @@ impl Downloader for HttpDownloader {
             let total_size = response.content_length();
             let mut buf_writer = BufWriter::with_capacity(self.config.buffer_size, writer);
 
-            let mut stream = response.bytes_stream();
+            let stream = response.bytes_stream();
+            tokio::pin!(stream);
             let mut downloaded: u64 = 0;
             let mut last_update = Instant::now();
             let update_interval = PROGRESS_UPDATE_INTERVAL;
             let read_timeout = self.config.read_timeout;
 
-            while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
-                .await
-                .map_err(|_| RdlpError::Network {
-                message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
-                url: Some(url_string.clone()),
-            })? {
-                let chunk = chunk_result.map_err(|e| RdlpError::Network {
-                    message: format!("Failed to read chunk: {e}"),
-                    url: Some(url_string.clone()),
-                })?;
-
-                match buf_writer.write_all(&chunk).await {
-                    Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
-                        debug!("Broken pipe on stdout, stopping gracefully");
-                        break;
+            loop {
+                match super::next_with_cancel_and_timeout(
+                    stream.as_mut(),
+                    cancel,
+                    read_timeout,
+                    &url_string,
+                )
+                .await?
+                {
+                    None => break,
+                    Some(Err(e)) => {
+                        return Err(RdlpError::Network {
+                            message: format!("Failed to read chunk: {e}"),
+                            url: Some(url_string.clone()),
+                        });
                     }
-                    Err(e) => return Err(RdlpError::Io(e)),
-                }
-                downloaded += chunk.len() as u64;
+                    Some(Ok(chunk)) => {
+                        match buf_writer.write_all(&chunk).await {
+                            Ok(()) => {}
+                            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                                debug!("Broken pipe on stdout, stopping gracefully");
+                                break;
+                            }
+                            Err(e) => return Err(RdlpError::Io(e)),
+                        }
+                        downloaded += chunk.len() as u64;
 
-                if let Some(ref callback) = progress {
-                    let now = Instant::now();
-                    if now.duration_since(last_update) >= update_interval {
-                        let elapsed = now.duration_since(start_time).as_secs_f64();
-                        let speed = if elapsed > 0.0 {
-                            downloaded as f64 / elapsed
-                        } else {
-                            0.0
-                        };
+                        if let Some(ref callback) = progress {
+                            let now = Instant::now();
+                            if now.duration_since(last_update) >= update_interval {
+                                let elapsed = now.duration_since(start_time).as_secs_f64();
+                                let speed = if elapsed > 0.0 {
+                                    downloaded as f64 / elapsed
+                                } else {
+                                    0.0
+                                };
 
-                        let progress_info = DownloadProgress::new(downloaded, total_size, speed);
-                        callback.on_progress(&progress_info);
-                        last_update = now;
+                                let progress_info =
+                                    DownloadProgress::new(downloaded, total_size, speed);
+                                callback.on_progress(&progress_info);
+                                last_update = now;
+                            }
+                        }
+
+                        if let Some(ref limiter) = self.rate_limiter {
+                            limiter.acquire(chunk.len()).await;
+                        }
                     }
-                }
-
-                if let Some(ref limiter) = self.rate_limiter {
-                    limiter.acquire(chunk.len()).await;
                 }
             }
 
@@ -282,27 +338,6 @@ impl Downloader for HttpDownloader {
         })?
     }
 
-    fn supports(&self, url: &str) -> bool {
-        url.starts_with("http://") || url.starts_with("https://")
-    }
-
-    async fn download_with_resume(
-        &self,
-        url: &str,
-        path: &Path,
-        resume_from: u64,
-        progress: Option<Box<dyn ProgressCallback>>,
-    ) -> Result<DownloadStats> {
-        // Trait method discards cancel (outer select! covers it). For cooperative
-        // cancel, callers use `download_with_resume_with_cancel` directly.
-        // TODO(#287): trait method itself may take cancel in a future BC-break.
-        self.download_with_resume_with_cancel(url, path, resume_from, progress, None)
-            .await
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-impl HttpDownloader {
     /// F6: cooperative-cancel-aware variant of `download_with_resume`.
     /// The trait method `download_with_resume` delegates here with `cancel: None`.
     /// Direct callers (e.g. tests) can pass a `CancellationToken` for mid-stream cancellation.

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -256,14 +256,27 @@ impl HttpDownloader {
             let read_timeout = self.config.read_timeout;
 
             loop {
-                match super::next_with_cancel_and_timeout(
+                let next = super::next_with_cancel_and_timeout(
                     stream.as_mut(),
                     cancel,
                     read_timeout,
                     &url_string,
                 )
-                .await?
-                {
+                .await;
+                // F6 / #307 follow-up: on cancel, flush whatever bytes are
+                // already in the BufWriter so any accumulator-mode caller
+                // gets all bytes that crossed the loop's write_all boundary
+                // before the cancel arm fired. Pattern matches
+                // download_with_resume_with_cancel below. Flush errors are
+                // swallowed in favour of surfacing the original Cancelled.
+                let next = match next {
+                    Err(RdlpError::Cancelled) => {
+                        let _ = buf_writer.flush().await;
+                        return Err(RdlpError::Cancelled);
+                    }
+                    other => other?,
+                };
+                match next {
                     None => break,
                     Some(Err(e)) => {
                         return Err(RdlpError::Network {


### PR DESCRIPTION
Closes #307 (`download_to_writer` cancel) + #308 (AIMD parallel-path cancel). Completes the F6 cooperative-cancellation work started in PR #303.

## Summary

Two related private-helper additions; the public `Downloader` trait surface is unchanged. Both fixes mirror the pattern from PR #303 (`download_with_resume_with_cancel` + `next_with_cancel_and_timeout`).

- **#307 (`512e9a2`)**: adds `HttpDownloader::download_to_writer_with_cancel(url, writer, progress, cancel)` inherent helper. Trait method delegates with `cancel: None` (BC). Stream consumption swapped from manual `tokio::time::timeout(read_timeout, stream.next())` loop to `next_with_cancel_and_timeout`. Pre-cancel guard short-circuits before any network round-trip.
- **#308 (`f15b220`)**: adds `cancel: Option<CancellationToken>` (owned, cheaply cloneable) to `download_parallel_adaptive`. Two cancel checks per chunk inside the `stream::try_unfold` closure: pre-dispatch guard before `next_chunk()` and `biased; tokio::select!` racing `sem.acquire_owned()` vs `token.cancelled()`. Callers pass `None` (no cancel in scope at the legacy/static parallel paths).
- **Fixup (`5d89d63`)**: flushes the `BufWriter` on the cancel path in `download_to_writer_with_cancel` before returning `Err(Cancelled)`. Matches the explicit flush-on-cancel pattern from `download_with_resume_with_cancel` (PR #303). Prevents silent data loss for accumulator-mode callers (LOW finding from security review).

## TDD discipline

- #307: 3 tests added (`cancel_before_start_returns_cancelled`, `cancel_mid_stream_returns_cancelled`, `cancel_none_passes_existing_behavior`). All failed pre-impl (compile error: method not found); all pass post-impl.
- #308: static guard test (`parallel_adaptive_cancel_uses_biased_select`) using `include_str!` source-grep mirroring `next_with_cancel_helper_uses_biased_select` from PR #303. Integration test was not written — a parallel-eligible test requires >10 MB probe+body mockito setup that would duplicate existing parallel tests and be sensitive to AIMD thresholds; the static `include_str!` check is the established codebase pattern.

## Reviews

- **security-reviewer**: PASS. 3 LOW findings, only one applied inline (flush-on-cancel for `download_to_writer_with_cancel`). The other 2 (per-chunk-body cancel inside `download_chunk_with_retry`; static-guard coverage for `download_format`'s biased select) are filed as #317.
- **code-reviewer**: APPROVE. 2 minor non-blocking nits.
- Pre-PR gate: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && bash scripts/check-dedup.sh` — all ✅.

## Follow-up

- #317 — per-chunk-body cancellation in `download_chunk_with_retry` + static guard for `download_format`'s biased select.