### PR TITLE
chore(downloader): resume-sidecar save hygiene — warn-once + now_secs hoist (#374, #375)

### DIFF
--- a/crates/rdlp-downloader/src/atomic.rs
+++ b/crates/rdlp-downloader/src/atomic.rs
@@ -5,6 +5,7 @@
 use std::path::Path;
 use std::time::SystemTime;
 
+use log::warn;
 use serde::Serialize;
 
 /// Atomically write `value` as JSON to `path` (write-temp-in-same-dir + rename).
@@ -52,6 +53,76 @@ pub(crate) fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
+}
+
+/// Consecutive resume-sidecar save *attempts* that must fail before a single
+/// operator-facing "resume unavailable" notice is emitted. Three consecutive
+/// failures indicate a structural condition (disk full, permissions) rather
+/// than transient flush jitter — early enough to signal, late enough to avoid
+/// false alarms. Applies across protocols (HLS saves per fragment; DASH saves
+/// at init, every batch, and final flush). Mirrors the crate's
+/// `MAX_CHUNK_RETRIES = 3` retry-count idiom.
+pub(crate) const SIDECAR_SAVE_FAILURE_THRESHOLD: u32 = 3;
+
+/// Tracks consecutive resume-sidecar save failures so the caller can emit a
+/// single "resume unavailable" notice instead of one log line per failed save.
+///
+/// `record_failure` returns `true` exactly once — when the consecutive-failure
+/// count first reaches the threshold. A successful save resets the consecutive
+/// count, but the one-shot warned latch persists for the tracker's lifetime
+/// (one notice per download; the operator already has the information).
+pub(crate) struct SaveFailureTracker {
+    consecutive: u32,
+    threshold: u32,
+    warned: bool,
+}
+
+impl SaveFailureTracker {
+    pub(crate) const fn new(threshold: u32) -> Self {
+        Self {
+            consecutive: 0,
+            threshold,
+            warned: false,
+        }
+    }
+
+    /// Record a failed save. Returns `true` exactly once, when the consecutive
+    /// failure count first reaches `threshold`, so the caller warns once.
+    pub(crate) const fn record_failure(&mut self) -> bool {
+        self.consecutive = self.consecutive.saturating_add(1);
+        if !self.warned && self.consecutive >= self.threshold {
+            self.warned = true;
+            return true;
+        }
+        false
+    }
+
+    /// Record a successful save: resets the consecutive counter. The one-shot
+    /// `warned` latch is intentionally NOT reset.
+    pub(crate) const fn record_success(&mut self) {
+        self.consecutive = 0;
+    }
+}
+
+/// Record the outcome of a resume-sidecar save attempt and emit a single
+/// operator-facing notice once failures become persistent. `proto` is the
+/// protocol label for the message ("HLS" / "DASH"). Centralizes the save-result
+/// handling shared by the HLS fragment downloader and the 3 DASH save sites.
+pub(crate) fn note_sidecar_save(
+    result: std::io::Result<()>,
+    tracker: &mut SaveFailureTracker,
+    proto: &str,
+) {
+    match result {
+        Ok(()) => tracker.record_success(),
+        Err(e) => {
+            if tracker.record_failure() {
+                warn!(
+                    "{proto} resume state could not be saved after {SIDECAR_SAVE_FAILURE_THRESHOLD} consecutive attempts ({e}); resume will be unavailable if this download is interrupted"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -116,6 +187,52 @@ mod tests {
             now_secs() > 1_577_836_800,
             "now_secs must reflect a real clock"
         );
+    }
+
+    #[test]
+    fn tracker_warns_once_at_threshold_then_stays_silent() {
+        let mut t = SaveFailureTracker::new(3);
+        assert!(!t.record_failure(), "1st failure: below threshold");
+        assert!(!t.record_failure(), "2nd failure: below threshold");
+        assert!(
+            t.record_failure(),
+            "3rd consecutive failure: warn exactly here"
+        );
+        assert!(
+            !t.record_failure(),
+            "4th failure: already warned, stay silent"
+        );
+        assert!(!t.record_failure(), "5th failure: still silent");
+    }
+
+    #[test]
+    fn tracker_success_resets_consecutive_count() {
+        let mut t = SaveFailureTracker::new(3);
+        assert!(!t.record_failure());
+        assert!(!t.record_failure());
+        t.record_success(); // resets the streak
+        assert!(!t.record_failure(), "post-reset 1st failure");
+        assert!(!t.record_failure(), "post-reset 2nd failure");
+        assert!(t.record_failure(), "post-reset 3rd failure trips threshold");
+    }
+
+    #[test]
+    fn tracker_warned_latch_survives_later_success_and_failures() {
+        // Once warned, a recovery then a fresh failure streak does NOT re-warn:
+        // one notice per download (operator already has the information).
+        let mut t = SaveFailureTracker::new(2);
+        assert!(!t.record_failure());
+        assert!(t.record_failure(), "warns at threshold 2");
+        t.record_success();
+        assert!(!t.record_failure(), "post-warn streak: no second warning");
+        assert!(!t.record_failure(), "still no second warning");
+    }
+
+    #[test]
+    fn tracker_threshold_one_warns_on_first_failure() {
+        let mut t = SaveFailureTracker::new(1);
+        assert!(t.record_failure(), "threshold 1 warns immediately");
+        assert!(!t.record_failure());
     }
 
     #[tokio::test]

--- a/crates/rdlp-downloader/src/atomic.rs
+++ b/crates/rdlp-downloader/src/atomic.rs
@@ -1,6 +1,9 @@
-//! Shared atomic JSON sidecar writer.
+//! Shared sidecar-save utilities: an atomic JSON writer, a monotonic-ish
+//! wall-clock helper, and a consecutive-save-failure tracker. Used by both the
+//! HLS (`fragments`) and DASH (`dash`) resume-state modules.
 
 use std::path::Path;
+use std::time::SystemTime;
 
 use serde::Serialize;
 
@@ -40,6 +43,15 @@ pub async fn atomic_write_json<T: Serialize + Send + 'static>(
     })
     .await
     .map_err(std::io::Error::other)?
+}
+
+/// Current Unix epoch seconds, or 0 if the system clock predates the epoch.
+/// Shared by the HLS and DASH resume-state modules for their `updated_at` stamp.
+#[must_use]
+pub(crate) fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]
@@ -93,6 +105,17 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 1, "exactly one file (the destination) must remain");
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn now_secs_is_after_2020() {
+        // 1_577_836_800 = 2020-01-01T00:00:00Z. A real clock is well past it;
+        // this guards against a regression that returns 0 on the happy path.
+        assert!(
+            now_secs() > 1_577_836_800,
+            "now_secs must reflect a real clock"
+        );
     }
 
     #[tokio::test]

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -28,6 +28,7 @@ use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
+use crate::atomic::{SIDECAR_SAVE_FAILURE_THRESHOLD, SaveFailureTracker};
 use crate::dash::errors::DashError;
 use crate::dash::manifest;
 use crate::dash::segments::SegmentPlan;
