### PR TITLE
feat: temp-name downloads as .rdlp-part, finalize to clean (#406 slice 1)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -10,6 +10,7 @@ mod execution;
 mod extraction;
 mod interactive;
 mod merge_download;
+mod naming;
 mod paths;
 mod playlist;
 mod postprocess;

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -49,7 +49,7 @@ pub(super) fn part_path(clean: &Path) -> PathBuf {
 /// `My.Video.rdlp-tmp-abc.mkv` → `My.Video`. The `.rdlp-part` marker is
 /// preferred; the pipeline `.rdlp-tmp-` marker is the fallback. Returns `None`
 /// if neither marker is present (the name is already clean).
-fn strip_temp_marker(file_name: &str) -> Option<&str> {
+pub(super) fn strip_temp_marker(file_name: &str) -> Option<&str> {
     let idx = file_name
         .find(PART_MARKER)
         .or_else(|| file_name.find(TMP_MARKER))?;

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -1,0 +1,82 @@
+//! Temp-file naming for the download → finalize lifecycle (#406).
+//!
+//! The clean, user-visible output name never appears on disk until the work is
+//! committed. The download writes a DETERMINISTIC `*.rdlp-part.*` name (so an
+//! interrupted download is resumable across process restarts); the post-process
+//! pipeline uses RANDOM `*.rdlp-tmp-{uuid}.*` names (defined in rdlp-postprocess).
+//! A single finalize step renames the survivor back to the clean name.
+
+use std::path::{Path, PathBuf};
+
+/// Deterministic download-in-progress marker. Resumable; same-directory; never
+/// carries a UUID (a random name would break resume on relaunch — see spec).
+#[allow(dead_code)] // used by finalize_to_clean in the next task
+pub(super) const PART_MARKER: &str = ".rdlp-part";
+
+/// Pipeline-intermediate marker (random per stage; owned by rdlp-postprocess).
+/// Mirrored here only so the finalize helper can strip either marker.
+#[allow(dead_code)] // used by finalize_to_clean in the next task
+pub(super) const TMP_MARKER: &str = ".rdlp-tmp-";
+
+/// The stdout sentinel. Temp-naming is meaningless when output goes to stdout.
+#[allow(dead_code)] // used by part_path and finalize_to_clean
+fn is_stdout(path: &Path) -> bool {
+    path.as_os_str() == "-"
+}
+
+/// Derive the deterministic `.rdlp-part` download path from the clean target.
+///
+/// `~/V/Title.mp4` → `~/V/Title.rdlp-part.mp4`. Always the SAME directory as the
+/// clean target, so the finalize rename never crosses a filesystem boundary
+/// (no `EXDEV`). Returns the input unchanged for the `-` stdout sentinel.
+#[allow(dead_code)] // will be used by orchestrator::download in the next task
+pub(super) fn part_path(clean: &Path) -> PathBuf {
+    if is_stdout(clean) {
+        return clean.to_path_buf();
+    }
+    let stem = clean
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("video");
+    let filename = clean.extension().and_then(|e| e.to_str()).map_or_else(
+        || format!("{stem}{PART_MARKER}"),
+        |ext| format!("{stem}{PART_MARKER}.{ext}"),
+    );
+    clean.with_file_name(filename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn part_path_inserts_marker_before_extension() {
+        let clean = PathBuf::from("/home/u/Videos/Title.mp4");
+        assert_eq!(
+            part_path(&clean),
+            PathBuf::from("/home/u/Videos/Title.rdlp-part.mp4")
+        );
+    }
+
+    #[test]
+    fn part_path_preserves_dotted_stem() {
+        let clean = PathBuf::from("/v/My.Video.S01E01.mkv");
+        assert_eq!(
+            part_path(&clean),
+            PathBuf::from("/v/My.Video.S01E01.rdlp-part.mkv")
+        );
+    }
+
+    #[test]
+    fn part_path_handles_no_extension() {
+        let clean = PathBuf::from("/v/noext");
+        assert_eq!(part_path(&clean), PathBuf::from("/v/noext.rdlp-part"));
+    }
+
+    #[test]
+    fn part_path_is_noop_for_stdout() {
+        let clean = PathBuf::from("-");
+        assert_eq!(part_path(&clean), PathBuf::from("-"));
+    }
+}

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -10,17 +10,14 @@ use std::path::{Path, PathBuf};
 
 /// Deterministic download-in-progress marker. Resumable; same-directory; never
 /// carries a UUID (a random name would break resume on relaunch — see spec).
-#[allow(dead_code)] // used by finalize_to_clean in the next task
 pub(super) const PART_MARKER: &str = ".rdlp-part";
 
 /// Pipeline-intermediate marker (random per stage; owned by rdlp-postprocess).
 /// Mirrored here only so the finalize helper can strip either marker.
-#[allow(dead_code)] // used by finalize_to_clean in the next task
 pub(super) const TMP_MARKER: &str = ".rdlp-tmp-";
 
 /// The stdout sentinel. Temp-naming is meaningless when output goes to stdout.
 /// Matches ONLY the exact `-` token, not a path whose last component is `-`.
-#[allow(dead_code)] // used by part_path and finalize_to_clean
 fn is_stdout(path: &Path) -> bool {
     path.as_os_str() == "-"
 }
@@ -44,6 +41,37 @@ pub(super) fn part_path(clean: &Path) -> PathBuf {
         _ => format!("{stem}{PART_MARKER}"),
     };
     clean.with_file_name(filename)
+}
+
+/// Recover the clean stem from a temp-named file, stripping EITHER marker.
+///
+/// Uses marker-SEARCH (not a first-dot split) so dotted stems survive:
+/// `My.Video.rdlp-tmp-abc.mkv` → `My.Video`. The `.rdlp-part` marker is
+/// preferred; the pipeline `.rdlp-tmp-` marker is the fallback. Returns `None`
+/// if neither marker is present (the name is already clean).
+fn strip_temp_marker(file_name: &str) -> Option<&str> {
+    let idx = file_name
+        .find(PART_MARKER)
+        .or_else(|| file_name.find(TMP_MARKER))?;
+    Some(&file_name[..idx])
+}
+
+/// Derive the clean output path for a temp-named survivor: marker-stripped stem
+/// plus the SURVIVOR's own extension (so a container change during post-processing,
+/// e.g., ts → mkv, is preserved in the final name). Returns `None` for stdout or
+/// for an already-clean name (no marker present).
+#[allow(dead_code)] // wired into the finalize path in a later task
+pub(super) fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
+    if is_stdout(survivor) {
+        return None;
+    }
+    let name = survivor.file_name()?.to_str()?;
+    let stem = strip_temp_marker(name)?;
+    let clean = match survivor.extension().and_then(|e| e.to_str()) {
+        Some(ext) if !ext.is_empty() => format!("{stem}.{ext}"),
+        _ => stem.to_owned(),
+    };
+    Some(survivor.with_file_name(clean))
 }
 
 #[cfg(test)]
@@ -85,5 +113,55 @@ mod tests {
     fn part_path_collapses_trailing_dot_to_no_extension() {
         let clean = PathBuf::from("/v/Title.");
         assert_eq!(part_path(&clean), PathBuf::from("/v/Title.rdlp-part"));
+    }
+
+    #[test]
+    fn strip_recovers_stem_from_part_marker() {
+        assert_eq!(strip_temp_marker("Title.rdlp-part.mp4"), Some("Title"));
+    }
+
+    #[test]
+    fn strip_recovers_stem_from_tmp_marker() {
+        assert_eq!(
+            strip_temp_marker("Title.rdlp-tmp-abc123.mkv"),
+            Some("Title")
+        );
+    }
+
+    #[test]
+    fn strip_preserves_dotted_stem() {
+        assert_eq!(
+            strip_temp_marker("My.Video.S01E01.rdlp-tmp-deadbeef.mkv"),
+            Some("My.Video.S01E01")
+        );
+    }
+
+    #[test]
+    fn strip_returns_none_when_no_marker() {
+        assert_eq!(strip_temp_marker("Title.mp4"), None);
+    }
+
+    #[test]
+    fn finalize_uses_survivor_extension_for_container_change() {
+        let survivor = PathBuf::from("/v/Title.rdlp-tmp-abc.mkv");
+        assert_eq!(
+            finalize_to_clean(&survivor),
+            Some(PathBuf::from("/v/Title.mkv"))
+        );
+    }
+
+    #[test]
+    fn finalize_strips_part_marker() {
+        let survivor = PathBuf::from("/v/Title.rdlp-part.mp4");
+        assert_eq!(
+            finalize_to_clean(&survivor),
+            Some(PathBuf::from("/v/Title.mp4"))
+        );
+    }
+
+    #[test]
+    fn finalize_is_none_for_stdout_or_clean_name() {
+        assert_eq!(finalize_to_clean(&PathBuf::from("-")), None);
+        assert_eq!(finalize_to_clean(&PathBuf::from("/v/Title.mp4")), None);
     }
 }

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -31,7 +31,6 @@ fn is_stdout(path: &Path) -> bool {
 /// `~/V/Title.mp4` → `~/V/Title.rdlp-part.mp4`. Always the SAME directory as the
 /// clean target, so the finalize rename never crosses a filesystem boundary
 /// (no `EXDEV`). Returns the input unchanged for the `-` stdout sentinel.
-#[allow(dead_code)] // will be used by orchestrator::download in the next task
 pub(super) fn part_path(clean: &Path) -> PathBuf {
     if is_stdout(clean) {
         return clean.to_path_buf();
@@ -80,6 +79,23 @@ pub(super) fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
         _ => stem.to_owned(),
     };
     Some(survivor.with_file_name(clean))
+}
+
+/// Atomically commit a finished `.rdlp-part` download to its clean output name.
+///
+/// Same-directory rename (no `EXDEV`); on failure the `.rdlp-part` file is left
+/// on disk (resumable) rather than a half-renamed state. Used by both the
+/// already-complete resume short-circuit and the normal download-completion
+/// path so the two share one error message and one rename call.
+pub(super) async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+    tokio::fs::rename(part, clean).await.with_context(|| {
+        format!(
+            "failed to finalize download {} -> {}",
+            part.display(),
+            clean.display()
+        )
+    })
 }
 
 #[cfg(test)]

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -19,6 +19,7 @@ pub(super) const PART_MARKER: &str = ".rdlp-part";
 pub(super) const TMP_MARKER: &str = ".rdlp-tmp-";
 
 /// The stdout sentinel. Temp-naming is meaningless when output goes to stdout.
+/// Matches ONLY the exact `-` token, not a path whose last component is `-`.
 #[allow(dead_code)] // used by part_path and finalize_to_clean
 fn is_stdout(path: &Path) -> bool {
     path.as_os_str() == "-"
@@ -38,10 +39,10 @@ pub(super) fn part_path(clean: &Path) -> PathBuf {
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("video");
-    let filename = clean.extension().and_then(|e| e.to_str()).map_or_else(
-        || format!("{stem}{PART_MARKER}"),
-        |ext| format!("{stem}{PART_MARKER}.{ext}"),
-    );
+    let filename = match clean.extension().and_then(|e| e.to_str()) {
+        Some(ext) if !ext.is_empty() => format!("{stem}{PART_MARKER}.{ext}"),
+        _ => format!("{stem}{PART_MARKER}"),
+    };
     clean.with_file_name(filename)
 }
 
@@ -78,5 +79,11 @@ mod tests {
     fn part_path_is_noop_for_stdout() {
         let clean = PathBuf::from("-");
         assert_eq!(part_path(&clean), PathBuf::from("-"));
+    }
+
+    #[test]
+    fn part_path_collapses_trailing_dot_to_no_extension() {
+        let clean = PathBuf::from("/v/Title.");
+        assert_eq!(part_path(&clean), PathBuf::from("/v/Title.rdlp-part"));
     }
 }

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -10,10 +10,14 @@ use std::path::{Path, PathBuf};
 
 /// Deterministic download-in-progress marker. Resumable; same-directory; never
 /// carries a UUID (a random name would break resume on relaunch — see spec).
+/// Its leading `.` is mirrored as `_` by `sanitize_filename` Step 1.5 to
+/// neutralize title collisions — keep the two in sync.
 pub(super) const PART_MARKER: &str = ".rdlp-part";
 
 /// Pipeline-intermediate marker (random per stage; owned by rdlp-postprocess).
 /// Mirrored here only so the finalize helper can strip either marker.
+/// Its leading `.` is mirrored as `_` by `sanitize_filename` Step 1.5 to
+/// neutralize title collisions — keep the two in sync.
 pub(super) const TMP_MARKER: &str = ".rdlp-tmp-";
 
 /// The stdout sentinel. Temp-naming is meaningless when output goes to stdout.

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -48,11 +48,15 @@ pub(super) fn part_path(clean: &Path) -> PathBuf {
 /// Uses marker-SEARCH (not a first-dot split) so dotted stems survive:
 /// `My.Video.rdlp-tmp-abc.mkv` → `My.Video`. The `.rdlp-part` marker is
 /// preferred; the pipeline `.rdlp-tmp-` marker is the fallback. Returns `None`
-/// if neither marker is present (the name is already clean).
+/// if neither marker is present (the name is already clean) or if a marker sits
+/// at index 0 (no stem precedes it).
 pub(super) fn strip_temp_marker(file_name: &str) -> Option<&str> {
     let idx = file_name
         .find(PART_MARKER)
         .or_else(|| file_name.find(TMP_MARKER))?;
+    if idx == 0 {
+        return None; // no real stem precedes the marker
+    }
     Some(&file_name[..idx])
 }
 
@@ -163,5 +167,32 @@ mod tests {
     fn finalize_is_none_for_stdout_or_clean_name() {
         assert_eq!(finalize_to_clean(&PathBuf::from("-")), None);
         assert_eq!(finalize_to_clean(&PathBuf::from("/v/Title.mp4")), None);
+    }
+
+    #[test]
+    fn strip_returns_none_for_marker_at_index_zero() {
+        assert_eq!(strip_temp_marker(".rdlp-part.mp4"), None);
+        // and finalize must therefore decline rather than produce a stemless name
+        assert_eq!(finalize_to_clean(&PathBuf::from("/v/.rdlp-part.mp4")), None);
+    }
+
+    #[test]
+    fn strip_prefers_part_marker_when_both_present() {
+        // part is found first and wins the or_else chain
+        assert_eq!(
+            strip_temp_marker("Title.rdlp-part.rdlp-tmp-abc.mkv"),
+            Some("Title")
+        );
+    }
+
+    #[test]
+    fn strip_truncates_when_stem_legitimately_contains_marker() {
+        // Documented trade-off: a title literally containing the marker substring
+        // is truncated at the first marker. sanitize_filename neutralizes this
+        // upstream; this test pins the helper's raw behavior.
+        assert_eq!(
+            strip_temp_marker("Guide.rdlp-part.intro.mp4"),
+            Some("Guide")
+        );
     }
 }

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -60,6 +60,9 @@ pub(super) fn strip_temp_marker(file_name: &str) -> Option<&str> {
     if idx == 0 {
         return None; // no real stem precedes the marker
     }
+    // SAFETY: PART_MARKER and TMP_MARKER are ASCII, so `find` returns an index
+    // on a UTF-8 char boundary; the byte-slice below can never split a codepoint.
+    debug_assert!(file_name.is_char_boundary(idx));
     Some(&file_name[..idx])
 }
 
@@ -83,10 +86,12 @@ pub(super) fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
 
 /// Atomically commit a finished `.rdlp-part` download to its clean output name.
 ///
-/// Same-directory rename (no `EXDEV`); on failure the `.rdlp-part` file is left
-/// on disk (resumable) rather than a half-renamed state. Used by both the
-/// already-complete resume short-circuit and the normal download-completion
-/// path so the two share one error message and one rename call.
+/// Same-directory rename (no `EXDEV`), atomic on POSIX. On failure the rename
+/// is a no-op: the `.rdlp-part` file is left intact (a re-run re-probes it and
+/// re-attempts finalize) and the clean name is not created — the error is
+/// surfaced to the caller via context. Used by both the already-complete resume
+/// short-circuit and the normal download-completion path so the two share one
+/// rename call and one error message.
 pub(super) async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
     use anyhow::Context as _;
     tokio::fs::rename(part, clean).await.with_context(|| {
@@ -96,6 +101,13 @@ pub(super) async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<(
             clean.display()
         )
     })
+}
+
+/// Best-effort removal of a `.rdlp-part` working file on explicit cancel, so a
+/// cancelled download leaves no artifact (#406). Errors are ignored: the file
+/// may legitimately not exist yet, and a failed unlink must not mask the cancel.
+pub(super) async fn discard_part(part: &Path) {
+    let _ = tokio::fs::remove_file(part).await;
 }
 
 #[cfg(test)]

--- a/crates/rdlp-api/src/orchestrator/paths.rs
+++ b/crates/rdlp-api/src/orchestrator/paths.rs
@@ -144,6 +144,16 @@ impl Orchestrator {
             })
             .collect();
 
+        // Step 1.5 (#406): neutralize the reserved temp-file markers so a user
+        // title containing them cannot collide with the download/pipeline naming
+        // scheme. Only the leading dot of each marker is changed to an
+        // underscore, so the visible title text is preserved while the strip
+        // logic (marker-search on the dotted form) can never mistake it for a
+        // real marker.
+        let sanitized = sanitized
+            .replace(super::naming::PART_MARKER, "_rdlp-part")
+            .replace(super::naming::TMP_MARKER, "_rdlp-tmp-");
+
         // Step 2: Trim leading/trailing dots and spaces (problematic on Windows)
         let trimmed = sanitized.trim_matches(|c| c == '.' || c == ' ');
 
@@ -194,5 +204,32 @@ impl Orchestrator {
         }
         // Fallback: simple truncation at char boundary
         name.chars().take(max_len).collect()
+    }
+}
+
+#[cfg(test)]
+mod sanitize_marker_tests {
+    use crate::orchestrator::Orchestrator;
+
+    #[test]
+    fn neutralizes_part_marker_in_title() {
+        let out = Orchestrator::sanitize_filename("foo.rdlp-part");
+        assert!(!out.contains(".rdlp-part"), "got: {out}");
+        assert_eq!(out, "foo_rdlp-part");
+    }
+
+    #[test]
+    fn neutralizes_tmp_marker_in_title() {
+        let out = Orchestrator::sanitize_filename("clip.rdlp-tmp-abc");
+        assert!(!out.contains(".rdlp-tmp-"), "got: {out}");
+        assert_eq!(out, "clip_rdlp-tmp-abc");
+    }
+
+    #[test]
+    fn leaves_ordinary_titles_unchanged() {
+        assert_eq!(
+            Orchestrator::sanitize_filename("Normal Title"),
+            "Normal Title"
+        );
     }
 }

--- a/crates/rdlp-api/src/orchestrator/paths.rs
+++ b/crates/rdlp-api/src/orchestrator/paths.rs
@@ -232,4 +232,32 @@ mod sanitize_marker_tests {
             "Normal Title"
         );
     }
