### PR TITLE
fix(postprocess): guard zero-denominator tb + force 8-bit AVS2 recode

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_pipeline.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_pipeline.rs
@@ -56,6 +56,63 @@ impl FFmpegRunner {
         }
     }
 
+    /// Enforce a decodable pixel format for codecs whose decoder can't read
+    /// back everything the encoder can write.
+    ///
+    /// libxavs2 (AVS2) can be driven at 10-bit, but **libdavs2 cannot decode
+    /// 10-bit AVS2** (`Un-supported bit-depth 10`) — rdlp must never emit an
+    /// AVS2 file it can't read back. The `libxavs2` wrapper also declares
+    /// only `AV_PIX_FMT_YUV420P` (8-bit), so `pick_video_pixel_format` already
+    /// returns 8-bit today; this makes the invariant explicit and regression-
+    /// proof against a future pixel-format-selection change. Non-AVS2 codecs
+    /// (e.g. libvvenc's 10-bit `yuv420p10`) pass through unchanged. (issue #332)
+    pub(super) fn enforce_decodable_pixfmt(
+        codec_name: &str,
+        picked: ffmpeg_the_third::format::Pixel,
+    ) -> ffmpeg_the_third::format::Pixel {
+        if codec_name == "libxavs2" {
+            ffmpeg_the_third::format::Pixel::YUV420P
+        } else {
+            picked
+        }
+    }
+
+    /// Rescale a frame pts from `src` to `dst` `time_base`.
+    ///
+    /// Errors on a zero-denominator `time_base` instead of letting `av_rescale_q`
+    /// return its `INT64_MIN` (`AV_NOPTS_VALUE`) sentinel, which would otherwise
+    /// be fed to the encoder and surface as a confusing muxer error downstream.
+    /// A zero-denominator tb only arises from a degenerate/corrupt container
+    /// reaching the `video_ist_time_base` fallback. (issue #331)
+    pub(super) fn rescale_frame_pts(
+        pts: i64,
+        src: ffmpeg_the_third::Rational,
+        dst: ffmpeg_the_third::Rational,
+    ) -> Result<i64> {
+        if src.denominator() == 0 || dst.denominator() == 0 {
+            return Err(PostProcessError::ffmpeg_failed(format!(
+                "cannot rescale frame pts: zero-denominator time_base \
+                 (src={}/{}, dst={}/{})",
+                src.numerator(),
+                src.denominator(),
+                dst.numerator(),
+                dst.denominator(),
+            )));
+        }
+        let src_q = ffmpeg_the_third::ffi::AVRational {
+            num: src.numerator(),
+            den: src.denominator(),
+        };
+        let dst_q = ffmpeg_the_third::ffi::AVRational {
+            num: dst.numerator(),
+            den: dst.denominator(),
+        };
+        // SAFETY: av_rescale_q is a pure arithmetic helper over plain values
+        // (no pointers/aliasing). Denominators are verified non-zero above, so
+        // it cannot return the INT64_MIN zero-denominator sentinel.
+        Ok(unsafe { ffmpeg_the_third::ffi::av_rescale_q(pts, src_q, dst_q) })
+    }
+
     /// Build a video filter graph for pixel format conversion.
     ///
     /// Uses `buffer` -> `format` -> `buffersink` to convert pixel format
