### PR TITLE
refactor(http/probe): shared probe_size helper in rdlp-http (closes #306)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6202,10 +6202,12 @@ dependencies = [
 name = "rdlp-http"
 version = "0.1.0"
 dependencies = [
+ "mockito",
  "openssl-sys",
  "rdlp-security",
  "rdlp-types",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "wreq",

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -68,7 +68,17 @@ where
         .await
 }
 
+/// Re-export of the shared `ProbeResult` from `rdlp-http`. Single source of
+/// truth for probe-result shape, used by both `HttpDownloader::probe` and
+/// `BaseExtractor::detect_file_size`. Closes #306.
+pub(crate) use rdlp_http::ProbeResult;
+
 /// Parse the `Content-Range` header's total-bytes field.
+///
+/// Used by `trait_impl::download_with_resume_with_cancel` to discover the
+/// total resource size from a resume Range response. The probe path uses
+/// `rdlp_http::probe_size` (which has its own parser); this helper is kept
+/// for the resume path's standalone header inspection.
 ///
 /// Accepts `bytes 0-N/TOTAL` (returns `Some(TOTAL)`) and returns `None` for
 /// `bytes 0-N/*` (server signalled unknown total per RFC 7233 §4.2), any
@@ -79,18 +89,6 @@ pub(crate) fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Op
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.split('/').nth(1))
         .and_then(|s| s.parse::<u64>().ok())
-}
-
-/// Result of the F3 single-GET probe in `HttpDownloader::probe`.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ProbeResult {
-    /// Total file size if the server reported it via Content-Range (206) or
-    /// Content-Length (200). `None` when neither header is parseable.
-    pub size: Option<u64>,
-    /// `true` if the server returned `206 Partial Content`, indicating it
-    /// honoured the Range request. RFC 7233 §4.1: 206 itself implies range
-    /// support; `Accept-Ranges` is not required.
-    pub supports_ranges: bool,
 }
 
 /// HTTP/HTTPS downloader