+
+    #[test]
+    fn neutralizes_marker_after_leading_dots() {
+        // Guards the neutralize-BEFORE-trim ordering: trim must not re-expose a marker.
+        let out = Orchestrator::sanitize_filename("..rdlp-part");
+        assert!(!out.contains(".rdlp-part"), "got: {out}");
+    }
+
+    #[test]
+    fn neutralizes_all_marker_occurrences() {
+        let out = Orchestrator::sanitize_filename("x.rdlp-part.rdlp-part");
+        assert!(!out.contains(".rdlp-part"), "got: {out}");
+    }
+
+    #[test]
+    fn neutralized_title_round_trips_to_intended_clean_name() {
+        // The cross-module invariant: a title containing the marker, once
+        // sanitized, survives a full part_path -> finalize_to_clean cycle and
+        // yields the SANITIZED clean name, never a truncation at title text.
+        use crate::orchestrator::naming::{finalize_to_clean, part_path};
+        use std::path::PathBuf;
+
+        let stem = Orchestrator::sanitize_filename("foo.rdlp-part"); // "foo_rdlp-part"
+        let clean = PathBuf::from(format!("/v/{stem}.mp4"));
+        let part = part_path(&clean);
+        assert_eq!(part, PathBuf::from("/v/foo_rdlp-part.rdlp-part.mp4"));
+        assert_eq!(finalize_to_clean(&part), Some(clean));
+    }
 }

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -161,27 +161,38 @@ impl Orchestrator {
                         .as_ref()
                         .expect("output_path set in is_none guard above");
 
-                    // Detect resume point (recalculate on retry for partial HLS)
-                    let resume_offset = self.detect_resume_point(path, format.filesize).await?;
+                    // Download writes the deterministic .rdlp-part name; the clean
+                    // name appears only after the download commits (#406).
+                    let part = crate::orchestrator::naming::part_path(path);
 
-                    // Check if file is already complete
+                    // Detect resume point against the part name (recalculate on
+                    // retry for partial HLS).
+                    let resume_offset = self.detect_resume_point(&part, format.filesize).await?;
+
+                    // Check if file is already complete: commit .rdlp-part -> clean.
                     if let Some(expected_size) = format.filesize
                         && resume_offset == expected_size
                     {
                         debug!("File already complete, skipping");
+                        crate::orchestrator::naming::finalize_part(&part, path).await?;
                         return Ok(Some(path.clone()));
                     }
 
                     // Download with CDN fallback
                     match self
-                        .download_with_cdn_fallback(&format, path, resume_offset)
+                        .download_with_cdn_fallback(&format, &part, resume_offset)
                         .await
                     {
                         Ok(Some(outcome)) => {
+                            crate::orchestrator::naming::finalize_part(&part, path).await?;
                             download_result = Some((vec![path.clone()], outcome.is_hls, None));
                             break;
                         }
-                        Ok(None) => return Ok(None),
+                        Ok(None) => {
+                            // Explicit cancel: drop the .rdlp-part working file.
+                            let _ = tokio::fs::remove_file(&part).await;
+                            return Ok(None);
+                        }
                         Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {
                             warn!("All CDN URLs failed: {e}");
                             warn!("Will re-extract fresh URLs after delay");

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -190,7 +190,7 @@ impl Orchestrator {
                         }
                         Ok(None) => {
                             // Explicit cancel: drop the .rdlp-part working file.
-                            let _ = tokio::fs::remove_file(&part).await;
+                            crate::orchestrator::naming::discard_part(&part).await;
                             return Ok(None);
                         }
                         Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -1,4 +1,4 @@
-use crate::orchestrator::naming::{finalize_to_clean, part_path};
+use crate::orchestrator::naming::{discard_part, finalize_part, finalize_to_clean, part_path};
 
 // Pins the round-trip the Single download path relies on: a .rdlp-part file
 // finalizes to exactly the clean output name (no marker residue, same dir).
@@ -15,4 +15,38 @@ async fn part_file_finalizes_to_clean_name() {
     assert!(clean.exists(), "clean name must exist after finalize");
     assert!(!part.exists(), "part name must be gone after finalize");
     assert_eq!(finalize_to_clean(&part), Some(clean));
+}
+
+#[tokio::test]
+async fn finalize_part_renames_and_reports_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let clean = dir.path().join("Show.mp4");
+    let part = part_path(&clean);
+
+    // Success: part exists -> renamed to clean.
+    tokio::fs::write(&part, b"data").await.unwrap();
+    finalize_part(&part, &clean).await.unwrap();
+    assert!(clean.exists() && !part.exists());
+
+    // Failure surfaces with context when the part is missing.
+    let err = finalize_part(&part, &clean).await.unwrap_err();
+    assert!(
+        format!("{err:#}").contains("failed to finalize download"),
+        "got: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn discard_part_removes_and_is_noop_when_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let clean = dir.path().join("Ep.mp4");
+    let part = part_path(&clean);
+
+    tokio::fs::write(&part, b"partial").await.unwrap();
+    discard_part(&part).await;
+    assert!(!part.exists(), "cancel must remove the .rdlp-part file");
+    assert!(!clean.exists(), "cancel must not create the clean name");
+
+    // Idempotent: discarding an already-absent part does not panic/error.
+    discard_part(&part).await;
 }

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -1,0 +1,18 @@
+use crate::orchestrator::naming::{finalize_to_clean, part_path};
+
+// Pins the round-trip the Single download path relies on: a .rdlp-part file
+// finalizes to exactly the clean output name (no marker residue, same dir).
+#[tokio::test]
+async fn part_file_finalizes_to_clean_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let clean = dir.path().join("Title.mp4");
+    let part = part_path(&clean);
+    assert_eq!(part, dir.path().join("Title.rdlp-part.mp4"));
+
+    tokio::fs::write(&part, b"bytes").await.unwrap();
+    tokio::fs::rename(&part, &clean).await.unwrap();
+
+    assert!(clean.exists(), "clean name must exist after finalize");
+    assert!(!part.exists(), "part name must be gone after finalize");
+    assert_eq!(finalize_to_clean(&part), Some(clean));
+}

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -11,7 +11,6 @@ use super::{
     errors::{OrchestratorError, Result},
 };
 use crate::events::Event;
-use anyhow::Context as _;
 use log::{debug, warn};
 use rdlp_types::Format;
 use std::fmt;
@@ -366,15 +365,7 @@ impl DownloadPhase {
                         if let Some(expected_size) = format.filesize
                             && resume_offset == expected_size
                         {
-                            tokio::fs::rename(&part, &output_path)
-                                .await
-                                .with_context(|| {
-                                    format!(
-                                        "failed to finalize completed download {} -> {}",
-                                        part.display(),
-                                        output_path.display()
-                                    )
-                                })?;
+                            super::naming::finalize_part(&part, &output_path).await?;
                             return Ok(Self::Complete { path: output_path });
                         }
 
@@ -446,15 +437,7 @@ impl DownloadPhase {
                         };
                         // Commit: rename .rdlp-part -> clean BEFORE post-processing
                         // (Slice 1 finalizes pre-PP; Slice 2 moves it post-PP).
-                        tokio::fs::rename(&part, &output_path)
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "failed to finalize download {} -> {}",
-                                    part.display(),
-                                    output_path.display()
-                                )
-                            })?;
+                        super::naming::finalize_part(&part, &output_path).await?;
                         (vec![output_path.clone()], outcome.is_hls)
                     }
                     DownloadPlan::Merge {

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -11,12 +11,15 @@ use super::{
     errors::{OrchestratorError, Result},
 };
 use crate::events::Event;
+use anyhow::Context as _;
 use log::{debug, warn};
 use rdlp_types::Format;
 use std::fmt;
 use std::path::PathBuf;
 use tracing::instrument;
 
+#[cfg(test)]
+mod finalize_tests;
 #[cfg(test)]
 mod tests;
 
@@ -351,14 +354,27 @@ impl DownloadPhase {
                 let state = match *plan {
                     DownloadPlan::Merge { .. } => DownloadState::Fresh,
                     DownloadPlan::Single(_) => {
+                        // Probe resume against the deterministic .rdlp-part name —
+                        // the download writes there, not to the clean name (#406).
+                        let part = super::naming::part_path(&output_path);
                         let resume_offset = orchestrator
-                            .detect_resume_point(&output_path, format.filesize)
+                            .detect_resume_point(&part, format.filesize)
                             .await?;
 
-                        // Check if file is already complete
+                        // Already complete: the bytes are under .rdlp-part; commit
+                        // them to the clean name before returning Complete.
                         if let Some(expected_size) = format.filesize
                             && resume_offset == expected_size
                         {
+                            tokio::fs::rename(&part, &output_path)
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "failed to finalize completed download {} -> {}",
+                                        part.display(),
+                                        output_path.display()
+                                    )
+                                })?;
                             return Ok(Self::Complete { path: output_path });
                         }
 
@@ -413,16 +429,32 @@ impl DownloadPhase {
                 // Branch on download plan
                 let (download_files, is_hls) = match *plan {
                     DownloadPlan::Single(_) => {
-                        // Single format: existing path
+                        // Download to the deterministic .rdlp-part name; the clean
+                        // name never appears on disk until the download commits.
+                        let part = super::naming::part_path(&output_path);
                         let Some(outcome) = orchestrator
-                            .download_with_cdn_fallback(&format, &output_path, state.offset())
+                            .download_with_cdn_fallback(&format, &part, state.offset())
                             .await?
                         else {
+                            // Explicit cancel: delete the .rdlp-part working file so
+                            // a cancel leaves no artifact (#406). Best-effort.
+                            let _ = tokio::fs::remove_file(&part).await;
                             orchestrator.emit(Event::Cancelled {
                                 id: orchestrator.download_id,
                             });
                             return Ok(Self::Cancelled);
                         };
+                        // Commit: rename .rdlp-part -> clean BEFORE post-processing
+                        // (Slice 1 finalizes pre-PP; Slice 2 moves it post-PP).
+                        tokio::fs::rename(&part, &output_path)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "failed to finalize download {} -> {}",
+                                    part.display(),
+                                    output_path.display()
+                                )
+                            })?;
                         (vec![output_path.clone()], outcome.is_hls)
                     }
                     DownloadPlan::Merge {

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -429,7 +429,7 @@ impl DownloadPhase {
                         else {
                             // Explicit cancel: delete the .rdlp-part working file so
                             // a cancel leaves no artifact (#406). Best-effort.
-                            let _ = tokio::fs::remove_file(&part).await;
+                            super::naming::discard_part(&part).await;
                             orchestrator.emit(Event::Cancelled {
                                 id: orchestrator.download_id,
                             });

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -60,6 +60,12 @@ pub struct Args {
     pub url: Option<String>,
 
     /// Output template or directory (e.g., "%(title)s.%(ext)s" or "./downloads/")
+    ///
+    /// Note: resume across restarts requires a deterministic name. Templates using
+    /// `%(epoch)s` (or a future live `%(autonumber)s`) render a different name each run,
+    /// so an interrupted download cannot be resumed and restarts from zero. Build the
+    /// template from stable metadata (`title`, `id`, `uploader`, `ext`, `upload_date`) for
+    /// resumable downloads.
     #[arg(short, long)]
     pub output: Option<String>,
 

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -62,10 +62,9 @@ pub struct Args {
     /// Output template or directory (e.g., "%(title)s.%(ext)s" or "./downloads/")
     ///
     /// Note: resume across restarts requires a deterministic name. Templates using
-    /// `%(epoch)s` (or a future live `%(autonumber)s`) render a different name each run,
-    /// so an interrupted download cannot be resumed and restarts from zero. Build the
-    /// template from stable metadata (`title`, `id`, `uploader`, `ext`, `upload_date`) for
-    /// resumable downloads.
+    /// `%(epoch)s` render a different name each run, so an interrupted download cannot
+    /// be resumed and restarts from zero. Build the template from stable metadata
+    /// (`title`, `id`, `uploader`, `ext`, `upload_date`) for resumable downloads.
     #[arg(short, long)]
     pub output: Option<String>,
 


### PR DESCRIPTION
## Summary (Slice 1 of #406)

Hide the clean user-visible output filename during the entire download by writing to a **deterministic** `*.rdlp-part.*` name (same directory), then atomically renaming it to the clean name once the download completes — **before** post-processing (yt-dlp's `.part` model). A crash/kill mid-download now leaves an unambiguous, resumable, auto-cleanable `.rdlp-part` artifact instead of a real-named partial that looks finished.

This is the first of two slices. **Slice 2** (separate PR) moves the finalize to *after* post-processing (PP seam `.rdlp-part` → `.rdlp-tmp-{uuid}`, `cleanup()` simplification, `original_stem`, `process_local_file`) and closes the `#339` non-temp-named Drop warning — which is why this PR uses `Refs`, not `Closes`.

## What changed

- New pure helper module `orchestrator/naming.rs`: `part_path` (deterministic `.rdlp-part`), `strip_temp_marker`/`finalize_to_clean` (built now, wired live in Slice 2), `finalize_part` (atomic same-dir rename), `discard_part` (best-effort cancel cleanup).
- `sanitize_filename` hardened to neutralize the reserved markers (`.rdlp-part`/`.rdlp-tmp-`) in user titles so a crafted title can't collide with the naming scheme.
- Wired into both download drivers' `Single` path — the state machine (`state/mod.rs`) and the playlist episode driver (`playlist/episode.rs`): resume probes the part name; finalize on success **and** on the resume-complete short-circuit; `discard_part` on explicit cancel.
- CLI `-o` help: resume-determinism caveat.

**Untouched by design:** the `Merge` path (its streams already carry stream-specific names; the clean name only appears at pipeline `cleanup()`), stdout (`-` sentinel), and the recently-hardened `FileTracker` cancel/Drop path (#404/#405).

## Design & research

Industry-standard pattern, research-backed (yt-dlp `.part`/`MoveFilesAfterDownloadPP`, Chrome `.crdownload`, Firefox `.part`, atomic-write idiom, build-system output commit). Full spec + research in the local design doc (gitignored). The download-name **must** be deterministic for resume — a random UUID would break resume on every protocol (validated).

## Verification

- Gate green: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && check-dedup.sh && check-url-redaction.sh`.
- TDD throughout; new tests: `naming` units (part_path/strip/finalize/round-trip/adversarial), `sanitize` marker neutralization + cross-module round-trip, `finalize_part`/`discard_part` filesystem tests.

## Reviews (mandatory pre-push)

- **security-reviewer:** Approve. No High/Critical. Audited traversal/symlink/TOCTOU on the new rename, marker-neutralization ordering, log hygiene (paths only, no URLs). One Medium (ASCII byte-slice safety) fixed with a `debug_assert` + invariant comment.
- **code-reviewer (whole diff):** Approve. Two Important items fixed before push: softened `finalize_part` doc-comment; added the cancel-delete + `finalize_part` seam tests (extracted `discard_part` to make the cancel path testable + DRY).

## Deferred follow-ups (tracked for Slice 2 / issues)

- Explicit cancel deletes the in-progress `.rdlp-part` (intentional "clean cancel" per #404/#405); crash/kill leaves it for resume.
- DRY: the part→resume→finalize block is mirrored across the two drivers — a shared helper is a good Slice-2 cleanup as the finalize moves post-PP.
- `%(epoch)s` templates can't resume (pre-existing, now documented).

Refs #406
