### PR TITLE
feat: encoder-aware recode speed-control panel (preset / deadline+cpu-used / speed_level) + CLI parity

### DIFF
--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -148,6 +148,15 @@ impl MergeOverrides for PostProcessOptions {
         if let Some(ref v) = self.recode_preset {
             config.postprocess.recode_preset = Some(v.clone());
         }
+        if let Some(v) = self.recode_deadline {
+            config.postprocess.recode_deadline = Some(v);
+        }
+        if let Some(v) = self.recode_cpu_used {
+            config.postprocess.recode_cpu_used = Some(v);
+        }
+        if let Some(v) = self.recode_speed_level {
+            config.postprocess.recode_speed_level = Some(v);
+        }
     }
 }
 

--- a/crates/rdlp-api/src/merge/tests_postprocess_network.rs
+++ b/crates/rdlp-api/src/merge/tests_postprocess_network.rs
@@ -614,6 +614,39 @@ fn test_postprocess_recode_threads_and_preset_propagate() {
 }
 
 #[test]
+fn test_postprocess_speed_controls_propagate() {
+    let mut config = Config::default();
+    let opts = PostProcessOptions {
+        recode_deadline: Some(rdlp_types::VpxDeadline::Good),
+        recode_cpu_used: Some(-4),
+        recode_speed_level: Some(3),
+        ..PostProcessOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert_eq!(
+        config.postprocess.recode_deadline,
+        Some(rdlp_types::VpxDeadline::Good)
+    );
+    assert_eq!(config.postprocess.recode_cpu_used, Some(-4));
+    assert_eq!(config.postprocess.recode_speed_level, Some(3));
+}
+
+#[test]
+fn test_postprocess_speed_controls_none_preserves_base() {
+    let mut config = Config::default();
+    config.postprocess.recode_deadline = Some(rdlp_types::VpxDeadline::Best);
+    config.postprocess.recode_cpu_used = Some(2);
+    config.postprocess.recode_speed_level = Some(5);
+    PostProcessOptions::default().merge_into(&mut config);
+    assert_eq!(
+        config.postprocess.recode_deadline,
+        Some(rdlp_types::VpxDeadline::Best)
+    );
+    assert_eq!(config.postprocess.recode_cpu_used, Some(2));
+    assert_eq!(config.postprocess.recode_speed_level, Some(5));
+}
+
+#[test]
 fn test_postprocess_recode_threads_none_preserves_base() {
     let mut config = Config::default();
     config.postprocess.recode_threads = Some(4);

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -217,6 +217,12 @@ pub struct PostProcessOptions {
     pub recode_threads: Option<u32>,
     /// Encoder preset override for video recode. `None` = per-codec default.
     pub recode_preset: Option<String>,
+    /// VPX/VP9 deadline (quality–speed tradeoff). `None` preserves base config.
+    pub recode_deadline: Option<rdlp_types::VpxDeadline>,
+    /// VPX/VP9 cpu-used (-8..=8 for VP9). `None` preserves base config.
+    pub recode_cpu_used: Option<i32>,
+    /// Generic speed-level for encoders that expose it (e.g. SVT-AV1 preset). `None` preserves base config.
+    pub recode_speed_level: Option<u32>,
 }
 
 /// Network, retry, and cookie options.

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -220,6 +220,18 @@ pub struct Args {
     #[arg(long, value_name = "PRESET")]
     pub recode_preset: Option<String>,
 
+    /// libvpx deadline for VP8/VP9 recode: best | good | realtime.
+    #[arg(long, value_name = "MODE")]
+    pub recode_deadline: Option<String>,
+
+    /// libvpx cpu-used for VP8/VP9 recode (VP9: -8..8, VP8: -16..16).
+    #[arg(long, value_name = "N", allow_hyphen_values = true)]
+    pub recode_cpu_used: Option<i32>,
+
+    /// libxavs2 `speed_level` for AVS2 recode (0..9).
+    #[arg(long, value_name = "N")]
+    pub recode_speed_level: Option<u32>,
+
     /// Remux to container for better seeking - no re-encoding
     /// Use --remux for interactive, --remux=mp4 for direct
     #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -381,7 +381,10 @@ pub fn merge_config(
             config.postprocess.recode_container.map(|c| c.as_ext()),
         ),
         config.postprocess.recode_preset.as_deref(),
-        config.postprocess.recode_deadline.map(rdlp_types::VpxDeadline::as_str),
+        config
+            .postprocess
+            .recode_deadline
+            .map(rdlp_types::VpxDeadline::as_str),
         config.postprocess.recode_cpu_used,
         config.postprocess.recode_speed_level,
     )

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -218,6 +218,15 @@ pub fn merge_config(
     if let Some(ref preset) = args.recode_preset {
         config.postprocess.recode_preset = Some(preset.clone());
     }
+    if let Some(ref deadline) = args.recode_deadline {
+        config.postprocess.recode_deadline = Some(
+            deadline
+                .parse::<rdlp_types::VpxDeadline>()
+                .map_err(|e| anyhow::anyhow!("invalid --recode-deadline: {e}"))?,
+        );
+    }
+    config.postprocess.recode_cpu_used = args.recode_cpu_used;
+    config.postprocess.recode_speed_level = args.recode_speed_level;
 
     // recode_audio: "copy", "auto", or an encoder name
     match args.recode_audio.as_str() {
@@ -363,6 +372,20 @@ pub fn merge_config(
     if config.postprocess.extract_audio && config.postprocess.audio_format.is_none() {
         config.postprocess.audio_format = Some(AudioFormat::Mp3);
     }
+
+    // Validate recode speed controls against the resolved encoder
+    rdlp_ffmpeg::validate_speed_controls(
+        rdlp_ffmpeg::resolve_recode_encoder(
+            config.postprocess.video_encoder.as_deref(),
+            config.postprocess.recode_video.map(|c| c.as_ext()),
+            config.postprocess.recode_container.map(|c| c.as_ext()),
+        ),
+        config.postprocess.recode_preset.as_deref(),
+        config.postprocess.recode_deadline.map(rdlp_types::VpxDeadline::as_str),
+        config.postprocess.recode_cpu_used,
+        config.postprocess.recode_speed_level,
+    )
+    .map_err(|e| anyhow::anyhow!("invalid recode speed control: {e}"))?;
 
     // Validate final config
     config

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -72,6 +72,9 @@ fn default_args() -> Args {
         recode_audio: "copy".to_string(),
         recode_threads: None,
         recode_preset: None,
+        recode_deadline: None,
+        recode_cpu_used: None,
+        recode_speed_level: None,
         fixup: "detect_or_warn".to_string(),
         match_filter: vec![],
         browser: None,
@@ -748,4 +751,49 @@ fn recode_threads_and_preset_flags_map_to_config() {
     let config = build_config(&args).expect("config builds");
     assert_eq!(config.postprocess.recode_threads, Some(6));
     assert_eq!(config.postprocess.recode_preset.as_deref(), Some("faster"));
+}
+
+#[test]
+fn speed_control_flags_map_to_config() {
+    use clap::Parser;
+    // VP9 supports deadline + cpu_used; speed_level is for libxavs2 only.
+    // Test that all three fields round-trip through config correctly by
+    // using a valid per-encoder combination: VP9 with deadline + cpu_used,
+    // then verify speed_level maps when set independently without an encoder.
+    let args = Args::try_parse_from([
+        "rdlp",
+        "--recode-video=webm",
+        "--video-encoder=libvpx-vp9",
+        "--recode-deadline=good",
+        "--recode-cpu-used=-4",
+        "https://example.com/v",
+    ])
+    .expect("args parse");
+    let config = build_config(&args).expect("config builds");
+    assert_eq!(
+        config.postprocess.recode_deadline,
+        Some(rdlp_types::VpxDeadline::Good)
+    );
+    assert_eq!(config.postprocess.recode_cpu_used, Some(-4));
+
+    // speed_level field mapping: verify it reaches config when no encoder
+    // is resolved (validator is a no-op when encoder is None).
+    let mut args2 = default_args();
+    args2.recode_speed_level = Some(3);
+    let config2 = merge_config(&args2, rdlp_api::Config::default(), no_interactive())
+        .expect("config2 builds");
+    assert_eq!(config2.postprocess.recode_speed_level, Some(3));
+}
+
+#[test]
+fn negative_cpu_used_parses_both_forms() {
+    use clap::Parser;
+    assert_eq!(
+        Args::parse_from(["rdlp", "--recode-cpu-used=-8", "URL"]).recode_cpu_used,
+        Some(-8)
+    );
+    assert_eq!(
+        Args::parse_from(["rdlp", "--recode-cpu-used", "-8", "URL"]).recode_cpu_used,
+        Some(-8)
+    );
 }

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -105,7 +105,8 @@ pub struct DownloadOptions {
     /// `VPx` deadline mode (`good`, `best`, `realtime`). `None` = encoder default.
     #[serde(default)]
     pub recode_deadline: Option<rdlp_types::VpxDeadline>,
-    /// `VPx` / AV1 cpu-used knob (-16..=16 depending on encoder). `None` = encoder default.
+    /// libvpx `-cpu-used` for VP8/VP9 recode. `None` = encoder default.
+    /// Range is encoder-specific (validated by `validate_speed_controls`).
     #[serde(default)]
     pub recode_cpu_used: Option<i32>,
     /// HEVC / VVC speed-level knob (encoder-specific range). `None` = encoder default.
@@ -603,6 +604,22 @@ mod tests {
         // deadline on an H.264 encoder must be rejected by the boundary validator.
         let err =
             rdlp_ffmpeg::validate_speed_controls(Some("libx264"), None, Some("good"), None, None);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_cpu_used() {
+        // VP9 cpu-used range is -8..=8; 16 must be rejected at the boundary.
+        let err =
+            rdlp_ffmpeg::validate_speed_controls(Some("libvpx-vp9"), None, None, Some(16), None);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_speed_level() {
+        // xavs2 speed_level range is 0..=9; 10 must be rejected at the boundary.
+        let err =
+            rdlp_ffmpeg::validate_speed_controls(Some("libxavs2"), None, None, None, Some(10));
         assert!(err.is_err());
     }
 

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -102,6 +102,15 @@ pub struct DownloadOptions {
     /// Encoder preset override for video recode. `None` = per-codec default.
     #[serde(default)]
     pub recode_preset: Option<String>,
+    /// `VPx` deadline mode (`good`, `best`, `realtime`). `None` = encoder default.
+    #[serde(default)]
+    pub recode_deadline: Option<rdlp_types::VpxDeadline>,
+    /// `VPx` / AV1 cpu-used knob (-16..=16 depending on encoder). `None` = encoder default.
+    #[serde(default)]
+    pub recode_cpu_used: Option<i32>,
+    /// HEVC / VVC speed-level knob (encoder-specific range). `None` = encoder default.
+    #[serde(default)]
+    pub recode_speed_level: Option<u32>,
     /// Enable verbose `FFmpeg` log capture for this download.
     /// `None` = use settings default.
     #[serde(default)]
@@ -226,6 +235,21 @@ pub async fn start_download(
     // called on the desktop path, so this guard is the only enforcement point).
     validate_recode_threads(options.recode_threads)?;
     validate_recode_preset(options.recode_preset.as_deref())?;
+    rdlp_ffmpeg::validate_speed_controls(
+        rdlp_ffmpeg::resolve_recode_encoder(
+            options.video_encoder.as_deref(),
+            options.recode_video.map(|c| c.as_ext()),
+            options.recode_container.map(|c| c.as_ext()),
+        ),
+        options.recode_preset.as_deref(),
+        options.recode_deadline.map(rdlp_types::VpxDeadline::as_str),
+        options.recode_cpu_used,
+        options.recode_speed_level,
+    )
+    .map_err(|e| AppError::InvalidInput {
+        field: "recode_speed_control".to_owned(),
+        message: e.to_string(),
+    })?;
 
     // Save a serializable snapshot of the options for retry (before any partial moves).
     let saved_options = serde_json::to_value(&options)
@@ -312,6 +336,9 @@ pub async fn start_download(
             recode_audio: options.recode_audio,
             recode_threads: options.recode_threads,
             recode_preset: options.recode_preset,
+            recode_deadline: options.recode_deadline,
+            recode_cpu_used: options.recode_cpu_used,
+            recode_speed_level: options.recode_speed_level,
             embed_thumbnail: Some(options.embed_thumbnail),
             embed_metadata: Some(settings.embed_metadata),
             write_thumbnail: write_thumbnail_resolved.then_some(true),
@@ -545,6 +572,9 @@ mod tests {
             recode_audio: None,
             recode_threads: None,
             recode_preset: None,
+            recode_deadline: None,
+            recode_cpu_used: None,
+            recode_speed_level: None,
             verbose: None,
         }
     }
@@ -566,6 +596,14 @@ mod tests {
         assert!(validate_recode_preset(Some(&"x".repeat(65))).is_err());
         assert!(validate_recode_preset(Some("faster")).is_ok());
         assert!(validate_recode_preset(None).is_ok());
+    }
+
+    #[test]
+    fn rejects_inapplicable_speed_control() {
+        // deadline on an H.264 encoder must be rejected by the boundary validator.
+        let err =
+            rdlp_ffmpeg::validate_speed_controls(Some("libx264"), None, Some("good"), None, None);
+        assert!(err.is_err());
     }
 
     // ------------------------------------------------------------------ //

--- a/crates/rdlp-desktop/src/test/select-mock.tsx
+++ b/crates/rdlp-desktop/src/test/select-mock.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 interface SelectCtx {
     value: string;
     onValueChange?: ((v: string) => void) | undefined;
+    // React Aria (Jolly UI) Select uses selectedKey/onSelectionChange instead of value/onValueChange.
+    onSelectionChange?: ((key: string) => void) | undefined;
     open: boolean;
     setOpen: (o: boolean) => void;
     disabled?: boolean | undefined;
-    items: Map<string, string>; // value → label text
+    items: Map<string, string>; // value/id → label text
 }
 
 const Ctx = React.createContext<SelectCtx | null>(null);
@@ -39,18 +41,25 @@ function useCtx() {
 function Select({
     value,
     onValueChange,
+    // React Aria (Jolly UI) props — used by KnobRow and other desktop components
+    selectedKey,
+    onSelectionChange,
     disabled,
     children,
 }: {
     value?: string;
     onValueChange?: (v: string) => void;
+    selectedKey?: string;
+    onSelectionChange?: (key: string) => void;
     disabled?: boolean;
     children: React.ReactNode;
 }) {
     const [open, setOpen] = React.useState(false);
     const [items] = React.useState(() => new Map<string, string>());
+    // Support both shadcn (value/onValueChange) and React Aria (selectedKey/onSelectionChange) APIs.
+    const resolvedValue = selectedKey ?? value ?? "";
     return (
-        <Ctx.Provider value={{ value: value ?? "", onValueChange, open, setOpen, disabled, items }}>
+        <Ctx.Provider value={{ value: resolvedValue, onValueChange, onSelectionChange, open, setOpen, disabled, items }}>
             <div data-slot="select">{children}</div>
         </Ctx.Provider>
     );
@@ -110,24 +119,33 @@ function SelectContent({ children }: { children: React.ReactNode }) {
 
 function SelectItem({
     value,
+    // React Aria (Jolly UI) uses `id` as the item key, not `value`.
+    id,
     children,
+    textValue: _textValue,
     ...rest
 }: {
-    value: string;
+    value?: string;
+    id?: string;
     children: React.ReactNode;
+    textValue?: string;
 } & React.HTMLAttributes<HTMLDivElement>) {
     const ctx = useCtx();
+    // The item's key is `id` (React Aria) or `value` (shadcn); fall back to the other.
+    const key = id ?? value ?? "";
     // Register label text synchronously so SelectValue can display it
     // in the same render pass (useEffect would be too late).
     const label = typeof children === "string" ? children : "";
-    ctx.items.set(value, label);
+    ctx.items.set(key, label);
 
     return (
         <div
             role="option"
-            aria-selected={ctx.value === value}
+            aria-selected={ctx.value === key}
             onClick={() => {
-                ctx.onValueChange?.(value);
+                // Fire whichever callback the parent wired up.
+                ctx.onSelectionChange?.(key);
+                ctx.onValueChange?.(key);
                 ctx.setOpen(false);
             }}
             {...rest}

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -142,10 +142,26 @@ export interface PlaylistContext {
 
 // ========== Video Codec Types (camelCase — Rust uses #[serde(rename_all = "camelCase")]) ==========
 
+/**
+ * Which encoder-specific parameter a SpeedKnob controls.
+ * Mirrors Rust `KnobField` (camelCase serde).
+ */
+export type KnobField = "preset" | "deadline" | "cpuUsed" | "speedLevel";
+
+/**
+ * A single speed-control knob for a video encoder.
+ * Mirrors Rust `SpeedKnob` with #[serde(tag = "kind")]:
+ *   { kind: "choice", field, label, choices, default } | { kind: "int", field, label, min, max, default }
+ */
+export type SpeedKnob =
+    | { kind: "choice"; field: KnobField; label: string; choices: string[]; default: string }
+    | { kind: "int"; field: KnobField; label: string; min: number; max: number; default: number };
+
 /** Info about a single video encoder available in the linked FFmpeg build. */
 export interface VideoEncoderInfo {
     encoderName: string;
     displayName: string;
+    speedControls: SpeedKnob[];
 }
 
 /** Info about a video codec with its available encoders. */
@@ -305,6 +321,9 @@ export interface DownloadOptions {
     recodeContainer: string | null;
     recodeThreads: number | null;
     recodePreset: string | null;
+    recodeDeadline: string | null;
+    recodeCpuUsed: number | null;
+    recodeSpeedLevel: number | null;
     verbose: boolean | null;
 }
 

--- a/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
@@ -61,6 +61,13 @@ const downloadConfigSchema = z.object({
             { message: "Enter 1–64 or leave blank for auto" },
         ),
     recodePreset: z.string(),
+    recodeDeadline: z.string(), // "" | "best" | "good" | "realtime"
+    recodeCpuUsed: z
+        .string()
+        .refine((v) => v === "" || /^-?\d+$/.test(v), { message: "Enter an integer or leave blank" }),
+    recodeSpeedLevel: z
+        .string()
+        .refine((v) => v === "" || /^\d+$/.test(v), { message: "Enter 0–9 or leave blank" }),
     extractAudio: z.string(),
     embedThumbnail: z.boolean(),
     embedSubtitles: z.boolean(),
@@ -93,6 +100,9 @@ export function DownloadConfig() {
             recodeAudioMode: "copy",
             recodeThreads: "",
             recodePreset: "",
+            recodeDeadline: "",
+            recodeCpuUsed: "",
+            recodeSpeedLevel: "",
             extractAudio: "",
             embedThumbnail: settings?.embed_thumbnail ?? true,
             embedSubtitles: settings?.embed_subtitles ?? false,
@@ -135,6 +145,9 @@ export function DownloadConfig() {
                         : null,
                     recodeThreads: value.recodeThreads ? Number(value.recodeThreads) : null,
                     recodePreset: value.recodePreset || null,
+                    recodeDeadline: null,
+                    recodeCpuUsed: null,
+                    recodeSpeedLevel: null,
                     normalizeAudio: value.normalizeAudio || null,
                     loudnorm: null,
                     loudnormPreset: null,

--- a/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
@@ -26,16 +26,17 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { DownloadOptions } from "@/types";
+import type { DownloadOptions, KnobField } from "@/types";
 import { KnobRow } from "./KnobRow";
 
 // Maps SpeedKnob field names to TanStack Form field names.
-const FIELD_BY_KNOB = {
+// Typed as Record<KnobField, ...> so adding/removing a KnobField variant is a compile error.
+const FIELD_BY_KNOB: Record<KnobField, "recodePreset" | "recodeDeadline" | "recodeCpuUsed" | "recodeSpeedLevel"> = {
     preset: "recodePreset",
     deadline: "recodeDeadline",
     cpuUsed: "recodeCpuUsed",
     speedLevel: "recodeSpeedLevel",
-} as const;
+};
 
 const NONE_SENTINEL = "none";
 

--- a/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/DownloadConfig.tsx
@@ -27,6 +27,15 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type { DownloadOptions } from "@/types";
+import { KnobRow } from "./KnobRow";
+
+// Maps SpeedKnob field names to TanStack Form field names.
+const FIELD_BY_KNOB = {
+    preset: "recodePreset",
+    deadline: "recodeDeadline",
+    cpuUsed: "recodeCpuUsed",
+    speedLevel: "recodeSpeedLevel",
+} as const;
 
 const NONE_SENTINEL = "none";
 
@@ -145,9 +154,9 @@ export function DownloadConfig() {
                         : null,
                     recodeThreads: value.recodeThreads ? Number(value.recodeThreads) : null,
                     recodePreset: value.recodePreset || null,
-                    recodeDeadline: null,
-                    recodeCpuUsed: null,
-                    recodeSpeedLevel: null,
+                    recodeDeadline: value.recodeDeadline || null,
+                    recodeCpuUsed: value.recodeCpuUsed === "" ? null : Number(value.recodeCpuUsed),
+                    recodeSpeedLevel: value.recodeSpeedLevel === "" ? null : Number(value.recodeSpeedLevel),
                     normalizeAudio: value.normalizeAudio || null,
                     loudnorm: null,
                     loudnormPreset: null,
@@ -190,6 +199,16 @@ export function DownloadConfig() {
     const { data: audioCodecs = [] } = useQuery(
         audioCodecsQueryOptions(resolvedContainer || null, recodeActive && !!resolvedContainer),
     );
+
+    // Derive speed-control knobs for the selected encoder (expert mode only).
+    // Must come after videoCodecs is declared.
+    const selectedEncoderKnobs =
+        (expertMode &&
+            videoCodecs
+                .flatMap((c) => c.encoders)
+                .find((e) => e.encoderName === recodeCodec)
+                ?.speedControls) ||
+        [];
 
     if (!formatData || !analyzeUrl) return null;
 
@@ -379,6 +398,12 @@ export function DownloadConfig() {
                                     onSelectionChange={(key) => {
                                         const val = key === NONE_SENTINEL ? "" : String(key);
                                         field.handleChange(val);
+                                        // Reset all knob fields whenever the encoder changes —
+                                        // prior values may be invalid for the new encoder.
+                                        form.setFieldValue("recodePreset", "");
+                                        form.setFieldValue("recodeDeadline", "");
+                                        form.setFieldValue("recodeCpuUsed", "");
+                                        form.setFieldValue("recodeSpeedLevel", "");
                                         if (!val) {
                                             form.setFieldValue("videoEncoder", "");
                                             form.setFieldValue("recodeContainerOverride", "");
@@ -500,24 +525,21 @@ export function DownloadConfig() {
                         </form.Field>
                     )}
 
-                    {/* Recode preset (visible when recode active, expert mode) */}
-                    {recodeActive && expertMode && (
-                        <form.Field name="recodePreset">
-                            {(field) => (
-                                <div className="flex items-center justify-between pl-3">
-                                    <span className="text-[10px] text-[var(--text-muted)]">Preset</span>
-                                    <Input
-                                        type="text"
+                    {/* Encoder speed-control knobs (descriptor-driven, expert mode only) */}
+                    {recodeActive &&
+                        expertMode &&
+                        selectedEncoderKnobs.map((knob) => (
+                            <form.Field key={knob.field} name={FIELD_BY_KNOB[knob.field]}>
+                                {(field) => (
+                                    <KnobRow
+                                        knob={knob}
                                         value={field.state.value}
+                                        onChange={field.handleChange}
                                         onBlur={field.handleBlur}
-                                        onChange={(e) => field.handleChange(e.target.value)}
-                                        placeholder="default"
-                                        className="h-5 w-[90px] px-1.5 py-0 rounded-[3px] bg-[var(--surface-elevated)] border border-[#2a2a3e] text-[10px] text-[var(--text-muted)] placeholder:text-[var(--text-muted)] outline-none focus:border-[#4a9eff]"
                                     />
-                                </div>
-                            )}
-                        </form.Field>
-                    )}
+                                )}
+                            </form.Field>
+                        ))}
 
                     {/* Extract Audio */}
                     <form.Field name="extractAudio">

--- a/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/EpisodeList.tsx
@@ -118,6 +118,9 @@ export function EpisodeList({ episodes, playlistUrl, playlistTitle }: EpisodeLis
             recodeContainer: null,
             recodeThreads: null,
             recodePreset: null,
+            recodeDeadline: null,
+            recodeCpuUsed: null,
+            recodeSpeedLevel: null,
             verbose: null,
         };
 

--- a/crates/rdlp-desktop/src/views/analyze/KnobRow.test.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/KnobRow.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { KnobRow } from "./KnobRow";
+import type { SpeedKnob } from "@/types";
+
+describe("KnobRow", () => {
+    it("renders a Choice knob label", () => {
+        const knob: SpeedKnob = {
+            kind: "choice",
+            field: "preset",
+            label: "Preset",
+            choices: ["faster", "medium"],
+            default: "medium",
+        };
+        render(<KnobRow knob={knob} value="" onChange={vi.fn()} onBlur={vi.fn()} />);
+        expect(screen.getByText("Preset")).toBeInTheDocument();
+    });
+
+    it("renders an Int knob as a bounded number input", () => {
+        const knob: SpeedKnob = {
+            kind: "int",
+            field: "cpuUsed",
+            label: "CPU used",
+            min: -8,
+            max: 8,
+            default: 1,
+        };
+        render(<KnobRow knob={knob} value="" onChange={vi.fn()} onBlur={vi.fn()} />);
+        const input = screen.getByPlaceholderText("1") as HTMLInputElement;
+        expect(input.min).toBe("-8");
+        expect(input.max).toBe("8");
+    });
+
+    it("renders an Int knob label", () => {
+        const knob: SpeedKnob = {
+            kind: "int",
+            field: "cpuUsed",
+            label: "CPU used",
+            min: -8,
+            max: 8,
+            default: 1,
+        };
+        render(<KnobRow knob={knob} value="" onChange={vi.fn()} onBlur={vi.fn()} />);
+        expect(screen.getByText("CPU used")).toBeInTheDocument();
+    });
+
+    it("passes value to the Int knob input", () => {
+        const knob: SpeedKnob = {
+            kind: "int",
+            field: "speedLevel",
+            label: "Speed Level",
+            min: 0,
+            max: 9,
+            default: 4,
+        };
+        render(<KnobRow knob={knob} value="3" onChange={vi.fn()} onBlur={vi.fn()} />);
+        const input = screen.getByDisplayValue("3") as HTMLInputElement;
+        expect(input).toBeInTheDocument();
+    });
+});

--- a/crates/rdlp-desktop/src/views/analyze/KnobRow.test.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/KnobRow.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { KnobRow } from "./KnobRow";
 import type { SpeedKnob } from "@/types";
@@ -56,5 +57,57 @@ describe("KnobRow", () => {
         render(<KnobRow knob={knob} value="3" onChange={vi.fn()} onBlur={vi.fn()} />);
         const input = screen.getByDisplayValue("3") as HTMLInputElement;
         expect(input).toBeInTheDocument();
+    });
+
+    it("renders all choice options including the Default sentinel", () => {
+        const knob: SpeedKnob = {
+            kind: "choice",
+            field: "preset",
+            label: "Preset",
+            choices: ["faster", "medium", "slower"],
+            default: "medium",
+        };
+        render(<KnobRow knob={knob} value="" onChange={vi.fn()} onBlur={vi.fn()} />);
+        // Open the select to make options visible
+        fireEvent.pointerDown(screen.getByRole("combobox"));
+        expect(screen.getByText("Default (medium)")).toBeInTheDocument();
+        expect(screen.getByText("faster")).toBeInTheDocument();
+        expect(screen.getByText("medium")).toBeInTheDocument();
+        expect(screen.getByText("slower")).toBeInTheDocument();
+    });
+
+    it("calls onChange with the chosen value when a choice option is selected", () => {
+        const knob: SpeedKnob = {
+            kind: "choice",
+            field: "preset",
+            label: "Preset",
+            choices: ["faster", "medium", "slower"],
+            default: "medium",
+        };
+        const onChange = vi.fn();
+        render(<KnobRow knob={knob} value="" onChange={onChange} onBlur={vi.fn()} />);
+        // Open the select
+        fireEvent.pointerDown(screen.getByRole("combobox"));
+        // Click the "faster" option
+        fireEvent.click(screen.getByRole("option", { name: "faster" }));
+        expect(onChange).toHaveBeenCalledWith("faster");
+    });
+
+    it("calls onChange with empty string when the Default sentinel is selected", () => {
+        const knob: SpeedKnob = {
+            kind: "choice",
+            field: "preset",
+            label: "Preset",
+            choices: ["faster", "medium"],
+            default: "medium",
+        };
+        const onChange = vi.fn();
+        render(<KnobRow knob={knob} value="faster" onChange={onChange} onBlur={vi.fn()} />);
+        // Open the select
+        fireEvent.pointerDown(screen.getByRole("combobox"));
+        // Click the Default sentinel
+        fireEvent.click(screen.getByText("Default (medium)"));
+        // NONE_SENTINEL → converted back to ""
+        expect(onChange).toHaveBeenCalledWith("");
     });
 });

--- a/crates/rdlp-desktop/src/views/analyze/KnobRow.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/KnobRow.tsx
@@ -66,6 +66,7 @@ export function KnobRow({
                     onBlur={onBlur}
                     onChange={(e) => onChange(e.target.value)}
                     placeholder={String(knob.default)}
+                    aria-label={knob.label}
                     className="h-5 w-[90px] px-1.5 py-0 rounded-[3px] bg-[var(--surface-elevated)] border border-[#2a2a3e] text-[10px] text-[var(--text-muted)] placeholder:text-[var(--text-muted)] outline-none focus:border-[#4a9eff]"
                 />
             )}

--- a/crates/rdlp-desktop/src/views/analyze/KnobRow.tsx
+++ b/crates/rdlp-desktop/src/views/analyze/KnobRow.tsx
@@ -1,0 +1,74 @@
+// KnobRow: pure presentational component that renders one speed-control knob.
+// A "choice" knob renders a Select; an "int" knob renders a bounded number input.
+// Bound to caller-managed form state via value/onChange/onBlur.
+
+import type { SpeedKnob } from "@/types";
+import {
+    Select,
+    SelectItem,
+    SelectListBox,
+    SelectPopover,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+
+const NONE_SENTINEL = "none";
+
+/** One descriptor knob, bound to a string value + change/blur handlers by the caller. */
+export function KnobRow({
+    knob,
+    value,
+    onChange,
+    onBlur,
+}: {
+    knob: SpeedKnob;
+    value: string;
+    onChange: (v: string) => void;
+    onBlur: () => void;
+}) {
+    return (
+        <div className="flex items-center justify-between pl-3">
+            <span className="text-[10px] text-[var(--text-muted)]">{knob.label}</span>
+            {knob.kind === "choice" ? (
+                <Select
+                    selectedKey={value || NONE_SENTINEL}
+                    onSelectionChange={(key) =>
+                        onChange(key === NONE_SENTINEL ? "" : String(key))
+                    }
+                    aria-label={knob.label}
+                >
+                    <SelectTrigger className="h-5 min-h-0 px-1.5 py-0 text-[10px] bg-[var(--surface-elevated)] border-[#2a2a3e] rounded-[3px] text-[var(--text-muted)] w-[90px]">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectPopover>
+                        <SelectListBox>
+                            <SelectItem
+                                id={NONE_SENTINEL}
+                                textValue={`Default (${knob.default})`}
+                            >
+                                Default ({knob.default})
+                            </SelectItem>
+                            {knob.choices.map((c) => (
+                                <SelectItem key={c} id={c} textValue={c}>
+                                    {c}
+                                </SelectItem>
+                            ))}
+                        </SelectListBox>
+                    </SelectPopover>
+                </Select>
+            ) : (
+                <Input
+                    type="number"
+                    min={knob.min}
+                    max={knob.max}
+                    value={value}
+                    onBlur={onBlur}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder={String(knob.default)}
+                    className="h-5 w-[90px] px-1.5 py-0 rounded-[3px] bg-[var(--surface-elevated)] border border-[#2a2a3e] text-[10px] text-[var(--text-muted)] placeholder:text-[var(--text-muted)] outline-none focus:border-[#4a9eff]"
+                />
+            )}
+        </div>
+    );
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -56,8 +56,10 @@ mod options;
 mod probe;
 mod remux;
 pub(crate) mod salvage;
+pub mod speed_controls;
 mod thumbnail;
 mod transcode;
+pub use speed_controls::{SpeedControlError, resolve_recode_encoder, validate_speed_controls};
 pub mod video_codecs;
 
 use std::path::Path;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -59,7 +59,9 @@ pub(crate) mod salvage;
 pub mod speed_controls;
 mod thumbnail;
 mod transcode;
-pub use speed_controls::{SpeedControlError, resolve_recode_encoder, validate_speed_controls};
+pub use speed_controls::{
+    SpeedControlError, default_codec_for_container, resolve_recode_encoder, validate_speed_controls,
+};
 pub mod video_codecs;
 
 use std::path::Path;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -48,6 +48,12 @@ pub struct VideoConvertOptions {
     /// Resolved encoder thread count. `None` = let the encode layer resolve it
     /// from `available_parallelism()`. Audio encoding is unaffected.
     pub threads: Option<u32>,
+    /// libvpx `-deadline` value (already a name string, e.g. "good").
+    pub deadline: Option<String>,
+    /// libvpx `-cpu-used`.
+    pub cpu_used: Option<i32>,
+    /// libxavs2 `-speed_level`.
+    pub speed_level: Option<u32>,
     /// If true, copy audio stream without re-encoding.
     ///
     /// Takes precedence over `audio_codec`. When `audio_copy` is true and

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -48,11 +48,13 @@ pub struct VideoConvertOptions {
     /// Resolved encoder thread count. `None` = let the encode layer resolve it
     /// from `available_parallelism()`. Audio encoding is unaffected.
     pub threads: Option<u32>,
-    /// libvpx `-deadline` value (already a name string, e.g. "good").
+    /// libvpx `-deadline` value, already lowered to its name string (e.g. `"good"`)
+    /// from the typed `VpxDeadline` at the `RecodeStage` boundary.
+    /// Validated upstream by `validate_speed_controls`.
     pub deadline: Option<String>,
     /// libvpx `-cpu-used`.
     pub cpu_used: Option<i32>,
-    /// libxavs2 `-speed_level`.
+    /// libxavs2 `-speed_level` (0..=9). `None` = encoder default (0).
     pub speed_level: Option<u32>,
     /// If true, copy audio stream without re-encoding.
     ///

--- a/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
@@ -7,9 +7,14 @@ use thiserror::Error;
 
 use super::video_codecs::{KnobField, KnobKindDef, resolve_encoder, speed_controls_def};
 
-/// Container-name -> default codec, mirroring `RecodeStage::default_codec_for`
-/// (`recode.rs:86`). Kept in sync by `resolver_matches_recode_stage_defaults`.
-fn default_codec_for_container(container: &str) -> &'static str {
+/// Return the default video codec to encode toward for a given container
+/// extension (e.g. `"webm"` → `"vp9"`, `"mp4"` → `"h264"`).
+///
+/// This is the **single source of truth** for the container → codec mapping.
+/// Both the speed-control validator and `RecodeStage` delegate here so they
+/// can never resolve differently.
+#[must_use]
+pub fn default_codec_for_container(container: &str) -> &'static str {
     match container.to_ascii_lowercase().as_str() {
         "webm" | "ivf" => "vp9",
         "ogg" => "theora",

--- a/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
@@ -1,0 +1,233 @@
+//! Shared recode-encoder resolution + strict per-encoder speed-control validation.
+//!
+//! The validator and `RecodeStage` MUST resolve the target encoder identically;
+//! both go through [`resolve_recode_encoder`] so they cannot drift.
+
+use thiserror::Error;
+
+use super::video_codecs::{KnobField, KnobKindDef, resolve_encoder, speed_controls_def};
+
+/// Container-name -> default codec, mirroring `RecodeStage::default_codec_for`
+/// (`recode.rs:86`). Kept in sync by `resolver_matches_recode_stage_defaults`.
+fn default_codec_for_container(container: &str) -> &'static str {
+    match container.to_ascii_lowercase().as_str() {
+        "webm" | "ivf" => "vp9",
+        "ogg" => "theora",
+        "mpg" | "vob" => "mpeg2",
+        _ => "h264",
+    }
+}
+
+/// Resolve the encoder a recode will actually use.
+///
+/// Precedence mirrors `RecodeStage`: explicit `video_encoder` override first,
+/// else the target container's default codec. Self-initializes `FFmpeg`.
+#[must_use]
+pub fn resolve_recode_encoder(
+    video_encoder: Option<&str>,
+    recode_video: Option<&str>,
+    recode_container: Option<&str>,
+) -> Option<&'static str> {
+    super::ensure_init().ok();
+    if let Some(ve) = video_encoder.filter(|s| !s.is_empty()) {
+        return resolve_encoder(ve);
+    }
+    let target = recode_container.or(recode_video)?;
+    resolve_encoder(default_codec_for_container(target))
+}
+
+/// Strict per-encoder speed-control validation error.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SpeedControlError {
+    /// Knob not applicable to the resolved encoder.
+    #[error("{knob:?} is not applicable to encoder '{encoder}'")]
+    NotApplicable {
+        /// The knob that was rejected.
+        knob: KnobField,
+        /// The encoder name the knob was checked against.
+        encoder: String,
+    },
+    /// Choice value not in the allowed set.
+    #[error("{knob:?} value '{value}' is not one of {choices:?}")]
+    NotInChoices {
+        /// The knob whose value was rejected.
+        knob: KnobField,
+        /// The supplied value.
+        value: String,
+        /// The encoder's allowed choices.
+        choices: Vec<String>,
+    },
+    /// Int knob given a non-integer value.
+    #[error("{knob:?} value '{value}' is not an integer")]
+    NotInteger {
+        /// The knob whose value failed to parse.
+        knob: KnobField,
+        /// The supplied (non-integer) value.
+        value: String,
+    },
+    /// Int value outside the encoder's range.
+    #[error("{knob:?} value {value} out of range {min}..={max}")]
+    OutOfRange {
+        /// The knob whose value was out of range.
+        knob: KnobField,
+        /// The supplied value.
+        value: i32,
+        /// Minimum allowed value (inclusive).
+        min: i32,
+        /// Maximum allowed value (inclusive).
+        max: i32,
+    },
+}
+
+fn check_knob(
+    field: KnobField,
+    value: Option<String>,
+    encoder: &str,
+) -> Result<(), SpeedControlError> {
+    let Some(val) = value else {
+        return Ok(());
+    };
+    let def = speed_controls_def(encoder)
+        .iter()
+        .find(|k| k.field == field)
+        .ok_or_else(|| SpeedControlError::NotApplicable {
+            knob: field,
+            encoder: encoder.to_string(),
+        })?;
+    match def.kind {
+        KnobKindDef::Choice { choices, .. } => {
+            if choices.contains(&val.as_str()) {
+                Ok(())
+            } else {
+                Err(SpeedControlError::NotInChoices {
+                    knob: field,
+                    value: val,
+                    choices: choices.iter().map(|s| (*s).to_string()).collect(),
+                })
+            }
+        }
+        KnobKindDef::Int { min, max, .. } => {
+            let n: i32 = val.parse().map_err(|_| SpeedControlError::NotInteger {
+                knob: field,
+                value: val.clone(),
+            })?;
+            if (min..=max).contains(&n) {
+                Ok(())
+            } else {
+                Err(SpeedControlError::OutOfRange {
+                    knob: field,
+                    value: n,
+                    min,
+                    max,
+                })
+            }
+        }
+    }
+}
+
+/// Strictly validate speed-control values against the resolved encoder's descriptor.
+///
+/// `None` knobs and an unresolvable encoder are accepted (an unresolvable
+/// encoder means no recode runs). Self-initializes `FFmpeg`.
+///
+/// # Errors
+///
+/// Returns [`SpeedControlError`] when a knob is inapplicable to the encoder or a
+/// value is outside the encoder's allowed set/range.
+pub fn validate_speed_controls(
+    encoder: Option<&str>,
+    preset: Option<&str>,
+    deadline: Option<&str>,
+    cpu_used: Option<i32>,
+    speed_level: Option<u32>,
+) -> Result<(), SpeedControlError> {
+    super::ensure_init().ok();
+    let Some(enc) = encoder else {
+        return Ok(());
+    };
+    check_knob(KnobField::Preset, preset.map(str::to_string), enc)?;
+    check_knob(KnobField::Deadline, deadline.map(str::to_string), enc)?;
+    check_knob(KnobField::CpuUsed, cpu_used.map(|n| n.to_string()), enc)?;
+    check_knob(
+        KnobField::SpeedLevel,
+        speed_level.map(|n| i32::try_from(n).unwrap_or(i32::MAX).to_string()),
+        enc,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deadline_rejected_on_x264() {
+        let err =
+            validate_speed_controls(Some("libx264"), None, Some("good"), None, None).unwrap_err();
+        assert!(matches!(
+            err,
+            SpeedControlError::NotApplicable {
+                knob: KnobField::Deadline,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cpu_used_range_is_per_encoder() {
+        // libvpx-vp9 range is -8..=8, so 9 is out of range
+        assert!(validate_speed_controls(Some("libvpx-vp9"), None, None, Some(9), None).is_err());
+        // libvpx (VP8) range is -16..=16, so 9 is in range
+        assert!(validate_speed_controls(Some("libvpx"), None, None, Some(9), None).is_ok());
+    }
+
+    #[test]
+    fn vvenc_preset_membership() {
+        assert!(
+            validate_speed_controls(Some("libvvenc"), Some("medium"), None, None, None).is_ok()
+        );
+        assert!(
+            validate_speed_controls(Some("libvvenc"), Some("ultrafast"), None, None, None).is_err()
+        );
+    }
+
+    #[test]
+    fn svtav1_preset_is_numeric() {
+        // 8 is within -2..=13
+        assert!(validate_speed_controls(Some("libsvtav1"), Some("8"), None, None, None).is_ok());
+        // 14 is outside -2..=13
+        assert!(validate_speed_controls(Some("libsvtav1"), Some("14"), None, None, None).is_err());
+        // non-integer string fails parse
+        assert!(
+            validate_speed_controls(Some("libsvtav1"), Some("fast"), None, None, None).is_err()
+        );
+    }
+
+    #[test]
+    fn none_values_and_unresolved_encoder_pass() {
+        assert!(validate_speed_controls(Some("libx264"), None, None, None, None).is_ok());
+        assert!(validate_speed_controls(None, Some("anything"), None, None, None).is_ok());
+    }
+
+    #[test]
+    fn resolver_prefers_explicit_encoder() {
+        super::super::ensure_init().ok();
+        if resolve_encoder("libx265").is_some() {
+            assert_eq!(
+                resolve_recode_encoder(Some("libx265"), Some("mp4"), None),
+                Some("libx265")
+            );
+        }
+    }
+
+    #[test]
+    fn resolver_matches_recode_stage_defaults() {
+        assert_eq!(default_codec_for_container("webm"), "vp9");
+        assert_eq!(default_codec_for_container("ivf"), "vp9");
+        assert_eq!(default_codec_for_container("ogg"), "theora");
+        assert_eq!(default_codec_for_container("mpg"), "mpeg2");
+        assert_eq!(default_codec_for_container("vob"), "mpeg2");
+        assert_eq!(default_codec_for_container("mp4"), "h264");
+        assert_eq!(default_codec_for_container("mkv"), "h264");
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/encoder_options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/encoder_options.rs
@@ -35,6 +35,15 @@ pub fn build_video_encoder_options(
     if let Some(crf) = opts.crf {
         kv.push(("crf", crf.to_string()));
     }
+    if let Some(ref deadline) = opts.deadline {
+        kv.push(("deadline", deadline.clone()));
+    }
+    if let Some(cpu) = opts.cpu_used {
+        kv.push(("cpu-used", cpu.to_string()));
+    }
+    if let Some(sl) = opts.speed_level {
+        kv.push(("speed_level", sl.to_string()));
+    }
 
     let threads = resolve_recode_threads(opts.threads);
     kv.push(("threads", threads.to_string()));
@@ -131,5 +140,44 @@ mod tests {
     fn row_mt_absent_at_single_thread() {
         let kv = build_video_encoder_options(&opts_with(None, Some(30), Some(1)), "libvpx-vp9");
         assert!(!kv.iter().any(|(k, _)| *k == "row-mt"));
+    }
+
+    #[test]
+    fn vpx_knobs_pushed_when_present() {
+        let opts = VideoConvertOptions {
+            deadline: Some("good".to_string()),
+            cpu_used: Some(-4),
+            threads: Some(4),
+            ..Default::default()
+        };
+        let kv = build_video_encoder_options(&opts, "libvpx-vp9");
+        assert!(kv.iter().any(|(k, v)| *k == "deadline" && v == "good"));
+        assert!(kv.iter().any(|(k, v)| *k == "cpu-used" && v == "-4"));
+    }
+
+    #[test]
+    fn speed_level_pushed_when_present() {
+        let opts = VideoConvertOptions {
+            speed_level: Some(5),
+            threads: Some(2),
+            ..Default::default()
+        };
+        let kv = build_video_encoder_options(&opts, "libxavs2");
+        assert!(kv.iter().any(|(k, v)| *k == "speed_level" && v == "5"));
+    }
+
+    #[test]
+    fn vpx_knobs_absent_when_none() {
+        let kv = build_video_encoder_options(
+            &VideoConvertOptions {
+                threads: Some(2),
+                ..Default::default()
+            },
+            "libvpx-vp9",
+        );
+        assert!(
+            !kv.iter()
+                .any(|(k, _)| *k == "deadline" || *k == "cpu-used" || *k == "speed_level")
+        );
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -22,6 +22,9 @@ pub struct VideoEncoderInfo {
     pub encoder_name: String,
     /// Human-readable display name (e.g., "x264 (H.264)")
     pub display_name: String,
+    /// Speed-control knobs this encoder exposes (preset / deadline+cpu-used /
+    /// `speed_level`). Empty when the encoder has no panel-controllable knob.
+    pub speed_controls: Vec<SpeedKnob>,
 }
 
 /// Information about a video codec and its available encoders.
@@ -51,8 +54,6 @@ pub enum KnobField {
 }
 
 /// Static-table form of a knob (lives next to `CODEC_PREFERENCES`).
-// Unused until Task 4 wires it into VideoEncoderInfo.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum KnobKindDef {
     Choice {
@@ -66,8 +67,6 @@ pub(crate) enum KnobKindDef {
     },
 }
 
-// Unused until Task 4 wires it into VideoEncoderInfo.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SpeedKnobDef {
     pub field: KnobField,
@@ -76,8 +75,6 @@ pub(crate) struct SpeedKnobDef {
 }
 
 /// Serde/IPC form of a knob (materialized into [`VideoEncoderInfo`]).
-// Unused until Task 4 wires it into VideoEncoderInfo.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
 pub enum SpeedKnob {
@@ -108,8 +105,6 @@ pub enum SpeedKnob {
 }
 
 impl SpeedKnob {
-    // Unused until Task 4 wires it into VideoEncoderInfo materialization.
-    #[allow(dead_code)]
     pub(crate) fn from_def(d: &SpeedKnobDef) -> Self {
         match d.kind {
             KnobKindDef::Choice { choices, default } => Self::Choice {
@@ -130,9 +125,6 @@ impl SpeedKnob {
 }
 
 // --- Per-encoder knob tables (verified against FFmpeg 8.0.1-mediaforge, 2026-06-09) ---
-// These constants are referenced only by speed_controls_def(), which is itself
-// unused until Task 4. The allows are removed once the wiring lands.
-#[allow(dead_code)]
 const PRESETS_X26X: &[&str] = &[
     "ultrafast",
     "superfast",
@@ -145,14 +137,10 @@ const PRESETS_X26X: &[&str] = &[
     "veryslow",
     "placebo",
 ];
-#[allow(dead_code)]
 const PRESETS_VVENC: &[&str] = &["faster", "fast", "medium", "slow", "slower"];
-#[allow(dead_code)]
 const PRESETS_XEVE: &[&str] = &["default", "fast", "medium", "slow", "placebo"];
-#[allow(dead_code)]
 const DEADLINE_VALUES: &[&str] = &["best", "good", "realtime"];
 
-#[allow(dead_code)]
 const KNOBS_X264: &[SpeedKnobDef] = &[SpeedKnobDef {
     field: KnobField::Preset,
     label: "Preset",
@@ -161,9 +149,7 @@ const KNOBS_X264: &[SpeedKnobDef] = &[SpeedKnobDef {
         default: "medium",
     },
 }];
-#[allow(dead_code)]
 const KNOBS_X265: &[SpeedKnobDef] = KNOBS_X264; // identical preset vocabulary
-#[allow(dead_code)]
 const KNOBS_VVENC: &[SpeedKnobDef] = &[SpeedKnobDef {
     field: KnobField::Preset,
     label: "Preset",
@@ -172,7 +158,6 @@ const KNOBS_VVENC: &[SpeedKnobDef] = &[SpeedKnobDef {
         default: "medium",
     },
 }];
-#[allow(dead_code)]
 const KNOBS_XEVE: &[SpeedKnobDef] = &[SpeedKnobDef {
     field: KnobField::Preset,
     label: "Preset",
@@ -181,7 +166,6 @@ const KNOBS_XEVE: &[SpeedKnobDef] = &[SpeedKnobDef {
         default: "medium",
     },
 }];
-#[allow(dead_code)]
 const KNOBS_SVTAV1: &[SpeedKnobDef] = &[SpeedKnobDef {
     field: KnobField::Preset,
     label: "Preset",
@@ -189,9 +173,8 @@ const KNOBS_SVTAV1: &[SpeedKnobDef] = &[SpeedKnobDef {
         min: -2,
         max: 13,
         default: -2,
-    },
+    }, // -2 = SVT-AV1 "auto" sentinel (encoder picks preset)
 }];
-#[allow(dead_code)]
 const KNOBS_VP9: &[SpeedKnobDef] = &[
     SpeedKnobDef {
         field: KnobField::Deadline,
@@ -211,7 +194,6 @@ const KNOBS_VP9: &[SpeedKnobDef] = &[
         },
     },
 ];
-#[allow(dead_code)]
 const KNOBS_VP8: &[SpeedKnobDef] = &[
     SpeedKnobDef {
         field: KnobField::Deadline,
@@ -231,7 +213,6 @@ const KNOBS_VP8: &[SpeedKnobDef] = &[
         },
     },
 ];
-#[allow(dead_code)]
 const KNOBS_XAVS2: &[SpeedKnobDef] = &[SpeedKnobDef {
     field: KnobField::SpeedLevel,
     label: "Speed level",
@@ -244,8 +225,6 @@ const KNOBS_XAVS2: &[SpeedKnobDef] = &[SpeedKnobDef {
 
 /// Speed-control descriptor for an encoder. Empty slice = encoder exposes no
 /// panel-controllable speed knob (or is not modeled yet, e.g. unlinked encoders).
-// Unused until Task 4 wires it into VideoEncoderInfo.
-#[allow(dead_code)]
 #[must_use]
 pub(crate) fn speed_controls_def(encoder: &str) -> &'static [SpeedKnobDef] {
     match encoder {
@@ -491,6 +470,10 @@ pub fn available_encoders_for_codec(codec: &str) -> Vec<VideoEncoderInfo> {
                 .map(|(enc, display)| VideoEncoderInfo {
                     encoder_name: (*enc).to_string(),
                     display_name: (*display).to_string(),
+                    speed_controls: speed_controls_def(enc)
+                        .iter()
+                        .map(SpeedKnob::from_def)
+                        .collect(),
                 })
                 .collect()
         })
@@ -517,6 +500,10 @@ pub fn list_available_codecs() -> Vec<VideoCodecInfo> {
                 .map(|(enc, display)| VideoEncoderInfo {
                     encoder_name: (*enc).to_string(),
                     display_name: (*display).to_string(),
+                    speed_controls: speed_controls_def(enc)
+                        .iter()
+                        .map(SpeedKnob::from_def)
+                        .collect(),
                 })
                 .collect();
 
@@ -653,5 +640,36 @@ mod tests {
     fn unlinked_or_unknown_encoder_has_no_knobs() {
         assert!(speed_controls_def("libkvazaar").is_empty());
         assert!(speed_controls_def("nonsense").is_empty());
+    }
+
+    #[test]
+    fn x264_and_x265_share_preset_vocabulary() {
+        let names = |k: &[SpeedKnobDef]| {
+            k.iter()
+                .find_map(|d| match d.kind {
+                    KnobKindDef::Choice { choices, .. } => Some(choices),
+                    KnobKindDef::Int { .. } => None,
+                })
+                .unwrap()
+        };
+        assert_eq!(
+            names(speed_controls_def("libx264")),
+            names(speed_controls_def("libx265"))
+        );
+    }
+
+    #[test]
+    fn list_available_codecs_carries_speed_controls() {
+        super::super::ensure_init().ok();
+        for c in list_available_codecs() {
+            for e in &c.encoders {
+                if e.encoder_name == "libvvenc" {
+                    assert!(
+                        !e.speed_controls.is_empty(),
+                        "libvvenc must expose a preset knob"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -36,6 +36,231 @@ pub struct VideoCodecInfo {
     pub encoders: Vec<VideoEncoderInfo>,
 }
 
+/// Which typed recode wire field a knob feeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum KnobField {
+    /// The encoder's `-preset` option (named string).
+    Preset,
+    /// The libvpx `-deadline` option (best / good / realtime).
+    Deadline,
+    /// The libvpx `-cpu-used` option (integer quality/speed trade-off).
+    CpuUsed,
+    /// The xavs2 `-speed_level` option (integer 0–9).
+    SpeedLevel,
+}
+
+/// Static-table form of a knob (lives next to `CODEC_PREFERENCES`).
+// Unused until Task 4 wires it into VideoEncoderInfo.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum KnobKindDef {
+    Choice {
+        choices: &'static [&'static str],
+        default: &'static str,
+    },
+    Int {
+        min: i32,
+        max: i32,
+        default: i32,
+    },
+}
+
+// Unused until Task 4 wires it into VideoEncoderInfo.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SpeedKnobDef {
+    pub field: KnobField,
+    pub label: &'static str,
+    pub kind: KnobKindDef,
+}
+
+/// Serde/IPC form of a knob (materialized into [`VideoEncoderInfo`]).
+// Unused until Task 4 wires it into VideoEncoderInfo.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum SpeedKnob {
+    /// Named-choice knob (e.g. preset, deadline).
+    Choice {
+        /// Which wire field this knob maps to.
+        field: KnobField,
+        /// Human-readable label for the UI.
+        label: String,
+        /// Ordered list of valid choice strings.
+        choices: Vec<String>,
+        /// Default choice string.
+        default: String,
+    },
+    /// Integer-range knob (e.g. cpu-used, speed-level, SVT-AV1 preset).
+    Int {
+        /// Which wire field this knob maps to.
+        field: KnobField,
+        /// Human-readable label for the UI.
+        label: String,
+        /// Minimum valid value (inclusive).
+        min: i32,
+        /// Maximum valid value (inclusive).
+        max: i32,
+        /// Default value.
+        default: i32,
+    },
+}
+
+impl SpeedKnob {
+    // Unused until Task 4 wires it into VideoEncoderInfo materialization.
+    #[allow(dead_code)]
+    pub(crate) fn from_def(d: &SpeedKnobDef) -> Self {
+        match d.kind {
+            KnobKindDef::Choice { choices, default } => Self::Choice {
+                field: d.field,
+                label: d.label.to_string(),
+                choices: choices.iter().map(|s| (*s).to_string()).collect(),
+                default: default.to_string(),
+            },
+            KnobKindDef::Int { min, max, default } => Self::Int {
+                field: d.field,
+                label: d.label.to_string(),
+                min,
+                max,
+                default,
+            },
+        }
+    }
+}
+
+// --- Per-encoder knob tables (verified against FFmpeg 8.0.1-mediaforge, 2026-06-09) ---
+// These constants are referenced only by speed_controls_def(), which is itself
+// unused until Task 4. The allows are removed once the wiring lands.
+#[allow(dead_code)]
+const PRESETS_X26X: &[&str] = &[
+    "ultrafast",
+    "superfast",
+    "veryfast",
+    "faster",
+    "fast",
+    "medium",
+    "slow",
+    "slower",
+    "veryslow",
+    "placebo",
+];
+#[allow(dead_code)]
+const PRESETS_VVENC: &[&str] = &["faster", "fast", "medium", "slow", "slower"];
+#[allow(dead_code)]
+const PRESETS_XEVE: &[&str] = &["default", "fast", "medium", "slow", "placebo"];
+#[allow(dead_code)]
+const DEADLINE_VALUES: &[&str] = &["best", "good", "realtime"];
+
+#[allow(dead_code)]
+const KNOBS_X264: &[SpeedKnobDef] = &[SpeedKnobDef {
+    field: KnobField::Preset,
+    label: "Preset",
+    kind: KnobKindDef::Choice {
+        choices: PRESETS_X26X,
+        default: "medium",
+    },
+}];
+#[allow(dead_code)]
+const KNOBS_X265: &[SpeedKnobDef] = KNOBS_X264; // identical preset vocabulary
+#[allow(dead_code)]
+const KNOBS_VVENC: &[SpeedKnobDef] = &[SpeedKnobDef {
+    field: KnobField::Preset,
+    label: "Preset",
+    kind: KnobKindDef::Choice {
+        choices: PRESETS_VVENC,
+        default: "medium",
+    },
+}];
+#[allow(dead_code)]
+const KNOBS_XEVE: &[SpeedKnobDef] = &[SpeedKnobDef {
+    field: KnobField::Preset,
+    label: "Preset",
+    kind: KnobKindDef::Choice {
+        choices: PRESETS_XEVE,
+        default: "medium",
+    },
+}];
+#[allow(dead_code)]
+const KNOBS_SVTAV1: &[SpeedKnobDef] = &[SpeedKnobDef {
+    field: KnobField::Preset,
+    label: "Preset",
+    kind: KnobKindDef::Int {
+        min: -2,
+        max: 13,
+        default: -2,
+    },
+}];
+#[allow(dead_code)]
+const KNOBS_VP9: &[SpeedKnobDef] = &[
+    SpeedKnobDef {
+        field: KnobField::Deadline,
+        label: "Deadline",
+        kind: KnobKindDef::Choice {
+            choices: DEADLINE_VALUES,
+            default: "good",
+        },
+    },
+    SpeedKnobDef {
+        field: KnobField::CpuUsed,
+        label: "CPU used",
+        kind: KnobKindDef::Int {
+            min: -8,
+            max: 8,
+            default: 1,
+        },
+    },
+];
+#[allow(dead_code)]
+const KNOBS_VP8: &[SpeedKnobDef] = &[
+    SpeedKnobDef {
+        field: KnobField::Deadline,
+        label: "Deadline",
+        kind: KnobKindDef::Choice {
+            choices: DEADLINE_VALUES,
+            default: "good",
+        },
+    },
+    SpeedKnobDef {
+        field: KnobField::CpuUsed,
+        label: "CPU used",
+        kind: KnobKindDef::Int {
+            min: -16,
+            max: 16,
+            default: 1,
+        },
+    },
+];
+#[allow(dead_code)]
+const KNOBS_XAVS2: &[SpeedKnobDef] = &[SpeedKnobDef {
+    field: KnobField::SpeedLevel,
+    label: "Speed level",
+    kind: KnobKindDef::Int {
+        min: 0,
+        max: 9,
+        default: 0,
+    },
+}];
+
+/// Speed-control descriptor for an encoder. Empty slice = encoder exposes no
+/// panel-controllable speed knob (or is not modeled yet, e.g. unlinked encoders).
+// Unused until Task 4 wires it into VideoEncoderInfo.
+#[allow(dead_code)]
+#[must_use]
+pub(crate) fn speed_controls_def(encoder: &str) -> &'static [SpeedKnobDef] {
+    match encoder {
+        "libx264" => KNOBS_X264,
+        "libx265" => KNOBS_X265,
+        "libvvenc" => KNOBS_VVENC,
+        "libxeve" => KNOBS_XEVE,
+        "libsvtav1" => KNOBS_SVTAV1,
+        "libvpx-vp9" => KNOBS_VP9,
+        "libvpx" => KNOBS_VP8,
+        "libxavs2" => KNOBS_XAVS2,
+        _ => &[],
+    }
+}
+
 /// Entry in the codec preferences table.
 struct CodecEntry {
     /// Canonical codec name
@@ -383,5 +608,50 @@ mod tests {
     fn test_available_encoders_for_unknown_codec() {
         let encoders = available_encoders_for_codec("nonexistent");
         assert!(encoders.is_empty());
+    }
+
+    #[test]
+    fn vp8_and_vp9_cpu_used_ranges_differ() {
+        let cpu = |k: &[SpeedKnobDef]| {
+            k.iter()
+                .find_map(|d| match (d.field, d.kind) {
+                    (KnobField::CpuUsed, KnobKindDef::Int { min, max, .. }) => Some((min, max)),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        assert_eq!(cpu(speed_controls_def("libvpx-vp9")), (-8, 8));
+        assert_eq!(cpu(speed_controls_def("libvpx")), (-16, 16));
+    }
+
+    #[test]
+    fn vvenc_presets_are_the_five_names() {
+        let knobs = speed_controls_def("libvvenc");
+        let first = knobs.first().expect("vvenc must have at least one knob");
+        match first.kind {
+            KnobKindDef::Choice { choices, default } => {
+                assert_eq!(choices, &["faster", "fast", "medium", "slow", "slower"]);
+                assert_eq!(default, "medium");
+            }
+            KnobKindDef::Int { .. } => panic!("vvenc preset should be a Choice"),
+        }
+    }
+
+    #[test]
+    fn svtav1_preset_is_numeric_range() {
+        let knobs = speed_controls_def("libsvtav1");
+        let first = knobs.first().expect("svtav1 must have at least one knob");
+        match first.kind {
+            KnobKindDef::Int { min, max, default } => {
+                assert_eq!((min, max, default), (-2, 13, -2));
+            }
+            KnobKindDef::Choice { .. } => panic!("svtav1 preset should be Int"),
+        }
+    }
+
+    #[test]
+    fn unlinked_or_unknown_encoder_has_no_knobs() {
+        assert!(speed_controls_def("libkvazaar").is_empty());
+        assert!(speed_controls_def("nonsense").is_empty());
     }
 }

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -53,6 +53,7 @@ pub use error::{CorruptionKind, PostProcessError, Result};
 pub use ffmpeg::{
     AudioCodecInfo, AudioEncoderInfo, AudioExtractOptions, AudioNormMode, ChapterEntry,
     FFmpegRunner, FfmpegLogBridge, LogForwarderGuard, LoudnormMeasurements, LoudnormPreset,
-    MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, StreamInfo, VideoCodecInfo,
-    VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs, encoding_tool_tag, set_verbose,
+    MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, SpeedControlError, StreamInfo,
+    VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs, encoding_tool_tag,
+    resolve_recode_encoder, set_verbose, validate_speed_controls,
 };

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -54,6 +54,7 @@ pub use ffmpeg::{
     AudioCodecInfo, AudioEncoderInfo, AudioExtractOptions, AudioNormMode, ChapterEntry,
     FFmpegRunner, FfmpegLogBridge, LogForwarderGuard, LoudnormMeasurements, LoudnormPreset,
     MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, SpeedControlError, StreamInfo,
-    VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs, encoding_tool_tag,
-    resolve_recode_encoder, set_verbose, validate_speed_controls,
+    VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs,
+    default_codec_for_container, encoding_tool_tag, resolve_recode_encoder, set_verbose,
+    validate_speed_controls,
 };

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -30,6 +30,12 @@ pub(super) struct RecodeParams {
     pub threads: Option<u32>,
     /// Encoder preset override; None preserves the per-codec default preset.
     pub preset_override: Option<String>,
+    /// VPX/AV1 deadline knob (e.g. `"good"`, `"best"`, `"realtime"`).
+    pub deadline: Option<String>,
+    /// VPX/AV1 cpu-used knob.
+    pub cpu_used: Option<i32>,
+    /// VVC/x265/SVT-AV1 speed-level knob.
+    pub speed_level: Option<u32>,
 }
 
 /// Transcodes video to a different container/codec.
@@ -82,14 +88,10 @@ impl RecodeStage {
     }
 
     /// Pick the default video codec to encode toward when no explicit
-    /// encoder override is given.
-    const fn default_codec_for(target: ContainerFormat) -> &'static str {
-        match target {
-            ContainerFormat::WebM | ContainerFormat::Ivf => "vp9",
-            ContainerFormat::Ogg => "theora",
-            ContainerFormat::Mpg | ContainerFormat::Vob => "mpeg2",
-            _ => "h264",
-        }
+    /// encoder override is given. Delegates to the single source in `rdlp-ffmpeg`
+    /// so the recode pipeline and `validate_speed_controls` never resolve differently.
+    fn default_codec_for(target: ContainerFormat) -> &'static str {
+        rdlp_ffmpeg::default_codec_for_container(target.as_ext())
     }
 
     /// Default `(preset, crf)` for a known target codec. Returns `(None, None)`
@@ -144,6 +146,9 @@ impl RecodeStage {
                 preset,
                 crf,
                 threads: params.threads,
+                deadline: params.deadline.clone(),
+                cpu_used: params.cpu_used,
+                speed_level: params.speed_level,
                 audio_copy: params.audio_copy,
                 audio_codec: params.audio_codec.clone(),
                 ..Default::default()
@@ -161,6 +166,9 @@ impl RecodeStage {
             preset,
             crf,
             threads: params.threads,
+            deadline: params.deadline.clone(),
+            cpu_used: params.cpu_used,
+            speed_level: params.speed_level,
             audio_copy: params.audio_copy,
             audio_codec: params.audio_codec.clone(),
             ..Default::default()
@@ -318,6 +326,9 @@ impl PipelineStage for RecodeStage {
                 audio_codec,
                 threads: msg.config.recode_threads,
                 preset_override: msg.config.recode_preset.clone(),
+                deadline: msg.config.recode_deadline.map(|d| d.as_str().to_string()),
+                cpu_used: msg.config.recode_cpu_used,
+                speed_level: msg.config.recode_speed_level,
             },
             can_remux,
         ) else {
@@ -566,6 +577,9 @@ mod tests {
             audio_codec: None,
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, true).unwrap();
         assert!(opts.remux_only);
@@ -609,6 +623,9 @@ mod tests {
             audio_codec: Some("libopus".to_string()),
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).unwrap();
         assert!(!opts.audio_copy);
@@ -624,6 +641,9 @@ mod tests {
             audio_codec: None,
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, true).unwrap();
         assert!(opts.remux_only);
@@ -639,6 +659,9 @@ mod tests {
             audio_codec: None,
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).unwrap();
         assert!(!opts.remux_only);
@@ -658,6 +681,9 @@ mod tests {
             audio_codec: Some("libopus".to_string()),
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).unwrap();
         assert!(!opts.audio_copy);
@@ -673,6 +699,9 @@ mod tests {
             audio_codec: None,
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let result = RecodeStage::build_convert_options(&params, false);
         assert!(result.is_none());
@@ -687,6 +716,9 @@ mod tests {
             audio_codec: None,
             threads: Some(6),
             preset_override: Some("faster".to_string()),
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).expect("encoder available");
         assert_eq!(opts.threads, Some(6));
@@ -702,9 +734,33 @@ mod tests {
             audio_codec: None,
             threads: None,
             preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
         };
         let opts = RecodeStage::build_convert_options(&params, false).expect("encoder available");
         assert_eq!(opts.preset.as_deref(), Some("medium"));
         assert_eq!(opts.threads, None);
+    }
+
+    #[test]
+    fn deadline_and_cpu_used_thread_into_convert_options() {
+        // deadline/cpu-used aren't meaningful for libx264, but build_convert_options
+        // threads them regardless — that's what this test verifies.
+        let params = RecodeParams {
+            target: ContainerFormat::Mp4,
+            encoder_override: Some("libx264".to_string()),
+            audio_copy: true,
+            audio_codec: None,
+            threads: None,
+            preset_override: None,
+            deadline: Some("good".to_string()),
+            cpu_used: Some(2),
+            speed_level: None,
+        };
+        let opts = RecodeStage::build_convert_options(&params, false).expect("libx264 available");
+        assert_eq!(opts.deadline.as_deref(), Some("good"));
+        assert_eq!(opts.cpu_used, Some(2));
+        assert_eq!(opts.speed_level, None);
     }
 }

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -43,6 +43,7 @@ pub mod subtitle_format;
 pub mod subtitle_kind;
 pub mod subtitle_selection;
 pub mod subtitle_track;
+pub mod vpx_deadline;
 
 // Re-export main types
 pub use audio_format::AudioFormat;
@@ -71,3 +72,4 @@ pub use subtitle_track::{
     SubtitleDiagnostic, SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack,
     normalize_from_info_dict,
 };
+pub use vpx_deadline::VpxDeadline;

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -8,6 +8,7 @@ use crate::audio_format::AudioFormat;
 use crate::container::ContainerFormat;
 use crate::fixup_policy::FixupPolicy;
 use crate::recode_audio_mode::RecodeAudioMode;
+use crate::vpx_deadline::VpxDeadline;
 
 /// Post-processing configuration controlling `FFmpeg` transforms and file handling.
 ///
@@ -83,6 +84,12 @@ pub struct PostProcess {
     /// `None` = use `RecodeStage`'s per-codec default preset. When `Some`, this
     /// value replaces that default and is passed verbatim to the encoder.
     pub recode_preset: Option<String>,
+    /// libvpx `-deadline` (VP8/VP9). `None` = encoder default (`good`).
+    pub recode_deadline: Option<VpxDeadline>,
+    /// libvpx `-cpu-used` (VP8: -16..=16, VP9: -8..=8). `None` = encoder default.
+    pub recode_cpu_used: Option<i32>,
+    /// libxavs2 `-speed_level` (0..=9). `None` = encoder default (0).
+    pub recode_speed_level: Option<u32>,
     /// Policy for automatic fixup of downloaded files.
     pub fixup: FixupPolicy,
 }
@@ -120,6 +127,9 @@ impl Default for PostProcess {
             recode_container: None,
             recode_threads: None,
             recode_preset: None,
+            recode_deadline: None,
+            recode_cpu_used: None,
+            recode_speed_level: None,
             fixup: FixupPolicy::default(),
         }
     }
@@ -170,5 +180,13 @@ mod tests {
         let pp = PostProcess::default();
         assert_eq!(pp.recode_threads, None);
         assert_eq!(pp.recode_preset, None);
+    }
+
+    #[test]
+    fn speed_control_fields_default_none() {
+        let pp = PostProcess::default();
+        assert_eq!(pp.recode_deadline, None);
+        assert_eq!(pp.recode_cpu_used, None);
+        assert_eq!(pp.recode_speed_level, None);
     }
 }

--- a/crates/rdlp-types/src/vpx_deadline.rs
+++ b/crates/rdlp-types/src/vpx_deadline.rs
@@ -1,0 +1,80 @@
+//! libvpx `-deadline` quality/speed tradeoff setting (VP8/VP9).
+
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// libvpx `-deadline` value (VP8/VP9). Named-int alias in `FFmpeg`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VpxDeadline {
+    /// Best quality; slowest encode. `FFmpeg` option value: `best`.
+    Best,
+    /// Balanced quality/speed tradeoff. `FFmpeg` option value: `good`.
+    Good,
+    /// Fastest encode; lowest quality. `FFmpeg` option value: `realtime`.
+    Realtime,
+}
+
+impl VpxDeadline {
+    /// `FFmpeg` `AVOption` value (resolved by `av_opt_set` as a named int constant).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Best => "best",
+            Self::Good => "good",
+            Self::Realtime => "realtime",
+        }
+    }
+}
+
+impl FromStr for VpxDeadline {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "best" => Ok(Self::Best),
+            "good" => Ok(Self::Good),
+            "realtime" => Ok(Self::Realtime),
+            other => Err(format!(
+                "invalid deadline '{other}' (expected best|good|realtime)"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_case_insensitively() {
+        assert_eq!("Good".parse::<VpxDeadline>().unwrap(), VpxDeadline::Good);
+        assert_eq!(
+            "realtime".parse::<VpxDeadline>().unwrap(),
+            VpxDeadline::Realtime
+        );
+    }
+
+    #[test]
+    fn rejects_unknown() {
+        assert!("medium".parse::<VpxDeadline>().is_err());
+    }
+
+    #[test]
+    fn serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&VpxDeadline::Best).unwrap(),
+            "\"best\""
+        );
+        assert_eq!(
+            serde_json::from_str::<VpxDeadline>("\"realtime\"").unwrap(),
+            VpxDeadline::Realtime
+        );
+    }
+
+    #[test]
+    fn as_str_roundtrips() {
+        for d in [VpxDeadline::Best, VpxDeadline::Good, VpxDeadline::Realtime] {
+            assert_eq!(d.as_str().parse::<VpxDeadline>().unwrap(), d);
+        }
+    }
+}

--- a/crates/rdlp-types/src/vpx_deadline.rs
+++ b/crates/rdlp-types/src/vpx_deadline.rs
@@ -27,6 +27,12 @@ impl VpxDeadline {
     }
 }
 
+impl std::fmt::Display for VpxDeadline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl FromStr for VpxDeadline {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -76,5 +82,10 @@ mod tests {
         for d in [VpxDeadline::Best, VpxDeadline::Good, VpxDeadline::Realtime] {
             assert_eq!(d.as_str().parse::<VpxDeadline>().unwrap(), d);
         }
+    }
+
+    #[test]
+    fn displays_as_str() {
+        assert_eq!(format!("{}", VpxDeadline::Good), "good");
     }
 }


### PR DESCRIPTION
## Summary

Replaces the desktop recode **Preset** free-text box with an **encoder-aware speed-control panel**, with **CLI parity**. Each FFmpeg encoder exposes exactly its real speed knob(s), rendered as the right widget, and **strictly validated at the trust boundary**.

- **Preset** (named: x264/x265/vvenc/xeve) → dropdown; **SVT-AV1** preset (numeric −2…13) → number input; **VP8/VP9** → `deadline` (best/good/realtime) + `cpu-used`; **AVS2** → `speed_level`. Encoders with no `-preset` no longer get values silently ignored.
- **Architecture (Approach C):** a per-encoder typed descriptor in `rdlp-ffmpeg` (`speed_controls_def`) is the **single source of truth**, surfaced to the frontend over the existing `available_codecs()` IPC and consulted by the strict validator. No hardcoded encoder→knob map in the frontend.
- Values travel as **discrete typed fields** (`recode_deadline: Option<VpxDeadline>`, `recode_cpu_used: Option<i32>`, `recode_speed_level: Option<u32>`) through all layers: `rdlp-types` → `rdlp-api` → `rdlp-postprocess` → FFmpeg, plus the desktop IPC and CLI.
- **CLI:** `--recode-deadline <best|good|realtime>`, `--recode-cpu-used <N>` (`allow_hyphen_values` for negatives), `--recode-speed-level <0-9>`.
- Closed a latent **resolver-drift** risk: `RecodeStage` and the validator now share one `default_codec_for_container` (single source).

## Verification evidence

Full pre-PR gate, all green on `ae94b83..HEAD`:
- `cargo fmt --check` ✅ · `cargo check --workspace` ✅ · `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (0 failed suites) · `check-dedup.sh` ✅ · `check-url-redaction.sh` ✅
- frontend `tsc --noEmit` ✅ · `vitest` ✅ 298 passed
- Per-task TDD: positive + negative tests per layer (VP8≠VP9 range guard, deadline-rejected-on-x264, SVT numeric preset, IPC out-of-range boundary tests, CLI both-form negative-arg parse).

## Reviews

- **security-reviewer (whole diff): PASS / Approve.** Validator confirmed unbypassable at desktop IPC + CLI; typed wire fields reject malformed input at serde; no-descriptor encoders rejected (`NotApplicable`); ranges enforced pre-`av_opt_set`; no info disclosure; resolver-drift structurally eliminated. Findings: 2 LOW (client-side zod UX only — backend is the authoritative gate).
- **code-reviewer (whole diff): Approve.** 6-layer type contract consistent + single-sourced; encoder-resolution + container-default divergence points probed and proven non-drifting; validation live on both paths. Findings: 3 Minor (cosmetic / defense-in-depth).

No Critical/High/Important findings. The LOW/Minor items (tighten frontend zod to encoder-dynamic ranges for nicer inline errors) are tracked as a follow-up — the Rust boundary already rejects all invalid input and `KnobRow` sets HTML `min`/`max`.

## ⚠️ Outstanding: live manual verification

Automated gate + reviews are green, but the **live GUI/CLI end-to-end checks were not run in this session** (headless). Before merge, recommend verifying locally:
- Desktop (Expert on): VVenC → preset dropdown (faster…slower); SVT-AV1 → numeric preset; VP9 → deadline + cpu-used; switch encoder → knobs reset; download completes.
- CLI: `--recode-video=webm --video-encoder=libvpx-vp9 --recode-deadline=good --recode-cpu-used=-4 <URL>` succeeds; `--recode-deadline=good` with `--video-encoder=libx264` is rejected.

## Follow-ups (to file)
- Speed-control descriptors for `libkvazaar`/`libopenh264`/`librav1e` (not linked in current build).
- CRF/QP quality control in the recode panel (vvenc/xeve/xavs2 use qp/rc_mode, not crf).
- Encoder-dynamic zod range validation for nicer inline frontend errors (defense-in-depth; backend already authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)