### PR TITLE
feat(ffmpeg): cancel-gate audio-copy + normalize-internal-merge stream-copy paths (#340)

### DIFF
--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -541,6 +541,7 @@ async fn mux_outputs(
             encoding_tool_override: Some(rdlp_ffmpeg::encoding_tool_tag("dash")),
             ..Default::default()
         };
+        // TODO(#340): DASH mux not cancel-gated — downloader cancellation is select!-based
         match runner
             .merge(video_path, audio_path, output_path, &opts, None, None)
             .await

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -33,6 +33,7 @@ impl FFmpegRunner {
             output,
             opts.salvage,
             progress_fn,
+            cancel,
             |inp, out, ext, resilient, pfn| {
                 let ctx = EncodeCallCtx {
                     progress_fn: pfn,
@@ -93,6 +94,7 @@ impl FFmpegRunner {
             output,
             opts.salvage,
             progress_fn,
+            cancel,
             |inp, out, ext, resilient, pfn| {
                 let ctx = EncodeCallCtx {
                     progress_fn: pfn,
@@ -143,6 +145,7 @@ impl FFmpegRunner {
         output: &Path,
         salvage: bool,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
         encode_fn: impl Fn(
             &Path,
             &Path,
@@ -198,10 +201,8 @@ impl FFmpegRunner {
                 output,
                 &super::super::RemuxOptions::default(),
                 progress_fn,
-                // The cancel-gated encode loops run before this final stream-copy
-                // merge (see normalize encode helpers); this `dispatch_normalize_sync`
-                // does not receive a cancel token. None is correct.
-                None,
+                // Cancel-gate the final stream-copy merge for large files (#340).
+                cancel,
             );
             // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
             #[allow(clippy::disallowed_methods)]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -89,8 +89,7 @@ impl FFmpegRunner {
         cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         if opts.copy {
-            // Copy path is a fast stream-copy; not gated for cancellation.
-            Self::extract_audio_copy_sync(input, output, progress_fn)
+            Self::extract_audio_copy_sync(input, output, progress_fn, cancel)
         } else {
             Self::extract_audio_transcode_sync(input, output, opts, progress_fn, cancel)
         }
@@ -103,6 +102,7 @@ impl FFmpegRunner {
         input: &Path,
         output: &Path,
         progress_fn: Option<&(dyn Fn(f64) + Send + Sync)>,
+        cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
 
@@ -168,6 +168,7 @@ impl FFmpegRunner {
 
         // Copy only audio packets
         for result in ictx.packets() {
+            crate::ffmpeg::transcode::check_cancelled(cancel)?;
             let (stream, mut packet) = result
                 .map_err(PostProcessError::from)
                 .context("failed to read packet during audio copy extract")?;

--- a/crates/rdlp-ffmpeg/tests/audio_extract_cancel.rs
+++ b/crates/rdlp-ffmpeg/tests/audio_extract_cancel.rs
@@ -86,3 +86,44 @@ async fn precancelled_token_aborts_audio_extract() {
         "error should mention cancellation; got: {msg}"
     );
 }
+
+#[tokio::test]
+async fn precancelled_token_aborts_audio_copy() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let Ok(src) = build_audio_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    // copy=true (no encoder) forces the stream-COPY path (#340).
+    let out = dir.path().join("out.m4a");
+    let opts = AudioExtractOptions {
+        encoder_name: None,
+        copy: true,
+        ..Default::default()
+    };
+
+    // Pre-cancel: the copy loop must bail before processing the whole input.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let res = runner
+        .extract_audio(&src, &out, &opts, None, Some(token))
+        .await;
+
+    assert!(
+        res.is_err(),
+        "pre-cancelled audio copy must return Err, got Ok"
+    );
+    let msg = format!("{:#}", res.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "error should mention cancellation; got: {msg}"
+    );
+}


### PR DESCRIPTION
Follow-up to #334 — completes cooperative-cancel coverage for the post-process stream-copy paths that share `PipelineMessage.cancel` (previously left ungated, so a cancel didn't abort a large stream-copy until it finished).

- **Audio-extract copy loop** (`extract_audio_copy_sync`): `check_cancelled(cancel)?` at loop top; cancel threaded through `extract_audio_sync` → copy fn. Safe-wrapper loop, `?` is leak-safe (RAII contexts).
- **Normalize-internal stream-copy merge** (`normalize/dispatch.rs`): `dispatch_normalize_sync` gains a `cancel` param so the final `merge_sync` receives the real job token (`Some(cancel)`) instead of `None`. Minimal ripple (1 fn + 2 callers that already held the token).
- **DASH mux** (`dash/download.rs`): left ungated with `TODO(#340)` — no `CancellationToken` in scope (DASH uses `select!`-based download cancellation, not `PipelineMessage.cancel`). Tracked as a follow-up (see linked issue).

New failing-first test `precancelled_token_aborts_audio_copy` (forces `copy:true`, pre-cancel → Err "cancel").

## Reviews
- Code: **Approve** — threading consistent (borrowed, no clones); copy-loop `?` confirmed leak-safe; normalize merge now gets the REAL token; DASH TODO appropriately scoped.
- Security: **Approve, no High/Critical** — `check_cancelled` is safe-Rust (no FFI leak on `?`); RAII contexts drop cleanly; cancel-mid-merge errors → existing FileTracker cleanup (finalization safety unchanged); no new inputs/unsafe/disclosure.

Closes #340