### PR TITLE
feat(desktop): render ~estimate + frag N/M in download progress (#381)

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/events.rs
+++ b/crates/rdlp-desktop/src-tauri/src/events.rs
@@ -31,6 +31,12 @@ pub struct DownloadProgressPayload {
     pub(crate) total_bytes: Option<u64>,
     /// `true` when `total_bytes` is an extrapolated estimate (segmented download).
     pub(crate) is_estimated: bool,
+    /// Fragments completed so far (segmented HLS/DASH downloads); `None` for
+    /// progressive HTTP. Drives the desktop `frag N/M` secondary counter.
+    pub(crate) segments_downloaded: Option<u64>,
+    /// Total fragment count (segmented HLS/DASH downloads); `None` for
+    /// progressive HTTP.
+    pub(crate) total_segments: Option<u64>,
 }
 
 /// Download completion payload emitted as `"download-complete"`.
@@ -159,6 +165,8 @@ pub fn emit_event(app: &AppHandle, job_id: &str, event: &Event) {
                 downloaded_bytes: progress.bytes_downloaded,
                 total_bytes: progress.total_bytes,
                 is_estimated: progress.is_estimated,
+                segments_downloaded: progress.segments_downloaded,
+                total_segments: progress.total_segments,
             };
 
             if let Err(e) = app.emit("download-progress", &payload) {
@@ -365,7 +373,9 @@ mod tests {
             eta: Some("01:30".to_owned()),
             downloaded_bytes: 1024,
             total_bytes: Some(2048),
-            is_estimated: false,
+            is_estimated: true,
+            segments_downloaded: Some(12),
+            total_segments: Some(40),
         };
         let json = serde_json::to_value(&payload).expect("serialization should succeed");
         assert_eq!(json["jobId"], "abc-123");
@@ -374,6 +384,12 @@ mod tests {
         assert_eq!(json["eta"], "01:30");
         assert_eq!(json["downloadedBytes"], 1024);
         assert_eq!(json["totalBytes"], 2048);
+        assert_eq!(json["isEstimated"], true);
+        assert_eq!(
+            json["segmentsDownloaded"], 12,
+            "frag-done counter on the wire"
+        );
+        assert_eq!(json["totalSegments"], 40, "frag-total counter on the wire");
     }
 
     #[test]

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -26,6 +26,10 @@ interface ProgressEntry {
     progress: number;
     speed: string | null;
     eta: string | null;
+    totalBytes: number | null;
+    isEstimated: boolean;
+    segmentsDownloaded: number | null;
+    totalSegments: number | null;
 }
 
 /**
@@ -77,6 +81,10 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                 progress: p.progress,
                 speed: p.speed,
                 eta: p.eta,
+                totalBytes: p.totalBytes,
+                isEstimated: p.isEstimated,
+                segmentsDownloaded: p.segmentsDownloaded,
+                totalSegments: p.totalSegments,
             });
             scheduleFlush();
         }),

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -241,6 +241,16 @@ export interface DownloadJob {
     logMessages?: string[];
     /** Current unit info, owned by Rust (`currentUnit` wire key). Null when no unit is active. */
     currentUnit: CurrentUnit | null;
+    /** Live progress fields merged client-side from `download-progress` events
+     *  (camelCase wire keys), not part of the Rust DownloadJob serialization.
+     *  Undefined until the first progress event lands for the job. */
+    totalBytes?: number | null;
+    /** True when `totalBytes` is an extrapolated estimate (segmented download). */
+    isEstimated?: boolean;
+    /** Fragments completed so far (segmented HLS/DASH); null/undefined otherwise. */
+    segmentsDownloaded?: number | null;
+    /** Total fragment count (segmented HLS/DASH); null/undefined otherwise. */
+    totalSegments?: number | null;
 }
 
 /**
@@ -315,9 +325,14 @@ export interface DownloadProgressPayload {
     downloadedBytes: number;
     totalBytes: number | null;
     /** True when totalBytes is an extrapolated estimate (segmented download).
-     *  Carry-only for now: not yet consumed by the UI (no total-size display);
-     *  ETA itself renders via the existing eta plumbing. */
+     *  Rendered as a `~`-prefixed total size in the desktop progress UI. */
     isEstimated: boolean;
+    /** Fragments completed so far (segmented HLS/DASH); null for progressive HTTP.
+     *  u64 on the wire; JS `number` is safe for fragment counts (always well
+     *  under Number.MAX_SAFE_INTEGER — real streams have thousands, not 2^53). */
+    segmentsDownloaded: number | null;
+    /** Total fragment count (segmented HLS/DASH); null for progressive HTTP. */
+    totalSegments: number | null;
 }
 
 /** Download completion payload emitted as "download-complete". */

