### PR TITLE
feat: byte-extrapolated progress + ETA for segmented downloads (#378)

### DIFF
--- a/crates/rdlp-api/src/dto.rs
+++ b/crates/rdlp-api/src/dto.rs
@@ -86,6 +86,8 @@ impl From<&Event> for EventDto {
                     "percentage": progress.progress.map(rdlp_types::Progress::percent),
                     "segments_downloaded": progress.segments_downloaded,
                     "total_segments": progress.total_segments,
+                    "eta_seconds": progress.eta.map(|d| d.as_secs()),
+                    "total_bytes_estimated": progress.is_estimated,
                 }),
             ),
 
@@ -273,6 +275,27 @@ mod tests {
             dto.payload["eta_seconds"].is_null(),
             "eta_seconds must serialize to null when eta is None"
         );
+    }
+
+    #[test]
+    fn progress_event_emits_eta_seconds_and_estimated_flag() {
+        // Known total + fast speed → eta Some(10s); not estimated.
+        let known = Event::Progress {
+            id: DownloadId::next(),
+            progress: rdlp_core::DownloadProgress::new(0, Some(10_000), 1000.0),
+        };
+        let dto = EventDto::from(&known);
+        assert_eq!(dto.payload["eta_seconds"].as_u64(), Some(10)); // 10000/1000 = 10s
+        assert_eq!(dto.payload["total_bytes_estimated"].as_bool(), Some(false));
+
+        // No total → eta null.
+        let unknown = Event::Progress {
+            id: DownloadId::next(),
+            progress: rdlp_core::DownloadProgress::new(50, None, 1000.0),
+        };
+        let dto = EventDto::from(&unknown);
+        assert!(dto.payload["eta_seconds"].is_null());
+        assert_eq!(dto.payload["total_bytes_estimated"].as_bool(), Some(false));
     }
 
     #[test]

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -75,6 +75,8 @@ fn default_args() -> Args {
         browser: None,
         trust_publisher: vec![],
         plugin: None,
+        download_timeout: None,
+        merge_timeout: None,
     }
 }
 

--- a/crates/rdlp-cli/src/event_handler.rs
+++ b/crates/rdlp-cli/src/event_handler.rs
@@ -157,9 +157,17 @@ impl CliEventHandler {
                 .expect("progress bar was just assigned")
         };
 
