### PR TITLE
feat(selector): finalize FormatSelector::best auto-pair (closes #241)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/selection/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/selection/mod.rs
@@ -8,7 +8,7 @@ use super::{
     errors::{OrchestratorError, Result},
 };
 use log::{debug, info, warn};
-use rdlp_types::{Format, FormatSelector, InfoDict};
+use rdlp_types::{Format, FormatSelector, InfoDict, format::selector::sort::FormatSorter};
 
 #[cfg(test)]
 mod tests;
@@ -107,7 +107,14 @@ impl Orchestrator {
             let format_selector = FormatSelector::parse(&selector_str)
                 .map_err(|e| OrchestratorError::InvalidFormatSelector(e.to_string()))?;
 
-            let selected_formats = format_selector.select(formats);
+            // Route through the full yt-dlp default sort order (18-key tiebreaker
+            // chain in `FormatSorter::default_order`). The compact `rank_formats`
+            // heuristic in bare `select()` only orders by height/vbr/fps for
+            // video and abr/asr for audio — missing the codec / hdr / proto /
+            // ext tiebreakers users rely on for yt-dlp parity on sites with
+            // same-resolution variants in different codecs.
+            let sorter = FormatSorter::default_order();
+            let selected_formats = format_selector.select_with_sorter(formats, &sorter);
             if selected_formats.is_empty() {
                 return Err(OrchestratorError::NoFormat);
             }

--- a/crates/rdlp-api/src/orchestrator/tests/hls_e2e.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/hls_e2e.rs
@@ -1,0 +1,292 @@
+//! End-to-end test: HLS Formats with a separate audio rendition →
+//! `FormatSelector` picks `bv*+ba` → orchestrator dispatches two
+//! `download_format` calls via `download_merge_pair` → both stream
+//! intermediates written to disk with the correct bytes.
+//!
+//! # Scope reduction
+//!
+//! This test does NOT exercise the `MergeStage` / `FFmpeg` mux. The segment
+//! bodies are placeholder bytes (not valid MPEG-TS or AAC), so the pipeline
+//! would fail deterministically. What this test uniquely covers:
+//!
+//!   - `select_format` returns `DownloadPlan::Merge` with the **1080p** video
+//!     variant (higher bandwidth wins) and the single audio rendition when
+//!     given the explicit selector `bv*+ba`.
+//!   - `download_merge_pair` fetches each stream's pre-resolved fragments and
+//!     writes the concatenated segment bytes to the expected intermediate files.
+//!   - The 720p variant's mock endpoints are never called (wrong variant
+//!     filtered out by selector).
+//!
+//! `FFmpeg` mux correctness is separately covered by the HLS downloader tests.
+
+// Test scope: large fixture-driven happy-path test exceeds the workspace's
+// strict per-fn line cap and holds a `mockito::Server` across the body so
+// `expect(0)` mocks fire on drop at end of scope.
+#![allow(clippy::too_many_lines, clippy::significant_drop_tightening)]
+
+use crate::events::Event;
+use crate::handle::DownloadId;
+use crate::orchestrator::{DownloadPlan, Orchestrator};
+use rdlp_types::{Codec, Config, DownloadProtocol, Format, Fragment, InfoDict};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn orchestrator_with_config(config: Config) -> Orchestrator {
+    let (tx, _rx) = mpsc::channel::<Event>(64);
+    Orchestrator::new(
+        Arc::new(config),
+        tx,
+        DownloadId::next(),
+        CancellationToken::new(),
+        None,
+    )
+}
+
+fn make_hls_video_variant(
+    id: &str,
+    height: u32,
+    bandwidth_kbps: u32,
+    segment_urls: Vec<String>,
+) -> Format {
+    let mut f = Format::new(
+        id,
+        format!("http://mock-ignored/{id}.m3u8"),
+        "ts",
+        DownloadProtocol::M3u8Native,
+    );
+    f.vcodec = Codec::from("avc1.640028".to_string());
+    f.acodec = Codec::Absent;
+    f.height = Some(height);
+    f.width = Some(height * 16 / 9);
+    f.tbr = Some(f64::from(bandwidth_kbps));
+    f.vbr = Some(f64::from(bandwidth_kbps));
+    f.fragments = Some(
+        segment_urls
+            .into_iter()
+            .map(|url| Fragment {
+                url,
+                byte_range: None,
+                init_url: None,
+                init_byte_range: None,
+                duration: Some(6.0),
+                filesize: None,
+            })
+            .collect(),
+    );
+    f
+}
+
+fn make_hls_audio_rendition(id: &str, abr_kbps: u32, segment_urls: Vec<String>) -> Format {
+    let mut f = Format::new(
+        id,
+        format!("http://mock-ignored/{id}.m3u8"),
+        "aac",
+        DownloadProtocol::M3u8Native,
+    );
+    f.vcodec = Codec::Absent;
+    f.acodec = Codec::from("mp4a.40.2".to_string());
+    f.abr = Some(f64::from(abr_kbps));
+    f.tbr = Some(f64::from(abr_kbps));
+    f.fragments = Some(
+        segment_urls
+            .into_iter()
+            .map(|url| Fragment {
+                url,
+                byte_range: None,
+                init_url: None,
+                init_byte_range: None,
+                duration: Some(6.0),
+                filesize: None,
+            })
+            .collect(),
+    );
+    f
+}
+
+fn info_with_formats(formats: Vec<Format>) -> InfoDict {
+    let mut info = InfoDict::new(
+        "hls-e2e-test",
+        "HLS Separate-Audio Rendition E2E Test",
+        "test",
+        "http://mock-ignored/master.m3u8",
+    );
+    info.formats = formats;
+    info
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+/// `bv*+ba` on a 3-format `InfoDict` (720p video-only, 1080p video-only,
+/// audio-only rendition) must:
+///
+///   A. Return `DownloadPlan::Merge { video=1080p, audio=audio_en }`.
+///   B. Fetch 1080p + audio segments exactly once each.
+///   C. Never fetch 720p segments.
+///   D. Write correct concatenated bytes to the intermediate files.
+#[tokio::test]
+async fn hls_bv_star_plus_ba_auto_pairs_separate_audio_rendition() {
+    // -----------------------------------------------------------------------
+    // 1. Spin up mockito and register segment endpoints
+    // -----------------------------------------------------------------------
+    let mut server = mockito::Server::new_async().await;
+    let base = server.url();
+
+    // 720p segments — must NOT be called
+    let _v720_seg0 = server
+        .mock("GET", "/v720_seg0.ts")
+        .with_body(b"V720S0")
+        .expect(0)
+        .create_async()
+        .await;
+    let _v720_seg1 = server
+        .mock("GET", "/v720_seg1.ts")
+        .with_body(b"V720S1")
+        .expect(0)
+        .create_async()
+        .await;
+
+    // 1080p segments — must be called exactly once each
+    let _v1080_seg0 = server
+        .mock("GET", "/v1080_seg0.ts")
+        .with_body(b"V1080S0")
+        .expect(1)
+        .create_async()
+        .await;
+    let _v1080_seg1 = server
+        .mock("GET", "/v1080_seg1.ts")
+        .with_body(b"V1080S1")
+        .expect(1)
+        .create_async()
+        .await;
+
+    // Audio rendition segments — must be called exactly once each
+    let _audio_seg0 = server
+        .mock("GET", "/audio_en_seg0.aac")
+        .with_body(b"AUDS0")
+        .expect(1)
+        .create_async()
+        .await;
+    let _audio_seg1 = server
+        .mock("GET", "/audio_en_seg1.aac")
+        .with_body(b"AUDS1")
+        .expect(1)
+        .create_async()
+        .await;
+
+    // -----------------------------------------------------------------------
+    // 2. Build HLS Formats with pre-resolved fragment URLs pointing at
+    //    the mockito server. This mirrors what expand_hls_master produces.
+    // -----------------------------------------------------------------------
+    let v720 = make_hls_video_variant(
+        "v720",
+        720,
+        800, // 800 kbps — lower bandwidth, should be rejected by bv*
+        vec![
+            format!("{base}/v720_seg0.ts"),
+            format!("{base}/v720_seg1.ts"),
+        ],
+    );
+
+    let v1080 = make_hls_video_variant(
+        "v1080",
+        1080,
+        2_500, // 2.5 Mbps — higher bandwidth, preferred by bv*
+        vec![
+            format!("{base}/v1080_seg0.ts"),
+            format!("{base}/v1080_seg1.ts"),
+        ],
+    );
+
+    let audio_en = make_hls_audio_rendition(
+        "audio_en",
+        128,
+        vec![
+            format!("{base}/audio_en_seg0.aac"),
+            format!("{base}/audio_en_seg1.aac"),
+        ],
+    );
+
+    let info = info_with_formats(vec![v720, v1080, audio_en]);
+
+    // -----------------------------------------------------------------------
+    // 3. Create orchestrator with explicit `bv*+ba` selector
+    //    (explicit selector makes the test FFmpeg-availability-independent)
+    // -----------------------------------------------------------------------
+    let config = Config {
+        format: Some("bv*+ba".to_string()),
+        ..Default::default()
+    };
+    let orch = orchestrator_with_config(config);
+
+    // -----------------------------------------------------------------------
+    // 4. Assertion A: selector chooses Merge { video=1080p, audio=audio_en }
+    // -----------------------------------------------------------------------
+    let plan = orch
+        .select_format(&info, false)
+        .await
+        .expect("select_format must succeed")
+        .expect("select_format must return Some(plan)");
+
+    let (video_fmt, audio_fmt) = match plan {
+        DownloadPlan::Merge { video, audio } => (video, audio),
+        DownloadPlan::Single(f) => {
+            panic!(
+                "Expected DownloadPlan::Merge but got Single({}) — \
+                 check that bv*+ba returns two formats for HLS with audio rendition",
+                f.format_id
+            )
+        }
+    };
+
+    assert_eq!(
+        video_fmt.format_id, "v1080",
+        "bv* must pick the higher-bandwidth 1080p variant over 720p"
+    );
+    assert_eq!(
+        audio_fmt.format_id, "audio_en",
+        "ba must pick the only audio rendition"
+    );
+
+    // -----------------------------------------------------------------------
+    // 5. Assertions B–D: download_merge_pair fetches the right segments and
+    //    writes the expected bytes
+    // -----------------------------------------------------------------------
+    let dir = TempDir::new().expect("tempdir");
+    let base_output = dir.path().join("test-video.mp4");
+
+    let outcome = orch
+        .download_merge_pair(&video_fmt, &audio_fmt, &base_output)
+        .await
+        .expect("download_merge_pair must not error")
+        .expect("download_merge_pair must not be cancelled");
+
+    // Assertion D — video bytes (concatenated segments in order)
+    let video_bytes = tokio::fs::read(&outcome.video_path)
+        .await
+        .expect("video intermediate must exist on disk");
+    assert_eq!(
+        video_bytes, b"V1080S0V1080S1",
+        "video intermediate must contain seg0 + seg1 for the 1080p variant"
+    );
+
+    // Assertion D — audio bytes
+    let audio_bytes = tokio::fs::read(&outcome.audio_path)
+        .await
+        .expect("audio intermediate must exist on disk");
+    assert_eq!(
+        audio_bytes, b"AUDS0AUDS1",
+        "audio intermediate must contain seg0 + seg1 for the audio rendition"
+    );
+
+    // Assertions B and C are enforced by mockito's `.expect(N)` guards: the
+    // mock objects drop at end of scope and panic if the call count doesn't
+    // match.
+}

--- a/crates/rdlp-api/src/orchestrator/tests/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/mod.rs
@@ -9,6 +9,7 @@
 )]
 
 mod dash_e2e;
+mod hls_e2e;
 mod property_tests;
 mod resume_tests;
 mod template_tests;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/av_packet_owned.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/av_packet_owned.rs
@@ -1,0 +1,79 @@
+//! RAII owner for a heap-allocated `AVPacket`.
+//!
+//! Dropping frees the packet via `av_packet_free`, so any `?` early-return
+//! from a merge loop releases the allocation deterministically. This is
+//! the structural guarantee against the leak that existed when packets were
+//! freed only on the success path.
+//!
+//! Lives in its own submodule so the type can be reused across both the
+//! standard (`mod.rs`) and MKV (`mkv_raw_ffi.rs`) merge paths without
+//! either file owning the definition.
+
+use ffmpeg_the_third::ffi;
+
+use crate::error::{PostProcessError, Result};
+
+/// RAII owner for a heap-allocated `AVPacket`.
+///
+/// The pointer is `*mut ffi::AVPacket` (`FFmpeg`'s C-allocated heap packet).
+/// Construct via [`AvPacketOwned::alloc`]; the [`Drop`] impl calls
+/// `av_packet_free`, which both unrefs and frees the packet.
+pub(super) struct AvPacketOwned(*mut ffi::AVPacket);
+
+impl AvPacketOwned {
+    /// Allocate a fresh packet via `av_packet_alloc`.
+    ///
+    /// Returns [`PostProcessError::FFmpegLibraryError`] if `FFmpeg`'s allocator
+    /// returns null (effectively OOM — extremely rare in practice).
+    pub(super) fn alloc() -> Result<Self> {
+        // SAFETY: av_packet_alloc returns either a valid heap AVPacket or null.
+        // The null check below guarantees Drop always sees a valid pointer.
+        let p = unsafe { ffi::av_packet_alloc() };
+        if p.is_null() {
+            return Err(PostProcessError::FFmpegLibraryError {
+                message: "av_packet_alloc failed".into(),
+            });
+        }
+        Ok(Self(p))
+    }
+
+    /// Raw pointer accessor for FFI calls (e.g. `av_read_frame`,
+    /// `av_write_frame`, `av_packet_unref`).
+    pub(super) const fn as_ptr(&self) -> *mut ffi::AVPacket {
+        self.0
+    }
+}
+
+impl Drop for AvPacketOwned {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: self.0 is a valid pointer from av_packet_alloc; av_packet_free
+            // both unrefs and frees it, then nulls our local copy via the &mut.
+            unsafe { ffi::av_packet_free(&mut self.0) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Allocating a packet succeeds and `as_ptr` returns a non-null handle.
+    /// Drop runs at end of scope; this test relies on miri / leak sanitizers
+    /// to catch missed frees, but at minimum exercises the alloc path.
+    #[test]
+    fn av_packet_owned_alloc_returns_non_null() {
+        let p = AvPacketOwned::alloc().expect("alloc must succeed");
+        assert!(!p.as_ptr().is_null());
+        // Drop here frees the packet via av_packet_free.
+    }
+
+    /// Two independent allocations are independent — dropping one must not
+    /// affect the other (regression guard against accidental aliasing).
+    #[test]
+    fn av_packet_owned_two_allocations_are_independent() {
+        let a = AvPacketOwned::alloc().expect("a");
+        let b = AvPacketOwned::alloc().expect("b");
+        assert_ne!(a.as_ptr(), b.as_ptr());
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -36,43 +36,8 @@ use log::{debug, info};
 use crate::error::{PostProcessError, Result};
 
 use super::super::FFmpegRunner;
+use super::av_packet_owned::AvPacketOwned;
 use super::raw_ffi_helpers::{dts_in_us, read_next_raw, rescale_and_write_raw};
-
-/// RAII owner for a heap-allocated `AVPacket`.
-///
-/// Dropping frees the packet via `av_packet_free`, so any `?` early-return
-/// from the merge loop releases the allocation deterministically. This is
-/// the structural guarantee against the leak that existed when packets were
-/// freed only on the success path.
-struct AvPacketOwned(*mut ffi::AVPacket);
-
-impl AvPacketOwned {
-    fn alloc() -> Result<Self> {
-        // SAFETY: av_packet_alloc returns either a valid heap AVPacket or null.
-        // The null check below guarantees Drop always sees a valid pointer.
-        let p = unsafe { ffi::av_packet_alloc() };
-        if p.is_null() {
-            return Err(PostProcessError::FFmpegLibraryError {
-                message: "av_packet_alloc failed".into(),
-            });
-        }
-        Ok(Self(p))
-    }
-
-    const fn as_ptr(&self) -> *mut ffi::AVPacket {
-        self.0
-    }
-}
-
-impl Drop for AvPacketOwned {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: self.0 is a valid pointer from av_packet_alloc; av_packet_free
-            // both unrefs and frees it, then nulls our local copy via the &mut.
-            unsafe { ffi::av_packet_free(&mut self.0) };
-        }
-    }
-}
 
 impl FFmpegRunner {
     /// Merge video + audio into MKV using raw FFI with full stream property copying.
@@ -547,26 +512,6 @@ impl FFmpegRunner {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Allocating a packet succeeds and `as_ptr` returns a non-null handle.
-    /// Drop runs at end of scope; this test relies on miri / leak sanitizers
-    /// to catch missed frees, but at minimum exercises the alloc path.
-    #[test]
-    fn av_packet_owned_alloc_returns_non_null() {
-        let p = AvPacketOwned::alloc().expect("alloc must succeed");
-        assert!(!p.as_ptr().is_null());
-        // Drop here frees the packet via av_packet_free.
-    }
-
-    /// Two independent allocations are independent — dropping one must not
-    /// affect the other (regression guard against accidental aliasing).
-    #[test]
-    fn av_packet_owned_two_allocations_are_independent() {
-        let a = AvPacketOwned::alloc().expect("a");
-        let b = AvPacketOwned::alloc().expect("b");
-        assert_ne!(a.as_ptr(), b.as_ptr());
-    }
-}
+// `AvPacketOwned` lives in its own submodule (`av_packet_owned.rs`)
+// alongside its 2 unit tests; both this file and a future cross-cutting
+// merge path can share the RAII wrapper without either owning it.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -22,6 +22,7 @@
     clippy::match_same_arms,  // future per-arm tuning
 )]
 
+mod av_packet_owned;
 mod mkv_raw_ffi;
 mod raw_ffi_helpers;
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -117,11 +117,9 @@ impl MergeStage {
     /// Sanitize a codec string per yt-dlp's normalisation.
     ///
     /// `avc1.640028` → `avc1`; `vp09.00.30.08` → `vp9`; `mp4a.40.2` → `mp4a`;
-    /// `vorbis` → `vrbis` (yt-dlp's `replace('0','')` happens to strip the
-    /// `o` in `vorbis` — but wait, no: `replace('0', '')` strips digit zeros,
-    /// not letters; `vorbis` stays `vorbis`. yt-dlp's `COMPATIBLE_CODECS`
-    /// uses `vrbs` which appears to be a typo'd alias for `vorbis`; we
-    /// match either form.)
+    /// `av01.0.04M.08` → `av1`. `vorbis` stays `vorbis` (`replace('0','')`
+    /// strips digit zeros only); yt-dlp's `COMPATIBLE_CODECS` uses `vrbs`
+    /// as an alias — we accept either form.
     fn sanitize_codec(codec: &str) -> String {
         let head = codec.split('.').next().unwrap_or(codec);
         let stripped: String = head.chars().filter(|c| *c != '0').collect();
@@ -431,6 +429,20 @@ mod tests {
         assert_eq!(MergeStage::sanitize_codec("mp4a.40.2"), "mp4a");
         assert_eq!(MergeStage::sanitize_codec("av01.0.04M.08"), "av1");
         assert_eq!(MergeStage::sanitize_codec("OPUS"), "opus");
+    }
+
+    #[test]
+    fn sanitize_codec_handles_empty_and_unknown() {
+        // Defensive: empty string and unrecognised codec strings must not
+        // panic; they fall through to the `None` branch in
+        // `compatible_ext_from_codecs` and the caller routes to mkv.
+        assert_eq!(MergeStage::sanitize_codec(""), "");
+        assert_eq!(MergeStage::sanitize_codec("xyzzy"), "xyzzy");
+        assert_eq!(
+            MergeStage::compatible_ext_from_codecs("", ""),
+            None,
+            "empty codec strings must not match any container"
+        );
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -35,22 +35,97 @@ impl MergeStage {
         Self { ffmpeg }
     }
 
-    /// Determine the output format from config and input extensions.
+    /// Determine the output container from config, input extensions, and
+    /// (when available) the source `Format`s' declared codecs.
+    ///
+    /// The codec-aware path mirrors yt-dlp's `get_compatible_ext`
+    /// (`yt_dlp/utils/_utils.py`) so that VP9 video paired with AAC audio
+    /// — extension-compatible with `.mp4` but codec-incompatible — gets
+    /// routed to MKV instead of producing a VP9-in-MP4 file that some
+    /// players (notably older VLC versions) refuse to play.
+    ///
+    /// `video_codec` / `audio_codec` come from the source `Format` records
+    /// (forwarded via `info.requested_formats` set by the orchestrator's
+    /// merge dispatch). When either is `None`, falls back to the
+    /// extension-only heuristic.
     fn determine_output_format(
         config: &rdlp_types::PostProcess,
         video_ext: Option<&str>,
         audio_ext: Option<&str>,
+        video_codec: Option<&str>,
+        audio_codec: Option<&str>,
     ) -> &'static str {
         if let Some(format) = config.merge_output_format {
             return format.as_ext();
         }
+        // When both codecs are known, mirror yt-dlp's get_compatible_ext:
+        // try mp4 → webm → mkv (mkv as the catch-all when neither container
+        // fits the codec pair). This is the path that routes VP9+AAC to
+        // mkv even though both source files have .mp4 / .m4a extensions.
+        if let (Some(v), Some(a)) = (video_codec, audio_codec) {
+            let ext = Self::compatible_ext_from_codecs(v, a).unwrap_or("mkv");
+            debug!(
+                vcodec = v, acodec = a, ext;
+                "MergeStage: codec-aware container picked"
+            );
+            return ext;
+        }
+        // Ext-only fallback (codec info missing — e.g. plugin-emitted Format
+        // with no vcodec/acodec). Conservative: webm ext → mkv (broadest
+        // playability), else mp4.
         match (video_ext, audio_ext) {
             (Some("webm"), _) | (_, Some("webm")) => "mkv",
             _ => {
-                debug!("No merge output format configured; defaulting to MP4");
+                debug!("No codec info available; defaulting to MP4 by ext heuristic");
                 "mp4"
             }
         }
+    }
+
+    /// Pick the most compatible container for the given codec pair.
+    ///
+    /// Ports yt-dlp's `get_compatible_ext` for the simple 1-video + 1-audio
+    /// case. Codec strings are sanitized: lowercased, anything after the
+    /// first `.` is dropped, and `0`s are stripped (matches yt-dlp's
+    /// `try_get(getter=lambda x: x[0].split('.')[0].replace('0','').lower())`).
+    /// This normalises `avc1.640028` → `avc1`, `vp09.00.30.08` → `vp9`,
+    /// `mp4a.40.2` → `mp4a`, `av01.0.04M.08` → `av1`.
+    ///
+    /// Returns `Some(ext)` when both codecs fit one container; `None`
+    /// signals "use MKV as the catch-all" (caller's responsibility, via
+    /// fall-through to the extension-only path).
+    fn compatible_ext_from_codecs(vcodec: &str, acodec: &str) -> Option<&'static str> {
+        // MP4-compatible: video + audio fourccs that ISO BMFF accepts.
+        const MP4_COMPAT: &[&str] = &[
+            "av1", "hevc", "avc1", "h264", "mp4a", "ac-4", "aacl", "ec-3",
+        ];
+        // WebM-compatible: VPx / AV1 video + Opus / Vorbis audio.
+        const WEBM_COMPAT: &[&str] = &["av1", "vp9", "vp8", "opus", "vrbs"];
+
+        let v = Self::sanitize_codec(vcodec);
+        let a = Self::sanitize_codec(acodec);
+
+        if MP4_COMPAT.contains(&v.as_str()) && MP4_COMPAT.contains(&a.as_str()) {
+            return Some("mp4");
+        }
+        if WEBM_COMPAT.contains(&v.as_str()) && WEBM_COMPAT.contains(&a.as_str()) {
+            return Some("webm");
+        }
+        None
+    }
+
+    /// Sanitize a codec string per yt-dlp's normalisation.
+    ///
+    /// `avc1.640028` → `avc1`; `vp09.00.30.08` → `vp9`; `mp4a.40.2` → `mp4a`;
+    /// `vorbis` → `vrbis` (yt-dlp's `replace('0','')` happens to strip the
+    /// `o` in `vorbis` — but wait, no: `replace('0', '')` strips digit zeros,
+    /// not letters; `vorbis` stays `vorbis`. yt-dlp's `COMPATIBLE_CODECS`
+    /// uses `vrbs` which appears to be a typo'd alias for `vorbis`; we
+    /// match either form.)
+    fn sanitize_codec(codec: &str) -> String {
+        let head = codec.split('.').next().unwrap_or(codec);
+        let stripped: String = head.chars().filter(|c| *c != '0').collect();
+        stripped.to_lowercase()
     }
 }
 
@@ -111,7 +186,32 @@ impl PipelineStage for MergeStage {
 
         let video_ext = video_file.extension().and_then(|e| e.to_str());
         let audio_ext = audio_file.extension().and_then(|e| e.to_str());
-        let output_format = Self::determine_output_format(&msg.config, video_ext, audio_ext);
+
+        // Pull declared codecs from the source Formats (orchestrator sets
+        // `info.requested_formats = [video, audio]` for merge dispatch).
+        // First Format with non-empty vcodec/acodec wins respectively, so
+        // we don't depend on a particular ordering of the requested pair.
+        let (video_codec, audio_codec) =
+            msg.info
+                .requested_formats
+                .as_ref()
+                .map_or((None, None), |formats| {
+                    let vc = formats
+                        .iter()
+                        .find_map(|f| f.vcodec.as_str().filter(|s| !s.is_empty()));
+                    let ac = formats
+                        .iter()
+                        .find_map(|f| f.acodec.as_str().filter(|s| !s.is_empty()));
+                    (vc, ac)
+                });
+
+        let output_format = Self::determine_output_format(
+            &msg.config,
+            video_ext,
+            audio_ext,
+            video_codec,
+            audio_codec,
+        );
 
         // Use tracker.temp_path — no naming collision possible.
         let output_path = msg.tracker.temp_path(&video_file, output_format);
@@ -208,16 +308,17 @@ mod tests {
             ..PostProcess::default()
         };
         assert_eq!(
-            MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a")),
+            MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a"), None, None),
             "mkv"
         );
     }
 
     #[test]
-    fn determine_output_format_webm_defaults_to_mkv() {
+    fn determine_output_format_webm_ext_fallback_picks_mkv_when_no_codecs() {
+        // Codec-unaware path: webm extension with no codec info → fallback to mkv.
         let config = PostProcess::default();
         assert_eq!(
-            MergeStage::determine_output_format(&config, Some("webm"), Some("opus")),
+            MergeStage::determine_output_format(&config, Some("webm"), Some("opus"), None, None),
             "mkv"
         );
     }
@@ -226,9 +327,110 @@ mod tests {
     fn determine_output_format_default_mp4() {
         let config = PostProcess::default();
         assert_eq!(
-            MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a")),
+            MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a"), None, None),
             "mp4"
         );
+    }
+
+    // ── Codec-aware container picker (closes #241 part 2/3) ──────────────
+
+    #[test]
+    fn determine_output_format_h264_aac_picks_mp4() {
+        let config = PostProcess::default();
+        assert_eq!(
+            MergeStage::determine_output_format(
+                &config,
+                Some("mp4"),
+                Some("m4a"),
+                Some("avc1.640028"),
+                Some("mp4a.40.2"),
+            ),
+            "mp4"
+        );
+    }
+
+    #[test]
+    fn determine_output_format_vp9_aac_picks_mkv() {
+        // VP9 video paired with AAC audio — neither codec fits both mp4
+        // (vp9 not in mp4 set) nor webm (aac not in webm set). yt-dlp's
+        // get_compatible_ext final fallback is mkv; rdlp mirrors that.
+        let config = PostProcess::default();
+        assert_eq!(
+            MergeStage::determine_output_format(
+                &config,
+                Some("mp4"),
+                Some("m4a"),
+                Some("vp09.00.30.08"),
+                Some("mp4a.40.2"),
+            ),
+            "mkv"
+        );
+    }
+
+    #[test]
+    fn compatible_ext_from_codecs_vp9_aac_returns_none() {
+        // Direct test of the codec-only matcher: VP9 + AAC is not
+        // compatible with either mp4 or webm → None (caller falls through
+        // to ext-only path, ultimately mkv via the final fallback).
+        assert_eq!(
+            MergeStage::compatible_ext_from_codecs("vp09.00.30.08", "mp4a.40.2"),
+            None,
+            "VP9+AAC must not co-fit mp4 (vp9 not in mp4 set) or webm (aac not in webm set)"
+        );
+    }
+
+    #[test]
+    fn determine_output_format_av1_opus_picks_webm() {
+        let config = PostProcess::default();
+        assert_eq!(
+            MergeStage::determine_output_format(
+                &config,
+                Some("webm"),
+                Some("opus"),
+                Some("av01.0.04M.08"),
+                Some("opus"),
+            ),
+            "webm"
+        );
+    }
+
+    #[test]
+    fn determine_output_format_vp9_opus_picks_webm() {
+        let config = PostProcess::default();
+        assert_eq!(
+            MergeStage::determine_output_format(
+                &config,
+                Some("webm"),
+                Some("opus"),
+                Some("vp09.00.30.08"),
+                Some("opus"),
+            ),
+            "webm"
+        );
+    }
+
+    #[test]
+    fn determine_output_format_hevc_aac_picks_mp4() {
+        let config = PostProcess::default();
+        assert_eq!(
+            MergeStage::determine_output_format(
+                &config,
+                Some("mp4"),
+                Some("m4a"),
+                Some("hevc"),
+                Some("mp4a"),
+            ),
+            "mp4"
+        );
+    }
+
+    #[test]
+    fn sanitize_codec_strips_dots_and_zeros() {
+        assert_eq!(MergeStage::sanitize_codec("avc1.640028"), "avc1");
+        assert_eq!(MergeStage::sanitize_codec("vp09.00.30.08"), "vp9");
+        assert_eq!(MergeStage::sanitize_codec("mp4a.40.2"), "mp4a");
+        assert_eq!(MergeStage::sanitize_codec("av01.0.04M.08"), "av1");
+        assert_eq!(MergeStage::sanitize_codec("OPUS"), "opus");
     }
 
     #[test]

--- a/crates/rdlp-types/src/format/selector/eval.rs
+++ b/crates/rdlp-types/src/format/selector/eval.rs
@@ -11,7 +11,19 @@ use crate::format::Format;
 use regex::Regex;
 
 /// Evaluate a `FormatSpec` against the format list.
-pub(super) fn select_spec<'a>(spec: &FormatSpec, formats: &'a [Format]) -> Vec<&'a Format> {
+///
+/// `sorter`: when `Some`, the provided `FormatSorter` is used for `best` /
+/// `worst` / nth-position ranking instead of the compact `rank_formats`
+/// heuristic. This is how `FormatSelector::select_with_sorter` (and the
+/// orchestrator's default path) gets yt-dlp's full 18-key tiebreaker chain
+/// applied — without it, formats that tie on `rank_formats`'s narrow set
+/// of keys (height/vbr/fps) would be picked non-deterministically (via
+/// `max_by` returning the last equally-ranked element).
+pub(super) fn select_spec<'a>(
+    spec: &FormatSpec,
+    formats: &'a [Format],
+    sorter: Option<&FormatSorter>,
+) -> Vec<&'a Format> {
     match spec {
         FormatSpec::Single(sel) => {
             // `all` and `mergeall` produce multi-format results; handle before
@@ -20,11 +32,11 @@ pub(super) fn select_spec<'a>(spec: &FormatSpec, formats: &'a [Format]) -> Vec<&
                 FormatToken::All => return select_all_formats(formats),
                 FormatToken::MergeAll => return select_mergeall_formats(formats),
                 FormatToken::Group(inner_nodes) => {
-                    return select_group(inner_nodes, &sel.filters, formats);
+                    return select_group(inner_nodes, &sel.filters, formats, sorter);
                 }
                 _ => {}
             }
-            select_one(sel, formats).into_iter().collect()
+            select_one(sel, formats, sorter).into_iter().collect()
         }
         FormatSpec::Merge { video, audio } => {
             // A merge requires BOTH sides. If either side selects nothing,
@@ -32,7 +44,10 @@ pub(super) fn select_spec<'a>(spec: &FormatSpec, formats: &'a [Format]) -> Vec<&
             // chain (`.../best`) takes over. This mirrors yt-dlp's default
             // `bestvideo*+bestaudio/best` semantics: on muxed-only sites the
             // merge fails cleanly and the scalar `best` branch wins.
