### PR TITLE
refactor(ffmpeg): bundle normalize encode params into EncodeCallCtx, drop too_many_arguments allows (#342)

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use crate::error::PostProcessError;
 
 use super::super::{FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis};
+use super::encode::EncodeCallCtx;
 use super::helpers::{
     TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD, audio_only_extension_for, build_alimiter_spec,
     build_loudnorm_pass2_filter, with_mux_retry,
@@ -33,15 +34,16 @@ impl FFmpegRunner {
             opts.salvage,
             progress_fn,
             |inp, out, ext, resilient, pfn| {
-                Self::peak_encode_audio_only(inp, out, ext, analysis, opts, resilient, pfn, cancel)
+                let ctx = EncodeCallCtx {
+                    progress_fn: pfn,
+                    cancel,
+                };
+                Self::peak_encode_audio_only(inp, out, ext, analysis, opts, resilient, &ctx)
             },
         )
     }
 
     /// Encode peak-normalized audio to an output file (video streams discarded).
-    // The cancel token pushes this internal encode-path helper to 8 params;
-    // bundling into a struct would obscure the call site for marginal benefit.
-    #[allow(clippy::too_many_arguments)]
     fn peak_encode_audio_only(
         input: &Path,
         output: &Path,
@@ -49,8 +51,7 @@ impl FFmpegRunner {
         analysis: &PeakAnalysis,
         opts: &NormalizeOptions,
         resilient: bool,
-        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-        cancel: Option<&CancellationToken>,
+        ctx: &EncodeCallCtx<'_>,
     ) -> anyhow::Result<()> {
         let gain_db = opts.target_peak_db - analysis.peak_db;
         let linear_limit = 10f64.powf(opts.target_peak_db / 20.0);
@@ -60,8 +61,7 @@ impl FFmpegRunner {
             final_output_ext,
             "peak encode",
             resilient,
-            progress_fn,
-            cancel,
+            ctx,
             |fmt, rate, ch_layout| {
                 let oversample_prefix = if gain_db >= TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD {
                     let rate_4x = rate * 4;
@@ -94,24 +94,16 @@ impl FFmpegRunner {
             opts.salvage,
             progress_fn,
             |inp, out, ext, resilient, pfn| {
-                Self::loudnorm_encode_audio_only(
-                    inp,
-                    out,
-                    ext,
-                    opts,
-                    measurements,
-                    resilient,
-                    pfn,
+                let ctx = EncodeCallCtx {
+                    progress_fn: pfn,
                     cancel,
-                )
+                };
+                Self::loudnorm_encode_audio_only(inp, out, ext, opts, measurements, resilient, &ctx)
             },
         )
     }
 
     /// Encode loudnorm-normalized audio to an output file (video streams discarded).
-    // The cancel token pushes this internal encode-path helper to 8 params;
-    // bundling into a struct would obscure the call site for marginal benefit.
-    #[allow(clippy::too_many_arguments)]
     fn loudnorm_encode_audio_only(
         input: &Path,
         output: &Path,
@@ -119,8 +111,7 @@ impl FFmpegRunner {
         opts: &NormalizeOptions,
         measurements: &LoudnormMeasurements,
         resilient: bool,
-        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-        cancel: Option<&CancellationToken>,
+        ctx: &EncodeCallCtx<'_>,
     ) -> anyhow::Result<()> {
         let loudnorm_core = build_loudnorm_pass2_filter(opts, measurements);
         let limiter = build_alimiter_spec(opts.target_tp);
@@ -130,8 +121,7 @@ impl FFmpegRunner {
             final_output_ext,
             "loudnorm pass 2",
             resilient,
-            progress_fn,
-            cancel,
+            ctx,
             |fmt, rate, ch_layout| {
                 format!(
                     "aformat=sample_fmts=dbl,{loudnorm_core},aresample,\

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -41,6 +41,18 @@ use super::helpers::{
 };
 use super::io_diag::validate_mux_header_state;
 
+/// Recurring plumbing passed through the normalize encode helpers.
+///
+/// Bundles the progress callback and cancel token that thread unchanged
+/// from `dispatch_normalize_sync` down into `encode_audio_only_sync`,
+/// keeping each helper's data-param list within the clippy argument limit.
+pub(super) struct EncodeCallCtx<'a> {
+    /// Optional 0.0–1.0 progress callback (PTS-based + final 1.0 on completion).
+    pub progress_fn: Option<&'a (dyn Fn(f64) + Send + Sync)>,
+    /// Optional cooperative-cancellation token checked per input packet.
+    pub cancel: Option<&'a CancellationToken>,
+}
+
 impl FFmpegRunner {
     /// Unified audio-only encode: decode → filter → encode → mux.
     ///
@@ -55,23 +67,24 @@ impl FFmpegRunner {
     /// When `resilient` is true, the input is opened with
     /// `discardcorrupt+genpts` format flags to recover from corrupt
     /// containers. This is used as Tier 3 recovery in `with_mux_retry`.
-    // The cancel token pushes the unified encode helper to 8 params; the
-    // build_filter closure + cancel are both load-bearing per-call inputs.
-    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+    #[allow(clippy::too_many_lines)]
     pub(super) fn encode_audio_only_sync(
         input: &Path,
         output: &Path,
         final_output_ext: &str,
         label: &str,
         resilient: bool,
-        progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
-        cancel: Option<&CancellationToken>,
+        ctx: &EncodeCallCtx<'_>,
         build_filter: impl FnOnce(
             /*fmt:*/ &str,
             /*rate:*/ u32,
             /*ch_layout:*/ &str,
         ) -> String,
     ) -> anyhow::Result<()> {
+        let EncodeCallCtx {
+            progress_fn,
+            cancel,
+        } = *ctx;
         crate::ffmpeg::ensure_init()?;
 
         let mut ictx = if resilient {


### PR DESCRIPTION
Follow-up to #334. Threading the cancel token pushed three private normalize encode helpers to 8 params, each carrying a `#[allow(clippy::too_many_arguments)]`. This bundles the two recurring plumbing params (`progress_fn`, `cancel`) into `EncodeCallCtx<'a>` (`pub(super)`, in `encode.rs`), dropping `peak_encode_audio_only`, `loudnorm_encode_audio_only`, and `encode_audio_only_sync` to 7 params and removing all three allows.

Pure refactor — behavior byte-for-byte unchanged (deref-copy of two `Option<&_>` fields reproduces the prior locals; `check_cancelled`/progress logic untouched). `encode_audio_only_sync` keeps its unrelated `too_many_lines` allow.

## Reviews
- Code: **Approve** — genuine no-behavior-change refactor; all 3 allows gone; clippy clean without them; call sites construct the ctx correctly.
- Security: **Approve, no findings** — confirmed pure param-bundling: no new inputs/IO/FFI/unsafe, cancel check preserved identically, `pub(super)` (no visibility widening).

Closes #342