### PR TITLE
fix(api,desktop): cancel during post-processing → Cancelled not Failed; show Processing status

### DIFF
--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -72,6 +72,26 @@ pub(crate) const fn request_needs_dedicated_client(net: &crate::request::Network
         || net.cookies_file.is_some()
 }
 
+/// Map a terminal download error to the event that should be emitted for it.
+///
+/// A user cancellation MUST surface as [`Event::Cancelled`] — never
+/// [`Event::Failed`] — so the UI buckets a deliberate cancel as cancelled
+/// rather than a failure. This matters most for cancels during post-processing
+/// (e.g. aborting a slow recode): the pipeline returns
+/// [`RdlpApiError::UserCancelled`] up the SAME error path as a genuine failure,
+/// so without this branch a cancelled recode lands in the "Failed" bucket.
+/// Every other error is a real failure.
+fn terminal_event(id: DownloadId, error: &RdlpApiError) -> Event {
+    if matches!(error, RdlpApiError::UserCancelled) {
+        Event::Cancelled { id }
+    } else {
+        Event::Failed {
+            id,
+            error: error.clone(),
+        }
+    }
+}
+
 /// Primary entry point for the rdlp download engine.
 ///
 /// Created via [`RdlpClient::builder()`] or [`RdlpClient::new()`].
@@ -291,14 +311,10 @@ impl RdlpClient {
                             last_err = Some(api_err);
                             continue;
                         }
-                        // Final failure — emit and return
+                        // Final failure — emit and return (cancellation
+                        // surfaces as Event::Cancelled, not Event::Failed).
                         // intentional: receiver may have disconnected
-                        let _ = tx
-                            .send(Event::Failed {
-                                id,
-                                error: api_err.clone(),
-                            })
-                            .await;
+                        let _ = tx.send(terminal_event(id, &api_err)).await;
                         return Err(api_err);
                     }
                 }
@@ -310,12 +326,7 @@ impl RdlpClient {
                 status: None,
             });
             // intentional: receiver may have disconnected
-            let _ = tx
-                .send(Event::Failed {
-                    id,
-                    error: err.clone(),
-                })
-                .await;
+            let _ = tx.send(terminal_event(id, &err)).await;
             Err(err)
         });
 
@@ -680,12 +691,8 @@ impl RdlpClient {
                 Err(e) => {
                     let err = RdlpApiError::from(e);
                     // intentional: receiver may have disconnected
-                    let _ = tx
-                        .send(Event::Failed {
-                            id,
-                            error: err.clone(),
-                        })
-                        .await;
+                    // (cancellation surfaces as Event::Cancelled, not Failed).
+                    let _ = tx.send(terminal_event(id, &err)).await;
                     Err(err)
                 }
             }
@@ -932,5 +939,67 @@ mod shared_client_tests {
         let mut req = DownloadRequest::new("https://example.com/a");
         req.network.proxy = Some("http://p:3128".into());
         assert!(client.shared_http_for(&req).is_none());
+    }
+}
+
+#[cfg(test)]
+mod terminal_event_tests {
+    use super::*;
+
+    /// A user cancellation during ANY phase (including post-processing/recode)
+    /// MUST surface as [`Event::Cancelled`], never [`Event::Failed`] — otherwise
+    /// the UI buckets a deliberate cancel as a failure. Regression guard for the
+    /// recode-cancel → "Failed" bug.
+    #[test]
+    fn user_cancelled_maps_to_cancelled_event() {
+        let id = DownloadId::next();
+        let event = terminal_event(id, &RdlpApiError::UserCancelled);
+        assert!(
+            matches!(event, Event::Cancelled { id: eid } if eid == id),
+            "UserCancelled must map to Event::Cancelled, got {event:?}",
+        );
+    }
+
+    /// Every non-cancel terminal error stays a genuine [`Event::Failed`].
+    #[test]
+    fn non_cancel_errors_map_to_failed_event() {
+        let id = DownloadId::next();
+        let cases = [
+            RdlpApiError::NetworkError {
+                message: "boom".into(),
+                status: Some(503),
+            },
+            RdlpApiError::IoError {
+                message: "disk full".into(),
+            },
+            RdlpApiError::FfmpegError {
+                message: "encoder error".into(),
+            },
+        ];
+        for err in cases {
+            let event = terminal_event(id, &err);
+            assert!(
+                matches!(event, Event::Failed { .. }),
+                "non-cancel error {err:?} must map to Event::Failed, got {event:?}",
+            );
+        }
+    }
+
+    /// The Failed event preserves the originating error verbatim (the patch must
+    /// not drop the error detail when routing through the helper).
+    #[test]
+    fn failed_event_preserves_error() {
+        let id = DownloadId::next();
+        let err = RdlpApiError::NetworkError {
+            message: "stale cdn".into(),
+            status: Some(403),
+        };
+        match terminal_event(id, &err) {
+            Event::Failed {
+                error: RdlpApiError::NetworkError { status, .. },
+                ..
+            } => assert_eq!(status, Some(403)),
+            other => panic!("expected Event::Failed(NetworkError), got {other:?}"),
+        }
     }
 }

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.test.ts
@@ -148,4 +148,33 @@ describe("registerDownloadEvents", () => {
         const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
         expect(jobs[0]!.progress).toBeCloseTo(0.47, 5);
     });