--- a/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.test.tsx
@@ -320,6 +320,69 @@ describe("JobCard — progress display", () => {
     });
 });
 
+describe("JobCard — segmented estimate + frag counter (#381)", () => {
+    it("renders a ~-prefixed estimated total size with an accessible label", () => {
+        render(
+            <JobCard
+                job={makeJob({
+                    status: "running",
+                    progress: 0.5,
+                    isEstimated: true,
+                    totalBytes: 1_288_490_188, // ~1.2 GB
+                })}
+            />,
+        );
+        // Visible tilde + formatted size; the tilde is aria-hidden and paired
+        // with an sr-only "approximately" so screen readers don't say "tilde".
+        expect(screen.getByText("1.2 GB")).toBeInTheDocument();
+        expect(screen.getByText("~")).toHaveAttribute("aria-hidden", "true");
+        expect(screen.getByText(/approximately/i)).toBeInTheDocument();
+    });
+
+    it("does NOT render the ~ estimate marker for an exact download", () => {
+        render(
+            <JobCard
+                job={makeJob({
+                    status: "running",
+                    progress: 0.5,
+                    isEstimated: false,
+                    totalBytes: 1_288_490_188,
+                })}
+            />,
+        );
+        expect(screen.queryByText("~")).not.toBeInTheDocument();
+        expect(screen.queryByText(/approximately/i)).not.toBeInTheDocument();
+    });
+
+    it("renders the frag N/M counter when segment counts are present", () => {
+        render(
+            <JobCard
+                job={makeJob({
+                    status: "running",
+                    progress: 0.3,
+                    segmentsDownloaded: 12,
+                    totalSegments: 40,
+                })}
+            />,
+        );
+        expect(screen.getByText("frag 12/40")).toBeInTheDocument();
+    });
+
+    it("omits the frag counter when segment counts are absent (progressive HTTP)", () => {
+        render(
+            <JobCard
+                job={makeJob({
+                    status: "running",
+                    progress: 0.3,
+                    segmentsDownloaded: null,
+                    totalSegments: null,
+                })}
+            />,
+        );
+        expect(screen.queryByText(/^frag /)).not.toBeInTheDocument();
+    });
+});
+
 describe("JobCard — processing (#336)", () => {
     it("shows the progress bar, decimal percent, and Cancel for a processing job", () => {
         render(<JobCard job={makeJob({ status: "processing", progress: 0.3, stage: "Recode" })} />);

--- a/crates/rdlp-desktop/src/views/queue/JobCard.tsx
+++ b/crates/rdlp-desktop/src/views/queue/JobCard.tsx
@@ -11,6 +11,7 @@ import { StatusBadge } from "@/components/StatusBadge";
 import { isTerminal as isTerminalStatus, isInFlight, jobSubLabel } from "@/lib/jobStatus";
 import { invokeTyped } from "@/api/invokeClient";
 import { cn, displayTitle, progressPercentLabel } from "@/lib/utils";
+import { formatSize } from "@/components/utils/formatUtils";
 import type { DownloadJob } from "@/types";
 
 interface JobCardProps {
@@ -102,6 +103,21 @@ export function JobCard({ job, compact = false }: JobCardProps) {
                             </span>
                             {job.speed && <span>{job.speed}</span>}
                             {job.status !== "processing" && job.eta && <span>ETA {job.eta}</span>}
+                            {/* Estimated total size (segmented download, no Content-Length).
+                                The "~" is hidden from the a11y tree and paired with an
+                                sr-only "approximately" so screen readers don't say "tilde"
+                                (aria-label on a static span is ignored by JAWS/NVDA). */}
+                            {job.isEstimated && job.totalBytes != null && (
+                                <span>
+                                    <span aria-hidden="true">~</span>
+                                    <span className="sr-only">approximately </span>
+                                    {formatSize(job.totalBytes)}
+                                </span>
+                            )}
+                            {/* Fragment counter for segmented HLS/DASH (CLI parity). */}
+                            {job.segmentsDownloaded != null && job.totalSegments != null && (
+                                <span>frag {job.segmentsDownloaded}/{job.totalSegments}</span>
+                            )}
                             {subLabel && (
                                 <span className="text-[#4a9eff] truncate">{subLabel}</span>
                             )}


### PR DESCRIPTION
## Summary

Follow-up to #378 (PR #379). PR #379 added `isEstimated` to the desktop progress payload as **carry-only** — never rendered — and the CLI's `~{total}` byte bar + `frag N/M` counter had no desktop parity. This wires it through end-to-end (full parity, per scope decision).

**Result:** `50%  4.2 MB/s  ETA 00:30  ~1.2 GB  frag 12/40`

## Changes (cross-layer IPC)

- **Rust IPC** (`events.rs`): add `segments_downloaded`/`total_segments` (`Option<u64>`) to `DownloadProgressPayload`, populated from the existing `DownloadProgress` source in `emit_event`. camelCase on the wire.
- **TS types** (`types/index.ts`): mirror `segmentsDownloaded`/`totalSegments` on the payload; add optional client-merged `totalBytes?`/`isEstimated?`/`segmentsDownloaded?`/`totalSegments?` to `DownloadJob` (like `logMessages` — not part of the Rust `DownloadJob` serialization, populated client-side from progress events).
- **Listener** (`registerDownloadEvents.ts`): plumb the 4 fields through the rAF-batched `ProgressEntry`; the `flush()` spread is unchanged.
- **JobCard** (`JobCard.tsx`): render a `~`-prefixed estimated total (gated on `isEstimated`) and a `frag N/M` counter (gated on both segment fields). Uses the existing `formatSize` helper.

## Accessibility (WCAG 2.1 AA — strict, empty axe allowlist)

The `~` is **`aria-hidden`** and paired with an **`sr-only "approximately"`** sibling (the in-tree `dialog.tsx` idiom). Research ([David MacDonald](https://www.davidmacd.com/blog/does-aria-label-override-static-text.html)) confirmed `aria-label` on a static `<span>` is **ignored by JAWS/NVDA** — the sr-only sibling is the cross-AT-reliable pattern. Screen readers announce "approximately 1.2 GB"; sighted users see `~1.2 GB`.

## Tests

- Rust: `test_progress_payload_serializes` asserts the new camelCase wire keys (`segmentsDownloaded`/`totalSegments`/`isEstimated`).
- vitest (4 new): `~`-estimate render + accessible label; **no** `~` on exact downloads; `frag N/M` present when segmented; **no** frag counter for progressive HTTP.

## Research

Validated via multi-source research before implementing: the a11y idiom (above), the canonical TanStack Query v5 `setQueryData` merge pattern (the existing `{ ...job, ...entry }` spread is idiomatic — no change needed), and confirmed frag N/M was genuinely absent from the desktop wire (hence the Rust IPC extension).

## Verification

Full gate green: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && (cd crates/rdlp-desktop && npx tsc --noEmit && npm run test) && bash scripts/check-dedup.sh`. Frontend: tsc clean, 288 vitest pass.

## Reviews

- **code-reviewer** (agent `a2489c1f3f76c22f1`): **Approve** — no findings. Verified Rust↔TS contract parity, gating, a11y idiom, genuine positive+negative tests.
- **security-reviewer** (agent `ae4957f83eeba3add`): **Approve with minor fixes** — no Critical/High. Two LOW: (1) a11y accessible-name composition — **declined**, the suggested `aria-label`-on-static-span conflicts with the validated research (ignored by JAWS/NVDA); the sr-only sibling is the correct pattern. (2) `number`/`u64` safe-integer assumption — **applied** as a documenting comment.

Threat model: outbound-only IPC (no new command/inbound surface), JSX auto-escapes (no dangerouslySetInnerHTML), no axios/Radix, display-only values gate no allocation/fetch.

Closes #381