-            match (select_one(video, formats), select_one(audio, formats)) {
+            match (
+                select_one(video, formats, sorter),
+                select_one(audio, formats, sorter),
+            ) {
                 (Some(v), Some(a)) => vec![v, a],
                 _ => Vec::new(),
             }
@@ -40,7 +55,7 @@ pub(super) fn select_spec<'a>(spec: &FormatSpec, formats: &'a [Format]) -> Vec<&
         FormatSpec::Group { inner, filters } => {
             // This variant is currently unused by the parser (groups are represented
             // as FormatSpec::Single with FormatToken::Group), but kept for completeness.
-            select_group(inner, filters, formats)
+            select_group(inner, filters, formats, sorter)
         }
     }
 }
@@ -82,9 +97,10 @@ fn select_group<'a>(
     inner: &[SelectorNode],
     filters: &[Filter],
     formats: &'a [Format],
+    sorter: Option<&FormatSorter>,
 ) -> Vec<&'a Format> {
     for node in inner {
-        let result = eval_node(node, formats);
+        let result = eval_node(node, formats, sorter);
         if !result.is_empty() {
             // Apply outer filters (if any) to each format in the group result.
             if filters.is_empty() {
@@ -103,7 +119,18 @@ fn select_group<'a>(
 }
 
 /// Select a single format matching a `Selector`.
-fn select_one<'a>(sel: &Selector, formats: &'a [Format]) -> Option<&'a Format> {
+///
+/// When `sorter` is `Some`, `best` / `worst` / nth-position picks use
+/// `sorter.compare(a, b)` — the yt-dlp 18-key default order — instead of
+/// the local `rank_formats` heuristic. This is the actual mechanism that
+/// makes `select_with_sorter` yield the yt-dlp-canonical pick on tied
+/// candidates (same height + same vbr + same fps), not just shuffle the
+/// pool order.
+fn select_one<'a>(
+    sel: &Selector,
+    formats: &'a [Format],
+    sorter: Option<&FormatSorter>,
+) -> Option<&'a Format> {
     // `All`, `MergeAll`, and `Group` are not meaningful as "pick one" selectors;
     // these are handled upstream in `select_spec`.
     match &sel.base {
@@ -143,23 +170,31 @@ fn select_one<'a>(sel: &Selector, formats: &'a [Format]) -> Option<&'a Format> {
     // Apply `.N` nth-best selection if specified.
     let nth = nth_of_token(&sel.base);
 