-        if progress.total_bytes.is_some() {
-            // HTTP: byte-based progress
+        if let Some(total) = progress.total_bytes {
+            // The estimated total refines as fragments complete — keep the bar
+            // length in sync, and surface the segment counter as secondary text.
+            pb.set_length(total);
             pb.set_position(progress.bytes_downloaded);
+            if progress.is_estimated
+                && let (Some(done), Some(segs_total)) =
+                    (progress.segments_downloaded, progress.total_segments)
+            {
+                pb.set_message(format!("frag {done}/{segs_total}"));
+            }
         } else if let Some(segs) = progress.segments_downloaded {
             // HLS: segment-based progress
             pb.set_position(segs);
@@ -180,14 +188,18 @@ impl CliEventHandler {
         // All three `expect` calls below are on static template string literals — infallible.
         #[allow(clippy::expect_used)]
         if let Some(total) = progress.total_bytes {
-            // HTTP download with known size
             let pb = self.multi_progress.add(ProgressBar::new(total));
+            let template = if progress.is_estimated {
+                // Estimated total (segmented download, no Content-Length): mark with ~,
+                // and reserve {msg} for the "frag N/M" secondary counter.
+                "{wide_bar:.cyan/blue} {bytes}/~{total_bytes} \
+                 ({bytes_per_sec}) [{elapsed_precise}] {msg}"
+            } else {
+                "{wide_bar:.cyan/blue} {bytes}/{total_bytes} \
+                 ({bytes_per_sec}) [{elapsed_precise}]"
+            };
             pb.set_style(
-                ProgressStyle::with_template(
-                    "{wide_bar:.cyan/blue} {bytes}/{total_bytes} \
-                     ({bytes_per_sec}) [{elapsed_precise}]",
-                )
-                .expect("static template string — infallible"),
+                ProgressStyle::with_template(template).expect("static template string — infallible"),
             );
             pb
         } else if let Some(total) = progress.total_segments {

--- a/crates/rdlp-cli/src/event_handler.rs
+++ b/crates/rdlp-cli/src/event_handler.rs
@@ -199,7 +199,8 @@ impl CliEventHandler {
                  ({bytes_per_sec}) [{elapsed_precise}]"
             };
             pb.set_style(
-                ProgressStyle::with_template(template).expect("static template string — infallible"),
+                ProgressStyle::with_template(template)
+                    .expect("static template string — infallible"),
             );
             pb
         } else if let Some(total) = progress.total_segments {

--- a/crates/rdlp-core/src/traits/downloader.rs
+++ b/crates/rdlp-core/src/traits/downloader.rs
@@ -212,6 +212,11 @@ pub struct DownloadProgress {
 
     /// Total stream duration in seconds (for HLS with duration tracking)
     pub total_duration: Option<f64>,
+
+    /// `true` when `total_bytes` is an extrapolated estimate (segmented download
+    /// with no Content-Length), not an authoritative total. Display layers may
+    /// prefix the total with "~". `false` for exact/byte-known downloads.
+    pub is_estimated: bool,
 }
 
 impl DownloadProgress {
@@ -247,6 +252,7 @@ impl DownloadProgress {
             total_segments: None,
             duration_downloaded: None,
             total_duration: None,
+            is_estimated: false,
         }
     }
 
@@ -294,6 +300,7 @@ impl DownloadProgress {
             total_segments: Some(total_segments),
             duration_downloaded: None,
             total_duration: None,
+            is_estimated: false,
         }
     }
 
@@ -352,6 +359,7 @@ impl DownloadProgress {
             total_segments: Some(total_segments),
             duration_downloaded: Some(duration_downloaded),
             total_duration: Some(total_duration),
+            is_estimated: false,
         }
     }
 
@@ -528,6 +536,22 @@ mod tests {
         assert_eq!(progress.progress.map(|p| p.percent()), Some(50.0));
         assert!(progress.eta.is_some());
         assert_eq!(progress.eta.unwrap().as_secs(), 5);
+    }
+
+    #[test]
+    fn new_constructors_default_is_estimated_false() {
+        assert!(
+            !DownloadProgress::new(10, Some(100), 50.0).is_estimated,
+            "new: exact total_bytes is not an estimate"
+        );
+        assert!(
+            !DownloadProgress::new_with_segments(10, 50.0, 1, 4).is_estimated,
+            "new_with_segments: no total_bytes, vacuously not estimated"
+        );
+        assert!(
+            !DownloadProgress::new_with_duration(10, 50.0, 1, 4, 2.0, 8.0).is_estimated,
+            "new_with_duration: no total_bytes, vacuously not estimated"
+        );
     }
 
     #[tokio::test]

--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -29,6 +29,8 @@ pub struct DownloadProgressPayload {
     pub(crate) downloaded_bytes: u64,
     /// Total expected bytes, if known.
     pub(crate) total_bytes: Option<u64>,
+    /// `true` when `total_bytes` is an extrapolated estimate (segmented download).
+    pub(crate) is_estimated: bool,
 }
 
 /// Download completion payload emitted as `"download-complete"`.
@@ -156,6 +158,7 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 eta: progress.eta.as_ref().map(format_eta),
                 downloaded_bytes: progress.bytes_downloaded,
                 total_bytes: progress.total_bytes,
+                is_estimated: progress.is_estimated,
             };
 
             if let Err(e) = app.emit("download-progress", &payload) {
@@ -362,6 +365,7 @@ mod tests {
             eta: Some("01:30".to_owned()),
             downloaded_bytes: 1024,
             total_bytes: Some(2048),
+            is_estimated: false,
         };
         let json = serde_json::to_value(&payload).expect("serialization should succeed");
         assert_eq!(json["jobId"], "abc-123");

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -314,6 +314,10 @@ export interface DownloadProgressPayload {
     eta: string | null;
     downloadedBytes: number;
     totalBytes: number | null;
+    /** True when totalBytes is an extrapolated estimate (segmented download).
+     *  Carry-only for now: not yet consumed by the UI (no total-size display);
+     *  ETA itself renders via the existing eta plumbing. */
+    isEstimated: boolean;
 }
 
 /** Download completion payload emitted as "download-complete". */

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use futures::StreamExt as _;
 use rdlp_core::{DownloadProgress, DownloadStats, ProgressCallback, Result};
-use rdlp_types::{Fragment, Progress};
+use rdlp_types::Fragment;
 use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
 use tokio_util::sync::CancellationToken;
 
@@ -27,25 +27,6 @@ use crate::atomic::{SIDECAR_SAVE_FAILURE_THRESHOLD, SaveFailureTracker};
 use crate::http::HttpDownloader;
 use crate::progress::SpeedMeter;
 use rdlp_security;
-
-/// Compute the progress fraction for a fragment download.
-///
-/// Byte-based when the total byte size is known (`expected_total`), otherwise
-/// **segment-based** (`frags_done / total_frags`). HLS pre-resolved-fragment
-/// downloads pass `expected_total = None` — without the segment fallback the
-/// emitted `progress` would be `None`, leaving UIs that read it (the desktop
-/// progress bar, `events.rs`) stuck at 0 until completion, then jumping to 100.
-/// Returns `None` only when neither a byte total nor any segments are known.
-fn fragment_progress_fraction(
-    expected_total: Option<u64>,
-    total_bytes: u64,
-    frags_done: u64,
-    total_frags: u64,
-) -> Option<Progress> {
-    expected_total
-        .map(|t| Progress::from_ratio(total_bytes, t))
-        .or_else(|| (total_frags > 0).then(|| Progress::from_ratio(frags_done, total_frags)))
-}
 
 /// Fetch a pre-resolved list of fragment URLs and concatenate them into
 /// `output` in order.
@@ -368,25 +349,19 @@ pub async fn download_pre_resolved_fragments(
         if let Some(cb) = progress
             && (now.duration_since(last_emit) >= PROGRESS_INTERVAL || frags_done == total_frags)
         {
-            cb.on_progress(&DownloadProgress {
-                bytes_downloaded: total_bytes,
-                total_bytes: expected_total,
-                progress: fragment_progress_fraction(
-                    expected_total,
-                    total_bytes,
-                    frags_done,
-                    total_frags,
-                ),
-                segments_downloaded: Some(frags_done),
-                total_segments: Some(total_frags),
-                // `None` while cold-starting (< 2 samples) or stalled collapses to
-                // 0 B/s for the f64 field — matches the pre-SpeedMeter behaviour.
-                speed: speed.bytes_per_sec().unwrap_or(0.0),
-                eta: speed.eta(expected_total.map(|t| t.saturating_sub(total_bytes))),
-                duration_downloaded: None,
-                total_duration: None,
-                is_estimated: false,
+            // Byte-extrapolation (yt-dlp): prefer a real Content-Length total;
+            // else estimate total = avg-bytes-per-frag × total_frags (available
+            // once >= 1 fragment completed). Feeding this to `new` makes BOTH the
+            // progress fraction and the ETA byte-based + self-correcting.
+            let est_total = expected_total.or_else(|| {
+                (frags_done > 0).then(|| total_bytes.saturating_mul(total_frags) / frags_done)
             });
+            let mut info =
+                DownloadProgress::new(total_bytes, est_total, speed.bytes_per_sec().unwrap_or(0.0));
+            info.segments_downloaded = Some(frags_done); // secondary "frag N/M" text
+            info.total_segments = Some(total_frags);
+            info.is_estimated = expected_total.is_none() && est_total.is_some();
+            cb.on_progress(&info);
             last_emit = now;
         }
 

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -385,6 +385,7 @@ pub async fn download_pre_resolved_fragments(
                 eta: speed.eta(expected_total.map(|t| t.saturating_sub(total_bytes))),
                 duration_downloaded: None,
                 total_duration: None,
+                is_estimated: false,
             });
             last_emit = now;
         }

--- a/crates/rdlp-downloader/src/fragments/tests.rs
+++ b/crates/rdlp-downloader/src/fragments/tests.rs
@@ -182,6 +182,10 @@ async fn fragment_progress_final_boundary_emit_covers_all_frags() {
     assert_eq!(last.segments_downloaded, Some(2));
     assert_eq!(last.total_segments, Some(2));
     assert_eq!(last.bytes_downloaded, 300);
+    assert!(
+        !last.is_estimated,
+        "explicit Content-Length is authoritative, not estimated"
+    );
 }
 
 #[tokio::test]
@@ -203,14 +207,20 @@ async fn fragment_progress_none_callback_runs_to_completion() {
 }
 
 #[tokio::test]
-async fn fragment_progress_expected_total_none_uses_segment_fraction() {
+async fn fragment_no_byte_total_uses_byte_extrapolation() {
+    // HLS with no Content-Length: progress + total must now be byte-extrapolated
+    // (total_bytes Some, is_estimated true).
     let mut server = mockito::Server::new_async().await;
-    let _f1 = server
-        .mock("GET", "/f1")
-        .with_body(vec![0u8; 100])
-        .create_async()
-        .await;
-    let frags = vec![frag(format!("{}/f1", server.url()))];
+    for i in 0..4_u32 {
+        server
+            .mock("GET", format!("/f{i}").as_str())
+            .with_body(vec![0u8; 100])
+            .create_async()
+            .await;
+    }
+    let frags: Vec<Fragment> = (0..4)
+        .map(|i| frag(format!("{}/f{i}", server.url())))
+        .collect();
     let cb = CaptureCallback::new();
     let tmp = tempfile::NamedTempFile::new().expect("tmp");
     let http = HttpDownloader::with_client(wreq::Client::new());
@@ -218,7 +228,7 @@ async fn fragment_progress_expected_total_none_uses_segment_fraction() {
         &http,
         &frags,
         None,
-        None,
+        None, /* expected_total */
         Some(&cb),
         tmp.path(),
         None,
@@ -227,23 +237,27 @@ async fn fragment_progress_expected_total_none_uses_segment_fraction() {
     .await
     .expect("ok");
     let evs = cb.events();
-    assert!(!evs.is_empty());
-    // No byte total is known (HLS), so `total_bytes` stays None — but `progress`
-    // is now the SEGMENT fraction so progress bars animate instead of jumping
-    // 0->100 at completion.
-    assert!(
-        evs.iter().all(|e| e.total_bytes.is_none()),
-        "byte total must remain unknown when expected_total is None"
-    );
-    assert!(
-        evs.iter().all(|e| e.progress.is_some()),
-        "progress must be the segment-based fraction, not None"
-    );
     let last = evs.last().expect("at least one event");
-    assert_eq!(last.segments_downloaded, Some(1));
-    assert_eq!(last.total_segments, Some(1));
-    let frac = last.progress.expect("final progress some").fraction();
-    assert!((frac - 1.0).abs() < 1e-6, "final event = 1/1 segments");
+    // Byte-extrapolation: a total is now known (estimated) — was None pre-change.
+    assert!(
+        last.total_bytes.is_some(),
+        "estimated total must be reported"
+    );
+    assert!(last.is_estimated, "no-Content-Length total is an estimate");
+    // NOTE: eta is intentionally NOT asserted here — SpeedMeter's 50ms sample
+    // gate yields speed 0 for instant mock downloads, so new()'s `speed > 1.0`
+    // eta gate produces None in-test. Byte-extrapolation eta is unit-covered by
+    // downloader.rs's `new()` eta test (real speed → Some). The byte-extrapolation
+    // *behavior* is guarded below by total_bytes.is_some() + is_estimated.
+    // Final fragment: frags_done == total_frags → est_total == total_bytes → 100%.
+    let frac = last.progress.expect("progress some").fraction();
+    assert!(
+        (frac - 1.0).abs() < 1e-6,
+        "final progress is 1/1; got {frac}"
+    );
+    // Segment counts survive as secondary info.
+    assert_eq!(last.segments_downloaded, Some(4));
+    assert_eq!(last.total_segments, Some(4));
 }
 
 #[tokio::test]
@@ -1168,35 +1182,6 @@ async fn cross_origin_fragment_url_does_not_forward_seed_headers() {
     )
     .await
     .expect("cross-origin fragment must not receive Referer");
-}
-
-// ── Progress fraction: byte-based when total known, segment-based otherwise ──
-//
-// HLS pre-resolved-fragment downloads pass `expected_total = None` (segment-
-// based progress), so the byte fraction is unavailable. Without a segment
-// fallback the emitted `progress` is `None` and UIs that read it (the desktop
-// bar, `events.rs`) sit at 0 then jump to 100. These guard the fallback.
-
-#[test]
-fn fragment_progress_fraction_prefers_byte_total() {
-    // Byte total known → byte-based fraction (progressive / sized HLS).
-    let p = fragment_progress_fraction(Some(1000), 500, 1, 4).expect("some");
-    assert!((p.fraction() - 0.5).abs() < 1e-6, "byte fraction 500/1000");
-}
-
-#[test]
-fn fragment_progress_fraction_falls_back_to_segments() {
-    // Byte total unknown (HLS) → segment-based fraction (the 0->100 jump fix).
-    let mid = fragment_progress_fraction(None, 0, 1, 4).expect("some");
-    assert!((mid.fraction() - 0.25).abs() < 1e-6, "segment fraction 1/4");
-    let done = fragment_progress_fraction(None, 12_345, 4, 4).expect("some");
-    assert!((done.fraction() - 1.0).abs() < 1e-6, "segment fraction 4/4");
-}
-
-#[test]
-fn fragment_progress_fraction_none_when_nothing_known() {
-    // No byte total and zero segments → no fraction to report.
-    assert!(fragment_progress_fraction(None, 0, 0, 0).is_none());
 }
 
 // ---- HLS resume tests (issue #354) ----

--- a/crates/rdlp-downloader/src/progress.rs
+++ b/crates/rdlp-downloader/src/progress.rs
@@ -104,18 +104,6 @@ impl SpeedMeter {
     pub(crate) const fn bytes_per_sec(&self) -> Option<f64> {
         self.smoothed
     }
-
-    /// Projected ETA given known `remaining_bytes`; `None` if remaining is
-    /// unknown or speed is unknown/zero.
-    pub(crate) fn eta(&self, remaining_bytes: Option<u64>) -> Option<Duration> {
-        let r = remaining_bytes?;
-        let speed = self.smoothed?;
-        if speed <= 0.0 {
-            return None;
-        }
-        #[allow(clippy::cast_precision_loss)]
-        Some(Duration::from_secs_f64(r as f64 / speed))
-    }
 }
 
 /// RAII guard for progress reporter tasks.
@@ -493,30 +481,5 @@ mod speed_meter_tests {
             after < 50.0 * MIB as f64,
             "EWMA must not jump to instantaneous 50 MiB/s; got {after}"
         );
-    }
-
-    #[test]
-    fn eta_uses_smoothed_speed() {
-        let mut m = SpeedMeter::new();
-        let t0 = Instant::now();
-        for i in 0..=40u64 {
-            m.update(i * (MIB / 10), t0 + Duration::from_millis(i * 100)); // ~1 MiB/s
-        }
-        let eta = m.eta(Some(10 * MIB)).expect("eta available");
-        assert!(
-            eta.as_secs_f64() > 5.0 && eta.as_secs_f64() < 20.0,
-            "eta {eta:?}"
-        );
-    }
-
-    #[test]
-    fn eta_none_when_speed_or_remaining_unknown() {
-        let mut m = SpeedMeter::new();
-        assert_eq!(m.eta(Some(MIB)), None, "no speed yet");
-        let t0 = Instant::now();
-        for i in 0..=40u64 {
-            m.update(i * MIB, t0 + Duration::from_millis(i * 100));
-        }
-        assert_eq!(m.eta(None), None, "unknown remaining");
     }
 }


### PR DESCRIPTION
## Summary

HLS / DASH-pre-resolved downloads had **no ETA** without a Content-Length and a jumpy segment-count progress %. This makes both the **progress fraction and the ETA byte-extrapolation-based** — the canonical yt-dlp / industry-standard approach (`downloaded / estimated_total`, where `estimated_total = bytes_so_far × total_frags / frags_done`), with an `is_estimated` marker so estimated totals render with `~`.

Closes #378.

## What changed

- **rdlp-core:** `+ is_estimated: bool` on `DownloadProgress` (false in all 3 constructors).
- **rdlp-downloader (`fragments.rs`):** the shared `download_pre_resolved_fragments` (HLS **and** DASH-pre-resolved) computes `est_total` and feeds the existing byte-based `DownloadProgress::new` → byte-ratio progress + `remaining/smoothed-rate` ETA (24h cap, `speed>1.0` gate); re-attaches segment counts for "frag N/M"; sets `is_estimated`. Removed the now-superseded `fragment_progress_fraction` helper and the orphaned `SpeedMeter::eta` (+ its 2 tests) — ETA is now owned solely by `new`.
- **rdlp-api (`dto.rs`):** `eta_seconds` + `total_bytes_estimated` on the download `Event::Progress` EventDto arm (**#378**).
- **rdlp-cli:** HLS now uses the byte bar (total is `Some`); when estimated it renders `{bytes}/~{total_bytes}` with `frag N/M` in the message and `set_length`s each tick as the estimate refines.
- **rdlp-desktop:** Tauri payload + TS carry `isEstimated` (carry-only; the ETA already renders via existing `format_eta` plumbing).

## Research basis (multi-source validated)

- ETA = `remaining / smoothed_rate` — smooth the **rate** (existing `SpeedMeter`, EWMA α≈0.3), divide raw; `None` when the end is unknown. (tqdm/indicatif/rich/Chrome; Firefox's ETA-smoothing is the documented minority.)
- Progress fraction = **byte-based with an extrapolated total** (yt-dlp) — segment-count is jumpy under variable sizes, duration-ratio measures content not transfer. Byte-extrapolation self-corrects and is the universal download mental model.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `cargo test` ✓ · `cargo check -p rdlp-desktop` ✓ · `bash scripts/check-dedup.sh` PASS.
- Frontend: `npx tsc --noEmit` ✓ · `npm run test` 284/284 ✓.
- Tests: byte-extrapolation regression guard (`total_bytes.is_some()` + `is_estimated` + 100% convergence at the final fragment — all fail against old code); `eta_seconds`/`total_bytes_estimated` DTO (present + null); `is_estimated` defaults. ETA-via-mock is intentionally not asserted (the 50 ms `SpeedMeter` gate → speed 0 → `new`'s `speed>1.0` gate → None in-test); `new()`'s ETA is unit-covered in `downloader.rs`.

## Reviews

- **security-reviewer:** Approve — no High/Critical. Arithmetic is overflow-/div-by-zero-safe (`saturating_mul` + `frags_done>0` gate); new wire fields carry only numeric/bool progress data; no new input/IPC/fetch; `SpeedMeter::eta` removal tightens (not loosens) the ETA gate. One LOW (theoretical saturating-overflow display glitch at petabyte scale; self-correcting) → deferred.
- **code-reviewer:** Approve — no Critical/Important. End-to-end `is_estimated` coherence verified; `est_total` converges exactly at completion; segment bar correctly retained for the duration-tracking path.

## Notes / follow-ups (non-blocking)

- The `config_tests.rs` 2-field edit is an incidental compile-unblock — the `default_args()` test helper lagged the network-connectivity sprint's `download_timeout`/`merge_timeout` `Args` fields (without it `cargo test -p rdlp-cli` won't build).
- Cross-channel naming (`total_bytes_estimated` on the EventDto JSON vs `isEstimated` on the Tauri payload) follows each channel's existing convention (cf. `eta_seconds` vs the Tauri `eta` string).
- Follow-ups: retire the now-callerless `new_with_segments` constructor; consume `isEstimated` in the desktop UI (parity with the CLI `~` bar); optional `checked_mul` fallback for the theoretical overflow.