@@ -350,6 +351,7 @@ async fn download_representation(
     fs::create_dir_all(parts_dir).await?;
 
     let mut total: u64 = 0;
+    let mut save_tracker = SaveFailureTracker::new(SIDECAR_SAVE_FAILURE_THRESHOLD);
 
     // ----- Init segment -----
     let init_part_path = parts_dir.join("init.m4s");
@@ -384,9 +386,11 @@ async fn download_representation(
                 } else {
                     s.init_audio_done = true;
                 }
-                if let Err(e) = s.save(state_path).await {
-                    warn!("DASH state save failed (init): {e}");
-                }
+                crate::atomic::note_sidecar_save(
+                    s.save(state_path).await,
+                    &mut save_tracker,
+                    "DASH",
+                );
             }
             debug!("DASH repr {repr_id}: init {len} bytes");
         }
@@ -494,9 +498,11 @@ async fn download_representation(
                 s.record_segment(repr_id, i as u64);
                 completed_since_save += 1;
                 if completed_since_save >= STATE_SAVE_BATCH {
-                    if let Err(e) = s.save(state_path).await {
-                        warn!("DASH state save failed (batch): {e}");
-                    }
+                    crate::atomic::note_sidecar_save(
+                        s.save(state_path).await,
+                        &mut save_tracker,
+                        "DASH",
+                    );
                     completed_since_save = 0;
                 }
             }