@@ -179,21 +236,11 @@ impl FFmpegRunner {
             // through `pts` land in different scales → `pts < dts` at the muxer.
             // See the time_base rationale in `video_transcode_phases` Phase 2.
             if let Some(pts) = filtered.pts() {
-                let src = ffmpeg_the_third::ffi::AVRational {
-                    num: filter_time_base.numerator(),
-                    den: filter_time_base.denominator(),
-                };
-                let dst = ffmpeg_the_third::ffi::AVRational {
-                    num: enc_time_base.numerator(),
-                    den: enc_time_base.denominator(),
-                };
-                // SAFETY: av_rescale_q is a pure arithmetic helper over plain
-                // values (no pointers/aliasing). On a degenerate zero-denominator
-                // tb it returns INT64_MIN (AV_NOPTS_VALUE) rather than dividing by
-                // zero; that sentinel then surfaces as a muxer error downstream,
-                // not UB. `enc_time_base` is 1/fps or a validated stream tb here.
-                let new_pts = unsafe { ffmpeg_the_third::ffi::av_rescale_q(pts, src, dst) };
-                filtered.set_pts(Some(new_pts));
+                filtered.set_pts(Some(Self::rescale_frame_pts(
+                    pts,
+                    filter_time_base,
+                    enc_time_base,
+                )?));
             }
 
             encoder.send_frame(&filtered)?;
@@ -268,5 +315,76 @@ impl FFmpegRunner {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FFmpegRunner;
+    use ffmpeg_the_third::Rational;
+    use ffmpeg_the_third::format::Pixel;
+
+    // --- enforce_decodable_pixfmt (issue #332) ---
+
+    #[test]
+    fn avs2_forces_8bit_yuv420p_from_10bit_source() {
+        // libdavs2 can't decode 10-bit AVS2 → a 10-bit pick must be forced to 8-bit.
+        assert_eq!(
+            FFmpegRunner::enforce_decodable_pixfmt("libxavs2", Pixel::YUV420P10),
+            Pixel::YUV420P
+        );
+    }
+
+    #[test]
+    fn avs2_8bit_pick_passes_through_as_yuv420p() {
+        assert_eq!(
+            FFmpegRunner::enforce_decodable_pixfmt("libxavs2", Pixel::YUV420P),
+            Pixel::YUV420P
+        );
+    }
+
+    #[test]
+    fn non_avs2_codecs_keep_their_pixfmt() {
+        // libvvenc legitimately encodes 10-bit; must NOT be forced to 8-bit.
+        assert_eq!(
+            FFmpegRunner::enforce_decodable_pixfmt("libvvenc", Pixel::YUV420P10),
+            Pixel::YUV420P10
+        );
+        // unrelated codec / format is untouched.
+        assert_eq!(
+            FFmpegRunner::enforce_decodable_pixfmt("libx264", Pixel::NV12),
+            Pixel::NV12
+        );
+    }
+
+    // --- rescale_frame_pts (issue #331) ---
+
+    #[test]
+    fn rescale_pts_converts_between_timebases() {
+        // 1536 ticks @ 1/12800 = 0.12s; in 1/25 tb that is frame 3.
+        assert_eq!(
+            FFmpegRunner::rescale_frame_pts(1536, Rational(1, 12800), Rational(1, 25)).unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn rescale_pts_identity_timebase_is_unchanged() {
+        assert_eq!(
+            FFmpegRunner::rescale_frame_pts(512, Rational(1, 12800), Rational(1, 12800)).unwrap(),
+            512
+        );
+    }
+
+    #[test]
+    fn rescale_pts_errors_on_zero_denominator_source() {
+        // Without the guard, av_rescale_q would return INT64_MIN (AV_NOPTS_VALUE)
+        // and feed it to the encoder. The guard must surface an error instead.
+        assert!(FFmpegRunner::rescale_frame_pts(100, Rational(1, 0), Rational(1, 25)).is_err());
+    }
+
+    #[test]
+    fn rescale_pts_errors_on_zero_denominator_target() {
+        assert!(FFmpegRunner::rescale_frame_pts(100, Rational(1, 25), Rational(1, 0)).is_err());
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -192,8 +192,11 @@ impl FFmpegRunner {
         video_encoder.set_width(video_decoder.width());
         video_encoder.set_height(video_decoder.height());
 
-        let target_pix_fmt =
+        let picked_pix_fmt =
             Self::pick_video_pixel_format(&video_enc_codec, video_decoder.format());
+        // Force a decoder-readable pixel format (e.g. 8-bit for AVS2, which
+        // libdavs2 can't decode at 10-bit). See `enforce_decodable_pixfmt`.
+        let target_pix_fmt = Self::enforce_decodable_pixfmt(video_codec_name, picked_pix_fmt);
         video_encoder.set_format(target_pix_fmt);
 
         // Propagate color/signal metadata decoder -> encoder so recode preserves the


### PR DESCRIPTION
Two recode-robustness follow-ups from #330, each behind a pure, unit-tested helper in `video_pipeline.rs`.

Closes #331
Closes #332

## #331 — `rescale_frame_pts`
The frame-pts rescale now returns a typed error when either `time_base` has a zero denominator, instead of letting `av_rescale_q` return its `INT64_MIN`/`AV_NOPTS_VALUE` sentinel and feeding it to the encoder (which surfaced later as a confusing muxer error). Only reachable via a degenerate/corrupt container hitting the stream-tb fallback. The `unsafe { av_rescale_q }` block is now strictly safer than the inline version it replaces (denominators verified non-zero first).

## #332 — `enforce_decodable_pixfmt`
AVS2 output is forced to 8-bit `yuv420p`. libxavs2 can be driven at 10-bit, but **libdavs2 cannot decode 10-bit AVS2** (`Un-supported bit-depth 10`) — rdlp must never emit an AVS2 file it can't read back. The wrapper already declares only `yuv420p`, so this makes the invariant explicit and regression-proof (e.g. against `pick_video_pixel_format`'s null-`pix_fmts` fallback returning a 10-bit preferred format). Non-AVS2 codecs (incl. libvvenc 10-bit) pass through unchanged.

## Tests (8 new unit tests in `video_pipeline::tests`)
- rescale: positive, identity, and **both** zero-denominator error paths (genuine regression guards — the pre-fix inline code had no `Result` and could never return `Err`).
- pixfmt: AVS2 10-bit→8-bit force, AVS2 8-bit passthrough, non-AVS2 (libvvenc 10-bit / libx264) passthrough.
- `recode_new_codecs` integration test still green (EVC/VVC/AVS2 unaffected).

## Verification
Full gate PASSED: `fmt --check` + `check` + `clippy --all-targets -D warnings` + `test` + `check -p rdlp-desktop` + `check-dedup.sh`.

## Reviews
- **security-reviewer**: Approve. One LOW (a non-physical `0/N` numerator time_base isn't guarded → would rescale to 0; unreachable from real containers, no crash/UB) + an informational note on the `"libxavs2"` string match. Both deferred.
- **code-reviewer**: Approve. Math/wiring/guards confirmed; negative tests are genuine regression guards; no VVC/EVC/x264/x265 regression.