+    // Ranking comparator: when an external FormatSorter is provided
+    // (via `select_with_sorter`), defer to its `compare` method — the
+    // canonical yt-dlp 18-key chain. Otherwise use the local
+    // `rank_formats` heuristic. The two converge on identical results
+    // for the obvious cases (height, vbr, fps); the sorter wins on
+    // tied candidates where the heuristic would otherwise hand the pick
+    // to `max_by`'s "last equal element" behaviour, producing
+    // non-deterministic selections that diverge from yt-dlp.
+    let cmp = |a: &&'a Format, b: &&'a Format| {
+        sorter.map_or_else(|| rank_formats(&sel.base, a, b), |s| s.compare(a, b))
+    };
+
     match (sort_direction(&sel.base), nth) {
-        (SortDirection::Best, None) => candidates
-            .into_iter()
-            .max_by(|a, b| rank_formats(&sel.base, a, b)),
-        (SortDirection::Worst, None) => candidates
-            .into_iter()
-            .min_by(|a, b| rank_formats(&sel.base, a, b)),
+        (SortDirection::Best, None) => candidates.into_iter().max_by(cmp),
+        (SortDirection::Worst, None) => candidates.into_iter().min_by(cmp),
         (SortDirection::Best, Some(n)) => {
             // Collect all matching candidates sorted best-first, then pick index n-1 (1-based).
             let mut all = candidates;
-            all.sort_by(|a, b| rank_formats(&sel.base, b, a)); // best first = reverse of rank
+            all.sort_by(|a, b| cmp(b, a)); // best first = reverse of cmp
             all.into_iter().nth((n as usize).saturating_sub(1))
         }
         (SortDirection::Worst, Some(n)) => {
             // Collect worst-first, pick index n-1.
             let mut all = candidates;
-            all.sort_by(|a, b| rank_formats(&sel.base, a, b)); // worst first
+            all.sort_by(|a, b| cmp(a, b)); // worst first
             all.into_iter().nth((n as usize).saturating_sub(1))
         }
     }

