### PR TITLE
feat: cross-platform CLI graceful cancellation (Ctrl+C/SIGTERM) — close #413

### DIFF
--- a/crates/rdlp-api/src/cancel.rs
+++ b/crates/rdlp-api/src/cancel.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 const DISCARD: u8 = 0;
-#[allow(dead_code)] // wired into Orchestrator + DownloadHandle in Tasks 2-3
 const KEEP: u8 = 1;
 
 /// Keep-vs-discard intent for the next cancellation.
@@ -19,7 +18,6 @@ const KEEP: u8 = 1;
 /// delete-on-cancel behavior, because the desktop cancels via the raw
 /// `CancellationToken` and never goes through [`crate::DownloadHandle::cancel`].
 /// Only an explicit interrupt (`set_keep`) opts into keeping the partial.
-#[allow(dead_code)] // wired into Orchestrator + DownloadHandle in Tasks 2-3
 #[allow(clippy::redundant_pub_crate)] // module is pub(crate); items use pub(crate) for explicitness
 #[derive(Clone)]
 pub(crate) struct CancelDisposition(Arc<AtomicU8>);
@@ -30,7 +28,6 @@ impl Default for CancelDisposition {
     }
 }
 
-#[allow(dead_code)] // wired into Orchestrator + DownloadHandle in Tasks 2-3
 #[allow(clippy::redundant_pub_crate)]
 impl CancelDisposition {
     /// A fresh disposition defaulting to `Discard`.

--- a/crates/rdlp-api/src/cancel.rs
+++ b/crates/rdlp-api/src/cancel.rs
@@ -1,0 +1,76 @@
+//! Cancellation disposition: whether a cancel should KEEP the resumable
+//! download partial (an interrupt — industry standard for download tools) or
+//! DISCARD it (an explicit cancel — the desktop "clear job" intent). #413.
+//!
+//! Shared (cheap `Arc` clone) between [`crate::DownloadHandle`] and the
+//! orchestrator so the signal-handler task can set the intent before cancelling
+//! the [`tokio_util::sync::CancellationToken`].
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const DISCARD: u8 = 0;
+#[allow(dead_code)] // wired into Orchestrator + DownloadHandle in Tasks 2-3
+const KEEP: u8 = 1;
+
+/// Keep-vs-discard intent for the next cancellation.
+///
+/// **Default is `Discard`** — this preserves the desktop's existing
+/// delete-on-cancel behavior, because the desktop cancels via the raw
+/// `CancellationToken` and never goes through [`crate::DownloadHandle::cancel`].
+/// Only an explicit interrupt (`set_keep`) opts into keeping the partial.
+#[allow(dead_code)] // wired into Orchestrator + DownloadHandle in Tasks 2-3
+#[allow(clippy::redundant_pub_crate)] // module is pub(crate); items use pub(crate) for explicitness
+#[derive(Clone)]
+pub(crate) struct CancelDisposition(Arc<AtomicU8>);
+
+impl Default for CancelDisposition {
+    fn default() -> Self {
+        Self(Arc::new(AtomicU8::new(DISCARD)))
+    }
+}
+
+#[allow(dead_code)] // wired into Orchestrator + DownloadHandle in Tasks 2-3
+#[allow(clippy::redundant_pub_crate)]
+impl CancelDisposition {
+    /// A fresh disposition defaulting to `Discard`.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the next cancel as an interrupt: KEEP the resumable `.rdlp-part`.
+    pub(crate) fn set_keep(&self) {
+        self.0.store(KEEP, Ordering::SeqCst);
+    }
+
+    /// True when the resumable partial should be kept (interrupt).
+    pub(crate) fn should_keep(&self) -> bool {
+        self.0.load(Ordering::SeqCst) == KEEP
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_defaults_to_discard() {
+        assert!(!CancelDisposition::new().should_keep());
+        assert!(!CancelDisposition::default().should_keep());
+    }
+
+    #[test]
+    fn test_set_keep_flips_to_keep() {
+        let d = CancelDisposition::new();
+        d.set_keep();
+        assert!(d.should_keep());
+    }
+
+    #[test]
+    fn test_clone_shares_state() {
+        let a = CancelDisposition::new();
+        let b = a.clone();
+        a.set_keep();
+        assert!(b.should_keep(), "clone must observe the shared store");
+    }
+}

--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -203,6 +203,7 @@ impl RdlpClient {
                 Some(registry),
                 Some(extractor_registry),
                 shared_http,
+                crate::cancel::CancelDisposition::new(), // Task 3 replaces with shared clone
             );
 
             // Load cookies: fatal when explicitly requested, non-fatal otherwise

--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -179,12 +179,14 @@ impl RdlpClient {
         let (tx, rx) = mpsc::channel::<Event>(256);
         let cancel_token = CancellationToken::new();
 
+        let cancel_disposition = crate::cancel::CancelDisposition::new();
         let shared_http = self.shared_http_for(&request);
         let config = Arc::new(self.build_config(&request));
         let interactive_flag = request.format.interactive;
         let url = request.url;
         let interactive_cb = self.interactive.clone();
         let token = cancel_token.clone();
+        let disposition_for_task = cancel_disposition.clone();
         let registry = Arc::clone(&self.temp_registry);
         let extractor_registry = Arc::clone(&self.extractor_registry);
 
@@ -203,7 +205,7 @@ impl RdlpClient {
                 Some(registry),
                 Some(extractor_registry),
                 shared_http,
-                crate::cancel::CancelDisposition::new(), // Task 3 replaces with shared clone
+                disposition_for_task,
             );
 
             // Load cookies: fatal when explicitly requested, non-fatal otherwise
@@ -331,7 +333,7 @@ impl RdlpClient {
             Err(err)
         });
 
-        DownloadHandle::new(id, rx, cancel_token, join_handle)
+        DownloadHandle::new(id, rx, cancel_token, cancel_disposition, join_handle)
     }
 
     /// Extract metadata without downloading.
@@ -715,7 +717,13 @@ impl RdlpClient {
             }
         });
 
