### PR TITLE
fix: preserve user's source file on local-file recode + graceful cancel — close #414

### DIFF
--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -672,7 +672,7 @@ impl RdlpClient {
             }
 
             match orchestrator
-                .run_postprocessing(&info, vec![path], false, false)
+                .run_postprocessing(&info, vec![path], false, true) // keep_inputs=true: user's source is borrowed, never deleted (#414)
                 .await
             {
                 Ok(output_files) => {

--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -672,7 +672,7 @@ impl RdlpClient {
             }
 
             match orchestrator
-                .run_postprocessing(&info, vec![path], false)
+                .run_postprocessing(&info, vec![path], false, false)
                 .await
             {
                 Ok(output_files) => {

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -108,6 +108,17 @@ pub async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
         // after the remove, `clean` is gone forever. Move the existing file aside
         // first and restore it if the rename fails, so `clean` is never lost.
         let backup = {
+            // A real media output path always has a file name; a root or
+            // directory path reaching this branch would be a caller-contract
+            // violation (the orchestrator only calls finalize_part on actual
+            // file paths). Verified here so the `.unwrap_or_default()` fallback
+            // is known-safe and an assertion fires in debug builds.
+            debug_assert!(
+                clean.file_name().is_some(),
+                "finalize_part: clean path has no file name component (degenerate path?) — \
+                 backup name would be empty: {}",
+                clean.display()
+            );
             let mut name = clean
                 .file_name()
                 .map(std::ffi::OsStr::to_os_string)
@@ -115,9 +126,19 @@ pub async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
             name.push(format!(".rdlp-bak-{}", uuid::Uuid::new_v4().simple()));
             clean.with_file_name(name)
         };
-        tokio::fs::rename(clean, &backup)
-            .await
-            .with_context(|| format!("failed to back up existing {}", clean.display()))?;
+        // NOTE (#414 follow-up): a second Ctrl+C force-exit (process::exit) in the
+        // micro-window between this backup rename and the rename below would orphan
+        // the `.rdlp-bak-{uuid}` file (it holds the user's data — no loss, just a
+        // leftover). finalize_part has no TempRegistry handle to register the backup
+        // for stale-sweep; tracked as a follow-up.
+        tokio::fs::rename(clean, &backup).await.with_context(|| {
+            format!(
+                "failed to back up existing {} while finalizing {} -> {}",
+                clean.display(),
+                part.display(),
+                clean.display()
+            )
+        })?;
         match tokio::fs::rename(part, clean).await {
             Ok(()) => {
                 // Success: drop the backup (best-effort; ignore errors).

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -83,23 +83,68 @@ pub fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
     Some(survivor.with_file_name(clean))
 }
 
-/// Atomically commit a finished `.rdlp-part` download to its clean output name.
+/// Atomically commit a finished temp-named file to its clean output name.
 ///
-/// Same-directory rename (no `EXDEV`), atomic on POSIX. On failure the rename
-/// is a no-op: the `.rdlp-part` file is left intact (a re-run re-probes it and
-/// re-attempts finalize) and the clean name is not created — the error is
-/// surfaced to the caller via context. Used by both the already-complete resume
-/// short-circuit and the normal download-completion path so the two share one
-/// rename call and one error message.
+/// Same-directory rename (no `EXDEV`). On POSIX `rename(2)` replaces an
+/// existing destination atomically. On Windows `MoveFileExW` fails if the
+/// destination exists unless `MOVEFILE_REPLACE_EXISTING` is set; `tokio::fs::rename`
+/// does NOT set that flag, so we must handle a pre-existing clean file before
+/// renaming. This matters for the borrowed-input (`keep_inputs=true`) same-
+/// container in-place case: the source is still on disk when finalize runs and
+/// the survivor must replace it (#414).
+///
+/// Uses a **backup-restore** pattern when `clean` already exists: the existing
+/// file is moved aside first, and restored if the final rename fails, so `clean`
+/// is never lost without `part` safely in place.
+///
+/// On failure the temp file is left intact and the error is surfaced to the
+/// caller via context.
 pub async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
     use anyhow::Context as _;
-    tokio::fs::rename(part, clean).await.with_context(|| {
-        format!(
-            "failed to finalize download {} -> {}",
-            part.display(),
-            clean.display()
-        )
-    })
+
+    if part != clean && tokio::fs::try_exists(clean).await.unwrap_or(false) {
+        // `clean` already exists (e.g. keep_inputs same-container in-place case).
+        // A bare remove-then-rename has a data-loss window: if the rename fails
+        // after the remove, `clean` is gone forever. Move the existing file aside
+        // first and restore it if the rename fails, so `clean` is never lost.
+        let backup = {
+            let mut name = clean
+                .file_name()
+                .map(std::ffi::OsStr::to_os_string)
+                .unwrap_or_default();
+            name.push(format!(".rdlp-bak-{}", uuid::Uuid::new_v4().simple()));
+            clean.with_file_name(name)
+        };
+        tokio::fs::rename(clean, &backup)
+            .await
+            .with_context(|| format!("failed to back up existing {}", clean.display()))?;
+        match tokio::fs::rename(part, clean).await {
+            Ok(()) => {
+                // Success: drop the backup (best-effort; ignore errors).
+                let _ = tokio::fs::remove_file(&backup).await;
+                Ok(())
+            }
+            Err(e) => {
+                // Restore the original so `clean` is never lost.
+                let _ = tokio::fs::rename(&backup, clean).await;
+                Err(e).with_context(|| {
+                    format!(
+                        "failed to finalize {} -> {} (original restored)",
+                        part.display(),
+                        clean.display()
+                    )
+                })
+            }
+        }
+    } else {
+        tokio::fs::rename(part, clean).await.with_context(|| {
+            format!(
+                "failed to finalize download {} -> {}",
+                part.display(),
+                clean.display()
+            )
+        })
+    }
 }
 
 /// Best-effort removal of a `.rdlp-part` working file on explicit cancel, so a
@@ -292,5 +337,53 @@ mod tests {
     #[test]
     fn seam_path_is_noop_for_stdout() {
         assert_eq!(seam_path(&PathBuf::from("-")), PathBuf::from("-"));
+    }
+
+    /// `finalize_part` must overwrite an existing clean file.
+    ///
+    /// This exercises the Windows-safe path: on POSIX `rename(2)` replaces
+    /// atomically, but `tokio::fs::rename` on Windows fails if the destination
+    /// already exists. For `process_local_file` with `keep_inputs=true`, the
+    /// borrowed source file still exists on disk when the survivor is finalized
+    /// to the same path (same-container in-place update), so `finalize_part`
+    /// must remove it first (#414).
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)] // std::fs helpers in test fixtures — per clippy.toml policy (c)
+    async fn test_finalize_part_overwrites_existing_clean() {
+        use std::io::Write as _;
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+
+        // The survivor (temp-named output from the pipeline).
+        let part = dir.path().join("video.rdlp-tmp-abc123.mp4");
+        // The pre-existing clean destination (the borrowed source still on disk).
+        let clean = dir.path().join("video.mp4");
+
+        // Write distinct sentinel content so we can tell which file won.
+        {
+            let mut f = std::fs::File::create(&part).expect("create part");
+            f.write_all(b"survivor-content").expect("write part");
+        }
+        {
+            let mut f = std::fs::File::create(&clean).expect("create clean");
+            f.write_all(b"old-source-content").expect("write clean");
+        }
+
+        assert!(part.exists(), "part must exist before finalize");
+        assert!(clean.exists(), "clean must exist before finalize");
+
+        finalize_part(&part, &clean)
+            .await
+            .expect("finalize_part must succeed even when clean already exists");
+
+        // The survivor's content is now at the clean path.
+        let content = std::fs::read(&clean).expect("read clean after finalize");
+        assert_eq!(
+            content, b"survivor-content",
+            "clean must contain survivor content"
+        );
+
+        // The temp part must be gone.
+        assert!(!part.exists(), "part must be removed after finalize");
     }
 }

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -342,7 +342,7 @@ impl Orchestrator {
 
         // Run post-processing if configured (or automatic for HLS).
         let final_files = self
-            .run_postprocessing(final_info, download_files, is_hls)
+            .run_postprocessing(final_info, download_files, is_hls, false)
             .await?;
         let survivor = final_files
             .into_iter()

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -116,6 +116,10 @@ impl Orchestrator {
     /// * `info` - Video metadata
     /// * `files` - Downloaded file paths
     /// * `is_hls` - Whether this was an HLS download (triggers automatic remux)
+    /// * `keep_inputs` - When `true`, input files are borrowed (not owned) by the
+    ///   pipeline: the originals are preserved on both success and cancel. Set for
+    ///   user-supplied source files that must not be deleted (e.g. `process_local_file`);
+    ///   `false` for files rdlp downloaded itself (the default everywhere else).
     ///
     /// # Returns
     /// * `Ok(paths)` - Processed file paths (may differ from input if conversion occurred)
@@ -125,6 +129,7 @@ impl Orchestrator {
         info: &rdlp_types::InfoDict,
         files: Vec<PathBuf>,
         is_hls: bool,
+        keep_inputs: bool,
     ) -> Result<Vec<PathBuf>> {
         debug!(
             "[PostProcess] Called: is_hls={is_hls}, pipeline={}",
@@ -165,6 +170,7 @@ impl Orchestrator {
             .run(
                 info.clone(),
                 files.clone(),
+                keep_inputs,
                 Arc::new(pp_config),
                 original_stem,
                 is_hls,

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -9,6 +9,7 @@ use crate::orchestrator::errors::OrchestratorError;
 use crate::orchestrator::eta::EtaEstimator;
 use log::{debug, warn};
 use rdlp_core::{PostProcessCallback, PostProcessCallbackFactory};
+use rdlp_postprocess::PipelineRunOptions;
 use rdlp_postprocess::pipeline::PipelineError;
 use rdlp_types::Progress;
 use std::path::PathBuf;
@@ -170,11 +171,13 @@ impl Orchestrator {
             .run(
                 info.clone(),
                 files.clone(),
-                keep_inputs,
+                PipelineRunOptions {
+                    keep_inputs,
+                    is_hls,
+                    verbose: self.config.verbose,
+                },
                 Arc::new(pp_config),
                 original_stem,
-                is_hls,
-                self.config.verbose,
                 callback_factory,
                 Some(self.cancel_token.clone()),
             )

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -31,10 +31,20 @@ async fn finalize_part_renames_and_reports_missing() {
     assert!(clean.exists() && !part.exists());
 
     // Failure surfaces with context when the part is missing.
+    // At this point `clean` exists (from the successful rename above), so the
+    // backup-restore branch fires: `clean` is backed up, the rename of the
+    // missing `part` fails, `clean` is restored, and the error includes
+    // "(original restored)". The key invariant is that `clean` is intact.
     let err = finalize_part(&part, &clean).await.unwrap_err();
+    let msg = format!("{err:#}");
     assert!(
-        format!("{err:#}").contains("failed to finalize download"),
-        "got: {err:#}"
+        msg.contains("failed to finalize") || msg.contains("No such file"),
+        "got: {msg}"
+    );
+    // The original `clean` must be restored after the failed rename.
+    assert!(
+        clean.exists(),
+        "clean must be restored after failed finalize"
     );
 }
 

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -490,7 +490,7 @@ impl DownloadPhase {
                 // re-returning UserCancelled so the client's terminal_event()
                 // still surfaces it as Event::Cancelled (PR #399). (#404)
                 let final_files = match orchestrator
-                    .run_postprocessing(&info, download_files.clone(), is_hls)
+                    .run_postprocessing(&info, download_files.clone(), is_hls, false)
                     .await
                 {
                     Ok(files) => files,

--- a/crates/rdlp-api/tests/process_local_file_e2e.rs
+++ b/crates/rdlp-api/tests/process_local_file_e2e.rs
@@ -1,0 +1,133 @@
+// Integration tests aren't covered by clippy's `allow-unwrap-in-tests`
+// (rust-clippy#13981) — re-allow at file scope. `disallowed_methods` permitted
+// for `std::fs` test fixtures per clippy.toml policy (c). `missing_docs`
+// exempt because integration tests aren't public API.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    missing_docs
+)]
+
+//! E2E test: `process_local_file` must NOT delete the user's source file.
+//!
+//! Industry standard: transform tools (ffmpeg, HandBrake, ImageMagick) never
+//! delete a user-supplied input by default. This test pins that invariant for
+//! `RdlpClient::process_local_file` (#414).
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! input fixture).
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use rdlp_api::RdlpClient;
+use rdlp_types::{Config, ContainerFormat, PostProcess};
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a tiny (2 s) H.264 yuv420p MP4 fixture — fast enough for a success
+/// path test.
+///
+/// # Panics
+/// Panics (with captured stderr) if ffmpeg is present but the fixture-build
+/// command exits non-zero. A broken ffmpeg (e.g. missing libx264) is a real
+/// problem and must not silently pass the test.
+fn build_short_mp4_fixture(dir: &Path) -> std::path::PathBuf {
+    let src = dir.join("source.mp4");
+    let out = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=2:s=320x240",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            src.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn ffmpeg");
+    if !out.status.success() {
+        panic!(
+            "ffmpeg fixture-build failed (exit {})\nstderr: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    src
+}
+
+/// `process_local_file` must preserve the user's source MP4 after a successful
+/// remux to MKV. Before the #414 fix (`keep_inputs=false`), the pipeline's
+/// `replace()` moved the source into the delete-set and `cleanup()` deleted it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_process_local_file_keeps_source_on_success() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg not available");
+        return;
+    }
+    let dir = TempDir::new().expect("tempdir");
+    let src = build_short_mp4_fixture(dir.path());
+
+    // Config: remux to MKV so the pipeline produces `source.mkv` distinct from
+    // `source.mp4`. This forces at least one pipeline stage (RemuxStage) to run
+    // and exercise the replace() → cleanup() path.
+    let config = Config {
+        progress: false,
+        postprocess: PostProcess {
+            remux_container: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        },
+        ..Default::default()
+    };
+    let client = RdlpClient::new(config).expect("client should build");
+
+    let src_clone = src.clone();
+    let mut handle = client.process_local_file(src_clone);
+
+    // Drain all events.
+    while let Some(_event) = handle.events().recv().await {}
+
+    let result = handle.wait().await;
+
+    // The source must survive regardless of whether the pipeline succeeded.
+    assert!(
+        src.exists(),
+        "process_local_file must NOT delete the user's source file (#414); source.mp4 is gone"
+    );
+
+    // The pipeline must have succeeded and produced an MKV output.
+    let output_files = result.expect("process_local_file should succeed");
+    assert!(
+        !output_files.output_files.is_empty(),
+        "Expected at least one output file"
+    );
+    let mkv_output = output_files
+        .output_files
+        .iter()
+        .find(|p| p.extension().is_some_and(|e| e.eq_ignore_ascii_case("mkv")));
+    assert!(
+        mkv_output.is_some(),
+        "Expected an MKV output file; got: {:?}",
+        output_files.output_files
+    );
+    assert!(
+        mkv_output.unwrap().exists(),
+        "MKV output file does not exist on disk"
+    );
+}

--- a/crates/rdlp-api/tests/process_local_file_e2e.rs
+++ b/crates/rdlp-api/tests/process_local_file_e2e.rs
@@ -62,13 +62,12 @@ fn build_short_mp4_fixture(dir: &Path) -> std::path::PathBuf {
         ])
         .output()
         .expect("failed to spawn ffmpeg");
-    if !out.status.success() {
-        panic!(
-            "ffmpeg fixture-build failed (exit {})\nstderr: {}",
-            out.status,
-            String::from_utf8_lossy(&out.stderr)
-        );
-    }
+    assert!(
+        out.status.success(),
+        "ffmpeg fixture-build failed (exit {})\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
     src
 }
 

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -30,6 +30,30 @@ use args::{Args, PluginCmd, PluginSubcommand};
 use commands::{fail_with, print_codecs, print_fields};
 use config::build_config;
 
+/// #413/#414: spawn the OS-signal → graceful-cancel task for an in-flight
+/// download or local-file job. First interrupt → graceful (record the
+/// conventional exit code + `interrupt()`, keeping any resumable partial or the
+/// user's source); second SIGINT → force-exit. Detached: aborts with the runtime
+/// when the job finishes normally.
+fn spawn_signal_task(interrupt: rdlp_api::InterruptHandle, exit_signal: Arc<AtomicU8>) {
+    use rdlp_cli::signal::{SignalAction, next_action, wait_for_signal};
+    tokio::spawn(async move {
+        let mut graceful_started = false;
+        loop {
+            let sig = wait_for_signal().await;
+            match next_action(graceful_started, sig) {
+                SignalAction::GracefulCancel(code) => {
+                    graceful_started = true;
+                    exit_signal.store(code, Ordering::SeqCst);
+                    interrupt.interrupt();
+                }
+                SignalAction::ForceExit(code) => std::process::exit(i32::from(code)),
+                SignalAction::Ignore => {}
+            }
+        }
+    });
+}
+
 /// Get optimal number of worker threads for I/O-heavy workloads
 fn optimal_worker_threads() -> usize {
     // For I/O-bound work (downloads), use 2x CPU cores
@@ -367,6 +391,12 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
     if !url.contains("://") && local_path.exists() {
         info!("Processing local file: {}", local_path.display());
         let mut handle = client.process_local_file(local_path.to_path_buf());
+
+        // #414: a long local transcode must cancel gracefully on Ctrl+C/SIGTERM
+        // (cooperative FFmpeg abort + the user's source preserved), not an
+        // abrupt kill.
+        spawn_signal_task(handle.interrupt_handle(), Arc::clone(&exit_signal));
+
         let mut event_handler = CliEventHandler::new(Arc::clone(&multi_progress), quiet);
 
         while let Some(event) = handle.events().recv().await {
@@ -378,6 +408,10 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
                 if let Some(path) = result.output_files.first() {
                     info!("Success! Processed file: {}", path.display());
                 }
+                Ok(())
+            }
+            Err(RdlpApiError::UserCancelled) => {
+                // User cancelled - already printed message via events
                 Ok(())
             }
             Err(e) => fail_with(&e, verbose),
@@ -397,28 +431,9 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
     // Start the download
     let mut handle = client.download(request);
 
-    // #413: drive cancellation from OS signals. First interrupt → graceful
-    // (keep the resumable partial); second SIGINT → force-exit 130.
-    {
-        use rdlp_cli::signal::{SignalAction, next_action, wait_for_signal};
-        let interrupt = handle.interrupt_handle();
-        let exit_for_task = Arc::clone(&exit_signal);
-        tokio::spawn(async move {
-            let mut graceful_started = false;
-            loop {
-                let sig = wait_for_signal().await;
-                match next_action(graceful_started, sig) {
-                    SignalAction::GracefulCancel(code) => {
-                        graceful_started = true;
-                        exit_for_task.store(code, Ordering::SeqCst);
-                        interrupt.interrupt();
-                    }
-                    SignalAction::ForceExit(code) => std::process::exit(i32::from(code)),
-                    SignalAction::Ignore => {}
-                }
-            }
-        });
-    }
+    // #413: drive cancellation from OS signals (first interrupt → graceful,
+    // keep the resumable partial; second SIGINT → force-exit).
+    spawn_signal_task(handle.interrupt_handle(), Arc::clone(&exit_signal));
 
     let mut event_handler = CliEventHandler::new(Arc::clone(&multi_progress), quiet);
 

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -48,7 +48,7 @@
 //! let config = Arc::new(PostProcess::default());
 //! let files = vec![PathBuf::from("video.mp4")];
 //!
-//! let output = pipeline.run(info, files, config, "video".to_string(), false, false, None, None).await?;
+//! let output = pipeline.run(info, files, false, config, "video".to_string(), false, false, None, None).await?;
 //! println!("Output: {output:?}");
 //! # Ok(())
 //! # }

--- a/crates/rdlp-postprocess/src/lib.rs
+++ b/crates/rdlp-postprocess/src/lib.rs
@@ -16,7 +16,7 @@
 //! ## Quick Start
 //!
 //! ```no_run
-//! use rdlp_postprocess::{Pipeline, TempRegistry};
+//! use rdlp_postprocess::{Pipeline, PipelineRunOptions, TempRegistry};
 //! use rdlp_postprocess::pipeline::PipelineStage;
 //! use rdlp_postprocess::{MergeStage, RemuxStage, MetadataStage, ThumbnailStage};
 //! use rdlp_postprocess::FFmpegRunner;
@@ -47,8 +47,9 @@
 //!
 //! let config = Arc::new(PostProcess::default());
 //! let files = vec![PathBuf::from("video.mp4")];
+//! let opts = PipelineRunOptions { keep_inputs: false, is_hls: false, verbose: false };
 //!
-//! let output = pipeline.run(info, files, false, config, "video".to_string(), false, false, None, None).await?;
+//! let output = pipeline.run(info, files, opts, config, "video".to_string(), None, None).await?;
 //! println!("Output: {output:?}");
 //! # Ok(())
 //! # }
@@ -87,7 +88,7 @@ pub use pipeline::stages::{
     AudioExtractStage, FinalizeMetadataStage, FixupStage, MergeStage, MetadataStage,
     NormalizeStage, RecodeStage, RemuxStage, SubtitleStage, ThumbnailStage,
 };
-pub use pipeline::{BatchInput, Pipeline, PipelineError, TempRegistry};
+pub use pipeline::{BatchInput, Pipeline, PipelineError, PipelineRunOptions, TempRegistry};
 
 // Re-export FFmpegRunner so callers don't need a direct rdlp-ffmpeg dependency
 pub use rdlp_ffmpeg::FFmpegRunner;

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -143,6 +143,19 @@ pub trait PipelineStage: Send + Sync {
 // Pipeline
 // ---------------------------------------------------------------------------
 
+/// Per-run pipeline options. Bundles the boolean flags so call sites are
+/// self-documenting and the flags can't be positionally transposed.
+#[derive(Debug, Clone, Copy)]
+pub struct PipelineRunOptions {
+    /// Borrow caller-supplied inputs (never delete them) — for a pre-existing
+    /// local file rather than a file rdlp downloaded (#414).
+    pub keep_inputs: bool,
+    /// The input is an HLS download (drives `RemuxStage`).
+    pub is_hls: bool,
+    /// Verbose logging.
+    pub verbose: bool,
+}
+
 /// Channel-based post-processing pipeline.
 pub struct Pipeline {
     stages: Vec<Arc<dyn PipelineStage>>,
@@ -171,9 +184,9 @@ impl Pipeline {
     ///
     /// Returns the final `current_files` from the tracker on success.
     ///
-    /// `keep_inputs = true` constructs a borrowing [`FileTracker`] that never
+    /// `opts.keep_inputs = true` constructs a borrowing [`FileTracker`] that never
     /// deletes the input files (success or cancel). Use this for user-supplied
-    /// source files (`process_local_file`). `keep_inputs = false` (the default
+    /// source files (`process_local_file`). `opts.keep_inputs = false` (the default
     /// everywhere else) gives the pipeline full ownership — inputs are deleted
     /// after successful processing.
     ///
@@ -182,16 +195,14 @@ impl Pipeline {
     /// Returns [`PipelineError`] if any fatal stage fails (merge, audio extract,
     /// normalize, remux, or recode). Non-fatal stages (subtitle, metadata,
     /// thumbnail, fixup) log warnings and continue.
-    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         &self,
         info: InfoDict,
         files: Vec<std::path::PathBuf>,
-        keep_inputs: bool,
+        opts: PipelineRunOptions,
         config: Arc<PostProcess>,
         original_stem: String,
-        is_hls: bool,
-        verbose: bool,
         callback_factory: Option<PostProcessCallbackFactory>,
         cancel: Option<CancellationToken>,
     ) -> anyhow::Result<Vec<std::path::PathBuf>> {
@@ -200,7 +211,7 @@ impl Pipeline {
                 anyhow::anyhow!("pipeline concurrency semaphore closed unexpectedly")
             })?;
 
-        let tracker = if keep_inputs {
+        let tracker = if opts.keep_inputs {
             FileTracker::new_borrowing(files, Arc::clone(&self.temp_registry))
         } else {
             FileTracker::new(files, Arc::clone(&self.temp_registry))
@@ -222,8 +233,8 @@ impl Pipeline {
             tracker,
             config,
             original_stem,
-            is_hls,
-            verbose,
+            is_hls: opts.is_hls,
+            verbose: opts.verbose,
             callback_factory,
             error_tx: Some(error_tx),
             warnings: Vec::new(),
@@ -295,11 +306,13 @@ impl Pipeline {
                     .run(
                         input.info,
                         input.files,
-                        false,
+                        PipelineRunOptions {
+                            keep_inputs: false,
+                            is_hls: input.is_hls,
+                            verbose,
+                        },
                         config,
                         input.original_stem,
-                        input.is_hls,
-                        verbose,
                         factory,
                         cancel_clone,
                     )

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -171,16 +171,23 @@ impl Pipeline {
     ///
     /// Returns the final `current_files` from the tracker on success.
     ///
+    /// `keep_inputs = true` constructs a borrowing [`FileTracker`] that never
+    /// deletes the input files (success or cancel). Use this for user-supplied
+    /// source files (`process_local_file`). `keep_inputs = false` (the default
+    /// everywhere else) gives the pipeline full ownership — inputs are deleted
+    /// after successful processing.
+    ///
     /// # Errors
     ///
     /// Returns [`PipelineError`] if any fatal stage fails (merge, audio extract,
     /// normalize, remux, or recode). Non-fatal stages (subtitle, metadata,
     /// thumbnail, fixup) log warnings and continue.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     pub async fn run(
         &self,
         info: InfoDict,
         files: Vec<std::path::PathBuf>,
+        keep_inputs: bool,
         config: Arc<PostProcess>,
         original_stem: String,
         is_hls: bool,
@@ -193,7 +200,11 @@ impl Pipeline {
                 anyhow::anyhow!("pipeline concurrency semaphore closed unexpectedly")
             })?;
 
-        let tracker = FileTracker::new(files, Arc::clone(&self.temp_registry));
+        let tracker = if keep_inputs {
+            FileTracker::new_borrowing(files, Arc::clone(&self.temp_registry))
+        } else {
+            FileTracker::new(files, Arc::clone(&self.temp_registry))
+        };
 
         let (error_tx, error_rx) = oneshot::channel::<PipelineError>();
 
@@ -284,6 +295,7 @@ impl Pipeline {
                     .run(
                         input.info,
                         input.files,
+                        false,
                         config,
                         input.original_stem,
                         input.is_hls,

--- a/crates/rdlp-postprocess/src/pipeline/tests.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tests.rs
@@ -1,14 +1,13 @@
 use super::*;
 use std::path::PathBuf;
 
-/// 8-tuple returned by `run_args` for `Pipeline::run` calls in tests.
+/// 7-tuple returned by `run_args` for `Pipeline::run` calls in tests.
 type RunArgs = (
     InfoDict,
     Vec<PathBuf>,
     Arc<PostProcess>,
     String,
-    bool,
-    bool,
+    PipelineRunOptions,
     Option<PostProcessCallbackFactory>,
     Option<CancellationToken>,
 );
@@ -101,8 +100,11 @@ fn run_args(files: Vec<PathBuf>) -> RunArgs {
         files,
         Arc::new(PostProcess::default()),
         "video".to_string(),
-        false,
-        false,
+        PipelineRunOptions {
+            keep_inputs: false,
+            is_hls: false,
+            verbose: false,
+        },
         None,
         None, // cancel — default to None for back-compat tests
     )
@@ -111,10 +113,10 @@ fn run_args(files: Vec<PathBuf>) -> RunArgs {
 #[tokio::test]
 async fn test_pipeline_passthrough() {
     let pipeline = make_pipeline(vec![Arc::new(PassthroughStage)]);
-    let (info, files, config, stem, hls, verbose, cb, cancel) =
+    let (info, files, config, stem, opts, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, opts, config, stem, cb, cancel)
         .await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), vec![PathBuf::from("/tmp/video.mp4")]);
@@ -123,10 +125,10 @@ async fn test_pipeline_passthrough() {
 #[tokio::test]
 async fn test_pipeline_skip_stage() {
     let pipeline = make_pipeline(vec![Arc::new(SkipStage), Arc::new(PassthroughStage)]);
-    let (info, files, config, stem, hls, verbose, cb, cancel) =
+    let (info, files, config, stem, opts, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, opts, config, stem, cb, cancel)
         .await;
     assert!(result.is_ok());
 }
@@ -134,10 +136,10 @@ async fn test_pipeline_skip_stage() {
 #[tokio::test]
 async fn test_pipeline_fatal_error_cascades() {
     let pipeline = make_pipeline(vec![Arc::new(FailStage), Arc::new(PassthroughStage)]);
-    let (info, files, config, stem, hls, verbose, cb, cancel) =
+    let (info, files, config, stem, opts, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, opts, config, stem, cb, cancel)
         .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -150,10 +152,10 @@ async fn test_pipeline_nonfatal_passes_through() {
         Arc::new(NonFatalFailStage),
         Arc::new(PassthroughStage),
     ]);
-    let (info, files, config, stem, hls, verbose, cb, cancel) =
+    let (info, files, config, stem, opts, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, opts, config, stem, cb, cancel)
         .await;
     assert!(result.is_ok());
 }
@@ -216,9 +218,9 @@ async fn test_pipeline_cleanup_does_not_block_runtime() {
         }
     });
 
-    let (info, files, config, stem, hls, verbose, cb, cancel) = run_args(vec![video.clone()]);
+    let (info, files, config, stem, opts, cb, cancel) = run_args(vec![video.clone()]);
     let result = pipeline
-        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, opts, config, stem, cb, cancel)
         .await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), vec![video]);
@@ -262,10 +264,9 @@ async fn test_pipeline_concurrent_semaphore() {
     for _ in 0..6 {
         let p = StdArc::clone(&pipeline);
         handles.push(tokio::spawn(async move {
-            let (info, files, config, stem, hls, verbose, cb, cancel) =
+            let (info, files, config, stem, opts, cb, cancel) =
                 run_args(vec![PathBuf::from("/tmp/v.mp4")]);
-            p.run(info, files, false, config, stem, hls, verbose, cb, cancel)
-                .await
+            p.run(info, files, opts, config, stem, cb, cancel).await
         }));
     }
     for h in handles {
@@ -306,24 +307,13 @@ async fn pipeline_run_returns_cancelled_when_token_pre_cancelled() {
     }
 
     let pipeline = make_pipeline(vec![Arc::new(CountingStage(Arc::clone(&count)))]);
-    let (info, files, config, stem, hls, verbose, cb, _) =
-        run_args(vec![PathBuf::from("/tmp/video.mp4")]);
+    let (info, files, config, stem, opts, cb, _) = run_args(vec![PathBuf::from("/tmp/video.mp4")]);
 
     let token = CancellationToken::new();
     token.cancel(); // pre-cancel BEFORE run
 
     let result = pipeline
-        .run(
-            info,
-            files,
-            false,
-            config,
-            stem,
-            hls,
-            verbose,
-            cb,
-            Some(token),
-        )
+        .run(info, files, opts, config, stem, cb, Some(token))
         .await;
 
     assert!(result.is_err(), "pre-cancelled token must surface as Err");
@@ -409,21 +399,10 @@ async fn pipeline_run_cancels_mid_pipeline() {
         Arc::new(DownstreamCountingStage(Arc::clone(&downstream_count))),
         Arc::new(DownstreamCountingStage(Arc::clone(&downstream_count))),
     ]);
-    let (info, files, config, stem, hls, verbose, cb, _) =
-        run_args(vec![PathBuf::from("/tmp/video.mp4")]);
+    let (info, files, config, stem, opts, cb, _) = run_args(vec![PathBuf::from("/tmp/video.mp4")]);
 
     let result = pipeline
-        .run(
-            info,
-            files,
-            false,
-            config,
-            stem,
-            hls,
-            verbose,
-            cb,
-            Some(token),
-        )
+        .run(info, files, opts, config, stem, cb, Some(token))
         .await;
 
     assert!(result.is_err(), "mid-pipeline cancel must surface as Err");
@@ -445,11 +424,10 @@ async fn pipeline_run_cancels_mid_pipeline() {
 #[tokio::test]
 async fn pipeline_run_with_none_cancel_runs_to_completion() {
     let pipeline = make_pipeline(vec![Arc::new(PassthroughStage)]);
-    let (info, files, config, stem, hls, verbose, cb, _) =
-        run_args(vec![PathBuf::from("/tmp/video.mp4")]);
+    let (info, files, config, stem, opts, cb, _) = run_args(vec![PathBuf::from("/tmp/video.mp4")]);
 
     let result = pipeline
-        .run(info, files, false, config, stem, hls, verbose, cb, None)
+        .run(info, files, opts, config, stem, cb, None)
         .await;
 
     assert!(

--- a/crates/rdlp-postprocess/src/pipeline/tests.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tests.rs
@@ -114,7 +114,7 @@ async fn test_pipeline_passthrough() {
     let (info, files, config, stem, hls, verbose, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
         .await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), vec![PathBuf::from("/tmp/video.mp4")]);
@@ -126,7 +126,7 @@ async fn test_pipeline_skip_stage() {
     let (info, files, config, stem, hls, verbose, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
         .await;
     assert!(result.is_ok());
 }
@@ -137,7 +137,7 @@ async fn test_pipeline_fatal_error_cascades() {
     let (info, files, config, stem, hls, verbose, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
         .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -153,7 +153,7 @@ async fn test_pipeline_nonfatal_passes_through() {
     let (info, files, config, stem, hls, verbose, cb, cancel) =
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
         .await;
     assert!(result.is_ok());
 }
@@ -218,7 +218,7 @@ async fn test_pipeline_cleanup_does_not_block_runtime() {
 
     let (info, files, config, stem, hls, verbose, cb, cancel) = run_args(vec![video.clone()]);
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, cancel)
+        .run(info, files, false, config, stem, hls, verbose, cb, cancel)
         .await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), vec![video]);
@@ -264,7 +264,7 @@ async fn test_pipeline_concurrent_semaphore() {
         handles.push(tokio::spawn(async move {
             let (info, files, config, stem, hls, verbose, cb, cancel) =
                 run_args(vec![PathBuf::from("/tmp/v.mp4")]);
-            p.run(info, files, config, stem, hls, verbose, cb, cancel)
+            p.run(info, files, false, config, stem, hls, verbose, cb, cancel)
                 .await
         }));
     }
@@ -313,7 +313,17 @@ async fn pipeline_run_returns_cancelled_when_token_pre_cancelled() {
     token.cancel(); // pre-cancel BEFORE run
 
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, Some(token))
+        .run(
+            info,
+            files,
+            false,
+            config,
+            stem,
+            hls,
+            verbose,
+            cb,
+            Some(token),
+        )
         .await;
 
     assert!(result.is_err(), "pre-cancelled token must surface as Err");
@@ -403,7 +413,17 @@ async fn pipeline_run_cancels_mid_pipeline() {
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
 
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, Some(token))
+        .run(
+            info,
+            files,
+            false,
+            config,
+            stem,
+            hls,
+            verbose,
+            cb,
+            Some(token),
+        )
         .await;
 
     assert!(result.is_err(), "mid-pipeline cancel must surface as Err");
@@ -429,7 +449,7 @@ async fn pipeline_run_with_none_cancel_runs_to_completion() {
         run_args(vec![PathBuf::from("/tmp/video.mp4")]);
 
     let result = pipeline
-        .run(info, files, config, stem, hls, verbose, cb, None)
+        .run(info, files, false, config, stem, hls, verbose, cb, None)
         .await;
 
     assert!(

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -106,6 +106,20 @@ impl FileTracker {
         }
     }
 
+    /// Whether `path` is a borrowed (user-owned) input that must never be
+    /// deleted or released by this tracker (#414). Centralises the membership
+    /// check used by `replace`, `cleanup`, and `Drop`.
+    ///
+    /// NOTE: comparison is by exact `PathBuf` equality. The pipeline preserves
+    /// borrowed paths byte-for-byte (stages clone `current_files[0]` and produce
+    /// NEW temp outputs; they never re-case or canonicalize the input), so this
+    /// holds on case-sensitive and case-insensitive filesystems alike today.
+    /// Hardening this against path-representation divergence (canonicalization /
+    /// case-folding) is tracked as a follow-up.
+    fn is_borrowed(&self, path: &Path) -> bool {
+        self.borrowed.iter().any(|b| b == path)
+    }
+
     /// Promote `new_files` to `current_files`, moving the old current files
     /// into `temp_files`.
     ///
@@ -116,7 +130,7 @@ impl FileTracker {
         for f in old {
             // #414: a borrowed (user-owned) input is never deleted — drop it from
             // tracking instead of queueing it in `temp_files`.
-            if self.borrowed.contains(&f) {
+            if self.is_borrowed(&f) {
                 continue;
             }
             self.temp_files.push(f);
@@ -125,6 +139,10 @@ impl FileTracker {
 
     /// Mark a path as a temp file without changing `current_files`.
     pub fn mark_temp(&mut self, path: PathBuf) {
+        debug_assert!(
+            !self.is_borrowed(&path),
+            "a borrowed (user-owned) input must never be marked temp (#414)"
+        );
         self.temp_files.push(path);
     }
 
@@ -194,8 +212,12 @@ impl FileTracker {
         // the `TempRegistry`. This drops the advisory lock + removes the `.lock`
         // sidecar so no stale entry survives; the orchestrator then renames the
         // now-unregistered temp file to its clean user-visible name.
+        // Skip borrowed paths: a borrowed source was never registered with the
+        // registry, so releasing it would be a contract violation.
         for file in &self.current_files {
-            self.temp_registry.release(file.as_path());
+            if !self.is_borrowed(file) {
+                self.temp_registry.release(file.as_path());
+            }
         }
 
         // Successful completion: disarm the cancel-cleanup Drop.
@@ -227,7 +249,7 @@ impl Drop for FileTracker {
         // expected, not a contract violation. Borrowed paths are excluded entirely
         // — they are user-owned and must never be deleted (#414). Drop never panics.
         for path in self.issued.iter().chain(self.current_files.iter()) {
-            if !is_temp_named(path) && !self.borrowed.contains(path) {
+            if !is_temp_named(path) && !self.is_borrowed(path) {
                 log::warn!(
                     "FileTracker::Drop deleting non-temp-named file {} — unexpected; \
                      current_files should be temp-namespaced",
@@ -243,7 +265,7 @@ impl Drop for FileTracker {
             .iter()
             .chain(self.current_files.iter())
             .chain(self.temp_files.iter())
-            .filter(|p| !self.borrowed.contains(p)) // #414: never delete borrowed
+            .filter(|p| !self.is_borrowed(p)) // #414: never delete borrowed
             .cloned()
             .collect();
         for path in to_delete {

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -39,6 +39,11 @@ fn is_temp_named(path: &Path) -> bool {
 /// intermediate files from leaking when a job is cancelled mid-pipeline (#335, #404).
 /// [`TempRegistry`] remains the crash/stale backstop for the case where the
 /// process dies before `Drop` runs.
+///
+/// When post-processing a pre-existing local file (`process_local_file`, #414),
+/// use [`new_borrowing`] so the user's original file is never deleted — neither
+/// on success nor on cancel. The download path uses [`new`] (empty borrowed set)
+/// and retains its existing behaviour unchanged.
 pub struct FileTracker {
     /// The live files currently being processed.
     pub(crate) current_files: Vec<PathBuf>,
@@ -47,6 +52,13 @@ pub struct FileTracker {
     /// Every path handed out by [`temp_path`] — the uncommitted-output set
     /// deleted on cancel-drop.
     issued: Vec<PathBuf>,
+    /// Caller-supplied, user-owned inputs that MUST NOT be deleted — neither on
+    /// success ([`cleanup`]) nor on cancel ([`Drop`]) — and are never moved into
+    /// the delete-set by [`replace`]. Empty for the download path (rdlp owns its
+    /// temp-named files); populated by `process_local_file` for a pre-existing
+    /// local file (#414). Encodes the ownership rule: delete what we created,
+    /// preserve what the user brought us.
+    borrowed: Vec<PathBuf>,
     /// Disarms the `Drop` cleanup once the job succeeds (`commit`/`cleanup`).
     committed: bool,
     temp_registry: Arc<TempRegistry>,
@@ -64,9 +76,28 @@ impl FileTracker {
     /// clear the working set), but a [`log::warn!`] is emitted naming the path,
     /// since it signals a caller-contract violation. The orchestrator satisfies
     /// this precondition by UUID-renaming inputs to `*.rdlp-tmp-*` before
-    /// constructing the tracker.
+    /// constructing the tracker. To post-process a pre-existing user-owned file
+    /// (which must NOT be deleted), use [`new_borrowing`] instead of satisfying
+    /// this precondition.
     pub const fn new(files: Vec<PathBuf>, temp_registry: Arc<TempRegistry>) -> Self {
         Self {
+            current_files: files,
+            temp_files: Vec::new(),
+            issued: Vec::new(),
+            borrowed: Vec::new(),
+            committed: false,
+            temp_registry,
+        }
+    }
+
+    /// Like [`new`], but marks every initial file as a **borrowed** user-owned
+    /// input: never deleted (success or cancel), never queued for deletion by
+    /// [`replace`]. For post-processing a pre-existing local file (#414) rather
+    /// than a file rdlp downloaded.
+    #[must_use]
+    pub fn new_borrowing(files: Vec<PathBuf>, temp_registry: Arc<TempRegistry>) -> Self {
+        Self {
+            borrowed: files.clone(),
             current_files: files,
             temp_files: Vec::new(),
             issued: Vec::new(),
@@ -77,9 +108,19 @@ impl FileTracker {
 
     /// Promote `new_files` to `current_files`, moving the old current files
     /// into `temp_files`.
+    ///
+    /// Borrowed (user-owned) inputs are dropped from tracking rather than
+    /// queued for deletion (#414).
     pub fn replace(&mut self, new_files: Vec<PathBuf>) {
         let old = std::mem::replace(&mut self.current_files, new_files);
-        self.temp_files.extend(old);
+        for f in old {
+            // #414: a borrowed (user-owned) input is never deleted — drop it from
+            // tracking instead of queueing it in `temp_files`.
+            if self.borrowed.contains(&f) {
+                continue;
+            }
+            self.temp_files.push(f);
+        }
     }
 
     /// Mark a path as a temp file without changing `current_files`.
@@ -183,9 +224,10 @@ impl Drop for FileTracker {
         // the working set). `temp_files` is deliberately EXCLUDED from this check:
         // it legitimately holds real-named superseded files (e.g. the original
         // download moved here by `replace()`), so a non-temp name there is
-        // expected, not a contract violation. Drop never panics.
+        // expected, not a contract violation. Borrowed paths are excluded entirely
+        // — they are user-owned and must never be deleted (#414). Drop never panics.
         for path in self.issued.iter().chain(self.current_files.iter()) {
-            if !is_temp_named(path) {
+            if !is_temp_named(path) && !self.borrowed.contains(path) {
                 log::warn!(
                     "FileTracker::Drop deleting non-temp-named file {} — unexpected; \
                      current_files should be temp-namespaced",
@@ -193,13 +235,15 @@ impl Drop for FileTracker {
                 );
             }
         }
-        // Delete all three sets (issued + current_files + superseded temp_files).
+        // Delete all three sets (issued + current_files + superseded temp_files),
+        // excluding borrowed (user-owned) inputs which must never be deleted (#414).
         // Collect into an owned Vec to avoid borrowing self while mutating it.
         let to_delete: Vec<PathBuf> = self
             .issued
             .iter()
             .chain(self.current_files.iter())
             .chain(self.temp_files.iter())
+            .filter(|p| !self.borrowed.contains(p)) // #414: never delete borrowed
             .cloned()
             .collect();
         for path in to_delete {
@@ -416,6 +460,88 @@ mod tests {
         assert!(
             !is_temp_named(Path::new("My.Video.mkv")),
             "dotted clean name must NOT be temp-named"
+        );
+    }
+
+    // ── #414 borrowed-input tests ────────────────────────────────────────────
+
+    /// A borrowed (user-owned) file must survive an uncommitted (cancel) Drop.
+    #[test]
+    fn test_drop_does_not_delete_borrowed_input() {
+        let dir = TempDir::new().unwrap();
+        let reg = test_registry();
+        let src = dir.path().join("localfile.mp4");
+        fs::write(&src, b"user data").unwrap();
+        {
+            let _t = FileTracker::new_borrowing(vec![src.clone()], reg);
+            // uncommitted drop here → cancel semantics
+        }
+        assert!(src.exists(), "borrowed user input must survive cancel-Drop");
+    }
+
+    /// After a `replace()`, the borrowed source must NOT be queued for deletion.
+    /// On an uncommitted Drop, the temp output is deleted but the source survives.
+    #[test]
+    fn test_replace_keeps_borrowed_then_drop() {
+        let dir = TempDir::new().unwrap();
+        let reg = test_registry();
+        let src = dir.path().join("localfile.mp4");
+        fs::write(&src, b"user data").unwrap();
+        let out;
+        {
+            let mut t = FileTracker::new_borrowing(vec![src.clone()], reg);
+            out = t.temp_path(&src, "mkv");
+            fs::write(&out, b"recoded").unwrap();
+            t.replace(vec![out.clone()]);
+            // uncommitted drop → cancel: out (current_files) deleted, src preserved
+        }
+        assert!(
+            src.exists(),
+            "borrowed source must survive replace + cancel-Drop"
+        );
+        assert!(
+            !out.exists(),
+            "non-borrowed issued temp must be deleted on cancel-Drop"
+        );
+    }
+
+    /// After a successful `cleanup()`, the borrowed source AND the recode output survive.
+    #[test]
+    fn test_cleanup_keeps_borrowed_after_replace() {
+        let dir = TempDir::new().unwrap();
+        let reg = test_registry();
+        let src = dir.path().join("localfile.mp4");
+        fs::write(&src, b"user data").unwrap();
+        let out;
+        {
+            let mut t = FileTracker::new_borrowing(vec![src.clone()], reg);
+            out = t.temp_path(&src, "mkv");
+            fs::write(&out, b"recoded").unwrap();
+            t.replace(vec![out.clone()]);
+            t.cleanup();
+        }
+        assert!(
+            src.exists(),
+            "borrowed source must survive successful cleanup"
+        );
+        assert!(out.exists(), "the survivor (recode output) must be kept");
+    }
+
+    /// #404 regression guard: a file owned via the NORMAL `new()` constructor
+    /// (rdlp-owned temp) must still be deleted on an uncommitted Drop.
+    #[test]
+    fn test_non_borrowed_temp_still_deleted_on_drop() {
+        let dir = TempDir::new().unwrap();
+        let reg = test_registry();
+        let tmp = dir.path().join("video.rdlp-tmp-abc.mp4");
+        fs::write(&tmp, b"partial").unwrap();
+        {
+            let _t = FileTracker::new(vec![tmp.clone()], reg);
+            // uncommitted drop → cancel semantics
+        }
+        assert!(
+            !tmp.exists(),
+            "non-borrowed owned temp must still be deleted on cancel"
         );
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -65,6 +65,24 @@ pub struct FileTracker {
 }
 
 impl FileTracker {
+    /// Shared constructor — the field list lives in exactly ONE place. Both
+    /// [`new`] and [`new_borrowing`] delegate here so changes to the struct
+    /// fields are made only once.
+    const fn with_borrowed(
+        files: Vec<PathBuf>,
+        borrowed: Vec<PathBuf>,
+        temp_registry: Arc<TempRegistry>,
+    ) -> Self {
+        Self {
+            current_files: files,
+            temp_files: Vec::new(),
+            issued: Vec::new(),
+            borrowed,
+            committed: false,
+            temp_registry,
+        }
+    }
+
     /// Create a new tracker with the given initial files.
     ///
     /// # Precondition
@@ -80,14 +98,7 @@ impl FileTracker {
     /// (which must NOT be deleted), use [`new_borrowing`] instead of satisfying
     /// this precondition.
     pub const fn new(files: Vec<PathBuf>, temp_registry: Arc<TempRegistry>) -> Self {
-        Self {
-            current_files: files,
-            temp_files: Vec::new(),
-            issued: Vec::new(),
-            borrowed: Vec::new(),
-            committed: false,
-            temp_registry,
-        }
+        Self::with_borrowed(files, Vec::new(), temp_registry)
     }
 
     /// Like [`new`], but marks every initial file as a **borrowed** user-owned
@@ -96,14 +107,8 @@ impl FileTracker {
     /// than a file rdlp downloaded.
     #[must_use]
     pub fn new_borrowing(files: Vec<PathBuf>, temp_registry: Arc<TempRegistry>) -> Self {
-        Self {
-            borrowed: files.clone(),
-            current_files: files,
-            temp_files: Vec::new(),
-            issued: Vec::new(),
-            committed: false,
-            temp_registry,
-        }
+        let borrowed = files.clone();
+        Self::with_borrowed(files, borrowed, temp_registry)
     }
 
     /// Whether `path` is a borrowed (user-owned) input that must never be

--- a/crates/rdlp-postprocess/tests/cancel_e2e.rs
+++ b/crates/rdlp-postprocess/tests/cancel_e2e.rs
@@ -36,7 +36,8 @@ use tokio_util::sync::CancellationToken;
 
 use rdlp_postprocess::pipeline::PipelineStage;
 use rdlp_postprocess::{
-    FFmpegRunner, Pipeline, PipelineError, RecodeStage, RemuxStage, TempRegistry,
+    FFmpegRunner, Pipeline, PipelineError, PipelineRunOptions, RecodeStage, RemuxStage,
+    TempRegistry,
 };
 use rdlp_types::{ContainerFormat, InfoDict, PostProcess};
 
@@ -174,11 +175,13 @@ async fn cancel_mid_recode_aborts_and_cleans_up() {
             .run(
                 info,
                 vec![input],
-                false,
+                PipelineRunOptions {
+                    keep_inputs: false,
+                    is_hls: false,
+                    verbose: false,
+                },
                 config,
                 "video".to_string(),
-                false,
-                false,
                 None,
                 Some(token_for_run),
             )
@@ -260,11 +263,13 @@ async fn cancel_after_remux_deletes_real_named_source() {
             .run(
                 info,
                 vec![input_for_run],
-                false,
+                PipelineRunOptions {
+                    keep_inputs: false,
+                    is_hls: true,
+                    verbose: false,
+                },
                 config,
                 "video".to_string(),
-                true, // is_hls -> RemuxStage runs
-                false,
                 None,
                 Some(token_for_run),
             )

--- a/crates/rdlp-postprocess/tests/cancel_e2e.rs
+++ b/crates/rdlp-postprocess/tests/cancel_e2e.rs
@@ -174,6 +174,7 @@ async fn cancel_mid_recode_aborts_and_cleans_up() {
             .run(
                 info,
                 vec![input],
+                false,
                 config,
                 "video".to_string(),
                 false,
@@ -259,6 +260,7 @@ async fn cancel_after_remux_deletes_real_named_source() {
             .run(
                 info,
                 vec![input_for_run],
+                false,
                 config,
                 "video".to_string(),
                 true, // is_hls -> RemuxStage runs


### PR DESCRIPTION
## Summary

Fixes a **data-loss bug**: post-processing a pre-existing local file (`rdlp --recode-video=mkv localfile.mp4`) deleted the user's source — on success *and* on cancel — then safely wires CLI graceful cancellation into the local-file path.

**Root cause:** `process_local_file` fed the user's raw source into a pipeline designed to consume rdlp's *own* temp download. The pipeline's `replace()` moved the source into the delete-set, so `cleanup()` (success) and `Drop` (cancel) deleted it. This wrongly applied yt-dlp's Case-A "delete the intermediate I downloaded" behavior to a Case-B user-owned file.

**Industry standard (researched, cited):** transform tools follow an *ownership asymmetry* — delete what *they* created, preserve what the *user* brought them. ffmpeg/HandBrakeCLI/ImageMagick never delete user input by default; no tool destroys user input on Ctrl+C. yt-dlp's delete-default applies only to files it downloaded.

## Changes

- **`FileTracker` borrowed-input ownership** (`rdlp-postprocess`): new `borrowed` set + `new_borrowing()`. Borrowed (user-owned) inputs are never deleted — `replace()` doesn't queue them, `Drop`/`cleanup` skip them (via an `is_borrowed` helper), the #339 warning ignores them. The download path uses `new()` (empty borrowed) → **byte-for-byte unchanged, #404 preserved**.
- **`keep_inputs: bool`** threaded through `Pipeline::run` + `run_postprocessing`; every caller passes `false` except `process_local_file` → `true`.
- **`finalize_part` backup-restore**: same-name in-place finalize (e.g. `--remux=mp4` on an `.mp4`) is now Windows-safe *and* has no data-loss window — the existing `clean` is moved to a `.rdlp-bak-{uuid}` sibling, `part`→`clean` is attempted, backup deleted on success / **restored on failure** so `clean` is never lost.
- **CLI graceful cancel for the local-file path** (`rdlp-cli`): a shared `spawn_signal_task` helper (download + local-file) + a `UserCancelled` arm. This re-applies the piece that was reverted from #413's PR precisely because it was blocked on this data-loss bug.

## Verification

**Pre-PR gate green:** fmt / check / clippy `-D warnings` / full test suite / desktop / dedup / url-redaction.

**Manual e2e (foreground `setsid -w`):**
- **Success** — `--recode-video=mkv src.mp4` → exit 0, `src.mp4` **kept** (991017 B), `src.mkv` produced (481451 B).
- **Cancel** — Ctrl+C mid-recode → exit **130**, `src.mp4` **kept** (no data loss), temp output cleaned, no error printed.
- **In-place** — `--remux=mp4 v.mp4` → exit 0, valid in-place output, no `.rdlp-bak` leftover.

**Tests:** 4 new `FileTracker` borrowed-set unit tests (incl. a #404 regression guard), `finalize_part` overwrite/restore tests, and a real-pipeline `process_local_file` e2e (self-skips without ffmpeg) — all green.

## Reviews

- **security-reviewer** (full `develop..HEAD`): **Approve-with-fixes** — no Critical/High. Two MEDIUM + two LOW. The cheap, invariant-hardening items (cleanup/mark_temp borrowed guards via `is_borrowed`, clearer finalize errors, degenerate-path guard) were **fixed in this PR**. Two latent MEDIUMs (no current trigger) deferred to **#416**: (M2) borrowed matching is exact-`PathBuf`-equality — robust today since no stage re-cases paths, hardening tracked; (M1) backup-file orphan in a µs force-exit window during in-place finalize — no data loss, needs a `TempRegistry` handle in `finalize_part`.
- **code-reviewer** (full `develop..HEAD`): **Approved** — cross-task seams compose cleanly; its Important findings (`cleanup()` releasing borrowed paths from the registry; backup error context) were fixed in this PR.

## Follow-ups
- **#416** — harden `FileTracker` borrowed matching (M2) + `finalize_part` backup orphan cleanup (M1).

Closes #414