### PR TITLE
feat: configurable recode encoder threads + preset (#337)

### DIFF
--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -142,6 +142,12 @@ impl MergeOverrides for PostProcessOptions {
         if let Some(ref v) = self.recode_audio {
             config.postprocess.recode_audio = v.clone();
         }
+        if let Some(v) = self.recode_threads {
+            config.postprocess.recode_threads = Some(v);
+        }
+        if let Some(ref v) = self.recode_preset {
+            config.postprocess.recode_preset = Some(v.clone());
+        }
     }
 }
 

--- a/crates/rdlp-api/src/merge/tests_postprocess_network.rs
+++ b/crates/rdlp-api/src/merge/tests_postprocess_network.rs
@@ -599,3 +599,26 @@ fn network_options_none_preserves_base_timeouts() {
     assert_eq!(config.read_timeout, Some(99));
     assert_eq!(config.pool_idle_timeout, Some(99));
 }
+
+#[test]
+fn test_postprocess_recode_threads_and_preset_propagate() {
+    let mut config = Config::default();
+    let opts = PostProcessOptions {
+        recode_threads: Some(6),
+        recode_preset: Some("faster".to_string()),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert_eq!(config.postprocess.recode_threads, Some(6));
+    assert_eq!(config.postprocess.recode_preset, Some("faster".to_string()));
+}
+
+#[test]
+fn test_postprocess_recode_threads_none_preserves_base() {
+    let mut config = Config::default();
+    config.postprocess.recode_threads = Some(4);
+    config.postprocess.recode_preset = Some("slow".to_string());
+    PostProcessOptions::default().merge_into(&mut config);
+    assert_eq!(config.postprocess.recode_threads, Some(4));
+    assert_eq!(config.postprocess.recode_preset, Some("slow".to_string()));
+}

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -213,6 +213,10 @@ pub struct PostProcessOptions {
     /// Audio handling during video recode.
     /// `None` preserves base config (defaults to Copy).
     pub recode_audio: Option<rdlp_types::RecodeAudioMode>,
+    /// Encoder thread count for video recode. `None` = auto (min(cores, 8)).
+    pub recode_threads: Option<u32>,
+    /// Encoder preset override for video recode. `None` = per-codec default.
+    pub recode_preset: Option<String>,
 }
 
 /// Network, retry, and cookie options.

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -211,6 +211,15 @@ pub struct Args {
     #[arg(long, value_name = "MODE", default_value = "copy")]
     pub recode_audio: String,
 
+    /// Encoder threads for video recode (1-64). Omit for auto (min(cores, 8)).
+    #[arg(long, value_name = "N")]
+    pub recode_threads: Option<u32>,
+
+    /// Encoder preset override for video recode (e.g. `faster`, `medium`, `slow`).
+    /// Omit to use the per-codec default. `libvvenc`: try `faster` for speed.
+    #[arg(long, value_name = "PRESET")]
+    pub recode_preset: Option<String>,
+
     /// Remux to container for better seeking - no re-encoding
     /// Use --remux for interactive, --remux=mp4 for direct
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -212,6 +212,13 @@ pub fn merge_config(
         );
     }
 
+    if let Some(threads) = args.recode_threads {
+        config.postprocess.recode_threads = Some(threads);
+    }
+    if let Some(ref preset) = args.recode_preset {
+        config.postprocess.recode_preset = Some(preset.clone());
+    }
+
     // recode_audio: "copy", "auto", or an encoder name
     match args.recode_audio.as_str() {
         "copy" => config.postprocess.recode_audio = RecodeAudioMode::Copy,

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -70,6 +70,8 @@ fn default_args() -> Args {
         list_encoders: false,
         recode_container: None,
         recode_audio: "copy".to_string(),
+        recode_threads: None,
+        recode_preset: None,
         fixup: "detect_or_warn".to_string(),
         match_filter: vec![],
         browser: None,
@@ -728,4 +730,22 @@ fn cli_pool_idle_timeout_above_max_is_rejected_by_validate() {
         msg.contains("pool_idle_timeout"),
         "rejection should cite pool_idle_timeout, got: {msg}"
     );
+}
+
+#[test]
+fn recode_threads_and_preset_flags_map_to_config() {
+    use clap::Parser;
+    let args = Args::try_parse_from([
+        "rdlp",
+        "--recode-video=mkv",
+        "--recode-threads",
+        "6",
+        "--recode-preset",
+        "faster",
+        "https://example.com/v",
+    ])
+    .expect("args parse");
+    let config = build_config(&args).expect("config builds");
+    assert_eq!(config.postprocess.recode_threads, Some(6));
+    assert_eq!(config.postprocess.recode_preset.as_deref(), Some("faster"));
 }

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -96,6 +96,12 @@ pub struct DownloadOptions {
     /// `None` = use default (Copy).
     #[serde(default)]
     pub recode_audio: Option<RecodeAudioMode>,
+    /// Encoder threads for video recode (1-64). `None` = auto.
+    #[serde(default)]
+    pub recode_threads: Option<u32>,
+    /// Encoder preset override for video recode. `None` = per-codec default.
+    #[serde(default)]
+    pub recode_preset: Option<String>,
     /// Enable verbose `FFmpeg` log capture for this download.
     /// `None` = use settings default.
     #[serde(default)]
@@ -115,6 +121,24 @@ pub struct PlaylistContext {
     pub playlist_index: usize,
     /// Total number of episodes in the playlist.
     pub playlist_count: usize,
+}
+
+/// Reject an out-of-range explicit recode thread count at the IPC boundary.
+///
+/// `None` (auto) and `1..=MAX_RECODE_THREADS` are accepted. The desktop path
+/// does not run `Config::validate()`, so this is the boundary guard.
+fn validate_recode_threads(threads: Option<u32>) -> Result<(), AppError> {
+    match threads {
+        None => Ok(()),
+        Some(t) if (1..=rdlp_types::config::MAX_RECODE_THREADS).contains(&t) => Ok(()),
+        Some(t) => Err(AppError::InvalidInput {
+            field: "recode_threads".to_owned(),
+            message: format!(
+                "recode_threads must be 1..={} (got {t})",
+                rdlp_types::config::MAX_RECODE_THREADS
+            ),
+        }),
+    }
 }
 
 /// Start a new download for the given URL.
@@ -182,6 +206,10 @@ pub async fn start_download(
             message: e.to_string(),
         })?;
     }
+
+    // Validate recode thread count at the IPC boundary (Config::validate is not
+    // called on the desktop path, so this guard is the only enforcement point).
+    validate_recode_threads(options.recode_threads)?;
 
     // Save a serializable snapshot of the options for retry (before any partial moves).
     let saved_options = serde_json::to_value(&options)
@@ -266,6 +294,8 @@ pub async fn start_download(
             video_encoder: options.video_encoder,
             recode_container: options.recode_container,
             recode_audio: options.recode_audio,
+            recode_threads: options.recode_threads,
+            recode_preset: options.recode_preset,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
             write_thumbnail: write_thumbnail_resolved.then_some(true),
@@ -497,8 +527,22 @@ mod tests {
             video_encoder: None,
             recode_container: None,
             recode_audio: None,
+            recode_threads: None,
+            recode_preset: None,
             verbose: None,
         }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Recode thread validation
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn rejects_out_of_range_recode_threads() {
+        assert!(validate_recode_threads(Some(0)).is_err());
+        assert!(validate_recode_threads(Some(rdlp_types::config::MAX_RECODE_THREADS + 1)).is_err());
+        assert!(validate_recode_threads(Some(8)).is_ok());
+        assert!(validate_recode_threads(None).is_ok());
     }
 
     // ------------------------------------------------------------------ //

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -123,6 +123,11 @@ pub struct PlaylistContext {
     pub playlist_count: usize,
 }
 
+/// Max byte length for an operator-supplied recode preset name. Generous —
+/// the longest legitimate value (`wavefrontsynchro=1:tiles=2x2`, set internally)
+/// is ~30 bytes; this only guards against a pathological IPC payload.
+const MAX_RECODE_PRESET_LEN: usize = 64;
+
 /// Reject an out-of-range explicit recode thread count at the IPC boundary.
 ///
 /// `None` (auto) and `1..=MAX_RECODE_THREADS` are accepted. The desktop path
@@ -138,6 +143,16 @@ fn validate_recode_threads(threads: Option<u32>) -> Result<(), AppError> {
                 rdlp_types::config::MAX_RECODE_THREADS
             ),
         }),
