### PR TITLE
fix(downloader): est_total overflow → None via checked_mul (#382)

### DIFF
--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -28,6 +28,35 @@ use crate::http::HttpDownloader;
 use crate::progress::SpeedMeter;
 use rdlp_security;
 
+/// Extrapolate the total download size for a fragmented stream.
+///
+/// Prefers a real Content-Length (`expected_total`) when known. Otherwise,
+/// once at least one fragment has completed, estimates the total as
+/// `avg-bytes-per-frag × total_frags` (= `total_bytes × total_frags /
+/// frags_done`), matching yt-dlp's fragment-downloader byte extrapolation.
+///
+/// Returns `None` when the total is genuinely unknown: no `expected_total`
+/// and either zero fragments completed, or the multiplication would overflow
+/// `u64` (practically unreachable — petabyte-scale). Feeding `None` into
+/// `DownloadProgress::new` yields honest indeterminate progress, per the
+/// "None when the end is unknown" principle, rather than a saturated
+/// `u64::MAX / frags_done` near-0%/century-ETA estimate.
+fn extrapolate_total(
+    expected_total: Option<u64>,
+    total_bytes: u64,
+    total_frags: u64,
+    frags_done: u64,
+) -> Option<u64> {
+    expected_total.or_else(|| {
+        // checked_mul → None on overflow (vs saturating_mul's u64::MAX);
+        // .flatten() collapses the then()-wrapped Option<Option<u64>>.
+        // The frags_done > 0 guard makes the division panic-free.
+        (frags_done > 0)
+            .then(|| total_bytes.checked_mul(total_frags).map(|v| v / frags_done))
+            .flatten()
+    })
+}
+
 /// Fetch a pre-resolved list of fragment URLs and concatenate them into
 /// `output` in order.
 ///
@@ -353,9 +382,7 @@ pub async fn download_pre_resolved_fragments(
             // else estimate total = avg-bytes-per-frag × total_frags (available
             // once >= 1 fragment completed). Feeding this to `new` makes BOTH the
             // progress fraction and the ETA byte-based + self-correcting.
-            let est_total = expected_total.or_else(|| {
-                (frags_done > 0).then(|| total_bytes.saturating_mul(total_frags) / frags_done)
-            });
+            let est_total = extrapolate_total(expected_total, total_bytes, total_frags, frags_done);
             let mut info =
                 DownloadProgress::new(total_bytes, est_total, speed.bytes_per_sec().unwrap_or(0.0));
             info.segments_downloaded = Some(frags_done); // secondary "frag N/M" text

--- a/crates/rdlp-downloader/src/fragments/tests.rs
+++ b/crates/rdlp-downloader/src/fragments/tests.rs
@@ -1483,3 +1483,46 @@ async fn hls_completes_when_sidecar_save_always_fails() {
         "sidecar path remained a directory; no partial/torn sidecar written"
     );
 }
+
+// --- extrapolate_total: byte-extrapolated total estimate (issue #382) ---
+
+#[test]
+fn extrapolate_total_returns_expected_when_content_length_known() {
+    // A real Content-Length total bypasses the extrapolation entirely.
+    assert_eq!(
+        extrapolate_total(Some(1000), 250, 10, 1),
+        Some(1000),
+        "expected_total present: return it verbatim, ignore the estimate"
+    );
+}
+
+#[test]
+fn extrapolate_total_estimates_from_average_fragment_size() {
+    // 200 bytes over 2 of 8 fragments => avg 100/frag => 100 * 8 = 800.
+    assert_eq!(
+        extrapolate_total(None, 200, 8, 2),
+        Some(800),
+        "no expected_total: estimate = total_bytes * total_frags / frags_done"
+    );
+}
+
+#[test]
+fn extrapolate_total_none_when_no_fragments_done() {
+    // frags_done == 0: nothing to extrapolate from; honest indeterminate.
+    assert_eq!(
+        extrapolate_total(None, 0, 8, 0),
+        None,
+        "frags_done == 0: estimate is unknown, must be None (not a div-by-zero)"
+    );
+}
+
+#[test]
+fn extrapolate_total_none_on_multiplication_overflow() {
+    // total_bytes * total_frags overflows u64 => None (indeterminate),
+    // NOT a saturated u64::MAX/frags_done nonsensical near-0% estimate.
+    let est = extrapolate_total(None, u64::MAX / 2 + 1, 2, 1);
+    assert_eq!(
+        est, None,
+        "overflowing extrapolation must yield None, per the \"None when unknown\" principle"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #378 (PR #379), resolving a deferred LOW-severity security-reviewer finding.

In `crates/rdlp-downloader/src/fragments.rs`, the byte-extrapolation progress total used `total_bytes.saturating_mul(total_frags) / frags_done`. On (practically-unreachable, petabyte-scale) overflow, `saturating_mul` yields `u64::MAX`, so the estimate becomes `u64::MAX / frags_done` — a nonsensical near-0%/century-ETA value until later fragments self-correct.

This change:
- Extracts the extrapolation into a pure `extrapolate_total(expected_total, total_bytes, total_frags, frags_done) -> Option<u64>` helper (testable in isolation).
- Switches `saturating_mul` → `checked_mul(total_frags).map(|v| v / frags_done)`, with `.flatten()` to collapse the `then()`-wrapped `Option<Option<u64>>` back to `Option<u64>`.
- Overflow → `None` → honest indeterminate progress, consistent with the "None when the end is unknown" principle (yt-dlp's fragment downloader leaves the total unset when it can't extrapolate — behaviorally identical). The `is_estimated` flag also correctly stays `false` on overflow.

The `frags_done > 0` guard is preserved, so the division remains panic-free.

## Tests (TDD, pure helper)

Four unit tests in `fragments/tests.rs`:
- `..._returns_expected_when_content_length_known` — `expected_total` bypass.
- `..._estimates_from_average_fragment_size` — normal extrapolation (200×8/2 = 800).
- `..._none_when_no_fragments_done` — `frags_done == 0` guard → `None`.
- `..._none_on_multiplication_overflow` — **negative/regression guard**: `(u64::MAX/2+1, 2, 1)` → `None`. Fails against the unpatched `saturating_mul` code (which returns `Some(u64::MAX)`).

## Research

Validated the approach via multi-source research before implementing: `checked_mul→None` is the canonical Rust "compute or bail" idiom (`saturating_*` is for when MAX is a valid sentinel), matches yt-dlp's unknown-total → indeterminate behavior, and follows existing in-tree precedent (`dash/segments.rs` uses `checked_div`→`Option` at division sites). Sources: [yt-dlp fragment.py](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/downloader/fragment.py); Rust stdlib `checked_mul` docs.

## Verification

Full pre-PR gate green: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && bash scripts/check-dedup.sh`.

## Reviews

- **security-reviewer** (agent `ad29775e17adb883d`): **Approve** — no findings. Confirmed no new panic path, `.flatten()` correct, value feeds only display (no SSRF/DoS/allocation impact).
- **code-reviewer** (agent `a83e721399488fe34`): **Approve** — no findings. Verified `.flatten()` typing, behavior-preserving extraction, guard intact, overflow test is a genuine regression guard, doc placement correct.

Closes #382