+
+    it("flips a running job to processing with its stage on postprocess-progress", async () => {
+        // Regression guard: post-processing (recode/remux) must move the job into
+        // the non-terminal `processing` bucket with a stage label. Before the fix
+        // the reducer touched only progress/eta, so the badge stayed "Downloading"
+        // (running) through the whole recode.
+        const job = makeJob({
+            id: "j1",
+            status: "running",
+            progress: 0.99,
+            speed: "5 MB/s",
+            eta: "00:01",
+        });
+        qc.setQueryData<DownloadJob[]>(queryKeys.downloads.list(), [job]);
+
+        await mockEmit("postprocess-progress", {
+            jobId: "j1",
+            stage: "Recode",
+            progress: 0.02,
+            eta: "01:30",
+        });
+
+        const jobs = qc.getQueryData<DownloadJob[]>(queryKeys.downloads.list())!;
+        expect(jobs[0]!.status).toBe("processing");
+        expect(jobs[0]!.stage).toBe("Recode");
+        expect(jobs[0]!.progress).toBeCloseTo(0.02, 5);
+        expect(jobs[0]!.eta).toBe("01:30");
+        expect(jobs[0]!.speed).toBeNull();
+    });
 });

--- a/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
+++ b/crates/rdlp-desktop/src/events/registerDownloadEvents.ts
@@ -19,7 +19,7 @@ import {
 } from "../lib/tauri";
 import { queryKeys } from "../query/queryKeys";
 import { appendLog } from "../components/LogViewer";
-import { cancelledJobPatch } from "../lib/jobStatus";
+import { cancelledJobPatch, postProcessingJobPatch } from "../lib/jobStatus";
 import type { DownloadJob } from "../types";
 
 interface ProgressEntry {
@@ -181,9 +181,7 @@ export function registerDownloadEvents(qc: QueryClient): () => void {
                         job.id === p.jobId
                             ? {
                                   ...job,
-                                  progress: p.progress,
-                                  speed: null,
-                                  eta: p.eta,
+                                  ...postProcessingJobPatch(p.stage, p.progress, p.eta),
                               }
                             : job,
                     ),

--- a/crates/rdlp-desktop/src/lib/jobStatus.test.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
     cancelledJobPatch,
+    postProcessingJobPatch,
     isTerminal,
     isDoneNotFailed,
     isInFlight,
@@ -19,6 +20,32 @@ describe("cancelledJobPatch", () => {
             speed: null,
             eta: null,
             progress: null,
+        });
+    });
+});
+
+describe("postProcessingJobPatch", () => {
+    // Regression guard: during recode/remux the job MUST flip to the
+    // "processing" bucket with its stage label — the postprocess-progress
+    // reducer previously updated only progress/eta, leaving the badge stuck on
+    // "Downloading" through the entire post-processing phase.
+    it("flips status to processing and mirrors stage/progress/eta, clearing speed", () => {
+        expect(postProcessingJobPatch("Recode", 0.42, "01:30")).toEqual({
+            status: "processing",
+            stage: "Recode",
+            progress: 0.42,
+            eta: "01:30",
+            speed: null,
+        });
+    });
+
+    it("passes through a null eta (pre-warm-up tick)", () => {
+        expect(postProcessingJobPatch("Merging", 0, null)).toEqual({
+            status: "processing",
+            stage: "Merging",
+            progress: 0,
+            eta: null,
+            speed: null,
         });
     });
 });