-        DownloadHandle::new(id, rx, cancel_token, join_handle)
+        DownloadHandle::new(
+            id,
+            rx,
+            cancel_token,
+            crate::cancel::CancelDisposition::new(),
+            join_handle,
+        )
     }
 
     /// Returns the shared client+jar to reuse for `request`, or `None` if it

--- a/crates/rdlp-api/src/handle.rs
+++ b/crates/rdlp-api/src/handle.rs
@@ -5,6 +5,7 @@
 //! with a running download — receiving events, cancelling, and waiting
 //! for the final result.
 
+use crate::cancel::CancelDisposition;
 use crate::errors::RdlpApiError;
 use crate::events::Event;
 use crate::result::DownloadResult;
@@ -52,26 +53,31 @@ impl fmt::Display for DownloadId {
 ///
 /// - [`events()`](Self::events) borrows the receiver for polling.
 /// - [`cancel()`](Self::cancel) is non-blocking and idempotent.
+/// - [`interrupt()`](Self::interrupt) is like cancel but keeps the resumable partial.
 /// - [`wait()`](Self::wait) consumes the handle and returns the final result.
 pub struct DownloadHandle {
     id: DownloadId,
     events_rx: mpsc::Receiver<Event>,
     cancel_token: CancellationToken,
+    cancel_disposition: CancelDisposition,
     join_handle: JoinHandle<Result<DownloadResult, RdlpApiError>>,
 }
 
 impl DownloadHandle {
     /// Create a new handle (crate-internal).
-    pub(crate) const fn new(
+    #[allow(clippy::missing_const_for_fn)] // Arc inside CancelDisposition prevents const
+    pub(crate) fn new(
         id: DownloadId,
         events_rx: mpsc::Receiver<Event>,
         cancel_token: CancellationToken,
+        cancel_disposition: CancelDisposition,
         join_handle: JoinHandle<Result<DownloadResult, RdlpApiError>>,
     ) -> Self {
         Self {
             id,
             events_rx,
             cancel_token,
+            cancel_disposition,
             join_handle,
         }
     }
@@ -105,6 +111,22 @@ impl DownloadHandle {
         self.cancel_token.cancel();
     }
 
+    /// Interrupt the download (Ctrl+C / SIGINT semantics): KEEP the resumable
+    /// `.rdlp-part` for resume, then cancel. Non-blocking, idempotent. #413.
+    pub fn interrupt(&self) {
+        self.cancel_disposition.set_keep();
+        self.cancel_token.cancel();
+    }
+
+    /// A detachable interrupt trigger that can be moved into a signal-handler
+    /// task while the handle retains `events()`/`wait()`. #413.
+    pub fn interrupt_handle(&self) -> InterruptHandle {
+        InterruptHandle {
+            token: self.cancel_token.clone(),
+            disposition: self.cancel_disposition.clone(),
+        }
+    }
+
     /// Wait for the download to complete, consuming the handle.
     ///
     /// Returns the final result or error. Drain all events from
@@ -121,6 +143,23 @@ impl DownloadHandle {
                 message: format!("Download task panicked: {join_err}"),
             }),
         }
+    }
+}
+
+/// Detached interrupt trigger (clonable bits of a [`DownloadHandle`]), so a
+/// signal-handler task can request a keep-the-partial cancel without holding
+/// the whole handle. #413.
+#[must_use = "InterruptHandle must be moved into the signal-handler task; dropping it makes interrupt() a no-op"]
+pub struct InterruptHandle {
+    token: CancellationToken,
+    disposition: CancelDisposition,
+}
+
+impl InterruptHandle {
+    /// Interrupt: KEEP the resumable partial, then cancel. Idempotent.
+    pub fn interrupt(&self) {
+        self.disposition.set_keep();
+        self.token.cancel();
     }
 }
 
