### PR TITLE
fix(desktop): cancel transitions UI to terminal state + progress scale fix (#353)

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -53,6 +53,14 @@ pub struct DownloadErrorPayload {
     pub(crate) retryable: bool,
 }
 
+/// Download cancellation payload emitted as `"download-cancelled"`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadCancelledPayload {
+    /// The UUID of the download job.
+    pub(crate) job_id: String,
+}
+
 /// Log severity level for download events.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -343,7 +351,16 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             }
         }
 
-        // Remaining unhandled events (SubtitlesFound, SubtitlesMissing, Cancelled, Started, Retrying from playlist)
+        Event::Cancelled { .. } => {
+            let payload = DownloadCancelledPayload {
+                job_id: job_id.to_owned(),
+            };
+            if let Err(e) = app.emit("download-cancelled", &payload) {
+                debug!("Failed to emit download-cancelled for job {job_id}: {e}");
+            }
+        }
+
+        // Remaining unhandled events (SubtitlesFound, SubtitlesMissing, Started, Retrying from playlist)
         _ => {}
     }
 }
@@ -451,5 +468,15 @@ mod tests {
         assert_eq!(json["jobId"], "abc-123");
         assert_eq!(json["stage"], "remux");
         assert_eq!(json["progress"], 0.45);
+    }
+
+    #[test]
+    fn test_cancelled_payload_serializes_camel_case() {
+        let payload = DownloadCancelledPayload {
+            job_id: "abc-123".to_owned(),
+        };
+        let v = serde_json::to_value(&payload).expect("serialization should succeed");
+        assert_eq!(v["jobId"], "abc-123");
+        assert!(v.get("job_id").is_none(), "must be camelCase on the wire");
     }
 }

--- a/crates/rdlp-desktop/src/api/downloads.test.ts
+++ b/crates/rdlp-desktop/src/api/downloads.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("./invokeClient", () => ({ invokeTyped: (...a: unknown[]) => invokeMock(...a) }));
+
+import { cancelDownload } from "./downloads";
+import { queryClient } from "../query/queryClient";
+import { queryKeys } from "../query/queryKeys";
+import type { DownloadJob } from "../types";
+
+function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
+    return {
+        id: "job-1",
+        url: "https://example.com/video",
+        title: "Test Video",
+        status: "running",
+        progress: 0,
+        speed: null,
+        eta: null,
+        error: null,
+        retryable: false,
+        started_at: null,
+        completed_at: null,
+        output_path: null,
+        options: null,
+        playlist: null,
+        statusMessage: null,
+        ...overrides,
+    };
+}
+
+describe("cancelDownload", () => {
+    beforeEach(() => {
+        invokeMock.mockReset();
+        invokeMock.mockResolvedValue(undefined);
+        queryClient.clear();
+    });
+
+    it("optimistically flips the job to cancelled without refetching", async () => {
+        const job = makeJob({
+            id: "j1",
+            status: "running",
+            progress: 0.47,
+            speed: "4.2 MB/s",
+            eta: "0:12",
+            statusMessage: "Video — 47%",
+            currentUnit: { unitIndex: 1, unitTotal: 2, unitTitle: "Video" },
+        });
+        queryClient.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+        const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+        await cancelDownload("j1");
+
+        const jobs = queryClient.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0]!.status).toBe("cancelled");
+        expect(jobs[0]!.statusMessage).toBeNull();
+        expect(jobs[0]!.currentUnit).toBeNull();
+        expect(jobs[0]!.speed).toBeNull();
+        expect(jobs[0]!.eta).toBeNull();
+        expect(jobs[0]!.progress).toBeNull();
+        expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+});

--- a/crates/rdlp-desktop/src/api/downloads.ts
+++ b/crates/rdlp-desktop/src/api/downloads.ts
@@ -4,6 +4,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { invokeTyped } from "./invokeClient";
 import { queryKeys } from "../query/queryKeys";
 import { queryClient } from "../query/queryClient";
+import { cancelledJobPatch } from "../lib/jobStatus";
 import type { DownloadJob, DownloadOptions, PlaylistContext } from "../types";
 
 /** Fetch the current download queue. */
@@ -43,7 +44,7 @@ export async function cancelDownload(jobId: string): Promise<void> {
         (old) =>
             old?.map((job) =>
                 job.id === jobId
-                    ? { ...job, status: "cancelled", statusMessage: null, currentUnit: null, speed: null, eta: null, progress: null }
+                    ? { ...job, ...cancelledJobPatch() }
                     : job,
             ),
     );

