### PR TITLE
fix(api): #414 cluster follow-ups — finalize/cancel/merge-naming hardening

### DIFF
--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -676,21 +676,16 @@ impl RdlpClient {
                 .await
             {
                 Ok(output_files) => {
-                    // Pipeline returns temp-named survivors (#406 Option X);
+                    // Pipeline returns temp-named survivors (#406 Option X / #412);
                     // finalize each to its clean name before reporting.
                     let mut finalized = Vec::with_capacity(output_files.len());
                     for f in output_files {
-                        match crate::orchestrator::naming::finalize_to_clean(&f) {
-                            Some(clean) => {
-                                crate::orchestrator::naming::finalize_part(&f, &clean)
-                                    .await
-                                    .map_err(|e| RdlpApiError::IoError {
-                                        message: format!("{e:#}"),
-                                    })?;
-                                finalized.push(clean);
-                            }
-                            None => finalized.push(f),
-                        }
+                        let clean = crate::orchestrator::naming::finalize_survivor(f)
+                            .await
+                            .map_err(|e| RdlpApiError::IoError {
+                                message: format!("{e:#}"),
+                            })?;
+                        finalized.push(clean);
                     }
                     let result = crate::DownloadResult {
                         id,

--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -981,6 +981,13 @@ mod terminal_event_tests {
     }
 
     /// Every non-cancel terminal error stays a genuine [`Event::Failed`].
+    ///
+    /// This loop includes [`RdlpApiError::FfmpegError`] — which is the variant
+    /// that [`OrchestratorError::PostProcessingFailed`] maps to via
+    /// `From<OrchestratorError>`. Regression guard: before the fix,
+    /// `PostProcessingFailed` did not exist and the non-cancel arm silently
+    /// returned `Ok(files)` instead of propagating an error at all, so this
+    /// case could never reach `terminal_event`.
     #[test]
     fn non_cancel_errors_map_to_failed_event() {
         let id = DownloadId::next();
@@ -995,14 +1002,50 @@ mod terminal_event_tests {
             RdlpApiError::FfmpegError {
                 message: "encoder error".into(),
             },
+            // PostProcessingFailed → FfmpegError → Event::Failed (the swallow fix).
+            RdlpApiError::from(
+                crate::orchestrator::OrchestratorError::PostProcessingFailed(
+                    "remux failed: codec not found".into(),
+                ),
+            ),
         ];
-        for err in cases {
-            let event = terminal_event(id, &err);
+        for err in &cases {
+            let event = terminal_event(id, err);
             assert!(
                 matches!(event, Event::Failed { .. }),
                 "non-cancel error {err:?} must map to Event::Failed, got {event:?}",
             );
         }
+    }
+
+    /// [`OrchestratorError::PostProcessingFailed`] must convert to
+    /// [`RdlpApiError::FfmpegError`], NOT to [`RdlpApiError::UserCancelled`].
+    ///
+    /// If it accidentally mapped to `UserCancelled` the UI would bucket a
+    /// failed remux as a deliberate user cancel — the same wrong behavior as
+    /// the recode-cancel → "Failed" bug, but in the opposite direction.
+    #[test]
+    fn postprocessing_failed_maps_to_ffmpeg_error_not_cancelled() {
+        use crate::orchestrator::OrchestratorError;
+
+        let orch_err = OrchestratorError::PostProcessingFailed("stage error: no codec".into());
+        let api_err = RdlpApiError::from(orch_err);
+
+        assert!(
+            matches!(api_err, RdlpApiError::FfmpegError { .. }),
+            "PostProcessingFailed must map to RdlpApiError::FfmpegError, got {api_err:?}",
+        );
+        assert!(
+            !matches!(api_err, RdlpApiError::UserCancelled),
+            "PostProcessingFailed must NOT map to UserCancelled",
+        );
+
+        let id = DownloadId::next();
+        let event = terminal_event(id, &api_err);
+        assert!(
+            matches!(event, Event::Failed { .. }),
+            "PostProcessingFailed must produce Event::Failed, got {event:?}",
+        );
     }
 
     /// The Failed event preserves the originating error verbatim (the patch must

--- a/crates/rdlp-api/src/client/mod.rs
+++ b/crates/rdlp-api/src/client/mod.rs
@@ -704,6 +704,13 @@ impl RdlpClient {
                 }
                 Err(e) => {
                     let err = RdlpApiError::from(e);
+                    // No orchestrator-owned sidecars to clean up here: the local-
+                    // file path never downloads a thumbnail and never writes session
+                    // state. The user's source file is borrowed (keep_inputs=true),
+                    // so FileTracker::Drop preserves it. The only temp artifacts are
+                    // the pipeline's own .rdlp-tmp-{uuid} files, which FileTracker::Drop
+                    // already removes on cancel/error (#414 / #404).
+                    //
                     // intentional: receiver may have disconnected
                     // (cancellation surfaces as Event::Cancelled, not Failed).
                     let _ = tx.send(terminal_event(id, &err)).await;

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -242,6 +242,7 @@ impl From<OrchestratorError> for RdlpApiError {
             OrchestratorError::Io(io_err) => Self::IoError {
                 message: io_err.to_string(),
             },
+            OrchestratorError::PostProcessingFailed(msg) => Self::FfmpegError { message: msg },
             OrchestratorError::InteractiveNotConfigured => Self::InvalidInput {
                 message: "Interactive selection not configured".into(),
             },

--- a/crates/rdlp-api/src/orchestrator/errors.rs
+++ b/crates/rdlp-api/src/orchestrator/errors.rs
@@ -49,6 +49,14 @@ pub enum OrchestratorError {
     #[error("Download failed: {0}")]
     DownloadFailed(#[source] RdlpError),
 
+    /// Post-processing pipeline failed with a fatal, non-cancel error.
+    ///
+    /// Propagated from [`run_postprocessing`] when the pipeline returns a
+    /// non-[`PipelineError::Cancelled`] failure. The caller receives
+    /// [`Event::Failed`] rather than a silent fallback to the unprocessed files.
+    #[error("Post-processing failed: {0}")]
+    PostProcessingFailed(String),
+
     /// Resume detection failed
     #[error("Failed to detect resume point: {0}")]
     ResumeDetectionFailed(String),

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -85,86 +85,108 @@ pub fn finalize_to_clean(survivor: &Path) -> Option<PathBuf> {
 
 /// Atomically commit a finished temp-named file to its clean output name.
 ///
-/// Same-directory rename (no `EXDEV`). On POSIX `rename(2)` replaces an
-/// existing destination atomically. On Windows `MoveFileExW` fails if the
-/// destination exists unless `MOVEFILE_REPLACE_EXISTING` is set; `tokio::fs::rename`
-/// does NOT set that flag, so we must handle a pre-existing clean file before
-/// renaming. This matters for the borrowed-input (`keep_inputs=true`) same-
-/// container in-place case: the source is still on disk when finalize runs and
-/// the survivor must replace it (#414).
+/// Same-directory rename (no `EXDEV`). On POSIX `rename(2)` atomically replaces an
+/// existing destination — so a direct rename is correct and safe even when `clean`
+/// already exists (the `keep_inputs=true` same-container in-place case, #414).
+/// No backup file is created on Unix; there is no orphan window.
 ///
-/// Uses a **backup-restore** pattern when `clean` already exists: the existing
-/// file is moved aside first, and restored if the final rename fails, so `clean`
-/// is never lost without `part` safely in place.
+/// On Windows `MoveFileExW` does NOT set `MOVEFILE_REPLACE_EXISTING` when called
+/// via `tokio::fs::rename`, so the rename fails if `clean` exists. For that case
+/// a **backup-restore** helper (`finalize_part_replace_windows`) moves `clean`
+/// aside first, renames `part` into place, and restores on failure — see its
+/// doc-comment for the rationale and the narrow orphan-window note (#416-M1).
 ///
 /// On failure the temp file is left intact and the error is surfaced to the
 /// caller via context.
 pub async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
     use anyhow::Context as _;
 
+    // POSIX rename(2) atomically REPLACES an existing destination, so a direct
+    // rename is correct even when `clean` already exists (the keep_inputs in-place
+    // case) — no backup file, no data-loss window. The backup-restore below is a
+    // Windows-only workaround: tokio::fs::rename there does not set
+    // MOVEFILE_REPLACE_EXISTING and fails if `clean` exists (#414 / #416-M1).
+    #[cfg(windows)]
     if part != clean && tokio::fs::try_exists(clean).await.unwrap_or(false) {
-        // `clean` already exists (e.g. keep_inputs same-container in-place case).
-        // A bare remove-then-rename has a data-loss window: if the rename fails
-        // after the remove, `clean` is gone forever. Move the existing file aside
-        // first and restore it if the rename fails, so `clean` is never lost.
-        let backup = {
-            // A real media output path always has a file name; a root or
-            // directory path reaching this branch would be a caller-contract
-            // violation (the orchestrator only calls finalize_part on actual
-            // file paths). Verified here so the `.unwrap_or_default()` fallback
-            // is known-safe and an assertion fires in debug builds.
-            debug_assert!(
-                clean.file_name().is_some(),
-                "finalize_part: clean path has no file name component (degenerate path?) — \
-                 backup name would be empty: {}",
-                clean.display()
-            );
-            let mut name = clean
-                .file_name()
-                .map(std::ffi::OsStr::to_os_string)
-                .unwrap_or_default();
-            name.push(format!(".rdlp-bak-{}", uuid::Uuid::new_v4().simple()));
-            clean.with_file_name(name)
-        };
-        // NOTE (#414 follow-up): a second Ctrl+C force-exit (process::exit) in the
-        // micro-window between this backup rename and the rename below would orphan
-        // the `.rdlp-bak-{uuid}` file (it holds the user's data — no loss, just a
-        // leftover). finalize_part has no TempRegistry handle to register the backup
-        // for stale-sweep; tracked as a follow-up.
-        tokio::fs::rename(clean, &backup).await.with_context(|| {
-            format!(
-                "failed to back up existing {} while finalizing {} -> {}",
-                clean.display(),
-                part.display(),
-                clean.display()
-            )
-        })?;
-        match tokio::fs::rename(part, clean).await {
-            Ok(()) => {
-                // Success: drop the backup (best-effort; ignore errors).
-                let _ = tokio::fs::remove_file(&backup).await;
-                Ok(())
-            }
-            Err(e) => {
-                // Restore the original so `clean` is never lost.
-                let _ = tokio::fs::rename(&backup, clean).await;
-                Err(e).with_context(|| {
-                    format!(
-                        "failed to finalize {} -> {} (original restored)",
-                        part.display(),
-                        clean.display()
-                    )
-                })
-            }
+        return finalize_part_replace_windows(part, clean).await;
+    }
+
+    // Unix (always) and Windows (when `clean` does not yet exist — the normal
+    // download case): a direct rename, atomic-replace on POSIX.
+    tokio::fs::rename(part, clean).await.with_context(|| {
+        format!(
+            "failed to finalize download {} -> {}",
+            part.display(),
+            clean.display()
+        )
+    })
+}
+
+/// Windows-only helper: replace a pre-existing `clean` file with `part`.
+///
+/// `tokio::fs::rename` on Windows does NOT set `MOVEFILE_REPLACE_EXISTING`, so it
+/// fails if `clean` already exists. This helper moves `clean` aside to a
+/// `.rdlp-bak-{uuid}` sidecar, renames `part` into its place, then removes the
+/// sidecar on success. On rename failure the sidecar is restored so `clean` is
+/// never permanently lost.
+///
+/// The backup is intentionally NOT named `.rdlp-tmp-*`: `TempRegistry::cleanup_stale`
+/// marker-scans `.rdlp-tmp-` names and would delete the user's sole in-window copy.
+/// A `.rdlp-bak-` sidecar is invisible to the stale-sweep, so the user's data
+/// survives a force-exit in the micro-window between the two renames (#416-M1).
+#[cfg(windows)]
+async fn finalize_part_replace_windows(part: &Path, clean: &Path) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    let backup = {
+        // A real media output path always has a file name; a root or directory
+        // path reaching this branch would be a caller-contract violation (the
+        // orchestrator only calls finalize_part on actual file paths). Verified
+        // here so the `.unwrap_or_default()` fallback is known-safe and an
+        // assertion fires in debug builds.
+        debug_assert!(
+            clean.file_name().is_some(),
+            "finalize_part: clean path has no file name component (degenerate path?) — \
+             backup name would be empty: {}",
+            clean.display()
+        );
+        let mut name = clean
+            .file_name()
+            .map(std::ffi::OsStr::to_os_string)
+            .unwrap_or_default();
+        name.push(format!(".rdlp-bak-{}", uuid::Uuid::new_v4().simple()));
+        clean.with_file_name(name)
+    };
+    // NOTE (#416-M1): a second Ctrl+C force-exit (process::exit) in the micro-window
+    // between this backup rename and the rename below would orphan the
+    // `.rdlp-bak-{uuid}` file (it holds the user's data — no loss, just a leftover).
+    // This orphan window is Windows-only; Unix takes the atomic direct-rename path
+    // in finalize_part and never reaches this helper.
+    tokio::fs::rename(clean, &backup).await.with_context(|| {
+        format!(
+            "failed to back up existing {} while finalizing {} -> {}",
+            clean.display(),
+            part.display(),
+            clean.display()
+        )
+    })?;
+    match tokio::fs::rename(part, clean).await {
+        Ok(()) => {
+            // Success: drop the backup (best-effort; ignore errors).
+            let _ = tokio::fs::remove_file(&backup).await;
+            Ok(())
         }
-    } else {
-        tokio::fs::rename(part, clean).await.with_context(|| {
-            format!(
-                "failed to finalize download {} -> {}",
-                part.display(),
-                clean.display()
-            )
-        })
+        Err(e) => {
+            // Restore the original so `clean` is never lost.
+            let _ = tokio::fs::rename(&backup, clean).await;
+            Err(e).with_context(|| {
+                format!(
+                    "failed to finalize {} -> {} (original restored)",
+                    part.display(),
+                    clean.display()
+                )
+            })
+        }
     }
 }
 
@@ -467,12 +489,15 @@ mod tests {
 
     /// `finalize_part` must overwrite an existing clean file.
     ///
-    /// This exercises the Windows-safe path: on POSIX `rename(2)` replaces
-    /// atomically, but `tokio::fs::rename` on Windows fails if the destination
-    /// already exists. For `process_local_file` with `keep_inputs=true`, the
-    /// borrowed source file still exists on disk when the survivor is finalized
-    /// to the same path (same-container in-place update), so `finalize_part`
-    /// must remove it first (#414).
+    /// For `process_local_file` with `keep_inputs=true`, the borrowed source file
+    /// still exists on disk when the survivor is finalized to the same path
+    /// (same-container in-place update), so `finalize_part` must handle a
+    /// pre-existing `clean` (#414).
+    ///
+    /// On Unix this is handled by the atomic direct-rename path (`rename(2)` replaces
+    /// an existing destination). On Windows `finalize_part_replace_windows` is used
+    /// instead (backup-restore). This test runs on Unix and exercises the direct-rename
+    /// path.
     #[tokio::test]
     #[allow(clippy::disallowed_methods)] // std::fs helpers in test fixtures — per clippy.toml policy (c)
     async fn test_finalize_part_overwrites_existing_clean() {
@@ -511,6 +536,60 @@ mod tests {
 
         // The temp part must be gone.
         assert!(!part.exists(), "part must be removed after finalize");
+    }
+
+    /// After `finalize_part` succeeds with a pre-existing `clean`, the directory
+    /// must contain ONLY the clean file — no `.rdlp-bak-*` sidecar and no leftover
+    /// `part` file.
+    ///
+    /// On Unix this pins the structural guarantee of the atomic direct-rename path:
+    /// no backup is ever written, so there is no sidecar to orphan even under a
+    /// force-exit. The force-exit orphan-window elimination itself is structural
+    /// (the `#[cfg(windows)]` cfg-gate) and is not directly unit-observable, but
+    /// the absence of a `.rdlp-bak-*` file proves the Unix path was taken.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)] // std::fs helpers in test fixtures — per clippy.toml policy (c)
+    async fn test_finalize_part_no_bak_sidecar_on_overwrite() {
+        use std::io::Write as _;
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+
+        let part = dir.path().join("clip.rdlp-tmp-xyz.mp4");
+        let clean = dir.path().join("clip.mp4");
+
+        {
+            let mut f = std::fs::File::create(&part).expect("create part");
+            f.write_all(b"new-content").expect("write part");
+        }
+        {
+            let mut f = std::fs::File::create(&clean).expect("create clean");
+            f.write_all(b"old-content").expect("write clean");
+        }
+
+        finalize_part(&part, &clean)
+            .await
+            .expect("finalize_part must succeed");
+
+        // Only `clean` must remain — no `part`, no `.rdlp-bak-*` sidecar.
+        let mut entries: Vec<String> = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .filter_map(std::result::Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        entries.sort();
+
+        assert_eq!(
+            entries,
+            vec!["clip.mp4"],
+            "directory must contain exactly the clean file — no sidecar, no part; got: {entries:?}"
+        );
+
+        // The content must be the survivor's.
+        let content = std::fs::read(&clean).expect("read clean");
+        assert_eq!(
+            content, b"new-content",
+            "clean must hold the survivor content"
+        );
     }
 
     /// `seam_stream` moves a raw `.{label}.{format_id}.{ext}` merge-stream file

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -194,6 +194,43 @@ pub(super) async fn discard_part(part: &Path) {
     let _ = tokio::fs::remove_file(part).await;
 }
 
+/// Seam a finished merge-stream download into the pipeline's `.rdlp-tmp-{uuid}`
+/// namespace, deriving the CLEAN stem from `clean_target` and preserving the
+/// stream's own extension.
+///
+/// Mirrors the Single-path seam (`part` → `seam`) so `MergeStage` and
+/// `original_stem_for` see only the clean stem, never the `.{label}.{format_id}`
+/// infix emitted by `merge_stream_path`. Each call generates a fresh UUID, so
+/// two streams with the same extension (rare) will not collide.
+///
+/// # Errors
+/// Propagates any I/O error from the underlying rename.
+pub async fn seam_stream(clean_target: &Path, stream: &Path) -> anyhow::Result<PathBuf> {
+    use anyhow::Context as _;
+
+    let ext = stream.extension().and_then(|e| e.to_str()).unwrap_or("");
+    // Build a clean intermediate path: same dir, clean stem, stream's extension.
+    // `with_extension("")` strips the target's extension entirely — only reached
+    // for an extension-less stream (a downloader always emits a container ext, so
+    // this is a defensive fallback, not a normal path).
+    let clean = if ext.is_empty() {
+        clean_target.with_extension("")
+    } else {
+        clean_target.with_extension(ext)
+    };
+    let seam = seam_path(&clean);
+    // finalize_part already names both paths in its context; wrap it so the
+    // failure is identifiable as a merge-stream seam (not a "download finalize").
+    finalize_part(stream, &seam).await.with_context(|| {
+        format!(
+            "seam_stream: failed to move merge stream {} -> {}",
+            stream.display(),
+            seam.display()
+        )
+    })?;
+    Ok(seam)
+}
+
 /// Derive a pipeline-namespace temp path `{clean_stem}.rdlp-tmp-{uuid}.{ext}`
 /// from the clean target, in the SAME directory. Used at the download->pipeline
 /// seam so the post-process `FileTracker` only ever sees its own `.rdlp-tmp-`
@@ -474,5 +511,81 @@ mod tests {
 
         // The temp part must be gone.
         assert!(!part.exists(), "part must be removed after finalize");
+    }
+
+    /// `seam_stream` moves a raw `.{label}.{format_id}.{ext}` merge-stream file
+    /// into the pipeline's `.rdlp-tmp-{uuid}` namespace, deriving the clean stem
+    /// from `clean_target` and preserving the stream's own extension.
+    ///
+    /// Failing-first test: the helper does not exist before this commit, so the
+    /// test can't even compile. Once the helper exists, it pins the exact invariant
+    /// that the `.video.f137` infix NEVER reaches the pipeline.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)] // std::fs helpers in test fixtures — per clippy.toml policy (c)
+    async fn seam_stream_moves_into_tmp_namespace_and_strips_label_infix() {
+        use std::io::Write as _;
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+
+        // The clean target the orchestrator computed (e.g. /v/Title.mkv).
+        let clean_target = dir.path().join("Title.mkv");
+        // The raw merge-stream file as produced by merge_stream_path.
+        let stream = dir.path().join("Title.video.f137.mp4");
+        {
+            let mut f = std::fs::File::create(&stream).expect("create stream");
+            f.write_all(b"video-bytes").expect("write");
+        }
+
+        let seam = seam_stream(&clean_target, &stream)
+            .await
+            .expect("seam_stream must succeed");
+
+        // 1. Lives in the same directory as clean_target.
+        assert_eq!(
+            seam.parent(),
+            clean_target.parent(),
+            "seam must be in the same directory as clean_target"
+        );
+
+        // 2. Name starts with the clean stem (not the .video.f137 infix).
+        let name = seam.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.starts_with("Title.rdlp-tmp-"),
+            "seam name must start with clean stem + tmp marker, got: {name}"
+        );
+
+        // 3. Name does NOT contain the label infix or format_id.
+        assert!(
+            !name.contains(".video."),
+            "seam name must not contain '.video.' infix, got: {name}"
+        );
+        assert!(
+            !name.contains("f137"),
+            "seam name must not contain 'f137' format_id, got: {name}"
+        );
+
+        // 4. Stream's own extension is preserved (mp4, not mkv).
+        assert!(
+            seam.extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("mp4")),
+            "seam must preserve the stream's extension (mp4), got: {name}"
+        );
+
+        // 5. The original stream file was moved (no longer exists).
+        assert!(
+            !stream.exists(),
+            "stream file must be gone after seam_stream"
+        );
+
+        // 6. The seam file exists on disk.
+        assert!(seam.exists(), "seam file must exist on disk");
+
+        // 7. finalize_to_clean recovers the correct clean path (stem + stream ext).
+        let expected_clean = dir.path().join("Title.mp4");
+        assert_eq!(
+            finalize_to_clean(&seam),
+            Some(expected_clean),
+            "finalize_to_clean on the seam must yield the clean path (stream ext preserved)"
+        );
     }
 }

--- a/crates/rdlp-api/src/orchestrator/naming.rs
+++ b/crates/rdlp-api/src/orchestrator/naming.rs
@@ -168,6 +168,25 @@ pub async fn finalize_part(part: &Path, clean: &Path) -> anyhow::Result<()> {
     }
 }
 
+/// Finalize a (possibly temp-named) pipeline survivor to its clean output name.
+///
+/// If the survivor carries a temp marker (`.rdlp-part` or `.rdlp-tmp-`), it is
+/// atomically renamed to the clean name and that clean path is returned.
+/// If the survivor already carries a clean name (no marker present, or the
+/// `-` stdout sentinel), it is returned unchanged and no rename is attempted.
+///
+/// This is the single coordinator-finalize call — the one place the clean name
+/// is created — covering PP-ran, PP-skipped, and FFmpeg-missing paths.
+pub async fn finalize_survivor(survivor: PathBuf) -> anyhow::Result<PathBuf> {
+    match finalize_to_clean(&survivor) {
+        Some(clean) => {
+            finalize_part(&survivor, &clean).await?;
+            Ok(clean)
+        }
+        None => Ok(survivor),
+    }
+}
+
 /// Best-effort removal of a `.rdlp-part` working file on explicit cancel, so a
 /// cancelled download leaves no artifact (#406). Errors are ignored: the file
 /// may legitimately not exist yet, and a failed unlink must not mask the cancel.
@@ -358,6 +377,55 @@ mod tests {
     #[test]
     fn seam_path_is_noop_for_stdout() {
         assert_eq!(seam_path(&PathBuf::from("-")), PathBuf::from("-"));
+    }
+
+    /// `finalize_survivor` renames a temp-named file to its clean path (Some arm).
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)] // std::fs helpers in test fixtures — per clippy.toml policy (c)
+    async fn finalize_survivor_renames_temp_named_file() {
+        use std::io::Write as _;
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+
+        let survivor = dir.path().join("Title.rdlp-tmp-abc.mkv");
+        let expected_clean = dir.path().join("Title.mkv");
+
+        {
+            let mut f = std::fs::File::create(&survivor).expect("create survivor");
+            f.write_all(b"content").expect("write");
+        }
+
+        let result = finalize_survivor(survivor.clone())
+            .await
+            .expect("finalize_survivor must succeed");
+
+        assert_eq!(result, expected_clean, "must return the clean path");
+        assert!(
+            expected_clean.exists(),
+            "clean file must exist after rename"
+        );
+        assert!(!survivor.exists(), "temp file must be gone after rename");
+    }
+
+    /// `finalize_survivor` returns a clean-named path unchanged (None arm).
+    #[tokio::test]
+    async fn finalize_survivor_passthrough_for_clean_name() {
+        // No file on disk needed — the None arm just echoes the input.
+        let clean = PathBuf::from("/v/Title.mkv");
+        let result = finalize_survivor(clean.clone())
+            .await
+            .expect("finalize_survivor must not error for clean name");
+        assert_eq!(result, clean, "clean name must be returned unchanged");
+    }
+
+    /// `finalize_survivor` is a no-op for the stdout `-` sentinel.
+    #[tokio::test]
+    async fn finalize_survivor_passthrough_for_stdout_sentinel() {
+        let stdout = PathBuf::from("-");
+        let result = finalize_survivor(stdout.clone())
+            .await
+            .expect("finalize_survivor must not error for stdout sentinel");
+        assert_eq!(result, stdout, "stdout sentinel must be returned unchanged");
     }
 
     /// `finalize_part` must overwrite an existing clean file.

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -348,14 +348,8 @@ impl Orchestrator {
             .into_iter()
             .next()
             .unwrap_or_else(|| output_path.clone());
-        // Coordinator finalize (Option X): mint the clean name once, post-PP.
-        let final_path = match crate::orchestrator::naming::finalize_to_clean(&survivor) {
-            Some(clean) => {
-                crate::orchestrator::naming::finalize_part(&survivor, &clean).await?;
-                clean
-            }
-            None => survivor,
-        };
+        // Coordinator finalize (Option X / #412): single helper covers all paths.
+        let final_path = crate::orchestrator::naming::finalize_survivor(survivor).await?;
 
         // HLS downloads produce .ts files that should be remuxed.
         if is_hls {

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -267,8 +267,17 @@ impl Orchestrator {
                     // Parallel download of video + audio
                     match self.download_merge_pair(&video, &audio, path).await {
                         Ok(Some(merge_outcome)) => {
+                            // Seam both streams into the pipeline's .rdlp-tmp-{uuid}
+                            // namespace (mirrors the Single-path seam and state/mod.rs
+                            // Merge branch — strips the .{label}.{format_id} infix).
+                            let video_seam =
+                                super::super::naming::seam_stream(path, &merge_outcome.video_path)
+                                    .await?;
+                            let audio_seam =
+                                super::super::naming::seam_stream(path, &merge_outcome.audio_path)
+                                    .await?;
                             download_result = Some((
-                                vec![merge_outcome.video_path, merge_outcome.audio_path],
+                                vec![video_seam, audio_seam],
                                 merge_outcome.is_hls,
                                 Some(vec![video, audio]),
                             ));

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -304,10 +304,14 @@ impl Orchestrator {
         }
         let final_info = &final_info_owned;
 
-        // Download thumbnail if needed (before post-processing so embed can find it)
-        if self.config.postprocess.embed_thumbnail || self.config.postprocess.write_thumbnail {
-            self.download_thumbnail(final_info, &output_path).await;
-        }
+        // Download thumbnail for embedding or standalone use. Capture the
+        // written path so a PP-cancel can delete it (#404 / #411).
+        let thumbnail_path =
+            if self.config.postprocess.embed_thumbnail || self.config.postprocess.write_thumbnail {
+                self.download_thumbnail(final_info, &output_path).await
+            } else {
+                None
+            };
 
         // Download subtitles: resolve per-episode URLs from language names.
         let episode_subs = if subtitle_langs.is_empty() {
@@ -340,10 +344,28 @@ impl Orchestrator {
             );
         }
 
-        // Run post-processing if configured (or automatic for HLS).
-        let final_files = self
-            .run_postprocessing(final_info, download_files, is_hls, false)
-            .await?;
+        // Run post-processing if configured (or automatic for HLS). On a user
+        // cancel, delete the orchestrator-owned sidecars (thumbnail + session
+        // state; the source is reclaimed by FileTracker::Drop) before returning
+        // UserCancelled so the caller surfaces Event::Cancelled (#404 / #411).
+        let final_files = match self
+            .run_postprocessing(final_info, download_files.clone(), is_hls, false)
+            .await
+        {
+            Ok(files) => files,
+            Err(e @ OrchestratorError::UserCancelled) => {
+                super::super::cleanup::cleanup_cancelled_artifacts(
+                    output_dir,
+                    self.config.output_to_stdout,
+                    &final_info.title,
+                    &download_files,
+                    thumbnail_path.as_deref(),
+                )
+                .await;
+                return Err(e);
+            }
+            Err(e) => return Err(e),
+        };
         let survivor = final_files
             .into_iter()
             .next()

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -7,7 +7,7 @@ use crate::events::Event;
 use crate::handle::DownloadId;
 use crate::orchestrator::errors::OrchestratorError;
 use crate::orchestrator::eta::EtaEstimator;
-use log::{debug, warn};
+use log::{debug, error, warn};
 use rdlp_core::{PostProcessCallback, PostProcessCallbackFactory};
 use rdlp_postprocess::PipelineRunOptions;
 use rdlp_postprocess::pipeline::PipelineError;
@@ -95,6 +95,26 @@ fn original_stem_for(files: &[PathBuf]) -> String {
                 )
             },
         )
+}
+
+/// Classify a pipeline error as either a user-cancel or a fatal failure.
+///
+/// This is a pure function extracted for testability. The cancel vs.
+/// non-cancel distinction is the only branching: a [`PipelineError::Cancelled`]
+/// becomes [`OrchestratorError::UserCancelled`] so the UI surfaces a deliberate
+/// cancel correctly; every other error becomes
+/// [`OrchestratorError::PostProcessingFailed`] so it propagates as
+/// [`Event::Failed`] rather than being silently swallowed.
+pub fn classify_pipeline_err(e: &anyhow::Error) -> OrchestratorError {
+    if matches!(
+        e.downcast_ref::<PipelineError>(),
+        Some(PipelineError::Cancelled)
+    ) {
+        OrchestratorError::UserCancelled
+    } else {
+        error!("Post-processing pipeline failed: {e:#}");
+        OrchestratorError::PostProcessingFailed(format!("{e:#}"))
+    }
 }
 
 impl Orchestrator {
@@ -199,20 +219,7 @@ impl Orchestrator {
                 }
                 Ok(output_files)
             }
-            Err(e) => {
-                // Cancellation MUST propagate as OrchestratorError::UserCancelled.
-                // Any non-cancel pipeline error keeps today's silent warn-and-fallback
-                // behaviour (returns the original input files; logs a warning).
-                if matches!(
-                    e.downcast_ref::<PipelineError>(),
-                    Some(PipelineError::Cancelled)
-                ) {
-                    return Err(OrchestratorError::UserCancelled);
-                }
-                warn!("Post-processing pipeline failed: {e}");
-                // Return original files on failure.
-                Ok(files)
-            }
+            Err(e) => Err(classify_pipeline_err(&e)),
         }
     }
 
@@ -264,6 +271,56 @@ impl Orchestrator {
 
         if deleted > 0 {
             debug!(deleted; "Cleaned up leftover segment files");
+        }
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+    use rdlp_postprocess::pipeline::PipelineError;
+
+    /// A [`PipelineError::Cancelled`] MUST classify as `UserCancelled`, not
+    /// `PostProcessingFailed`. Regression guard: the cancel→Failed bug.
+    #[test]
+    fn cancelled_pipeline_error_maps_to_user_cancelled() {
+        let err = anyhow::Error::new(PipelineError::Cancelled);
+        let result = classify_pipeline_err(&err);
+        assert!(
+            matches!(result, OrchestratorError::UserCancelled),
+            "PipelineError::Cancelled must map to UserCancelled, got {result:?}",
+        );
+    }
+
+    /// Any non-cancel pipeline error MUST classify as `PostProcessingFailed`,
+    /// NOT as `Ok(files)`. This pins the fix: before the change the non-cancel
+    /// arm silently returned `Ok(files)` — the error was swallowed entirely so
+    /// this test didn't exist (no classifier fn existed). A `StageFailure` error
+    /// classified here would previously have been silently swallowed.
+    #[test]
+    fn non_cancel_pipeline_error_maps_to_postprocessing_failed() {
+        let err = anyhow::anyhow!("stage failed: remux codec error");
+        let result = classify_pipeline_err(&err);
+        assert!(
+            matches!(result, OrchestratorError::PostProcessingFailed(_)),
+            "non-cancel error must map to PostProcessingFailed, got {result:?}",
+        );
+    }
+
+    /// The error message is preserved in `PostProcessingFailed` so operators
+    /// can read the root cause from `Event::Failed.error.user_message()`.
+    #[test]
+    fn postprocessing_failed_preserves_message() {
+        let err = anyhow::anyhow!("codec unavailable");
+        let result = classify_pipeline_err(&err);
+        match result {
+            OrchestratorError::PostProcessingFailed(msg) => {
+                assert!(
+                    msg.contains("codec unavailable"),
+                    "message not preserved: {msg}",
+                );
+            }
+            other => panic!("expected PostProcessingFailed, got {other:?}"),
         }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/state/finalize_tests.rs
@@ -31,21 +31,22 @@ async fn finalize_part_renames_and_reports_missing() {
     assert!(clean.exists() && !part.exists());
 
     // Failure surfaces with context when the part is missing.
-    // At this point `clean` exists (from the successful rename above), so the
-    // backup-restore branch fires: `clean` is backed up, the rename of the
-    // missing `part` fails, `clean` is restored, and the error includes
-    // "(original restored)". The key invariant is that `clean` is intact.
+    // At this point `clean` exists (from the successful rename above).
+    // On Unix: the direct atomic rename fires and fails (part is gone) — the
+    // OS never touches `clean`, so it remains intact and the error contains
+    // "No such file" or "failed to finalize".
+    // On Windows: the backup-restore branch fires — `clean` is backed up,
+    // the rename of the missing `part` fails, `clean` is restored, and the
+    // error includes "(original restored)". Either way the key invariant is
+    // that `clean` is intact after the error.
     let err = finalize_part(&part, &clean).await.unwrap_err();
     let msg = format!("{err:#}");
     assert!(
         msg.contains("failed to finalize") || msg.contains("No such file"),
         "got: {msg}"
     );
-    // The original `clean` must be restored after the failed rename.
-    assert!(
-        clean.exists(),
-        "clean must be restored after failed finalize"
-    );
+    // The original `clean` must still exist after the failed rename.
+    assert!(clean.exists(), "clean must be intact after failed finalize");
 }
 
 #[tokio::test]

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -511,17 +511,9 @@ impl DownloadPhase {
                     .into_iter()
                     .next()
                     .unwrap_or_else(|| output_path.clone());
-                // Coordinator finalize (Option X): the ONE place the clean name
-                // is created — covers PP-ran, PP-skipped, and FFmpeg-missing. The
-                // pipeline (and the no-PP bypass) returns a temp-named survivor.
-                let final_path = match super::naming::finalize_to_clean(&survivor) {
-                    Some(clean) => {
-                        super::naming::finalize_part(&survivor, &clean).await?;
-                        clean
-                    }
-                    // No marker → already a clean name; use as-is.
-                    None => survivor,
-                };
+                // Coordinator finalize (Option X / #412): single helper covers
+                // PP-ran, PP-skipped, and FFmpeg-missing paths.
+                let final_path = super::naming::finalize_survivor(survivor).await?;
 
                 // Verify the output file actually exists
                 if !final_path.exists() {

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -465,7 +465,15 @@ impl DownloadPhase {
                         // returns true
                         info.requested_formats = Some(vec![video.clone(), audio.clone()]);
 
-                        (vec![outcome.video_path, outcome.audio_path], outcome.is_hls)
+                        // Seam both streams into the pipeline's .rdlp-tmp-{uuid}
+                        // namespace so FileTracker and original_stem_for see only
+                        // the clean stem (never the .{label}.{format_id} infix from
+                        // merge_stream_path — mirrors the Single-path seam above).
+                        let video_seam =
+                            super::naming::seam_stream(&output_path, &outcome.video_path).await?;
+                        let audio_seam =
+                            super::naming::seam_stream(&output_path, &outcome.audio_path).await?;
+                        (vec![video_seam, audio_seam], outcome.is_hls)
                     }
                 };
 


### PR DESCRIPTION
Finishes the #414 follow-up cluster: five tightly-coupled post-process / file-lifecycle hardening fixes surfaced during the #406/#414 reviews. All in `crates/rdlp-api/`.

## Changes (one commit per issue)

- **#412** — `refactor`: extract `finalize_survivor` helper, collapsing the 3 duplicated coordinator-finalize blocks (`state/mod.rs`, `playlist/episode.rs`, `client/mod.rs`) to one. Behavior-preserving.
- **#410** — `fix`: a non-cancel **fatal** post-process error no longer gets swallowed as `Ok(files)` (which minted the clean output name over an *un-processed* file + emitted `Event::Completed`). It now propagates as `OrchestratorError::PostProcessingFailed` → `RdlpApiError::FfmpegError` → `Event::Failed`. This matches **yt-dlp's default** (`ignoreerrors=False`) — the old behavior was a silent, unflagged `ignoreerrors=True`, and `Ok(fallback)`-on-failure is the canonical Rust swallowed-error anti-pattern. Cancel still surfaces as `Event::Cancelled`.
- **#411** — `fix`: wire `cleanup_cancelled_artifacts` (delete downloaded thumbnail + session-state) into the **playlist episode** PP-cancel path (mirrors the single-video path). `process_local_file` documented as needing none (no sidecars).
- **#409** — `fix`: merge (video+audio) downloads no longer leak a `.video.fNNN` infix into the final name (`Title.video.f137.mkv` → `Title.mkv`). New `seam_stream` seams merge streams into the pipeline's `.rdlp-tmp-{uuid}` namespace, restoring the `seam_path` invariant the Single path already honors. Also fixes latent merge thumbnail discovery.
- **#416-M1** — `fix`: `finalize_part`'s backup-restore dance is now `#[cfg(windows)]`-only; Unix does a direct atomic rename (POSIX `rename(2)` replaces), eliminating the force-exit orphan window on Linux/macOS. **Note:** the issue's original suggestion (mark the backup `.rdlp-tmp-` for stale-sweep) was rejected as a **data-loss trap** — `TempRegistry::cleanup_stale` marker-scans `.rdlp-tmp-`, and in the force-exit window the backup holds the user's *sole* copy. The backup stays `.rdlp-bak-` (invisible to the sweep). (#416 M2 — canonical borrowed-path matching — already shipped in #420.)

## Verification

- Full gate green at HEAD: `cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test` (463 rdlp-api tests) + `check-dedup.sh` + `check-url-redaction.sh` + `check-wit-drift.sh` + `cargo check -p rdlp-desktop`.
- Each commit passed per-task spec + code-quality review.

## Reviews (whole-diff, pre-push)

- **security-reviewer** → **Approve**. Zero Critical/High. No data-loss/clobber/traversal. One MEDIUM (latent, hypothetical) tracked as **#422**.
- **code-reviewer** → **Approve**. All cross-task seams compose correctly (#410 Err skips finalize at all 3 sites; #409 seamed paths flow correctly into #411's cleanup).

## Follow-ups filed

- **#421** — Windows-CI unit tests for the `#[cfg(windows)]` `finalize_part_replace_windows` path (untested by Linux CI).
- **#422** — audit pipeline-stage `anyhow` contexts for raw-URL inlining before `Event::Failed` (redaction defense-in-depth).

Closes #409
Closes #410
Closes #411
Closes #412
Closes #416