### PR TITLE
fix(desktop): keyboard-accessible JobCard + HistoryRow selection (closes #361)

### DIFF
--- a/crates/rdlp-desktop/src/views/history/HistoryRow.test.tsx
+++ b/crates/rdlp-desktop/src/views/history/HistoryRow.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { render } from "@/test/test-utils";
+import { HistoryRow } from "./HistoryRow";
+import { uiStore, setSelectedJob } from "@/stores/uiStore";
+import { startDownload } from "@/api/downloads";
+import { invokeTyped } from "@/api/invokeClient";
+import type { DownloadJob } from "@/types";
+
+vi.mock("@/stores/uiStore", async () => {
+    const { Store } = await import("@tanstack/store");
+    return {
+        uiStore: new Store({ selectedJobId: null as string | null }),
+        setSelectedJob: vi.fn(),
+        setView: vi.fn(),
+    };
+});
+vi.mock("@/api/downloads", () => ({ startDownload: vi.fn().mockResolvedValue("job-1") }));
+vi.mock("@/api/invokeClient", () => ({ invokeTyped: vi.fn().mockResolvedValue(undefined) }));
+
+function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
+    return {
+        id: "job-1", url: "https://example.com/video", title: "Done Video",
+        status: "completed", progress: 1, speed: null, eta: null, error: null,
+        retryable: false, started_at: null, completed_at: 1_700_000_000,
+        output_path: "/tmp/v.mp4", options: null, playlist: null, statusMessage: null,
+        ...overrides,
+    };
+}
+
+describe("HistoryRow — selection a11y", () => {
+    beforeEach(() => { vi.clearAllMocks(); });
+
+    it("exposes a Select button with accessible name + aria-pressed=false", () => {
+        render(<HistoryRow job={makeJob({ id: "job-1", title: "Done Video" })} />);
+        const sel = screen.getByRole("button", { name: "Select: Done Video" });
+        expect(sel).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("exposes aria-pressed=true when selected", () => {
+        uiStore.setState((prev) => ({ ...prev, selectedJobId: "job-1" }));
+        try {
+            render(<HistoryRow job={makeJob({ id: "job-1", title: "Done Video" })} />);
+            expect(screen.getByRole("button", { name: "Select: Done Video" })).toHaveAttribute("aria-pressed", "true");
+        } finally {
+            uiStore.setState((prev) => ({ ...prev, selectedJobId: null }));
+        }
+    });
+
+    it("Select button click selects the job", () => {
+        render(<HistoryRow job={makeJob()} />);
+        fireEvent.click(screen.getByRole("button", { name: /^Select:/ }));
+        expect(vi.mocked(setSelectedJob)).toHaveBeenCalledWith("job-1");
+    });
+
+    it("Enter on the Select button selects the job", async () => {
+        const user = userEvent.setup();
+        render(<HistoryRow job={makeJob()} />);
+        screen.getByRole("button", { name: /^Select:/ }).focus();
+        await user.keyboard("{Enter}");
+        expect(vi.mocked(setSelectedJob)).toHaveBeenCalledWith("job-1");
+    });
+
+    it("Space on the Select button selects the job", async () => {
+        const user = userEvent.setup();
+        render(<HistoryRow job={makeJob()} />);
+        screen.getByRole("button", { name: /^Select:/ }).focus();
+        await user.keyboard("{ }");
+        expect(vi.mocked(setSelectedJob)).toHaveBeenCalledWith("job-1");
+    });
+
+    it("action buttons are NOT descendants of the Select button (axe nested-interactive guard)", () => {
+        render(<HistoryRow job={makeJob({ output_path: "/tmp/v.mp4" })} />);
+        const sel = screen.getByRole("button", { name: /^Select:/ });
+        expect(screen.getByLabelText("Reveal in folder")).toBeInTheDocument();
+        expect(sel.querySelector('[aria-label="Reveal in folder"]')).toBeNull();
+    });
+
+    it("Reveal calls reveal_in_folder and does NOT select", () => {
+        render(<HistoryRow job={makeJob({ output_path: "/tmp/v.mp4" })} />);
+        fireEvent.click(screen.getByLabelText("Reveal in folder"));
+        expect(vi.mocked(invokeTyped)).toHaveBeenCalledWith("reveal_in_folder", { path: "/tmp/v.mp4" });
+        expect(vi.mocked(setSelectedJob)).not.toHaveBeenCalled();
+    });
+
+    it("Re-download calls startDownload and does NOT select", () => {
+        const job = makeJob({ options: {} as unknown as DownloadJob["options"], url: "u", title: "t" });
+        render(<HistoryRow job={job} />);
+        fireEvent.click(screen.getByLabelText("Re-download"));
+        expect(vi.mocked(startDownload)).toHaveBeenCalledWith("u", job.options, "t");
+        expect(vi.mocked(setSelectedJob)).not.toHaveBeenCalled();
+    });
+
+    it("Reveal hidden with no output_path; Re-download hidden with no options", () => {
+        render(<HistoryRow job={makeJob({ output_path: null, options: null })} />);
+        expect(screen.queryByLabelText("Reveal in folder")).not.toBeInTheDocument();
+        expect(screen.queryByLabelText("Re-download")).not.toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/views/history/HistoryRow.tsx
+++ b/crates/rdlp-desktop/src/views/history/HistoryRow.tsx
@@ -2,6 +2,7 @@
 
 import { useStore } from "@tanstack/react-store";
 import { FolderOpen, RotateCcw } from "lucide-react";
+import { Button as AriaButton } from "react-aria-components";
 import { uiStore, setSelectedJob, setView } from "@/stores/uiStore";
 import { startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -46,16 +47,22 @@ export function HistoryRow({ job }: HistoryRowProps) {
 
     return (
         <div
-            onClick={() => setSelectedJob(job.id)}
             className={cn(
-                "flex items-center gap-3 p-3 rounded-[6px] cursor-pointer transition-colors border",
+                "relative flex items-center gap-3 p-3 rounded-[6px] transition-colors border",
                 isSelected
                     ? "bg-[#0f1a2e] border-[#2a3a5a]"
                     : "bg-[var(--surface-elevated)] border-[#1a1a2e] hover:border-[#2a2a3e]",
             )}
         >
+            <AriaButton
+                onPress={() => setSelectedJob(job.id)}
+                aria-label={`Select: ${job.title ?? job.url}`}
+                aria-pressed={isSelected}
+                className="absolute inset-0 z-0 rounded-[6px] cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-[#4a9eff] focus-visible:ring-inset"
+            />
+
             {/* Thumbnail */}
-            <div className="w-[56px] h-[36px] shrink-0 rounded-[3px] overflow-hidden bg-[#0e0e1e]">
+            <div className="relative z-10 pointer-events-none w-[56px] h-[36px] shrink-0 rounded-[3px] overflow-hidden bg-[#0e0e1e]">
                 <Thumbnail
                     src={null}
                     alt={job.title ?? ""}
@@ -64,7 +71,7 @@ export function HistoryRow({ job }: HistoryRowProps) {
             </div>
 
             {/* Content */}
-            <div className="flex-1 min-w-0">
+            <div className="relative z-10 pointer-events-none flex-1 min-w-0">
                 <p className="text-[13px] font-medium text-[#eeeeee] truncate leading-snug">
                     {job.title ?? job.url}
                 </p>
@@ -83,7 +90,7 @@ export function HistoryRow({ job }: HistoryRowProps) {
             </div>
 
             {/* Status + actions */}
-            <div className="flex items-center gap-1.5 shrink-0">
+            <div className="relative z-20 flex items-center gap-1.5 shrink-0">
                 <StatusBadge status={job.status} />
                 {job.output_path && (
                     <button

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -2,9 +2,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { render } from "@/test/test-utils";
 import { JobCard } from "./JobCard";
-import { setSelectedJob } from "@/stores/uiStore";
+import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { invokeTyped } from "@/api/invokeClient";
 import type { DownloadJob } from "@/types";
@@ -179,10 +180,50 @@ describe("JobCard — progress display", () => {
         expect(screen.queryByLabelText("Reveal in folder")).not.toBeInTheDocument();
     });
 
-    it("card click selects the job", () => {
-        const { container } = render(<JobCard job={makeJob({ title: "Pick Me", status: "running" })} />);
-        fireEvent.click(container.firstChild as HTMLElement);
+    it("Select button click selects the job", () => {
+        render(<JobCard job={makeJob({ title: "Pick Me", status: "running" })} />);
+        fireEvent.click(screen.getByRole("button", { name: /^Select:/ }));
         expect(vi.mocked(setSelectedJob)).toHaveBeenCalledWith("job-1");
+    });
+
+    it("exposes a Select button with accessible name and aria-pressed=false when unselected", () => {
+        render(<JobCard job={makeJob({ id: "job-1", title: "Pick Me" })} />);
+        const sel = screen.getByRole("button", { name: "Select: Pick Me" });
+        expect(sel).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("exposes aria-pressed=true when the job is selected", () => {
+        uiStore.setState((prev) => ({ ...prev, selectedJobId: "job-1" }));
+        try {
+            render(<JobCard job={makeJob({ id: "job-1", title: "Pick Me" })} />);
+            const sel = screen.getByRole("button", { name: "Select: Pick Me" });
+            expect(sel).toHaveAttribute("aria-pressed", "true");
+        } finally {
+            uiStore.setState((prev) => ({ ...prev, selectedJobId: null }));
+        }
+    });
+
+    it("Enter on the Select button selects the job", async () => {
+        const user = userEvent.setup();
+        render(<JobCard job={makeJob({ title: "Pick Me", status: "running" })} />);
+        screen.getByRole("button", { name: /^Select:/ }).focus();
+        await user.keyboard("{Enter}");
+        expect(vi.mocked(setSelectedJob)).toHaveBeenCalledWith("job-1");
+    });
+
+    it("Space on the Select button selects the job", async () => {
+        const user = userEvent.setup();
+        render(<JobCard job={makeJob({ title: "Pick Me", status: "running" })} />);
+        screen.getByRole("button", { name: /^Select:/ }).focus();
+        await user.keyboard("{ }");
+        expect(vi.mocked(setSelectedJob)).toHaveBeenCalledWith("job-1");
+    });
+
+    it("action buttons are NOT descendants of the Select button (axe nested-interactive guard)", () => {
+        render(<JobCard job={makeJob({ status: "running" })} />);
+        const sel = screen.getByRole("button", { name: /^Select:/ });
+        expect(screen.getByLabelText("Cancel download")).toBeInTheDocument();
+        expect(sel.querySelector('[aria-label="Cancel download"]')).toBeNull();
     });
 
     it("a button click does not also select the job", () => {

--- a/crates/rdlp-desktop/src/views/queue/JobCard.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.tsx
@@ -4,6 +4,7 @@
 
 import { useStore } from "@tanstack/react-store";
 import { X, RotateCcw, FolderOpen } from "lucide-react";
+import { Button as AriaButton } from "react-aria-components";
 import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -50,9 +51,8 @@ export function JobCard({ job, compact = false }: JobCardProps) {
 
     return (
         <div
-            onClick={() => setSelectedJob(job.id)}
             className={cn(
-                "flex gap-3 rounded-[6px] cursor-pointer transition-colors border",
+                "relative flex gap-3 rounded-[6px] transition-colors border",
                 compact
                     ? "p-2 border-l-2 border-l-[#4a9eff]"
                     : "p-3",
@@ -62,8 +62,18 @@ export function JobCard({ job, compact = false }: JobCardProps) {
                 compact && !isSelected && "border-t-[#1a1a2e] border-r-[#1a1a2e] border-b-[#1a1a2e]",
             )}
         >
+            {/* Full-card selection control (keyboard-operable). Action buttons are
+                DOM siblings (z-20), never descendants — keeps axe nested-interactive
+                from firing. */}
+            <AriaButton
+                onPress={() => setSelectedJob(job.id)}
+                aria-label={`Select: ${compactTitle}`}
+                aria-pressed={isSelected}
+                className="absolute inset-0 z-0 rounded-[6px] cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-[#4a9eff] focus-visible:ring-inset"
+            />
+
             {/* Main content */}
-            <div className="flex-1 min-w-0 flex flex-col gap-1">
+            <div className="relative z-10 pointer-events-none flex-1 min-w-0 flex flex-col gap-1">
                 {/* Title + status */}
                 <div className="flex items-start gap-2">
                     <p className={cn(
@@ -112,7 +122,7 @@ export function JobCard({ job, compact = false }: JobCardProps) {
             </div>
 
             {/* Action buttons */}
-            <div className="flex items-center gap-1 shrink-0">
+            <div className="relative z-20 flex items-center gap-1 shrink-0">
                 {isRunning && (
                     <button
                         onClick={(e) => { e.stopPropagation(); void handleCancel(); }}


### PR DESCRIPTION
Closes #361.

Replaces the mouse-only `<div onClick={setSelectedJob}>` selection on **JobCard** and **HistoryRow** with an invisible **React Aria `Button` overlay** (`absolute inset-0 z-0`), making row selection keyboard-operable.

## Why this shape
- axe gate is **empty-allowlist WCAG 2.1 AA**. The naive fix (`role="button"`/wrap-in-button on the card) would nest the action buttons in an interactive ancestor → axe **`nested-interactive`** → fail. So: the overlay `<AriaButton>` carries selection; the action buttons (Cancel/Retry/Reveal/Remove · Reveal/Re-download) are DOM **siblings** at `z-20` (never descendants) → `nested-interactive` cannot fire. Content is `z-10 pointer-events-none` so whole-card mouse-click falls through to the button.
- **GridList rejected** (the textbook component) — `GridListSection` is alpha in rac 1.16/1.17 and GridList is incompatible with the TanStack-Virtualizer flat-array model QueueView uses (interleaved playlist headers). Documented in the spec.
- `JobMiniCard` already a clean `<button>` — unchanged.

## A11y model
Tab → row Select button (Enter/Space selects, `:focus-visible` ring) → action buttons. Name via `aria-label="Select: <title>"`; role=button; state via `aria-pressed` (consistent with existing LogViewer-chip precedent). WCAG 2.1.1 / 4.1.2 / 2.4.7.

## Tests (positive + negative, both components)
Select-button name + `aria-pressed` (true & false), **Enter/Space → select via `@testing-library/user-event`** (the WCAG keyboard proof), **action-buttons-NOT-descendants-of-Select-button** (the `nested-interactive` structural guard), action-button isolation (Reveal/Re-download/Cancel don't select), conditional hiding. 219 FE tests green.

## Verification
`cargo fmt --check` · `clippy -D warnings` · `cargo test` · `check-dedup` · `cargo check -p rdlp-desktop` · `tsc` (exit 0) · `npm run test` 219 ✓

⚠️ **Live Cypress axe run deferred** (CI off; heavy in sandbox). The empty `a11y-allowlist.ts` (must stay empty) + the unit not-descendants structural guard are the backstops; **please run `npm run dev` + `npm run test:e2e` locally to confirm axe is green on queue-active + history before merge.**

## Reviews (pre-push, full diff)
- **security-reviewer:** Approve — display-layer only; aria-label is auto-escaped React text; Reveal guard/handlers unchanged; no new IPC/deps.
- **code-reviewer:** Approve — sibling structure genuinely guarantees no `nested-interactive`; accessible name + keyboard path real and tested; with the live-axe caveat above.

## Follow-up (noted, out of scope)
HistoryRow still uses the scalar `useStore` selector (JobCard uses the boolean form) — a minor re-render perf nuance, not a11y.