### PR TITLE
feat: recode/post-process ETA + sub-1% progress visibility (#338)

### DIFF
--- a/crates/rdlp-api/src/dto.rs
+++ b/crates/rdlp-api/src/dto.rs
@@ -92,12 +92,17 @@ impl From<&Event> for EventDto {
             Event::PostProcessing { stage, .. } => ("post_processing", json!({ "stage": stage })),
 
             Event::PostProcessProgress {
-                stage, progress, ..
+                stage,
+                progress,
+                eta,
+                ..
             } => (
                 "postprocess_progress",
                 json!({
                     "stage": stage,
                     "progress": progress,
+                    // Whole seconds (floored) — matches the human-facing countdown display.
+                    "eta_seconds": eta.map(|d| d.as_secs()),
                 }),
             ),
 
@@ -249,6 +254,7 @@ mod tests {
             id,
             stage: "remux".into(),
             progress: rdlp_types::Progress::new(0.42),
+            eta: None,
         };
 
         let dto = EventDto::from(&event);
@@ -262,6 +268,10 @@ mod tests {
         assert!(
             (progress - 0.42).abs() < 1e-5,
             "expected 0.42 fraction, got {progress}"
+        );
+        assert!(
+            dto.payload["eta_seconds"].is_null(),
+            "eta_seconds must serialize to null when eta is None"
         );
     }
 

--- a/crates/rdlp-api/src/events.rs
+++ b/crates/rdlp-api/src/events.rs
@@ -8,6 +8,7 @@ use crate::errors::RdlpApiError;
 use crate::handle::DownloadId;
 use rdlp_core::DownloadProgress;
 use rdlp_types::{InfoDict, Progress};
+use std::time::Duration;
 
 /// A download lifecycle event.
 ///
@@ -66,6 +67,8 @@ pub enum Event {
         stage: String,
         /// Clamped progress fraction. Use [`Progress::percent`] at display sites.
         progress: Progress,
+        /// Smoothed estimated time remaining for this stage, once past warm-up.
+        eta: Option<Duration>,
     },
 
     /// Subtitles were found for the requested languages.
@@ -237,6 +240,7 @@ mod tests {
                 id,
                 stage: "remux".into(),
                 progress: Progress::new(0.45),
+                eta: None,
             },
             Event::SubtitlesFound {
                 id,

--- a/crates/rdlp-api/src/orchestrator/eta.rs
+++ b/crates/rdlp-api/src/orchestrator/eta.rs
@@ -1,0 +1,161 @@
+//! Smoothed ETA estimation for post-processing stages.
+
+use std::sync::{Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+/// Fractions below this are too noisy to derive a stable ETA from (the first
+/// frames of a slow encoder, or a lookahead-fill phase). Below it, return None.
+const ETA_WARMUP_FRAC: f64 = 0.005; // 0.5%
+/// EWMA smoothing factor for the ETA (mirrors `adaptive::EWMA_ALPHA = 0.3`).
+const ETA_EWMA_ALPHA: f64 = 0.3;
+
+/// Average-rate ETA: `elapsed * (1 - frac) / frac`. `None` when `frac` is
+/// non-positive or already complete (`>= 1.0`). Uses `try_from_secs_f64`
+/// (stable since 1.66; workspace floor is 1.85) so a non-finite OR finite-but-
+/// overflowing result yields `None` instead of panicking — never panics /
+/// divides by zero. (Validated 2026-06-07: `from_secs_f64` panics on
+/// negative/NaN/inf AND finite overflow; the checked variant covers all four.)
+#[must_use]
+pub fn estimate_eta(elapsed: Duration, frac: f64) -> Option<Duration> {
+    if frac <= 0.0 || frac >= 1.0 {
+        return None;
+    }
+    Duration::try_from_secs_f64(elapsed.as_secs_f64() * (1.0 - frac) / frac).ok()
+}
+
+/// EWMA convex combination: `alpha * raw + (1 - alpha) * prev`. The result
+/// always lies between `prev` and `raw` for `alpha` in `[0, 1]`.
+fn smooth(prev: f64, raw: f64, alpha: f64) -> f64 {
+    alpha.mul_add(raw, (1.0 - alpha) * prev)
+}
+
+/// Per-stage smoothed ETA estimator. `update` takes `&self` (the progress
+/// callback is `&self`), so state lives behind a `Mutex`. The clock starts
+/// lazily on the first `update`, so setup time before the first progress tick
+/// does not inflate the estimate.
+pub struct EtaEstimator {
+    inner: Mutex<EtaState>,
+}
+
+#[derive(Default)]
+struct EtaState {
+    start: Option<Instant>,
+    smoothed_secs: Option<f64>,
+}
+
+impl EtaEstimator {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(EtaState::default()),
+        }
+    }
+
+    /// Update with the latest progress fraction; return a smoothed ETA, or
+    /// `None` during warm-up / when not computable.
+    pub(crate) fn update(&self, frac: f64) -> Option<Duration> {
+        let now = Instant::now();
+        let mut s = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let start = *s.start.get_or_insert(now);
+        if frac < ETA_WARMUP_FRAC {
+            return None;
+        }
+        let raw_secs = estimate_eta(now.duration_since(start), frac)?.as_secs_f64();
+        let smoothed = s
+            .smoothed_secs
+            .map_or(raw_secs, |prev| smooth(prev, raw_secs, ETA_EWMA_ALPHA));
+        s.smoothed_secs = Some(smoothed);
+        drop(s); // release the lock before the (cheap) f64→Duration conversion
+        Duration::try_from_secs_f64(smoothed).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn estimate_eta_uses_average_rate_formula() {
+        // elapsed * (1 - frac) / frac
+        assert_eq!(
+            estimate_eta(Duration::from_secs(10), 0.5),
+            Some(Duration::from_secs(10))
+        );
+        assert_eq!(
+            estimate_eta(Duration::from_secs(10), 0.25),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn estimate_eta_none_on_nonpositive_or_complete_frac() {
+        assert_eq!(estimate_eta(Duration::from_secs(10), 0.0), None);
+        assert_eq!(estimate_eta(Duration::from_secs(10), -0.5), None);
+        assert_eq!(estimate_eta(Duration::from_secs(10), 1.0), None);
+        assert_eq!(estimate_eta(Duration::from_secs(10), 1.5), None);
+    }
+
+    #[test]
+    fn estimator_warmup_returns_none_below_threshold_then_some() {
+        let est = EtaEstimator::new();
+        // Below warm-up fraction → None (early ratios too noisy).
+        assert!(est.update(0.0).is_none());
+        assert!(est.update(0.001).is_none());
+        // Above warm-up → Some (a real, bounded estimate).
+        let eta = est.update(0.5);
+        assert!(eta.is_some(), "past warm-up the estimator yields an ETA");
+    }
+
+    #[test]
+    fn estimator_smoothing_returns_finite_nonnegative() {
+        // The exact raw estimates depend on Instant timing (non-deterministic),
+        // so this only guards that smoothing yields a finite, non-negative
+        // duration and never panics; the convex-combination bound is checked
+        // deterministically by `smooth_is_a_convex_combination`.
+        let est = EtaEstimator::new();
+        let _ = est.update(0.5);
+        let second = est.update(0.6);
+        assert!(second.is_some());
+        // Bounded + finite (no NaN/inf leaking through).
+        let secs = second
+            .unwrap_or_else(|| Duration::from_secs(0))
+            .as_secs_f64();
+        assert!(secs.is_finite() && secs >= 0.0);
+    }
+
+    #[test]
+    fn smooth_is_a_convex_combination() {
+        // 0.3*20 + 0.7*10 = 13.0 — strictly between prev and raw.
+        assert!((smooth(10.0, 20.0, 0.3) - 13.0).abs() < 1e-9);
+        // Bounded by the two inputs regardless of order.
+        let s = smooth(100.0, 5.0, 0.3);
+        assert!(
+            (5.0..=100.0).contains(&s),
+            "smoothed must lie within [raw, prev]"
+        );
+        // alpha = 0 → keeps prev; alpha = 1 → takes raw.
+        assert!((smooth(10.0, 20.0, 0.0) - 10.0).abs() < 1e-9);
+        assert!((smooth(10.0, 20.0, 1.0) - 20.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn estimator_warmup_threshold_is_inclusive() {
+        // Guard is `frac < ETA_WARMUP_FRAC`, so frac == 0.005 is NOT gated.
+        let est = EtaEstimator::new();
+        assert!(
+            est.update(0.005).is_some(),
+            "warm-up threshold is inclusive"
+        );
+    }
+
+    #[test]
+    fn estimator_completion_tick_past_warmup_is_none() {
+        // frac >= 1.0 (a completion tick) past warm-up → estimate_eta None → update None.
+        let est = EtaEstimator::new();
+        let _ = est.update(0.5);
+        assert!(
+            est.update(1.0).is_none(),
+            "nothing remaining at frac == 1.0"
+        );
+    }
+}

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -4,6 +4,7 @@ mod archive;
 mod container_resolver;
 mod download;
 pub mod errors;
+mod eta;
 mod execution;
 mod extraction;
 mod interactive;

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -6,6 +6,7 @@ use super::{Orchestrator, Result};
 use crate::events::Event;
 use crate::handle::DownloadId;
 use crate::orchestrator::errors::OrchestratorError;
+use crate::orchestrator::eta::EtaEstimator;
 use log::{debug, warn};
 use rdlp_core::{PostProcessCallback, PostProcessCallbackFactory};
 use rdlp_postprocess::pipeline::PipelineError;
@@ -22,14 +23,17 @@ struct PostProcessBridge {
     event_tx: mpsc::Sender<Event>,
     download_id: DownloadId,
     stage: String,
+    eta: EtaEstimator,
 }
 
 impl PostProcessCallback for PostProcessBridge {
     fn on_progress(&self, progress: Progress) {
+        let eta = self.eta.update(f64::from(progress.fraction()));
         let _ = self.event_tx.try_send(Event::PostProcessProgress {
             id: self.download_id,
             stage: self.stage.clone(),
             progress,
+            eta,
         });
     }
 
@@ -62,6 +66,7 @@ fn make_callback_factory(
             event_tx: event_tx.clone(),
             download_id,
             stage: stage_name.to_owned(),
+            eta: EtaEstimator::new(),
         })
     })
 }

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -86,6 +86,8 @@ pub struct PostProcessProgressPayload {
     pub(crate) stage: String,
     /// Progress as a fraction in `[0.0, 1.0]`.
     pub(crate) progress: f64,
+    /// Formatted ETA string (e.g. `"02:30"`), once past warm-up.
+    pub(crate) eta: Option<String>,
 }
 
 /// Payload for "unit-started" Tauri event.
@@ -214,12 +216,16 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
         }
 
         Event::PostProcessProgress {
-            stage, progress, ..
+            stage,
+            progress,
+            eta,
+            ..
         } => {
             let payload = PostProcessProgressPayload {
                 job_id: job_id.to_owned(),
                 stage: stage.clone(),
                 progress: f64::from(progress.fraction()),
+                eta: eta.as_ref().map(format_eta),
             };
             if let Err(e) = app.emit("postprocess-progress", &payload) {
                 debug!("Failed to emit postprocess-progress for job {job_id}: {e}");
@@ -409,11 +415,13 @@ mod tests {
             job_id: "abc-123".to_owned(),
             stage: "remux".to_owned(),
             progress: 0.45,
+            eta: Some("02:30".to_owned()),
         };
         let json = serde_json::to_value(&payload).expect("serialization should succeed");
         assert_eq!(json["jobId"], "abc-123");
         assert_eq!(json["stage"], "remux");
         assert_eq!(json["progress"], 0.45);
+        assert_eq!(json["eta"], "02:30");
     }
 
     #[test]

--- a/crates/rdlp-desktop/src/components/JobMiniCard.tsx
+++ b/crates/rdlp-desktop/src/components/JobMiniCard.tsx
@@ -3,7 +3,7 @@
 
 import { setView, setSelectedJob } from "@/stores/uiStore";
 import { isInFlight } from "@/lib/jobStatus";
-import { cn, displayTitle, progressPercent } from "@/lib/utils";
+import { cn, displayTitle, progressPercentLabel } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 interface JobMiniCardProps {
@@ -33,7 +33,7 @@ export function JobMiniCard({ job, className }: JobMiniCardProps) {
             <div className="flex items-center justify-between gap-2 mb-1">
                 <span className="text-[11px] text-[#eeeeee] truncate flex-1 leading-tight">{title}</span>
                 {inFlight && (
-                    <span className="text-[10px] text-[#aaaaaa] shrink-0 font-mono">{progressPercent(job.progress)}%</span>
+                    <span className="text-[10px] text-[#aaaaaa] shrink-0 font-mono">{progressPercentLabel(job.progress, job.status === "processing")}%</span>
                 )}
                 {isPending && (
                     <span className="text-[10px] text-[var(--text-muted)] shrink-0">Queued</span>

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -175,7 +175,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                                   ...job,
                                   progress: p.progress,
                                   speed: null,
-                                  eta: null,
+                                  eta: p.eta,
                               }
                             : job,
                     ),

--- a/crates/rdlp-desktop/src/lib/jobStatus.test.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.test.ts
@@ -48,8 +48,20 @@ function makeJob(status: JobStatus, id = "j", overrides: Partial<DownloadJob> = 
 const ALL_STATUSES: JobStatus[] = ["pending", "running", "processing", "completed", "failed", "cancelled"];
 
 describe("jobSubLabel", () => {
-    it("returns the stage while processing", () => {
-        expect(jobSubLabel(makeJob("processing", "a", { stage: "Recode" }))).toBe("Recode");
+    it("shows stage, decimal percent, and ETA while processing", () => {
+        expect(
+            jobSubLabel(makeJob("processing", "a", { stage: "Recode", progress: 0.004, eta: "02:30" })),
+        ).toBe("Recode — 0.4% · 02:30");
+    });
+    it("shows decimal percent without ETA before warm-up while processing", () => {
+        expect(
+            jobSubLabel(makeJob("processing", "a", { stage: "Recode", progress: 0.004, eta: null })),
+        ).toBe("Recode — 0.4%");
+    });
+    it("falls back to 'Processing' when stage is null (no literal 'null')", () => {
+        const label = jobSubLabel(makeJob("processing", "a", { stage: null, progress: 0.004, eta: null }));
+        expect(label).toBe("Processing — 0.4%");
+        expect(label).not.toContain("null");
     });
     it("formats a merge sub-unit with percent", () => {
         expect(jobSubLabel(makeJob("running", "a", { currentUnit: { index: 1, total: 2, title: "Video" }, progress: 0.67 }))).toBe("Video — 67%");
@@ -64,7 +76,15 @@ describe("jobSubLabel", () => {
         expect(jobSubLabel(makeJob("running", "a", { currentUnit: { index: 1, total: 2, title: "Bonus" } }))).toBe("Ep 1/2 — Bonus");
     });
     it("prefers stage over currentUnit while processing", () => {
-        expect(jobSubLabel(makeJob("processing", "a", { stage: "Merge", currentUnit: { index: 1, total: 2, title: "Video" } }))).toBe("Merge");
+        expect(
+            jobSubLabel(
+                makeJob("processing", "a", {
+                    stage: "Merge",
+                    progress: 0,
+                    currentUnit: { index: 1, total: 2, title: "Video" },
+                }),
+            ),
+        ).toBe("Merge — 0.0%");
     });
 });
 

--- a/crates/rdlp-desktop/src/lib/jobStatus.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.ts
@@ -24,7 +24,11 @@ export function cancelledJobPatch(): Partial<DownloadJob> {
 
 /** The per-job sub-label, derived during render from canonical fields. Null = no sub-label. */
 export function jobSubLabel(job: DownloadJob): string | null {
-    if (job.status === "processing") return job.stage;
+    if (job.status === "processing") {
+        const pct = ((job.progress ?? 0) * 100).toFixed(1);
+        const eta = job.eta ? ` · ${job.eta}` : "";
+        return `${job.stage ?? "Processing"} — ${pct}%${eta}`;
+    }
     const u = job.currentUnit;
     if (!u) return null;
     const pct = Math.round((job.progress ?? 0) * 100);

--- a/crates/rdlp-desktop/src/lib/utils.test.ts
+++ b/crates/rdlp-desktop/src/lib/utils.test.ts
@@ -2,7 +2,7 @@
 // Unit tests for lib/utils.ts — cn() and parseUploadTimestamp().
 
 import { describe, test, expect } from "vitest";
-import { cn, displayTitle, parseUploadTimestamp, progressPercent, TITLE_PLACEHOLDER } from "./utils";
+import { cn, displayTitle, parseUploadTimestamp, progressPercent, progressPercentLabel, TITLE_PLACEHOLDER } from "./utils";
 
 // ---------------------------------------------------------------------------
 // cn()
@@ -143,5 +143,25 @@ describe("progressPercent", () => {
     it("treats null/undefined as 0", () => {
         expect(progressPercent(null)).toBe(0);
         expect(progressPercent(undefined)).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// progressPercentLabel()
+// ---------------------------------------------------------------------------
+
+describe("progressPercentLabel", () => {
+    it("renders one decimal when processing so sub-1% movement is legible", () => {
+        expect(progressPercentLabel(0.004, true)).toBe("0.4");
+        expect(progressPercentLabel(0.3, true)).toBe("30.0");
+    });
+    it("renders a whole integer when NOT processing (no display churn)", () => {
+        expect(progressPercentLabel(0.004, false)).toBe("0");
+        expect(progressPercentLabel(0.47, false)).toBe("47");
+        expect(progressPercentLabel(1, false)).toBe("100");
+    });
+    it("treats null/undefined as 0 in both modes", () => {
+        expect(progressPercentLabel(null, true)).toBe("0.0");
+        expect(progressPercentLabel(undefined, false)).toBe("0");
     });
 });

--- a/crates/rdlp-desktop/src/lib/utils.ts
+++ b/crates/rdlp-desktop/src/lib/utils.ts
@@ -74,3 +74,18 @@ export function displayTitle(title: string | null | undefined): string {
 export function progressPercent(fraction: number | null | undefined): number {
     return Math.round((fraction ?? 0) * 100);
 }
+
+/**
+ * Format a 0–1 progress fraction as a percent string. In-flight post-processing
+ * (e.g. a slow recode) is shown with one decimal so movement below 1% is legible;
+ * all other states use a whole percent to avoid display churn.
+ */
+export function progressPercentLabel(
+    fraction: number | null | undefined,
+    isProcessing: boolean,
+): string {
+    if (isProcessing) {
+        return ((fraction ?? 0) * 100).toFixed(1);
+    }
+    return String(progressPercent(fraction));
+}

--- a/crates/rdlp-desktop/src/shell/BottomDrawer.test.tsx
+++ b/crates/rdlp-desktop/src/shell/BottomDrawer.test.tsx
@@ -48,6 +48,13 @@ describe("BottomDrawer — processing job surfaces as active (#336)", () => {
         expect(status).not.toHaveTextContent("Ready");
     });
 
+    it("renders a sub-1% processing percent with one decimal (#338), not '0%'", () => {
+        renderDrawer([makeJob("processing", { title: "Recoding Video", progress: 0.004 })]);
+        const status = screen.getByTestId("drawer-status");
+        expect(status).toHaveTextContent("0.4%");
+        expect(status).not.toHaveTextContent("0%");
+    });
+
     it("falls back to the 'Ready' state when no job is in flight", () => {
         renderDrawer([makeJob("completed", { title: "Done Video" })]);
         const status = screen.getByTestId("drawer-status");

--- a/crates/rdlp-desktop/src/shell/BottomDrawer.tsx
+++ b/crates/rdlp-desktop/src/shell/BottomDrawer.tsx
@@ -12,7 +12,7 @@ import { downloadsQueryOptions } from "@/api/downloads";
 import { isInFlight, isTerminal } from "@/lib/jobStatus";
 import { LogViewer, appendLog } from "@/components/LogViewer";
 import { StatusBadge } from "@/components/StatusBadge";
-import { progressPercent } from "@/lib/utils";
+import { progressPercentLabel } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 // Re-export appendLog so event registration can use it
@@ -48,7 +48,7 @@ function JobsPanel({ jobs }: JobsPanelProps) {
                     <StatusBadge status={job.status} className="shrink-0" />
                     {isInFlight(job.status) && job.progress !== null && (
                         <span className="text-[10px] text-[var(--text-muted)] font-mono shrink-0">
-                            {progressPercent(job.progress)}%
+                            {progressPercentLabel(job.progress, job.status === "processing")}%
                         </span>
                     )}
                 </Button>
@@ -111,7 +111,7 @@ export function BottomDrawer() {
                             </span>
                             {activeJob.progress !== null && (
                                 <span className="text-[10px] text-[#aaaaaa] font-mono shrink-0">
-                                    {progressPercent(activeJob.progress)}%
+                                    {progressPercentLabel(activeJob.progress, activeJob.status === "processing")}%
                                 </span>
                             )}
                             {activeJob.speed && (

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -346,6 +346,7 @@ export interface PostProcessProgressPayload {
     jobId: string;
     stage: string;
     progress: number; // 0.0–1.0
+    eta: string | null;
 }
 
 /** Unit-started payload emitted as "unit-started" (playlist episode or merge stream start). */

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -321,14 +321,38 @@ describe("JobCard — progress display", () => {
 });
 
 describe("JobCard — processing (#336)", () => {
-    it("shows the progress bar and Cancel for a processing job", () => {
+    it("shows the progress bar, decimal percent, and Cancel for a processing job", () => {
         render(<JobCard job={makeJob({ status: "processing", progress: 0.3, stage: "Recode" })} />);
         expect(screen.getByLabelText("Cancel download")).toBeInTheDocument();
-        expect(screen.getByText("30%")).toBeInTheDocument();
+        expect(screen.getByText("30.0%")).toBeInTheDocument();
     });
-    it("shows the stage as the sub-label while processing", () => {
-        render(<JobCard job={makeJob({ status: "processing", progress: 0.3, stage: "Recode" })} />);
-        expect(screen.getByText("Recode")).toBeInTheDocument();
+    it("shows the stage with decimal percent as the sub-label while processing", () => {
+        render(<JobCard job={makeJob({ status: "processing", progress: 0.004, stage: "Recode" })} />);
+        expect(screen.getByText("Recode — 0.4%")).toBeInTheDocument();
+    });
+    it("shows the ETA in the sub-label while processing once available", () => {
+        render(
+            <JobCard
+                job={makeJob({ status: "processing", progress: 0.004, stage: "Recode", eta: "02:30" })}
+            />,
+        );
+        expect(screen.getByText("Recode — 0.4% · 02:30")).toBeInTheDocument();
+    });
+    it("shows the ETA only in the sub-label (no separate ETA chip) while processing", () => {
+        render(
+            <JobCard
+                job={makeJob({ status: "processing", progress: 0.004, stage: "Recode", eta: "02:30" })}
+            />,
+        );
+        // The dedicated "ETA <value>" footer chip is suppressed for processing jobs.
+        expect(screen.queryByText(/^ETA /)).not.toBeInTheDocument();
+        // The ETA value still appears, but only embedded in the sub-label.
+        expect(screen.getByText("Recode — 0.4% · 02:30")).toBeInTheDocument();
+        expect(screen.getAllByText(/02:30/)).toHaveLength(1);
+    });
+    it("a running job still shows the dedicated 'ETA <value>' chip (guard against over-suppression)", () => {
+        render(<JobCard job={makeJob({ status: "running", progress: 0.5, eta: "00:30" })} />);
+        expect(screen.getByText("ETA 00:30")).toBeInTheDocument();
     });
     it("a completed job shows no Cancel button", () => {
         render(<JobCard job={makeJob({ status: "completed", progress: 1 })} />);

--- a/crates/rdlp-desktop/src/views/queue/JobCard.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.tsx
@@ -10,7 +10,7 @@ import { cancelDownload, removeJob, startDownload } from "@/api/downloads";
 import { StatusBadge } from "@/components/StatusBadge";
 import { isTerminal as isTerminalStatus, isInFlight, jobSubLabel } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
-import { cn, displayTitle, progressPercent } from "@/lib/utils";
+import { cn, displayTitle, progressPercentLabel } from "@/lib/utils";
 import type { DownloadJob } from "@/types";
 
 interface JobCardProps {
@@ -97,9 +97,11 @@ export function JobCard({ job, compact = false }: JobCardProps) {
                             />
                         </div>
                         <div className="flex items-center gap-3 text-[10px] text-[var(--text-muted)] font-mono">
-                            <span className="text-[#aaaaaa]">{progressPercent(job.progress)}%</span>
+                            <span className="text-[#aaaaaa]">
+                                {progressPercentLabel(job.progress, job.status === "processing")}%
+                            </span>
                             {job.speed && <span>{job.speed}</span>}
-                            {job.eta && <span>ETA {job.eta}</span>}
+                            {job.status !== "processing" && job.eta && <span>ETA {job.eta}</span>}
                             {subLabel && (
                                 <span className="text-[#4a9eff] truncate">{subLabel}</span>
                             )}

--- a/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobDetails.tsx
@@ -9,7 +9,7 @@ import { downloadsQueryOptions, cancelDownload, removeJob, startDownload } from 
 import { StatusBadge } from "@/components/StatusBadge";
 import { isTerminal as isTerminalStatus, isInFlight, jobSubLabel } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
-import { cn, progressPercent } from "@/lib/utils";
+import { cn, progressPercentLabel } from "@/lib/utils";
 
 function formatDate(ts: number | null): string {
     if (!ts) return "—";
@@ -67,10 +67,12 @@ export function JobDetails() {
             {inFlight && (
                 <div>
                     <div className="flex items-center justify-between text-[10px] text-[var(--text-muted)] mb-1">
-                        <span className="font-mono text-[#aaaaaa]">{progressPercent(job.progress)}%</span>
+                        <span className="font-mono text-[#aaaaaa]">
+                            {progressPercentLabel(job.progress, job.status === "processing")}%
+                        </span>
                         <div className="flex items-center gap-2">
                             {job.speed && <span>{job.speed}</span>}
-                            {job.eta && <span>ETA {job.eta}</span>}
+                            {job.status !== "processing" && job.eta && <span>ETA {job.eta}</span>}
                         </div>
                     </div>
                     <div className="h-[3px] rounded-full bg-[#1a1a2e] overflow-hidden">


### PR DESCRIPTION
## Summary

Slow encoders (e.g. `libvvenc`) made the recode/post-process stage look frozen at "0%". This adds a smoothed **ETA** and renders progress **below 1%** so a working slow encode is visibly distinct from a stalled one.

Closes #338.

## Backend (`rdlp-api`)

- New `EtaEstimator` (`orchestrator/eta.rs`): pure `estimate_eta = elapsed*(1-frac)/frac` via `Duration::try_from_secs_f64().ok()` (panic-safe on negative/NaN/inf/overflow), a warm-up gate (`ETA_WARMUP_FRAC = 0.005` — suppresses VVenC lookahead-fill swings), and EWMA smoothing (`ETA_EWMA_ALPHA = 0.3`, mirrors `adaptive::EWMA_ALPHA`).
- Computed at the single chokepoint: `PostProcessBridge` (one instance per stage, lazy clock start on first tick). The rdlp-ffmpeg `Fn(f64)` callback and the `PostProcessCallback` trait are **unchanged** (smallest blast radius).
- `eta: Option<Duration>` added to `Event::PostProcessProgress`; `eta_seconds` on the `EventDto` wire.

## Desktop

- Tauri `PostProcessProgressPayload` +`eta: Option<String>` (reuses the existing `format_eta`); TS type + `registerDownloadEvents` stores it.
- `jobSubLabel` processing branch now shows decimal % + ETA (e.g. `Recode — 0.4% · 02:30`, null-stage guarded).
- Shared `progressPercentLabel(fraction, isProcessing)` helper decimal-izes the **main** % for processing jobs across all 4 surfaces (JobCard / JobDetails / JobMiniCard / BottomDrawer); non-processing states keep integer % (no churn). The duplicate footer ETA chip is suppressed for processing jobs (the sub-label already carries it).

## Design note

Bridge-centric: ETA is computed once at the only `Event::PostProcessProgress` constructor, so **all** post-process stages get an ETA for free — less code than gating it to recode. Mirrors the existing download-ETA plumbing (`Option<Duration>` → `format_eta` → TS string).

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `cargo test` ✓ · `cargo check -p rdlp-desktop` ✓ · `bash scripts/check-dedup.sh` PASS.
- Frontend: `npx tsc --noEmit` ✓ · `npm run test` 284/284 ✓.
- Tests: pure `estimate_eta` (formula + frac≤0/≥1 → None, no panic) + `smooth` convex bound + warm-up boundary (inclusive) + completion-tick → None; `progressPercentLabel` decimal/integer/null; `jobSubLabel` null-stage/sub-1%/ETA cases; BottomDrawer sub-1%; JobCard single-ETA (no duplicate) + running-job-still-shows-chip guard.

## Reviews

- **security-reviewer:** Approve — no High/Critical (display-only; no new IPC/fetch/untrusted-input; panic-safe `try_from_secs_f64` + poison-safe Mutex; no secret leakage; React text nodes, no `dangerouslySetInnerHTML`).
- **code-reviewer:** Approve — no Critical/Important. ETA contract coherent end-to-end.

## Validation catch

Research-and-validate before building corrected two plan assumptions: the third event constructor was `events.rs` (not `commands/download.rs`, a `..` match arm), and `jobSubLabel`'s processing branch showed *no* percent at all (the issue's `registerDownloadEvents.ts:183` line ref was stale) — so the real fix was enriching that branch. Also switched `from_secs_f64` → `try_from_secs_f64` for finite-overflow panic-safety.

## Follow-ups (non-blocking)

- Surface `eta_seconds` on the `Event::Progress` (download) DTO arm for wire parity (data already in `DownloadProgress.eta`).
- (Optional) Add `JobDetails.test.tsx` mirroring the JobCard processing-% + ETA-chip-suppression tests.