+    }
+}
+
+fn validate_recode_preset(preset: Option<&str>) -> Result<(), AppError> {
+    match preset {
+        Some(p) if p.len() > MAX_RECODE_PRESET_LEN => Err(AppError::InvalidInput {
+            field: "recode_preset".to_owned(),
+            message: format!("preset name too long (max {MAX_RECODE_PRESET_LEN} bytes)"),
+        }),
+        _ => Ok(()),
     }
 }
 
@@ -210,6 +225,7 @@ pub async fn start_download(
     // Validate recode thread count at the IPC boundary (Config::validate is not
     // called on the desktop path, so this guard is the only enforcement point).
     validate_recode_threads(options.recode_threads)?;
+    validate_recode_preset(options.recode_preset.as_deref())?;
 
     // Save a serializable snapshot of the options for retry (before any partial moves).
     let saved_options = serde_json::to_value(&options)
@@ -543,6 +559,13 @@ mod tests {
         assert!(validate_recode_threads(Some(rdlp_types::config::MAX_RECODE_THREADS + 1)).is_err());
         assert!(validate_recode_threads(Some(8)).is_ok());
         assert!(validate_recode_threads(None).is_ok());
+    }
+
+    #[test]
+    fn rejects_overlong_recode_preset() {
+        assert!(validate_recode_preset(Some(&"x".repeat(65))).is_err());
+        assert!(validate_recode_preset(Some("faster")).is_ok());
+        assert!(validate_recode_preset(None).is_ok());
     }
 
     // ------------------------------------------------------------------ //

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -303,6 +303,8 @@ export interface DownloadOptions {
     videoEncoder: string | null;
     recodeAudio: RecodeAudioMode | null;
     recodeContainer: string | null;
+    recodeThreads: number | null;
+    recodePreset: string | null;
     verbose: boolean | null;
 }
 

--- a/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
@@ -53,6 +53,8 @@ const downloadConfigSchema = z.object({
     recodeContainerOverride: z.string(),
     videoEncoder: z.string(),
     recodeAudioMode: z.string(),
+    recodeThreads: z.string(),
+    recodePreset: z.string(),
     extractAudio: z.string(),
     embedThumbnail: z.boolean(),
     embedSubtitles: z.boolean(),
@@ -83,6 +85,8 @@ export function DownloadConfig() {
             recodeContainerOverride: "",
             videoEncoder: "",
             recodeAudioMode: "copy",
+            recodeThreads: "",
+            recodePreset: "",
             extractAudio: "",
             embedThumbnail: settings?.embed_thumbnail ?? true,
             embedSubtitles: settings?.embed_subtitles ?? false,
@@ -123,6 +127,8 @@ export function DownloadConfig() {
                         : value.recodeAudioMode
                         ? { mode: "encoder" as const, name: value.recodeAudioMode }
                         : null,
+                    recodeThreads: value.recodeThreads ? Number(value.recodeThreads) : null,
+                    recodePreset: value.recodePreset || null,
                     normalizeAudio: value.normalizeAudio || null,
                     loudnorm: null,
                     loudnormPreset: null,
@@ -451,6 +457,44 @@ export function DownloadConfig() {
                                             </SelectListBox>
                                         </SelectPopover>
                                     </Select>
+                                </div>
+                            )}
+                        </form.Field>
+                    )}
+
+                    {/* Recode threads (visible when recode active, expert mode) */}
+                    {recodeActive && expertMode && (
+                        <form.Field name="recodeThreads">
+                            {(field) => (
+                                <div className="flex items-center justify-between pl-3">
+                                    <span className="text-[10px] text-[var(--text-muted)]">Threads</span>
+                                    <Input
+                                        type="text"
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) => field.handleChange(e.target.value)}
+                                        placeholder="auto"
+                                        className="h-5 w-[90px] px-1.5 py-0 rounded-[3px] bg-[var(--surface-elevated)] border border-[#2a2a3e] text-[10px] text-[var(--text-muted)] placeholder:text-[var(--text-muted)] outline-none focus:border-[#4a9eff]"
+                                    />
+                                </div>
+                            )}
+                        </form.Field>
+                    )}
+
+                    {/* Recode preset (visible when recode active, expert mode) */}
+                    {recodeActive && expertMode && (
+                        <form.Field name="recodePreset">
+                            {(field) => (
+                                <div className="flex items-center justify-between pl-3">
+                                    <span className="text-[10px] text-[var(--text-muted)]">Preset</span>
+                                    <Input
+                                        type="text"
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) => field.handleChange(e.target.value)}
+                                        placeholder="default"
+                                        className="h-5 w-[90px] px-1.5 py-0 rounded-[3px] bg-[var(--surface-elevated)] border border-[#2a2a3e] text-[10px] text-[var(--text-muted)] placeholder:text-[var(--text-muted)] outline-none focus:border-[#4a9eff]"
+                                    />
                                 </div>
                             )}
                         </form.Field>

