### PR TITLE
feat: finalize clean name post-PP; close #406 (slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5997,6 +5997,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "uuid",
  "wreq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 rdlp-redact = { path = "crates/rdlp-redact" }
 
+# UUID generation
+uuid = { version = "1", features = ["v4"] }
+
 # Async runtime
 tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "fs", "process", "io-util", "io-std", "signal"] }
 tokio-util = { version = "0.7", features = ["rt"] }

--- a/crates/rdlp-api/Cargo.toml
+++ b/crates/rdlp-api/Cargo.toml
@@ -25,6 +25,7 @@ rdlp-redact = { workspace = true, features = ["log-kv"] }
 rdlp-plugin = { path = "../rdlp-plugin" }
 
 dirs = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/rdlp-api/Cargo.toml
+++ b/crates/rdlp-api/Cargo.toml
@@ -25,7 +25,7 @@ rdlp-redact = { workspace = true, features = ["log-kv"] }
 rdlp-plugin = { path = "../rdlp-plugin" }
 
 dirs = { workspace = true }
-uuid = { version = "1", features = ["v4"] }
+uuid = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -673,9 +673,25 @@ impl RdlpClient {
                 .await
             {
                 Ok(output_files) => {
+                    // Pipeline returns temp-named survivors (#406 Option X);
+                    // finalize each to its clean name before reporting.
+                    let mut finalized = Vec::with_capacity(output_files.len());
+                    for f in output_files {
+                        match crate::orchestrator::naming::finalize_to_clean(&f) {
+                            Some(clean) => {
+                                crate::orchestrator::naming::finalize_part(&f, &clean)
+                                    .await
+                                    .map_err(|e| RdlpApiError::IoError {
+                                        message: format!("{e:#}"),
+                                    })?;
+                                finalized.push(clean);
+                            }
+                            None => finalized.push(f),
+                        }
+                    }
                     let result = crate::DownloadResult {
                         id,
-                        output_files,
+                        output_files: finalized,
                         info,
                         stats: rdlp_core::DownloadStats::new(0, std::time::Duration::ZERO, 0),
                     };

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -10,7 +10,7 @@ mod execution;
 mod extraction;
 mod interactive;
 mod merge_download;
-mod naming;
+pub mod naming;
 mod paths;
 mod playlist;
 mod postprocess;

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -260,10 +260,27 @@ mod tests {
         let seam = seam_path(&clean);
         let name = seam.file_name().unwrap().to_str().unwrap();
         assert!(name.starts_with("My.Video.rdlp-tmp-"), "got: {name}");
-        assert!(Path::new(name)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("mp4")), "got: {name}");
+        assert!(
+            Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("mp4")),
+            "got: {name}"
+        );
         assert_eq!(seam.parent(), clean.parent());
+        // the segment between ".rdlp-tmp-" and the extension is a 32-char hex uuid
+        let id_seg = name
+            .strip_prefix("My.Video.rdlp-tmp-")
+            .and_then(|s| s.strip_suffix(".mp4"))
+            .expect("seam name shape");
+        assert_eq!(
+            id_seg.len(),
+            32,
+            "uuid simple form is 32 hex chars: {id_seg}"
+        );
+        assert!(
+            id_seg.chars().all(|c| c.is_ascii_hexdigit()),
+            "got: {id_seg}"
+        );
         // round-trips back to the clean name via the Slice-1 strip helper
         assert_eq!(finalize_to_clean(&seam), Some(clean));
     }

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -110,6 +110,32 @@ pub(super) async fn discard_part(part: &Path) {
     let _ = tokio::fs::remove_file(part).await;
 }
 
+/// Derive a pipeline-namespace temp path `{clean_stem}.rdlp-tmp-{uuid}.{ext}`
+/// from the clean target, in the SAME directory. Used at the download->pipeline
+/// seam so the post-process `FileTracker` only ever sees its own `.rdlp-tmp-`
+/// namespace (its marker logic and hardened cancel/Drop path stay untouched).
+/// The clean stem is recovered via marker-search, so a `.rdlp-part` input or a
+/// clean target both yield the same stem. Returns the input unchanged for the
+/// `-` stdout sentinel.
+#[allow(dead_code)] // wired into the seam at Task 4/5/6
+pub(super) fn seam_path(clean: &Path) -> PathBuf {
+    if is_stdout(clean) {
+        return clean.to_path_buf();
+    }
+    let raw = clean
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("video");
+    // If `clean` was actually a `.rdlp-part` name, recover the true stem.
+    let stem = strip_temp_marker(raw).unwrap_or(raw);
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    let filename = match clean.extension().and_then(|e| e.to_str()) {
+        Some(ext) if !ext.is_empty() => format!("{stem}{TMP_MARKER}{id}.{ext}"),
+        _ => format!("{stem}{TMP_MARKER}{id}"),
+    };
+    clean.with_file_name(filename)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -226,5 +252,30 @@ mod tests {
             strip_temp_marker("Guide.rdlp-part.intro.mp4"),
             Some("Guide")
         );
+    }
+
+    #[test]
+    fn seam_path_is_in_tmp_namespace_same_dir_and_ext() {
+        let clean = PathBuf::from("/v/My.Video.mp4");
+        let seam = seam_path(&clean);
+        let name = seam.file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with("My.Video.rdlp-tmp-"), "got: {name}");
+        assert!(Path::new(name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("mp4")), "got: {name}");
+        assert_eq!(seam.parent(), clean.parent());
+        // round-trips back to the clean name via the Slice-1 strip helper
+        assert_eq!(finalize_to_clean(&seam), Some(clean));
+    }
+
+    #[test]
+    fn seam_path_unique_across_calls() {
+        let clean = PathBuf::from("/v/X.mp4");
+        assert_ne!(seam_path(&clean), seam_path(&clean));
+    }
+
+    #[test]
+    fn seam_path_is_noop_for_stdout() {
+        assert_eq!(seam_path(&PathBuf::from("-")), PathBuf::from("-"));
     }
 }

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -70,8 +70,7 @@ pub(super) fn strip_temp_marker(file_name: &str) -> Option<&str> {
 /// plus the SURVIVOR's own extension (so a container change during post-processing,
 /// e.g., ts → mkv, is preserved in the final name). Returns `None` for stdout or
 /// for an already-clean name (no marker present).
-#[allow(dead_code)] // wired into the finalize path in a later task
-pub(super) fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
+pub fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
     if is_stdout(survivor) {
         return None;
     }
@@ -92,7 +91,7 @@ pub(super) fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
 /// surfaced to the caller via context. Used by both the already-complete resume
 /// short-circuit and the normal download-completion path so the two share one
 /// rename call and one error message.
-pub(super) async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
+pub async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
     use anyhow::Context as _;
     tokio::fs::rename(part, clean).await.with_context(|| {
         format!(
@@ -117,8 +116,7 @@ pub(super) async fn discard_part(part: &Path) {
 /// The clean stem is recovered via marker-search, so a `.rdlp-part` input or a
 /// clean target both yield the same stem. Returns the input unchanged for the
 /// `-` stdout sentinel.
-#[allow(dead_code)] // wired into the seam at Task 4/5/6
-pub(super) fn seam_path(clean: &Path) -> PathBuf {
+pub fn seam_path(clean: &Path) -> PathBuf {
     if is_stdout(clean) {
         return clean.to_path_buf();
     }

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -184,8 +184,12 @@ impl Orchestrator {
                         .await
                     {
                         Ok(Some(outcome)) => {
-                            crate::orchestrator::naming::finalize_part(&part, path).await?;
-                            download_result = Some((vec![path.clone()], outcome.is_hls, None));
+                            // Seam: move the finished .rdlp-part into the pipeline's
+                            // own .rdlp-tmp-{uuid} namespace; the clean name is
+                            // minted only after PP by the coordinator finalize (#406).
+                            let seam = crate::orchestrator::naming::seam_path(path);
+                            crate::orchestrator::naming::finalize_part(&part, &seam).await?;
+                            download_result = Some((vec![seam], outcome.is_hls, None));
                             break;
                         }
                         Ok(None) => {
@@ -337,7 +341,18 @@ impl Orchestrator {
         let final_files = self
             .run_postprocessing(final_info, download_files, is_hls)
             .await?;
-        let final_path = final_files.into_iter().next().unwrap_or(output_path);
+        let survivor = final_files
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| output_path.clone());
+        // Coordinator finalize (Option X): mint the clean name once, post-PP.
+        let final_path = match crate::orchestrator::naming::finalize_to_clean(&survivor) {
+            Some(clean) => {
+                crate::orchestrator::naming::finalize_part(&survivor, &clean).await?;
+                clean
+            }
+            None => survivor,
+        };
 
         // HLS downloads produce .ts files that should be remuxed.
         if is_hls {

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -71,6 +71,31 @@ fn make_callback_factory(
     })
 }
 
+/// Clean stem for sidecar (thumbnail/subtitle) discovery: the first file's name
+/// with any temp marker stripped, so a `.rdlp-tmp-{uuid}` / `.rdlp-part` pipeline
+/// input still resolves the originally-named sidecars (#406 slice 2).
+fn original_stem_for(files: &[PathBuf]) -> String {
+    files
+        .first()
+        .and_then(|f| f.file_name())
+        .and_then(|n| n.to_str())
+        .map_or_else(
+            || "video".to_owned(),
+            |name| {
+                super::naming::strip_temp_marker(name).map_or_else(
+                    || {
+                        std::path::Path::new(name)
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("video")
+                            .to_owned()
+                    },
+                    ToOwned::to_owned,
+                )
+            },
+        )
+}
+
 impl Orchestrator {
     /// Check if post-processing is needed based on configuration
     pub(super) fn needs_postprocessing(&self) -> bool {
@@ -128,12 +153,7 @@ impl Orchestrator {
 
         debug!("Running post-processing pipeline...");
 
-        let original_stem = files
-            .first()
-            .and_then(|f| f.file_stem())
-            .and_then(|s| s.to_str())
-            .unwrap_or("video")
-            .to_owned();
+        let original_stem = original_stem_for(&files);
 
         // Build a per-stage progress callback factory.
         let callback_factory = Some(make_callback_factory(
@@ -236,5 +256,34 @@ impl Orchestrator {
         if deleted > 0 {
             debug!(deleted; "Cleaned up leftover segment files");
         }
+    }
+}
+
+#[cfg(test)]
+mod original_stem_tests {
+    use super::*;
+
+    #[test]
+    fn original_stem_strips_temp_marker() {
+        let files = vec![PathBuf::from("/v/My.Video.rdlp-tmp-abc.mp4")];
+        assert_eq!(original_stem_for(&files), "My.Video");
+    }
+
+    #[test]
+    fn original_stem_strips_part_marker() {
+        let files = vec![PathBuf::from("/v/Clip.rdlp-part.ts")];
+        assert_eq!(original_stem_for(&files), "Clip");
+    }
+
+    #[test]
+    fn original_stem_plain_name_unchanged() {
+        let files = vec![PathBuf::from("/v/My.Video.mp4")];
+        assert_eq!(original_stem_for(&files), "My.Video");
+    }
+
+    #[test]
+    fn original_stem_empty_defaults_to_video() {
+        let files: Vec<PathBuf> = vec![];
+        assert_eq!(original_stem_for(&files), "video");
     }
 }

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -55,8 +55,8 @@ async fn seam_then_finalize_yields_clean_name() {
     assert!(clean.exists() && !seam.exists());
 }
 
-/// Slice 2 (#406): pins the two arms of the finalize contract that
-/// `process_local_file` (and the playlist episode path) relies on.
+/// Slice 2 (#406): pins the contract of the `finalize_to_clean` + `finalize_part`
+/// helper pair that `process_local_file` (and the playlist episode path) depends on.
 ///
 /// - `Some` arm: a temp-named survivor (`Title.rdlp-tmp-<uuid>.mkv`) is renamed
 ///   to `Title.mkv` on disk; `finalize_to_clean` returns the clean path.
@@ -64,8 +64,9 @@ async fn seam_then_finalize_yields_clean_name() {
 ///   `finalize_to_clean` returning `None` — the orchestrator treats this as
 ///   "already at the final name, no rename needed" and uses the path as-is.
 ///
-/// Together these two cases cover both branches of the `match finalize_to_clean`
-/// expression in `process_local_file` (client/mod.rs).
+/// This test pins the naming helper contract itself, not the client/mod.rs
+/// wiring (integration testing the full download→finalize path requires
+/// `FFmpeg` and is out of scope for unit tests).
 #[tokio::test]
 async fn process_local_finalize_some_renames_none_passes_through() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -1,4 +1,6 @@
-use crate::orchestrator::naming::{discard_part, finalize_part, finalize_to_clean, part_path};
+use crate::orchestrator::naming::{
+    discard_part, finalize_part, finalize_to_clean, part_path, seam_path,
+};
 
 // Pins the round-trip the Single download path relies on: a .rdlp-part file
 // finalizes to exactly the clean output name (no marker residue, same dir).
@@ -34,6 +36,23 @@ async fn finalize_part_renames_and_reports_missing() {
         format!("{err:#}").contains("failed to finalize download"),
         "got: {err:#}"
     );
+}
+
+#[tokio::test]
+async fn seam_then_finalize_yields_clean_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let clean = dir.path().join("Show.mp4");
+    let part = part_path(&clean);
+    tokio::fs::write(&part, b"x").await.unwrap();
+
+    let seam = seam_path(&clean);
+    finalize_part(&part, &seam).await.unwrap();
+    assert!(seam.exists() && !part.exists());
+
+    let target = finalize_to_clean(&seam).unwrap();
+    finalize_part(&seam, &target).await.unwrap();
+    assert_eq!(target, clean);
+    assert!(clean.exists() && !seam.exists());
 }
 
 #[tokio::test]

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -55,6 +55,61 @@ async fn seam_then_finalize_yields_clean_name() {
     assert!(clean.exists() && !seam.exists());
 }
 
+/// Slice 2 (#406): pins the two arms of the finalize contract that
+/// `process_local_file` (and the playlist episode path) relies on.
+///
+/// - `Some` arm: a temp-named survivor (`Title.rdlp-tmp-<uuid>.mkv`) is renamed
+///   to `Title.mkv` on disk; `finalize_to_clean` returns the clean path.
+/// - `None` arm: an already-clean-named survivor (`Title.mkv`) passes
+///   `finalize_to_clean` returning `None` — the orchestrator treats this as
+///   "already at the final name, no rename needed" and uses the path as-is.
+///
+/// Together these two cases cover both branches of the `match finalize_to_clean`
+/// expression in `process_local_file` (client/mod.rs).
+#[tokio::test]
+async fn process_local_finalize_some_renames_none_passes_through() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // --- Some arm: temp-named survivor → clean name via finalize_part ---
+    let clean_mkv = dir.path().join("Title.mkv");
+    let seam = seam_path(&clean_mkv);
+    // The seam name must contain the tmp marker.
+    assert!(
+        seam.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains(".rdlp-tmp-")),
+        "seam_path must produce a .rdlp-tmp-* name"
+    );
+    tokio::fs::write(&seam, b"pipeline output").await.unwrap();
+
+    // finalize_to_clean on the temp-named file returns Some(clean).
+    let derived_clean = finalize_to_clean(&seam).expect("Some arm must derive clean path");
+    assert_eq!(
+        derived_clean, clean_mkv,
+        "derived clean path must match target"
+    );
+    finalize_part(&seam, &derived_clean).await.unwrap();
+    assert!(
+        clean_mkv.exists(),
+        "clean file must exist after finalize_part"
+    );
+    assert!(!seam.exists(), "seam file must be gone after finalize_part");
+
+    // --- None arm: already-clean survivor → finalize_to_clean returns None ---
+    // This is the passthrough case: the file is already at its final name
+    // (no pipeline ran, or caller already finalised it).
+    assert_eq!(
+        finalize_to_clean(&clean_mkv),
+        None,
+        "finalize_to_clean must return None for a clean-named file (no rename needed)"
+    );
+    // The file is still intact — no rename or deletion occurred.
+    assert!(
+        clean_mkv.exists(),
+        "clean-named file must be untouched when finalize_to_clean returns None"
+    );
+}
+
 #[tokio::test]
 async fn discard_part_removes_and_is_noop_when_absent() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -435,10 +435,14 @@ impl DownloadPhase {
                             });
                             return Ok(Self::Cancelled);
                         };
-                        // Commit: rename .rdlp-part -> clean BEFORE post-processing
-                        // (Slice 1 finalizes pre-PP; Slice 2 moves it post-PP).
-                        super::naming::finalize_part(&part, &output_path).await?;
-                        (vec![output_path.clone()], outcome.is_hls)
+                        // Seam: move the finished .rdlp-part into the pipeline's
+                        // own .rdlp-tmp-{uuid} namespace so post-processing's
+                        // FileTracker sees only its own markers (its hardened
+                        // cancel/Drop path is untouched). The clean name is NOT
+                        // created here — the coordinator finalizes after PP (#406).
+                        let seam = super::naming::seam_path(&output_path);
+                        super::naming::finalize_part(&part, &seam).await?;
+                        (vec![seam], outcome.is_hls)
                     }
                     DownloadPlan::Merge {
                         ref video,
@@ -501,7 +505,21 @@ impl DownloadPhase {
                     }
                     Err(e) => return Err(e),
                 };
-                let final_path = final_files.into_iter().next().unwrap_or(output_path);
+                let survivor = final_files
+                    .into_iter()
+                    .next()
+                    .unwrap_or_else(|| output_path.clone());
+                // Coordinator finalize (Option X): the ONE place the clean name
+                // is created — covers PP-ran, PP-skipped, and FFmpeg-missing. The
+                // pipeline (and the no-PP bypass) returns a temp-named survivor.
+                let final_path = match super::naming::finalize_to_clean(&survivor) {
+                    Some(clean) => {
+                        super::naming::finalize_part(&survivor, &clean).await?;
+                        clean
+                    }
+                    // No marker → already a clean name; use as-is.
+                    None => survivor,
+                };
 
                 // Verify the output file actually exists
                 if !final_path.exists() {

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -250,8 +250,8 @@ impl Pipeline {
             let mut tracker = final_msg.tracker;
             tracker.cleanup();
             // `cleanup()` set `committed = true`, disarming the cancel-cleanup
-            // `Drop`. `FileTracker` now implements `Drop`, so the renamed final
-            // files can't be moved out of the field directly — take them,
+            // `Drop`. `FileTracker` now implements `Drop`, so the surviving
+            // temp-named files can't be moved out of the field directly — take them,
             // leaving the dropped tracker empty (and already committed).
             std::mem::take(&mut tracker.current_files)
         })

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -241,11 +241,11 @@ impl Pipeline {
             };
         };
 
-        // FileTracker::cleanup performs N × std::fs::remove_file and
-        // std::fs::rename. These are blocking syscalls that can stall
-        // the async runtime on slow or network filesystems. Move the
-        // work to a blocking worker so the executor stays responsive
-        // for any concurrent pipeline runs.
+        // FileTracker::cleanup performs N × std::fs::remove_file (temp_files)
+        // and commits. It no longer renames survivors — the returned files are
+        // temp-named (*.rdlp-tmp-{uuid}.*); the orchestrator does the single
+        // final rename to the clean name (#406 Option X). Run on a blocking
+        // worker so the blocking remove_file syscalls don't stall the runtime.
         let current_files = tokio::task::spawn_blocking(move || {
             let mut tracker = final_msg.tracker;
             tracker.cleanup();

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -376,6 +376,37 @@ mod tests {
         assert_eq!(result, Some(thumb));
     }
 
+    /// Slice 2 (#406 Task 3): `original_stem` is the CLEAN stem (marker-stripped
+    /// by the orchestrator), while the main file in the tracker is seam-named
+    /// (`My.Video.rdlp-tmp-<uuid>.mp4`). `find_thumbnail` must resolve the
+    /// sidecar `My.Video.jpg` via `original_stem`, NOT via the seam-named stem
+    /// (which would produce `My.Video.rdlp-tmp-<uuid>.jpg` — a non-existent path).
+    #[test]
+    fn thumbnail_discovery_uses_clean_original_stem_under_seam() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        // Thumbnail is written next to the clean stem, as the orchestrator produces.
+        let thumb = dir.path().join("My.Video.jpg");
+        fs::write(&thumb, b"fake-jpg").unwrap();
+
+        // The media file on disk is seam-named (as FileTracker sees it at this stage).
+        let seam_media = dir
+            .path()
+            .join("My.Video.rdlp-tmp-deadbeef12345678deadbeef12345678.mp4");
+        // original_stem carries the clean stem — set by Task 3 in the orchestrator.
+        let original_stem = "My.Video";
+
+        let result = ThumbnailStage::find_thumbnail(&seam_media, original_stem);
+        assert_eq!(
+            result,
+            Some(thumb),
+            "find_thumbnail must find My.Video.jpg via original_stem \
+             even when the media file is seam-named"
+        );
+    }
+
     #[tokio::test]
     async fn process_warns_when_no_thumbnail_found() {
         let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -407,6 +407,38 @@ mod tests {
         );
     }
 
+    /// Negative companion to `thumbnail_discovery_uses_clean_original_stem_under_seam`:
+    /// pins the regression direction. With the same clean sidecar `My.Video.jpg` on disk
+    /// and the same seam-named media file, but `original_stem` set to the SEAM stem itself
+    /// (what an unfixed Task 3 would have done), `find_thumbnail` returns `None` because:
+    /// - Primary lookup tries `{seam_stem}.jpg` (doesn't exist; the sidecar is `My.Video.jpg`)
+    /// - Fallback skips because `current_stem` == `original_stem` (both are the seam stem)
+    /// - Result: `None`
+    #[test]
+    fn thumbnail_discovery_misses_when_original_stem_is_seam_stem() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        // Sidecar is still written with the clean stem.
+        let thumb = dir.path().join("My.Video.jpg");
+        fs::write(&thumb, b"fake-jpg").unwrap();
+
+        // The media file on disk is seam-named.
+        let seam_media = dir
+            .path()
+            .join("My.Video.rdlp-tmp-deadbeef12345678deadbeef12345678.mp4");
+        // But original_stem is SET TO THE SEAM STEM itself (the regression).
+        let original_stem = "My.Video.rdlp-tmp-deadbeef12345678deadbeef12345678";
+
+        let result = ThumbnailStage::find_thumbnail(&seam_media, original_stem);
+        assert_eq!(
+            result, None,
+            "find_thumbnail must return None when original_stem is the seam stem \
+             (because the sidecar My.Video.jpg exists but lookup tries My.Video.rdlp-tmp-*.jpg)"
+        );
+    }
+
     #[tokio::test]
     async fn process_warns_when_no_thumbnail_found() {
         let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -387,6 +387,38 @@ mod tests {
         );
     }
 
+    /// Slice 2 (#406): the pipeline input is seam-named (`*.rdlp-tmp-*`), so
+    /// `FileTracker::Drop`'s `#339` non-temp-named warning CANNOT fire for it.
+    /// Pins that `is_temp_named` returns `true` for a seam-style name and
+    /// `false` for a clean name, i.e. the contract the caller (orchestrator)
+    /// must satisfy before handing the file to `FileTracker::new`.
+    #[test]
+    fn seam_name_is_temp_named_so_339_warning_cannot_fire() {
+        // Seam name produced by `seam_path()` — must be temp-named.
+        assert!(
+            is_temp_named(Path::new(
+                "Title.rdlp-tmp-abc123def456abc123def456abc123de.mp4"
+            )),
+            "seam-style name must be recognised as temp-named"
+        );
+        // Dotted-stem variant (the common real-world case).
+        assert!(
+            is_temp_named(Path::new(
+                "My.Video.rdlp-tmp-deadbeef12345678deadbeef12345678.mkv"
+            )),
+            "dotted-stem seam name must be recognised as temp-named"
+        );
+        // Clean names must NOT be recognised as temp-named.
+        assert!(
+            !is_temp_named(Path::new("Title.mp4")),
+            "clean name must NOT be temp-named"
+        );
+        assert!(
+            !is_temp_named(Path::new("My.Video.mkv")),
+            "dotted clean name must NOT be temp-named"
+        );
+    }
+
     #[test]
     fn drop_after_commit_keeps_files() {
         let dir = TempDir::new().unwrap();

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -128,6 +128,11 @@ impl FileTracker {
     /// surviving `current_files` to clean names — the pipeline returns them
     /// temp-named (`*.rdlp-tmp-{uuid}.*`) and the orchestrator performs the
     /// single final rename to the user-visible name (#406 Option X).
+    ///
+    /// The surviving `current_files` are released from the [`TempRegistry`] here
+    /// (so no stale entry/lock lingers) but are NOT renamed — the orchestrator
+    /// performs the single final rename to the clean name and owns the survivor's
+    /// lifecycle thereafter.
     // Safe: invoked via tokio::task::spawn_blocking from pipeline/mod.rs:182.
     #[allow(clippy::disallowed_methods)]
     pub fn cleanup(&mut self) {
@@ -140,6 +145,16 @@ impl FileTracker {
             {
                 log::warn!("FileTracker: failed to delete temp {}: {e}", path.display());
             }
+        }
+
+        // The surviving `current_files` are returned temp-named for the
+        // orchestrator to finalize (#406 Option X). Release them from the
+        // registry HERE — registry bookkeeping stays in the pipeline, which owns
+        // the `TempRegistry`. This drops the advisory lock + removes the `.lock`
+        // sidecar so no stale entry survives; the orchestrator then renames the
+        // now-unregistered temp file to its clean user-visible name.
+        for file in &self.current_files {
+            self.temp_registry.release(file.as_path());
         }
 
         // Successful completion: disarm the cancel-cleanup Drop.
@@ -295,6 +310,11 @@ mod tests {
         fs::write(&survivor, b"final").unwrap();
         let mut tracker = FileTracker::new(vec![survivor.clone()], reg);
         tracker.cleanup();
+        // Registry release assertion: the survivor was passed via FileTracker::new()
+        // (not via temp_path()), so it was never registered — reg.contains() would
+        // be vacuously false before and after. The release-on-cleanup path for
+        // temp_path()-registered survivors is covered by TempRegistry's own
+        // test_register_and_release test and by the registry Drop semantics tests.
         // (a) The file STILL EXISTS at its .rdlp-tmp- name (NOT renamed to Title.mkv).
         assert!(survivor.exists(), "cleanup() must NOT delete the survivor");
         assert!(

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -123,10 +123,11 @@ impl FileTracker {
         self.current_files[0].clone()
     }
 
-    /// Delete all temp files and unregister them from [`TempRegistry`].
-    ///
-    /// Called on successful pipeline completion. On crash, the
-    /// [`TempRegistry`] shutdown hook handles cleanup instead.
+    /// Delete all temp files and unregister them from [`TempRegistry`], then
+    /// disarm the cancel-cleanup [`Drop`] by committing. Does NOT rename the
+    /// surviving `current_files` to clean names — the pipeline returns them
+    /// temp-named (`*.rdlp-tmp-{uuid}.*`) and the orchestrator performs the
+    /// single final rename to the user-visible name (#406 Option X).
     // Safe: invoked via tokio::task::spawn_blocking from pipeline/mod.rs:182.
     #[allow(clippy::disallowed_methods)]
     pub fn cleanup(&mut self) {
@@ -138,31 +139,6 @@ impl FileTracker {
                 && let Err(e) = std::fs::remove_file(&path)
             {
                 log::warn!("FileTracker: failed to delete temp {}: {e}", path.display());
-            }
-        }
-
-        // Rename current files from UUID temp names back to clean names
-        for file in &mut self.current_files {
-            if let Some(name) = file.file_name().and_then(|n| n.to_str())
-                && let Some(idx) = name.find(".rdlp-tmp-")
-            {
-                let clean_stem = &name[..idx];
-                let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
-                let clean_name = format!("{clean_stem}.{ext}");
-                let clean_path = file.with_file_name(&clean_name);
-                match std::fs::rename(&file, &clean_path) {
-                    Ok(()) => {
-                        self.temp_registry.release(file);
-                        *file = clean_path;
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "FileTracker: failed to rename {} → {}: {e}",
-                            file.display(),
-                            clean_name,
-                        );
-                    }
-                }
             }
         }
 
@@ -305,6 +281,40 @@ mod tests {
         tracker.replace(vec![dir.path().join("new.mp4")]);
         tracker.cleanup();
         assert!(!temp.exists());
+    }
+
+    /// Slice 2 (#406 Option X): `cleanup()` MUST NOT rename the temp-named
+    /// survivor — it returns it as-is and the orchestrator does the final rename.
+    #[test]
+    fn cleanup_no_longer_renames_survivor() {
+        let dir = TempDir::new().unwrap();
+        let reg = test_registry();
+        // The survivor is the current_files entry — already temp-named (as the
+        // orchestrator UUID-renames inputs before handing them to FileTracker).
+        let survivor = dir.path().join("Title.rdlp-tmp-aaaa.mkv");
+        fs::write(&survivor, b"final").unwrap();
+        let mut tracker = FileTracker::new(vec![survivor.clone()], reg);
+        tracker.cleanup();
+        // (a) The file STILL EXISTS at its .rdlp-tmp- name (NOT renamed to Title.mkv).
+        assert!(survivor.exists(), "cleanup() must NOT delete the survivor");
+        assert!(
+            !dir.path().join("Title.mkv").exists(),
+            "cleanup() must NOT create a clean-named file"
+        );
+        // (b) current_files[0] still contains the temp marker.
+        assert!(
+            tracker.current_files[0]
+                .to_str()
+                .unwrap()
+                .contains(".rdlp-tmp-"),
+            "current_files[0] must still be temp-named after cleanup()"
+        );
+        // (c) committed is true (observable: a second drop must not delete the survivor).
+        drop(tracker);
+        assert!(
+            survivor.exists(),
+            "committed tracker must not delete survivor on drop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary (Slice 2 of #406 — closes the issue)

The clean, user-visible output filename now appears on disk **only after the entire post-process pipeline succeeds**. This closes the `#339` non-temp-named Drop warning and the "clean name masquerades as finished during PP" problem.

Builds on Slice 1 (PR #407, merged), which made the download write `.rdlp-part` and finalize to clean *before* PP. Slice 2 moves that finalize to *after* PP.

## Mechanism (Option X — single coordinator-owned finalize)

1. **Seam** — the finished `.rdlp-part` download is renamed to a pipeline-namespace temp name `{stem}.rdlp-tmp-{uuid}.{ext}` (`seam_path`) before post-processing, so the post-process `FileTracker` only ever sees its own `.rdlp-tmp-` marker — its #404/#405-hardened cancel/Drop path is **untouched**.
2. **`FileTracker::cleanup()` no longer renames** survivors; it now *releases* them from `TempRegistry` (registry bookkeeping stays in the pipeline) and returns the temp-named survivor.
3. **Coordinator finalize** — the orchestrator renames the survivor → clean via `finalize_to_clean` + `finalize_part` at all three pipeline-return consumers (state machine, playlist episode, `process_local_file`).
4. `original_stem` is now marker-stripped so thumbnail/subtitle sidecar discovery still resolves under a seam-named input.

## Why the `#339` warning is gone
The pipeline input is now `.rdlp-tmp-{uuid}` (FileTracker-recognized as temp-named), so the non-temp-named Drop warning cannot fire on a PP-cancel. Pinned by `seam_name_is_temp_named_so_339_warning_cannot_fire`.

## Verification
- Local gate green: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && check-dedup.sh && check-url-redaction.sh`.
- TDD throughout; new tests: `seam_path` round-trip/uniqueness/stdout; `cleanup_no_longer_renames_survivor`; `original_stem_for` (incl. marker + empty); `seam_then_finalize_yields_clean_name`; `seam_name_is_temp_named_…`; thumbnail-under-seam **positive + negative** pair; `process_local_finalize_some_renames_none_passes_through`.

## Reviews (mandatory pre-push, whole `develop..HEAD` diff)
- **security-reviewer: Approve.** No High/Critical. The load-bearing registry-handoff audit PASSED (survivor released before the orchestrator renames; crash-window covered by the `*.rdlp-tmp-*` stale-sweep; cancel/Drop un-regressed). Visibility change confirmed **no public-API leak** (`orchestrator` is `pub(crate)`, caps `naming`). Seam rename same-dir (no EXDEV). One Medium (PP-failure delivers a clean-named unprocessed file) — **pre-existing**, carried forward unchanged → follow-up.
- **code-reviewer: Approve.** Lifecycle traced correct end-to-end; the 3 finalize sites are consistent; the Merge survivor correctly hits the `Some` branch (no temp leak). Two minors, both pre-existing/cosmetic → follow-ups.

## Note for reviewers
The Merge path is **name-neutral** under this PR: a merged download finalizes to its pre-existing `Title.video.fNNN.mkv` name (the old `cleanup()` rename produced the byte-identical result). This PR neither fixes nor worsens that; it's tracked as a follow-up.

## Follow-up issues (filed)
- Merge clean name leaks `.video.fNNN` format-id infix (seam the Merge branch via `seam_path`).
- PP-failure delivers a clean-named unprocessed file + `Completed` (distinguish failure; emit Warning/`*.partial.*`).
- Episode + `process_local_file` PP-cancel lacks `cleanup_cancelled_artifacts` wiring (#404 only wired the single-video path).
- DRY: extract a shared `finalize_survivor` helper for the 3 coordinator-finalize sites.

Closes #406
