### PR TITLE
feat(downloader): thread cancel through chunk-retry + per-chunk-body cancel + static guards (closes #317)

### DIFF
--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -14,7 +14,6 @@ mod tests;
 pub(crate) use parallel::download_chunk_with_retry;
 
 use backon::Retryable;
-use futures::StreamExt;
 use log::warn;
 use rdlp_core::{
     DownloadProgress, DownloadStats, ProgressCallback, RdlpError, Result, RetryConfig,
@@ -308,7 +307,12 @@ impl HttpDownloader {
         }
     }
 
-    /// Download a specific byte range with shared progress tracking
+    /// Download a specific byte range with shared progress tracking.
+    ///
+    /// `cancel` — when `Some`, each chunk poll races the token via
+    /// `next_with_cancel_and_timeout`. On cancellation the `BufWriter` is
+    /// flushed before returning `RdlpError::Cancelled` so partial bytes already
+    /// buffered reach disk.
     pub(crate) async fn download_range_with_progress(
         &self,
         url: &str,
@@ -316,7 +320,15 @@ impl HttpDownloader {
         end: u64,
         chunk_path: &Path,
         progress_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
+        cancel: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<u64> {
+        // Pre-cancel guard: bail before any network I/O if already cancelled.
+        if let Some(token) = cancel
+            && token.is_cancelled()
+        {
+            return Err(RdlpError::Cancelled);
+        }
+
         let client = self.client.clone();
         let url = url.to_string();
         let hdrs = self.headers();
@@ -354,39 +366,45 @@ impl HttpDownloader {
         })?;
         let mut writer = BufWriter::with_capacity(self.config.buffer_size, file);
 
-        let mut stream = response.bytes_stream();
+        let stream = response.bytes_stream();
+        tokio::pin!(stream);
         let mut downloaded = 0u64;
         let read_timeout = self.config.read_timeout;
 
-        while let Some(chunk_result) = tokio::time::timeout(read_timeout, stream.next())
-            .await
-            .map_err(|_| RdlpError::Network {
-                message: format!("Read timed out (no data for {}s)", read_timeout.as_secs()),
-                url: Some(url.clone()),
-            })?
-        {
-            let chunk = chunk_result.map_err(|e| RdlpError::Network {
-                message: format!("Failed to read chunk body from {url}: {e}"),
-                url: Some(url.clone()),
-            })?;
+        loop {
+            match next_with_cancel_and_timeout(stream.as_mut(), cancel, read_timeout, &url).await {
+                Ok(Some(Ok(chunk))) => {
+                    writer.write_all(&chunk).await.map_err(|e| {
+                        RdlpError::Io(std::io::Error::new(
+                            e.kind(),
+                            format!(
+                                "failed to write to chunk file '{}': {e}",
+                                chunk_path.display()
+                            ),
+                        ))
+                    })?;
+                    downloaded += chunk.len() as u64;
 
-            writer.write_all(&chunk).await.map_err(|e| {
-                RdlpError::Io(std::io::Error::new(
-                    e.kind(),
-                    format!(
-                        "failed to write to chunk file '{}': {e}",
-                        chunk_path.display()
-                    ),
-                ))
-            })?;
-            downloaded += chunk.len() as u64;
+                    if let Some(ref counter) = progress_counter {
+                        counter.fetch_add(chunk.len() as u64, std::sync::atomic::Ordering::Relaxed);
+                    }
 
-            if let Some(ref counter) = progress_counter {
-                counter.fetch_add(chunk.len() as u64, std::sync::atomic::Ordering::Relaxed);
-            }
-
-            if let Some(ref limiter) = self.rate_limiter {
-                limiter.acquire(chunk.len()).await;
+                    if let Some(ref limiter) = self.rate_limiter {
+                        limiter.acquire(chunk.len()).await;
+                    }
+                }
+                Ok(Some(Err(e))) => {
+                    return Err(RdlpError::Network {
+                        message: format!("Failed to read chunk body from {url}: {e}"),
+                        url: Some(url.clone()),
+                    });
+                }
+                Ok(None) => break,
+                Err(RdlpError::Cancelled) => {
+                    let _ = writer.flush().await;
+                    return Err(RdlpError::Cancelled);
+                }
+                Err(e) => return Err(e),
             }
         }
 

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -31,9 +31,17 @@ const MAX_CHUNK_RETRIES: u32 = 3;
 /// (1s, 2s, 3s). Partial files are cleaned up between attempts. Only
 /// retryable errors (5xx, 429, network, I/O) trigger retries.
 ///
+/// `cancel` — when `Some`, cancellation is checked at the top of every loop
+/// iteration and forwarded into `download_range_with_progress`. The backoff
+/// sleep is also raced against the token so cancellation fires immediately.
+///
 /// This is a different retry domain from the inner `with_retry` on
 /// `send()` — this handles failures that occur *during* body transfer,
 /// not connection-level failures.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Each argument carries a distinct semantic role (downloader, url, byte range, sink path, progress counter, chunk identifier, cancel token); extracting a params struct would obscure the call sites inside the AIMD unfold closure without removing complexity."
+)]
 pub async fn download_chunk_with_retry(
     downloader: &HttpDownloader,
     url: &str,
@@ -42,15 +50,28 @@ pub async fn download_chunk_with_retry(
     chunk_path: &Path,
     progress: Option<Arc<AtomicU64>>,
     chunk_id: u64,
+    cancel: Option<&CancellationToken>,
 ) -> Result<u64> {
     let mut retries = 0u32;
 
     loop {
+        // Pre-iteration cancel guard.
+        if let Some(token) = cancel
+            && token.is_cancelled()
+        {
+            let _ = tokio::fs::remove_file(chunk_path).await;
+            return Err(RdlpError::Cancelled);
+        }
+
         match downloader
-            .download_range_with_progress(url, start, end, chunk_path, progress.clone())
+            .download_range_with_progress(url, start, end, chunk_path, progress.clone(), cancel)
             .await
         {
             Ok(bytes) => return Ok(bytes),
+            Err(RdlpError::Cancelled) => {
+                let _ = tokio::fs::remove_file(chunk_path).await;
+                return Err(RdlpError::Cancelled);
+            }
             Err(e) => {
                 if retries < MAX_CHUNK_RETRIES && is_retryable_error(&e) {
                     retries += 1;
@@ -61,7 +82,18 @@ pub async fn download_chunk_with_retry(
                     );
                     // Clean up partial file before retry
                     let _ = tokio::fs::remove_file(chunk_path).await;
-                    tokio::time::sleep(Duration::from_secs(u64::from(retries))).await;
+                    // Race the backoff sleep against cancel so we don't block.
+                    if let Some(token) = cancel {
+                        tokio::select! {
+                            biased;
+                            () = token.cancelled() => {
+                                return Err(RdlpError::Cancelled);
+                            }
+                            () = tokio::time::sleep(Duration::from_secs(u64::from(retries))) => {}
+                        }
+                    } else {
+                        tokio::time::sleep(Duration::from_secs(u64::from(retries))).await;
+                    }
                 } else {
                     return Err(e);
                 }
@@ -414,6 +446,7 @@ impl HttpDownloader {
                             &chunk_path,
                             Some(progress),
                             chunk_id,
+                            cancel_for_chunk.as_ref(),
                         )
                         .await;
 
@@ -504,6 +537,7 @@ impl HttpDownloader {
                         &chunk_path,
                         progress,
                         chunk_id as u64,
+                        None,
                     )
                     .await;
                     if let Err(ref e) = result {

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -288,8 +288,17 @@ async fn test_chunk_retry_succeeds_on_second_attempt() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result =
-        download_chunk_with_retry(&downloader, &url, 0, 1023, &chunk_path, Some(progress), 0).await;
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(progress),
+        0,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1024);
@@ -324,8 +333,17 @@ async fn test_chunk_retry_exhausted_returns_error() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result =
-        download_chunk_with_retry(&downloader, &url, 0, 1023, &chunk_path, Some(progress), 0).await;
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(progress),
+        0,
+        None,
+    )
+    .await;
 
     assert!(result.is_err());
 }
@@ -359,8 +377,17 @@ async fn test_chunk_retry_non_retryable_fails_immediately() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result =
-        download_chunk_with_retry(&downloader, &url, 0, 1023, &chunk_path, Some(progress), 0).await;
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(progress),
+        0,
+        None,
+    )
+    .await;
 
     assert!(result.is_err());
     // mockito's expect(1) will panic on Drop if more than 1 request was made
@@ -413,8 +440,17 @@ async fn test_chunk_retry_cleans_partial_file() {
     let url = format!("{}/video.mp4", server.url());
     let progress = Arc::new(AtomicU64::new(0));
 
-    let result =
-        download_chunk_with_retry(&downloader, &url, 0, 511, &chunk_path, Some(progress), 0).await;
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        511,
+        &chunk_path,
+        Some(progress),
+        0,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     // The file should contain the successful download, not the partial data
@@ -1126,6 +1162,105 @@ async fn download_to_writer_cancel_none_passes_existing_behavior() {
         .unwrap();
 
     assert_eq!(stats.bytes_downloaded, 4096);
+}
+
+// ── #317: per-chunk-body cancel static guard ───────────────────────────────
+
+#[test]
+fn download_chunk_with_retry_passes_cancel_to_range() {
+    // Static guard: download_chunk_with_retry MUST forward the cancel parameter
+    // to download_range_with_progress, not None. This asserts the call-site text
+    // contains `cancel` as the last argument (not a literal `None`).
+    // Integration-style slow-chunk mockito tests would require SERVER_SENT_EVENTS
+    // chunked encoding support in mockito, which is not available cleanly;
+    // the static check is cheaper and catches the most likely regression.
+    let source = include_str!("parallel.rs");
+
+    let start = source
+        .find("pub async fn download_chunk_with_retry")
+        .expect("download_chunk_with_retry not found in parallel.rs");
+
+    let after_start = &source[start..];
+    // End at the next blank-line-separated fn.
+    let end = after_start[1..]
+        .find("\npub async fn ")
+        .or_else(|| after_start[1..].find("\nasync fn "))
+        .map_or(after_start.len(), |i| i + 1);
+    let body = &after_start[..end];
+
+    // The call to download_range_with_progress must pass `cancel` (not `None`).
+    // Use balanced-paren matching so nested calls like `progress.clone()` don't
+    // truncate the call argument span.
+    let call_idx = body
+        .find("download_range_with_progress(")
+        .expect("download_chunk_with_retry must call download_range_with_progress");
+    let after_open = &body[call_idx + "download_range_with_progress(".len()..];
+    let mut depth: i32 = 1;
+    let mut end_offset = None;
+    for (i, ch) in after_open.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    end_offset = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let close = end_offset.expect("call must have a balanced closing paren");
+    let call_args = &after_open[..close];
+
+    assert!(
+        call_args.contains("cancel"),
+        "download_chunk_with_retry must pass `cancel` to download_range_with_progress, \
+         not `None`. Found call args: {call_args:?}"
+    );
+    assert!(
+        !call_args.contains(", None)") && !call_args.ends_with("None"),
+        "download_chunk_with_retry must NOT pass literal `None` as the cancel arg. \
+         Found call args: {call_args:?}"
+    );
+}
+
+// ── #317: download_format biased-select static guard ───────────────────────
+
+#[test]
+fn download_format_uses_biased_select() {
+    // Static guard: Downloader::download_format's outer cancel select! MUST
+    // include `biased;` so cancel-priority is deterministic. Mirrors
+    // parallel_adaptive_cancel_uses_biased_select (issue #317).
+    let source = include_str!("trait_impl.rs");
+
+    let start = source
+        .find("async fn download_format")
+        .expect("download_format not found in trait_impl.rs");
+
+    let after_start = &source[start..];
+    // End at the next top-level `async fn` or `fn ` definition.
+    let end = after_start[1..]
+        .find("\n    async fn ")
+        .or_else(|| after_start[1..].find("\n    fn "))
+        .map_or(after_start.len(), |i| i + 1);
+    let body = &after_start[..end];
+
+    let select_idx = body
+        .find("tokio::select!")
+        .expect("download_format must contain a tokio::select! for cancel");
+    let after_select = &body[select_idx..];
+    let first_arm = after_select
+        .find("=>")
+        .expect("tokio::select! must have at least one arm");
+    let header = &after_select[..first_arm];
+
+    assert!(
+        header.contains("biased;"),
+        "tokio::select! in download_format MUST use `biased;` \
+         to deterministically prioritize the cancel arm. \
+         Found header: {header:?}"
+    );
 }
 
 // ── #308: AIMD parallel-path static biased-select guard ────────────────────


### PR DESCRIPTION
Closes #317 — the two LOW security-review findings filed during PR #318:

1. **Per-chunk-body cooperative cancel**: `cancel` threaded into `download_chunk_with_retry` + `download_range_with_progress`. Body-stream loop migrated to `next_with_cancel_and_timeout` (F6 helper from PR #303) for biased cancel priority. Flushes BufWriter on cancel before propagating; pre-iteration cancel guard with chunk-file cleanup; **backoff sleep raced against cancel** via `biased; tokio::select!` (improvement over the LOW-finding's anticipated trade-off — cancel is now responsive even during retry backoff).
2. **Static guards**: `download_format_uses_biased_select` (mirrors `parallel_adaptive_cancel_uses_biased_select` from PR #318) and `download_chunk_with_retry_passes_cancel_to_range` (balanced-paren matching to confirm cancel forwarded, not literal `None`).

`download_parallel_adaptive` (PR #308) now passes `cancel_for_chunk.as_ref()` through to `download_chunk_with_retry`, completing the parallel-path cancel chain. Trait `Downloader` surface unchanged.

Removed stale `use futures::StreamExt;` import (subsumed by the F6 helper). Added `#[allow(clippy::too_many_arguments, reason = ...)]` on `download_chunk_with_retry` (8 args after cancel).

## Reviews
- **security-reviewer**: PASS. 2 LOW observations: (a) backoff-cancel path correctly cleans up via pre-sleep `remove_file`; (b) a redundant `ends_with("None")` arm in the static guard could be dropped (the `.contains(", None)")` arm is load-bearing). Both informational.
- **code-reviewer**: APPROVE. Minor note: `download_parallel_static` (legacy non-adaptive path) still uses `None` for cancel — out of scope for #317, suggested as a future parity issue.
- Pre-PR gate: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` — all ✅.

## Out of scope / follow-up note
- `download_parallel_static` (`ChunkSizeStrategy::Fixed`/`Legacy`) is the last HTTP-chunk path without cancel propagation. Today it's outer-orchestrator-select-only. Filing for parity is acceptable; #317 scopes to the AIMD adaptive path.