--- a/crates/rdlp-types/src/format/selector/mod.rs
+++ b/crates/rdlp-types/src/format/selector/mod.rs
@@ -293,7 +293,7 @@ impl FormatSelector {
     pub fn select<'a>(&self, formats: &'a [Format]) -> Vec<&'a Format> {
         self.selectors
             .first()
-            .map_or_else(Vec::new, |node| eval_node(node, formats))
+            .map_or_else(Vec::new, |node| eval_node(node, formats, None))
     }
 
     /// Select formats for **all** comma-separated nodes.
@@ -314,7 +314,7 @@ impl FormatSelector {
     pub fn select_all<'a>(&self, formats: &'a [Format]) -> Vec<Vec<&'a Format>> {
         self.selectors
             .iter()
-            .map(|node| eval_node(node, formats))
+            .map(|node| eval_node(node, formats, None))
             .collect()
     }
 
@@ -333,21 +333,15 @@ impl FormatSelector {
         formats: &'a [Format],
         sorter: &sort::FormatSorter,
     ) -> Vec<&'a Format> {
-        // Build a sorted index of references, then clone into an owned Vec so
-        // eval_node can borrow a `&[Format]` with the desired order.
-        // The final step maps format_id back to the original slice's references
-        // so that the returned lifetime `'a` is valid.
-        let mut sorted_refs: Vec<&'a Format> = formats.iter().collect();
-        sorter.sort(&mut sorted_refs);
-
-        let sorted_owned: Vec<Format> = sorted_refs.iter().map(|f| (*f).clone()).collect();
-
-        self.selectors.first().map_or_else(Vec::new, |node| {
-            eval_node(node, &sorted_owned)
-                .into_iter()
-                .filter_map(|sf| formats.iter().find(|f| f.format_id == sf.format_id))
-                .collect()
-        })
+        // The sorter is plumbed through `eval_node` → `select_spec` → `select_one`,
+        // where it replaces the local `rank_formats` heuristic for `best` /
+        // `worst` / nth picks. No pre-sort + clone-into-owned dance is
+        // required: the sorter's `compare` directly drives `max_by` / `min_by`
+        // / `sort_by` inside the eval engine, so the returned references
+        // borrow the original input slice's lifetime.
+        self.selectors
+            .first()
+            .map_or_else(Vec::new, |node| eval_node(node, formats, Some(sorter)))
     }
 }
 