@@ -516,9 +522,7 @@ async fn download_representation(
     // whatever did complete before the failure).
     {
         let mut s = state_arc.lock().await;
-        if let Err(e) = s.save(state_path).await {
-            warn!("DASH state save failed (final): {e}");
-        }
+        crate::atomic::note_sidecar_save(s.save(state_path).await, &mut save_tracker, "DASH");
     }
     if let Some(e) = stream_err {
         return Err(e);

--- a/crates/rdlp-downloader/src/dash/state.rs
+++ b/crates/rdlp-downloader/src/dash/state.rs
@@ -8,11 +8,12 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 use url::Url;
+
+use crate::atomic::now_secs;
 
 /// Current schema version. Bump on incompatible field changes.
 pub const STATE_VERSION: u32 = 1;
@@ -106,12 +107,6 @@ impl DashDownloadState {
             .get(repr_id)
             .is_some_and(|v| v.binary_search(&idx).is_ok())
     }
-}
-
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -17,13 +17,13 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use futures::StreamExt as _;
-use log::warn;
 use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback, Result};
 use rdlp_types::{Fragment, Progress};
 use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
 use tokio_util::sync::CancellationToken;
 
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
+use crate::atomic::{SIDECAR_SAVE_FAILURE_THRESHOLD, SaveFailureTracker};
 use crate::http::HttpDownloader;
 use crate::progress::SpeedMeter;
 use rdlp_security;
