### PR TITLE
fix(downloader): resume native-HLS downloads from last completed fragment (#354)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -114,7 +114,10 @@ impl Orchestrator {
     ) -> Result<Option<DownloadOutcome>> {
         let is_hls = format.is_hls();
 
-        // HLS downloads use segment-based resume (tracked in .hls_state.json), not byte offsets
+        // HLS resume is fragment-based and fully downloader-internal: the fragment
+        // downloader persists/loads <output>.hls_state.json itself (see
+        // rdlp_downloader::fragments). The byte-offset `resume_from` is therefore
+        // unused for HLS — pass 0.
         let effective_resume = if is_hls { 0 } else { resume_from };
 
         let estimated_size = if is_hls {

--- a/crates/rdlp-downloader/Cargo.toml
+++ b/crates/rdlp-downloader/Cargo.toml
@@ -30,11 +30,11 @@ serde_json = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 dash-mpd = { workspace = true }
 rdlp-ffmpeg = { path = "../rdlp-ffmpeg" }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 mockito = { workspace = true }
-tempfile = { workspace = true }
 proptest = "1.4"
 
 [lints.rust]

--- a/crates/rdlp-downloader/src/atomic.rs
+++ b/crates/rdlp-downloader/src/atomic.rs
@@ -1,0 +1,132 @@
+//! Shared atomic JSON sidecar writer.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+/// Atomically write `value` as JSON to `path` (write-temp-in-same-dir + rename).
+/// A kill mid-write leaves the previous file intact — never a torn file.
+///
+/// Does NOT fsync: acceptable for resume sidecars (worst case on power loss =
+/// re-download one segment). Same-filesystem only — `new_in(dir)` places the
+/// temp next to the destination so `persist` is a same-fs rename, not a copy.
+/// `tempfile` RAII-cleans the temp on any early return.
+///
+/// POSIX uses `rename(2)` (fully atomic replace). Windows uses `MoveFileExW` +
+/// `MOVEFILE_REPLACE_EXISTING`, which is not atomic if the destination is held
+/// open by another process — fine here, the sidecar is a private per-download
+/// file. `PersistError` is generic (`PersistError<File>`); `.error` is the
+/// inner `std::io::Error` we surface.
+///
+/// # Errors
+/// Returns an `std::io::Error` if serialization, the temp write, or the rename
+/// fails, or if the blocking task panics/cancels.
+// Callsite is in Task 2 (DASH save migration) — not yet wired.
+#[allow(dead_code)]
+pub async fn atomic_write_json<T: Serialize + Send + 'static>(
+    path: &Path,
+    value: T,
+) -> std::io::Result<()> {
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map_or_else(|| std::path::PathBuf::from("."), Path::to_path_buf);
+    let dest = path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        use std::io::Write;
+        let body = serde_json::to_vec(&value).map_err(std::io::Error::other)?;
+        let mut tmp = tempfile::NamedTempFile::new_in(&dir)?;
+        tmp.write_all(&body)?;
+        tmp.persist(&dest).map_err(|e| e.error)?;
+        Ok(())
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Sample {
+        a: u32,
+        b: String,
+    }
+
+    #[tokio::test]
+    async fn writes_roundtrippable_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.json");
+        let value = Sample {
+            a: 7,
+            b: "hi".into(),
+        };
+        atomic_write_json(&path, value).await.expect("write");
+        let body = tokio::fs::read_to_string(&path).await.expect("read");
+        let back: Sample = serde_json::from_str(&body).expect("parse");
+        assert_eq!(
+            back,
+            Sample {
+                a: 7,
+                b: "hi".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn leaves_no_temp_file_behind_on_success() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.json");
+        atomic_write_json(
+            &path,
+            Sample {
+                a: 1,
+                b: "x".into(),
+            },
+        )
+        .await
+        .expect("write");
+        let mut entries = tokio::fs::read_dir(dir.path()).await.expect("read_dir");
+        let mut count = 0;
+        while let Some(e) = entries.next_entry().await.expect("entry") {
+            assert_eq!(e.file_name(), "state.json", "unexpected leftover temp file");
+            count += 1;
+        }
+        assert_eq!(count, 1, "exactly one file (the destination) must remain");
+    }
+
+    #[tokio::test]
+    async fn overwrites_existing_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.json");
+        atomic_write_json(
+            &path,
+            Sample {
+                a: 1,
+                b: "first".into(),
+            },
+        )
+        .await
+        .expect("write1");
+        atomic_write_json(
+            &path,
+            Sample {
+                a: 2,
+                b: "second".into(),
+            },
+        )
+        .await
+        .expect("write2");
+        let body = tokio::fs::read_to_string(&path).await.expect("read");
+        let back: Sample = serde_json::from_str(&body).expect("parse");
+        assert_eq!(
+            back,
+            Sample {
+                a: 2,
+                b: "second".into()
+            }
+        );
+    }
+}

--- a/crates/rdlp-downloader/src/atomic.rs
+++ b/crates/rdlp-downloader/src/atomic.rs
@@ -21,8 +21,6 @@ use serde::Serialize;
 /// # Errors
 /// Returns an `std::io::Error` if serialization, the temp write, or the rename
 /// fails, or if the blocking task panics/cancels.
-// Callsite is in Task 2 (DASH save migration) — not yet wired.
-#[allow(dead_code)]
 pub async fn atomic_write_json<T: Serialize + Send + 'static>(
     path: &Path,
     value: T,

--- a/crates/rdlp-downloader/src/dash/state.rs
+++ b/crates/rdlp-downloader/src/dash/state.rs
@@ -83,8 +83,7 @@ impl DashDownloadState {
     /// serialization error wrapped as `io::Error::other`.
     pub async fn save(&mut self, path: &Path) -> std::io::Result<()> {
         self.updated_at = now_secs();
-        let body = serde_json::to_string(self).map_err(std::io::Error::other)?;
-        fs::write(path, body).await
+        crate::atomic::atomic_write_json(path, self.clone()).await
     }
 
     /// Mark segment `idx` of representation `repr_id` as completed.
@@ -113,4 +112,30 @@ fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn save_then_load_matching_roundtrips_through_atomic_writer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("v.dash_state.json");
+        let url = Url::parse("https://cdn.example.com/path/manifest.mpd").expect("url");
+        let mut state = DashDownloadState::new(&url, "v1".into(), Some("a1".into()));
+        state.record_segment("v1", 0);
+        state.record_segment("v1", 1);
+        state.init_video_done = true;
+        state.save(&path).await.expect("save");
+
+        let loaded = DashDownloadState::load_matching(&path, &url, "v1", Some("a1"))
+            .await
+            .expect("must load matching state");
+        assert_eq!(loaded.state_version, STATE_VERSION);
+        assert_eq!(loaded.video_repr_id, "v1");
+        assert!(loaded.init_video_done);
+        assert!(loaded.is_segment_done("v1", 0));
+        assert!(loaded.is_segment_done("v1", 1));
+    }
 }

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -478,5 +478,7 @@ async fn fetch_with_optional_range(
         })
 }
 