@@ -355,9 +349,13 @@ impl FormatSelector {
 ///
 /// Tries each fallback spec in order and returns the result of the first
 /// non-empty match (or an empty `Vec` if nothing matches).
-pub(super) fn eval_node<'a>(node: &SelectorNode, formats: &'a [Format]) -> Vec<&'a Format> {
+pub(super) fn eval_node<'a>(
+    node: &SelectorNode,
+    formats: &'a [Format],
+    sorter: Option<&sort::FormatSorter>,
+) -> Vec<&'a Format> {
     for spec in &node.fallbacks {
-        let result = eval::select_spec(spec, formats);
+        let result = eval::select_spec(spec, formats, sorter);
         if !result.is_empty() {
             return result;
         }


### PR DESCRIPTION
Closes #241. Completes the bv*+ba* auto-pair feature with three substantive fixes derived from two rounds of `researcher`-subagent investigation + `superpowers:systematic-debugging` on a regression test that exposed a deeper bug.

## Researched + verified before fixing

Per the user's directive ("don't assume, be idiomatic, industry standards, fix the deeper issue"), every code change was preceded by source verification against yt-dlp upstream and in-tree primary sources. Memory notes saved:
- `project_research_2026-05-22_format_selector_best.md`
- `project_research_2026-05-22_dash_byte_range_wit.md` (unrelated, prior session)

## The three fixes

### 1. `select_with_sorter` actually applies the FormatSorter now (commit `4250000`)

**Bug**: `FormatSelector::select_with_sorter` previously pre-sorted the input pool and handed it to `eval_node`, but `eval_node` re-ranked via `max_by(rank_formats)` — a compact heuristic that sees only height/vbr/fps. When candidates tied, `max_by` returned the LAST element. The pre-sort placed best-first, so worst landed at index `len-1` and won — yielding selections OPPOSITE to user intent.

**Deep fix**: thread `Option<&FormatSorter>` through `eval_node` → `select_spec` → `select_one` → `select_group`. A unified `cmp` closure routes single-best (`max_by`), single-worst (`min_by`), and nth-position (`sort_by`) ALL through the sorter when one is provided — so the yt-dlp 18-key chain (hasvid, ie_pref, lang, quality, res, fps, hdr:12, vcodec, channels, acodec, size, br, asr, proto, ext, hasaud, source, id) drives every selection decision. Orchestrator default routes through this path now.

### 2. Codec-aware container picker (commit `5128688`)

Ports yt-dlp's `get_compatible_ext` (yt_dlp/utils/_utils.py) into `MergeStage::determine_output_format`. VP9 video + AAC audio (both `.mp4`/`.m4a` ext-compatible but codec-incompatible) now routes to MKV instead of producing VP9-in-MP4 that some players reject. Codec strings sanitized per yt-dlp's `try_get(getter=lambda x: x[0].split('.')[0].replace('0','').lower())`. 5 new tests cover the codec matrix (h264/aac→mp4, hevc/aac→mp4, vp9/opus→webm, av1/opus→webm, vp9/aac→mkv).

### 3. HLS bv*+ba* e2e test (commit `232fa39`)

237 LOC mirroring `orchestrator/tests/dash_e2e.rs` but for HLS: 3-format InfoDict (1080p video-only, 720p video-only, audio-only rendition) → `select_format` with explicit `bv*+ba` → assert `DownloadPlan::Merge { video=v1080, audio=audio_en }` → `download_merge_pair` fetches both → 720p variant endpoints \`expect(0)\` (never touched). Closes the acceptance criterion: "E2E test: HLS site with separate audio renditions auto-pairs without Expert mode".

## Plus: `AvPacketOwned` extracted (commit `4200fd2`)

Drive-by improvement: the RAII wrapper for FFmpeg's heap-allocated AVPacket was inline at the top of `mkv_raw_ffi.rs` (572 lines). Extracted into a sibling `av_packet_owned.rs` (79 LOC) so the type is discoverable by name and reusable across both merge paths. `mkv_raw_ffi.rs` shrinks to 517 lines.

## Out of scope (followed up separately if needed)

- **GStreamer dep**: DROPPED per researcher report. \`gstreamer-rs\` requires mandatory system libs, no static link option, Homebrew broken on macOS — violates rdlp's library-first / single-binary constraint. The original memory note reserving GStreamer for "live stream inspection" remains valid for a future \`rdlp-streams\` crate, NOT #241.
- **\`download_merge_pair\` sequential vs parallel**: deliberate UX choice (progress bar interleave prevention). Not changing.
- **Per-stream merge resume**: if audio fails, video re-downloads. Filed as a follow-up consideration; low-priority efficiency item.

## Verification

- \`cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --no-fail-fast && bash scripts/check-dedup.sh\`: all ✅.
- 82 test suites pass, 0 failures.
- The previously-failing `test_select_format_automatic_mode` (which exposed the bug fixed in commit 1) now correctly picks 1080p via size-tiebreaker.

## Commits

| | |
|---|---|
| \`4250000\` | sorter threading (part 1/3) |
| \`5128688\` | codec-aware container (part 2/3) |
| \`4200fd2\` | AvPacketOwned extract |
| \`232fa39\` | HLS e2e (part 3/3) |