--- a/crates/rdlp-desktop/src/api/downloads.ts
+++ b/crates/rdlp-desktop/src/api/downloads.ts
@@ -34,7 +34,19 @@ export async function startDownload(
 /** Cancel a running download. */
 export async function cancelDownload(jobId: string): Promise<void> {
     await invokeTyped<void>("cancel_download", { jobId });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.downloads.list() });
+    // Optimistic terminal flip. The backend sets JobStatus::Cancelled
+    // asynchronously and confirms via the "download-cancelled" event
+    // (registerDownloadEvents). We must NOT invalidateQueries here: a
+    // refetch would race the async cancel and read stale "running".
+    queryClient.setQueryData<DownloadJob[]>(
+        queryKeys.downloads.list(),
+        (old) =>
+            old?.map((job) =>
+                job.id === jobId
+                    ? { ...job, status: "cancelled", statusMessage: null, currentUnit: null, speed: null, eta: null, progress: null }
+                    : job,
+            ),
+    );
 }
 
 /** Remove a completed/failed/cancelled job from the queue. */

--- a/crates/rdlp-desktop/src/components/JobMiniCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobMiniCard.tsx
@@ -2,7 +2,7 @@
 // Click switches to Queue view and selects the job.
 
 import { setView, setSelectedJob } from "@/stores/uiStore";