@@ -152,5 +191,59 @@ mod tests {
         let id = DownloadId::next();
         let id2 = id;
         assert_eq!(id, id2);
+    }
+
+    #[tokio::test]
+    async fn test_interrupt_sets_keep_and_cancels() {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let token = CancellationToken::new();
+        let disposition = crate::cancel::CancelDisposition::new();
+        let jh = tokio::spawn(async {
+            Ok(crate::result::DownloadResult {
+                id: DownloadId::next(),
+                output_files: vec![],
+                info: rdlp_types::InfoDict::new("id", "title", "ext", "url"),
+                stats: rdlp_core::DownloadStats::new(0, std::time::Duration::ZERO, 0),
+            })
+        });
+        let handle = DownloadHandle::new(
+            DownloadId::next(),
+            rx,
+            token.clone(),
+            disposition.clone(),
+            jh,
+        );
+        let ih = handle.interrupt_handle();
+        ih.interrupt();
+        assert!(token.is_cancelled(), "interrupt cancels the token");
+        assert!(disposition.should_keep(), "interrupt sets Keep");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_leaves_discard_default() {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let token = CancellationToken::new();
+        let disposition = crate::cancel::CancelDisposition::new();
+        let jh = tokio::spawn(async {
+            Ok(crate::result::DownloadResult {
+                id: DownloadId::next(),
+                output_files: vec![],
+                info: rdlp_types::InfoDict::new("id", "title", "ext", "url"),
+                stats: rdlp_core::DownloadStats::new(0, std::time::Duration::ZERO, 0),
+            })
+        });
+        let handle = DownloadHandle::new(
+            DownloadId::next(),
+            rx,
+            token.clone(),
+            disposition.clone(),
+            jh,
+        );
+        handle.cancel();
+        assert!(token.is_cancelled());
+        assert!(
+            !disposition.should_keep(),
+            "cancel() keeps the Discard default"
+        );
     }
 }

--- a/crates/rdlp-api/src/lib.rs
+++ b/crates/rdlp-api/src/lib.rs
@@ -34,6 +34,8 @@ pub mod result;
 #[cfg(feature = "serde")]
 pub mod dto;
 
+/// Cancellation disposition: keep-vs-discard intent for partial files.
+pub(crate) mod cancel;
 /// Conditional merge of request overrides into Config.
 pub(crate) mod merge;
 /// Internal orchestrator (moved from rdlp-cli).

--- a/crates/rdlp-api/src/lib.rs
+++ b/crates/rdlp-api/src/lib.rs
@@ -47,7 +47,7 @@ pub(crate) mod plugin_bootstrap;
 pub use client::RdlpClient;
 pub use errors::RdlpApiError;
 pub use events::Event;
-pub use handle::{DownloadHandle, DownloadId};
+pub use handle::{DownloadHandle, DownloadId, InterruptHandle};
 pub use orchestrator::InteractiveCallback;
 pub use rdlp_core::{DownloadProgress, config_io};
 pub use rdlp_postprocess::TempRegistry;