+pub(crate) mod state;
+
 #[cfg(test)]
 mod tests;

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -11,14 +11,16 @@
 // workspace MSRV is 1.85.
 #![allow(clippy::duration_suboptimal_units)]
 
+use std::io::SeekFrom;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
 use futures::StreamExt as _;
+use log::warn;
 use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback, Result};
 use rdlp_types::{Fragment, Progress};
-use tokio::io::AsyncWriteExt as _;
+use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
 use tokio_util::sync::CancellationToken;
 
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
@@ -72,6 +74,18 @@ fn fragment_progress_fraction(
 /// price of parallelism — sequential mode (`concurrent_fragments = 1`)
 /// preserves the strict "at most 1 extra fragment after cancel" semantic.
 ///
+/// # Resume
+///
+/// Fragment-level resume is self-managed via a `<output>.hls_state.json`
+/// sidecar (see `HlsResumeState`). On entry the helper matches the
+/// sidecar against a path-only fingerprint of `fragments` + the fragment
+/// count; on a match (and when the existing partial is at least as long as the
+/// last confirmed byte boundary and the download is incomplete) it truncates
+/// any torn tail to that boundary, seeks, and skips the already-completed
+/// fragments. Otherwise it starts fresh. The sidecar is rewritten atomically
+/// after each fragment and removed on successful completion; it is left in
+/// place on cancel or error so a later run can resume.
+///
 /// # Same-origin header gate
 ///
 /// `Format.http_headers` (Referer, Cookie, Authorization, Origin) are forwarded
@@ -114,22 +128,64 @@ pub async fn download_pre_resolved_fragments(
         .and_then(|u| url::Url::parse(u).ok())
         .map(|u| u.origin());
 
+    // ---- Resume setup (issue #354) ----
+    let state_file = state_path(output);
+    let fingerprint = state::fragment_fingerprint(fragments);
+    let total = fragments.len() as u64;
+    let actual_len = tokio::fs::metadata(output).await.map_or(0, |m| m.len());
+    let loaded = state::HlsResumeState::load_matching(&state_file, fingerprint, total).await;
+    // Resume only when state matches, the partial is at least as long as the
+    // last confirmed boundary, and the download is not already complete.
+    let resume = loaded
+        .as_ref()
+        .is_some_and(|s| actual_len >= s.byte_len && s.fragments_done < total);
+    let mut hls_state = loaded
+        .filter(|_| resume)
+        .unwrap_or_else(|| state::HlsResumeState::new(fingerprint, total));
+    let skip = hls_state.fragments_done as usize;
+
     let mut out_file = tokio::fs::OpenOptions::new()
         .write(true)
         .create(true)
-        .truncate(true)
+        .truncate(false)
         .open(output)
         .await
         .map_err(|e| rdlp_core::RdlpError::Download {
             message: format!("create output: {e}"),
             url: Some(output.display().to_string()),
         })?;
+    if resume {
+        // Drop any torn tail past the last confirmed boundary, then append.
+        out_file
+            .set_len(hls_state.byte_len)
+            .await
+            .map_err(|e| rdlp_core::RdlpError::Download {
+                message: format!("truncate to resume boundary: {e}"),
+                url: Some(output.display().to_string()),
+            })?;
+        out_file
+            .seek(SeekFrom::Start(hls_state.byte_len))
+            .await
+            .map_err(|e| rdlp_core::RdlpError::Download {
+                message: format!("seek to resume boundary: {e}"),
+                url: Some(output.display().to_string()),
+            })?;
+    } else {
+        // Fresh start: equivalent to the previous unconditional truncate(true).
+        out_file
+            .set_len(0)
+            .await
+            .map_err(|e| rdlp_core::RdlpError::Download {
+                message: format!("truncate output: {e}"),
+                url: Some(output.display().to_string()),
+            })?;
+    }
 
-    let mut total_bytes: u64 = 0;
+    let mut total_bytes: u64 = hls_state.byte_len;
 
     const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
     let mut last_emit = Instant::now();
-    let mut frags_done: u64 = 0;
+    let mut frags_done: u64 = hls_state.fragments_done;
     let total_frags = fragments.len() as u64;
     let mut speed = SpeedMeter::new();
 
@@ -203,7 +259,7 @@ pub async fn download_pre_resolved_fragments(
     // even though fetches overlap. Each task emits init-bytes (when needed)
     // immediately preceding fragment-bytes in a single Vec<u8>, so RFC 8216
     // §4.3.2.5 decode-ordering is preserved without a group-by-init pre-pass.
-    let stream = futures::stream::iter(tasks.into_iter().map(|(frag, needs_init)| {
+    let stream = futures::stream::iter(tasks.into_iter().skip(skip).map(|(frag, needs_init)| {
         let sem = Arc::clone(&sem);
         let base = base_url.map(str::to_string);
         let cancel = cancel.cloned();
@@ -299,6 +355,12 @@ pub async fn download_pre_resolved_fragments(
         speed.update(total_bytes, now);
         frags_done += 1;
 
+        hls_state.fragments_done = frags_done;
+        hls_state.byte_len = total_bytes;
+        if let Err(e) = hls_state.save(&state_file).await {
+            warn!("HLS resume state save failed (continuing): {e}");
+        }
+
         // Emit progress (100ms throttle OR fragment-N boundary).
         if let Some(cb) = progress
             && (now.duration_since(last_emit) >= PROGRESS_INTERVAL || frags_done == total_frags)
@@ -341,6 +403,9 @@ pub async fn download_pre_resolved_fragments(
             url: Some(output.display().to_string()),
         })?;
 
+    // Download completed — drop the resume sidecar.
+    let _ = tokio::fs::remove_file(&state_file).await;
+
     let elapsed = started.elapsed();
     #[allow(clippy::cast_precision_loss)]
     let avg = if elapsed.as_secs_f64() > 0.0 {
@@ -356,6 +421,15 @@ pub async fn download_pre_resolved_fragments(
         retries: 0,
         fragments: Some(fragments.len()),
     })
+}
+
+/// Sidecar path for HLS resume state: `<output>.hls_state.json`.
+/// Appends the suffix to the full filename so it never collides with the
+/// output's own extension.
+fn state_path(output: &Path) -> std::path::PathBuf {
+    let mut s = output.as_os_str().to_os_string();
+    s.push(".hls_state.json");
+    std::path::PathBuf::from(s)
 }
 
 /// Resolve a fragment URL against an optional base URL.

--- a/crates/rdlp-downloader/src/fragments/state.rs
+++ b/crates/rdlp-downloader/src/fragments/state.rs
@@ -6,10 +6,6 @@
 //! are async (`tokio::fs`) because the workspace bans blocking `std::fs` in
 //! async contexts; the file is tiny.
 
-// Callers land in Task 4 (resume integration in fragments.rs); this attribute
-// is removed there. Until then the pub items are reachable only from tests.
-#![allow(dead_code)]
-
 use std::path::Path;
 use std::time::SystemTime;
 

--- a/crates/rdlp-downloader/src/fragments/state.rs
+++ b/crates/rdlp-downloader/src/fragments/state.rs
@@ -74,6 +74,13 @@ impl HlsResumeState {
 
     /// Load iff present, parseable, and matching version + fingerprint + total.
     /// `None` ⇒ the caller starts fresh (fail-safe).
+    ///
+    /// Also rejects internally-inconsistent state: `fragments_done > 0` with
+    /// `byte_len == 0` is physically impossible from normal operation
+    /// (`byte_len` always advances with `fragments_done`). A corrupted/zeroed
+    /// sidecar in that shape would otherwise pass the gate, seek the output to
+    /// offset 0, and skip the already-done fragments — silently dropping their
+    /// bytes.
     #[must_use]
     pub async fn load_matching(
         path: &Path,
@@ -84,7 +91,8 @@ impl HlsResumeState {
         let s: Self = serde_json::from_str(&body).ok()?;
         (s.state_version == STATE_VERSION
             && s.fingerprint == fingerprint
-            && s.total_fragments == total_fragments)
+            && s.total_fragments == total_fragments
+            && !(s.fragments_done > 0 && s.byte_len == 0))
             .then_some(s)
     }
 
@@ -222,6 +230,23 @@ mod tests {
             HlsResumeState::load_matching(&path, 111, 10)
                 .await
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn load_matching_none_on_inconsistent_done_without_bytes() {
+        // fragments_done > 0 with byte_len == 0 is physically impossible from
+        // normal operation; a corrupted sidecar like this must be rejected so
+        // resume can't seek to 0 and skip real fragments (silent corruption).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("out.hls_state.json");
+        let bogus = r#"{"state_version":1,"fingerprint":111,"total_fragments":10,"fragments_done":4,"byte_len":0,"updated_at":0}"#.to_string();
+        tokio::fs::write(&path, bogus).await.expect("write bogus");
+        assert!(
+            HlsResumeState::load_matching(&path, 111, 10)
+                .await
+                .is_none(),
+            "inconsistent done>0/byte_len==0 sidecar must be rejected"
         );
     }
 }

--- a/crates/rdlp-downloader/src/fragments/state.rs
+++ b/crates/rdlp-downloader/src/fragments/state.rs
@@ -1,0 +1,231 @@
+//! Resume state for native-HLS pre-resolved-fragment downloads.
+//!
+//! Mirrors `dash::state::DashDownloadState`: persisted to
+//! `<output>.hls_state.json`, matched on schema version + a path-only
+//! fingerprint so CDN host/token rotation does not break resume. Load/save
+//! are async (`tokio::fs`) because the workspace bans blocking `std::fs` in
+//! async contexts; the file is tiny.
+
+// Callers land in Task 4 (resume integration in fragments.rs); this attribute
+// is removed there. Until then the pub items are reachable only from tests.
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use rdlp_types::Fragment;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+/// Current schema version. Bump on incompatible field changes.
+pub const STATE_VERSION: u32 = 1;
+
+/// Persisted state of an in-progress native-HLS fragment download.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlsResumeState {
+    /// Schema version. Mismatches force a fresh start.
+    pub state_version: u32,
+    /// FNV-1a-64 of the ordered, path-only fragment URLs (+ count). CDN-tolerant:
+    /// host and query are ignored so token/host rotation does not break resume.
+    pub fingerprint: u64,
+    /// Total fragments in the resolved list.
+    pub total_fragments: u64,
+    /// Number of fragments fully written to the output so far.
+    pub fragments_done: u64,
+    /// Byte length of the output confirmed flushed at the last checkpoint.
+    pub byte_len: u64,
+    /// Unix epoch seconds — for stale-state diagnosis.
+    pub updated_at: u64,
+}
+
+/// Ordered, path-only FNV-1a-64 over the fragment list. Stable across runs;
+/// ignores host/query so CDN token/host rotation does not break resume. The
+/// fragment count is folded in first so two lists with the same paths but
+/// different lengths never collide.
+#[must_use]
+pub fn fragment_fingerprint(fragments: &[Fragment]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = OFFSET;
+    let mut feed = |bytes: &[u8]| {
+        for &b in bytes {
+            h ^= u64::from(b);
+            h = h.wrapping_mul(PRIME);
+        }
+    };
+    feed(&(fragments.len() as u64).to_le_bytes());
+    for f in fragments {
+        let path = url::Url::parse(&f.url).map_or_else(|_| f.url.clone(), |u| u.path().to_string());
+        feed(path.as_bytes());
+        feed(b"\n");
+    }
+    h
+}
+
+impl HlsResumeState {
+    /// Fresh state for a new download of `total_fragments` fragments.
+    #[must_use]
+    pub fn new(fingerprint: u64, total_fragments: u64) -> Self {
+        Self {
+            state_version: STATE_VERSION,
+            fingerprint,
+            total_fragments,
+            fragments_done: 0,
+            byte_len: 0,
+            updated_at: now_secs(),
+        }
+    }
+
+    /// Load iff present, parseable, and matching version + fingerprint + total.
+    /// `None` ⇒ the caller starts fresh (fail-safe).
+    #[must_use]
+    pub async fn load_matching(
+        path: &Path,
+        fingerprint: u64,
+        total_fragments: u64,
+    ) -> Option<Self> {
+        let body = fs::read_to_string(path).await.ok()?;
+        let s: Self = serde_json::from_str(&body).ok()?;
+        (s.state_version == STATE_VERSION
+            && s.fingerprint == fingerprint
+            && s.total_fragments == total_fragments)
+            .then_some(s)
+    }
+
+    /// Persist state to `path` atomically, updating the `updated_at` stamp.
+    ///
+    /// # Errors
+    /// Returns the underlying I/O error from the atomic write, or a JSON
+    /// serialization error wrapped as `io::Error::other`.
+    pub async fn save(&mut self, path: &Path) -> std::io::Result<()> {
+        self.updated_at = now_secs();
+        crate::atomic::atomic_write_json(path, self.clone()).await
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rdlp_types::Fragment;
+
+    fn frag(url: &str) -> Fragment {
+        Fragment {
+            url: url.to_string(),
+            byte_range: None,
+            init_url: None,
+            init_byte_range: None,
+            duration: None,
+            filesize: None,
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_path_only_stable_across_host_and_query() {
+        let a = vec![
+            frag("https://cdn1.example.com/v/seg-0.ts?token=AAA"),
+            frag("https://cdn1.example.com/v/seg-1.ts?token=AAA"),
+        ];
+        let b = vec![
+            frag("https://cdn2.OTHER.net/v/seg-0.ts?token=ZZZ"),
+            frag("https://cdn2.OTHER.net/v/seg-1.ts?token=ZZZ"),
+        ];
+        assert_eq!(
+            fragment_fingerprint(&a),
+            fragment_fingerprint(&b),
+            "host + query must not affect the fingerprint (path-only)"
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_on_path_change() {
+        let a = vec![frag("https://x/seg-0.ts"), frag("https://x/seg-1.ts")];
+        let b = vec![frag("https://x/seg-0.ts"), frag("https://x/seg-2.ts")];
+        assert_ne!(fragment_fingerprint(&a), fragment_fingerprint(&b));
+    }
+
+    #[test]
+    fn fingerprint_changes_on_count_change() {
+        let a = vec![frag("https://x/seg-0.ts")];
+        let b = vec![frag("https://x/seg-0.ts"), frag("https://x/seg-0.ts")];
+        assert_ne!(
+            fragment_fingerprint(&a),
+            fragment_fingerprint(&b),
+            "count is folded into the fingerprint"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_then_load_matching_roundtrips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("out.hls_state.json");
+        let fp = 0xDEAD_BEEF;
+        let mut s = HlsResumeState::new(fp, 10);
+        s.fragments_done = 4;
+        s.byte_len = 4096;
+        s.save(&path).await.expect("save");
+
+        let loaded = HlsResumeState::load_matching(&path, fp, 10)
+            .await
+            .expect("must load matching");
+        assert_eq!(loaded.fragments_done, 4);
+        assert_eq!(loaded.byte_len, 4096);
+        assert_eq!(loaded.total_fragments, 10);
+    }
+
+    #[test]
+    fn fingerprint_handles_relative_urls_via_fallback() {
+        // Relative paths don't parse as absolute URLs → fingerprint falls back
+        // to the raw string. Must be deterministic and not panic, and must
+        // still distinguish different relative paths.
+        let a = vec![frag("seg-0.ts"), frag("seg-1.ts")];
+        let b = vec![frag("seg-0.ts"), frag("seg-1.ts")];
+        let c = vec![frag("seg-0.ts"), frag("seg-2.ts")];
+        assert_eq!(
+            fragment_fingerprint(&a),
+            fragment_fingerprint(&b),
+            "identical relative-path lists must hash equally (deterministic fallback)"
+        );
+        assert_ne!(
+            fragment_fingerprint(&a),
+            fragment_fingerprint(&c),
+            "differing relative paths must still diverge"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_matching_none_on_fingerprint_total_version_or_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("out.hls_state.json");
+        let mut s = HlsResumeState::new(111, 10);
+        s.fragments_done = 4;
+        s.byte_len = 4096;
+        s.save(&path).await.expect("save");
+
+        assert!(
+            HlsResumeState::load_matching(&path, 222, 10)
+                .await
+                .is_none()
+        );
+        assert!(HlsResumeState::load_matching(&path, 111, 9).await.is_none());
+        let missing = dir.path().join("nope.hls_state.json");
+        assert!(
+            HlsResumeState::load_matching(&missing, 111, 10)
+                .await
+                .is_none()
+        );
+
+        let bogus = r#"{"state_version":999,"fingerprint":111,"total_fragments":10,"fragments_done":4,"byte_len":4096,"updated_at":0}"#.to_string();
+        tokio::fs::write(&path, bogus).await.expect("write bogus");
+        assert!(
+            HlsResumeState::load_matching(&path, 111, 10)
+                .await
+                .is_none()
+        );
+    }
+}

--- a/crates/rdlp-downloader/src/fragments/tests.rs
+++ b/crates/rdlp-downloader/src/fragments/tests.rs
@@ -1198,3 +1198,255 @@ fn fragment_progress_fraction_none_when_nothing_known() {
     // No byte total and zero segments → no fraction to report.
     assert!(fragment_progress_fraction(None, 0, 0, 0).is_none());
 }
+
+// ---- HLS resume tests (issue #354) ----
+
+use super::state::{HlsResumeState, fragment_fingerprint};
+
+/// Deterministic N fragments where body[i] = i (mod 256), each served by a
+/// fresh mock on `server`. Returns (frags, expected full concatenation).
+/// Distinct from `build_ordered_frags` only in that the caller controls the
+/// path stem so two servers can serve byte-identical bodies for resume tests.
+async fn seeded_frags(server: &mut mockito::Server, n: usize) -> (Vec<Fragment>, Vec<u8>) {
+    let mut expected = Vec::with_capacity(n);
+    let mut frags = Vec::with_capacity(n);
+    for i in 0..n {
+        let body = vec![(i % 256) as u8];
+        expected.push(body[0]);
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_body(body)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        frags.push(frag(format!("{}/seg-{i}.ts", server.url())));
+    }
+    (frags, expected)
+}
+
+#[tokio::test]
+async fn full_download_removes_sidecar() {
+    let mut server = mockito::Server::new_async().await;
+    let (frags, expected) = seeded_frags(&mut server, 5).await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = dir.path().join("video.ts");
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    download_pre_resolved_fragments(&http, &frags, None, None, None, &output, None, None)
+        .await
+        .expect("full download ok");
+    let written = tokio::fs::read(&output).await.unwrap();
+    assert_eq!(written, expected);
+    let sidecar = output.with_extension("ts.hls_state.json");
+    assert!(
+        !sidecar.exists(),
+        "sidecar must be removed on successful completion"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_writes_sidecar_with_progress() {
+    // Sequential (concurrency=1) so the cancel lands deterministically between
+    // fragments. A blackhole at index 2 hangs; cancel fires after f0+f1 land.
+    let mut server = mockito::Server::new_async().await;
+    for i in 0..2_u32 {
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_body(vec![i as u8; 10])
+            .create_async()
+            .await;
+    }
+    let port = spawn_blackhole().await;
+    let mut frags: Vec<Fragment> = (0..2)
+        .map(|i| frag(format!("{}/seg-{i}.ts", server.url())))
+        .collect();
+    frags.push(frag(format!("http://127.0.0.1:{port}/seg-2.ts")));
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = dir.path().join("video.ts");
+    let token = tokio_util::sync::CancellationToken::new();
+    let token_clone = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        token_clone.cancel();
+    });
+    let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(1);
+    let res = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        download_pre_resolved_fragments(
+            &http,
+            &frags,
+            None,
+            None,
+            None,
+            &output,
+            None,
+            Some(&token),
+        ),
+    )
+    .await
+    .expect("test timeout");
+    assert!(matches!(res, Err(rdlp_core::RdlpError::Cancelled)));
+
+    let partial_len = tokio::fs::metadata(&output)
+        .await
+        .expect("partial exists")
+        .len();
+    assert!(partial_len > 0, "partial must be present");
+    let sidecar = output.with_extension("ts.hls_state.json");
+    assert!(
+        sidecar.exists(),
+        "sidecar must persist on cancel for resume"
+    );
+
+    let fp = fragment_fingerprint(&frags);
+    let total = frags.len() as u64;
+    let st = HlsResumeState::load_matching(&sidecar, fp, total)
+        .await
+        .expect("sidecar must match the same fragment list");
+    assert!(st.fragments_done >= 1, "at least one fragment recorded");
+    assert_eq!(
+        st.byte_len, partial_len,
+        "byte_len tracks the flushed partial"
+    );
+}
+
+#[tokio::test]
+async fn resume_is_byte_identical_and_skips_done_fragments() {
+    // Reference: uninterrupted full download.
+    let mut ref_server = mockito::Server::new_async().await;
+    let (ref_frags, expected) = seeded_frags(&mut ref_server, 6).await;
+    let refdir = tempfile::tempdir().expect("tempdir");
+    let refout = refdir.path().join("ref.ts");
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    download_pre_resolved_fragments(&http, &ref_frags, None, None, None, &refout, None, None)
+        .await
+        .expect("reference ok");
+    let reference = tokio::fs::read(&refout).await.unwrap();
+    assert_eq!(reference, expected);
+
+    // Craft a partial of the first 3 fragments + a matching sidecar.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = dir.path().join("video.ts");
+    let done = 3usize;
+    tokio::fs::write(&output, &reference[..done]).await.unwrap();
+
+    // Resume server: paths identical (so the path-only fingerprint matches),
+    // but the already-done fragments are 501 — if resume re-fetches them the
+    // download errors, proving they were skipped. Remaining fragments serve
+    // their real bodies.
+    let mut server = mockito::Server::new_async().await;
+    for i in 0..done {
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_status(501)
+            .create_async()
+            .await;
+    }
+    for i in done..6 {
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_body(vec![(i % 256) as u8])
+            .expect(1)
+            .create_async()
+            .await;
+    }
+    let frags: Vec<Fragment> = (0..6)
+        .map(|i| frag(format!("{}/seg-{i}.ts", server.url())))
+        .collect();
+
+    let sidecar = output.with_extension("ts.hls_state.json");
+    let mut st = HlsResumeState::new(fragment_fingerprint(&frags), 6);
+    st.fragments_done = done as u64;
+    st.byte_len = done as u64; // 1 byte per fragment
+    st.save(&sidecar).await.expect("seed sidecar");
+
+    download_pre_resolved_fragments(&http, &frags, None, None, None, &output, None, None)
+        .await
+        .expect("resume must succeed without hitting the 501 done-fragments");
+
+    let written = tokio::fs::read(&output).await.unwrap();
+    assert_eq!(written, reference, "resumed output must be byte-identical");
+    assert!(!sidecar.exists(), "sidecar removed after completion");
+}
+
+#[tokio::test]
+async fn fingerprint_mismatch_restarts_from_zero() {
+    let mut server = mockito::Server::new_async().await;
+    let (frags, expected) = seeded_frags(&mut server, 4).await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = dir.path().join("video.ts");
+
+    // Seed a stale partial + sidecar whose fingerprint does NOT match `frags`.
+    tokio::fs::write(&output, b"STALEDATA").await.unwrap();
+    let sidecar = output.with_extension("ts.hls_state.json");
+    let mut st = HlsResumeState::new(0x1234_5678, 4); // wrong fingerprint
+    st.fragments_done = 2;
+    st.byte_len = 9; // matches "STALEDATA"
+    st.save(&sidecar).await.expect("seed sidecar");
+
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    download_pre_resolved_fragments(&http, &frags, None, None, None, &output, None, None)
+        .await
+        .expect("mismatch restarts cleanly");
+    let written = tokio::fs::read(&output).await.unwrap();
+    assert_eq!(
+        written, expected,
+        "stale partial discarded; fresh full download"
+    );
+    assert!(!sidecar.exists());
+}
+
+#[tokio::test]
+async fn extra_tail_is_truncated_to_byte_len_on_resume() {
+    // Reference full download.
+    let mut ref_server = mockito::Server::new_async().await;
+    let (ref_frags, _expected) = seeded_frags(&mut ref_server, 5).await;
+    let refdir = tempfile::tempdir().expect("tempdir");
+    let refout = refdir.path().join("ref.ts");
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    download_pre_resolved_fragments(&http, &ref_frags, None, None, None, &refout, None, None)
+        .await
+        .expect("reference ok");
+    let reference = tokio::fs::read(&refout).await.unwrap();
+
+    // Partial = first 2 fragments + a torn extra byte; sidecar says byte_len=2.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = dir.path().join("video.ts");
+    let mut partial = reference[..2].to_vec();
+    partial.push(0xFF); // torn tail beyond the confirmed boundary
+    tokio::fs::write(&output, &partial).await.unwrap();
+
+    let mut server = mockito::Server::new_async().await;
+    for i in 0..2 {
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_status(501)
+            .create_async()
+            .await;
+    }
+    for i in 2..5 {
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_body(vec![(i % 256) as u8])
+            .expect(1)
+            .create_async()
+            .await;
+    }
+    let frags: Vec<Fragment> = (0..5)
+        .map(|i| frag(format!("{}/seg-{i}.ts", server.url())))
+        .collect();
+    let sidecar = output.with_extension("ts.hls_state.json");
+    let mut st = HlsResumeState::new(fragment_fingerprint(&frags), 5);
+    st.fragments_done = 2;
+    st.byte_len = 2; // confirmed boundary BEFORE the torn 0xFF byte
+    st.save(&sidecar).await.expect("seed sidecar");
+
+    download_pre_resolved_fragments(&http, &frags, None, None, None, &output, None, None)
+        .await
+        .expect("resume truncates torn tail then completes");
+    let written = tokio::fs::read(&output).await.unwrap();
+    assert_eq!(
+        written, reference,
+        "torn tail dropped; final byte-identical"
+    );
+}

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -278,6 +278,8 @@
 
 /// Adaptive chunk sizing and connection tuning (AIMD controller)
 pub(crate) mod adaptive;
+/// Shared atomic JSON sidecar writer
+pub(crate) mod atomic;
 /// Intelligent chunk size calculation for optimal download performance
 pub mod chunking;
 /// DASH (Dynamic Adaptive Streaming over HTTP) downloader for static VoD MPDs


### PR DESCRIPTION
## Summary

Gives native-HLS (`M3u8`/`M3u8Native`) downloads **real fragment-level resume**, at parity with DASH. Previously HLS had *no* resume — `download_pre_resolved_fragments` opened the output with `truncate(true)` and persisted nothing, so the `{output}.hls_state.json` referenced in `CLAUDE.md`/the orchestrator was a phantom and a cancelled/crashed download re-downloaded from fragment 0 on re-run.

Closes #354.

## What changed

- **`atomic.rs` (new)** — shared `atomic_write_json` (write temp in same dir + `persist`/rename in `spawn_blocking`). A kill mid-write never leaves a torn sidecar.
- **`dash/state.rs`** — `DashDownloadState::save` migrated to the atomic helper, fixing DASH's pre-existing latent non-atomic `fs::write` torn-state bug (bonus beyond scope).
- **`fragments/state.rs` (new)** — `HlsResumeState`: schema version + **path-only FNV-1a fingerprint** (CDN-tolerant — host/query rotation doesn't break resume) + completed-count + confirmed byte length. `load_matching` fails safe (`None`) on any version/fingerprint/total mismatch, parse failure, or internally-inconsistent state.
- **`fragments.rs`** — `download_pre_resolved_fragments` gains self-managed resume (no signature change): non-truncating open + `set_len`/`seek` to the last confirmed byte boundary (drops torn tails), `.skip` already-completed fragments over the **full init-deduped** task list, per-fragment atomic sidecar save, remove-on-success / keep-on-cancel. `# Resume` rustdoc added.
- **`rdlp-api/.../download.rs`** — comment accuracy only.

## Design note

This deliberately uses **per-protocol resume granularity + shared cross-cutting mechanics** (the `atomic_write_json` helper is used by both HLS and DASH). A unified `ResumeState` trait was researched and **rejected** (HTTP's "state" is just a byte length; aria2's unified control file needs a uniform piece bitfield — wrong fit). The near-identical `HlsResumeState::save` / `DashDownloadState::save` divergence is therefore **intentional**, not duplication to "fix".

## Verification

- `cargo fmt --check` ✓ · `cargo check` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `cargo test` ✓ (168 in `rdlp-downloader`, full workspace green) · `cargo check -p rdlp-desktop` ✓ · `bash scripts/check-dedup.sh` PASS.
- Tests cover positive + negatives: byte-identical resume (proves skip via 501-trap on done-fragment paths), cancel-persists-sidecar, fingerprint-mismatch-restart, extra-tail-truncate, atomic no-leftover-temp, all `load_matching` mismatch/inconsistency cases.

## Reviews

- **security-reviewer:** Approve. One MEDIUM (M1 — accept inconsistent `fragments_done>0 && byte_len==0` sidecar → silent corruption) fixed in `de2ada6` + negative test, then re-confirmed resolved. Same-origin header gate untouched; path-only fingerprint confirmed token-safe; temp `0600`; no secret leakage.
- **code-reviewer:** Approve. No Critical/Important.

## Follow-ups (non-blocking)

- Operator feedback when the resume sidecar repeatedly fails to save (e.g. disk-full) so "resume unavailable" is visible.
- Hoist the duplicated 5-line `now_secs` helper (shared by `dash/state.rs` + `fragments/state.rs`) into a shared util.
