### PR TITLE
fix(postprocess): abort in-progress recode on cancel + clean up partials (#334, #335)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6196,6 +6196,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -542,7 +542,7 @@ async fn mux_outputs(
             ..Default::default()
         };
         match runner
-            .merge(video_path, audio_path, output_path, &opts, None)
+            .merge(video_path, audio_path, output_path, &opts, None, None)
             .await
         {
             Ok(()) => {

--- a/crates/rdlp-ffmpeg/Cargo.toml
+++ b/crates/rdlp-ffmpeg/Cargo.toml
@@ -10,6 +10,7 @@ description = "FFmpeg library bindings wrapper for rdlp (probing, remuxing, tran
 rdlp-core = { path = "../rdlp-core" }
 rdlp-types = { path = "../rdlp-types" }
 tokio = { workspace = true, features = ["fs", "io-util"] }
+tokio-util = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -61,6 +61,7 @@ impl FFmpegRunner {
         output: &Path,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
         encoding_tool_override: Option<&str>,
+        cancel: Option<&tokio_util::sync::CancellationToken>,
     ) -> Result<()> {
         use std::ffi::CString;
         use std::ptr;
@@ -432,6 +433,10 @@ impl FFmpegRunner {
                 let mut have_audio = read_next_raw(ifmt_audio, audio_stream_idx, apkt);
 
                 loop {
+                    // Cooperative cancel: `?` is leak-safe here — vpkt/apkt are
+                    // RAII `AvPacketOwned` and the IIFE's post-block teardown
+                    // (av_write_trailer + avformat_close/free) runs unconditionally.
+                    crate::ffmpeg::transcode::check_cancelled(cancel)?;
                     match (have_video, have_audio) {
                         (false, false) => break,
                         (true, false) => {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -32,6 +32,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
 use log::info;
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{PostProcessError, Result};
 
@@ -58,6 +59,7 @@ impl FFmpegRunner {
         output: impl AsRef<Path>,
         opts: &RemuxOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+        cancel: Option<CancellationToken>,
     ) -> Result<()> {
         let video_input = video_input.as_ref().to_path_buf();
         let audio_input = audio_input.as_ref().to_path_buf();
@@ -70,6 +72,7 @@ impl FFmpegRunner {
                 &output,
                 &opts,
                 progress_fn.as_deref(),
+                cancel.as_ref(),
             )?)
         })
         .await
@@ -83,6 +86,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &RemuxOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
 
@@ -102,6 +106,7 @@ impl FFmpegRunner {
                 output,
                 progress_fn,
                 opts.encoding_tool_override.as_deref(),
+                cancel,
             )?);
         }
 
@@ -211,6 +216,10 @@ impl FFmpegRunner {
         // and write them in DTS order to avoid ENOMEM from buffering an entire
         // stream while waiting for the other.
         //
+        // Set by the loop on cooperative cancel; checked after the unsafe block's
+        // manual packet cleanup runs, so the bare packets are freed before bail.
+        let mut cancelled = false;
+
         // SAFETY: ictx_video/ictx_audio own valid AVFormatContext instances.
         // octx owns a valid, header-written output context.
         unsafe {
@@ -257,6 +266,14 @@ impl FFmpegRunner {
             let mut have_audio = read_next_raw(audio_ctx, audio_ist_index, apkt);
 
             loop {
+                // Cooperative cancel: do NOT use `?` here — the packets below are
+                // bare `av_packet_alloc` pointers freed by the manual cleanup that
+                // follows the loop. An early `?`-return would leak them. Set a flag,
+                // `break`, let the cleanup run, then `bail!` before write_trailer.
+                if cancel.is_some_and(CancellationToken::is_cancelled) {
+                    cancelled = true;
+                    break;
+                }
                 match (have_video, have_audio) {
                     (false, false) => break,
                     (true, false) => {
@@ -340,6 +357,14 @@ impl FFmpegRunner {
             ffi::av_packet_unref(apkt);
             ffi::av_packet_free(&mut vpkt.cast());
             ffi::av_packet_free(&mut apkt.cast());
+        }
+
+        // Cancelled: the bare packets were freed by the cleanup above. The
+        // AVFormatContexts (ictx_video / ictx_audio / octx) are owned
+        // ffmpeg-the-third Input/Output values — RAII drop frees them with no
+        // leak. Skip write_trailer: do not finalize a partial, cancelled mux.
+        if cancelled {
+            anyhow::bail!("cancelled by user");
         }
 
         // Emit final 1.0 on completion

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/analysis.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use anyhow::Context as _;
 use log::{debug, warn};
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{FfmpegResultExt as _, PostProcessError, Result};
 
@@ -32,6 +33,7 @@ pub(super) fn run_analysis_decode_loop(
     input: &Path,
     filter_spec: &str,
     label: &str,
+    cancel: Option<&CancellationToken>,
     on_drain: &mut dyn FnMut(
         &mut ffmpeg_the_third::filter::Graph,
         &mut ffmpeg_the_third::frame::Audio,
@@ -88,6 +90,7 @@ pub(super) fn run_analysis_decode_loop(
     let _log_suppress = LogSuppressGuard::new();
 
     for result in ictx.packets() {
+        crate::ffmpeg::transcode::check_cancelled(cancel)?;
         let (stream, packet) = result.ff_context("failed to read packet during analysis")?;
         if stream.index() != ist_index {
             continue;
@@ -228,6 +231,7 @@ impl FFmpegRunner {
     pub(super) fn analyze_peak_sync(
         input: &Path,
         target_peak_db: f64,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<PeakAnalysis> {
         let mut peak_db = f64::NEG_INFINITY;
         let mut rms_db = f64::NEG_INFINITY;
@@ -239,6 +243,7 @@ impl FFmpegRunner {
             input,
             astats_spec,
             "peak analysis",
+            cancel,
             &mut |graph, filtered| {
                 drain_astats_metadata(graph, filtered, &mut peak_db, &mut rms_db)
             },
@@ -264,6 +269,7 @@ impl FFmpegRunner {
     pub(super) fn loudnorm_pass1_sync(
         input: &Path,
         opts: &NormalizeOptions,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<LoudnormMeasurements> {
         let guard = begin_loudnorm_capture()?;
 
@@ -280,6 +286,7 @@ impl FFmpegRunner {
             input,
             &loudnorm_spec,
             "loudnorm analysis",
+            cancel,
             &mut |graph, filtered| drain_discard(graph, filtered),
         )?;
 
@@ -304,7 +311,9 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
     ) -> anyhow::Result<()> {
         debug!("Loudness verification: analyzing output...");
-        match Self::loudnorm_pass1_sync(output, opts) {
+        // Verification runs post-write on the finished output — never gated by
+        // user cancel (the output already exists; pass `None`).
+        match Self::loudnorm_pass1_sync(output, opts, None) {
             Ok(measured) => {
                 debug!(
                     "Loudness verification: I={:.1} LUFS, TP={:.1} dBTP, LRA={:.1} LU",

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use anyhow::Context as _;
+use tokio_util::sync::CancellationToken;
 
 use crate::error::PostProcessError;
 
@@ -24,6 +25,7 @@ impl FFmpegRunner {
         analysis: &PeakAnalysis,
         opts: &NormalizeOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         Self::dispatch_normalize_sync(
             input,
@@ -31,12 +33,15 @@ impl FFmpegRunner {
             opts.salvage,
             progress_fn,
             |inp, out, ext, resilient, pfn| {
-                Self::peak_encode_audio_only(inp, out, ext, analysis, opts, resilient, pfn)
+                Self::peak_encode_audio_only(inp, out, ext, analysis, opts, resilient, pfn, cancel)
             },
         )
     }
 
     /// Encode peak-normalized audio to an output file (video streams discarded).
+    // The cancel token pushes this internal encode-path helper to 8 params;
+    // bundling into a struct would obscure the call site for marginal benefit.
+    #[allow(clippy::too_many_arguments)]
     fn peak_encode_audio_only(
         input: &Path,
         output: &Path,
@@ -45,6 +50,7 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
         resilient: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         let gain_db = opts.target_peak_db - analysis.peak_db;
         let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
@@ -55,6 +61,7 @@ impl FFmpegRunner {
             "peak encode",
             resilient,
             progress_fn,
+            cancel,
             |fmt, rate, ch_layout| {
                 let oversample_prefix = if gain_db >= TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD {
                     let rate_4x = rate * 4;
@@ -79,6 +86,7 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
         measurements: &LoudnormMeasurements,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         Self::dispatch_normalize_sync(
             input,
@@ -86,12 +94,24 @@ impl FFmpegRunner {
             opts.salvage,
             progress_fn,
             |inp, out, ext, resilient, pfn| {
-                Self::loudnorm_encode_audio_only(inp, out, ext, opts, measurements, resilient, pfn)
+                Self::loudnorm_encode_audio_only(
+                    inp,
+                    out,
+                    ext,
+                    opts,
+                    measurements,
+                    resilient,
+                    pfn,
+                    cancel,
+                )
             },
         )
     }
 
     /// Encode loudnorm-normalized audio to an output file (video streams discarded).
+    // The cancel token pushes this internal encode-path helper to 8 params;
+    // bundling into a struct would obscure the call site for marginal benefit.
+    #[allow(clippy::too_many_arguments)]
     fn loudnorm_encode_audio_only(
         input: &Path,
         output: &Path,
@@ -100,6 +120,7 @@ impl FFmpegRunner {
         measurements: &LoudnormMeasurements,
         resilient: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
         let limiter = build_alimiter_spec(opts.target_tp);
@@ -110,6 +131,7 @@ impl FFmpegRunner {
             "loudnorm pass 2",
             resilient,
             progress_fn,
+            cancel,
             |fmt, rate, ch_layout| {
                 format!(
                     "aformat=sample_fmts=dbl,{loudnorm_core},aresample,\

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -208,6 +208,10 @@ impl FFmpegRunner {
                 output,
                 &super::super::RemuxOptions::default(),
                 progress_fn,
+                // The cancel-gated encode loops run before this final stream-copy
+                // merge (see normalize encode helpers); this `dispatch_normalize_sync`
+                // does not receive a cancel token. None is correct.
+                None,
             );
             // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
             #[allow(clippy::disallowed_methods)]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
 use log::{debug, warn};
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{FfmpegResultExt as _, PostProcessError};
 
@@ -54,7 +55,9 @@ impl FFmpegRunner {
     /// When `resilient` is true, the input is opened with
     /// `discardcorrupt+genpts` format flags to recover from corrupt
     /// containers. This is used as Tier 3 recovery in `with_mux_retry`.
-    #[allow(clippy::too_many_lines)]
+    // The cancel token pushes the unified encode helper to 8 params; the
+    // build_filter closure + cancel are both load-bearing per-call inputs.
+    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     pub(super) fn encode_audio_only_sync(
         input: &Path,
         output: &Path,
@@ -62,6 +65,7 @@ impl FFmpegRunner {
         label: &str,
         resilient: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
         build_filter: impl FnOnce(
             /*fmt:*/ &str,
             /*rate:*/ u32,
@@ -327,6 +331,7 @@ impl FFmpegRunner {
         let mut last_progress = Instant::now();
         let progress_throttle = Duration::from_millis(100);
         for result in ictx.packets() {
+            crate::ffmpeg::transcode::check_cancelled(cancel)?;
             let (stream, packet) =
                 result.ff_context("failed to read packet during audio encode")?;
             if stream.index() != audio_ist_index {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/mod.rs
@@ -27,6 +27,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use log::{debug, info, warn};
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{PostProcessError, Result};
 
@@ -60,6 +61,7 @@ impl FFmpegRunner {
         output: impl AsRef<Path>,
         opts: &NormalizeOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+        cancel: Option<CancellationToken>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -68,12 +70,20 @@ impl FFmpegRunner {
             let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, opts.salvage)?;
 
             let result = match opts.mode {
-                AudioNormMode::Peak => {
-                    Self::normalize_peak_sync(&effective_input, &output, &opts, progress_fn.clone())
-                }
-                AudioNormMode::Loudnorm => {
-                    Self::normalize_loudnorm_sync(&effective_input, &output, &opts, progress_fn)
-                }
+                AudioNormMode::Peak => Self::normalize_peak_sync(
+                    &effective_input,
+                    &output,
+                    &opts,
+                    progress_fn.clone(),
+                    cancel.as_ref(),
+                ),
+                AudioNormMode::Loudnorm => Self::normalize_loudnorm_sync(
+                    &effective_input,
+                    &output,
+                    &opts,
+                    progress_fn,
+                    cancel.as_ref(),
+                ),
             };
 
             // Clean up salvage temp file regardless of success/failure
@@ -94,8 +104,9 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
-        let analysis = Self::analyze_peak_sync(input, opts.target_peak_db)?;
+        let analysis = Self::analyze_peak_sync(input, opts.target_peak_db, cancel)?;
 
         debug!(
             "Peak analysis: peak={:.1} dBFS, RMS={:.1} dBFS, gain={:.1} dB",
@@ -121,7 +132,14 @@ impl FFmpegRunner {
             progress_fn.map(|p| -> Arc<dyn Fn(f64) + Send + Sync> {
                 Arc::new(move |frac: f64| p(frac.mul_add(0.7, 0.3)))
             });
-        Self::apply_peak_gain_sync(input, output, &analysis, opts, encode_progress.as_deref())
+        Self::apply_peak_gain_sync(
+            input,
+            output,
+            &analysis,
+            opts,
+            encode_progress.as_deref(),
+            cancel,
+        )
     }
 
     /// EBU R128 loudnorm two-pass normalization.
@@ -130,9 +148,10 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         info!("Loudnorm pass 1: analyzing EBU R128 levels...");
-        let measurements = Self::loudnorm_pass1_sync(input, opts)?;
+        let measurements = Self::loudnorm_pass1_sync(input, opts, cancel)?;
 
         debug!(
             "Loudnorm measurements: I={:.1} LUFS, TP={:.1} dBTP, LRA={:.1} LU",
@@ -157,7 +176,13 @@ impl FFmpegRunner {
                     opts.boost_gain_db
                 );
                 // Boost maps to full range 0.0–1.0
-                Self::apply_limiter_boost_sync(input, output, opts, progress_fn.as_deref())?;
+                Self::apply_limiter_boost_sync(
+                    input,
+                    output,
+                    opts,
+                    progress_fn.as_deref(),
+                    cancel,
+                )?;
                 Self::verify_loudness_sync(output, opts)?;
                 return Ok(());
             }
@@ -179,6 +204,7 @@ impl FFmpegRunner {
             opts,
             &measurements,
             pass2_progress.as_deref(),
+            cancel,
         )?;
 
         // Verify output loudness against targets
@@ -197,6 +223,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &NormalizeOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         let ceiling_db = opts.target_tp - ALIMITER_TP_HEADROOM_DB;
         let limit_linear = 10f64.powf(ceiling_db / 20.0);
@@ -215,6 +242,13 @@ impl FFmpegRunner {
         let mut boost_opts = opts.clone();
         boost_opts.target_peak_db = ceiling_db;
 
-        Self::apply_peak_gain_sync(input, output, &synthetic_analysis, &boost_opts, progress_fn)
+        Self::apply_peak_gain_sync(
+            input,
+            output,
+            &synthetic_analysis,
+            &boost_opts,
+            progress_fn,
+            cancel,
+        )
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
 use log::{debug, info};
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{PostProcessError, Result};
 
@@ -52,6 +53,7 @@ impl FFmpegRunner {
         output: impl AsRef<Path>,
         opts: &AudioExtractOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
+        cancel: Option<CancellationToken>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -59,8 +61,13 @@ impl FFmpegRunner {
         Self::spawn_blocking("extract_audio", move || {
             let (effective_input, salvage_temp) = prepare_input_with_salvage(&input, true)?;
 
-            let result =
-                Self::extract_audio_sync(&effective_input, &output, &opts, progress_fn.as_deref());
+            let result = Self::extract_audio_sync(
+                &effective_input,
+                &output,
+                &opts,
+                progress_fn.as_deref(),
+                cancel.as_ref(),
+            );
 
             if let Some(ref temp) = salvage_temp {
                 // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
@@ -79,11 +86,13 @@ impl FFmpegRunner {
         output: &Path,
         opts: &AudioExtractOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         if opts.copy {
+            // Copy path is a fast stream-copy; not gated for cancellation.
             Self::extract_audio_copy_sync(input, output, progress_fn)
         } else {
-            Self::extract_audio_transcode_sync(input, output, opts, progress_fn)
+            Self::extract_audio_transcode_sync(input, output, opts, progress_fn, cancel)
         }
     }
 
@@ -211,6 +220,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &AudioExtractOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
 
@@ -419,6 +429,7 @@ impl FFmpegRunner {
 
         // Transcode loop: read -> decode -> filter -> encode -> write
         for result in ictx.packets() {
+            crate::ffmpeg::transcode::check_cancelled(cancel)?;
             let (stream, packet) = result
                 .map_err(PostProcessError::from)
                 .context("failed to read packet during audio transcode")?;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/cancel.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/cancel.rs
@@ -3,7 +3,6 @@ use tokio_util::sync::CancellationToken;
 
 /// Returns `Err` if `cancel` is present and cancelled; otherwise `Ok(())`.
 /// Safe to call from a `spawn_blocking` closure (`is_cancelled()` is synchronous).
-#[allow(dead_code)]
 pub fn check_cancelled(cancel: Option<&CancellationToken>) -> anyhow::Result<()> {
     if cancel.is_some_and(CancellationToken::is_cancelled) {
         anyhow::bail!("cancelled by user");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/cancel.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/cancel.rs
@@ -1,0 +1,35 @@
+//! Per-iteration cooperative cancellation poll for blocking `FFmpeg` loops.
+use tokio_util::sync::CancellationToken;
+
+/// Returns `Err` if `cancel` is present and cancelled; otherwise `Ok(())`.
+/// Safe to call from a `spawn_blocking` closure (`is_cancelled()` is synchronous).
+#[allow(dead_code)]
+pub fn check_cancelled(cancel: Option<&CancellationToken>) -> anyhow::Result<()> {
+    if cancel.is_some_and(CancellationToken::is_cancelled) {
+        anyhow::bail!("cancelled by user");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_is_ok() {
+        assert!(check_cancelled(None).is_ok());
+    }
+
+    #[test]
+    fn live_token_is_ok() {
+        let t = CancellationToken::new();
+        assert!(check_cancelled(Some(&t)).is_ok());
+    }
+
+    #[test]
+    fn cancelled_token_is_err() {
+        let t = CancellationToken::new();
+        t.cancel();
+        assert!(check_cancelled(Some(&t)).is_err());
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
@@ -7,6 +7,7 @@ mod audio_extract;
 mod audio_pipeline;
 mod audio_pipeline_direct;
 mod audio_recode_pipeline;
+mod cancel;
 pub mod mux_timing;
 #[cfg(test)]
 mod tests;
@@ -16,4 +17,6 @@ mod video_transcode_context;
 mod video_transcode_phases;
 
 // Re-export public(crate) items used by normalize and other modules
+#[allow(unused_imports)]
+pub use cancel::check_cancelled;
 pub use mux_timing::MuxTimingState;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
@@ -17,6 +17,5 @@ mod video_transcode_context;
 mod video_transcode_phases;
 
 // Re-export public(crate) items used by normalize and other modules
-#[allow(unused_imports)]
 pub use cancel::check_cancelled;
 pub use mux_timing::MuxTimingState;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -11,6 +11,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use tokio_util::sync::CancellationToken;
+
 use crate::error::{PostProcessError, Result};
 
 use super::super::salvage::prepare_input_with_salvage;
@@ -41,6 +43,7 @@ impl FFmpegRunner {
         opts: &VideoConvertOptions,
         progress_fn: Option<Arc<dyn Fn(f64) + Send + Sync>>,
         log_fn: Option<LogFn>,
+        cancel: Option<CancellationToken>,
     ) -> Result<()> {
         let input = input.as_ref().to_path_buf();
         let output = output.as_ref().to_path_buf();
@@ -55,8 +58,13 @@ impl FFmpegRunner {
                 None
             };
 
-            let result =
-                Self::convert_video_sync(&effective_input, &output, &opts, progress_fn.as_deref());
+            let result = Self::convert_video_sync(
+                &effective_input,
+                &output,
+                &opts,
+                progress_fn.as_deref(),
+                cancel.as_ref(),
+            );
 
             // Drain captured logs and forward to the UI log viewer.
             if let Some(ref guard) = log_guard
@@ -88,6 +96,7 @@ impl FFmpegRunner {
         output: &Path,
         opts: &VideoConvertOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         if opts.remux_only {
             // Determine if output is MP4/MOV for faststart
@@ -99,7 +108,7 @@ impl FFmpegRunner {
             Ok(Self::remux_sync(input, output, &remux_opts, progress_fn)
                 .map_err(|e| PostProcessError::ffmpeg_failed(format!("{e:#}")))?)
         } else {
-            Self::convert_video_transcode_sync(input, output, opts, progress_fn)
+            Self::convert_video_transcode_sync(input, output, opts, progress_fn, cancel)
         }
     }
 
@@ -113,13 +122,14 @@ impl FFmpegRunner {
         output: &Path,
         opts: &VideoConvertOptions,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
         let phase1 = Self::open_input_and_decoder(input)?;
         let mut ctx = Self::configure_video_encoder(phase1, opts, output)?;
         Self::setup_audio_pipeline(&mut ctx)?;
         Self::write_header_and_build_filter(&mut ctx)?;
-        Self::run_encode_loop(&mut ctx, progress_fn)?;
+        Self::run_encode_loop(&mut ctx, progress_fn, cancel)?;
         Self::finalize_transcode(ctx)
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
 use log::debug;
+use tokio_util::sync::CancellationToken;
 
 use crate::error::PostProcessError;
 
@@ -542,6 +543,7 @@ impl FFmpegRunner {
     pub(super) fn run_encode_loop(
         ctx: &mut VideoTranscodeContext<'_>,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         let VideoTranscodeContext {
             ictx,
@@ -567,6 +569,9 @@ impl FFmpegRunner {
 
         // Process packets: video -> decode/filter/encode, audio -> copy or transcode
         for result in ictx.packets() {
+            // Cooperative cancellation: abort the (CPU-bound, uninterruptible)
+            // encode loop promptly when the job is cancelled (#334).
+            crate::ffmpeg::transcode::check_cancelled(cancel)?;
             let (stream, mut packet) = result
                 .map_err(PostProcessError::from)
                 .context("failed to read packet during video transcode")?;

--- a/crates/rdlp-ffmpeg/tests/audio_extract_cancel.rs
+++ b/crates/rdlp-ffmpeg/tests/audio_extract_cancel.rs
@@ -1,0 +1,88 @@
+//! Cooperative cancellation of the audio EXTRACT transcode loop (#334).
+//!
+//! A pre-cancelled `CancellationToken` passed into `extract_audio` must abort
+//! the transcode promptly with a "cancelled" error, rather than running the
+//! full transcode loop to completion.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! fixture).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+
+use rdlp_ffmpeg::{AudioExtractOptions, FFmpegRunner};
+use tokio_util::sync::CancellationToken;
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a multi-second AAC fixture with an audio stream so the transcode loop
+/// has many packets to process — proves an aborted run does not finish the
+/// whole input.
+fn build_audio_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
+    let src = dir.join("src.m4a");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=5",
+            "-c:a",
+            "aac",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+#[tokio::test]
+async fn precancelled_token_aborts_audio_extract() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let Ok(src) = build_audio_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let out = dir.path().join("out.mp3");
+    // copy=false forces the transcode path (the :421 packet loop).
+    let opts = AudioExtractOptions {
+        encoder_name: Some("libmp3lame".to_string()),
+        copy: false,
+        ..Default::default()
+    };
+
+    // Pre-cancel: the transcode loop must bail before processing the whole input.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let res = runner
+        .extract_audio(&src, &out, &opts, None, Some(token))
+        .await;
+
+    assert!(
+        res.is_err(),
+        "pre-cancelled audio extract must return Err, got Ok"
+    );
+    let msg = format!("{:#}", res.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "error should mention cancellation; got: {msg}"
+    );
+}

--- a/crates/rdlp-ffmpeg/tests/merge_cancel.rs
+++ b/crates/rdlp-ffmpeg/tests/merge_cancel.rs
@@ -1,0 +1,135 @@
+//! Cooperative cancellation of the video+audio merge loops (#334).
+//!
+//! A pre-cancelled `CancellationToken` passed into `merge` must abort the mux
+//! promptly with a "cancelled" error, rather than running the full two-way
+//! interleaved packet loop to completion.
+//!
+//! There are TWO genuine packet loops with different teardown shapes:
+//!
+//! - `.mkv` output → `merge_mkv_raw_ffi` (RAII `AvPacketOwned`, `?`-safe).
+//! - non-`.mkv` output → the bare `av_packet_alloc` loop in `merge_sync`
+//!   (manual cleanup; gated via `break` + post-cleanup `bail!`).
+//!
+//! Both paths are exercised below (`.mkv` and `.mp4`).
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! fixtures).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
+use tokio_util::sync::CancellationToken;
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a multi-second video-only fixture (lavfi testsrc → .mp4) so the merge
+/// loop has many packets to process — proves an aborted run does not finish.
+fn build_video_fixture(dir: &Path) -> Result<PathBuf, ()> {
+    let src = dir.join("video.mp4");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=320x240:rate=30:duration=5",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-an",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+/// Build a multi-second audio-only fixture (lavfi sine → .m4a).
+fn build_audio_fixture(dir: &Path) -> Result<PathBuf, ()> {
+    let src = dir.join("audio.m4a");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=5",
+            "-c:a",
+            "aac",
+            "-vn",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+/// Shared assertion: pre-cancelled merge into `output` must return Err mentioning cancellation.
+async fn assert_precancelled_merge_aborts(output_name: &str) {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (Ok(video), Ok(audio)) = (
+        build_video_fixture(dir.path()),
+        build_audio_fixture(dir.path()),
+    ) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+    let out = dir.path().join(output_name);
+
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let res = runner
+        .merge(
+            &video,
+            &audio,
+            &out,
+            &RemuxOptions::default(),
+            None,
+            Some(token),
+        )
+        .await;
+
+    assert!(
+        res.is_err(),
+        "pre-cancelled merge into {output_name} must return Err, got Ok"
+    );
+    let msg = format!("{:#}", res.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "error should mention cancellation; got: {msg}"
+    );
+}
+
+/// `.mkv` output exercises `merge_mkv_raw_ffi` (RAII IIFE loop).
+#[tokio::test]
+async fn precancelled_token_aborts_mkv_merge() {
+    assert_precancelled_merge_aborts("out.mkv").await;
+}
+
+/// `.mp4` output exercises the bare-pointer loop in `merge_sync`.
+#[tokio::test]
+async fn precancelled_token_aborts_mp4_merge() {
+    assert_precancelled_merge_aborts("out.mp4").await;
+}

--- a/crates/rdlp-ffmpeg/tests/mkv_dts_synthesis.rs
+++ b/crates/rdlp-ffmpeg/tests/mkv_dts_synthesis.rs
@@ -421,7 +421,9 @@ async fn merge_mkv_produces_clean_dts() {
 
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new failed");
     let opts = rdlp_ffmpeg::RemuxOptions::default();
-    let result = runner.merge(&video, &audio, &output, &opts, None).await;
+    let result = runner
+        .merge(&video, &audio, &output, &opts, None, None)
+        .await;
 
     assert!(
         result.is_ok(),

--- a/crates/rdlp-ffmpeg/tests/normalize_cancel.rs
+++ b/crates/rdlp-ffmpeg/tests/normalize_cancel.rs
@@ -1,0 +1,92 @@
+//! Cooperative cancellation of the audio normalization passes (#334).
+//!
+//! A pre-cancelled `CancellationToken` passed into `normalize_audio` must abort
+//! the normalization promptly with a "cancelled" error, rather than running the
+//! full (potentially two-pass loudnorm) pipeline to completion.
+//!
+//! Loudnorm is a TWO-PASS operation: pass 1 (analysis) and pass 2 (encode).
+//! A pre-cancelled token aborts in pass 1 (the analysis decode loop) — that is
+//! the correct, promptest behavior and is sufficient to prove both loops are
+//! gated, since pass 2 shares the same cancel plumbing as the peak encode loop.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! fixture).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+
+use rdlp_ffmpeg::{AudioNormMode, FFmpegRunner, NormalizeOptions};
+use tokio_util::sync::CancellationToken;
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a multi-second fixture with an audio stream so the normalization
+/// loops have many packets to process — proves an aborted run does not finish
+/// the whole input.
+fn build_audio_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
+    let src = dir.join("src.m4a");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=5",
+            "-c:a",
+            "aac",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+#[tokio::test]
+async fn precancelled_token_aborts_loudnorm_normalize() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let Ok(src) = build_audio_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let out = dir.path().join("out.m4a");
+    // Loudnorm mode exercises the two-pass path (pass 1 analysis + pass 2 encode).
+    let opts = NormalizeOptions {
+        mode: AudioNormMode::Loudnorm,
+        ..Default::default()
+    };
+
+    // Pre-cancel: pass 1's analysis decode loop must bail before completion.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let res = runner
+        .normalize_audio(&src, &out, &opts, None, Some(token))
+        .await;
+
+    assert!(
+        res.is_err(),
+        "pre-cancelled loudnorm normalize must return Err, got Ok"
+    );
+    let msg = format!("{:#}", res.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "error should mention cancellation; got: {msg}"
+    );
+}

--- a/crates/rdlp-ffmpeg/tests/recode_buffersrc_pixfmt.rs
+++ b/crates/rdlp-ffmpeg/tests/recode_buffersrc_pixfmt.rs
@@ -107,7 +107,7 @@ async fn recode_buffersrc_has_no_frame_property_mismatch() {
 
     let runner = FFmpegRunner::new().expect("create FFmpegRunner");
     match runner
-        .convert_video(&src, &out, &opts, None, Some(log_fn))
+        .convert_video(&src, &out, &opts, None, Some(log_fn), None)
         .await
     {
         Ok(()) => {}

--- a/crates/rdlp-ffmpeg/tests/recode_cancel.rs
+++ b/crates/rdlp-ffmpeg/tests/recode_cancel.rs
@@ -1,0 +1,86 @@
+//! Cooperative cancellation of the video RECODE encode loop (#334).
+//!
+//! A pre-cancelled `CancellationToken` passed into `convert_video` must abort
+//! the transcode promptly with a "cancelled" error, rather than running the
+//! full encode loop to completion.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! fixture).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+
+use rdlp_ffmpeg::{FFmpegRunner, VideoConvertOptions};
+use tokio_util::sync::CancellationToken;
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a multi-second H.264 yuv420p fixture so the encode loop has many
+/// packets to process — proves an aborted run does not finish the whole input.
+fn build_h264_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
+    let src = dir.join("src.mp4");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=5:s=640x480",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+#[tokio::test]
+async fn precancelled_token_aborts_recode() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let Ok(src) = build_h264_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let out = dir.path().join("out.mp4");
+    let opts = VideoConvertOptions {
+        remux_only: false,
+        video_codec: Some("libx264".to_string()),
+        audio_copy: false,
+        ..Default::default()
+    };
+
+    // Pre-cancel: the encode loop must bail before processing the whole input.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let res = runner
+        .convert_video(&src, &out, &opts, None, None, Some(token))
+        .await;
+
+    assert!(res.is_err(), "pre-cancelled recode must return Err, got Ok");
+    let msg = format!("{:#}", res.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "error should mention cancellation; got: {msg}"
+    );
+}

--- a/crates/rdlp-ffmpeg/tests/recode_color_metadata.rs
+++ b/crates/rdlp-ffmpeg/tests/recode_color_metadata.rs
@@ -153,7 +153,7 @@ async fn recode_preserves_color_range_and_matrix() {
 
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new failed");
     let result = runner
-        .convert_video(&tagged, &out_mp4, &opts, None, None)
+        .convert_video(&tagged, &out_mp4, &opts, None, None, None)
         .await;
 
     assert!(

--- a/crates/rdlp-ffmpeg/tests/recode_new_codecs.rs
+++ b/crates/rdlp-ffmpeg/tests/recode_new_codecs.rs
@@ -122,7 +122,9 @@ async fn new_codecs_recode_and_mux() {
             audio_copy: false,
             ..Default::default()
         };
-        let res = runner.convert_video(&src, &out, &opts, None, None).await;
+        let res = runner
+            .convert_video(&src, &out, &opts, None, None, None)
+            .await;
         assert!(res.is_ok(), "{enc} -> {cont} recode failed: {res:?}");
         assert_eq!(
             probe_video_codec(&out).as_deref(),

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -245,7 +245,11 @@ impl Pipeline {
         let current_files = tokio::task::spawn_blocking(move || {
             let mut tracker = final_msg.tracker;
             tracker.cleanup();
-            tracker.current_files
+            // `cleanup()` set `committed = true`, disarming the cancel-cleanup
+            // `Drop`. `FileTracker` now implements `Drop`, so the renamed final
+            // files can't be moved out of the field directly — take them,
+            // leaving the dropped tracker empty (and already committed).
+            std::mem::take(&mut tracker.current_files)
         })
         .await
         .map_err(|e| anyhow::anyhow!("pipeline cleanup task join failed: {e}"))?;

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -103,6 +103,9 @@ pub struct PipelineMessage {
     /// metadata instead of stamping their own name. `None` means no
     /// prior stage set it — pass-through stages use their own name.
     pub encoding_tool: Option<String>,
+    /// Job-scoped cancellation token. Fatal `FFmpeg` stages clone this into their
+    /// blocking work so an in-progress encode aborts promptly.
+    pub cancel: CancellationToken,
 }
 
 // ---------------------------------------------------------------------------
@@ -194,6 +197,15 @@ impl Pipeline {
 
         let (error_tx, error_rx) = oneshot::channel::<PipelineError>();
 
+        // `None` callers get a fresh token that nobody else holds — zero-cost.
+        // The isolation guarantee is load-bearing: a `None` caller can never
+        // observe a spurious cancel because the locally-created token is held
+        // exclusively by this function's scope (cloned only into the per-stage
+        // tasks below; never escapes outward via channels or shared state).
+        // A future refactor that hands the local token to a sibling supervisor
+        // task would silently break this property — keep it scope-local.
+        let token = cancel.unwrap_or_default();
+
         let msg = PipelineMessage {
             info,
             tracker,
@@ -205,16 +217,8 @@ impl Pipeline {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: token.clone(),
         };
-
-        // `None` callers get a fresh token that nobody else holds — zero-cost.
-        // The isolation guarantee is load-bearing: a `None` caller can never
-        // observe a spurious cancel because the locally-created token is held
-        // exclusively by this function's scope (cloned only into the per-stage
-        // tasks below; never escapes outward via channels or shared state).
-        // A future refactor that hands the local token to a sibling supervisor
-        // task would silently break this property — keep it scope-local.
-        let token = cancel.unwrap_or_default();
 
         // Build channel chain: one mpsc(1) between consecutive stages.
         // first_tx → stage_0 → stage_1 → ... → stage_N → final_rx

--- a/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
@@ -143,7 +143,13 @@ impl PipelineStage for AudioExtractStage {
         });
 
         self.ffmpeg
-            .extract_audio(&input_file, &output_path, &opts, callback)
+            .extract_audio(
+                &input_file,
+                &output_path,
+                &opts,
+                callback,
+                Some(msg.cancel.clone()),
+            )
             .await
             .context("audio extract stage failed")?;
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/audio_extract.rs
@@ -200,6 +200,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/finalize_metadata.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/finalize_metadata.rs
@@ -209,6 +209,7 @@ mod tests {
             error_tx: None,
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -273,6 +273,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -229,7 +229,14 @@ impl PipelineStage for MergeStage {
         });
 
         self.ffmpeg
-            .merge(&video_file, &audio_file, &output_path, &opts, callback)
+            .merge(
+                &video_file,
+                &audio_file,
+                &output_path,
+                &opts,
+                callback,
+                Some(msg.cancel.clone()),
+            )
             .await
             .context("merge stage failed")?;
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/metadata.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/metadata.rs
@@ -234,6 +234,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
@@ -165,6 +165,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/normalize.rs
@@ -116,7 +116,13 @@ impl PipelineStage for NormalizeStage {
         });
 
         self.ffmpeg
-            .normalize_audio(&input_file, &output_path, &opts, callback)
+            .normalize_audio(
+                &input_file,
+                &output_path,
+                &opts,
+                callback,
+                Some(msg.cancel.clone()),
+            )
             .await
             .context("normalize stage failed")?;
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -371,6 +371,7 @@ impl PipelineStage for RecodeStage {
                 &opts,
                 progress_callback,
                 log_callback,
+                Some(msg.cancel.clone()),
             )
             .await
             .context("recode stage failed")?;

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -479,6 +479,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -156,6 +156,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 
@@ -235,6 +236,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         };
         assert!(RemuxStage::target_ext(&msg, "mp4").is_none());
     }
@@ -259,6 +261,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         };
         assert_eq!(RemuxStage::target_ext(&msg, "ts"), Some("mp4"));
     }

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
@@ -256,6 +256,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -298,6 +298,7 @@ mod tests {
             error_tx: Some(error_tx),
             warnings: Vec::new(),
             encoding_tool: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -17,13 +17,23 @@ use crate::pipeline::registry::TempRegistry;
 /// the output to `current_files` and move the old files to `temp_files`.
 /// When the pipeline completes successfully, [`cleanup`] deletes all temp files.
 ///
-/// Crash cleanup is handled by [`TempRegistry`] — `FileTracker` does NOT
-/// implement `Drop` with file deletion.
+/// On `Drop` without a prior [`commit`] (or [`cleanup`], which commits as its
+/// last step), `FileTracker` performs graceful-cancel cleanup: it deletes every
+/// uncommitted path it issued via [`temp_path`] plus any `current_files`, and
+/// releases each from [`TempRegistry`]. This prevents partial recode output and
+/// intermediate files from leaking when a job is cancelled mid-pipeline (#335).
+/// [`TempRegistry`] remains the crash/stale backstop for the case where the
+/// process dies before `Drop` runs.
 pub struct FileTracker {
     /// The live files currently being processed.
     pub(crate) current_files: Vec<PathBuf>,
     /// Files that have been superseded by a later stage's output.
     pub(crate) temp_files: Vec<PathBuf>,
+    /// Every path handed out by [`temp_path`] — the uncommitted-output set
+    /// deleted on cancel-drop.
+    issued: Vec<PathBuf>,
+    /// Disarms the `Drop` cleanup once the job succeeds (`commit`/`cleanup`).
+    committed: bool,
     temp_registry: Arc<TempRegistry>,
 }
 
@@ -33,6 +43,8 @@ impl FileTracker {
         Self {
             current_files: files,
             temp_files: Vec::new(),
+            issued: Vec::new(),
+            committed: false,
             temp_registry,
         }
     }
@@ -55,7 +67,7 @@ impl FileTracker {
     /// The path is immediately registered with [`TempRegistry`] so that a
     /// crash before the stage completes will still clean it up.
     #[must_use]
-    pub fn temp_path(&self, base: &Path, ext: &str) -> PathBuf {
+    pub fn temp_path(&mut self, base: &Path, ext: &str) -> PathBuf {
         let dir = base.parent().unwrap_or_else(|| Path::new("."));
         let raw_stem = base.file_stem().and_then(|s| s.to_str()).unwrap_or("video");
         // Strip any existing .rdlp-tmp-{uuid} suffixes to prevent stacking
@@ -64,7 +76,15 @@ impl FileTracker {
         let filename = format!("{stem}.rdlp-tmp-{id}.{ext}");
         let path = dir.join(filename);
         self.temp_registry.register(&path);
+        // Record the issued path so an uncommitted Drop deletes it (#335).
+        self.issued.push(path.clone());
         path
+    }
+
+    /// Disarm the cancel-cleanup `Drop`, marking the job as successfully
+    /// committed so its output files are kept.
+    pub const fn commit(&mut self) {
+        self.committed = true;
     }
 
     /// Return the first current file (convenience for single-file stages).
@@ -119,6 +139,46 @@ impl FileTracker {
                 }
             }
         }
+
+        // Successful completion: disarm the cancel-cleanup Drop.
+        self.committed = true;
+    }
+}
+
+impl Drop for FileTracker {
+    /// Graceful-cancel cleanup: if the job did not [`commit`](FileTracker::commit)
+    /// (or [`cleanup`](FileTracker::cleanup), which commits last), delete every
+    /// uncommitted issued path and any `current_files`, releasing each from the
+    /// [`TempRegistry`] (#335).
+    // Safe: synchronous remove_file in Drop is unavoidable — Drop cannot be
+    // async, and this mirrors the existing justification on `cleanup()` and the
+    // registry's own shutdown hook.
+    #[allow(clippy::disallowed_methods)]
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        // Collect into an owned Vec to avoid borrowing self while mutating it.
+        let to_delete: Vec<PathBuf> = self
+            .issued
+            .iter()
+            .chain(self.current_files.iter())
+            .cloned()
+            .collect();
+        for path in to_delete {
+            // The issued and current sets may overlap (mark_temp re-files
+            // issued paths); the exists() guard + idempotent release make this
+            // safe to run per path.
+            if path.exists()
+                && let Err(e) = std::fs::remove_file(&path)
+            {
+                log::warn!(
+                    "FileTracker: failed to delete uncommitted {} on cancel: {e}",
+                    path.display(),
+                );
+            }
+            self.temp_registry.release(&path);
+        }
     }
 }
 
@@ -154,7 +214,7 @@ mod tests {
     #[test]
     fn test_temp_path_generates_unique_uuid_paths() {
         let reg = test_registry();
-        let tracker = FileTracker::new(vec![], reg);
+        let mut tracker = FileTracker::new(vec![], reg);
         let p1 = tracker.temp_path(&PathBuf::from("/tmp/video.mp4"), "mp4");
         let p2 = tracker.temp_path(&PathBuf::from("/tmp/video.mp4"), "mp4");
         assert_ne!(p1, p2);
@@ -169,7 +229,7 @@ mod tests {
         // and causes registration to skip silently.
         let dir = TempDir::new().unwrap();
         let reg = test_registry();
-        let tracker = FileTracker::new(vec![], reg.clone());
+        let mut tracker = FileTracker::new(vec![], reg.clone());
         let path = tracker.temp_path(&dir.path().join("video.mp4"), "mp4");
         assert!(reg.contains(&path));
     }
@@ -191,5 +251,58 @@ mod tests {
         tracker.replace(vec![dir.path().join("new.mp4")]);
         tracker.cleanup();
         assert!(!temp.exists());
+    }
+
+    #[test]
+    fn drop_uncommitted_deletes_issued_temp_output() {
+        let dir = TempDir::new().unwrap();
+        let reg = Arc::new(TempRegistry::new());
+        let input = dir.path().join("in.rdlp-tmp-aaa.mkv");
+        fs::write(&input, b"x").unwrap();
+        let partial = {
+            let mut tracker = FileTracker::new(vec![input.clone()], reg.clone());
+            let out = tracker.temp_path(&input, "mkv"); // issued, NOT replace()-promoted
+            fs::write(&out, b"partial").unwrap();
+            assert!(out.exists());
+            out
+            // tracker dropped here WITHOUT commit() → cancel semantics
+        };
+        assert!(
+            !partial.exists(),
+            "issued partial output must be deleted on uncommitted drop"
+        );
+        assert!(
+            !input.exists(),
+            "input intermediate (current_files) must be deleted too"
+        );
+        assert!(
+            !reg.contains(&partial),
+            "registry entry for partial must be released"
+        );
+    }
+
+    #[test]
+    fn drop_after_commit_keeps_files() {
+        let dir = TempDir::new().unwrap();
+        let reg = Arc::new(TempRegistry::new());
+        let input = dir.path().join("in.rdlp-tmp-bbb.mkv");
+        fs::write(&input, b"x").unwrap();
+        let kept = {
+            let mut tracker = FileTracker::new(vec![input.clone()], reg.clone());
+            let out = tracker.temp_path(&input, "mkv");
+            fs::write(&out, b"final").unwrap();
+            tracker.commit(); // success path disarms Drop
+            out
+        };
+        // `reg` is held alive past the tracker's drop, mirroring production
+        // (`Pipeline` owns the `Arc<TempRegistry>` for its whole lifetime).
+        // Without this keepalive, dropping the last `Arc` triggers
+        // `TempRegistry`'s own sweep, which deletes the committed-but-still-
+        // registered output and masks what this test is asserting.
+        assert!(
+            reg.contains(&kept),
+            "committed output stays registered until pipeline-level cleanup"
+        );
+        assert!(kept.exists(), "committed tracker must NOT delete on drop");
     }
 }

--- a/crates/rdlp-postprocess/tests/cancel_e2e.rs
+++ b/crates/rdlp-postprocess/tests/cancel_e2e.rs
@@ -1,0 +1,181 @@
+//! End-to-end proof that cancelling a recode pipeline mid-flight aborts the
+//! encode AND leaves zero `*.rdlp-tmp-*` artifacts behind (#334, #335).
+//!
+//! This stitches the full stack together: a real [`Pipeline`] containing a
+//! [`RecodeStage`] configured to actually re-encode (so the blocking FFmpeg
+//! loop runs), driven against a real H.264 fixture. Cancelling the job's
+//! [`CancellationToken`] mid-encode must:
+//!   1. surface as [`PipelineError::Cancelled`] (mirroring the orchestrator
+//!      downcast at `crates/rdlp-api/src/orchestrator/postprocess.rs:172-177`),
+//!      and
+//!   2. trigger [`FileTracker`]'s RAII cancel-cleanup, so the partial recode
+//!      temp output (`*.rdlp-tmp-*`) is deleted — no leftover artifacts.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! input fixture).
+//!
+//! ## Timing approach
+//!
+//! Spawn `run(...)` on a task, sleep ~250 ms, then `token.cancel()`. The
+//! fixture is 30 s of `testsrc` re-encoded with libx264 — far longer than the
+//! sub-second cancel window, so the encode loop is guaranteed to still be
+//! running when the cancel fires. This exercises the *mid-flight* abort path
+//! (the cooperative `check_cancelled` in the FFmpeg encode loop from Tasks
+//! 4-7), not merely the pre-loop classification a pre-cancelled token would
+//! hit. A pre-cancel fallback is unnecessary because the long fixture makes
+//! the spawn+sleep+cancel timing robust.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::pipeline::PipelineStage;
+use rdlp_postprocess::{FFmpegRunner, Pipeline, PipelineError, RecodeStage, TempRegistry};
+use rdlp_types::{ContainerFormat, InfoDict, PostProcess};
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a long (30 s) H.264 yuv420p fixture so the recode encode loop has
+/// thousands of frames to process — guarantees the encode is still in flight
+/// when the cancel fires ~250 ms in.
+fn build_long_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
+    let src = dir.join("src.mp4");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=30:s=1280x720",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+/// Count files in `dir` whose name contains `.rdlp-tmp-` (leftover pipeline
+/// temp artifacts) or ends in `.lock` (registry sidecars).
+// Flat scan — pipeline temp files are expected in this dir, not subdirectories.
+fn leftover_artifacts(dir: &Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if name.contains(".rdlp-tmp-") || name.ends_with(".lock") {
+            out.push(path);
+        }
+    }
+    out
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_mid_recode_aborts_and_cleans_up() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = TempDir::new().expect("tempdir");
+    let Ok(src) = build_long_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+
+    // Move the fixture into a clean output dir so leftover-artifact scanning
+    // only sees pipeline-produced files (the recode temp output lands adjacent
+    // to its input).
+    let work = dir.path().join("work");
+    std::fs::create_dir(&work).unwrap();
+    let input = work.join("video.mp4");
+    std::fs::rename(&src, &input).unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpegRunner::new"));
+    let stages: Vec<Arc<dyn PipelineStage>> = vec![Arc::new(RecodeStage::new(ffmpeg))];
+    let pipeline = Arc::new(Pipeline::new(stages, Arc::new(TempRegistry::new()), 4));
+
+    // Recode to MKV with an EXPLICIT encoder so the remux (stream-copy) fast
+    // path is disabled and the real transcode loop runs (`video_encoder` set
+    // forces `can_remux == false` in RecodeStage::process).
+    let config = Arc::new(PostProcess {
+        recode_video: Some(ContainerFormat::Mkv),
+        video_encoder: Some("libx264".to_string()),
+        ..PostProcess::default()
+    });
+
+    let info = InfoDict::new(
+        "id".to_string(),
+        "Cancel Test".to_string(),
+        "TestExtractor".to_string(),
+        "https://example.com/video".to_string(),
+    );
+
+    let token = CancellationToken::new();
+    let token_for_run = token.clone();
+    let pipeline_for_run = Arc::clone(&pipeline);
+
+    let handle = tokio::spawn(async move {
+        pipeline_for_run
+            .run(
+                info,
+                vec![input],
+                config,
+                "video".to_string(),
+                false,
+                false,
+                None,
+                Some(token_for_run),
+            )
+            .await
+    });
+
+    // Let the encode loop get going, then cancel mid-flight.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    token.cancel();
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(10), handle)
+        .await
+        .expect("pipeline must complete within 10s after cancel (timeout = cancel regressed/hung)")
+        .expect("pipeline task join");
+
+    // (1) The run must classify as Cancelled — mirror the orchestrator downcast.
+    let err = result.expect_err("mid-recode cancel must surface as Err");
+    assert!(
+        matches!(
+            err.downcast_ref::<PipelineError>(),
+            Some(PipelineError::Cancelled)
+        ),
+        "expected PipelineError::Cancelled, got: {err:?}"
+    );
+
+    // (2) Zero leftover temp artifacts — the FileTracker RAII Drop must have
+    // deleted the partial recode output and released its registry lock.
+    let leftovers = leftover_artifacts(&work);
+    assert!(
+        leftovers.is_empty(),
+        "cancel-cleanup must leave zero *.rdlp-tmp-*/.lock artifacts; found: {leftovers:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Cancelling (or Removing) a job that had reached a fatal FFmpeg post-process stage did **not** stop the work: the UI marked it cancelled/`Completed` while the backend encode kept running to completion — burning a core, writing GBs, and orphaning temp files (reproduced end-to-end: a `libvvenc` 1080p recode ran on as a zombie after cancel, ~3.1 GB orphaned, only stoppable by `kill`).

This PR makes cancellation **cooperative** inside the blocking FFmpeg loops and adds **RAII cleanup** so a cancel leaves nothing behind.

- `check_cancelled(Option<&CancellationToken>)` helper polled per packet in every blocking loop: video recode, audio-extract transcode, **both** loudnorm passes, and the merge loops (non-MKV uses `break`+bail-after-cleanup to avoid leaking bare `av_packet_alloc` packets; MKV uses `?` with `AvPacketOwned` RAII).
- The job `CancellationToken` rides on `PipelineMessage.cancel`; the 4 `FFmpegRunner` entry points take an owned `Option<CancellationToken>` moved into `spawn_blocking`.
- `FileTracker` gains a `Drop` that, when not `committed`, deletes the temp paths it issued (`issued` set) + `current_files` and releases their `TempRegistry` entries. `cleanup()` (success) sets `committed` to disarm it. So cancel/error/panic unwinds → message drops → partials reaped. No side channel needed.
- Cancellation classification rides the **existing** `Pipeline::run` `token.is_cancelled()` check → `PipelineError::Cancelled` → `UserCancelled` (no new error type).

Scope was kept additive — no change to the `Pipeline` structure, stage order, `PipelineStage::process` signature, or the existing cancel classifier.

## Verification

Pre-PR gate green: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && bash scripts/check-dedup.sh`.

Tests (TDD, failing-first per commit): per-loop cancel tests (recode/audio/normalize/merge ×2, ffmpeg-gated, self-skip if absent) + an e2e `cancel_e2e` that cancels a recode pipeline mid-flight and asserts `PipelineError::Cancelled` **and** zero `*.rdlp-tmp-*`/`.lock` artifacts (exercises the encode-loop abort and the RAII cleanup together).

## Reviews

- **Security review (pre-push, full diff): PASS** — no Critical/High. Audited arbitrary-file-deletion via Drop (paths are `temp_path`-issued, no traversal/symlink concern, current callers UUID-rename), FFI memory safety on both merge cancel paths (no double-free/leak/UAF), Drop panic-safety (errors→log, no unwrap/`?`), and partial-file promotion windows (none). 2 LOW findings → tracked as #339/#340.
- **Code review (pre-push, full diff): Approve** — idiom uniform across the 4 entry points; FileTracker Drop reliably reaps every stage's partial; two merge teardown shapes both correct; dedup advisory pairs are pre-existing test scaffolding, not the cancel code.

## Follow-ups (filed, non-blocking)

- #339 — FileTracker::Drop temp-naming precondition (latent data-loss guard)
- #340 — cancel-gate the stream-copy paths (audio-extract copy, normalize-internal merge)
- #341 — pre-existing merge raw-FFI packet leak on write-error + MKV `write_trailer`-on-cancel asymmetry
- #342 — normalize helpers `too_many_arguments` → CallOptions refactor

Closes #334
Closes #335