### PR TITLE
refactor(desktop): DownloadJob state-contract de-dup — Rust single source of truth (#368)

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -370,7 +370,7 @@ pub async fn start_download(
                         job.output_path = output_files.first().map(|p| p.display().to_string());
                     }
                     Event::Failed { error, .. } => {
-                        // stage intentionally left as-is: only read while status == Processing.
+                        // stage + current_unit intentionally left as-is: only read while in-flight / processing.
                         job.status = JobStatus::Failed;
                         job.completed_at = Some(chrono::Utc::now().timestamp());
                         job.error = Some(error.user_message().into_owned());

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -365,6 +365,7 @@ pub async fn start_download(
                         job.status = JobStatus::Completed;
                         job.progress = Some(1.0);
                         job.stage = None;
+                        job.clear_current_unit();
                         job.completed_at = Some(chrono::Utc::now().timestamp());
                         job.output_path = output_files.first().map(|p| p.display().to_string());
                     }
@@ -388,6 +389,17 @@ pub async fn start_download(
                         // PostProcessProgress.progress is a `Progress` directly (NOT the
                         // Option<Progress> wrapped in Event::Progress.progress).
                         job.set_postprocess_progress(stage.clone(), f64::from(progress.fraction()));
+                    }
+                    Event::PlaylistItemStarted {
+                        index,
+                        total,
+                        title,
+                        ..
+                    } => {
+                        job.set_current_unit(*index, *total, title.clone());
+                    }
+                    Event::UnitCompleted { .. } => {
+                        job.clear_current_unit();
                     }
                     _ => {}
                 }

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -73,21 +73,6 @@ pub(crate) enum LogLevel {
     Debug,
 }
 
-/// Format-selected payload emitted as `"format-selected"`.
-///
-/// Sent when the download engine selects a format, informing the
-/// frontend of the chosen quality and format identifier.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FormatSelectedPayload {
-    /// The UUID of the download job.
-    pub(crate) job_id: String,
-    /// The selected format identifier (e.g. `"hls-720"`).
-    pub(crate) format_id: String,
-    /// Human-readable quality description (e.g. `"1080p"`).
-    pub(crate) quality: String,
-}
-
 /// Post-processing progress payload emitted as `"postprocess-progress"`.
 ///
 /// Sent for every [`Event::PostProcessProgress`] update. The `progress`
@@ -111,14 +96,6 @@ pub(crate) struct UnitStartedPayload {
     pub(crate) unit_index: usize,
     pub(crate) unit_total: usize,
     pub(crate) unit_title: String,
-}
-
-/// Payload for "unit-completed" Tauri event.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct UnitCompletedPayload {
-    pub(crate) job_id: String,
-    pub(crate) unit_index: usize,
 }
 
 /// Log message payload emitted as `"download-log"`.
@@ -281,16 +258,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
         Event::FormatSelected {
             format_id, quality, ..
         } => {
-            let payload = FormatSelectedPayload {
-                job_id: job_id.to_owned(),
-                format_id: format_id.clone(),
-                quality: quality.clone(),
-            };
-            if let Err(e) = app.emit("format-selected", &payload) {
-                debug!("Failed to emit format-selected for job {job_id}: {e}");
-            }
-
-            // Also emit as a log message for the status bar
+            // Emit as a log message for the status bar
             let log = DownloadLogPayload {
                 job_id: job_id.to_owned(),
                 level: LogLevel::Info,
@@ -341,16 +309,6 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             }
         }
 
-        Event::UnitCompleted { index, .. } => {
-            let payload = UnitCompletedPayload {
-                job_id: job_id.to_owned(),
-                unit_index: *index,
-            };
-            if let Err(e) = app.emit("unit-completed", &payload) {
-                debug!("Failed to emit unit-completed for job {job_id}: {e}");
-            }
-        }
-
         Event::Cancelled { .. } => {
             let payload = DownloadCancelledPayload {
                 job_id: job_id.to_owned(),
@@ -360,7 +318,8 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
             }
         }
 
-        // Remaining unhandled events (SubtitlesFound, SubtitlesMissing, Started, Retrying from playlist)
+        // Remaining unhandled events (SubtitlesFound, SubtitlesMissing, Started,
+        // UnitCompleted, Retrying from playlist)
         _ => {}
     }
 }