--- a/crates/rdlp-api/src/orchestrator/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/mod.rs
@@ -114,6 +114,8 @@ pub struct Orchestrator {
     pub(super) cancel_token: CancellationToken,
     /// Optional interactive callback for user input
     pub(super) interactive: Option<Arc<dyn InteractiveCallback>>,
+    /// Keep-vs-discard intent for cancellation (#413). Default Discard.
+    pub(super) cancel_disposition: crate::cancel::CancelDisposition,
 }
 
 impl Orchestrator {
@@ -154,6 +156,9 @@ impl Orchestrator {
     /// process-level cached built-in registry (no plugin support in that path).
     /// Callers that support plugins **MUST** pass a pre-built registry from
     /// [`RdlpClient`] so plugins are available for every download.
+    ///
+    /// Uses a fresh `Discard` [`crate::cancel::CancelDisposition`]; callers
+    /// needing a shared keep-vs-discard intent use [`Self::new_with_shared`].
     #[must_use]
     pub fn new_with_registry(
         config: Arc<Config>,
@@ -173,6 +178,7 @@ impl Orchestrator {
             temp_registry,
             extractor_registry,
             None,
+            crate::cancel::CancelDisposition::new(),
         )
     }
 
@@ -196,6 +202,7 @@ impl Orchestrator {
         temp_registry: Option<Arc<TempRegistry>>,
         extractor_registry: Option<Arc<ExtractorRegistry>>,
         shared_http: Option<SharedHttpClient>,
+        cancel_disposition: crate::cancel::CancelDisposition,
     ) -> Self {
         let (http_client, cookie_jar) = if let Some(shared) = shared_http {
             (shared.client, shared.cookie_jar)
@@ -256,6 +263,7 @@ impl Orchestrator {
             download_id,
             cancel_token,
             interactive,
+            cancel_disposition,
         }
     }
 
@@ -293,6 +301,11 @@ impl Orchestrator {
         ];
 
         Some(Arc::new(Pipeline::new(stages, temp_registry, 2)))
+    }
+
+    /// Whether a cancellation should keep the resumable download partial.
+    pub(super) fn should_keep_partial(&self) -> bool {
+        self.cancel_disposition.should_keep()
     }
 
     /// Emit an event to the event channel, ignoring send failures.
@@ -507,6 +520,28 @@ impl Orchestrator {
             Ok(Err(e)) => warn!("Failed to write to download archive: {e}"),
             Err(e) => warn!("Archive record task join failed: {e}"),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+mod cancel_disposition_tests {
+    use super::*;
+    use crate::events::Event;
+    use crate::handle::DownloadId;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn test_should_keep_partial_reflects_disposition() {
+        let config = Arc::new(rdlp_types::Config::default());
+        let (tx, _rx) = mpsc::channel::<Event>(1);
+        let id = DownloadId::next();
+        let token = CancellationToken::new();
+        let orch = Orchestrator::new(config, tx, id, token, None);
+        assert!(!orch.should_keep_partial(), "default is Discard");
+        orch.cancel_disposition.set_keep();
+        assert!(orch.should_keep_partial(), "after set_keep -> Keep");
     }
 }
 

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -193,8 +193,11 @@ impl Orchestrator {
                             break;
                         }
                         Ok(None) => {
-                            // Explicit cancel: drop the .rdlp-part working file.
-                            crate::orchestrator::naming::discard_part(&part).await;
+                            // #413: interrupt keeps the resumable partial; explicit
+                            // cancel (default) deletes it.
+                            if !self.should_keep_partial() {
+                                crate::orchestrator::naming::discard_part(&part).await;
+                            }
                             return Ok(None);
                         }
                         Err(e) if attempt < MAX_EXTRACT_RETRIES && is_reextractable_error(&e) => {

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -427,9 +427,11 @@ impl DownloadPhase {
                             .download_with_cdn_fallback(&format, &part, state.offset())
                             .await?
                         else {
-                            // Explicit cancel: delete the .rdlp-part working file so
-                            // a cancel leaves no artifact (#406). Best-effort.
-                            super::naming::discard_part(&part).await;
+                            // #413: an interrupt keeps the resumable .rdlp-part for
+                            // resume; an explicit cancel (default) deletes it.
+                            if !orchestrator.should_keep_partial() {
+                                super::naming::discard_part(&part).await;
+                            }
                             orchestrator.emit(Event::Cancelled {
                                 id: orchestrator.download_id,
                             });

--- a/crates/rdlp-cli/src/lib.rs
+++ b/crates/rdlp-cli/src/lib.rs
@@ -21,3 +21,5 @@ pub mod interactive;
 /// drive them without going through `clap`'s argument parsing.
 #[path = "plugin_cmd.rs"]
 pub mod plugin_cmd;
+/// Cross-platform shutdown-signal handling and escalation state machine (#413).
+pub mod signal;

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -20,6 +20,7 @@ use rdlp_api::{RdlpApiError, RdlpClient};
 use rdlp_cli::event_handler::CliEventHandler;
 use rdlp_cli::interactive::DialoguerCallback;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -70,11 +71,19 @@ fn main() -> Result<()> {
         .build()
         .context("failed to build Tokio runtime")?;
 
-    runtime.block_on(async_main())
+    let exit_signal = Arc::new(AtomicU8::new(0));
+    let result = runtime.block_on(async_main(Arc::clone(&exit_signal)));
+
+    // #413: a graceful signal-cancel set the conventional exit code; emit it.
+    let code = exit_signal.load(Ordering::SeqCst);
+    if code != 0 {
+        std::process::exit(i32::from(code)); // 130 = SIGINT, 143 = SIGTERM
+    }
+    result
 }
 
 #[allow(clippy::too_many_lines)] // top-level CLI dispatch; extracting sub-functions would add indirection without clarity
-async fn async_main() -> Result<()> {
+async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
     let args = Args::parse();
 
     // Build config with precedence: CLI > config file > defaults
@@ -387,6 +396,30 @@ async fn async_main() -> Result<()> {
 
     // Start the download
     let mut handle = client.download(request);
+
+    // #413: drive cancellation from OS signals. First interrupt → graceful
+    // (keep the resumable partial); second SIGINT → force-exit 130.
+    {
+        use rdlp_cli::signal::{SignalAction, next_action, wait_for_signal};
+        let interrupt = handle.interrupt_handle();
+        let exit_for_task = Arc::clone(&exit_signal);
+        tokio::spawn(async move {
+            let mut graceful_started = false;
+            loop {
+                let sig = wait_for_signal().await;
+                match next_action(graceful_started, sig) {
+                    SignalAction::GracefulCancel(code) => {
+                        graceful_started = true;
+                        exit_for_task.store(code, Ordering::SeqCst);
+                        interrupt.interrupt();
+                    }
+                    SignalAction::ForceExit(code) => std::process::exit(i32::from(code)),
+                    SignalAction::Ignore => {}
+                }
+            }
+        });
+    }
+
     let mut event_handler = CliEventHandler::new(Arc::clone(&multi_progress), quiet);
 
     // Drain all events (progress, status, etc.)

--- a/crates/rdlp-cli/src/signal.rs
+++ b/crates/rdlp-cli/src/signal.rs
@@ -1,0 +1,137 @@
+//! Cross-platform shutdown-signal handling for the CLI (#413).
+//!
+//! Handles SIGINT + SIGTERM (Unix) and `CTRL_C` + `CTRL_CLOSE` (Windows) via
+//! `tokio::signal`. First interrupt = graceful cancel (keep the resumable
+//! partial); second SIGINT = force-exit. Uses `tokio::signal` — not the
+//! `ctrlc` crate, which fights tokio's signal driver.
+
+use std::future;
+use tokio::signal;
+
+/// Which class of shutdown signal fired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Signal {
+    /// SIGINT / Ctrl+C — interactive; escalates on repeat.
+    Interrupt,
+    /// SIGTERM / Windows console-close — programmatic; never escalates.
+    Terminate,
+}
+
+/// What the signal task should do for `(graceful_started, signal)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalAction {
+    /// Begin graceful cancel; carry the exit code to emit later (130/143).
+    GracefulCancel(u8),
+    /// A human pressed Ctrl+C again (or during a programmatic stop) — exit now.
+    ForceExit,
+    /// Repeat programmatic signal while already cancelling — ignore.
+    Ignore,
+}
+
+/// Pure state transition for the escalation state machine (#413, validated).
+/// `graceful_started` is the flag the caller keeps across iterations.
+#[must_use]
+pub const fn next_action(graceful_started: bool, sig: Signal) -> SignalAction {
+    match (graceful_started, sig) {
+        // First interrupt OR first programmatic stop: begin graceful cancel.
+        (false, Signal::Interrupt) => SignalAction::GracefulCancel(130),
+        (false, Signal::Terminate) => SignalAction::GracefulCancel(143),
+        // Any human interrupt after a graceful cancel has begun: force-exit now.
+        (true, Signal::Interrupt) => SignalAction::ForceExit,
+        // Repeat programmatic signal while already cancelling: ignore (preserve
+        // the systemd/docker grace window — do NOT force).
+        (true, Signal::Terminate) => SignalAction::Ignore,
+    }
+}
+
+/// Resolve on the first shutdown signal; report its class.
+///
+/// cfg-gated `let`-bindings (NOT `#[cfg]` inside `select!` — unsupported,
+/// tokio #3974) with `future::pending()` stubs on the non-applicable platform.
+///
+/// # Panics
+///
+/// Panics if the OS refuses to install a signal handler (out of file
+/// descriptors, or a double-registration race). Either condition is
+/// unrecoverable at startup, so a panic is the correct response.
+pub async fn wait_for_signal() -> Signal {
+    let ctrl_c = async {
+        #[allow(clippy::expect_used)]
+        // tokio signal install — propagation impossible; panic is correct
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        #[allow(clippy::expect_used)]
+        // tokio signal install — propagation impossible; panic is correct
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = future::pending::<()>();
+
+    #[cfg(windows)]
+    let win_close = async {
+        #[allow(clippy::expect_used)]
+        // tokio signal install — propagation impossible; panic is correct
+        signal::windows::ctrl_close()
+            .expect("failed to install CtrlClose handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(windows))]
+    let win_close = future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c    => Signal::Interrupt,
+        () = terminate => Signal::Terminate,
+        () = win_close => Signal::Terminate,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_sigint_graceful_130() {
+        assert_eq!(
+            next_action(false, Signal::Interrupt),
+            SignalAction::GracefulCancel(130)
+        );
+    }
+    #[test]
+    fn test_first_sigterm_graceful_143() {
+        assert_eq!(
+            next_action(false, Signal::Terminate),
+            SignalAction::GracefulCancel(143)
+        );
+    }
+    #[test]
+    fn test_second_sigint_force_exits() {
+        assert_eq!(
+            next_action(true, Signal::Interrupt),
+            SignalAction::ForceExit
+        );
+    }
+    #[test]
+    fn test_sigint_after_sigterm_force_exits() {
+        // Load-bearing: a human must be able to force-quit a slow programmatic
+        // (SIGTERM) shutdown. `graceful_started` is signal-agnostic, so this is
+        // deliberately the SAME (true, Interrupt) arm as test_second_sigint_force_exits
+        // — documented separately because it pins a distinct user-facing guarantee.
+        assert_eq!(
+            next_action(true, Signal::Interrupt),
+            SignalAction::ForceExit
+        );
+    }
+    #[test]
+    fn test_repeat_sigterm_ignored() {
+        assert_eq!(next_action(true, Signal::Terminate), SignalAction::Ignore);
+    }
+}

--- a/crates/rdlp-cli/src/signal.rs
+++ b/crates/rdlp-cli/src/signal.rs
@@ -22,8 +22,9 @@ pub enum Signal {
 pub enum SignalAction {
     /// Begin graceful cancel; carry the exit code to emit later (130/143).
     GracefulCancel(u8),
-    /// A human pressed Ctrl+C again (or during a programmatic stop) — exit now.
-    ForceExit,
+    /// A human pressed Ctrl+C again (or during a programmatic stop) — exit now
+    /// with this exit code.
+    ForceExit(u8),
     /// Repeat programmatic signal while already cancelling — ignore.
     Ignore,
 }
@@ -37,7 +38,7 @@ pub const fn next_action(graceful_started: bool, sig: Signal) -> SignalAction {
         (false, Signal::Interrupt) => SignalAction::GracefulCancel(130),
         (false, Signal::Terminate) => SignalAction::GracefulCancel(143),
         // Any human interrupt after a graceful cancel has begun: force-exit now.
-        (true, Signal::Interrupt) => SignalAction::ForceExit,
+        (true, Signal::Interrupt) => SignalAction::ForceExit(130),
         // Repeat programmatic signal while already cancelling: ignore (preserve
         // the systemd/docker grace window — do NOT force).
         (true, Signal::Terminate) => SignalAction::Ignore,
@@ -116,7 +117,7 @@ mod tests {
     fn test_second_sigint_force_exits() {
         assert_eq!(
             next_action(true, Signal::Interrupt),
-            SignalAction::ForceExit
+            SignalAction::ForceExit(130)
         );
     }
     #[test]
@@ -127,7 +128,7 @@ mod tests {
         // — documented separately because it pins a distinct user-facing guarantee.
         assert_eq!(
             next_action(true, Signal::Interrupt),
-            SignalAction::ForceExit
+            SignalAction::ForceExit(130)
         );
     }
     #[test]


### PR DESCRIPTION
## Summary

Wires CLI interrupt signals to rdlp's existing `CancellationToken` cancellation machinery, with industry-standard download-tool semantics: **first interrupt = graceful cancel that keeps the resumable partial; second Ctrl+C = force-exit; POSIX exit codes.**

- **`CancelDisposition`** (`Arc<AtomicU8>`, default **Discard**) travels beside the `CancellationToken`. On a CLI interrupt the signal task sets **Keep** then cancels → the orchestrator's two cancel arms (single-download + playlist-episode) **skip deleting the `.rdlp-part`**, leaving it resumable. The desktop cancels via the raw token (never through `interrupt()`) and inherits the **Discard** default → unchanged delete-on-cancel.
- **`DownloadHandle::interrupt()` + detachable `InterruptHandle`** — set Keep then cancel. `cancel()` is unchanged (leaves Discard).
- **Cross-platform signal handling** (`crates/rdlp-cli/src/signal.rs`): `tokio::signal` for Ctrl+C + SIGTERM (Unix) + Ctrl+Close (Windows) via cfg-gated `let`-bindings (not `#[cfg]` inside `select!`). A pure, fully-tested `next_action()` escalation state machine; the load-bearing case — a human Ctrl+C must always force-quit even a slow programmatic (SIGTERM) shutdown — is pinned by a test.
- **Exit codes** 130 (SIGINT) / 143 (SIGTERM) emitted from `main` after the runtime unwinds, so normal cleanup runs on the graceful path. All exit-code literals live in `signal.rs` (`GracefulCancel(u8)` / `ForceExit(u8)`); `main.rs` has none.

**Scope:** the **download** path only, exactly as the validated design/plan specified. No new dependencies (`tokio` `signal` feature already enabled; tokio 1.49.0 ≥ 1.44 incl. PR #7122 Windows fix). Desktop cancel path untouched.

## Verification

**Pre-PR gate (all green):** `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && check-dedup.sh && check-url-redaction.sh`. `cargo tree -p tokio` → v1.49.0.

**Manual signal e2e (foreground via `setsid -w`, not backgrounded — `&` would inherit `SIG_IGN`):**
- **SIGINT** → exit **130**, `.rdlp-part` + `.rdlp_state.json` **kept**, log: "Progress saved. Run the same command again to resume." Re-running **resumed and finalized** to the clean `991017`-byte file (exit 0).
- **SIGTERM** → exit **143**, partial kept.
- **Double Ctrl+C** → second forces exit **130**.

## Reviews

- **security-reviewer** (full `develop..HEAD`): **Approve** — no Critical/High. One LOW (orphaned temps on double-Ctrl+C force-exit, backstopped by the existing TempRegistry stale-sweep). Confirmed: Discard default correct, state sidecars carry no credentials, no new URL-in-log surfaces, atomic ordering sound.
- **code-reviewer** (full `develop..HEAD`): cross-task seams verified (shared-Arc identity end-to-end, `cancel()` stays Discard, both `discard_part` arms gated, no leftover TDD `#[allow]`). Its one Important finding — extend graceful cancel to the **local-file transcode** path — was investigated and **deliberately deferred** because wiring it surfaced a latent **data-loss bug** (`FileTracker::Drop` deletes a non-temp-named `current_files` entry → the user's source file on a local-file cancel). Split to **#414** with a clean repro + acceptance criteria + TDD plan, rather than shipping a half-fixed data-loss path.

## Follow-ups
- **#414** — graceful cancel for the local-file path + the FileTracker source-deletion guard (the discovered data-loss bug).
- LOW (security): tighten the force-exit path to give `FileTracker::Drop` a brief window before `process::exit` (non-blocking; stale-sweep covers it today).

Closes #413