--- a/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
@@ -53,7 +53,13 @@ const downloadConfigSchema = z.object({
     recodeContainerOverride: z.string(),
     videoEncoder: z.string(),
     recodeAudioMode: z.string(),
-    recodeThreads: z.string(),
+    // 1–64 mirrors rdlp_types MAX_RECODE_THREADS; blank = auto
+    recodeThreads: z
+        .string()
+        .refine(
+            (v) => v === "" || (/^\d+$/.test(v) && Number(v) >= 1 && Number(v) <= 64),
+            { message: "Enter 1–64 or leave blank for auto" },
+        ),
     recodePreset: z.string(),
     extractAudio: z.string(),
     embedThumbnail: z.boolean(),

--- a/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
@@ -116,6 +116,8 @@ export function EpisodeList({ episodes, playlistUrl, playlistTitle }: EpisodeLis
             videoEncoder: null,
             recodeAudio: null,
             recodeContainer: null,
+            recodeThreads: null,
+            recodePreset: null,
             verbose: null,
         };
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -45,6 +45,9 @@ pub struct VideoConvertOptions {
     pub preset: Option<String>,
     /// Constant Rate Factor for quality-based encoding.
     pub crf: Option<u32>,
+    /// Resolved encoder thread count. `None` = let the encode layer resolve it
+    /// from `available_parallelism()`. Audio encoding is unaffected.
+    pub threads: Option<u32>,
     /// If true, copy audio stream without re-encoding.
     ///
     /// Takes precedence over `audio_codec`. When `audio_copy` is true and
@@ -58,6 +61,17 @@ pub struct VideoConvertOptions {
     /// When true, capture `FFmpeg` C-level log messages and forward them via
     /// the log callback. Enables verbose encoder output in the UI log viewer.
     pub verbose: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_convert_options_threads_defaults_none() {
+        let opts = VideoConvertOptions::default();
+        assert_eq!(opts.threads, None);
+    }
 }
 
 /// A chapter entry for metadata embedding.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/encoder_options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/encoder_options.rs
@@ -1,0 +1,135 @@
+//! Build the ordered encoder-option key/value list for a video recode.
+//!
+//! Kept pure (no [`ffmpeg_the_third::Dictionary`], no encoder open) so the
+//! full matrix — preset, crf, threads, and per-encoder wide-parallelism params
+//! — is unit-testable.  The caller turns the returned pairs into an
+//! [`ffmpeg_the_third::Dictionary`] and passes it to `open_as_with`.
+
+use crate::ffmpeg::options::VideoConvertOptions;
+use crate::ffmpeg::transcode::thread_resolve::{
+    WIDE_PARALLELISM_THRESHOLD, resolve_recode_threads,
+};
+
+/// libvvenc tuning string applied above `WIDE_PARALLELISM_THRESHOLD` threads.
+/// `wavefrontsynchro=1` enables wavefront-parallel processing; `tiles=2x2`
+/// splits the frame into a 2×2 grid for balanced spatial parallelism on typical
+/// HD/4K sources — without these, libvvenc does not spread work past ~8 threads.
+const VVENC_WIDE_PARAMS: &str = "wavefrontsynchro=1:tiles=2x2";
+
+/// Produce `(key, value)` pairs to pass to `open_as_with`.
+///
+/// `encoder_name` is the resolved encoder name (e.g. `"libvvenc"`,
+/// `"libx265"`, `"libvpx-vp9"`). Always emits an explicit positive `threads`
+/// (libvvenc at 0 runs main-thread-only). Above `WIDE_PARALLELISM_THRESHOLD`,
+/// adds the per-encoder params required to actually use the threads.
+#[must_use]
+pub fn build_video_encoder_options(
+    opts: &VideoConvertOptions,
+    encoder_name: &str,
+) -> Vec<(&'static str, String)> {
+    let mut kv: Vec<(&'static str, String)> = Vec::new();
+
+    if let Some(ref preset) = opts.preset {
+        kv.push(("preset", preset.clone()));
+    }
+    if let Some(crf) = opts.crf {
+        kv.push(("crf", crf.to_string()));
+    }
+
+    let threads = resolve_recode_threads(opts.threads);
+    kv.push(("threads", threads.to_string()));
+
+    if threads > 1 && (encoder_name.contains("vpx") || encoder_name.contains("aom")) {
+        kv.push(("row-mt", "1".to_string()));
+    }
+    if threads > WIDE_PARALLELISM_THRESHOLD && encoder_name.contains("vvenc") {
+        kv.push(("vvenc-params", VVENC_WIDE_PARAMS.to_string()));
+    }
+
+    kv
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_with(
+        preset: Option<&str>,
+        crf: Option<u32>,
+        threads: Option<u32>,
+    ) -> VideoConvertOptions {
+        VideoConvertOptions {
+            preset: preset.map(String::from),
+            crf,
+            threads,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn always_sets_explicit_positive_threads() {
+        let kv = build_video_encoder_options(&opts_with(None, None, Some(6)), "libx265");
+        assert!(kv.iter().any(|(k, v)| *k == "threads" && v == "6"));
+    }
+
+    #[test]
+    fn threads_never_zero_even_when_unset() {
+        let kv = build_video_encoder_options(&opts_with(None, None, None), "libvvenc");
+        let t = kv
+            .iter()
+            .find(|(k, _)| *k == "threads")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_ne!(t, "0");
+        assert!(t.parse::<u32>().unwrap() >= 1);
+    }
+
+    #[test]
+    fn preset_override_reaches_options() {
+        let kv = build_video_encoder_options(&opts_with(Some("faster"), None, Some(4)), "libvvenc");
+        assert!(kv.iter().any(|(k, v)| *k == "preset" && v == "faster"));
+    }
+
+    #[test]
+    fn crf_reaches_options() {
+        let kv =
+            build_video_encoder_options(&opts_with(Some("medium"), Some(28), Some(4)), "libx265");
+        assert!(kv.iter().any(|(k, v)| *k == "crf" && v == "28"));
+    }
+
+    #[test]
+    fn vpx_gets_row_mt() {
+        let kv = build_video_encoder_options(&opts_with(None, Some(30), Some(4)), "libvpx-vp9");
+        assert!(kv.iter().any(|(k, v)| *k == "row-mt" && v == "1"));
+    }
+
+    #[test]
+    fn vvenc_wide_params_only_above_threshold() {
+        let narrow = build_video_encoder_options(&opts_with(None, None, Some(8)), "libvvenc");
+        assert!(!narrow.iter().any(|(k, _)| *k == "vvenc-params"));
+        let wide = build_video_encoder_options(&opts_with(None, None, Some(16)), "libvvenc");
+        assert!(wide.iter().any(|(k, _)| *k == "vvenc-params"));
+    }
+
+    #[test]
+    fn x265_no_wide_params() {
+        let kv =
+            build_video_encoder_options(&opts_with(Some("medium"), Some(28), Some(16)), "libx265");
+        assert!(
+            !kv.iter()
+                .any(|(k, _)| *k == "vvenc-params" || *k == "row-mt")
+        );
+    }
+
+    #[test]
+    fn aom_gets_row_mt() {
+        let kv = build_video_encoder_options(&opts_with(None, Some(28), Some(4)), "libaom-av1");
+        assert!(kv.iter().any(|(k, v)| *k == "row-mt" && v == "1"));
+    }
+
+    #[test]
+    fn row_mt_absent_at_single_thread() {
+        let kv = build_video_encoder_options(&opts_with(None, Some(30), Some(1)), "libvpx-vp9");
+        assert!(!kv.iter().any(|(k, _)| *k == "row-mt"));
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
@@ -11,6 +11,7 @@ mod cancel;
 pub mod mux_timing;
 #[cfg(test)]
 mod tests;
+pub mod thread_resolve;
 mod video_convert;
 mod video_pipeline;
 mod video_transcode_context;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
@@ -8,6 +8,7 @@ mod audio_pipeline;
 mod audio_pipeline_direct;
 mod audio_recode_pipeline;
 mod cancel;
+pub mod encoder_options;
 pub mod mux_timing;
 #[cfg(test)]
 mod tests;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/thread_resolve.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/thread_resolve.rs
@@ -1,0 +1,63 @@
+//! Resolve the concrete encoder thread count for a recode.
+//!
+//! The auto path (`None`) caps at `AUTO_RECODE_THREADS_CAP`, which matches
+//! x265's auto frame-thread table and the VMAF quality sweet-spot, and bounds
+//! encoder RAM on a memory-constrained desktop. Explicit values pass through
+//! (already range-validated by `Config::validate()`), clamped to >=1.
+
+use std::thread::available_parallelism;
+
+/// Auto-default cap for `recode_threads` when unset. See module docs.
+pub const AUTO_RECODE_THREADS_CAP: u32 = 8;
+
+/// Above this resolved thread count, encoders need per-encoder wide-parallelism
+/// params (libvvenc tiles/wavefront; libvpx/libaom row-mt) to actually use the
+/// extra threads. See `encoder_options::build_video_encoder_options`.
+// Not yet consumed outside this crate; wired in Task 5.
+#[allow(dead_code)]
+pub const WIDE_PARALLELISM_THRESHOLD: u32 = 8;
+
+/// Fallback when `available_parallelism()` errors (e.g. sandboxed/seccomp).
+const PARALLELISM_FALLBACK: u32 = 4;
+
+/// Resolve an `Option<u32>` recode-thread setting to a concrete positive count.
+///
+/// - `Some(n)` -> `n.max(1)` (range already enforced by `Config::validate`).
+/// - `None` -> `min(available_parallelism(), AUTO_RECODE_THREADS_CAP)`,
+///   falling back to `PARALLELISM_FALLBACK` if detection fails.
+// Not yet consumed outside this crate; wired in Task 5.
+#[allow(dead_code)]
+#[must_use]
+pub fn resolve_recode_threads(configured: Option<u32>) -> u32 {
+    configured.map_or_else(
+        || {
+            let cores = available_parallelism().map_or(PARALLELISM_FALLBACK, |n| {
+                u32::try_from(n.get()).unwrap_or(PARALLELISM_FALLBACK)
+            });
+            cores.clamp(1, AUTO_RECODE_THREADS_CAP)
+        },
+        |n| n.max(1),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_value_passes_through() {
+        assert_eq!(resolve_recode_threads(Some(3)), 3);
+        assert_eq!(resolve_recode_threads(Some(16)), 16);
+    }
+
+    #[test]
+    fn explicit_zero_is_floored_to_one() {
+        assert_eq!(resolve_recode_threads(Some(0)), 1);
+    }
+
+    #[test]
+    fn auto_is_within_one_to_cap() {
+        let n = resolve_recode_threads(None);
+        assert!((1..=AUTO_RECODE_THREADS_CAP).contains(&n), "got {n}");
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/thread_resolve.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/thread_resolve.rs
@@ -13,8 +13,6 @@ pub const AUTO_RECODE_THREADS_CAP: u32 = 8;
 /// Above this resolved thread count, encoders need per-encoder wide-parallelism
 /// params (libvvenc tiles/wavefront; libvpx/libaom row-mt) to actually use the
 /// extra threads. See `encoder_options::build_video_encoder_options`.
-// Not yet consumed outside this crate; wired in Task 5.
-#[allow(dead_code)]
 pub const WIDE_PARALLELISM_THRESHOLD: u32 = 8;
 
 /// Fallback when `available_parallelism()` errors (e.g. sandboxed/seccomp).
@@ -25,8 +23,6 @@ const PARALLELISM_FALLBACK: u32 = 4;
 /// - `Some(n)` -> `n.max(1)` (range already enforced by `Config::validate`).
 /// - `None` -> `min(available_parallelism(), AUTO_RECODE_THREADS_CAP)`,
 ///   falling back to `PARALLELISM_FALLBACK` if detection fails.
-// Not yet consumed outside this crate; wired in Task 5.
-#[allow(dead_code)]
 #[must_use]
 pub fn resolve_recode_threads(configured: Option<u32>) -> u32 {
     configured.map_or_else(
@@ -47,6 +43,7 @@ mod tests {
     #[test]
     fn explicit_value_passes_through() {
         assert_eq!(resolve_recode_threads(Some(3)), 3);
+        // explicit values bypass AUTO_RECODE_THREADS_CAP (already range-validated by Config::validate)
         assert_eq!(resolve_recode_threads(Some(16)), 16);
     }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -266,13 +266,15 @@ impl FFmpegRunner {
             video_encoder.set_bit_rate(0);
         }
 
-        // Open encoder with preset/CRF options
+        // Build encoder options (preset/crf/threads/wide-parallelism) via the
+        // pure helper so the full matrix is unit-tested. Always sets explicit
+        // threads — libvvenc at thread_count=0 runs main-thread-only.
         let mut enc_opts = ffmpeg_the_third::Dictionary::new();
-        if let Some(ref preset) = opts.preset {
-            enc_opts.set("preset", preset);
-        }
-        if let Some(crf) = opts.crf {
-            enc_opts.set("crf", &crf.to_string());
+        for (key, value) in crate::ffmpeg::transcode::encoder_options::build_video_encoder_options(
+            opts,
+            video_codec_name,
+        ) {
+            enc_opts.set(key, &value);
         }
         let video_encoder = video_encoder
             .open_as_with(video_enc_codec, enc_opts)

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -26,6 +26,10 @@ pub(super) struct RecodeParams {
     pub encoder_override: Option<String>,
     pub audio_copy: bool,
     pub audio_codec: Option<String>,
+    /// Resolved-or-configured encoder thread count (None = auto at encode layer).
+    pub threads: Option<u32>,
+    /// Encoder preset override; None preserves the per-codec default preset.
+    pub preset_override: Option<String>,
 }
 
 /// Transcodes video to a different container/codec.
@@ -132,12 +136,14 @@ impl RecodeStage {
 
         if let Some(ref requested) = params.encoder_override {
             let encoder_name = video_codecs::resolve_encoder(requested)?;
-            let (preset, crf) = Self::default_preset_crf(encoder_name);
+            let (default_preset, crf) = Self::default_preset_crf(encoder_name);
+            let preset = params.preset_override.clone().or(default_preset);
             return Some(VideoConvertOptions {
                 remux_only: false,
                 video_codec: Some(encoder_name.to_string()),
                 preset,
                 crf,
+                threads: params.threads,
                 audio_copy: params.audio_copy,
                 audio_codec: params.audio_codec.clone(),
                 ..Default::default()
@@ -146,13 +152,15 @@ impl RecodeStage {
 
         let target_codec = Self::default_codec_for(params.target);
         let encoder = video_codecs::resolve_encoder(target_codec);
-        let (preset, crf) = Self::default_preset_crf_for_codec(target_codec);
+        let (default_preset, crf) = Self::default_preset_crf_for_codec(target_codec);
+        let preset = params.preset_override.clone().or(default_preset);
 
         Some(VideoConvertOptions {
             remux_only: false,
             video_codec: encoder.map(String::from),
             preset,
             crf,
+            threads: params.threads,
             audio_copy: params.audio_copy,
             audio_codec: params.audio_codec.clone(),
             ..Default::default()
@@ -308,6 +316,8 @@ impl PipelineStage for RecodeStage {
                 encoder_override: msg.config.video_encoder.clone(),
                 audio_copy,
                 audio_codec,
+                threads: msg.config.recode_threads,
+                preset_override: msg.config.recode_preset.clone(),
             },
             can_remux,
         ) else {
@@ -554,6 +564,8 @@ mod tests {
             encoder_override: None,
             audio_copy: true,
             audio_codec: None,
+            threads: None,
+            preset_override: None,
         };
         let opts = RecodeStage::build_convert_options(&params, true).unwrap();
         assert!(opts.remux_only);
@@ -595,6 +607,8 @@ mod tests {
             encoder_override: None,
             audio_copy: false,
             audio_codec: Some("libopus".to_string()),
+            threads: None,
+            preset_override: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).unwrap();
         assert!(!opts.audio_copy);
@@ -608,6 +622,8 @@ mod tests {
             encoder_override: None,
             audio_copy: true,
             audio_codec: None,
+            threads: None,
+            preset_override: None,
         };
         let opts = RecodeStage::build_convert_options(&params, true).unwrap();
         assert!(opts.remux_only);
@@ -621,6 +637,8 @@ mod tests {
             encoder_override: None,
             audio_copy: true,
             audio_codec: None,
+            threads: None,
+            preset_override: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).unwrap();
         assert!(!opts.remux_only);
@@ -638,6 +656,8 @@ mod tests {
             encoder_override: None,
             audio_copy: false,
             audio_codec: Some("libopus".to_string()),
+            threads: None,
+            preset_override: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).unwrap();
         assert!(!opts.audio_copy);
@@ -651,8 +671,40 @@ mod tests {
             encoder_override: Some("nonexistent_enc_xyz".to_string()),
             audio_copy: true,
             audio_codec: None,
+            threads: None,
+            preset_override: None,
         };
         let result = RecodeStage::build_convert_options(&params, false);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn threads_and_preset_override_flow_into_options() {
+        let params = RecodeParams {
+            target: ContainerFormat::Mkv,
+            encoder_override: Some("libx265".to_string()),
+            audio_copy: true,
+            audio_codec: None,
+            threads: Some(6),
+            preset_override: Some("faster".to_string()),
+        };
+        let opts = RecodeStage::build_convert_options(&params, false).expect("encoder available");
+        assert_eq!(opts.threads, Some(6));
+        assert_eq!(opts.preset.as_deref(), Some("faster"));
+    }
+
+    #[test]
+    fn preset_none_keeps_per_codec_default() {
+        let params = RecodeParams {
+            target: ContainerFormat::Mp4,
+            encoder_override: Some("libx265".to_string()),
+            audio_copy: true,
+            audio_codec: None,
+            threads: None,
+            preset_override: None,
+        };
+        let opts = RecodeStage::build_convert_options(&params, false).expect("encoder available");
+        assert_eq!(opts.preset.as_deref(), Some("medium"));
+        assert_eq!(opts.threads, None);
     }
 }

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -9,6 +9,14 @@ use crate::browser_type::BrowserType;
 use crate::postprocess::PostProcess;
 use crate::subtitle_format::SubtitleFormat;
 
+/// Hard ceiling for an explicit [`PostProcess::recode_threads`] value.
+///
+/// Mirrors `concurrent_fragments`' 64 cap: bounds peak encoder memory, which
+/// scales with thread count (each frame thread allocates reconstruction
+/// buffers ≈ one uncompressed frame). The *auto* default is far lower; this is
+/// only the ceiling for explicit overrides.
+pub const MAX_RECODE_THREADS: u32 = 64;
+
 /// Errors from configuration validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigValidationError {
@@ -482,6 +490,15 @@ impl Config {
             return Err(ConfigValidationError::OutOfRange {
                 field: "concurrent_fragments",
                 reason: "must be 1..=64 (caps peak transient memory under parallel fragment fetch)",
+            });
+        }
+        if let Some(threads) = self.postprocess.recode_threads
+            && !(1..=MAX_RECODE_THREADS).contains(&threads)
+        {
+            return Err(ConfigValidationError::OutOfRange {
+                field: "recode_threads",
+                reason: "must be 1..=64 (bounds peak encoder RAM; 0 is invalid — \
+                         leave unset for auto-detect)",
             });
         }
         if self.buffer_size == 0 {

--- a/crates/rdlp-types/src/config_tests.rs
+++ b/crates/rdlp-types/src/config_tests.rs
@@ -647,3 +647,38 @@ fn test_validate_parallel_threshold_none_is_valid() {
         "None must be valid (uses downloader default)"
     );
 }
+
+#[test]
+fn validate_rejects_zero_recode_threads() {
+    let mut cfg = Config::default();
+    cfg.postprocess.recode_threads = Some(0);
+    assert!(matches!(
+        cfg.validate().unwrap_err(),
+        ConfigValidationError::OutOfRange {
+            field: "recode_threads",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn validate_rejects_recode_threads_above_cap() {
+    let mut cfg = Config::default();
+    cfg.postprocess.recode_threads = Some(MAX_RECODE_THREADS + 1);
+    assert!(matches!(
+        cfg.validate().unwrap_err(),
+        ConfigValidationError::OutOfRange {
+            field: "recode_threads",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn validate_accepts_recode_threads_in_range() {
+    let mut cfg = Config::default();
+    for threads in [1, 8, MAX_RECODE_THREADS] {
+        cfg.postprocess.recode_threads = Some(threads);
+        assert!(cfg.validate().is_ok(), "threads={threads} must be valid");
+    }
+}

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -73,6 +73,16 @@ pub struct PostProcess {
     pub recode_audio: RecodeAudioMode,
     /// Override the output container for recode (independent of `recode_video`).
     pub recode_container: Option<ContainerFormat>,
+    /// Encoder thread count for video recode. `None` = auto-detect at startup
+    /// (`min(available_parallelism(), 8)`). `Some(n)` sets an explicit count.
+    /// Validated post-load by `Config::validate()`: must be 1..=64 when set
+    /// (the 64 ceiling bounds peak encoder RAM: threads × frame buffers).
+    /// Audio stages are unaffected — audio encoders are single-threaded.
+    pub recode_threads: Option<u32>,
+    /// Encoder preset override for video recode (e.g. `"faster"`, `"medium"`).
+    /// `None` = use `RecodeStage`'s per-codec default preset. When `Some`, this
+    /// value replaces that default and is passed verbatim to the encoder.
+    pub recode_preset: Option<String>,
     /// Policy for automatic fixup of downloaded files.
     pub fixup: FixupPolicy,
 }
@@ -108,6 +118,8 @@ impl Default for PostProcess {
             video_encoder: None,
             recode_audio: RecodeAudioMode::default(),
             recode_container: None,
+            recode_threads: None,
+            recode_preset: None,
             fixup: FixupPolicy::default(),
         }
     }
@@ -151,5 +163,12 @@ mod tests {
         let parsed: PostProcess = serde_json::from_str("{}").unwrap();
         assert!(parsed.embed_thumbnail);
         assert_eq!(parsed.fixup, FixupPolicy::DetectOrWarn);
+    }
+
+    #[test]
+    fn recode_threads_and_preset_default_to_none() {
+        let pp = PostProcess::default();
+        assert_eq!(pp.recode_threads, None);
+        assert_eq!(pp.recode_preset, None);
     }
 }


### PR DESCRIPTION
Closes #337. Follow-ups tracked in #397.

## Summary

Recode encodes ran effectively **single-threaded** (libvvenc 1080p measured at ~1 core / ~0.5–1 fps → multi-day jobs). Root cause: the encoder was opened with only `preset`+`crf`, never `threads`, so libavcodec defaulted to 1 — and **libvvenc at `thread_count=0` runs main-thread-only**. This makes encoder threads + preset operator-configurable end-to-end.

- **`recode_threads`** — `None` = auto `min(available_parallelism(), 8)` (x265 auto-table / VMAF sweet-spot, bounds RAM); explicit `1..=64` (`MAX_RECODE_THREADS`). Always sets an **explicit positive** thread count at encoder open. Above 8 threads, adds the per-encoder params that actually spread work: libvvenc `wavefrontsynchro=1:tiles=2x2`, libvpx/libaom `row-mt=1`.
- **`recode_preset`** — `None` = RecodeStage's per-codec default; `Some` overrides, passed verbatim to the encoder.
- **Audio stays single-threaded** (unchanged) — audio encoders are inherently single-threaded; the existing `set_single_thread_codec()` RAM optimization is preserved.
- Surfaces: CLI (`--recode-threads`, `--recode-preset`) and the desktop Expert panel (per-download, with an IPC range-check since `Config::validate` isn't on that path).

The two tunables flow `PostProcess` → `Config::validate` → `VideoConvertOptions` → pure `build_video_encoder_options` helper (sets the option dict at the `avcodec_open2` chokepoint) → RecodeStage; and for the desktop: TS form → IPC (`validate_recode_threads` + `validate_recode_preset`) → `rdlp-api::PostProcessOptions` → `merge_into` → `config.postprocess`.

## Design basis

Two cited research passes (industry threading models + per-encoder `thread_count` behavior) established: single video knob + audio fixed at 1 (HandBrake/Jellyfin/Tdarr norm); generic `thread_count` honored by all target encoders via the options dict; libvvenc explicit-positive requirement; `min(cores,8)` auto-default. No-magic-numbers: `MAX_RECODE_THREADS`, `AUTO_RECODE_THREADS_CAP`, `WIDE_PARALLELISM_THRESHOLD`, `VVENC_WIDE_PARAMS`, `PARALLELISM_FALLBACK` are all named consts; `MAX_RECODE_THREADS` is the single source of truth shared by CLI validation and the desktop IPC guard.

## Reviews

- **Per-task**: spec-compliance + code-quality review on each of the 9 tasks.
- **Whole-PR security review** → Approve-with-fixes: the one Medium (frontend numeric validation / NaN→null silent-drop) **fixed in `696340e`** and re-reviewed clean. Posture: no shell/process exec (in-process libavcodec FFI); resource ceiling enforced on every path; trust boundary (`validate_recode_threads`) has no bypass; preset length capped at IPC. LOW items → #397.
- **Whole-PR code review** → Approve-with-minor-fixes: same fix; cross-layer type/None-semantics coherent at all 7 seams. Minors → #397.

## Test Plan

- [x] `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test` — green
- [x] `cargo check -p rdlp-desktop`, `tsc --noEmit`, `check-dedup.sh`, `check-url-redaction.sh` — green
- [x] Unit coverage: validate boundaries (0/1/8/64/65), resolver floor+auto-cap, encoder-option matrix (threads always set, vvenc wide-params >8 only, vpx/aom row-mt, x265 none), RecodeStage preset-override + None-fallback, rdlp-api propagation, CLI flag mapping, IPC validators
- [ ] **Manual VVC end-to-end (do before merge):** `cargo run --release -p rdlp-cli -- --recode-video=mkv --video-encoder=libvvenc --recode-preset=faster "<URL>"` → confirm process CPU% ≫ 100% (multi-core) and record before/after fps vs the 1-core baseline.