@@ -429,19 +388,6 @@ mod tests {
         assert_eq!(json["jobId"], "abc-123");
         assert_eq!(json["error"], "connection timeout");
         assert_eq!(json["retryable"], true);
-    }
-
-    #[test]
-    fn test_format_selected_payload_serializes() {
-        let payload = FormatSelectedPayload {
-            job_id: "abc-123".to_owned(),
-            format_id: "hls-720".to_owned(),
-            quality: "720p".to_owned(),
-        };
-        let json = serde_json::to_value(&payload).expect("serialization should succeed");
-        assert_eq!(json["jobId"], "abc-123");
-        assert_eq!(json["formatId"], "hls-720");
-        assert_eq!(json["quality"], "720p");
     }
 
     #[test]

--- a/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/download_queue.rs
@@ -29,6 +29,15 @@ pub enum JobStatus {
     Cancelled,
 }
 
+/// Live snapshot of the in-progress sub-unit (playlist episode or merge phase).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurrentUnit {
+    pub(crate) index: usize,
+    pub(crate) total: usize,
+    pub(crate) title: String,
+}
+
 /// Serializable metadata for a single download job.
 ///
 /// This struct is sent to the frontend over IPC. Progress and speed
@@ -52,6 +61,9 @@ pub struct DownloadJob {
     pub(crate) eta: Option<String>,
     /// Active post-processing stage name (e.g. "Recode"); `None` outside post-processing.
     pub(crate) stage: Option<String>,
+    /// Live snapshot of the in-progress sub-unit; `None` when not in a unit.
+    #[serde(rename = "currentUnit")]
+    pub(crate) current_unit: Option<CurrentUnit>,
     /// Error message if the job failed.
     pub(crate) error: Option<String>,
     /// Whether a failed job can be retried.
@@ -81,6 +93,20 @@ impl DownloadJob {
         self.status = JobStatus::Processing;
         self.stage = Some(stage);
         self.progress = Some(fraction);
+    }
+
+    /// Record the in-progress sub-unit (playlist episode or merge Video/Audio).
+    pub(crate) fn set_current_unit(&mut self, index: usize, total: usize, title: String) {
+        self.current_unit = Some(CurrentUnit {
+            index,
+            total,
+            title,
+        });
+    }
+
+    /// Clear the in-progress sub-unit (unit finished / job done).
+    pub(crate) fn clear_current_unit(&mut self) {
+        self.current_unit = None;
     }
 }
 
@@ -155,6 +181,7 @@ impl DownloadQueue {
             speed: None,
             eta: None,
             stage: None,
+            current_unit: None,
             error: None,
             retryable: false,
             started_at: None,
@@ -569,5 +596,42 @@ mod tests {
         assert_eq!(job.status, JobStatus::Running);
         assert_eq!(job.started_at, Some(1_700_000_000));
         assert!(queue.take_cancel("job-1").is_some());
+    }
+
+    #[test]
+    fn set_current_unit_records_snapshot() {
+        let mut q = DownloadQueue::new();
+        q.add_job("j", "https://example.com/v", None, None);
+        let job = q.get_job_mut("j").unwrap();
+        job.set_current_unit(1, 2, "Video".to_owned());
+        let u = job.current_unit.as_ref().expect("set");
+        assert_eq!((u.index, u.total, u.title.as_str()), (1, 2, "Video"));
+    }
+
+    #[test]
+    fn clear_current_unit_resets() {
+        let mut q = DownloadQueue::new();
+        q.add_job("j", "https://example.com/v", None, None);
+        let job = q.get_job_mut("j").unwrap();
+        job.set_current_unit(3, 12, "Ep 3".to_owned());
+        job.clear_current_unit();
+        assert!(job.current_unit.is_none());
+    }
+
+    #[test]
+    fn current_unit_serializes_to_camelcase_key_or_null() {
+        let mut q = DownloadQueue::new();
+        q.add_job("j", "https://example.com/v", None, None);
+        let job = q.get_job_mut("j").unwrap();
+        job.set_current_unit(2, 2, "Audio".to_owned());
+        let v = serde_json::to_value(&*job).unwrap();
+        assert_eq!(
+            v["currentUnit"],
+            serde_json::json!({"index":2,"total":2,"title":"Audio"})
+        );
+
+        q.add_job("k", "https://example.com/w", None, None);
+        let v2 = serde_json::to_value(q.get_job("k").unwrap()).unwrap();
+        assert_eq!(v2["currentUnit"], serde_json::json!(null));
     }
 }

--- a/crates/rdlp-desktop/src/api/downloads.test.ts
+++ b/crates/rdlp-desktop/src/api/downloads.test.ts
@@ -24,7 +24,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         output_path: null,
         options: null,
         playlist: null,
-        statusMessage: null,
+        currentUnit: null,
         stage: null,
         ...overrides,
     };