@@ -260,22 +258,24 @@ impl HttpDownloader {
     pub(crate) async fn probe(&self, url: &str) -> Result<ProbeResult> {
         use config::PROBE_WINDOW_BYTES;
 
+        // F3 probe delegates to the shared `rdlp_http::probe_size` helper
+        // (closes #306). Retry semantics preserved via the with_retry
+        // wrapper; the shared helper itself is leaf-level (no retry).
+        // Non-2xx and network errors after retry both produce the
+        // `ProbeResult { size: None, supports_ranges: false }` form so the
+        // caller falls back to sequential download.
         let client = self.client.clone();
         let url_string = url.to_string();
         let hdrs = self.headers();
-        let range = format!("bytes=0-{}", PROBE_WINDOW_BYTES - 1);
+        let window = PROBE_WINDOW_BYTES;
+        let timeout = self.config.read_timeout;
 
-        let Ok(resp) = with_retry(&self.config.retry_config, "HTTP probe (F3)", || {
+        let probed = with_retry(&self.config.retry_config, "HTTP probe (F3)", || {
             let client = client.clone();
             let url = url_string.clone();
             let hdrs = hdrs.clone();
-            let range = range.clone();
             async move {
-                client
-                    .get(&url)
-                    .headers(hdrs)
-                    .header("Range", range)
-                    .send()
+                rdlp_http::probe_size(&client, &url, Some(&hdrs), window, timeout)
                     .await
                     .map_err(|e| RdlpError::Network {
                         message: format!("probe failed: {e}"),
@@ -283,28 +283,12 @@ impl HttpDownloader {
                     })
             }
         })
-        .await
-        else {
-            return Ok(ProbeResult {
-                size: None,
-                supports_ranges: false,
-            });
-        };
+        .await;
 
-        match resp.status().as_u16() {
-            206 => Ok(ProbeResult {
-                size: parse_content_range_total(resp.headers()),
-                supports_ranges: true,
-            }),
-            200 => Ok(ProbeResult {
-                size: resp.content_length(),
-                supports_ranges: false,
-            }),
-            _ => Ok(ProbeResult {
-                size: None,
-                supports_ranges: false,
-            }),
-        }
+        Ok(probed.unwrap_or(ProbeResult {
+            size: None,
+            supports_ranges: false,
+        }))
     }
 
     /// Download a specific byte range with shared progress tracking.
@@ -602,6 +586,10 @@ where
 
 #[cfg(test)]
 mod content_range_tests {
+    //! Tests for the local `parse_content_range_total` helper. The probe
+    //! path uses `rdlp_http::probe_size`'s internal parser; this helper
+    //! is the standalone version used by the resume path in
+    //! `trait_impl::download_with_resume_with_cancel`.
     use super::*;
     use wreq::header::HeaderMap;
 

--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -11,6 +11,7 @@ rdlp-types = { path = "../rdlp-types" }
 rdlp-security = { path = "../rdlp-security" }
 rdlp-crypto = { path = "../rdlp-crypto" }
 rdlp-jsinterp = { path = "../rdlp-jsinterp" }
+rdlp-http = { path = "../rdlp-http" }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 dash-mpd = { workspace = true, default-features = false }
@@ -34,7 +35,6 @@ urlencoding = "2"
 hex = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 mockito = { workspace = true }
-rdlp-http = { path = "../rdlp-http" }
 rdlp-cookies = { path = "../rdlp-cookies" }
 
 # Documentation-completeness rationale only — do NOT lift extractor-

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -383,46 +383,23 @@ impl BaseExtractor {
         log_prefix: Option<&str>,
         timeout: std::time::Duration,
     ) -> Option<u64> {
-        // Strategy 1: HEAD request
-        if let Ok(response) = http_client.head(url).timeout(timeout).send().await
-            && let Some(size) = response.content_length().filter(|&s| s > 0)
-        {
-            if let Some(prefix) = log_prefix {
-                debug!(size, method = "HEAD"; "[{prefix}] Detected Content-Length");
-            }
-            return Some(size);
-        }
-
-        // Strategy 2: Range request fallback
-        if let Ok(response) = http_client
-            .get(url)
-            .header("Range", "bytes=0-0")
-            .timeout(timeout)
-            .send()
+        // Delegate to the shared `rdlp_http::probe_size` helper (closes #306).
+        // Single Range GET — saves one RTT vs the previous HEAD-then-Range
+        // fallback. window_bytes=1 keeps bandwidth at "header-only" cost since
+        // the extractor only needs the size header, not body bytes.
+        let res = rdlp_http::probe_size(http_client, url, None, 1, timeout)
             .await
-            && let Some(size) = Self::parse_content_range_total(response.headers())
-        {
-            if let Some(prefix) = log_prefix {
-                debug!(size, method = "Range"; "[{prefix}] Detected Content-Range");
-            }
-            return Some(size);
+            .ok()?;
+        let size = res.size?;
+        if let Some(prefix) = log_prefix {
+            let method = if res.supports_ranges {
+                "Range"
+            } else {
+                "Content-Length"
+            };
+            debug!(size, method; "[{prefix}] Detected size via probe_size");
         }
-
-        None
-    }
-
-    /// Parse total file size from a Content-Range header.
-    ///
-    /// Parses the format `bytes 0-0/123456` and returns the total size.
-    fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Option<u64> {
-        headers
-            .get("content-range")?
-            .to_str()
-            .ok()?
-            .split('/')
-            .nth(1)?
-            .parse()
-            .ok()
+        Some(size)
     }
 
     // ========================================================================

--- a/crates/rdlp-http/Cargo.toml
+++ b/crates/rdlp-http/Cargo.toml
@@ -12,6 +12,7 @@ wreq = { workspace = true }
 wreq-util = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+thiserror = { workspace = true }
 
 # `prefix-symbols` is documented Linux/Android-only by wreq upstream; on
 # macOS it emits a broken `build_script_main_*` mangling that breaks the
@@ -34,6 +35,7 @@ openssl-sys = { version = "0.9", features = ["vendored"] }
 [dev-dependencies]
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+mockito = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"

--- a/crates/rdlp-http/src/lib.rs
+++ b/crates/rdlp-http/src/lib.rs
@@ -32,9 +32,11 @@
 
 mod client;
 mod config;
+pub mod probe;
 
 pub use client::HttpClientFactory;
 pub use config::HttpClientConfig;
+pub use probe::{DEFAULT_PROBE_WINDOW_BYTES, ProbeError, ProbeResult, probe_size};
 
 /// Re-export `wreq` for downstream crates so they can consume the HTTP
 /// client library via a single facade (`rdlp_http::wreq::Client`, etc).

--- a/crates/rdlp-http/src/probe.rs
+++ b/crates/rdlp-http/src/probe.rs
@@ -64,7 +64,11 @@ pub async fn probe_size(
     window_bytes: u64,
     timeout: Duration,
 ) -> Result<ProbeResult, ProbeError> {
-    let range = format!("bytes=0-{}", window_bytes.saturating_sub(1));
+    // Clamp window_bytes to >= 1 (security-review LOW). Passing 0 would
+    // wrap saturating_sub to u64::MAX, producing `bytes=0-18446744073709551615`
+    // — effectively a full-body GET, defeating the probe's intent.
+    let window = window_bytes.max(1);
+    let range = format!("bytes=0-{}", window - 1);
     let mut req = client.get(url).timeout(timeout).header("Range", &range);
     if let Some(h) = headers {
         req = req.headers(h.clone());

--- a/crates/rdlp-http/src/probe.rs
+++ b/crates/rdlp-http/src/probe.rs
@@ -1,0 +1,211 @@
+//! Shared HTTP-probe helper.
+//!
+//! Performs a single F3-style `GET Range` request to determine
+//! `Content-Range` total (or `Content-Length` fallback) without
+//! downloading the full body. Used by both the downloader
+//! (`HttpDownloader::probe`) and the extractor
+//! (`BaseExtractor::detect_file_size`).
+//!
+//! Threat model: this helper is leaf-level — no retry, no header
+//! gating. Callers compose retry / cancel / header-trust as needed.
+
+use std::time::Duration;
+
+/// Default probe window (256 KiB). Matches the rdlp-downloader F3 probe
+/// constant. Callers MAY pass a smaller window (e.g. `1`) for
+/// header-only probes where body bandwidth is constrained.
+pub const DEFAULT_PROBE_WINDOW_BYTES: u64 = 256 * 1_024;
+
+/// Outcome of a single HTTP probe.
+#[derive(Debug, Clone, Copy)]
+pub struct ProbeResult {
+    /// Total file size, parsed from `Content-Range` (206) or
+    /// `Content-Length` (200). `None` if neither was parseable.
+    pub size: Option<u64>,
+    /// Whether the server honoured the `Range` header (HTTP 206).
+    /// `false` on 200 (range ignored), 4xx, 5xx, or network failure.
+    pub supports_ranges: bool,
+}
+
+/// Errors that can arise during a single probe.
+///
+/// The helper never retries; callers compose retry policy as needed.
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError {
+    /// Underlying wreq error (DNS, TLS, connect, etc.).
+    #[error("probe network error: {0}")]
+    Network(#[from] wreq::Error),
+}
+
+/// Probe a URL with a single `GET Range: bytes=0-{window_bytes - 1}` request.
+///
+/// Status handling:
+/// - 206 → parse total from `Content-Range`, `supports_ranges = true`.
+/// - 200 → server ignored Range; parse total from `Content-Length`,
+///   `supports_ranges = false`.
+/// - other (4xx/5xx) → `ProbeResult { size: None, supports_ranges: false }`.
+///   Non-2xx is "no info", not an error; caller decides next step.
+///
+/// `window_bytes` controls how much body the server is asked for; the
+/// response body is dropped without being read. Smaller windows trade
+/// off slightly less wasted bandwidth on cancelled streams; larger
+/// windows may align with a downstream caller's chunk-0 boundary.
+///
+/// `headers` are applied verbatim — no same-origin gating (callers
+/// gate at their own boundary). `timeout` bounds the entire request.
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Network`] on DNS, TLS, connect, or send failure.
+pub async fn probe_size(
+    client: &wreq::Client,
+    url: &str,
+    headers: Option<&wreq::header::HeaderMap>,
+    window_bytes: u64,
+    timeout: Duration,
+) -> Result<ProbeResult, ProbeError> {
+    let range = format!("bytes=0-{}", window_bytes.saturating_sub(1));
+    let mut req = client.get(url).timeout(timeout).header("Range", &range);
+    if let Some(h) = headers {
+        req = req.headers(h.clone());
+    }
+    let resp = req.send().await?;
+    Ok(match resp.status().as_u16() {
+        206 => ProbeResult {
+            size: parse_content_range_total(resp.headers()),
+            supports_ranges: true,
+        },
+        200 => ProbeResult {
+            size: resp.content_length(),
+            supports_ranges: false,
+        },
+        _ => ProbeResult {
+            size: None,
+            supports_ranges: false,
+        },
+    })
+}
+
+fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Option<u64> {
+    headers
+        .get("content-range")?
+        .to_str()
+        .ok()?
+        .split('/')
+        .nth(1)?
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::significant_drop_tightening,
+    reason = "mockito::Server is a temporary owned by each test fn and dropped at end of scope; tightening would require restructuring every test"
+)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    fn make_client() -> wreq::Client {
+        wreq::Client::new()
+    }
+
+    /// 206 response with Content-Range header → `size` parsed, `supports_ranges = true`.
+    #[tokio::test]
+    async fn probe_206_parses_content_range() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/file")
+            .with_status(206)
+            .with_header("Content-Range", "bytes 0-0/123456")
+            .with_body("")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let url = format!("{}/file", server.url());
+        let result = probe_size(&client, &url, None, 1, Duration::from_secs(5))
+            .await
+            .expect("probe should succeed");
+
+        assert_eq!(result.size, Some(123_456));
+        assert!(result.supports_ranges);
+        mock.assert_async().await;
+    }
+
+    /// 200 response → `Content-Length` used as size, `supports_ranges = false`.
+    ///
+    /// mockito overrides the Content-Length header to match the actual body
+    /// byte length, so the test body length IS the asserted size. (A 64 KiB
+    /// body keeps the test fast while still exercising a real multi-byte
+    /// length parse.)
+    #[tokio::test]
+    async fn probe_200_falls_back_to_content_length() {
+        const BODY_LEN: usize = 64 * 1024;
+        let body = vec![0u8; BODY_LEN];
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/file")
+            .with_status(200)
+            .with_body(&body[..])
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let url = format!("{}/file", server.url());
+        let result = probe_size(&client, &url, None, 1, Duration::from_secs(5))
+            .await
+            .expect("probe should succeed");
+
+        assert_eq!(result.size, Some(BODY_LEN as u64));
+        assert!(!result.supports_ranges);
+        mock.assert_async().await;
+    }
+
+    /// Non-2xx response → `ProbeResult { size: None, supports_ranges: false }`, no error.
+    #[tokio::test]
+    async fn probe_non_2xx_returns_none_no_error() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/file")
+            .with_status(403)
+            .with_body("Forbidden")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let url = format!("{}/file", server.url());
+        let result = probe_size(&client, &url, None, 1, Duration::from_secs(5))
+            .await
+            .expect("probe should succeed even on 403");
+
+        assert_eq!(result.size, None);
+        assert!(!result.supports_ranges);
+        mock.assert_async().await;
+    }
+
+    /// Malformed Content-Range (no `/`) → `size = None`, `supports_ranges = true`.
+    #[tokio::test]
+    async fn probe_206_malformed_content_range_returns_none_size() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/file")
+            .with_status(206)
+            .with_header("Content-Range", "bytes 0-0-garbage")
+            .with_body("")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let url = format!("{}/file", server.url());
+        let result = probe_size(&client, &url, None, 1, Duration::from_secs(5))
+            .await
+            .expect("probe should succeed");
+
+        assert_eq!(result.size, None);
+        // Server returned 206 so supports_ranges must be true even if we
+        // could not parse the total.
+        assert!(result.supports_ranges);
+        mock.assert_async().await;
+    }
+}


### PR DESCRIPTION
Closes #306. Consolidates the duplicate F3-style HTTP probe between rdlp-downloader and rdlp-extractor into a single shared leaf helper in `rdlp-http` (Option 2 from the issue body — cross-crate sharing via a leaf crate, no layering inversion).

## Architecture
- New `rdlp-http::probe` module exports `probe_size(client, url, headers, window_bytes, timeout) -> Result<ProbeResult, ProbeError>`, plus `ProbeResult`, `ProbeError`, and `DEFAULT_PROBE_WINDOW_BYTES` (256 KiB to match the existing F3 constant).
- `HttpDownloader::probe` becomes a thin wrapper preserving the existing `with_retry` semantics + `self.headers()` context. Local `pub(crate) ProbeResult` replaced with `pub(crate) use rdlp_http::ProbeResult` for single source of truth.
- `BaseExtractor::detect_file_size` delegates with `window_bytes=1` (header-only; saves 1 RTT vs the previous HEAD-then-Range fallback and ~256 KiB of bandwidth per probe).
- Local `parse_content_range_total` in downloader/http/mod.rs is kept (used by the resume path in `download_with_resume_with_cancel`, separate from probe). Its 5 unit tests remain.

## Behaviour change
`BaseExtractor::detect_file_size` now does ONE round-trip (single Range GET) instead of TWO (HEAD then Range fallback). Servers that honour HEAD but reject Range will fail to `None` size — vanishingly rare on modern CDNs serving media.

## Reviews
- **security-reviewer**: PASS. One LOW finding fixed inline in commit 42809c7 (`window_bytes=0` would have wrapped to a full-body GET via `saturating_sub` on 0). Defensive clamp at the function boundary.
- **code-reviewer**: APPROVE. 3 minor non-blockers (chunked-200 documentation nit; the same window_bytes=0 nit caught by security; `parse_content_range_total` duplication between resume-path and probe — kept deliberately).
- Pre-PR gate: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` — all ✅.

## Test coverage
4 mockito tests in `rdlp_http::probe::tests`: 206+Content-Range parse, 200+Content-Length fallback, non-2xx → None, 206+malformed Content-Range → None size. Downloader's existing probe tests still pass via the wrapper.