### PR TITLE
feat(desktop): distinct 'Processing' job status during post-processing (#336)

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -369,6 +369,7 @@ pub async fn start_download(
                         job.output_path = output_files.first().map(|p| p.display().to_string());
                     }
                     Event::Failed { error, .. } => {
+                        // stage intentionally left as-is: only read while status == Processing.
                         job.status = JobStatus::Failed;
                         job.completed_at = Some(chrono::Utc::now().timestamp());
                         job.error = Some(error.user_message().into_owned());

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -364,6 +364,7 @@ pub async fn start_download(
                     Event::Completed { output_files, .. } => {
                         job.status = JobStatus::Completed;
                         job.progress = Some(1.0);
+                        job.stage = None;
                         job.completed_at = Some(chrono::Utc::now().timestamp());
                         job.output_path = output_files.first().map(|p| p.display().to_string());
                     }
@@ -376,6 +377,16 @@ pub async fn start_download(
                     Event::Cancelled { .. } => {
                         job.status = JobStatus::Cancelled;
                         job.completed_at = Some(chrono::Utc::now().timestamp());
+                    }
+                    Event::PostProcessing { stage, .. } => {
+                        job.begin_postprocessing(stage.clone());
+                    }
+                    Event::PostProcessProgress {
+                        stage, progress, ..
+                    } => {
+                        // PostProcessProgress.progress is a `Progress` directly (NOT the
+                        // Option<Progress> wrapped in Event::Progress.progress).
+                        job.set_postprocess_progress(stage.clone(), f64::from(progress.fraction()));
                     }
                     _ => {}
                 }

--- a/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
@@ -71,16 +71,12 @@ pub struct DownloadJob {
 impl DownloadJob {
     /// Mark the job as entering a post-processing stage (download finished,
     /// `FFmpeg` work in progress). Sets status to [`JobStatus::Processing`].
-    // Wired into the background event loop in Task 2 of #336.
-    #[allow(dead_code)]
     pub(crate) fn begin_postprocessing(&mut self, stage: String) {
         self.status = JobStatus::Processing;
         self.stage = Some(stage);
     }
 
     /// Update post-processing progress for the current stage.
-    // Wired into the background event loop in Task 2 of #336.
-    #[allow(dead_code)]
     pub(crate) fn set_postprocess_progress(&mut self, stage: String, fraction: f64) {
         self.status = JobStatus::Processing;
         self.stage = Some(stage);

--- a/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
@@ -484,8 +484,10 @@ mod tests {
         assert_eq!(job.stage, None);
     }
 
+    /// Documents the field shape the event-loop `Completed` arm produces
+    /// (that arm lives in a spawn closure and isn't unit-testable here).
     #[test]
-    fn completed_after_processing_clears_stage() {
+    fn completed_job_shape_has_no_stage() {
         let mut q = DownloadQueue::new();
         let job = running_job(&mut q);
         job.set_postprocess_progress("Recode".to_owned(), 0.4);

--- a/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
@@ -19,6 +19,8 @@ pub enum JobStatus {
     Pending,
     /// Actively downloading.
     Running,
+    /// Download finished; post-processing (recode/remux/embed) in progress.
+    Processing,
     /// Download finished successfully.
     Completed,
     /// Download failed with an error.
@@ -48,6 +50,8 @@ pub struct DownloadJob {
     pub(crate) speed: Option<String>,
     /// Estimated time remaining (e.g. `"00:42"`).
     pub(crate) eta: Option<String>,
+    /// Active post-processing stage name (e.g. "Recode"); `None` outside post-processing.
+    pub(crate) stage: Option<String>,
     /// Error message if the job failed.
     pub(crate) error: Option<String>,
     /// Whether a failed job can be retried.
@@ -62,6 +66,26 @@ pub struct DownloadJob {
     pub(crate) options: Option<SavedDownloadOptions>,
     /// Playlist membership — `None` for standalone downloads.
     pub(crate) playlist: Option<PlaylistContext>,
+}
+
+impl DownloadJob {
+    /// Mark the job as entering a post-processing stage (download finished,
+    /// `FFmpeg` work in progress). Sets status to [`JobStatus::Processing`].
+    // Wired into the background event loop in Task 2 of #336.
+    #[allow(dead_code)]
+    pub(crate) fn begin_postprocessing(&mut self, stage: String) {
+        self.status = JobStatus::Processing;
+        self.stage = Some(stage);
+    }
+
+    /// Update post-processing progress for the current stage.
+    // Wired into the background event loop in Task 2 of #336.
+    #[allow(dead_code)]
+    pub(crate) fn set_postprocess_progress(&mut self, stage: String, fraction: f64) {
+        self.status = JobStatus::Processing;
+        self.stage = Some(stage);
+        self.progress = Some(fraction);
+    }
 }
 
 /// A serializable snapshot of the options used when a download was started.
@@ -134,6 +158,7 @@ impl DownloadQueue {
             progress: None,
             speed: None,
             eta: None,
+            stage: None,
             error: None,
             retryable: false,
             started_at: None,
@@ -408,6 +433,122 @@ mod tests {
         let mut queue = DownloadQueue::new();
         let cancel_fn: Box<dyn Fn() + Send + Sync> = Box::new(|| {});
         assert!(!queue.start_job("nonexistent", cancel_fn, 0));
+    }
+
+    fn running_job(q: &mut DownloadQueue) -> &mut DownloadJob {
+        q.add_job("j", "https://example.com/v", None, None);
+        let job = q.get_job_mut("j").expect("job exists");
+        job.status = JobStatus::Running;
+        job
+    }
+
+    #[test]
+    fn begin_postprocessing_flips_to_processing_and_records_stage() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        job.begin_postprocessing("Recode".to_owned());
+        assert_eq!(job.status, JobStatus::Processing);
+        assert_eq!(job.stage.as_deref(), Some("Recode"));
+    }
+
+    #[test]
+    fn set_postprocess_progress_sets_status_stage_progress() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        job.set_postprocess_progress("Recode".to_owned(), 0.5);
+        assert_eq!(job.status, JobStatus::Processing);
+        assert_eq!(job.stage.as_deref(), Some("Recode"));
+        assert_eq!(job.progress, Some(0.5));
+    }
+
+    #[test]
+    fn postprocess_progress_resets_per_stage() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        job.set_postprocess_progress("Recode".to_owned(), 0.9);
+        job.set_postprocess_progress("EmbedThumbnail".to_owned(), 0.1);
+        assert_eq!(job.stage.as_deref(), Some("EmbedThumbnail"));
+        assert_eq!(job.progress, Some(0.1));
+    }
+
+    #[test]
+    fn begin_postprocessing_is_idempotent() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        job.begin_postprocessing("Recode".to_owned());
+        job.begin_postprocessing("Recode".to_owned());
+        assert_eq!(job.status, JobStatus::Processing);
+    }
+
+    #[test]
+    fn fresh_running_job_is_not_processing() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        assert_eq!(job.status, JobStatus::Running);
+        assert_eq!(job.stage, None);
+    }
+
+    #[test]
+    fn completed_after_processing_clears_stage() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        job.set_postprocess_progress("Recode".to_owned(), 0.4);
+        job.status = JobStatus::Completed;
+        job.stage = None;
+        job.progress = Some(1.0);
+        assert_eq!(job.status, JobStatus::Completed);
+        assert_eq!(job.stage, None);
+    }
+
+    #[test]
+    fn processing_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_value(JobStatus::Processing).unwrap(),
+            serde_json::json!("processing")
+        );
+    }
+
+    #[test]
+    fn all_statuses_serialize_to_expected_strings() {
+        for (variant, expected) in [
+            (JobStatus::Pending, "pending"),
+            (JobStatus::Running, "running"),
+            (JobStatus::Processing, "processing"),
+            (JobStatus::Completed, "completed"),
+            (JobStatus::Failed, "failed"),
+            (JobStatus::Cancelled, "cancelled"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(variant).unwrap(),
+                serde_json::json!(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn download_job_serializes_stage_field() {
+        let mut q = DownloadQueue::new();
+        let job = running_job(&mut q);
+        job.begin_postprocessing("Recode".to_owned());
+        let v = serde_json::to_value(&*job).unwrap();
+        assert_eq!(v["stage"], serde_json::json!("Recode"));
+
+        q.add_job("k", "https://example.com/w", None, None);
+        let other = q.get_job("k").unwrap();
+        let v2 = serde_json::to_value(other).unwrap();
+        assert_eq!(v2["stage"], serde_json::json!(null));
+    }
+
+    #[test]
+    fn clear_completed_does_not_remove_processing_job() {
+        let mut q = DownloadQueue::new();
+        q.add_job("j", "https://example.com/v", None, None);
+        q.get_job_mut("j")
+            .unwrap()
+            .begin_postprocessing("Recode".to_owned());
+        let removed = q.clear_completed();
+        assert_eq!(removed, 0);
+        assert!(q.get_job("j").is_some());
     }
 
     #[test]

--- a/crates/rdlp-desktop/src/api/downloads.test.ts
+++ b/crates/rdlp-desktop/src/api/downloads.test.ts
@@ -25,6 +25,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
+        stage: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/components/JobMiniCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobMiniCard.tsx
@@ -2,6 +2,7 @@
 // Click switches to Queue view and selects the job.
 
 import { setView, setSelectedJob } from "@/stores/uiStore";
+import { isInFlight } from "@/lib/jobStatus";
 import { cn, displayTitle, progressPercent } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
@@ -13,7 +14,7 @@ interface JobMiniCardProps {
 export function JobMiniCard({ job, className }: JobMiniCardProps) {
     const progress = job.progress ?? 0;
     const title = displayTitle(job.title);
-    const isRunning = job.status === "running";
+    const inFlight = isInFlight(job.status);
     const isPending = job.status === "pending";
 
     function handleClick() {
@@ -31,14 +32,14 @@ export function JobMiniCard({ job, className }: JobMiniCardProps) {
         >
             <div className="flex items-center justify-between gap-2 mb-1">
                 <span className="text-[11px] text-[#eeeeee] truncate flex-1 leading-tight">{title}</span>
-                {isRunning && (
+                {inFlight && (
                     <span className="text-[10px] text-[#aaaaaa] shrink-0 font-mono">{progressPercent(job.progress)}%</span>
                 )}
                 {isPending && (
                     <span className="text-[10px] text-[var(--text-muted)] shrink-0">Queued</span>
                 )}
             </div>
-            {isRunning && (
+            {inFlight && (
                 <div className="h-[2px] rounded-full bg-[#1a1a2e] overflow-hidden">
                     <div
                         className="h-full bg-[#4a9eff] transition-[width] duration-300 rounded-full"

--- a/crates/rdlp-desktop/src/components/StatusBadge.test.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBadge.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusBadge } from "./StatusBadge";
+import type { JobStatus } from "@/types";
+
+describe("StatusBadge", () => {
+    it("renders 'Processing' for processing status", () => {
+        render(<StatusBadge status="processing" />);
+        expect(screen.getByText("Processing")).toBeInTheDocument();
+    });
+    it("processing uses role=status, not alert", () => {
+        render(<StatusBadge status="processing" />);
+        expect(screen.getByRole("status")).toHaveTextContent("Processing");
+    });
+    it("maps every status to its label", () => {
+        const cases: [JobStatus, string][] = [
+            ["pending", "Queued"], ["running", "Downloading"], ["processing", "Processing"],
+            ["completed", "Completed"], ["failed", "Failed"], ["cancelled", "Cancelled"],
+        ];
+        for (const [status, label] of cases) {
+            const { unmount } = render(<StatusBadge status={status} />);
+            expect(screen.getByText(label)).toBeInTheDocument();
+            unmount();
+        }
+    });
+});

--- a/crates/rdlp-desktop/src/components/StatusBadge.tsx
+++ b/crates/rdlp-desktop/src/components/StatusBadge.tsx
@@ -17,6 +17,10 @@ const statusConfig: Record<JobStatus, { label: string; className: string }> = {
         label: "Downloading",
         className: "text-[#e8a838] bg-[#2a1f0a] border border-[#3a2a0e]",
     },
+    processing: {
+        label: "Processing",
+        className: "text-[#a78bfa] bg-[#1e1733] border border-[#2a2147]",
+    },
     completed: {
         label: "Completed",
         className: "text-[#4a9e4a] bg-[#0a2010] border border-[#0e3014]",

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -25,6 +25,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
+        stage: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/lib/jobStatus.test.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.test.ts
@@ -3,6 +3,7 @@ import {
     cancelledJobPatch,
     isTerminal,
     isDoneNotFailed,
+    isInFlight,
     jobMatchesFilter,
     countByBucket,
     tallyByStatus,
@@ -39,10 +40,11 @@ function makeJob(status: JobStatus, id = "j"): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
+        stage: null,
     };
 }
 
-const ALL_STATUSES: JobStatus[] = ["pending", "running", "completed", "failed", "cancelled"];
+const ALL_STATUSES: JobStatus[] = ["pending", "running", "processing", "completed", "failed", "cancelled"];
 
 describe("isTerminal", () => {
     it("is true for completed, cancelled, failed", () => {
@@ -97,29 +99,29 @@ describe("jobMatchesFilter", () => {
 describe("countByBucket", () => {
     it("counts a single completed job", () => {
         expect(countByBucket([makeJob("completed")])).toEqual({
-            all: 1, active: 0, completed: 1, cancelled: 0, failed: 0,
+            all: 1, active: 0, processing: 0, completed: 1, cancelled: 0, failed: 0,
         });
     });
     it("counts active = running + pending", () => {
         expect(countByBucket([makeJob("running"), makeJob("pending")])).toEqual({
-            all: 2, active: 2, completed: 0, cancelled: 0, failed: 0,
+            all: 2, active: 2, processing: 0, completed: 0, cancelled: 0, failed: 0,
         });
     });
     it("counts a mixed list into distinct buckets", () => {
         const jobs = [makeJob("running"), makeJob("completed"), makeJob("cancelled"), makeJob("failed")];
         expect(countByBucket(jobs)).toEqual({
-            all: 4, active: 1, completed: 1, cancelled: 1, failed: 1,
+            all: 4, active: 1, processing: 0, completed: 1, cancelled: 1, failed: 1,
         });
     });
     it("returns all zeros for an empty list", () => {
         expect(countByBucket([])).toEqual({
-            all: 0, active: 0, completed: 0, cancelled: 0, failed: 0,
+            all: 0, active: 0, processing: 0, completed: 0, cancelled: 0, failed: 0,
         });
     });
-    it("partitions cleanly: all === active+completed+cancelled+failed", () => {
+    it("partitions cleanly: all === active+processing+completed+cancelled+failed", () => {
         const jobs = ALL_STATUSES.flatMap((s) => [makeJob(s), makeJob(s)]);
         const c = countByBucket(jobs);
-        expect(c.all).toBe(c.active + c.completed + c.cancelled + c.failed);
+        expect(c.all).toBe(c.active + c.processing + c.completed + c.cancelled + c.failed);
     });
     it("does NOT count a cancelled job as completed (regression: #364)", () => {
         const c = countByBucket([makeJob("cancelled")]);
@@ -138,17 +140,59 @@ describe("tallyByStatus", () => {
     it("counts each status exactly", () => {
         const jobs = [makeJob("running"), makeJob("completed"), makeJob("cancelled")];
         expect(tallyByStatus(jobs)).toEqual({
-            pending: 0, running: 1, completed: 1, failed: 0, cancelled: 1,
+            pending: 0, running: 1, processing: 0, completed: 1, failed: 0, cancelled: 1,
         });
     });
     it("returns all zeros for an empty list", () => {
         expect(tallyByStatus([])).toEqual({
-            pending: 0, running: 0, completed: 0, failed: 0, cancelled: 0,
+            pending: 0, running: 0, processing: 0, completed: 0, failed: 0, cancelled: 0,
         });
     });
     it("a cancelled job increments only cancelled (regression guard)", () => {
         const t = tallyByStatus([makeJob("cancelled")]);
         expect(t.cancelled).toBe(1);
         expect(t.completed).toBe(0);
+    });
+});
+
+describe("processing bucket + isInFlight", () => {
+    it("counts a processing job in its own bucket", () => {
+        expect(countByBucket([makeJob("processing")])).toEqual({
+            all: 1, active: 0, processing: 1, completed: 0, cancelled: 0, failed: 0,
+        });
+    });
+    it("counts a mixed list across all buckets", () => {
+        const jobs = [makeJob("running"), makeJob("processing"), makeJob("completed"), makeJob("cancelled"), makeJob("failed")];
+        expect(countByBucket(jobs)).toEqual({ all: 5, active: 1, processing: 1, completed: 1, cancelled: 1, failed: 1 });
+    });
+    it("partitions cleanly incl. processing", () => {
+        const jobs = ALL_STATUSES.map((s) => makeJob(s));
+        const c = countByBucket(jobs);
+        expect(c.all).toBe(c.active + c.processing + c.completed + c.cancelled + c.failed);
+    });
+    it("processing matches only its own filter", () => {
+        expect(jobMatchesFilter("processing", "processing")).toBe(true);
+        expect(jobMatchesFilter("processing", "all")).toBe(true);
+        expect(jobMatchesFilter("processing", "active")).toBe(false);
+        expect(jobMatchesFilter("processing", "completed")).toBe(false);
+    });
+    it("tallyByStatus counts processing", () => {
+        expect(tallyByStatus([makeJob("processing")]).processing).toBe(1);
+        expect(tallyByStatus([]).processing).toBe(0);
+    });
+    it("processing is not terminal", () => {
+        expect(isTerminal("processing")).toBe(false);
+        expect(isDoneNotFailed("processing")).toBe(false);
+    });
+    it("isInFlight is true for running and processing only", () => {
+        expect(isInFlight("running")).toBe(true);
+        expect(isInFlight("processing")).toBe(true);
+        expect(isInFlight("pending")).toBe(false);
+        expect(isInFlight("completed")).toBe(false);
+        expect(isInFlight("failed")).toBe(false);
+        expect(isInFlight("cancelled")).toBe(false);
+    });
+    it("countByBucket does not throw for processing", () => {
+        expect(() => countByBucket([makeJob("processing")])).not.toThrow();
     });
 });

--- a/crates/rdlp-desktop/src/lib/jobStatus.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.ts
@@ -24,17 +24,18 @@ export function cancelledJobPatch(): Partial<DownloadJob> {
 }
 
 /** Categorizable buckets used by the Queue filter tabs + STATS panel. */
-export type QueueBucket = "active" | "completed" | "cancelled" | "failed";
+export type QueueBucket = "active" | "processing" | "completed" | "cancelled" | "failed";
 
 /** Filter keys = the buckets plus the catch-all. Canonical definition. */
 export type QueueFilter = "all" | QueueBucket;
 
 /**
  * Single source of truth: which `JobStatus` values fall into each bucket.
- * The five statuses are partitioned across the four buckets with no overlap.
+ * The six statuses are partitioned across the five buckets with no overlap.
  */
 const BUCKET_STATUSES: Record<QueueBucket, readonly JobStatus[]> = {
     active: ["running", "pending"],
+    processing: ["processing"],
     completed: ["completed"],
     cancelled: ["cancelled"],
     failed: ["failed"],
@@ -80,6 +81,7 @@ export function countByBucket(jobs: DownloadJob[]): Record<QueueFilter, number> 
     const counts: Record<QueueFilter, number> = {
         all: jobs.length,
         active: 0,
+        processing: 0,
         completed: 0,
         cancelled: 0,
         failed: 0,
@@ -88,15 +90,21 @@ export function countByBucket(jobs: DownloadJob[]): Record<QueueFilter, number> 
     return counts;
 }
 
-/** Per-status tally across all five `JobStatus` values, derived from the job list. */
+/** Per-status tally across all six `JobStatus` values, derived from the job list. */
 export function tallyByStatus(jobs: DownloadJob[]): Record<JobStatus, number> {
     const tally: Record<JobStatus, number> = {
         pending: 0,
         running: 0,
+        processing: 0,
         completed: 0,
         failed: 0,
         cancelled: 0,
     };
     for (const job of jobs) tally[job.status]++;
     return tally;
+}
+
+/** In-flight: actively downloading OR post-processing — shows progress, is cancellable. */
+export function isInFlight(status: JobStatus): boolean {
+    return status === "running" || status === "processing";
 }

--- a/crates/rdlp-desktop/src/shell/BottomDrawer.test.tsx
+++ b/crates/rdlp-desktop/src/shell/BottomDrawer.test.tsx
@@ -1,0 +1,57 @@
+// Regression test for #336: a job in the `processing` (post-processing) state
+// must surface in the BottomDrawer status line as the active job — it must NOT
+// fall through to the idle "Ready" state. Before the isInFlight migration the
+// status line gated on `status === "running"`, so a processing job looked idle.
+
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { render, createTestQueryClient } from "@/test/test-utils";
+import { BottomDrawer } from "./BottomDrawer";
+import { downloadsQueryOptions } from "@/api/downloads";
+import type { DownloadJob, JobStatus } from "@/types";
+
+function makeJob(status: JobStatus, overrides: Partial<DownloadJob> = {}): DownloadJob {
+    return {
+        id: "job-1",
+        url: "https://example.com/v",
+        title: "Test Video",
+        status,
+        progress: 0.5,
+        speed: null,
+        eta: null,
+        error: null,
+        retryable: false,
+        started_at: null,
+        completed_at: null,
+        output_path: null,
+        options: null,
+        playlist: null,
+        statusMessage: null,
+        stage: null,
+        ...overrides,
+    };
+}
+
+function renderDrawer(jobs: DownloadJob[]) {
+    const qc = createTestQueryClient();
+    qc.setQueryData(downloadsQueryOptions().queryKey, jobs);
+    return render(<BottomDrawer />, { queryClient: qc });
+}
+
+describe("BottomDrawer — processing job surfaces as active (#336)", () => {
+    it("shows the processing job title in the status line, not the idle 'Ready' state", () => {
+        renderDrawer([makeJob("processing", { title: "Processing Video" })]);
+        const status = screen.getByTestId("drawer-status");
+        // The active job title is shown...
+        expect(status).toHaveTextContent("Processing Video");
+        // ...and the idle "Ready" placeholder is NOT.
+        expect(status).not.toHaveTextContent("Ready");
+    });
+
+    it("falls back to the 'Ready' state when no job is in flight", () => {
+        renderDrawer([makeJob("completed", { title: "Done Video" })]);
+        const status = screen.getByTestId("drawer-status");
+        expect(status).toHaveTextContent("Ready");
+        expect(status).not.toHaveTextContent("Done Video");
+    });
+});

--- a/crates/rdlp-desktop/src/shell/BottomDrawer.tsx
+++ b/crates/rdlp-desktop/src/shell/BottomDrawer.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabList, Tab, TabPanel } from "@/components/ui/tabs";
 import { uiStore, toggleBottomDrawer, setSelectedJob, setView } from "@/stores/uiStore";
 import { downloadsQueryOptions } from "@/api/downloads";
+import { isInFlight, isTerminal } from "@/lib/jobStatus";
 import { LogViewer, appendLog } from "@/components/LogViewer";
 import { StatusBadge } from "@/components/StatusBadge";
 import { progressPercent } from "@/lib/utils";
@@ -45,7 +46,7 @@ function JobsPanel({ jobs }: JobsPanelProps) {
                             : (job.title ?? job.url)}
                     </span>
                     <StatusBadge status={job.status} className="shrink-0" />
-                    {(job.status === "running" || job.status === "pending") && job.progress !== null && (
+                    {isInFlight(job.status) && job.progress !== null && (
                         <span className="text-[10px] text-[var(--text-muted)] font-mono shrink-0">
                             {progressPercent(job.progress)}%
                         </span>
@@ -61,8 +62,8 @@ export function BottomDrawer() {
     const [activeTab, setActiveTab] = useState<string>("logs");
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
 
-    const activeJob = jobs.find((j) => j.status === "running");
-    const activeCount = jobs.filter((j) => j.status === "running" || j.status === "pending").length;
+    const activeJob = jobs.find((j) => isInFlight(j.status));
+    const activeCount = jobs.filter((j) => !isTerminal(j.status)).length;
 
     return (
         <Tabs

--- a/crates/rdlp-desktop/src/shell/IconRail.tsx
+++ b/crates/rdlp-desktop/src/shell/IconRail.tsx
@@ -7,6 +7,7 @@ import { useStore } from "@tanstack/react-store";
 import { useQuery } from "@tanstack/react-query";
 import { uiStore, setView } from "@/stores/uiStore";
 import { downloadsQueryOptions } from "@/api/downloads";
+import { isTerminal } from "@/lib/jobStatus";
 import { cn } from "@/lib/utils";
 import type { AppView } from "@/types";
 import { TooltipTrigger } from "react-aria-components";
@@ -24,9 +25,7 @@ export function IconRail() {
     const activeView = useStore(uiStore, (s) => s.activeView);
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
 
-    const activeCount = jobs.filter(
-        (j) => j.status === "running" || j.status === "pending",
-    ).length;
+    const activeCount = jobs.filter((j) => !isTerminal(j.status)).length;
 
     return (
         <div

--- a/crates/rdlp-desktop/src/shell/NavPanel.tsx
+++ b/crates/rdlp-desktop/src/shell/NavPanel.tsx
@@ -5,6 +5,7 @@ import { useStore } from "@tanstack/react-store";
 import { useQuery } from "@tanstack/react-query";
 import { uiStore } from "@/stores/uiStore";
 import { downloadsQueryOptions } from "@/api/downloads";
+import { isTerminal } from "@/lib/jobStatus";
 import { JobMiniCard } from "@/components/JobMiniCard";
 import { QueueNav } from "@/views/queue/QueueNav";
 import { HistoryNav } from "@/views/history/HistoryNav";
@@ -12,7 +13,7 @@ import { SettingsNav } from "@/views/settings/SettingsNav";
 
 function AnalyzeNav() {
     const { data: jobs = [] } = useQuery(downloadsQueryOptions());
-    const activeJobs = jobs.filter((j) => j.status === "running" || j.status === "pending");
+    const activeJobs = jobs.filter((j) => !isTerminal(j.status));
 
     return (
         <div className="flex flex-col h-full overflow-y-auto p-2 gap-3">

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -205,6 +205,7 @@ export interface PlaylistContext {
 export type JobStatus =
     | "pending"
     | "running"
+    | "processing"
     | "completed"
     | "failed"
     | "cancelled";
@@ -229,6 +230,8 @@ export interface DownloadJob {
     playlist?: PlaylistContext | null;
     /** Latest log message from the download-log event (frontend-only, not from Rust). */
     statusMessage: string | null;
+    /** Current post-processing stage label (e.g. "Merging", "Transcoding"); null outside processing. */
+    stage: string | null;
     /** Accumulated log messages from download-log events (frontend-only, not from Rust). */
     logMessages?: string[];
     /** Current unit info set by unit-started (frontend-only, not from Rust). */

--- a/crates/rdlp-desktop/src/views/history/HistoryRow.test.tsx
+++ b/crates/rdlp-desktop/src/views/history/HistoryRow.test.tsx
@@ -24,7 +24,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         id: "job-1", url: "https://example.com/video", title: "Done Video",
         status: "completed", progress: 1, speed: null, eta: null, error: null,
         retryable: false, started_at: null, completed_at: 1_700_000_000,
-        output_path: "/tmp/v.mp4", options: null, playlist: null, statusMessage: null,
+        output_path: "/tmp/v.mp4", options: null, playlist: null, statusMessage: null, stage: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -319,3 +319,24 @@ describe("JobCard — progress display", () => {
         expect(screen.getByText("Video — 50%")).toBeInTheDocument();
     });
 });
+
+describe("JobCard — processing (#336)", () => {
+    it("shows the progress bar and Cancel for a processing job", () => {
+        render(<JobCard job={makeJob({ status: "processing", progress: 0.3, stage: "Recode" })} />);
+        expect(screen.getByLabelText("Cancel download")).toBeInTheDocument();
+        expect(screen.getByText("30%")).toBeInTheDocument();
+    });
+    it("shows the stage as the sub-label while processing", () => {
+        render(<JobCard job={makeJob({ status: "processing", progress: 0.3, stage: "Recode" })} />);
+        expect(screen.getByText("Recode")).toBeInTheDocument();
+    });
+    it("a completed job shows no Cancel button", () => {
+        render(<JobCard job={makeJob({ status: "completed", progress: 1 })} />);
+        expect(screen.queryByLabelText("Cancel download")).not.toBeInTheDocument();
+    });
+    it("a running job still shows progress + Cancel", () => {
+        render(<JobCard job={makeJob({ status: "running", progress: 0.5 })} />);
+        expect(screen.getByLabelText("Cancel download")).toBeInTheDocument();
+        expect(screen.getByText("50%")).toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -44,6 +44,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
+        stage: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/views/queue/JobCard.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.tsx
@@ -8,7 +8,7 @@ import { Button as AriaButton } from "react-aria-components";
 import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
-import { isTerminal as isTerminalStatus } from "@/lib/jobStatus";
+import { isTerminal as isTerminalStatus, isInFlight } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
 import { cn, displayTitle, progressPercent } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
@@ -21,11 +21,12 @@ interface JobCardProps {
 
 export function JobCard({ job, compact = false }: JobCardProps) {
     const isSelected = useStore(uiStore, (s) => s.selectedJobId === job.id);
-    const isRunning = job.status === "running";
     const isFailed = job.status === "failed";
     const isCompleted = job.status === "completed";
     const isTerminal = isTerminalStatus(job.status);
     const progress = job.progress ?? 0;
+    const inFlight = isInFlight(job.status);
+    const subLabel = job.status === "processing" ? job.stage : job.statusMessage;
 
     async function handleCancel() {
         await cancelDownload(job.id);
@@ -87,7 +88,7 @@ export function JobCard({ job, compact = false }: JobCardProps) {
                 </div>
 
                 {/* Progress bar */}
-                {isRunning && (
+                {inFlight && (
                     <div>
                         <div className="h-[3px] rounded-full bg-[#1a1a2e] overflow-hidden mb-1">
                             <div
@@ -99,8 +100,8 @@ export function JobCard({ job, compact = false }: JobCardProps) {
                             <span className="text-[#aaaaaa]">{progressPercent(job.progress)}%</span>
                             {job.speed && <span>{job.speed}</span>}
                             {job.eta && <span>ETA {job.eta}</span>}
-                            {job.statusMessage && (
-                                <span className="text-[#4a9eff] truncate">{job.statusMessage}</span>
+                            {subLabel && (
+                                <span className="text-[#4a9eff] truncate">{subLabel}</span>
                             )}
                         </div>
                     </div>
@@ -124,7 +125,7 @@ export function JobCard({ job, compact = false }: JobCardProps) {
 
             {/* Action buttons */}
             <div className="relative z-20 flex items-center gap-1 shrink-0">
-                {isRunning && (
+                {inFlight && (
                     <button
                         onClick={(e) => { e.stopPropagation(); void handleCancel(); }}
                         aria-label="Cancel download"

--- a/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
@@ -7,7 +7,7 @@ import { FolderOpen, RotateCcw, X } from "lucide-react";
 import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { downloadsQueryOptions, cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
-import { isTerminal as isTerminalStatus } from "@/lib/jobStatus";
+import { isTerminal as isTerminalStatus, isInFlight } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
 import { cn, progressPercent } from "@/lib/utils";
 
@@ -30,9 +30,9 @@ export function JobDetails() {
         );
     }
 
-    const isRunning = job.status === "running";
     const isFailed = job.status === "failed";
     const isCompleted = job.status === "completed";
+    const inFlight = isInFlight(job.status);
     const isTerminal = isTerminalStatus(job.status);
 
     const handleCancel = () => { cancelDownload(job.id).catch(console.error); };
@@ -63,7 +63,7 @@ export function JobDetails() {
             </div>
 
             {/* Progress (running) */}
-            {isRunning && (
+            {inFlight && (
                 <div>
                     <div className="flex items-center justify-between text-[10px] text-[var(--text-muted)] mb-1">
                         <span className="font-mono text-[#aaaaaa]">{progressPercent(job.progress)}%</span>
@@ -205,7 +205,7 @@ export function JobDetails() {
                         Retry
                     </button>
                 )}
-                {isRunning && (
+                {inFlight && (
                     <button
                         onClick={handleCancel}
                         className="flex items-center gap-2 px-3 py-1.5 rounded-[4px] text-[12px] text-[var(--text-muted)] hover:text-[#e85858] hover:bg-[#2a0a0a] transition-colors"

--- a/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
+++ b/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
@@ -87,11 +87,12 @@ export function PlaylistGroupHeader({
             </div>
 
             {/* Active episode indicator */}
-            {stats.running > 0 && (() => {
-                const activeJob = jobs.find((j) => j.status === "running");
-                return activeJob?.statusMessage ? (
+            {(stats.running > 0 || stats.processing > 0) && (() => {
+                const activeJob = jobs.find((j) => isInFlight(j.status));
+                const label = activeJob?.statusMessage ?? activeJob?.stage;
+                return label ? (
                     <p className="text-[10px] text-[#aaaaaa] truncate" aria-live="polite">
-                        {activeJob.statusMessage}
+                        {label}
                     </p>
                 ) : null;
             })()}

--- a/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
+++ b/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
@@ -4,7 +4,7 @@
 import { useMemo } from "react";
 import { ChevronDown, ChevronRight, XCircle } from "lucide-react";
 import { cancelDownload } from "@/api/downloads";
-import { tallyByStatus } from "@/lib/jobStatus";
+import { isInFlight, isTerminal, tallyByStatus } from "@/lib/jobStatus";
 import type { DownloadJob } from "@/types";
 
 interface PlaylistGroupHeaderProps {
@@ -29,12 +29,12 @@ export function PlaylistGroupHeader({
         return { ...tally, total, progressFraction };
     }, [jobs]);
 
-    const hasActive = stats.running > 0 || stats.pending > 0;
+    const hasActive = stats.running > 0 || stats.pending > 0 || stats.processing > 0;
 
     async function handleCancelAll() {
-        const activeJobs = jobs.filter((j) => j.status === "running" || j.status === "pending");
+        const activeJobs = jobs.filter((j) => !isTerminal(j.status));
         for (const job of activeJobs) {
-            if (job.status === "running") {
+            if (isInFlight(job.status)) {
                 void cancelDownload(job.id);
             }
         }

--- a/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
+++ b/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
@@ -101,6 +101,9 @@ export function PlaylistGroupHeader({
                 {stats.running > 0 && (
                     <span className="text-[#4a9eff]">{stats.running} downloading</span>
                 )}
+                {stats.processing > 0 && (
+                    <span className="text-[#a78bfa]">{stats.processing} processing</span>
+                )}
                 {stats.completed > 0 && (
                     <span className="text-[#22C55E]">{stats.completed} completed</span>
                 )}

--- a/crates/rdlp-desktop/src/views/queue/QueueNav.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueNav.test.tsx
@@ -24,6 +24,7 @@ function makeJob(status: JobStatus, id: string): DownloadJob {
         options: null,
         playlist: null,
         statusMessage: null,
+        stage: null,
     };
 }
 

--- a/crates/rdlp-desktop/src/views/queue/QueueNav.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueNav.test.tsx
@@ -100,3 +100,45 @@ describe("QueueNav — STATS bucketing (#364)", () => {
         expect(screen.queryByRole("button", { name: /clear finished/i })).not.toBeInTheDocument();
     });
 });
+
+describe("QueueNav — processing bucket (#336)", () => {
+    beforeEach(() => {
+        setQueueFilter("all");
+    });
+
+    it("counts a processing job only in the Processing row", () => {
+        renderNav([makeJob("processing", "a")]);
+        expect(statValue("Processing")).toBe("1");
+        expect(statValue("Active")).toBe("0");
+        expect(statValue("Completed")).toBe("0");
+        expect(statValue("Failed")).toBe("0");
+    });
+
+    it("shows distinct counts for a mixed queue incl. processing", () => {
+        renderNav([
+            makeJob("running", "a"),
+            makeJob("processing", "b"),
+            makeJob("completed", "c"),
+            makeJob("cancelled", "d"),
+            makeJob("failed", "e"),
+        ]);
+        expect(statValue("Total")).toBe("5");
+        expect(statValue("Active")).toBe("1");
+        expect(statValue("Processing")).toBe("1");
+        expect(statValue("Completed")).toBe("1");
+        expect(statValue("Cancelled")).toBe("1");
+        expect(statValue("Failed")).toBe("1");
+    });
+
+    it("activates the processing filter on click", async () => {
+        const user = userEvent.setup();
+        renderNav([makeJob("processing", "a")]);
+        await user.click(screen.getByRole("button", { name: /processing/i }));
+        expect(queueFilterStore.state.filter).toBe("processing");
+    });
+
+    it("does not show 'Clear Finished' for a processing-only queue", () => {
+        renderNav([makeJob("processing", "a")]);
+        expect(screen.queryByRole("button", { name: /clear finished/i })).not.toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/views/queue/QueueNav.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueNav.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 const filters: { key: QueueFilter; label: string }[] = [
     { key: "all", label: "All" },
     { key: "active", label: "Active" },
+    { key: "processing", label: "Processing" },
     { key: "completed", label: "Completed" },
     { key: "cancelled", label: "Cancelled" },
     { key: "failed", label: "Failed" },
@@ -21,6 +22,7 @@ const filters: { key: QueueFilter; label: string }[] = [
 const statRows: { key: QueueFilter; label: string; valueClass: string }[] = [
     { key: "all", label: "Total", valueClass: "text-[#aaaaaa]" },
     { key: "active", label: "Active", valueClass: "text-[#e8a838]" },
+    { key: "processing", label: "Processing", valueClass: "text-[#a78bfa]" },
     { key: "completed", label: "Completed", valueClass: "text-[#4a9e4a]" },
     { key: "cancelled", label: "Cancelled", valueClass: "text-[var(--text-muted)]" },
     { key: "failed", label: "Failed", valueClass: "text-[#e85858]" },

--- a/crates/rdlp-desktop/src/views/queue/QueueView.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueView.tsx
@@ -9,7 +9,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { Download } from "lucide-react";
 import { downloadsQueryOptions } from "@/api/downloads";
 import { queueFilterStore } from "@/stores/queueFilterStore";
-import { jobMatchesFilter, isDoneNotFailed, type QueueFilter } from "@/lib/jobStatus";
+import { jobMatchesFilter, isDoneNotFailed, isTerminal, type QueueFilter } from "@/lib/jobStatus";
 import { PlaylistGroupHeader } from "./PlaylistGroupHeader";
 import { JobCard } from "./JobCard";
 import type { DownloadJob, QueueItem } from "@/types";
@@ -63,10 +63,10 @@ function buildFlatItems(
         }
     }
 
-    // Sort groups: active-first (has running/pending), then by most recent started_at
+    // Sort groups: active-first (has ongoing: pending/running/processing), then by most recent started_at
     const sortedGroups = [...playlistGroups.entries()].sort(([, aJobs], [, bJobs]) => {
-        const aHasActive = aJobs.some((j) => j.status === "running" || j.status === "pending");
-        const bHasActive = bJobs.some((j) => j.status === "running" || j.status === "pending");
+        const aHasActive = aJobs.some((j) => !isTerminal(j.status));
+        const bHasActive = bJobs.some((j) => !isTerminal(j.status));
         if (aHasActive !== bHasActive) return aHasActive ? -1 : 1;
 
         const aLatest = Math.max(...aJobs.map((j) => j.started_at ?? 0));

--- a/crates/rdlp-desktop/src/views/queue/QueueView.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueView.tsx
@@ -16,10 +16,11 @@ import type { DownloadJob, QueueItem } from "@/types";
 
 const STATUS_ORDER: Record<string, number> = {
     running: 0,
-    pending: 1,
-    failed: 2,
-    completed: 3,
-    cancelled: 4,
+    processing: 1,
+    pending: 2,
+    failed: 3,
+    completed: 4,
+    cancelled: 5,
 };
 
 /** Height constants for estimateSize callback. */

--- a/crates/rdlp-desktop/src/views/queue/QueueView.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueView.tsx
@@ -76,8 +76,8 @@ function buildFlatItems(
 
     // Sort standalone by status priority, then by started_at
     const sortedStandalone = [...standaloneJobs].sort((a, b) => {
-        const aOrder = STATUS_ORDER[a.status] ?? 5;
-        const bOrder = STATUS_ORDER[b.status] ?? 5;
+        const aOrder = STATUS_ORDER[a.status] ?? 6;
+        const bOrder = STATUS_ORDER[b.status] ?? 6;
         if (aOrder !== bOrder) return aOrder - bOrder;
         return (b.started_at ?? 0) - (a.started_at ?? 0);
     });


### PR DESCRIPTION
## Summary

Fixes #336 — a job in post-processing showed a stuck **"Downloading"** badge (and a 100% / idle progress bar). Adds a distinct **Processing** status, owned by the Rust event loop (single source of truth).

- **Rust (`src-tauri`):** `JobStatus::Processing` + a `stage: Option<String>` field on `DownloadJob` + `begin_postprocessing`/`set_postprocess_progress` methods. The event loop sets Processing + stage + per-stage `progress` on `Event::PostProcessing`/`PostProcessProgress`, and clears `stage` on `Completed`. Progress now tracks the post-process stage (0→100% per stage), never stuck at 100%.
- **TS:** mirror `"processing"` + `stage`; `processing` is its **own queue bucket** in `lib/jobStatus.ts` (filter tab + STATS row), label **"Processing"** (violet badge, role=status). New `isInFlight` predicate (running||processing) gates the card progress bar + Cancel button — a processing job stays cancellable (recode is interruptible per #343).
- **Whole-surface consistency:** BottomDrawer (no longer flips to "Ready" during recode), NavPanel active list, IconRail count, JobMiniCard, PlaylistGroupHeader (processing chip + cancel-all + active-episode), QueueView sort — all migrated off `status === "running"` to the correct axis predicate (`!isTerminal` for ongoing-membership/counts, `isInFlight` for the working-job/progress display).

## Architecture / validation
- Distinct post-processing status is the industry norm (qBittorrent Moving/Checking, yt-dlp postprocess phase, Seal "Merging"); folding it into "active/completed" is the documented mistake. "Processing" chosen over "Post-processing" (less jargon) — validated via research.
- Rust = single source of truth; TS `setQueryData` stays optimistic-only (TanStack-validated). The broader `statusMessage`/`currentUnit` contract de-dup is **Slice 2 → #368**.

## Test Plan
- [x] `cargo fmt --check`, `cargo clippy -p rdlp-desktop --all-targets -- -D warnings`, `cargo test -p rdlp-desktop` — green (Event-free `DownloadJob`-method tests: begin/set/idempotency/per-stage-reset/serde-all-variants/`stage` field/`clear_completed` exclusion).
- [x] `npx tsc --noEmit`; `npm run test` — **267 passed** (processing own-bucket isolation, `isInFlight` truth table, badge label/role, QueueNav STATS, JobCard progress+Cancel during processing, BottomDrawer "not Ready while processing" regression guard).
- [x] `npm run test:e2e` (Cypress) — **30/30**, `a11y.cy.ts` 8/8 (WCAG 2.1 AA; new Processing badge/chip 6.27:1, allowlist empty).

## Reviews
- **security-reviewer** (full `develop..HEAD`): ✅ Approve — no blocking; `stage` is operator/pipeline-controlled (not attacker input), no `dangerouslySetInnerHTML`, no new IPC/deps; processing correctly excluded from `clear_completed`.
- **code-reviewer** (full diff, re-reviewed after fixes): ✅ Approve — surfaced that 3 shell surfaces (BottomDrawer/NavPanel/JobMiniCard) + cancel-all/IconRail/sort/episode-indicator still gated on `running` (bug resurfacing); all folded in before push and re-verified.

## Follow-ups
- #368 — Slice 2: migrate `statusMessage`/`currentUnit` to Rust, drop redundant frontend status re-derivation, replace the `cancelDownload` "must NOT invalidate" workaround with `cancelQueries` + rollback.