### PR TITLE
fix: clean orphaned artifacts on cancel-during-post-processing (#404)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/cleanup.rs
+++ b/crates/rdlp-api/src/orchestrator/cleanup.rs
@@ -17,9 +17,6 @@ use super::session_state::{self, SessionState};
 /// source download files. Every delete is `exists()`-guarded and best-effort —
 /// failures are logged, never propagated, so cleanup cannot turn a cancel into
 /// a failure.
-// Wired into the PP-cancel arm in Task 4 (#404). `expect` (not `allow`) so the
-// lint self-clears — it becomes an error the moment the caller is added.
-#[cfg_attr(not(test), expect(dead_code))]
 pub(super) async fn cleanup_cancelled_artifacts(
     output_dir: &Path,
     output_to_stdout: bool,

--- a/crates/rdlp-api/src/orchestrator/cleanup.rs
+++ b/crates/rdlp-api/src/orchestrator/cleanup.rs
@@ -1,0 +1,149 @@
+//! Cancel-path cleanup for orchestrator-owned sidecars.
+//!
+//! On a post-processing cancel the pipeline's `FileTracker` reclaims its own
+//! files (the source download via `temp_files`), but the orchestrator owns two
+//! artifacts the pipeline never sees: the downloaded thumbnail and the
+//! `.rdlp_state.json` session-state file. This module deletes them. Called on
+//! the PP-cancel path only — download-time cancel intentionally retains resume
+//! state (see the #404 design spec).
+
+use std::path::{Path, PathBuf};
+
+use super::Orchestrator;
+use super::session_state::{self, SessionState};
+
+/// Idempotently delete the orchestrator-owned artifacts of a cancelled job:
+/// the session-state file, the downloaded thumbnail, and (defensively) any
+/// source download files. Every delete is `exists()`-guarded and best-effort —
+/// failures are logged, never propagated, so cleanup cannot turn a cancel into
+/// a failure.
+// Wired into the PP-cancel arm in Task 4 (#404). `expect` (not `allow`) so the
+// lint self-clears — it becomes an error the moment the caller is added.
+#[cfg_attr(not(test), expect(dead_code))]
+pub(super) async fn cleanup_cancelled_artifacts(
+    output_dir: &Path,
+    output_to_stdout: bool,
+    title: &str,
+    source_files: &[PathBuf],
+    thumbnail: Option<&Path>,
+) {
+    // Session state — skip in stdout mode (none is ever written there).
+    if !output_to_stdout {
+        let sanitized = Orchestrator::sanitize_filename(title);
+        let state_path = session_state::single_video_state_path(output_dir, &sanitized);
+        // SessionState::delete is itself NotFound-tolerant + best-effort, so no
+        // exists()-guard is needed here (unlike the thumbnail/source blocks below).
+        SessionState::delete(&state_path).await;
+    }
+
+    // Downloaded thumbnail (exact captured path).
+    if let Some(thumb) = thumbnail
+        && thumb.exists()
+        && let Err(e) = tokio::fs::remove_file(thumb).await
+    {
+        log::warn!(
+            "cleanup_cancelled_artifacts: failed to delete thumbnail {}: {e}",
+            thumb.display()
+        );
+    }
+
+    // Source download files — defense-in-depth; normally already removed by the
+    // pipeline's FileTracker::Drop (temp_files).
+    for file in source_files {
+        if file.exists()
+            && let Err(e) = tokio::fs::remove_file(file).await
+        {
+            log::warn!(
+                "cleanup_cancelled_artifacts: failed to delete source {}: {e}",
+                file.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn deletes_session_state_thumbnail_and_source() {
+        let dir = TempDir::new().unwrap();
+        let out = dir.path();
+        let title = "My Video";
+        let sanitized = Orchestrator::sanitize_filename(title);
+        let state = out.join(format!("{sanitized}.rdlp_state.json"));
+        let thumb = out.join("My Video.webp");
+        let source = out.join("My Video [id].mp4");
+        for p in [&state, &thumb, &source] {
+            tokio::fs::write(p, b"x").await.unwrap();
+        }
+
+        cleanup_cancelled_artifacts(
+            out,
+            false,
+            title,
+            std::slice::from_ref(&source),
+            Some(thumb.as_path()),
+        )
+        .await;
+
+        assert!(!state.exists(), "session state must be deleted");
+        assert!(!thumb.exists(), "thumbnail must be deleted");
+        assert!(!source.exists(), "source download must be deleted");
+    }
+
+    #[tokio::test]
+    async fn idempotent_when_absent() {
+        let dir = TempDir::new().unwrap();
+        // Nothing exists — must not panic or error.
+        cleanup_cancelled_artifacts(
+            dir.path(),
+            false,
+            "Gone",
+            &[dir.path().join("missing.mp4")],
+            Some(&dir.path().join("missing.webp")),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn stdout_mode_skips_session_state() {
+        let dir = TempDir::new().unwrap();
+        let title = "Z";
+        let sanitized = Orchestrator::sanitize_filename(title);
+        let state = dir.path().join(format!("{sanitized}.rdlp_state.json"));
+        tokio::fs::write(&state, b"x").await.unwrap();
+
+        cleanup_cancelled_artifacts(dir.path(), true, title, &[], None).await;
+
+        assert!(state.exists(), "stdout mode must NOT delete session state");
+    }
+
+    #[tokio::test]
+    async fn deletes_thumbnail_when_source_and_state_absent() {
+        // The primary PP-cancel state: FileTracker::Drop already removed the
+        // source download, but the thumbnail is still on disk. The thumbnail
+        // must be deleted even though the state file and source are absent.
+        let dir = TempDir::new().unwrap();
+        let out = dir.path();
+        let title = "Partial";
+        let thumb = out.join("Partial.webp");
+        tokio::fs::write(&thumb, b"x").await.unwrap();
+        let absent_source = out.join("Partial [id].mp4"); // never created
+
+        cleanup_cancelled_artifacts(
+            out,
+            false,
+            title,
+            std::slice::from_ref(&absent_source),
+            Some(thumb.as_path()),
+        )
+        .await;
+
+        assert!(
+            !thumb.exists(),
+            "thumbnail must be deleted even when source/state absent"
+        );
+    }
+}

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -1,6 +1,7 @@
 //! Orchestrator module for coordinating extraction, download, and post-processing
 
 mod archive;
+mod cleanup;
 mod container_resolver;
 mod download;
 pub mod errors;

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -448,23 +448,44 @@ impl DownloadPhase {
                     }
                 };
 
-                // Download thumbnail for embedding or standalone use
-                if orchestrator.config.postprocess.embed_thumbnail
+                // Download thumbnail for embedding or standalone use. Capture the
+                // written path so a PP-cancel can delete it (#404).
+                let thumbnail_path = if orchestrator.config.postprocess.embed_thumbnail
                     || orchestrator.config.postprocess.write_thumbnail
                 {
-                    orchestrator.download_thumbnail(&info, &output_path).await;
-                }
+                    orchestrator.download_thumbnail(&info, &output_path).await
+                } else {
+                    None
+                };
 
                 // Download subtitles (interactive selection or config-based)
                 orchestrator
                     .download_subtitles(&info, &output_path, &subtitle_selection)
                     .await?;
 
-                // Run post-processing (FFmpegMerger at priority 100 will
-                // merge when it detects 2 files with requested_formats set)
-                let final_files = orchestrator
-                    .run_postprocessing(&info, download_files, is_hls)
-                    .await?;
+                // Run post-processing. On a user cancel, clean the
+                // orchestrator-owned sidecars (thumbnail + session state; the
+                // source is already reclaimed by FileTracker::Drop) BEFORE
+                // re-returning UserCancelled so the client's terminal_event()
+                // still surfaces it as Event::Cancelled (PR #399). (#404)
+                let final_files = match orchestrator
+                    .run_postprocessing(&info, download_files.clone(), is_hls)
+                    .await
+                {
+                    Ok(files) => files,
+                    Err(e @ OrchestratorError::UserCancelled) => {
+                        super::cleanup::cleanup_cancelled_artifacts(
+                            &orchestrator.config.output_directory,
+                            orchestrator.config.output_to_stdout,
+                            &info.title,
+                            &download_files,
+                            thumbnail_path.as_deref(),
+                        )
+                        .await;
+                        return Err(e);
+                    }
+                    Err(e) => return Err(e),
+                };
                 let final_path = final_files.into_iter().next().unwrap_or(output_path);
 
                 // Verify the output file actually exists

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -339,7 +339,7 @@ mod tests {
         let original = dir.path().join("video.mp4");
         fs::write(&original, b"orig").unwrap();
         {
-            let mut tracker = FileTracker::new(vec![original.clone()], reg.clone());
+            let mut tracker = FileTracker::new(vec![original.clone()], reg);
             let promoted = dir.path().join("video.rdlp-tmp-zzz.mp4");
             fs::write(&promoted, b"new").unwrap();
             tracker.replace(vec![promoted]); // original -> temp_files

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -33,9 +33,10 @@ fn is_temp_named(path: &Path) -> bool {
 ///
 /// On `Drop` without a prior [`commit`] (or [`cleanup`], which commits as its
 /// last step), `FileTracker` performs graceful-cancel cleanup: it deletes every
-/// uncommitted path it issued via [`temp_path`] plus any `current_files`, and
-/// releases each from [`TempRegistry`]. This prevents partial recode output and
-/// intermediate files from leaking when a job is cancelled mid-pipeline (#335).
+/// uncommitted path it issued via [`temp_path`] plus any `current_files` and
+/// superseded `temp_files`, and releases each from [`TempRegistry`]. This
+/// prevents partial recode output and
+/// intermediate files from leaking when a job is cancelled mid-pipeline (#335, #404).
 /// [`TempRegistry`] remains the crash/stale backstop for the case where the
 /// process dies before `Drop` runs.
 pub struct FileTracker {
@@ -185,6 +186,23 @@ impl Drop for FileTracker {
         if self.committed {
             return;
         }
+        // Visible guard (#339): `issued` + `current_files` SHOULD be temp-
+        // namespaced. If a caller violated the `new()` precondition by passing a
+        // non-temp file, warn (but still delete — the cancel intent is to clear
+        // the working set). `temp_files` is deliberately EXCLUDED from this check:
+        // it legitimately holds real-named superseded files (e.g. the original
+        // download moved here by `replace()`), so a non-temp name there is
+        // expected, not a contract violation. Drop never panics.
+        for path in self.issued.iter().chain(self.current_files.iter()) {
+            if !is_temp_named(path) {
+                log::warn!(
+                    "FileTracker::Drop deleting non-temp-named file {} — unexpected; \
+                     current_files should be temp-namespaced",
+                    path.display(),
+                );
+            }
+        }
+        // Delete all three sets (issued + current_files + superseded temp_files).
         // Collect into an owned Vec to avoid borrowing self while mutating it.
         let to_delete: Vec<PathBuf> = self
             .issued
@@ -194,20 +212,8 @@ impl Drop for FileTracker {
             .cloned()
             .collect();
         for path in to_delete {
-            // Visible guard (#339): every deletable path SHOULD be
-            // temp-namespaced. If a caller violated the `new()` precondition by
-            // passing a non-temp file, warn (but still delete — the cancel
-            // intent is to clear the working set). Drop never panics.
-            if !is_temp_named(&path) {
-                log::warn!(
-                    "FileTracker::Drop deleting non-temp-named file {} — unexpected; \
-                     current_files should be temp-namespaced",
-                    path.display(),
-                );
-            }
-            // The issued and current sets may overlap (mark_temp re-files
-            // issued paths); the exists() guard + idempotent release make this
-            // safe to run per path.
+            // The sets may overlap (mark_temp re-files issued paths); the
+            // exists() guard + idempotent release make this safe to run per path.
             if path.exists()
                 && let Err(e) = std::fs::remove_file(&path)
             {

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -173,8 +173,10 @@ impl FileTracker {
 impl Drop for FileTracker {
     /// Graceful-cancel cleanup: if the job did not [`commit`](FileTracker::commit)
     /// (or [`cleanup`](FileTracker::cleanup), which commits last), delete every
-    /// uncommitted issued path and any `current_files`, releasing each from the
-    /// [`TempRegistry`] (#335).
+    /// uncommitted issued path, any `current_files`, AND any `temp_files`
+    /// (superseded working files / the original download), releasing each from
+    /// the [`TempRegistry`] (#335, #404). This mirrors the success-path
+    /// `cleanup()`, which already drains `temp_files` — cancel is now symmetric.
     // Safe: synchronous remove_file in Drop is unavoidable — Drop cannot be
     // async, and this mirrors the existing justification on `cleanup()` and the
     // registry's own shutdown hook.
@@ -188,6 +190,7 @@ impl Drop for FileTracker {
             .issued
             .iter()
             .chain(self.current_files.iter())
+            .chain(self.temp_files.iter())
             .cloned()
             .collect();
         for path in to_delete {
@@ -323,6 +326,28 @@ mod tests {
         assert!(
             !reg.contains(&partial),
             "registry entry for partial must be released"
+        );
+    }
+
+    #[test]
+    fn drop_uncommitted_deletes_temp_files() {
+        // A stage supersedes the original input via replace(), moving it into
+        // temp_files. On an uncommitted (cancel) drop, that superseded file MUST
+        // be deleted — this is the #404 source-.mp4 leak.
+        let dir = TempDir::new().unwrap();
+        let reg = Arc::new(TempRegistry::new());
+        let original = dir.path().join("video.mp4");
+        fs::write(&original, b"orig").unwrap();
+        {
+            let mut tracker = FileTracker::new(vec![original.clone()], reg.clone());
+            let promoted = dir.path().join("video.rdlp-tmp-zzz.mp4");
+            fs::write(&promoted, b"new").unwrap();
+            tracker.replace(vec![promoted]); // original -> temp_files
+            // dropped here WITHOUT commit() -> cancel semantics
+        }
+        assert!(
+            !original.exists(),
+            "superseded original in temp_files must be deleted on uncommitted drop (#404)"
         );
     }
 

--- a/crates/rdlp-postprocess/tests/cancel_e2e.rs
+++ b/crates/rdlp-postprocess/tests/cancel_e2e.rs
@@ -35,7 +35,9 @@ use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
 
 use rdlp_postprocess::pipeline::PipelineStage;
-use rdlp_postprocess::{FFmpegRunner, Pipeline, PipelineError, RecodeStage, TempRegistry};
+use rdlp_postprocess::{
+    FFmpegRunner, Pipeline, PipelineError, RecodeStage, RemuxStage, TempRegistry,
+};
 use rdlp_types::{ContainerFormat, InfoDict, PostProcess};
 
 fn ffmpeg_available() -> bool {
@@ -66,6 +68,36 @@ fn build_long_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
             "ultrafast",
             "-pix_fmt",
             "yuv420p",
+            src.to_str().unwrap(),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if ok { Ok(src) } else { Err(()) }
+}
+
+/// Build a long (30 s) H.264 **MPEG-TS** fixture. The `.ts` extension forces
+/// `RemuxStage` (is_hls) to remux ts → mp4, which `replace()`s the original
+/// into `temp_files` — the exact #404 condition.
+fn build_long_ts_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
+    let src = dir.join("src.ts");
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=30:s=1280x720",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            "-f",
+            "mpegts",
             src.to_str().unwrap(),
         ])
         .status()
@@ -177,5 +209,84 @@ async fn cancel_mid_recode_aborts_and_cleans_up() {
     assert!(
         leftovers.is_empty(),
         "cancel-cleanup must leave zero *.rdlp-tmp-*/.lock artifacts; found: {leftovers:?}"
+    );
+}
+
+/// #404 guard: cancelling mid-recode after a Remux stage has superseded the
+/// original download must delete the **real-named** source file (which lives in
+/// `temp_files`), not just the `*.rdlp-tmp-*` intermediates.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_after_remux_deletes_real_named_source() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = TempDir::new().expect("tempdir");
+    let Ok(src) = build_long_ts_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+    let work = dir.path().join("work");
+    std::fs::create_dir(&work).unwrap();
+    let input = work.join("video.ts"); // real-named HLS download
+    std::fs::rename(&src, &input).unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpegRunner::new"));
+    let stages: Vec<Arc<dyn PipelineStage>> = vec![
+        Arc::new(RemuxStage::new(Arc::clone(&ffmpeg))), // ts->mp4: video.ts -> temp_files
+        Arc::new(RecodeStage::new(ffmpeg)),             // slow encode -> cancel target
+    ];
+    let pipeline = Arc::new(Pipeline::new(stages, Arc::new(TempRegistry::new()), 4));
+
+    let config = Arc::new(PostProcess {
+        recode_video: Some(ContainerFormat::Mkv),
+        video_encoder: Some("libx264".to_string()),
+        ..PostProcess::default()
+    });
+    let info = InfoDict::new(
+        "id".to_string(),
+        "Cancel Src".to_string(),
+        "TestExtractor".to_string(),
+        "https://example.com/video".to_string(),
+    );
+
+    let token = CancellationToken::new();
+    let token_for_run = token.clone();
+    let pipeline_for_run = Arc::clone(&pipeline);
+    let input_for_run = input.clone();
+    let handle = tokio::spawn(async move {
+        pipeline_for_run
+            .run(
+                info,
+                vec![input_for_run],
+                config,
+                "video".to_string(),
+                true, // is_hls -> RemuxStage runs
+                false,
+                None,
+                Some(token_for_run),
+            )
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    token.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("pipeline must complete within 10s after cancel")
+        .expect("pipeline task join");
+
+    let err = result.expect_err("mid-recode cancel must surface as Err");
+    assert!(
+        matches!(
+            err.downcast_ref::<PipelineError>(),
+            Some(PipelineError::Cancelled)
+        ),
+        "expected PipelineError::Cancelled, got: {err:?}"
+    );
+    assert!(
+        !input.exists(),
+        "real-named source in temp_files must be deleted on cancel (#404)"
     );
 }


### PR DESCRIPTION
Closes #404.

## Problem
Cancelling during post-processing (e.g. an HLS recode) left three orphans in the output dir: the source `.mp4` (recode input, ~1.6 GB), the downloaded thumbnail `.webp`, and the `.rdlp_state.json` session-state file.

## Fix — two owner-aligned layers
- **L1 (`rdlp-postprocess`)** — `FileTracker::Drop` now reclaims `temp_files` on cancel, in addition to `issued` + `current_files`. For HLS/merge jobs an earlier stage (`replace()`) moves the original download into `temp_files`, which `Drop` previously ignored. This makes cancel **symmetric** with the success-path `cleanup()` (which already drains `temp_files`). The `#339` non-temp-named warning is scoped to `issued`+`current_files` only, since `temp_files` legitimately holds real-named superseded files.
- **L2 (`rdlp-api`)** — new `cleanup_cancelled_artifacts()` deletes the orchestrator-owned sidecars (session-state + exact-captured thumbnail; source covered by L1), idempotent/`exists()`-guarded/best-effort. Wired into the **post-processing cancel path only** (`Err(UserCancelled)` → cleanup → re-return the same error, preserving PR #399's `terminal_event` → `Event::Cancelled` mapping).

Scope is deliberately **post-download cancel only** — download-time cancel intentionally retains resume state (single keeps its partial + `.rdlp_state.json`; merge already self-cleans), so those arms are untouched.

## Verification
Pre-PR gate green: `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo check -p rdlp-desktop`, `check-dedup.sh`, `check-url-redaction.sh`.

Tests: new `drop_uncommitted_deletes_temp_files` (L1, fails against unpatched Drop); new e2e `cancel_after_remux_deletes_real_named_source` (real Remux→Recode cancel, asserts the real-named source is deleted — proven to fail when L1 is reverted); 4 `cleanup_cancelled_artifacts` unit tests (incl. the primary "thumbnail-deleted-when-source/state-absent" PP-cancel state).

## Reviews
- **security-reviewer:** APPROVE — no HIGH/Critical. Path-traversal via attacker-influenced `title` neutralized by `sanitize_filename`; `temp_files` keeper-guard verified (write-flag-gated); match arm precise; Drop panic-safe; log hygiene clean.
- **code-reviewer:** Approve-with-minor-fixes — 2 minors (misleading Drop warning on the now-expected path; stale struct doc) fixed in `f348de6`; 1 noted acceptable gap (wiring integration test) → follow-up.

## Follow-up
- Temp-name pipeline inputs up front to make the `FileTracker::new` precondition real (and stop the non-temp-named warning entirely). Filed separately.