@@ -44,8 +44,7 @@ describe("cancelDownload", () => {
             progress: 0.47,
             speed: "4.2 MB/s",
             eta: "0:12",
-            statusMessage: "Video — 47%",
-            currentUnit: { unitIndex: 1, unitTotal: 2, unitTitle: "Video" },
+            currentUnit: { index: 1, total: 2, title: "Video" },
         });
         queryClient.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
         const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -54,7 +53,6 @@ describe("cancelDownload", () => {
 
         const jobs = queryClient.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
         expect(jobs[0]!.status).toBe("cancelled");
-        expect(jobs[0]!.statusMessage).toBeNull();
         expect(jobs[0]!.currentUnit).toBeNull();
         expect(jobs[0]!.speed).toBeNull();
         expect(jobs[0]!.eta).toBeNull();

--- a/crates/rdlp-desktop/src/api/downloads.test.ts
+++ b/crates/rdlp-desktop/src/api/downloads.test.ts
@@ -60,3 +60,35 @@ describe("cancelDownload", () => {
         expect(invalidateSpy).not.toHaveBeenCalled();
     });
 });
+
+describe("cancelDownload — optimistic guard (#368)", () => {
+    it("optimistically flips to cancelled on success", async () => {
+        const key = queryKeys.downloads.list();
+        queryClient.setQueryData(key, [makeJob({ id: "a", status: "running" })]);
+        invokeMock.mockResolvedValueOnce(undefined);
+        await cancelDownload("a");
+        expect(queryClient.getQueryData<DownloadJob[]>(key)![0]!.status).toBe("cancelled");
+    });
+    it("flips optimistically BEFORE the IPC resolves", async () => {
+        const key = queryKeys.downloads.list();
+        queryClient.setQueryData(key, [makeJob({ id: "a", status: "running" })]);
+        // Hold the IPC open so we can observe the in-flight optimistic state.
+        let release!: () => void;
+        invokeMock.mockReturnValueOnce(new Promise<void>((res) => (release = res)));
+        const p = cancelDownload("a");
+        // The documented pattern guards via cancelQueries() then writes the optimistic
+        // flip — all before the cancel_download IPC resolves. Drain pending microtasks
+        // (cancelQueries settles) without releasing the held IPC, then assert the flip.
+        await new Promise((r) => setTimeout(r, 0));
+        expect(queryClient.getQueryData<DownloadJob[]>(key)![0]!.status).toBe("cancelled");
+        release();
+        await p;
+    });
+    it("rolls back when the IPC rejects", async () => {
+        const key = queryKeys.downloads.list();
+        queryClient.setQueryData(key, [makeJob({ id: "a", status: "running" })]);
+        invokeMock.mockRejectedValueOnce(new Error("boom"));
+        await expect(cancelDownload("a")).rejects.toThrow("boom");
+        expect(queryClient.getQueryData<DownloadJob[]>(key)![0]!.status).toBe("running"); // rolled back
+    });
+});

--- a/crates/rdlp-desktop/src/api/downloads.ts
+++ b/crates/rdlp-desktop/src/api/downloads.ts
@@ -32,22 +32,21 @@ export async function startDownload(
     return jobId;
 }
 
-/** Cancel a running download. */
+/** Cancel a running download. Optimistically flips to cancelled; rolls back on IPC failure. */
 export async function cancelDownload(jobId: string): Promise<void> {
-    await invokeTyped<void>("cancel_download", { jobId });
-    // Optimistic terminal flip. The backend sets JobStatus::Cancelled
-    // asynchronously and confirms via the "download-cancelled" event
-    // (registerDownloadEvents). We must NOT invalidateQueries here: a
-    // refetch would race the async cancel and read stale "running".
-    queryClient.setQueryData<DownloadJob[]>(
-        queryKeys.downloads.list(),
-        (old) =>
-            old?.map((job) =>
-                job.id === jobId
-                    ? { ...job, ...cancelledJobPatch() }
-                    : job,
-            ),
+    const key = queryKeys.downloads.list();
+    // Guard the optimistic write against an in-flight refetch (TanStack optimistic-updates pattern).
+    await queryClient.cancelQueries({ queryKey: key });
+    const previous = queryClient.getQueryData<DownloadJob[]>(key);
+    queryClient.setQueryData<DownloadJob[]>(key, (old) =>
+        old?.map((job) => (job.id === jobId ? { ...job, ...cancelledJobPatch() } : job)),
     );
+    try {
+        await invokeTyped<void>("cancel_download", { jobId });
+    } catch (e) {
+        if (previous) queryClient.setQueryData(key, previous); // rollback
+        throw e;
+    }
 }
 
 /** Remove a completed/failed/cancelled job from the queue. */

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -24,7 +24,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         output_path: null,
         options: null,
         playlist: null,
-        statusMessage: null,
+        currentUnit: null,
         stage: null,
         ...overrides,
     };
