### PR TITLE
feat(downloader): cancel-gate DASH static-VoD resume path (#347)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/execution.rs
+++ b/crates/rdlp-api/src/orchestrator/execution.rs
@@ -96,6 +96,7 @@ impl Orchestrator {
                 output_path,
                 resume_from,
                 progress_callback,
+                Some(&self.cancel_token),
             )
         } else {
             downloader.download_format(

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -111,6 +111,10 @@ pub trait Downloader: Send + Sync {
     /// * `path` - Local file path to save to
     /// * `resume_from` - Byte offset to resume from
     /// * `progress` - Optional progress callback
+    /// * `cancel` - Optional cooperative-cancellation token. Downloaders with
+    ///   long-running blocking work (segment loops, `FFmpeg` mux) must honour it;
+    ///   the default impl ignores it (the orchestrator's outer `select!` covers
+    ///   the non-cooperative case). Mirrors [`Self::download_format`].
     ///
     /// # Returns
     /// Download statistics
@@ -120,7 +124,9 @@ pub trait Downloader: Send + Sync {
         path: &Path,
         _resume_from: u64,
         progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&CancellationToken>,
     ) -> Result<DownloadStats> {
+        let _ = cancel; // default impl: outer select! handles cancellation
         // Default implementation doesn't support resume, just downloads normally
         self.download_to_file(url, path, progress).await
     }

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -24,6 +24,7 @@ use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
@@ -43,7 +44,12 @@ const STATE_SAVE_BATCH: usize = 16;
 /// `output_path`. Intermediates are deleted on success and retained on
 /// mux failure for diagnosis. Resume state is tracked under
 /// `<output>.dash_state.json` and pruned on successful mux.
-#[allow(clippy::too_many_lines, clippy::similar_names)]
+// TODO: bundle run() params into a DashRunOptions struct to drop this allow.
+#[allow(
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::too_many_arguments
+)]
 pub async fn run(
     http_downloader: &HttpDownloader,
     retry_config: Arc<RetryConfig>,
@@ -52,6 +58,7 @@ pub async fn run(
     mpd_url: &str,
     output_path: &Path,
     progress: Option<Box<dyn ProgressCallback>>,
+    cancel: Option<&CancellationToken>,
 ) -> Result<DownloadStats> {
     let mpd_url_parsed = Url::parse(mpd_url).map_err(|e| RdlpError::Extraction {
         message: format!("invalid MPD URL: {e}"),
@@ -157,6 +164,7 @@ pub async fn run(
         Arc::clone(&bytes_total),
         progress_arc.clone(),
         &mpd_origin,
+        cancel,
     )
     .await?;
 
@@ -190,6 +198,7 @@ pub async fn run(
             Arc::clone(&bytes_total),
             progress_arc.clone(),
             &mpd_origin,
+            cancel,
         )
         .await?
     } else {
@@ -202,7 +211,13 @@ pub async fn run(
     // output) is preserved by performing the mux here, before returning.
     // Intermediates are deleted on success and retained on failure for
     // diagnosis.
-    mux_outputs(&video_final, has_audio.then_some(&audio_final), output_path).await?;
+    mux_outputs(
+        &video_final,
+        has_audio.then_some(&audio_final),
+        output_path,
+        cancel,
+    )
+    .await?;
 
     // Mux succeeded → wipe resume state.
     if let Err(e) = fs::remove_file(&state_file).await {
@@ -317,7 +332,16 @@ async fn download_representation(
     bytes_counter: Arc<AtomicU64>,
     log_callback: Option<Arc<dyn ProgressCallback>>,
     mpd_origin: &url::Origin,
+    cancel: Option<&CancellationToken>,
 ) -> Result<u64> {
+    // #347: cooperative-cancel gate before any work for this representation
+    // (init segment + segment loop). Mirrors the fragment downloader idiom
+    // (fragments.rs:138 / :329) — a pre-cancelled token returns
+    // `RdlpError::Cancelled` before any network round-trip.
+    if cancel.is_some_and(CancellationToken::is_cancelled) {
+        return Err(RdlpError::Cancelled);
+    }
+
     if let Some(parent) = final_path.parent()
         && !parent.as_os_str().is_empty()
     {
@@ -411,6 +435,7 @@ async fn download_representation(
     let sem = controller.semaphore().clone();
 
     let mpd_origin_owned = mpd_origin.clone();
+    let cancel_owned = cancel.cloned();
     let mut stream = futures::stream::iter(to_fetch.into_iter().map(|(i, u)| {
         let http = http.clone();
         let retry = Arc::clone(retry);
@@ -418,7 +443,20 @@ async fn download_representation(
         let sem = sem.clone();
         let controller = Arc::clone(&controller);
         let mpd_origin = mpd_origin_owned.clone();
+        let cancel = cancel_owned.clone();
         async move {
+            // #347: per-segment cooperative-cancel check at the top of each
+            // fetch task, mirroring the fragment downloader's per-iteration
+            // gate (fragments.rs:329). A cancel that fires mid-download stops
+            // in-flight segment tasks from issuing further network round-trips.
+            // Checks before enqueueing each fetch; an in-flight segment body is
+            // not interrupted mid-read (no fetch_with_optional_cancel equivalent
+            // for DASH yet — new fetches stop on cancel, which covers the
+            // common case).
+            if cancel.as_ref().is_some_and(CancellationToken::is_cancelled) {
+                return Err(RdlpError::Cancelled);
+            }
+
             // Acquire a semaphore permit so the adaptive controller governs
             // actual concurrency (mirrors the HLS pattern in merge.rs).
             let _permit = sem.acquire_owned().await.map_err(|_| RdlpError::Download {
@@ -532,6 +570,7 @@ async fn mux_outputs(
     video_path: &Path,
     audio_path: Option<&Path>,
     output_path: &Path,
+    cancel: Option<&CancellationToken>,
 ) -> Result<()> {
     if let Some(audio_path) = audio_path {
         let runner = FFmpegRunner::new().map_err(|e| {
@@ -541,9 +580,18 @@ async fn mux_outputs(
             encoding_tool_override: Some(rdlp_ffmpeg::encoding_tool_tag("dash")),
             ..Default::default()
         };
-        // TODO(#340): DASH mux not cancel-gated — downloader cancellation is select!-based
+        // #347/#340: DASH mux is now cancel-gated. `merge` takes an OWNED
+        // `Option<CancellationToken>`; clone from the borrowed token. The
+        // FFmpeg packet loop checks it cooperatively (merge/mod.rs).
         match runner
-            .merge(video_path, audio_path, output_path, &opts, None, None)
+            .merge(
+                video_path,
+                audio_path,
+                output_path,
+                &opts,
+                None,
+                cancel.cloned(),
+            )
             .await
         {
             Ok(()) => {
@@ -645,6 +693,84 @@ async fn download_one(
         warn!("DASH segment fetch retry after {dur:?}: {err}");
     })
     .await
+}
+
+#[cfg(test)]
+mod cancel_tests {
+    //! Issue #347: the DASH static-VoD resume path (`run` → segment fetch →
+    //! `mux_outputs` → `merge`) must be cooperatively cancel-gated, mirroring
+    //! the fragment downloader idiom (`Err(RdlpError::Cancelled)` returned at
+    //! the top of the segment loop). A pre-cancelled token must abort
+    //! `download_representation` BEFORE any segment is fetched.
+    use super::*;
+    use rdlp_core::RetryConfig;
+    use std::sync::atomic::AtomicU64;
+    use tokio_util::sync::CancellationToken;
+
+    fn fast_retry() -> Arc<RetryConfig> {
+        Arc::new(RetryConfig {
+            max_retries: 0,
+            ..RetryConfig::default()
+        })
+    }
+
+    /// Negative (regression guard for #347): a pre-cancelled token makes
+    /// `download_representation` return `RdlpError::Cancelled` WITHOUT fetching
+    /// any segment. The mockito server has NO mocks registered and asserts
+    /// nothing is requested — if the cancel gate were absent, the fetch would
+    /// hit the server (or fail with a network error), not `Cancelled`.
+    #[tokio::test]
+    async fn download_representation_pre_cancelled_aborts_before_fetch() {
+        let server = mockito::Server::new_async().await;
+        let mpd_url = format!("{}/manifest.mpd", server.url());
+        let mpd_origin = url::Url::parse(&mpd_url).unwrap().origin();
+        let seg_url = url::Url::parse(&format!("{}/seg0.m4s", server.url())).unwrap();
+
+        let http = HttpDownloader::with_client(wreq::Client::new());
+        let retry = fast_retry();
+        let state = Arc::new(Mutex::new(DashDownloadState::new(
+            &url::Url::parse(&mpd_url).unwrap(),
+            "v0".to_string(),
+            None,
+        )));
+        let tmp = std::env::temp_dir().join(format!("rdlp_dash_cancel_{}", std::process::id()));
+        tokio::fs::create_dir_all(&tmp).await.unwrap();
+        let final_path = tmp.join("out.video.m4s");
+        let parts = tmp.join("out.video.parts");
+        let state_file = tmp.join("out.dash_state.json");
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let token = CancellationToken::new();
+        token.cancel(); // pre-cancel
+
+        let res = download_representation(
+            &http,
+            &retry,
+            8,
+            64 * 1024,
+            "v0",
+            None, // no init segment
+            vec![seg_url],
+            &final_path,
+            &parts,
+            state,
+            &state_file,
+            true,
+            counter,
+            None,
+            &mpd_origin,
+            Some(&token),
+        )
+        .await;
+
+        // Best-effort cleanup of the temp dir.
+        let _ = tokio::fs::remove_dir_all(&tmp).await;
+
+        assert!(
+            matches!(res, Err(RdlpError::Cancelled)),
+            "expected Cancelled on a pre-cancelled token, got: {res:?}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rdlp-downloader/src/dash/mod.rs
+++ b/crates/rdlp-downloader/src/dash/mod.rs
@@ -165,6 +165,9 @@ impl Downloader for DashDownloader {
         path: &Path,
         progress: Option<Box<dyn ProgressCallback>>,
     ) -> Result<DownloadStats> {
+        // No cancel token at this entry point (the trait method has no cancel
+        // slot); the cancel-aware path is `download_with_resume`, which the
+        // orchestrator uses for the resume case (#347).
         download::run(
             &self.http_downloader,
             Arc::clone(&self.retry_config),
@@ -173,6 +176,34 @@ impl Downloader for DashDownloader {
             url,
             path,
             progress,
+            None,
+        )
+        .await
+    }
+
+    /// DASH resume entry point. The legacy MPD-URL path does not support byte
+    /// offset resume (it resumes per-segment via `<output>.dash_state.json`),
+    /// so `resume_from` is ignored. The override exists to thread `cancel`
+    /// into `download::run` so the segment loop and final mux are
+    /// cooperatively cancel-gated rather than relying solely on the
+    /// orchestrator's outer `select!` (#347).
+    async fn download_with_resume(
+        &self,
+        url: &str,
+        path: &Path,
+        _resume_from: u64,
+        progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&tokio_util::sync::CancellationToken>,
+    ) -> Result<DownloadStats> {
+        download::run(
+            &self.http_downloader,
+            Arc::clone(&self.retry_config),
+            self.concurrent_segments,
+            self.buffer_size,
+            url,
+            path,
+            progress,
+            cancel,
         )
         .await
     }

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -74,7 +74,13 @@ async fn test_resume_fails_when_server_returns_200() {
 
     // Try to resume - should fail with error, NOT overwrite the file
     let result = downloader
-        .download_with_resume(&format!("{}/video.mp4", server.url()), path, 1000, None)
+        .download_with_resume(
+            &format!("{}/video.mp4", server.url()),
+            path,
+            1000,
+            None,
+            None,
+        )
         .await;
 
     mock.assert_async().await;
@@ -551,7 +557,7 @@ async fn test_parallel_resume() {
 
     // Resume download - should use parallel resume
     let result = downloader
-        .download_with_resume(&url, &output, already_downloaded, None)
+        .download_with_resume(&url, &output, already_downloaded, None, None)
         .await;
 
     // Verify success

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -192,11 +192,12 @@ impl Downloader for HttpDownloader {
         path: &Path,
         resume_from: u64,
         progress: Option<Box<dyn ProgressCallback>>,
+        cancel: Option<&CancellationToken>,
     ) -> Result<DownloadStats> {
-        // Trait method discards cancel (outer select! covers it). For cooperative
-        // cancel, callers use `download_with_resume_with_cancel` directly.
-        // TODO(#287): trait method itself may take cancel in a future BC-break.
-        self.download_with_resume_with_cancel(url, path, resume_from, progress, None)
+        // #347: the trait method now threads `cancel` into the cooperative-cancel
+        // variant so the resume path stops mid-stream rather than relying solely
+        // on the orchestrator's outer select!.
+        self.download_with_resume_with_cancel(url, path, resume_from, progress, cancel)
             .await
     }
 }
@@ -352,8 +353,9 @@ impl HttpDownloader {
     }
 
     /// F6: cooperative-cancel-aware variant of `download_with_resume`.
-    /// The trait method `download_with_resume` delegates here with `cancel: None`.
-    /// Direct callers (e.g. tests) can pass a `CancellationToken` for mid-stream cancellation.
+    /// The trait method `download_with_resume` delegates here, threading its
+    /// `cancel` argument through (#347). Direct callers can also pass a
+    /// `CancellationToken` for mid-stream cancellation.
     pub(crate) async fn download_with_resume_with_cancel(
         &self,
         url: &str,


### PR DESCRIPTION
Closes the last residual of the #334 zombie pattern: a cancel during a DASH **resume** abandoned the future via the orchestrator's outer `select!` but the `spawn_blocking` segment-downloads + mux kept running.

Mirrors the `download_format` precedent (fulfilling the `TODO(#287)`):
- `Downloader::download_with_resume` trait gains `cancel: Option<&CancellationToken>` (default `let _ = cancel`).
- `HttpDownloader` forwards it to its existing `download_with_resume_with_cancel` (was `None`).
- `DashDownloader` adds a `download_with_resume` override → `download::run(.., cancel)`.
- `download::run` gates `download_representation` (pre-work + per-segment, idiom from `fragments.rs:138/:329`, returns `RdlpError::Cancelled`) and passes the token to `mux_outputs` → `merge` (per-packet gated since #348).
- Orchestrator passes `Some(&self.cancel_token)` on the resume branch (`execution.rs:94`).

New failing-first test `download_representation_pre_cancelled_aborts_before_fetch` (mockito-no-mocks → asserts no fetch + `Cancelled`).

## Reviews
- Security: **PASS, no Critical/High** — confirmed the cancel stops the zombie (segment loop returns early; merge gated); trait `let _ = cancel` default safe (only HTTP+DASH override); `RdlpError::Cancelled` is the correct variant; state file correctly preserved for resume. 2 LOW design notes.
- Code: **Approve** — faithful mirror of `download_format`; all callers updated; gate idiom matches `fragments.rs`; failing-first test is a genuine regression guard. 3 Minor (folded in: too_many_args TODO, per-segment scope comment, test create_dir_all).

Full workspace gate green.

Closes #347