### PR TITLE
chore(wit): resync vendored plugin WIT to host v0.4.0 (fix check-wit-drift)

### DIFF
--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/extractor.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/extractor.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.3.0;
+package rdlp:plugin@0.4.0;
 
 world extractor-plugin {
     import host-fetch;

--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/host.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/host.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.3.0;
+package rdlp:plugin@0.4.0;
 
 interface host-fetch {
     record request {
@@ -178,6 +178,19 @@ interface host-extract-helpers {
     record mpd-fragment {
         url: string,
         duration: option<f64>,
+        /// Subrange of `url` to fetch via HTTP `Range:` header.
+        /// `(start, end_exclusive)`. Matches `rdlp_types::Fragment.byte_range`.
+        /// When set, plugins receive DASH ranged media segments (SegmentList /
+        /// SegmentBase with `@mediaRange`).
+        byte-range: option<tuple<u64, u64>>,
+        /// `<Initialization>` segment URI for THIS fragment. Per-fragment so
+        /// multi-init streams work correctly. When `none`, plugins fall back
+        /// to the format-level fragment-base-url (yt-dlp `initialization_url`
+        /// convention).
+        init-url: option<string>,
+        /// Subrange of `init-url`. Same `(start, end_exclusive)` convention
+        /// as `byte-range`.
+        init-byte-range: option<tuple<u64, u64>>,
     }
 
     record mpd-format {

--- a/examples/plugins/example-extractor/wit/deps/rdlp-plugin/types.wit
+++ b/examples/plugins/example-extractor/wit/deps/rdlp-plugin/types.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.3.0;
+package rdlp:plugin@0.4.0;
 
 interface types {
     record plugin-info {

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/extractor.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/extractor.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.3.0;
+package rdlp:plugin@0.4.0;
 
 world extractor-plugin {
     import host-fetch;

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/host.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/host.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.3.0;
+package rdlp:plugin@0.4.0;
 
 interface host-fetch {
     record request {
@@ -178,6 +178,19 @@ interface host-extract-helpers {
     record mpd-fragment {
         url: string,
         duration: option<f64>,
+        /// Subrange of `url` to fetch via HTTP `Range:` header.
+        /// `(start, end_exclusive)`. Matches `rdlp_types::Fragment.byte_range`.
+        /// When set, plugins receive DASH ranged media segments (SegmentList /
+        /// SegmentBase with `@mediaRange`).
+        byte-range: option<tuple<u64, u64>>,
+        /// `<Initialization>` segment URI for THIS fragment. Per-fragment so
+        /// multi-init streams work correctly. When `none`, plugins fall back
+        /// to the format-level fragment-base-url (yt-dlp `initialization_url`
+        /// convention).
+        init-url: option<string>,
+        /// Subrange of `init-url`. Same `(start, end_exclusive)` convention
+        /// as `byte-range`.
+        init-byte-range: option<tuple<u64, u64>>,
     }
 
     record mpd-format {

--- a/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/types.wit
+++ b/examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/types.wit
@@ -1,4 +1,4 @@
-package rdlp:plugin@0.3.0;
+package rdlp:plugin@0.4.0;
 
 interface types {
     record plugin-info {


### PR DESCRIPTION
## What

`scripts/check-wit-drift.sh` (a CI step in `ci.yml`) was **red on develop**: both vendored WIT copies the plugin examples carry lagged the host contract at `crates/rdlp-plugin/wit` (host = `v0.4.0`).

- `examples/plugins/example-extractor/wit/deps/rdlp-plugin/` — drifted
- `examples/plugins/ytdlp-hello-world/wit/deps/rdlp-plugin/` — still `v0.3.0`, missing the additive DASH byte-range / per-fragment `init` fields added in the v0.4.0 contract

This was **pre-existing on develop**, unrelated to any recent feature PR — surfaced while reviewing #417.

## Fix

The script's own documented remediation: `cp crates/rdlp-plugin/wit/*.wit` → both vendored dirs. `check-wit-drift.sh` now reports `WIT vendor parity OK (3 files × 2 vendored copies match)`.

## Safety
- The bump is **additive** (new optional fields on the `fragment` record) — backward-compatible for plugins that don't use them.
- The example plugins are **not workspace members**; whole-workspace `cargo check` still passes.
- CI does not build these two examples' source (they're not in the golden-wasm build list) — they're WIT-parity fixtures.

## Out of scope
Regenerating the example plugins' generated **bindings** (`example-extractor/src/bindings.rs`, `ytdlp-hello-world/extractor_plugin/*`) against v0.4.0 — they're fixtures, not built in CI. File a follow-up if full example regeneration is wanted.