@@ -54,11 +54,10 @@ describe("registerDownloadEvents", () => {
         const job = makeJob({
             id: "j1",
             status: "running",
-            statusMessage: "Video — 47%",
             progress: 0.47,
             speed: "4.2 MB/s",
             eta: "0:12",
-            currentUnit: { unitTitle: "Video", unitIndex: 1, unitTotal: 2 },
+            currentUnit: { index: 1, total: 2, title: "Video" },
         });
         qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
 
@@ -66,7 +65,6 @@ describe("registerDownloadEvents", () => {
 
         const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
         expect(jobs[0]!.status).toBe("cancelled");
-        expect(jobs[0]!.statusMessage).toBeNull();
         expect(jobs[0]!.currentUnit).toBeNull();
         expect(jobs[0]!.speed).toBeNull();
         expect(jobs[0]!.eta).toBeNull();
@@ -109,20 +107,6 @@ describe("registerDownloadEvents", () => {
 
         const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
         expect(jobs[0]!.logMessages).toEqual(["First", "Second", "Third"]);
-    });
-
-    it("also updates statusMessage on download-log event", async () => {
-        const job = makeJob({ id: "job-42" });
-        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
-
-        await mockEmit("download-log", {
-            jobId: "job-42",
-            level: "info",
-            message: "Merging streams",
-        });
-
-        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
-        expect(jobs[0]!.statusMessage).toBe("Merging streams");
     });
 
     it("does not affect other jobs when a log event arrives", async () => {

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -14,10 +14,8 @@ import {
     onDownloadError,
     onDownloadCancelled,
     onDownloadLog,
-    onFormatSelected,
     onPostProcessProgress,
     onUnitStarted,
-    onUnitCompleted,
 } from "../lib/tauri";
 import { queryKeys } from "../query/queryKeys";
 import { appendLog } from "../components/LogViewer";
@@ -58,19 +56,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                 return old.map((job) => {
                     const entry = batch.get(job.id);
                     if (!entry) return job;
-
-                    // For merge downloads, show "Video — 67%" or "Audio — 23%"
-                    const unit = job.currentUnit;
-                    const isMerge = unit
-                        && unit.unitTotal === 2
-                        && (unit.unitTitle === "Video" || unit.unitTitle === "Audio");
-
-                    const updates: Partial<DownloadJob> = { ...entry };
-                    if (isMerge) {
-                        updates.statusMessage = `${unit.unitTitle} \u2014 ${Math.round(entry.progress * 100)}%`;
-                    }
-
-                    return { ...job, ...updates };
+                    return { ...job, ...entry };
                 });
             },
         );
@@ -111,9 +97,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                                   progress: 1,
                                   output_path: p.filepath || null,
                                   completed_at: Math.floor(Date.now() / 1000),
-                                  statusMessage: null,
                                   currentUnit: null,
-                                  completedUnits: 0,
                               }
                             : job,
                     ),
@@ -171,7 +155,6 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                         job.id === p.jobId
                             ? {
                                   ...job,
-                                  statusMessage: p.message,
                                   logMessages: [...(job.logMessages || []), p.message],
                               }
                             : job,
@@ -181,24 +164,8 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
     );
 
     unlisteners.push(
-        onFormatSelected((p) => {
-            if (!mounted) return;
-            qc.setQueryData<DownloadJob[]>(
-                queryKeys.downloads.list(),
-                (old) =>
-                    old?.map((job) =>
-                        job.id === p.jobId
-                            ? { ...job, statusMessage: `Format: ${p.quality}` }
-                            : job,
-                    ),
-            );
-        }),
-    );
-
-    unlisteners.push(
         onPostProcessProgress((p) => {
             if (!mounted) return;
-            const pct = Math.round(p.progress * 100);
             qc.setQueryData<DownloadJob[]>(
                 queryKeys.downloads.list(),
                 (old) =>
@@ -209,7 +176,6 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                                   progress: p.progress,
                                   speed: null,
                                   eta: null,
-                                  statusMessage: `${p.stage}… ${pct}%`,
                               }
                             : job,
                     ),
@@ -220,14 +186,6 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
     unlisteners.push(
         onUnitStarted((p) => {
             if (!mounted) return;
-            // Determine if this is a merge download (Video/Audio) or a playlist episode
-            const isMerge = p.unitTotal === 2
-                && (p.unitTitle === "Video" || p.unitTitle === "Audio");
-
-            const statusMessage = isMerge
-                ? p.unitTitle   // "Video" or "Audio" — percentage appended by progress handler
-                : `Ep ${p.unitIndex}/${p.unitTotal} \u2014 ${p.unitTitle}`;
-
             qc.setQueryData<DownloadJob[]>(
                 queryKeys.downloads.list(),
                 (old) =>
@@ -235,30 +193,11 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                         job.id === p.jobId
                             ? {
                                   ...job,
-                                  statusMessage,
                                   currentUnit: {
-                                      unitIndex: p.unitIndex,
-                                      unitTotal: p.unitTotal,
-                                      unitTitle: p.unitTitle,
+                                      index: p.unitIndex,
+                                      total: p.unitTotal,
+                                      title: p.unitTitle,
                                   },
-                              }
-                            : job,
-                    ),
-            );
-        }),
-    );
-
-    unlisteners.push(
-        onUnitCompleted((p) => {
-            if (!mounted) return;
-            qc.setQueryData<DownloadJob[]>(
-                queryKeys.downloads.list(),
-                (old) =>
-                    old?.map((job) =>
-                        job.id === p.jobId
-                            ? {
-                                  ...job,
-                                  completedUnits: (job.completedUnits ?? 0) + 1,
                               }
                             : job,
                     ),

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -193,6 +193,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                         job.id === p.jobId
                             ? {
                                   ...job,
+                                  // Live-push mirror of the Rust-owned `current_unit`; the queue refetch reconciles to Rust's value.
                                   currentUnit: {
                                       index: p.unitIndex,
                                       total: p.unitTotal,

--- a/crates/rdlp-desktop/src/lib/jobStatus.test.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.test.ts
@@ -7,6 +7,7 @@ import {
     jobMatchesFilter,
     countByBucket,
     tallyByStatus,
+    jobSubLabel,
 } from "./jobStatus";
 import type { JobStatus, DownloadJob } from "../types";
 
@@ -14,7 +15,6 @@ describe("cancelledJobPatch", () => {
     it("sets cancelled status and clears all transient progress fields", () => {
         expect(cancelledJobPatch()).toEqual({
             status: "cancelled",
-            statusMessage: null,
             currentUnit: null,
             speed: null,
             eta: null,
@@ -23,8 +23,8 @@ describe("cancelledJobPatch", () => {
     });
 });
 
-function makeJob(status: JobStatus, id = "j"): DownloadJob {
-    return {
+function makeJob(status: JobStatus, id = "j", overrides: Partial<DownloadJob> = {}): DownloadJob {
+    const base: DownloadJob = {
         id,
         url: "https://example.com/v",
         title: null,
@@ -39,12 +39,34 @@ function makeJob(status: JobStatus, id = "j"): DownloadJob {
         output_path: null,
         options: null,
         playlist: null,
-        statusMessage: null,
+        currentUnit: null,
         stage: null,
     };
+    return { ...base, status, id, ...overrides };
 }
 
 const ALL_STATUSES: JobStatus[] = ["pending", "running", "processing", "completed", "failed", "cancelled"];
+
+describe("jobSubLabel", () => {
+    it("returns the stage while processing", () => {
+        expect(jobSubLabel(makeJob("processing", "a", { stage: "Recode" }))).toBe("Recode");
+    });
+    it("formats a merge sub-unit with percent", () => {
+        expect(jobSubLabel(makeJob("running", "a", { currentUnit: { index: 1, total: 2, title: "Video" }, progress: 0.67 }))).toBe("Video — 67%");
+    });
+    it("formats a playlist episode", () => {
+        expect(jobSubLabel(makeJob("running", "a", { currentUnit: { index: 3, total: 12, title: "Ep title" } }))).toBe("Ep 3/12 — Ep title");
+    });
+    it("returns null with no stage and no unit", () => {
+        expect(jobSubLabel(makeJob("running", "a"))).toBeNull();
+    });
+    it("treats total:2 with a non-Video/Audio title as playlist", () => {
+        expect(jobSubLabel(makeJob("running", "a", { currentUnit: { index: 1, total: 2, title: "Bonus" } }))).toBe("Ep 1/2 — Bonus");
+    });
+    it("prefers stage over currentUnit while processing", () => {
+        expect(jobSubLabel(makeJob("processing", "a", { stage: "Merge", currentUnit: { index: 1, total: 2, title: "Video" } }))).toBe("Merge");
+    });
+});
 
 describe("isTerminal", () => {
     it("is true for completed, cancelled, failed", () => {

--- a/crates/rdlp-desktop/src/lib/jobStatus.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.ts
@@ -15,12 +15,23 @@ import type { DownloadJob, JobStatus } from "../types";
 export function cancelledJobPatch(): Partial<DownloadJob> {
     return {
         status: "cancelled",
-        statusMessage: null,
         currentUnit: null,
         speed: null,
         eta: null,
         progress: null,
     };
+}
+
+/** The per-job sub-label, derived during render from canonical fields. Null = no sub-label. */
+export function jobSubLabel(job: DownloadJob): string | null {
+    if (job.status === "processing") return job.stage;
+    const u = job.currentUnit;
+    if (!u) return null;
+    const pct = Math.round((job.progress ?? 0) * 100);
+    if (u.total === 2 && (u.title === "Video" || u.title === "Audio")) {
+        return `${u.title} — ${pct}%`;
+    }
+    return `Ep ${u.index}/${u.total} — ${u.title}`;
 }
 
 /** Categorizable buckets used by the Queue filter tabs + STATS panel. */

--- a/crates/rdlp-desktop/src/lib/tauri.ts
+++ b/crates/rdlp-desktop/src/lib/tauri.ts
@@ -15,13 +15,11 @@ import type {
     DownloadOptions,
     DownloadProgressPayload,
     FormatListResponse,
-    FormatSelectedPayload,
     PostProcessProgressPayload,
     SearchFilter,
     SearchFilterDescriptor,
     SearchPageResponse,
     SearchSiteInfo,
-    UnitCompletedPayload,
     UnitStartedPayload,
 } from "../types";
 
@@ -146,15 +144,6 @@ export function onDownloadLog(
     );
 }
 
-/** Subscribe to format-selected events. Returns an unlisten function. */
-export function onFormatSelected(
-    callback: (payload: FormatSelectedPayload) => void,
-): Promise<UnlistenFn> {
-    return listen<FormatSelectedPayload>("format-selected", (event) =>
-        callback(event.payload),
-    );
-}
-
 /** Subscribe to post-processing progress events. Returns an unlisten function. */
 export function onPostProcessProgress(
     callback: (payload: PostProcessProgressPayload) => void,
@@ -169,13 +158,6 @@ export function onUnitStarted(
     handler: (payload: UnitStartedPayload) => void,
 ): Promise<UnlistenFn> {
     return listen<UnitStartedPayload>("unit-started", (e) => handler(e.payload));
-}
-
-/** Subscribe to unit-completed events (playlist episode or merge stream done). Returns an unlisten function. */
-export function onUnitCompleted(
-    handler: (payload: UnitCompletedPayload) => void,
-): Promise<UnlistenFn> {
-    return listen<UnitCompletedPayload>("unit-completed", (e) => handler(e.payload));
 }
 
 /** Validate a format expression and return matching format IDs. */

--- a/crates/rdlp-desktop/src/shell/BottomDrawer.test.tsx
+++ b/crates/rdlp-desktop/src/shell/BottomDrawer.test.tsx
@@ -26,7 +26,7 @@ function makeJob(status: JobStatus, overrides: Partial<DownloadJob> = {}): Downl
         output_path: null,
         options: null,
         playlist: null,
-        statusMessage: null,
+        currentUnit: null,
         stage: null,
         ...overrides,
     };

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -210,6 +210,13 @@ export type JobStatus =
     | "failed"
     | "cancelled";
 
+/** Active unit info owned by Rust, serialized under the `currentUnit` wire key. */
+export interface CurrentUnit {
+    index: number;
+    total: number;
+    title: string;
+}
+
 /** Serializable metadata for a single download job (snake_case — default serde). */
 export interface DownloadJob {
     id: string;
@@ -228,20 +235,12 @@ export interface DownloadJob {
     options: DownloadOptions | null;
     /** Playlist membership — null for standalone downloads. Omitted in legacy fixtures. */
     playlist?: PlaylistContext | null;
-    /** Latest log message from the download-log event (frontend-only, not from Rust). */
-    statusMessage: string | null;
     /** Current post-processing stage label (e.g. "Merging", "Transcoding"); null outside processing. */
     stage: string | null;
     /** Accumulated log messages from download-log events (frontend-only, not from Rust). */
     logMessages?: string[];
-    /** Current unit info set by unit-started (frontend-only, not from Rust). */
-    currentUnit?: {
-        unitIndex: number;
-        unitTotal: number;
-        unitTitle: string;
-    } | null;
-    /** Number of completed units tracked by unit-completed events (frontend-only). */
-    completedUnits?: number;
+    /** Current unit info, owned by Rust (`currentUnit` wire key). Null when no unit is active. */
+    currentUnit: CurrentUnit | null;
 }
 
 /**

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -334,13 +334,6 @@ export interface DownloadCancelledPayload {
     jobId: string;
 }
 
-/** Format-selected payload emitted as "format-selected". */
-export interface FormatSelectedPayload {
-    jobId: string;
-    formatId: string;
-    quality: string;
-}
-
 /** Log message payload emitted as "download-log". */
 export interface DownloadLogPayload {
     jobId: string;
@@ -361,12 +354,6 @@ export interface UnitStartedPayload {
     unitIndex: number;
     unitTotal: number;
     unitTitle: string;
-}
-
-/** Unit-completed payload emitted as "unit-completed" (playlist episode or merge stream done). */
-export interface UnitCompletedPayload {
-    jobId: string;
-    unitIndex: number;
 }
 
 // ========== Settings Types ==========

--- a/crates/rdlp-desktop/src/views/history/HistoryRow.test.tsx
+++ b/crates/rdlp-desktop/src/views/history/HistoryRow.test.tsx
@@ -24,7 +24,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         id: "job-1", url: "https://example.com/video", title: "Done Video",
         status: "completed", progress: 1, speed: null, eta: null, error: null,
         retryable: false, started_at: null, completed_at: 1_700_000_000,
-        output_path: "/tmp/v.mp4", options: null, playlist: null, statusMessage: null, stage: null,
+        output_path: "/tmp/v.mp4", options: null, playlist: null, currentUnit: null, stage: null,
         ...overrides,
     };
 }

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -43,7 +43,7 @@ function makeJob(overrides: Partial<DownloadJob> = {}): DownloadJob {
         output_path: null,
         options: null,
         playlist: null,
-        statusMessage: null,
+        currentUnit: null,
         stage: null,
         ...overrides,
     };
@@ -314,8 +314,8 @@ describe("JobCard — progress display", () => {
         expect(screen.queryByText(/^ETA /)).not.toBeInTheDocument();
     });
 
-    it("shows statusMessage when running and present", () => {
-        render(<JobCard job={makeJob({ status: "running", progress: 0.5, statusMessage: "Video — 50%" })} />);
+    it("shows the derived sub-label for a merge unit when running", () => {
+        render(<JobCard job={makeJob({ status: "running", progress: 0.5, currentUnit: { index: 1, total: 2, title: "Video" } })} />);
         expect(screen.getByText("Video — 50%")).toBeInTheDocument();
     });
 });

--- a/crates/rdlp-desktop/src/views/queue/JobCard.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.tsx
@@ -8,7 +8,7 @@ import { Button as AriaButton } from "react-aria-components";
 import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
-import { isTerminal as isTerminalStatus, isInFlight } from "@/lib/jobStatus";
+import { isTerminal as isTerminalStatus, isInFlight, jobSubLabel } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
 import { cn, displayTitle, progressPercent } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
@@ -26,7 +26,7 @@ export function JobCard({ job, compact = false }: JobCardProps) {
     const isTerminal = isTerminalStatus(job.status);
     const progress = job.progress ?? 0;
     const inFlight = isInFlight(job.status);
-    const subLabel = job.status === "processing" ? job.stage : job.statusMessage;
+    const subLabel = jobSubLabel(job);
 
     async function handleCancel() {
         await cancelDownload(job.id);

--- a/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
@@ -7,7 +7,7 @@ import { FolderOpen, RotateCcw, X } from "lucide-react";
 import { uiStore, setSelectedJob } from "@/stores/uiStore";
 import { downloadsQueryOptions, cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
-import { isTerminal as isTerminalStatus, isInFlight } from "@/lib/jobStatus";
+import { isTerminal as isTerminalStatus, isInFlight, jobSubLabel } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
 import { cn, progressPercent } from "@/lib/utils";
 
@@ -34,6 +34,7 @@ export function JobDetails() {
     const isCompleted = job.status === "completed";
     const inFlight = isInFlight(job.status);
     const isTerminal = isTerminalStatus(job.status);
+    const subLabel = jobSubLabel(job);
 
     const handleCancel = () => { cancelDownload(job.id).catch(console.error); };
     const handleRemove = () => {
@@ -78,8 +79,8 @@ export function JobDetails() {
                             style={{ width: `${(job.progress ?? 0) * 100}%` }}
                         />
                     </div>
-                    {job.statusMessage && (
-                        <p className="text-[10px] text-[#4a9eff] mt-1 truncate">{job.statusMessage}</p>
+                    {subLabel && (
+                        <p className="text-[10px] text-[#4a9eff] mt-1 truncate">{subLabel}</p>
                     )}
                 </div>
             )}

--- a/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
+++ b/crates/rdlp-desktop/src/views/queue/PlaylistGroupHeader.tsx
@@ -4,7 +4,7 @@
 import { useMemo } from "react";
 import { ChevronDown, ChevronRight, XCircle } from "lucide-react";
 import { cancelDownload } from "@/api/downloads";
-import { isInFlight, isTerminal, tallyByStatus } from "@/lib/jobStatus";
+import { isInFlight, isTerminal, jobSubLabel, tallyByStatus } from "@/lib/jobStatus";
 import type { DownloadJob } from "@/types";
 
 interface PlaylistGroupHeaderProps {
@@ -89,7 +89,7 @@ export function PlaylistGroupHeader({
             {/* Active episode indicator */}
             {(stats.running > 0 || stats.processing > 0) && (() => {
                 const activeJob = jobs.find((j) => isInFlight(j.status));
-                const label = activeJob?.statusMessage ?? activeJob?.stage;
+                const label = activeJob ? jobSubLabel(activeJob) : null;
                 return label ? (
                     <p className="text-[10px] text-[#aaaaaa] truncate" aria-live="polite">
                         {label}

--- a/crates/rdlp-desktop/src/views/queue/QueueNav.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/QueueNav.test.tsx
@@ -23,7 +23,7 @@ function makeJob(status: JobStatus, id: string): DownloadJob {
         output_path: null,
         options: null,
         playlist: null,
-        statusMessage: null,
+        currentUnit: null,
         stage: null,
     };
 }


### PR DESCRIPTION
## Summary

Closes #368 (Slice 2 of the #336 status work). De-duplicates the `DownloadJob` state contract so the Rust backend is the single source of truth for displayed fields, eliminating the frontend-only-in-cache dual-write that a `queue` refetch silently clobbered. Net **−24 lines**.

- **Rust:** new `CurrentUnit { index, total, title }` struct (separate from `PlaylistContext` per C-NEWTYPE) + `#[serde(rename="currentUnit")] current_unit: Option<CurrentUnit>` + `set_current_unit`/`clear_current_unit` methods. Event loop sets it on `Event::PlaylistItemStarted`, clears on `UnitCompleted`/`Completed`.
- **TS:** removed the stored `statusMessage` — the per-job sub-label is now **derived at render** via a pure `jobSubLabel(job)` (processing→stage; merge→"Video — N%"; playlist→"Ep i/n — title"). Removed dead `completedUnits`. Reshaped `currentUnit` to the Rust-mirrored `CurrentUnit | null`. Read-sites (JobCard/JobDetails/PlaylistGroupHeader) use `jobSubLabel`.
- **Dead-code prune:** removed the orphaned `format-selected`/`unit-completed` Tauri emits + payload types + `onFormatSelected`/`onUnitCompleted` wrappers (kept the `download-log` mirror + the Rust-internal `UnitCompleted` arm).
- **`cancelDownload`:** replaced the "must NOT invalidate" workaround with the documented `cancelQueries` + snapshot + rollback pattern.

## Architecture / validation
Validated via deep multi-source research (React "Avoid Redundant State"; TanStack Query/TkDodo "don't use the QueryCache as a local state manager"; Rust API Guidelines C-NEWTYPE/C-METHOD; serde.rs). The cache now holds only server-owned fields; presentation is derived; refetch is non-destructive.

## Test Plan
- [x] `cargo fmt --check`, `clippy -D warnings`, `cargo test -p rdlp-desktop` — green (Rust `current_unit` set/clear + serde `currentUnit`/null tests).
- [x] `npx tsc --noEmit`; `npm run test` — **275 passed** (`jobSubLabel` branch tests incl. merge/playlist/processing/null + the total:2-non-Video boundary; `cancelDownload` mid-flight-flip [load-bearing] + rollback + race-guard; updated event-handler + factory tests). `rg "statusMessage|completedUnits" src` clean.
- [x] `npm run test:e2e` (Cypress) — **30/30**, a11y 8/8 (allowlist empty).

## Reviews
- **security-reviewer** (full `develop..HEAD`): ✅ Approve — no blocking; `current_unit.title` is pipeline-controlled + rendered as text (no XSS); cancel rollback rethrows; removed emits carried no security state. LOW title-length-cap → #371.
- **code-reviewer** (full diff): ✅ Approve — `statusMessage` fully gone, dead-code prune complete, `jobSubLabel` faithful, `cancelDownload` matches the documented pattern. Doc-sync (stale `CLAUDE.md` gotchas) addressed; `onUnitStarted` live-mirror comment added.

## Follow-ups
- #370 — move per-job `logMessages` out of the query cache (same dual-write class; needs a bounded per-job store).
- #371 — clamp `CurrentUnit.title` length (defense-in-depth).