### PR TITLE
ci: enforce check-url-redaction gate in Lint job (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Check no CLI FFmpeg usage
         run: bash scripts/check-no-cli.sh
 
+      - name: Check URL log redaction
+        # Fails if any raw URL is interpolated into an operator-visible string
+        # in rdlp-extractor (RdlpError message/reason fields, RdlpError ctor
+        # message-args, positional log macros, structured-kv log fields).
+        # Multiline-aware; credential URLs must be wrapped in
+        # rdlp_redact::RedactedUrl / rdlp_security::sanitize_for_logging (#328/#392).
+        run: bash scripts/check-url-redaction.sh
+
       - name: Check WIT vendor drift
         # The example-extractor plugin vendors a byte-copy of the host's WIT
         # contract under examples/plugins/example-extractor/wit/deps/rdlp-plugin.


### PR DESCRIPTION
Wires `scripts/check-url-redaction.sh` (added in #392, multiline-aware + canary-verified) into the CI `Lint` job, mirroring the existing `check-no-cli.sh` / `check-wit-drift.sh` steps — so raw-URL interpolations in rdlp-extractor operator-visible strings fail the PR, not just a local run. Also added to the documented pre-PR gate in CLAUDE.md (local).

Trivial CI-config change running an already-reviewed committed script; no new code paths/inputs/deps.

Refs #392, #328.