@@ -188,6 +188,7 @@ pub async fn download_pre_resolved_fragments(
     let mut frags_done: u64 = hls_state.fragments_done;
     let total_frags = fragments.len() as u64;
     let mut speed = SpeedMeter::new();
+    let mut save_tracker = SaveFailureTracker::new(SIDECAR_SAVE_FAILURE_THRESHOLD);
 
     // Pre-loop cancellation check.
     if cancel.is_some_and(CancellationToken::is_cancelled) {
@@ -357,9 +358,11 @@ pub async fn download_pre_resolved_fragments(
 
         hls_state.fragments_done = frags_done;
         hls_state.byte_len = total_bytes;
-        if let Err(e) = hls_state.save(&state_file).await {
-            warn!("HLS resume state save failed (continuing): {e}");
-        }
+        crate::atomic::note_sidecar_save(
+            hls_state.save(&state_file).await,
+            &mut save_tracker,
+            "HLS",
+        );
 
         // Emit progress (100ms throttle OR fragment-N boundary).
         if let Some(cb) = progress
@@ -426,7 +429,7 @@ pub async fn download_pre_resolved_fragments(
 /// Sidecar path for HLS resume state: `<output>.hls_state.json`.
 /// Appends the suffix to the full filename so it never collides with the
 /// output's own extension.
-fn state_path(output: &Path) -> std::path::PathBuf {
+pub(crate) fn state_path(output: &Path) -> std::path::PathBuf {
     let mut s = output.as_os_str().to_os_string();
     s.push(".hls_state.json");
     std::path::PathBuf::from(s)

--- a/crates/rdlp-downloader/src/fragments/state.rs
+++ b/crates/rdlp-downloader/src/fragments/state.rs
@@ -7,11 +7,12 @@
 //! async contexts; the file is tiny.
 
 use std::path::Path;
-use std::time::SystemTime;
 
 use rdlp_types::Fragment;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
+
+use crate::atomic::now_secs;
 
 /// Current schema version. Bump on incompatible field changes.
 pub const STATE_VERSION: u32 = 1;
@@ -105,12 +106,6 @@ impl HlsResumeState {
         self.updated_at = now_secs();
         crate::atomic::atomic_write_json(path, self.clone()).await
     }
-}
-
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/rdlp-downloader/src/fragments/tests.rs
+++ b/crates/rdlp-downloader/src/fragments/tests.rs
@@ -1450,3 +1450,51 @@ async fn extra_tail_is_truncated_to_byte_len_on_resume() {
         "torn tail dropped; final byte-identical"
     );
 }
+
+#[tokio::test]
+async fn hls_completes_when_sidecar_save_always_fails() {
+    // Force EVERY sidecar save to fail by pre-creating the sidecar path as a
+    // directory: atomic_write_json's rename-onto-a-directory fails each time,
+    // while the separate output file writes normally. The download must still
+    // complete correctly (resume is best-effort; a save failure is non-fatal).
+    let mut server = mockito::Server::new_async().await;
+    let mut expected = Vec::new();
+    let mut frags = Vec::new();
+    for i in 0..4_u32 {
+        let body = vec![i as u8; 8];
+        expected.extend_from_slice(&body);
+        server
+            .mock("GET", format!("/seg-{i}.ts").as_str())
+            .with_body(body)
+            .create_async()
+            .await;
+        frags.push(frag(format!("{}/seg-{i}.ts", server.url())));
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = dir.path().join("video.ts");
+    // Use the production sidecar-path helper so this test can't silently pass
+    // for the wrong reason if the suffix scheme changes.
+    let sidecar = super::state_path(&output);
+    tokio::fs::create_dir(&sidecar)
+        .await
+        .expect("mkdir sidecar-as-dir");
+
+    let http = HttpDownloader::with_client(wreq::Client::new()).with_concurrent_fragments(1);
+    let stats =
+        download_pre_resolved_fragments(&http, &frags, None, None, None, &output, None, None)
+            .await
+            .expect("download must complete despite every sidecar save failing");
+
+    assert_eq!(stats.bytes_downloaded, 32, "all 4×8 bytes downloaded");
+    let written = tokio::fs::read(&output).await.unwrap();
+    assert_eq!(written, expected, "output bytes correct under save failure");
+    // The sidecar path is still the directory we created — never overwritten,
+    // and remove_file on a directory is a no-op error swallowed by `let _`.
+    assert!(
+        tokio::fs::metadata(&sidecar)
+            .await
+            .expect("still exists")
+            .is_dir(),
+        "sidecar path remained a directory; no partial/torn sidecar written"
+    );
+}


### PR DESCRIPTION
## Summary

Two non-blocking follow-ups from PR #373 (HLS fragment resume), both resume-sidecar-save hygiene in `rdlp-downloader`.

Closes #375. Closes #374.

## #375 — hoist duplicated `now_secs`

The 5-line epoch-seconds helper was byte-identical in `dash/state.rs` and `fragments/state.rs`. Hoisted into `crate::atomic` as `pub(crate) fn now_secs`; both modules now import it; dead `use std::time::SystemTime;` removed from both. The `atomic` module doc broadens to "shared sidecar-save utilities."

## #374 — warn once on repeated resume-sidecar save failure

Previously every failed sidecar save logged a `warn!`, one line per fragment/segment — noisy on a sustained failure (disk full, permissions). Now a shared `SaveFailureTracker` (consecutive-count + documented threshold const `SIDECAR_SAVE_FAILURE_THRESHOLD = 3` + one-shot warned latch) emits a **single** "resume unavailable" notice after 3 consecutive failures, then stays quiet; the consecutive count resets on any successful save. Wired symmetrically into the HLS save site (`fragments.rs`) and all 3 DASH save sites (`dash/download.rs`, one tracker per `download_representation`) via a shared `note_sidecar_save` helper.

The save itself is still attempted every time — only the logging is gated. Resume safety is unchanged.

### Design notes
- **Threshold = 3** chosen from first principles (1 spuriously fires on transient flush jitter; 5+ too slow for short streams; 3 ≈ sustained/structural) and mirrors the crate's existing `MAX_CHUNK_RETRIES = 3` idiom. yt-dlp is a *negative* precedent here — its `.ytdl` write has no error handling and crashes on `ENOSPC` (yt-dlp#6757); rdlp's log-and-continue is already more correct.
- No-magic-numbers: threshold is a documented `const` (like `STATE_SAVE_BATCH`), not a literal.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `cargo test` ✓ (174 in `rdlp-downloader`, full workspace green) · `cargo check -p rdlp-desktop` ✓ · `bash scripts/check-dedup.sh` PASS.
- Tests: 4 `SaveFailureTracker` branch tests (below/at/above threshold, success-reset, latch-survives, threshold=1); HLS graceful-degradation integration test (sidecar path pre-created as a directory → every save fails → download still completes byte-correct, sidecar dir untouched — uses the production `state_path` helper so it can't pass for the wrong reason); positive `now_secs` test.

## Reviews

- **security-reviewer:** Approve — no High/Critical (all informational; confirmed no secret/URL/token leakage in the warn `{e}`, save never skipped, `saturating_add` no overflow, tracker is local non-shared state).
- **code-reviewer:** Approve — no Critical/Important. Two minor nits (cross-protocol threshold doc wording; extract the duplicated DASH blocks into a shared helper) both applied before push; refactor re-reviewed clean.
