### PR TITLE
fix(extractor): redact URLs in error/log strings + multiline-aware gate (#392)

### DIFF
--- a/crates/rdlp-extractor/src/extractors/abxxx/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/abxxx/mod.rs
@@ -192,7 +192,10 @@ impl InfoExtractor for AbxxxExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video id from URL: {url}"),
+            message: format!(
+                "Could not extract video id from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
         let slug = patterns::extract_slug(url);

--- a/crates/rdlp-extractor/src/extractors/eporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/eporner/mod.rs
@@ -367,7 +367,10 @@ async fn build_info(
         let dload = parse_dload_formats(page_url, html);
         if dload.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No formats found for EPorner video: {page_url}"),
+                message: format!(
+                    "No formats found for EPorner video: {}",
+                    rdlp_redact::RedactedUrl::new(&page_url)
+                ),
                 url: Some(page_url.to_string().into()),
             });
         }
@@ -423,7 +426,10 @@ impl InfoExtractor for EPornerExtractor {
             .and_then(|c| c.get(1))
             .map(|m| m.as_str().to_string())
             .ok_or_else(|| RdlpError::Extraction {
-                message: format!("EPorner: could not extract video id from URL: {url}"),
+                message: format!(
+                    "EPorner: could not extract video id from URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             })?;
 

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -245,7 +245,8 @@ fn try_direct_media(url: &str, pf: &PrefetchResponse) -> Result<Option<InfoDict>
             }
             Err(e) => {
                 log::warn!(
-                    "DASH expansion failed for {url}: {e}; falling back to legacy single-Format path"
+                    "DASH expansion failed for {}: {e}; falling back to legacy single-Format path",
+                    rdlp_redact::RedactedUrl::new(url)
                 );
                 let mut info = InfoDict::new(&video_id, &title, "Generic", url);
                 let format = Format::new("dash", url, "mpd", DownloadProtocol::HttpDashSegments);

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -186,7 +186,10 @@ impl InfoExtractor for HQPornerExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video ID: {url}"),
+            message: format!(
+                "Could not extract video ID: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 
@@ -222,7 +225,10 @@ impl InfoExtractor for HQPornerExtractor {
 
         if mydaddy_result.formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No video formats found for URL: {url}"),
+                message: format!(
+                    "No video formats found for URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -108,7 +108,13 @@ impl InfoExtractor for KoreanPornMovieExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let slug = patterns::extract_slug(url).ok_or_else(|| {
-            RdlpError::extraction(format!("Could not extract slug from URL: {url}"), url)
+            RdlpError::extraction(
+                format!(
+                    "Could not extract slug from URL: {}",
+                    rdlp_redact::RedactedUrl::new(url)
+                ),
+                url,
+            )
         })?;
 
         debug!("[KoreanPornMovie] Extracting: {slug}");

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
@@ -100,7 +100,10 @@ const KEYS_URL: &str = "https://raw.githubusercontent.com/yogesh-hacker/Megaclou
 /// - Both extraction strategies fail (`RdlpError::Extraction`)
 pub async fn extract_sources(embed_url: &str, ctx: &ExtractionContext) -> Result<MegacloudSources> {
     let source_id = extract_source_id(embed_url).ok_or_else(|| RdlpError::Extraction {
-        message: format!("Could not extract source ID from embed URL: {embed_url}"),
+        message: format!(
+            "Could not extract source ID from embed URL: {}",
+            rdlp_redact::RedactedUrl::new(&embed_url)
+        ),
         url: Some(embed_url.to_string().into()),
     })?;
     debug!(source_id:%; "Extracted Megacloud source ID");

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -307,7 +307,10 @@ impl InfoExtractor for NineAnimeExtractor {
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         // Extract IDs from URL
         let anime_id = patterns::extract_anime_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract anime ID from URL: {url}"),
+            message: format!(
+                "Could not extract anime ID from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/mod.rs
@@ -317,8 +317,9 @@ impl InfoExtractor for NineAnimeExtractor {
         let episode_id =
             patterns::extract_episode_id(url).ok_or_else(|| RdlpError::Extraction {
                 message: format!(
-                    "Could not extract episode ID from URL: {url}. \
-                 Use a URL with ?ep= parameter."
+                    "Could not extract episode ID from URL: {}. \
+                 Use a URL with ?ep= parameter.",
+                    rdlp_redact::RedactedUrl::new(url)
                 ),
                 url: Some(url.to_string().into()),
             })?;
@@ -393,8 +394,9 @@ impl InfoExtractor for NineAnimeExtractor {
         let episode_id =
             patterns::extract_episode_id(url).ok_or_else(|| RdlpError::Extraction {
                 message: format!(
-                    "Could not extract episode ID from URL: {url}. \
-                 Use a URL with ?ep= parameter."
+                    "Could not extract episode ID from URL: {}. \
+                 Use a URL with ?ep= parameter.",
+                    rdlp_redact::RedactedUrl::new(url)
                 ),
                 url: Some(url.to_string().into()),
             })?;

--- a/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/playlist.rs
@@ -48,7 +48,10 @@ use crate::base::common::BaseExtractor;
 /// - All episode resolution attempts fail (`RdlpError::Extraction`)
 pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<InfoDict>> {
     let anime_id = patterns::extract_anime_id(url).ok_or_else(|| RdlpError::Extraction {
-        message: format!("Could not extract anime ID from URL: {url}"),
+        message: format!(
+            "Could not extract anime ID from URL: {}",
+            rdlp_redact::RedactedUrl::new(&url)
+        ),
         url: Some(url.to_string().into()),
     })?;
 
@@ -173,7 +176,10 @@ pub async fn extract_season(url: &str, ctx: &ExtractionContext) -> Result<Vec<In
 
     if results.is_empty() {
         return Err(RdlpError::Extraction {
-            message: format!("Failed to extract any episodes from anime: {url}"),
+            message: format!(
+                "Failed to extract any episodes from anime: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         });
     }

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -310,7 +310,10 @@ impl InfoExtractor for PornHubExtractor {
 
         // Get video ID
         let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video ID: {url}"),
+            message: format!(
+                "Could not extract video ID: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 
@@ -348,7 +351,10 @@ impl InfoExtractor for PornHubExtractor {
 
         if formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No video formats found for URL: {url}"),
+                message: format!(
+                    "No video formats found for URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }

--- a/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
@@ -48,7 +48,10 @@ pub async fn extract_playlist(
 ) -> Result<Vec<InfoDict>> {
     let playlist_id =
         super::patterns::extract_playlist_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract playlist ID: {url}"),
+            message: format!(
+                "Could not extract playlist ID: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 
@@ -97,7 +100,10 @@ pub async fn extract_playlist(
 
     if all_video_urls.is_empty() {
         return Err(RdlpError::Extraction {
-            message: format!("No videos found in playlist: {url}"),
+            message: format!(
+                "No videos found in playlist: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         });
     }
@@ -209,7 +215,10 @@ pub async fn extract_playlist(
 
     if results.is_empty() {
         return Err(RdlpError::Extraction {
-            message: format!("Failed to extract any videos from playlist: {url}"),
+            message: format!(
+                "Failed to extract any videos from playlist: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         });
     }

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -403,7 +403,10 @@ async fn fetch_formats_from_endpoint(
     BaseExtractor::log_if_verbose(
         ctx,
         "RedTube",
-        &format!("Fetching format JSON from: {absolute_url}"),
+        &format!(
+            "Fetching format JSON from: {}",
+            rdlp_redact::RedactedUrl::new(&absolute_url)
+        ),
     );
 
     // Fetch the JSON endpoint
@@ -411,9 +414,9 @@ async fn fetch_formats_from_endpoint(
         Ok(r) => r,
         Err(e) => {
             if e.is_timeout() {
-                debug!(url:? = absolute_url; "[RedTube] Request timed out");
+                debug!(url:? = rdlp_redact::RedactedUrl::new(&absolute_url); "[RedTube] Request timed out");
             } else if e.is_connect() {
-                debug!(url:? = absolute_url; "[RedTube] Connection failed: {e}");
+                debug!(url:? = rdlp_redact::RedactedUrl::new(&absolute_url); "[RedTube] Connection failed: {e}");
             } else {
                 debug!("[RedTube] Request failed: {e}");
             }
@@ -426,7 +429,11 @@ async fn fetch_formats_from_endpoint(
         BaseExtractor::log_if_verbose(
             ctx,
             "RedTube",
-            &format!("HTTP {} for URL: {}", response.status(), absolute_url),
+            &format!(
+                "HTTP {} for URL: {}",
+                response.status(),
+                rdlp_redact::RedactedUrl::new(&absolute_url)
+            ),
         );
         return None;
     }

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -265,7 +265,8 @@ impl InfoExtractor for RedTubeExtractor {
             return Err(RdlpError::Extraction {
                 message: format!(
                     "No video sources found in JavaScript or HTML. \
-                     Video may be unavailable. URL: {url}"
+                     Video may be unavailable. URL: {}",
+                    rdlp_redact::RedactedUrl::new(url)
                 ),
                 url: Some(url.to_string().into()),
             });

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -227,7 +227,10 @@ impl InfoExtractor for RedTubeExtractor {
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         // Get video ID using BaseExtractor
         let video_id = self.extract_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video ID from URL: {url}"),
+            message: format!(
+                "Could not extract video ID from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 

--- a/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
@@ -151,7 +151,8 @@ impl InfoExtractor for SpankBangExtractor {
             let key = formats::parse_streamkey(&webpage).ok_or_else(|| RdlpError::Extraction {
                 message: format!(
                     "SpankBang: neither inline stream_data nor data-streamkey present \
-                     on page {url}"
+                     on page {}",
+                    rdlp_redact::RedactedUrl::new(url)
                 ),
                 url: Some(url.to_string().into()),
             })?;

--- a/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/mod.rs
@@ -100,7 +100,10 @@ impl InfoExtractor for SpankBangExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("SpankBang: could not extract video ID from URL: {url}"),
+            message: format!(
+                "SpankBang: could not extract video ID from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 
@@ -161,7 +164,10 @@ impl InfoExtractor for SpankBangExtractor {
 
         if formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("SpankBang: no playable formats found for {url}"),
+                message: format!(
+                    "SpankBang: no playable formats found for {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
@@ -108,7 +108,10 @@ pub async fn parse_moviefap_xml(
 
     if video_data.is_empty() {
         return Err(RdlpError::Extraction {
-            message: format!("No video sources found in MovieFap XML response from: {cdn_url}"),
+            message: format!(
+                "No video sources found in MovieFap XML response from: {}",
+                rdlp_redact::RedactedUrl::new(&cdn_url)
+            ),
             url: Some(cdn_url.to_string().into()),
         });
     }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/info.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/info.rs
@@ -116,7 +116,11 @@ impl InfoExtractor for TNAFlixExtractor {
                 url: Some(url.to_string().into()),
             })?;
 
-            BaseExtractor::log_if_verbose(ctx, "MovieFap", &format!("cdn.php URL: {cdn_url}"));
+            BaseExtractor::log_if_verbose(
+                ctx,
+                "MovieFap",
+                &format!("cdn.php URL: {}", rdlp_redact::RedactedUrl::new(&cdn_url)),
+            );
 
             ajax::parse_moviefap_xml(&self.base, &cdn_url, url, ctx).await?
         } else {

--- a/crates/rdlp-extractor/src/extractors/tnaflix/info.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/info.rs
@@ -142,7 +142,8 @@ impl InfoExtractor for TNAFlixExtractor {
             if video_data.is_empty() {
                 return Err(RdlpError::Extraction {
                     message: format!(
-                        "No video source tags found in HTML. Video may be unavailable. URL: {url}"
+                        "No video source tags found in HTML. Video may be unavailable. URL: {}",
+                        rdlp_redact::RedactedUrl::new(url)
                     ),
                     url: Some(url.to_string().into()),
                 });

--- a/crates/rdlp-extractor/src/extractors/tnaflix/info.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/info.rs
@@ -78,7 +78,10 @@ impl InfoExtractor for TNAFlixExtractor {
 
         // Get video ID using BaseExtractor
         let video_id = self.extract_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video ID from URL: {url}"),
+            message: format!(
+                "Could not extract video ID from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 
@@ -106,7 +109,10 @@ impl InfoExtractor for TNAFlixExtractor {
         let video_data = if is_moviefap {
             // MovieFap: fetch XML from cdn.php
             let cdn_url = cdn_url_opt.ok_or_else(|| RdlpError::Extraction {
-                message: format!("Could not find cdn.php URL in MovieFap page: {url}"),
+                message: format!(
+                    "Could not find cdn.php URL in MovieFap page: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             })?;
 
@@ -150,7 +156,10 @@ impl InfoExtractor for TNAFlixExtractor {
 
         if formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No video formats found for URL: {url}"),
+                message: format!(
+                    "No video formats found for URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }

--- a/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
@@ -145,8 +145,9 @@ pub async fn fetch_player_js(
             }
             Ok(resp) => {
                 debug!(
-                    "[XHamster] Player JS fetch returned {}: {full_url}",
-                    resp.status()
+                    "[XHamster] Player JS fetch returned {}: {}",
+                    resp.status(),
+                    rdlp_redact::RedactedUrl::new(&full_url)
                 );
             }
             Err(e) => {

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -218,7 +218,7 @@ impl XHamsterExtractor {
             .captures(&webpage)
             .and_then(|caps| caps.get(1))
         {
-            debug!(video_url:? = video_url.as_str(); "[XHamster] Found video URL in embed page");
+            debug!(video_url:? = rdlp_redact::RedactedUrl::new(video_url.as_str()); "[XHamster] Found video URL in embed page");
             return self.extract_video(video_url.as_str(), ctx).await;
         }
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -78,7 +78,10 @@ impl XHamsterExtractor {
 
         // Extract video ID and display ID
         let video_id = patterns::extract_video_id(&url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video ID: {url}"),
+            message: format!(
+                "Could not extract video ID: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
         let display_id = patterns::extract_display_id(&url);
@@ -163,7 +166,10 @@ impl XHamsterExtractor {
 
         if formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No video formats found for URL: {url}"),
+                message: format!(
+                    "No video formats found for URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }
@@ -234,7 +240,10 @@ impl XHamsterExtractor {
         }
 
         Err(RdlpError::Extraction {
-            message: format!("Could not extract video URL from embed page: {url}"),
+            message: format!(
+                "Could not extract video URL from embed page: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })
     }

--- a/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
@@ -29,7 +29,10 @@ impl XHamsterExtractor {
     ) -> Result<Vec<InfoDict>> {
         let (user_id, _is_user) =
             patterns::extract_user_info(url).ok_or_else(|| RdlpError::Extraction {
-                message: format!("Could not extract user ID: {url}"),
+                message: format!(
+                    "Could not extract user ID: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             })?;
 
@@ -102,7 +105,10 @@ impl XHamsterExtractor {
 
         if total == 0 {
             return Err(RdlpError::Extraction {
-                message: format!("No videos found on user page: {url}"),
+                message: format!(
+                    "No videos found on user page: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }
@@ -172,7 +178,10 @@ impl XHamsterExtractor {
 
         if results.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("Failed to extract any videos from user page: {url}"),
+                message: format!(
+                    "Failed to extract any videos from user page: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }

--- a/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
@@ -49,7 +49,7 @@ impl XHamsterExtractor {
                 format!("{url}/{page}")
             };
 
-            debug!(page, url:? = page_url; "[XHamster] Fetching user page");
+            debug!(page, url:? = rdlp_redact::RedactedUrl::new(&page_url); "[XHamster] Fetching user page");
 
             let response = (|| async { ctx.http_client.get(&page_url).send().await })
                 .retry(

--- a/crates/rdlp-extractor/src/extractors/xnxx/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/mod.rs
@@ -138,7 +138,8 @@ impl InfoExtractor for XNXXExtractor {
         if formats.is_empty() {
             return Err(RdlpError::Extraction {
                 message: format!(
-                    "xnxx: no video formats found (html5player calls missing). URL: {url}"
+                    "xnxx: no video formats found (html5player calls missing). URL: {}",
+                    rdlp_redact::RedactedUrl::new(url)
                 ),
                 url: Some(url.to_string().into()),
             });

--- a/crates/rdlp-extractor/src/extractors/xnxx/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/mod.rs
@@ -115,7 +115,10 @@ impl InfoExtractor for XNXXExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("xnxx: could not extract video ID from URL: {url}"),
+            message: format!(
+                "xnxx: could not extract video ID from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -204,7 +204,8 @@ impl InfoExtractor for XTitsExtractor {
             .map(|m| m.as_str().to_string())
             .ok_or_else(|| RdlpError::Extraction {
                 message: format!(
-                    "Could not find KVS flashvars on page. Video may be unavailable. URL: {url}"
+                    "Could not find KVS flashvars on page. Video may be unavailable. URL: {}",
+                    rdlp_redact::RedactedUrl::new(url)
                 ),
                 url: Some(url.to_string().into()),
             })?;

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -190,7 +190,10 @@ impl InfoExtractor for XTitsExtractor {
         let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
 
         let video_id = patterns::extract_video_id(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video ID: {url}"),
+            message: format!(
+                "Could not extract video ID: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 
@@ -211,7 +214,10 @@ impl InfoExtractor for XTitsExtractor {
 
         if video_formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No video formats found in flashvars. URL: {url}"),
+                message: format!(
+                    "No video formats found in flashvars. URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }

--- a/crates/rdlp-extractor/src/extractors/xvideos/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/mod.rs
@@ -106,7 +106,10 @@ impl XVideosExtractor {
 
         if formats.is_empty() {
             return Err(RdlpError::Extraction {
-                message: format!("No video formats found on page. URL: {url}"),
+                message: format!(
+                    "No video formats found on page. URL: {}",
+                    rdlp_redact::RedactedUrl::new(&url)
+                ),
                 url: Some(url.to_string().into()),
             });
         }
@@ -163,7 +166,10 @@ impl InfoExtractor for XVideosExtractor {
 
     async fn extract(&self, url: &str, ctx: &ExtractionContext) -> Result<InfoDict> {
         let eid = patterns::extract_eid(url).ok_or_else(|| RdlpError::Extraction {
-            message: format!("Could not extract video EID from URL: {url}"),
+            message: format!(
+                "Could not extract video EID from URL: {}",
+                rdlp_redact::RedactedUrl::new(&url)
+            ),
             url: Some(url.to_string().into()),
         })?;
 

--- a/crates/rdlp-extractor/src/hls/detector.rs
+++ b/crates/rdlp-extractor/src/hls/detector.rs
@@ -119,7 +119,7 @@ impl HlsSizeDetector {
         BaseExtractor::validate_url_security(m3u8_url)?;
 
         if self.verbose {
-            debug!(url:? = m3u8_url; "HLS counting segments");
+            debug!(url:? = rdlp_redact::RedactedUrl::new(m3u8_url); "HLS counting segments");
         }
 
         // Parse playlist to extract segment URLs
@@ -165,7 +165,7 @@ impl HlsSizeDetector {
         BaseExtractor::validate_url_security(m3u8_url)?;
 
         if self.verbose {
-            debug!(url:? = m3u8_url; "HLS detecting size");
+            debug!(url:? = rdlp_redact::RedactedUrl::new(m3u8_url); "HLS detecting size");
         }
 
         // Step 1: Parse playlist to extract segment URLs
@@ -270,7 +270,10 @@ impl HlsSizeDetector {
             // (404 / 410 / 403) to needlessly retry.
             return Err(RdlpError::Http {
                 status: response.status().as_u16(),
-                reason: format!("playlist fetch: {m3u8_url}"),
+                reason: format!(
+                    "playlist fetch: {}",
+                    rdlp_redact::RedactedUrl::new(m3u8_url)
+                ),
             });
         }
 

--- a/crates/rdlp-extractor/src/hls/detector.rs
+++ b/crates/rdlp-extractor/src/hls/detector.rs
@@ -240,12 +240,18 @@ impl HlsSizeDetector {
         let response = request.send().await.map_err(|e| {
             if e.is_timeout() {
                 RdlpError::Network {
-                    message: format!("Timeout fetching playlist: {m3u8_url}"),
+                    message: format!(
+                        "Timeout fetching playlist: {}",
+                        rdlp_redact::RedactedUrl::new(m3u8_url)
+                    ),
                     url: Some(m3u8_url.to_string().into()),
                 }
             } else if e.is_connect() {
                 RdlpError::Network {
-                    message: format!("Connection failed for playlist: {m3u8_url}: {e}"),
+                    message: format!(
+                        "Connection failed for playlist: {}: {e}",
+                        rdlp_redact::RedactedUrl::new(m3u8_url)
+                    ),
                     url: Some(m3u8_url.to_string().into()),
                 }
             } else {

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -224,7 +224,10 @@ impl HlsSizeDetector {
             // retry.
             return Err(RdlpError::Http {
                 status: range_response.status().as_u16(),
-                reason: format!("segment HEAD: {segment_url}"),
+                reason: format!(
+                    "segment HEAD: {}",
+                    rdlp_redact::RedactedUrl::new(&segment_url)
+                ),
             });
         }
 

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -196,12 +196,18 @@ impl HlsSizeDetector {
             .map_err(|e| {
                 if e.is_timeout() {
                     RdlpError::Network {
-                        message: format!("Timeout for segment: {segment_url}"),
+                        message: format!(
+                            "Timeout for segment: {}",
+                            rdlp_redact::RedactedUrl::new(&segment_url)
+                        ),
                         url: Some(segment_url.to_string().into()),
                     }
                 } else if e.is_connect() {
                     RdlpError::Network {
-                        message: format!("Connection failed for segment: {segment_url}: {e}"),
+                        message: format!(
+                            "Connection failed for segment: {}: {e}",
+                            rdlp_redact::RedactedUrl::new(&segment_url)
+                        ),
                         url: Some(segment_url.to_string().into()),
                     }
                 } else {
@@ -239,7 +245,10 @@ impl HlsSizeDetector {
         }
 
         Err(RdlpError::Extraction {
-            message: format!("Could not detect segment size for: {segment_url}"),
+            message: format!(
+                "Could not detect segment size for: {}",
+                rdlp_redact::RedactedUrl::new(&segment_url)
+            ),
             url: Some(segment_url.to_string().into()),
         })
     }

--- a/crates/rdlp-extractor/src/hls/segments.rs
+++ b/crates/rdlp-extractor/src/hls/segments.rs
@@ -26,7 +26,7 @@ impl HlsSizeDetector {
     /// * `Err(_)` - Network error, parse error, or master playlist detected
     pub(super) async fn parse_playlist(&self, m3u8_url: &str) -> Result<Vec<String>> {
         if self.verbose {
-            debug!(url:? = m3u8_url; "HLS fetching playlist");
+            debug!(url:? = rdlp_redact::RedactedUrl::new(m3u8_url); "HLS fetching playlist");
         }
 
         let playlist_text = self.fetch_playlist_text(m3u8_url).await?;

--- a/crates/rdlp-extractor/src/hls/variants.rs
+++ b/crates/rdlp-extractor/src/hls/variants.rs
@@ -193,7 +193,7 @@ impl HlsSizeDetector {
         validate_hls_url(m3u8_url)?;
 
         if self.verbose {
-            debug!(url:? = m3u8_url; "HLS detecting metadata");
+            debug!(url:? = rdlp_redact::RedactedUrl::new(m3u8_url); "HLS detecting metadata");
         }
 
         let playlist_text = match self.fetch_playlist_text(m3u8_url).await {
@@ -438,7 +438,7 @@ impl HlsSizeDetector {
         if self.verbose {
             debug!(
                 variants = variants.len(),
-                url:? = m3u8_url;
+                url:? = rdlp_redact::RedactedUrl::new(m3u8_url);
                 "HLS master playlist expanded into variants"
             );
         }

--- a/scripts/check-url-redaction.sh
+++ b/scripts/check-url-redaction.sh
@@ -6,20 +6,27 @@
 # Exit 1 = FAIL (raw URL interpolations remain).
 #
 # Usage: bash scripts/check-url-redaction.sh
+#
+# All rg invocations use -U (multiline) so that format! arguments split across lines
+# (e.g. `message: format!(\n    "... {url}"`) are caught.  Patterns 1-3 use
+# "(?:[^"\\]|\\.)*" to stay inside the format-string literal, which also eliminates
+# the need to filter out RedactedUrl wraps: compliant code passes the URL as a
+# positional argument *outside* the string, so the in-string {*url} pattern never
+# fires on it.
 
 set -euo pipefail
 
 TARGET="crates/rdlp-extractor/src"
 FAIL=0
 
-# Helper: run rg, filter out already-compliant lines and test files, report hits.
+# Helper: run rg -U (multiline), filter out already-compliant lines and test files,
+# report hits.
 # Args: <label> <rg-pattern>
 check() {
     local label="$1"
     local pattern="$2"
-    # grep -v filters: lines already wrapped, test modules, comment lines
     local hits
-    hits=$(rg --type rust -n "$pattern" "$TARGET" 2>/dev/null \
+    hits=$(rg -U --type rust -n "$pattern" "$TARGET" 2>/dev/null \
         | grep -v 'RedactedUrl' \
         | grep -v 'sanitize_for_logging' \
         | grep -v '/tests/' \
@@ -34,25 +41,28 @@ check() {
 }
 
 # 1. message: format!("... {url / *_url ...}")
+#    "(?:[^"\\]|\\.)*" matches only inside the string literal (stops at closing "),
+#    so a following `url: None` field is never caught as a false positive.
 check "message:format" \
-    'message:\s*format!\([^)]*\{[a-z_]*url'
+    'message:\s*format!\(\s*"(?:[^"\\]|\\.)*\{[a-z_]*url'
 
 # 2. reason: format!("... {url / *_url ...}")
 check "reason:format" \
-    'reason:\s*format!\([^)]*\{[a-z_]*url'
+    'reason:\s*format!\(\s*"(?:[^"\\]|\\.)*\{[a-z_]*url'
 
 # 3. RdlpError::(extraction|network|download)(format!("... {*url ..."), ...)
 check "RdlpError::*_ctor:format" \
-    'RdlpError::(extraction|network|download)\s*\(\s*(&)?format!\("[^"]*\{[a-z_]*url'
+    'RdlpError::(extraction|network|download)\s*\(\s*(&)?format!\(\s*"(?:[^"\\]|\\.)*\{[a-z_]*url'
 
 # 4. log_if_verbose positional interpolation of *_url
+#    [^;]* is bounded by the statement terminator; -U ensures any wrapped call is caught.
 check "log_if_verbose:format" \
     'log_if_verbose\s*\([^;]*\{[a-z_]*url'
 
-# 5. Structured-kv log fields: (url|video_url|...) :? or :% = <bare var>
-#    Must NOT be followed by rdlp_redact:: or sanitize_for_logging
+# 5. Structured-kv log fields: any *url* field used with :? or :% = <bare var>
+#    Durable class [a-z_]*url[a-z_]* catches future names (manifest_url, master_url, …).
 check "structured-kv:url_field" \
-    '(url|video_url|embed_url|m3u8_url|segment_url|cdn_url|api_url|full_url|page_url):[?%]\s*='
+    '[a-z_]*url[a-z_]*:[?%]\s*='
 
 if [[ $FAIL -eq 0 ]]; then
     echo "PASS — no raw URL interpolations found in $TARGET"

--- a/scripts/check-url-redaction.sh
+++ b/scripts/check-url-redaction.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# check-url-redaction.sh — CI gate: verify all operator-visible URL interpolations in
+# rdlp-extractor are wrapped with rdlp_redact::RedactedUrl (or sanitize_for_logging).
+#
+# Exit 0 = PASS (no offenders found).
+# Exit 1 = FAIL (raw URL interpolations remain).
+#
+# Usage: bash scripts/check-url-redaction.sh
+
+set -euo pipefail
+
+TARGET="crates/rdlp-extractor/src"
+FAIL=0
+
+# Helper: run rg, filter out already-compliant lines and test files, report hits.
+# Args: <label> <rg-pattern>
+check() {
+    local label="$1"
+    local pattern="$2"
+    # grep -v filters: lines already wrapped, test modules, comment lines
+    local hits
+    hits=$(rg --type rust -n "$pattern" "$TARGET" 2>/dev/null \
+        | grep -v 'RedactedUrl' \
+        | grep -v 'sanitize_for_logging' \
+        | grep -v '/tests/' \
+        | grep -v '#\[cfg(test)\]' \
+        | grep -v '^\s*//' \
+        || true)
+    if [[ -n "$hits" ]]; then
+        echo "FAIL [$label] — raw URL interpolation(s) found:"
+        echo "$hits" | sed 's/^/  /'
+        FAIL=1
+    fi
+}
+
+# 1. message: format!("... {url / *_url ...}")
+check "message:format" \
+    'message:\s*format!\([^)]*\{[a-z_]*url'
+
+# 2. reason: format!("... {url / *_url ...}")
+check "reason:format" \
+    'reason:\s*format!\([^)]*\{[a-z_]*url'
+
+# 3. RdlpError::(extraction|network|download)(format!("... {*url ..."), ...)
+check "RdlpError::*_ctor:format" \
+    'RdlpError::(extraction|network|download)\s*\(\s*(&)?format!\("[^"]*\{[a-z_]*url'
+
+# 4. log_if_verbose positional interpolation of *_url
+check "log_if_verbose:format" \
+    'log_if_verbose\s*\([^;]*\{[a-z_]*url'
+
+# 5. Structured-kv log fields: (url|video_url|...) :? or :% = <bare var>
+#    Must NOT be followed by rdlp_redact:: or sanitize_for_logging
+check "structured-kv:url_field" \
+    '(url|video_url|embed_url|m3u8_url|segment_url|cdn_url|api_url|full_url|page_url):[?%]\s*='
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "PASS — no raw URL interpolations found in $TARGET"
+    exit 0
+else
+    echo ""
+    echo "FIX: wrap each raw URL with rdlp_redact::RedactedUrl::new(...)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #392 (follow-up to #328). Completes the URL-redaction sweep into rdlp-extractor's operator-visible strings, and adds a **structural gate** so it stays closed.

After #328 type-enforced the `RdlpError.url` *field* and the credential-class downloader sites, ~48 raw-URL interpolations remained in rdlp-extractor across several forms. This wraps them all with `rdlp_redact::RedactedUrl::new` (or `rdlp_security::sanitize_for_logging`):

- `RdlpError` `message:` format strings (35 single + 9 multi-line)
- `RdlpError::Http` `reason:` strings (incl. CDN `m3u8_url`/`segment_url`)
- `RdlpError::extraction(format!(...), …)` constructor message-args
- positional log macros (`debug!`/`warn!`) + `log_if_verbose`
- structured-kv tracing fields (`url:% = RedactedUrl::new(…)`)

## The durable guard

`scripts/check-url-redaction.sh` — fails CI if any raw-URL interpolation appears in an rdlp-extractor operator-visible string (message/reason/ctor-message/positional-log/structured-kv). **Multiline-aware** (`rg -U` + bounded string-literal matcher) and **canary-verified**: a multiline `RdlpError` offender makes it FAIL with file:line; clean tree PASSes. Filters compliant `RedactedUrl`/`sanitize_for_logging` sites.

This guard is the real fix — manual sweeps missed sites **four times** (single-line backstop blind to multiline; `reason:` ≠ `message:`; constructor-message form; structured-kv) until the gate made completeness verifiable.

## Verification
Full gate green: fmt / clippy `--all-targets -D warnings` / test / desktop / dedup / **check-url-redaction (PASS)**. Independent multiline residual sweep across all forms: 0 real residuals.

## Reviews
- security-reviewer (iterated): each round surfaced a missed form → fixed; final independent sweep + gate confirm **zero residual**.
- code-reviewer: transform correct; **empirically caught the gate's multiline false-negative** (canary test) → fixed (`-U` + bounded-literal patterns + durable `[a-z_]*url` field class) → re-verified.

## Risk
These are predominantly **page URLs** (low credential risk) plus a few CDN `m3u8`/`segment` URLs (higher). Defense-in-depth: `RdlpError` Display renders `{message}`/`{reason}` to logs/UI, so all are now redacted.

## Follow-up
Recommend wiring `scripts/check-url-redaction.sh` into the CI workflow + the documented pre-PR gate (it's committed and runnable now; enforcement wiring is a small ops change).