-import { cn, displayTitle } from "@/lib/utils";
+import { cn, displayTitle, progressPercent } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 interface JobMiniCardProps {
@@ -32,7 +32,7 @@ export function JobMiniCard({ job, className }: JobMiniCardProps) {
             <div className="flex items-center justify-between gap-2 mb-1">
                 <span className="text-[11px] text-[#eeeeee] truncate flex-1 leading-tight">{title}</span>
                 {isRunning && (
-                    <span className="text-[10px] text-[#aaaaaa] shrink-0 font-mono">{Math.round(progress)}%</span>
+                    <span className="text-[10px] text-[#aaaaaa] shrink-0 font-mono">{progressPercent(job.progress)}%</span>
                 )}
                 {isPending && (
                     <span className="text-[10px] text-[var(--text-muted)] shrink-0">Queued</span>
@@ -42,7 +42,7 @@ export function JobMiniCard({ job, className }: JobMiniCardProps) {
                 <div className="h-[2px] rounded-full bg-[#1a1a2e] overflow-hidden">
                     <div
                         className="h-full bg-[#4a9eff] transition-[width] duration-300 rounded-full"
-                        style={{ width: `${progress}%` }}
+                        style={{ width: `${progress * 100}%` }}
                     />
                 </div>
             )}

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 // Tests for registerDownloadEvents — verifying cache mutations per event type.
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
 import { mockEmit, clearEventListeners } from "@/test/tauri-mock";
 import { queryKeys } from "../query/queryKeys";
@@ -34,6 +34,8 @@ describe("registerDownloadEvents", () => {
     let cleanup: () => void;
 
     beforeEach(() => {
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 1; });
+        vi.stubGlobal("cancelAnimationFrame", () => {});
         qc = new QueryClient({
             defaultOptions: { queries: { retry: false, staleTime: Infinity } },
         });
@@ -44,6 +46,7 @@ describe("registerDownloadEvents", () => {
         cleanup();
         clearEventListeners();
         qc.clear();
+        vi.unstubAllGlobals();
     });
 
     it("transitions a running job to cancelled on download-cancelled", async () => {
@@ -149,5 +152,15 @@ describe("registerDownloadEvents", () => {
 
         const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
         expect(jobs[0]!.logMessages).toEqual(["Previous message", "New message"]);
+    });
+
+    it("stores download-progress as a 0-1 fraction (not 0-100)", async () => {
+        const job = makeJob({ id: "j1", status: "running" });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("download-progress", { jobId: "j1", progress: 0.47, speed: "5 MB/s", eta: "01:00" });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0]!.progress).toBeCloseTo(0.47, 5);
     });
 });

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -46,6 +46,29 @@ describe("registerDownloadEvents", () => {
         qc.clear();
     });
 
+    it("transitions a running job to cancelled on download-cancelled", async () => {
+        const job = makeJob({
+            id: "j1",
+            status: "running",
+            statusMessage: "Video — 47%",
+            progress: 0.47,
+            speed: "4.2 MB/s",
+            eta: "0:12",
+            currentUnit: { unitTitle: "Video", unitIndex: 1, unitTotal: 2 },
+        });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("download-cancelled", { jobId: "j1" });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0]!.status).toBe("cancelled");
+        expect(jobs[0]!.statusMessage).toBeNull();
+        expect(jobs[0]!.currentUnit).toBeNull();
+        expect(jobs[0]!.speed).toBeNull();
+        expect(jobs[0]!.eta).toBeNull();
+        expect(jobs[0]!.progress).toBeNull();
+    });
+
     it("appends a log message to logMessages on download-log event", async () => {
         const job = makeJob({ id: "job-42" });
         qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -12,6 +12,7 @@ import {
     onDownloadProgress,
     onDownloadComplete,
     onDownloadError,
+    onDownloadCancelled,
     onDownloadLog,
     onFormatSelected,
     onPostProcessProgress,
@@ -133,6 +134,30 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                                   status: "failed" as const,
                                   error: p.error,
                                   retryable: p.retryable,
+                              }
+                            : job,
+                    ),
+            );
+        }),
+    );
+
+    unlisteners.push(
+        onDownloadCancelled((p) => {
+            if (!mounted) return;
+            pending.delete(p.jobId);
+            qc.setQueryData<DownloadJob[]>(
+                queryKeys.downloads.list(),
+                (old) =>
+                    old?.map((job) =>
+                        job.id === p.jobId
+                            ? {
+                                  ...job,
+                                  status: "cancelled" as const,
+                                  statusMessage: null,
+                                  currentUnit: null,
+                                  speed: null,
+                                  eta: null,
+                                  progress: null,
                               }
                             : job,
                     ),

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -66,7 +66,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
 
                     const updates: Partial<DownloadJob> = { ...entry };
                     if (isMerge) {
-                        updates.statusMessage = `${unit.unitTitle} \u2014 ${Math.round(entry.progress)}%`;
+                        updates.statusMessage = `${unit.unitTitle} \u2014 ${Math.round(entry.progress * 100)}%`;
                     }
 
                     return { ...job, ...updates };
@@ -87,7 +87,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
         onDownloadProgress((p) => {
             if (!mounted) return;
             pending.set(p.jobId, {
-                progress: p.progress * 100,
+                progress: p.progress,
                 speed: p.speed,
                 eta: p.eta,
             });
@@ -107,7 +107,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                             ? {
                                   ...job,
                                   status: "completed" as const,
-                                  progress: 100,
+                                  progress: 1,
                                   output_path: p.filepath || null,
                                   completed_at: Math.floor(Date.now() / 1000),
                                   statusMessage: null,
@@ -213,7 +213,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                         job.id === p.jobId
                             ? {
                                   ...job,
-                                  progress: pct,
+                                  progress: p.progress,
                                   speed: null,
                                   eta: null,
                                   statusMessage: `${p.stage}… ${pct}%`,

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -21,6 +21,7 @@ import {
 } from "../lib/tauri";
 import { queryKeys } from "../query/queryKeys";
 import { appendLog } from "../components/LogViewer";
+import { cancelledJobPatch } from "../lib/jobStatus";
 import type { DownloadJob } from "../types";
 
 interface ProgressEntry {
@@ -150,15 +151,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                 (old) =>
                     old?.map((job) =>
                         job.id === p.jobId
-                            ? {
-                                  ...job,
-                                  status: "cancelled" as const,
-                                  statusMessage: null,
-                                  currentUnit: null,
-                                  speed: null,
-                                  eta: null,
-                                  progress: null,
-                              }
+                            ? { ...job, ...cancelledJobPatch() }
                             : job,
                     ),
             );

--- a/crates/rdlp-desktop/src/lib/jobStatus.test.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { cancelledJobPatch } from "./jobStatus";
+
+describe("cancelledJobPatch", () => {
+    it("sets cancelled status and clears all transient progress fields", () => {
+        expect(cancelledJobPatch()).toEqual({
+            status: "cancelled",
+            statusMessage: null,
+            currentUnit: null,
+            speed: null,
+            eta: null,
+            progress: null,
+        });
+    });
+});

--- a/crates/rdlp-desktop/src/lib/jobStatus.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.ts
@@ -1,0 +1,24 @@
+// Shared job lifecycle state transitions for the downloads cache.
+
+import type { DownloadJob } from "../types";
+
+/**
+ * The field patch applied when a job reaches the terminal `cancelled` state:
+ * sets `status` and clears every transient progress field.
+ *
+ * Single source of truth used by BOTH cancel paths — the optimistic flip in
+ * `api/downloads.cancelDownload` and the `download-cancelled` event reducer in
+ * `events/registerDownloadEvents`. They MUST stay in lock-step; a field added
+ * to one path but not the other would desync the optimistic and confirmed
+ * cancel state. Spread over the existing job: `{ ...job, ...cancelledJobPatch() }`.
+ */
+export function cancelledJobPatch(): Partial<DownloadJob> {
+    return {
+        status: "cancelled",
+        statusMessage: null,
+        currentUnit: null,
+        speed: null,
+        eta: null,
+        progress: null,
+    };
+}

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -7,6 +7,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
     AppSettings,
+    DownloadCancelledPayload,
     DownloadCompletePayload,
     DownloadErrorPayload,
     DownloadJob,
@@ -123,6 +124,15 @@ export function onDownloadError(
     callback: (payload: DownloadErrorPayload) => void,
 ): Promise<UnlistenFn> {
     return listen<DownloadErrorPayload>("download-error", (event) =>
+        callback(event.payload),
+    );
+}
+
+/** Subscribe to download cancellation events. Returns an unlisten function. */
+export function onDownloadCancelled(
+    callback: (payload: DownloadCancelledPayload) => void,
+): Promise<UnlistenFn> {
+    return listen<DownloadCancelledPayload>("download-cancelled", (event) =>
         callback(event.payload),
     );
 }

--- a/crates/rdlp-desktop/src/lib/utils.test.ts
+++ b/crates/rdlp-desktop/src/lib/utils.test.ts
@@ -2,7 +2,7 @@
 // Unit tests for lib/utils.ts — cn() and parseUploadTimestamp().
 
 import { describe, test, expect } from "vitest";
-import { cn, displayTitle, parseUploadTimestamp, TITLE_PLACEHOLDER } from "./utils";
+import { cn, displayTitle, parseUploadTimestamp, progressPercent, TITLE_PLACEHOLDER } from "./utils";
 
 // ---------------------------------------------------------------------------
 // cn()
@@ -128,5 +128,20 @@ describe("displayTitle", () => {
         // change what users see; rename here too if you change the
         // shared placeholder.
         expect(TITLE_PLACEHOLDER).toBe("Unknown");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// progressPercent()
+// ---------------------------------------------------------------------------
+
+describe("progressPercent", () => {
+    it("converts a 0-1 fraction to a whole percent", () => {
+        expect(progressPercent(0.47)).toBe(47);
+        expect(progressPercent(1)).toBe(100);
+    });
+    it("treats null/undefined as 0", () => {
+        expect(progressPercent(null)).toBe(0);
+        expect(progressPercent(undefined)).toBe(0);
     });
 });

--- a/crates/rdlp-desktop/src/lib/utils.ts
+++ b/crates/rdlp-desktop/src/lib/utils.ts
@@ -69,3 +69,8 @@ export function displayTitle(title: string | null | undefined): string {
     const trimmed = title.trim();
     return trimmed.length === 0 ? TITLE_PLACEHOLDER : trimmed;
 }
+
+/** Convert a 0–1 progress fraction to a rounded whole-percent number. */
+export function progressPercent(fraction: number | null | undefined): number {
+    return Math.round((fraction ?? 0) * 100);
+}

--- a/crates/rdlp-desktop/src/shell/BottomDrawer.tsx
+++ b/crates/rdlp-desktop/src/shell/BottomDrawer.tsx
@@ -11,6 +11,7 @@ import { uiStore, toggleBottomDrawer, setSelectedJob, setView } from "@/stores/u
 import { downloadsQueryOptions } from "@/api/downloads";
 import { LogViewer, appendLog } from "@/components/LogViewer";
 import { StatusBadge } from "@/components/StatusBadge";
+import { progressPercent } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 // Re-export appendLog so event registration can use it
@@ -46,7 +47,7 @@ function JobsPanel({ jobs }: JobsPanelProps) {
                     <StatusBadge status={job.status} className="shrink-0" />
                     {(job.status === "running" || job.status === "pending") && job.progress !== null && (
                         <span className="text-[10px] text-[var(--text-muted)] font-mono shrink-0">
-                            {Math.round(job.progress)}%
+                            {progressPercent(job.progress)}%
                         </span>
                     )}
                 </Button>
@@ -109,7 +110,7 @@ export function BottomDrawer() {
                             </span>
                             {activeJob.progress !== null && (
                                 <span className="text-[10px] text-[#aaaaaa] font-mono shrink-0">
-                                    {Math.round(activeJob.progress)}%
+                                    {progressPercent(activeJob.progress)}%
                                 </span>
                             )}
                             {activeJob.speed && (

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -327,6 +327,11 @@ export interface DownloadErrorPayload {
     retryable: boolean;
 }
 
+/** Download cancellation payload emitted as "download-cancelled". */
+export interface DownloadCancelledPayload {
+    jobId: string;
+}
+
 /** Format-selected payload emitted as "format-selected". */
 export interface FormatSelectedPayload {
     jobId: string;

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -1,0 +1,77 @@
+// Tests for views/queue/JobCard — display-layer progress rendering.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { render } from "@/test/test-utils";
+import { JobCard } from "./JobCard";
+import type { DownloadJob } from "@/types";
+
+// Stub Tauri stores and IPC — JobCard reads uiStore + calls Tauri commands.
+vi.mock("@/stores/uiStore", async () => {
+    const { Store } = await import("@tanstack/store");
+    return {
+        uiStore: new Store({ selectedJobId: null as string | null }),
+        setSelectedJob: vi.fn(),
+    };
+});
+vi.mock("@/api/downloads", () => ({
+    cancelDownload: vi.fn(),
+    removeJob: vi.fn(),
+    startDownload: vi.fn(),
+}));
+vi.mock("@/api/invokeClient", () => ({
+    invokeTyped: vi.fn(),
+}));
+
+function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
+    return {
+        id: "job-1",
+        url: "https://example.com/video",
+        title: "Test Video",
+        status: "running",
+        progress: 0,
+        speed: null,
+        eta: null,
+        error: null,
+        retryable: false,
+        started_at: null,
+        completed_at: null,
+        output_path: null,
+        options: null,
+        playlist: null,
+        statusMessage: null,
+        ...overrides,
+    };
+}
+
+describe("JobCard — progress display", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders a 0-1 progress fraction as whole percent", () => {
+        render(<JobCard job={makeJob({ status: "running", progress: 0.47 })} />);
+        expect(screen.getByText("47%")).toBeInTheDocument();
+    });
+
+    it("sizes the progress bar width to the 0-1 fraction scaled to percent", () => {
+        const { container } = render(
+            <JobCard job={makeJob({ status: "running", progress: 0.47 })} />,
+        );
+        // The fill bar is the only element with an inline width style. Guards the
+        // higher-risk width path against a double-conversion (e.g. 4700%).
+        const bar = container.querySelector('[style*="width"]') as HTMLElement | null;
+        expect(bar).not.toBeNull();
+        expect(bar!.style.width).toBe("47%");
+    });
+
+    it("renders 0 progress as 0%", () => {
+        render(<JobCard job={makeJob({ status: "running", progress: 0 })} />);
+        expect(screen.getByText("0%")).toBeInTheDocument();
+    });
+
+    it("renders 1.0 progress as 100%", () => {
+        render(<JobCard job={makeJob({ status: "running", progress: 1.0 })} />);
+        expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/views/queue/JobCard.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.tsx
@@ -8,7 +8,7 @@ import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
 import { invokeTyped } from "@/api/invokeClient";
-import { cn } from "@/lib/utils";
+import { cn, progressPercent } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 interface JobCardProps {
@@ -82,11 +82,11 @@ export function JobCard({ job, compact = false }: JobCardProps) {
                         <div className="h-[3px] rounded-full bg-[#1a1a2e] overflow-hidden mb-1">
                             <div
                                 className="h-full bg-[#4a9eff] transition-[width] duration-300 rounded-full"
-                                style={{ width: `${progress}%` }}
+                                style={{ width: `${progress * 100}%` }}
                             />
                         </div>
                         <div className="flex items-center gap-3 text-[10px] text-[var(--text-muted)] font-mono">
-                            <span className="text-[#aaaaaa]">{Math.round(progress)}%</span>
+                            <span className="text-[#aaaaaa]">{progressPercent(job.progress)}%</span>
                             {job.speed && <span>{job.speed}</span>}
                             {job.eta && <span>ETA {job.eta}</span>}
                             {job.statusMessage && (

--- a/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
@@ -8,7 +8,7 @@ import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { downloadsQueryOptions, cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
 import { invokeTyped } from "@/api/invokeClient";
-import { cn } from "@/lib/utils";
+import { cn, progressPercent } from "@/lib/utils";
 
 function formatDate(ts: number | null): string {
     if (!ts) return "—";
@@ -65,7 +65,7 @@ export function JobDetails() {
             {isRunning && (
                 <div>
                     <div className="flex items-center justify-between text-[10px] text-[var(--text-muted)] mb-1">
-                        <span className="font-mono text-[#aaaaaa]">{Math.round(job.progress ?? 0)}%</span>
+                        <span className="font-mono text-[#aaaaaa]">{progressPercent(job.progress)}%</span>
                         <div className="flex items-center gap-2">
                             {job.speed && <span>{job.speed}</span>}
                             {job.eta && <span>ETA {job.eta}</span>}
@@ -74,7 +74,7 @@ export function JobDetails() {
                     <div className="h-[3px] rounded-full bg-[#1a1a2e] overflow-hidden">
                         <div
                             className="h-full bg-[#4a9eff] transition-[width] duration-300 rounded-full"
-                            style={{ width: `${job.progress ?? 0}%` }}
+                            style={{ width: `${(job.progress ?? 0) * 100}%` }}
                         />
                     </div>
                     {job.statusMessage && (


### PR DESCRIPTION
Closes #353.

## Problem
Cancelling a download in the desktop GUI left the job UI stuck: badge frozen on "Downloading", Cancel control still pressable, progress bar frozen at ~1% (real ~47%). Backend cancellation worked correctly — this was a frontend state bug.

## Root cause (3 independent defects)
1. **Dropped terminal event.** The orchestrator emits `Event::Cancelled`, it reaches the desktop event loop, but `emit_event` dropped it in a catch-all `_ => {}` arm — so the webview never learned the job ended. (Regression surfaced by the #347 follow-up `55e9f50`, which switched cancel from `Event::Failed` → `Event::Cancelled`; the old `Failed` path used to drive the terminal transition.)
2. **Cancel-handler refetch race.** `cancelDownload` called `invalidateQueries`, refetching `queue()` *before* the async backend cancel set `JobStatus::Cancelled` — reading back stale `running`. Nothing later corrected it.
3. **Progress scale mismatch.** The event stream wrote progress on a 0–100 scale while the `queue()` snapshot returns the documented 0–1 fraction (root `CLAUDE.md`: "internal scale is always 0–1"). Any refetch collapsed the bar to ~1%.

## Fix
- Emit a `download-cancelled` Tauri event (`DownloadCancelledPayload { jobId }`) + frontend `onDownloadCancelled` listener + reducer handler that flips the job to terminal `cancelled`.
- `cancelDownload`: drop the racing `invalidateQueries`; optimistically flip via `setQueryData`, confirmed by the event. (`startDownload`/`removeJob`/`clearCompletedJobs` keep `invalidateQueries` — load-bearing: row add/remove has no event.)
- Normalize the frontend progress cache field to the 0–1 fraction (writers stop rescaling); render via a shared `progressPercent` helper across the 4 live readers.
- Extract `cancelledJobPatch()` as the single source of truth for the cancel field-set (used by both cancel paths).

## Tests
Failing-first throughout: Rust payload camelCase shape; cancelled-event reducer transition (load-bearing — seeds non-null transient fields, asserts all nulled); cancel optimistic flip + `invalidateQueries` NOT called; progress stored as 0–1; reader renders 0.47 → "47%" incl. bar `width: 47%`; `progressPercent` + `cancelledJobPatch` unit tests.

## Verification
`cargo fmt --check` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `cargo test` ✓ · `npx tsc --noEmit` ✓ · `npm run test` 178 ✓ · `scripts/check-dedup.sh` ✓

## Reviews (pre-push, full BASE..HEAD diff)
- **security-reviewer:** APPROVE — no new IPC/inbound surface, payload carries only the backend-owned job-id, no log/PII leak, no `dangerouslySetInnerHTML`, no new deps.
- **code-reviewer:** APPROVE — cancel state machine sound end-to-end, 0–1 normalization complete (no remaining mismatch), retained invalidates correct, tests load-bearing. Minor (dead-code consolidation) addressed via the shared helper + tracked in #356.

## Scope split
- #355 — implausible HLS speed ("1.3 GiB/s"): independent backend speed-sampling defect.
- #356 — remove dead `components/JobCard.tsx`.

## Manual GUI verification
Recommended before merge (covers the AppHandle emit arm that can't be unit-tested): cancel a live HLS download → badge → Cancelled, Cancel control gone, bar tracked real % beforehand.