### PR TITLE
style: cargo fmt + Cargo.lock sync after #328 merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5984,6 +5984,7 @@ dependencies = [
  "rdlp-plugin",
  "rdlp-postprocess",
  "rdlp-ratelimit",
+ "rdlp-redact",
  "rdlp-security",
  "rdlp-types",
  "serde",
@@ -6019,6 +6020,7 @@ dependencies = [
  "rdlp-plugin",
  "rdlp-plugin-manifest",
  "rdlp-ratelimit",
+ "rdlp-redact",
  "rdlp-security",
  "rdlp-table",
  "rdlp-types",
@@ -6064,6 +6066,7 @@ dependencies = [
  "backon",
  "dirs",
  "log",
+ "rdlp-redact",
  "rdlp-types",
  "regex",
  "serde",
@@ -6136,6 +6139,7 @@ dependencies = [
  "rdlp-ffmpeg",
  "rdlp-http",
  "rdlp-ratelimit",
+ "rdlp-redact",
  "rdlp-security",
  "rdlp-types",
  "serde",
@@ -6169,6 +6173,7 @@ dependencies = [
  "rdlp-crypto",
  "rdlp-http",
  "rdlp-jsinterp",
+ "rdlp-redact",
  "rdlp-security",
  "rdlp-types",
  "regex",
@@ -6248,6 +6253,7 @@ dependencies = [
  "rdlp-http",
  "rdlp-jsinterp",
  "rdlp-plugin-manifest",
+ "rdlp-redact",
  "rdlp-security",
  "rdlp-types",
  "regex",
@@ -6331,6 +6337,8 @@ version = "0.1.0"
 dependencies = [
  "log",
  "regex",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/rdlp-downloader/tests/hls_pre_resolved.rs
+++ b/crates/rdlp-downloader/tests/hls_pre_resolved.rs
@@ -42,7 +42,10 @@ async fn fragments_none_returns_typed_download_error() {
         message.contains("expand_hls_in_place"),
         "error message must mention expand_hls_in_place; got: {message}"
     );
-    assert_eq!(url.as_ref().map(rdlp_redact::RedactedUrlBuf::expose), Some("https://example.com/v.m3u8"));
+    assert_eq!(
+        url.as_ref().map(rdlp_redact::RedactedUrlBuf::expose),
+        Some("https://example.com/v.m3u8")
+    );
     // Output file must NOT have been created — no playlist was fetched.
     assert!(!output.exists());
 }


### PR DESCRIPTION
Post-merge hygiene: the #328 fix-commit's `cargo fmt` rewrapped an assert in `hls_pre_resolved.rs` and Task 8's rdlp-redact tracing dev-deps weren't reflected in `Cargo.lock` — neither was staged, so develop was left failing `cargo fmt --check` (CI's first job) with a stale lockfile. This syncs both. No logic change.

Refs #328.