--- a/crates/rdlp-desktop/src/lib/jobStatus.ts
+++ b/crates/rdlp-desktop/src/lib/jobStatus.ts
@@ -22,6 +22,31 @@ export function cancelledJobPatch(): Partial<DownloadJob> {
     };
 }
 
+/**
+ * The field patch applied on each post-processing progress tick: flips the job
+ * into the non-terminal `processing` state and mirrors the live stage/progress/
+ * eta. `speed` is cleared — post-processing has no transfer rate.
+ *
+ * Live-push mirror of the Rust-owned status (Rust's event loop sets
+ * `JobStatus::Processing` via `begin_postprocessing`); without this flip the
+ * `postprocess-progress` reducer left `status` at the download-phase `running`,
+ * so the badge stayed "Downloading" through the entire recode/remux. Spread over
+ * the existing job: `{ ...job, ...postProcessingJobPatch(stage, progress, eta) }`.
+ */
+export function postProcessingJobPatch(
+    stage: string,
+    progress: number,
+    eta: string | null,
+): Partial<DownloadJob> {
+    return {
+        status: "processing",
+        stage,
+        progress,
+        eta,
+        speed: null,
+    };
+}
+
 /** The per-job sub-label, derived during render from canonical fields. Null = no sub-label. */
 export function jobSubLabel(job: DownloadJob): string | null {
     if (job.status === "processing") {


### PR DESCRIPTION
## Summary
Two cancel/post-process status-correctness bugs, found by cancelling a live VVC recode in the desktop app (the recode aborted and temp files cleaned up correctly — only the *status* was wrong):

1. **Backend (`rdlp-api`): cancel during post-processing surfaced as `Failed`, not `Cancelled`.** The download/post-processing error arms blanket-mapped every `RdlpApiError` to `Event::Failed`, including `RdlpApiError::UserCancelled` — so a cancelled recode landed in the **Failed** bucket ("Download cancelled — retry may not help"). Added `terminal_event(id, &RdlpApiError)` routing `UserCancelled → Event::Cancelled` (every other error stays `Failed`), wired into the 3 generic terminal-error emit sites in `client/mod.rs`.

2. **Desktop (`rdlp-desktop`): job stayed "Downloading" through the whole recode.** The `postprocess-progress` reducer updated only `progress`/`eta`, never `status` — so the badge never reached the **Processing** bucket that PR #369 added (Rust's event loop already sets `JobStatus::Processing`; the frontend just never mirrored it). Added `postProcessingJobPatch()` (mirroring `cancelledJobPatch`) and applied it in the reducer as the live-push mirror.

## Tests (TDD, failing-first verified)
- `terminal_event`: `UserCancelled→Cancelled`, non-cancel errors→`Failed`, error preserved.
- `postProcessingJobPatch`: status/stage/progress/eta mirror, speed cleared, null-eta tick.
- `registerDownloadEvents` integration: `postprocess-progress` flips `running→processing`+stage (verified failing against the unpatched reducer).

## Verification
`cargo fmt --check` ✅ · `cargo clippy -p rdlp-api -p rdlp-desktop --all-targets -D warnings` ✅ · `cargo test -p rdlp-api` ✅ (408) · frontend `vitest` ✅ (291) + `tsc --noEmit` ✅ · `check-dedup.sh` ✅ · `check-url-redaction.sh` ✅

## Reviews
Pre-push `security-reviewer` + `code-reviewer` over the full diff — both **Approve**, no blocking/HIGH findings (match precision confirmed; two unchanged inline-`IoError` sites verified unreachable by cancel; `stage` renders plain-text, no XSS).