### PR TITLE
ci(security): gate rdlp-postprocess for raw-URL log redaction (#422)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,13 @@ jobs:
         run: bash scripts/check-no-cli.sh
 
       - name: Check URL log redaction
-        # Fails if any raw URL is interpolated into an operator-visible string
-        # in rdlp-extractor (RdlpError message/reason fields, RdlpError ctor
-        # message-args, positional log macros, structured-kv log fields).
+        # Fails if any raw URL is interpolated into an operator-visible string in
+        # rdlp-extractor (RdlpError message/reason fields, RdlpError ctor message-args,
+        # positional log macros, structured-kv log fields) OR in the rdlp-postprocess
+        # pipeline (fatal-stage `.context(...)` / error / log macros that reach
+        # Event::Failed via classify_pipeline_err's `{e:#}` flatten — #422).
         # Multiline-aware; credential URLs must be wrapped in
-        # rdlp_redact::RedactedUrl / rdlp_security::sanitize_for_logging (#328/#392).
+        # rdlp_redact::RedactedUrl / rdlp_security::sanitize_for_logging (#328/#392/#422).
         run: bash scripts/check-url-redaction.sh
 
       - name: Check WIT vendor drift

--- a/scripts/check-url-redaction.sh
+++ b/scripts/check-url-redaction.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # check-url-redaction.sh — CI gate: verify all operator-visible URL interpolations in
-# rdlp-extractor are wrapped with rdlp_redact::RedactedUrl (or sanitize_for_logging).
+# rdlp-extractor AND the post-processing pipeline (rdlp-postprocess) are wrapped with
+# rdlp_redact::RedactedUrl (or sanitize_for_logging).
 #
 # Exit 0 = PASS (no offenders found).
 # Exit 1 = FAIL (raw URL interpolations remain).
@@ -13,22 +14,37 @@
 # the need to filter out RedactedUrl wraps: compliant code passes the URL as a
 # positional argument *outside* the string, so the in-string {*url} pattern never
 # fires on it.
+#
+# Scope rationale (#422): the fatal post-process stages (Merge/Remux/Recode/
+# AudioExtract/Normalize) author the `.context(...)` strings that
+# `classify_pipeline_err` flattens via `{e:#}` into `OrchestratorError::
+# PostProcessingFailed` → `Event::Failed`.  Today those contexts are static
+# literals (no URL), but a future stage that fetches a URL (e.g. a remote-subtitle
+# or plugin post-processor) could inline one.  Gating rdlp-postprocess closes that
+# regression window at the authoring surface.  The classifier itself lives in
+# rdlp-api but cannot introduce a URL (it only formats `{e:#}` + a static string),
+# so it needs no separate gate.  rdlp-ffmpeg is intentionally NOT gated: its only
+# `url` token is `AVFormatContext.url`, which for a file muxer is the local output
+# path (not a network URL) and appears only in diagnostic logs.
 
 set -euo pipefail
 
-TARGET="crates/rdlp-extractor/src"
+EXTRACTOR_TARGET="crates/rdlp-extractor/src"
+PIPELINE_TARGET="crates/rdlp-postprocess/src"
 FAIL=0
 
 # Helper: run rg -U (multiline), filter out already-compliant lines and test files,
 # report hits.
-# Args: <label> <rg-pattern>
+# Args: <label> <rg-pattern> [target-dir]   (target defaults to the extractor crate)
 check() {
     local label="$1"
     local pattern="$2"
+    local target="${3:-$EXTRACTOR_TARGET}"
     local hits
-    hits=$(rg -U --type rust -n "$pattern" "$TARGET" 2>/dev/null \
+    hits=$(rg -U --type rust -n "$pattern" "$target" 2>/dev/null \
         | grep -v 'RedactedUrl' \
         | grep -v 'sanitize_for_logging' \
+        | grep -v 'safe_url' \
         | grep -v '/tests/' \
         | grep -v '#\[cfg(test)\]' \
         | grep -v '^\s*//' \
@@ -64,8 +80,33 @@ check "log_if_verbose:format" \
 check "structured-kv:url_field" \
     '[a-z_]*url[a-z_]*:[?%]\s*='
 
+# ---------------------------------------------------------------------------
+# Post-processing pipeline (rdlp-postprocess) — #422 defense-in-depth.
+#
+# Fatal-stage `.context(...)` strings reach Event::Failed via classify_pipeline_err's
+# `{e:#}` flatten, so a URL inlined into any error/log macro here would surface to
+# the operator unredacted.  Two durable classes:
+#
+#   P1. Any error/log-producing macro whose string literal inlines `{*url}` —
+#       covers `.context(format!("…{url}"))`, `.with_context(|| format!(…{url}))`,
+#       bare `anyhow!`/`bail!`, and the `error!`/`warn!`/`info!`/`debug!`/`trace!`/
+#       `panic!` log macros.  `format!` is in the alternation, so any `.context(...)`
+#       built from a `format!` is caught regardless of the surrounding call.
+#   P2. Structured-kv `*url*` fields (same class as #5, re-run against the pipeline).
+# ---------------------------------------------------------------------------
+
+# P1. error/log macro inlining {*url} in the string literal.
+check "pp:macro:format_url" \
+    '(format!|anyhow!|bail!|error!|warn!|info!|debug!|trace!|panic!)\(\s*"(?:[^"\\]|\\.)*\{[a-z_]*url' \
+    "$PIPELINE_TARGET"
+
+# P2. Structured-kv log fields in the pipeline.
+check "pp:structured-kv:url_field" \
+    '[a-z_]*url[a-z_]*:[?%]\s*=' \
+    "$PIPELINE_TARGET"
+
 if [[ $FAIL -eq 0 ]]; then
-    echo "PASS — no raw URL interpolations found in $TARGET"
+    echo "PASS — no raw URL interpolations found in $EXTRACTOR_TARGET or $PIPELINE_TARGET"
     exit 0
 else
     echo ""


### PR DESCRIPTION
## Summary

Extends the URL-log-redaction CI grep-gate (`scripts/check-url-redaction.sh`) to also scan **`crates/rdlp-postprocess/src`** — defense-in-depth for #422.

The fatal post-process stages (Merge/Remux/Recode/AudioExtract/Normalize) author the `.context(...)` strings that `classify_pipeline_err` flattens via `{e:#}` into `OrchestratorError::PostProcessingFailed` → `Event::Failed` (→ DTO). A URL inlined into any such error/log macro would surface to the operator unredacted.

## Audit finding (the pipeline path is clean today)

Full trace of everything feeding the `{e:#}` chain:
- **Fatal-stage `.context()` strings** (merge/remux/recode/audio_extract/normalize) — all **static literals**, no interpolation.
- **Deeper FFmpeg layer** — contexts also static; the only `url` variable is `io_diag.rs` reading `AVFormatContext.url`, which for a file muxer is the **local output path** (not a network URL), and only in a diagnostic log, never the error chain.
- **Three `run_postprocessing` call sites** (client/mod.rs, episode.rs, state/mod.rs) — add no URL context.

**Conclusion: no raw URL can reach `Event::Failed` via the fatal pipeline path today** — the issue's MEDIUM/latent hypothesis confirmed exactly as written. This PR installs the durable regression guard so a *future* URL-fetching stage can't reopen the window silently.

## Changes

- `scripts/check-url-redaction.sh`:
  - rename global `TARGET` → `EXTRACTOR_TARGET`; add `PIPELINE_TARGET="crates/rdlp-postprocess/src"`
  - `check()` takes an optional 3rd `target` arg (default `$EXTRACTOR_TARGET` — backward-compatible with the 5 existing calls)
  - add `grep -v 'safe_url'` to the shared filter (the codebase's sanitized-name convention)
  - two pipeline checks: `pp:macro:format_url` (any `format!`/`anyhow!`/`bail!`/`error!`/`warn!`/`info!`/`debug!`/`trace!`/`panic!` inlining `{*url}`) + `pp:structured-kv:url_field`
- `.github/workflows/ci.yml`: comment-only update reflecting the broadened scope.

`rdlp-api`'s `classify_pipeline_err` needs no gate (only formats `{e:#}` + a static string — cannot introduce a URL). `rdlp-ffmpeg` is intentionally **not** gated (its only `url` token is the local file-muxer output path).

## Verification

- **Canary-verified (failing-first):** 5 raw-URL idioms caught — `.context(format!("…{url}"))`, `.with_context(|| format!("…{master_url}"))`, `bail!("…{url}")`, `error!("…{url}")`, structured-kv `manifest_url:? = url`; 4 compliant forms pass — RedactedUrl-wrapped positional, `safe_url` convention, sanitized non-url-named var.
- Gate **PASSES** on the clean tree (both targets clean).
- `bash -n` syntax ok; `cargo fmt --check` ok; all four check scripts (`check-url-redaction`, `check-dedup`, `check-no-cli`, `check-wit-drift`) pass.

## Reviews

- **Code review:** Approve — validated regex coverage (all in-use macros), `safe_url` filter convention-consistency (same line-level behavior as the pre-existing `RedactedUrl`/`sanitize_for_logging` filters), `check()` backward-compat, and the deliberate non-gating of rdlp-api/rdlp-ffmpeg. No blocking findings.
- **Security review:** not separately dispatched — the change adds a build-time defensive gate with no runtime code path, no new external input, and no new attack surface (it only *adds* protection).

## Follow-up

The audit surfaced two genuine **out-of-scope** raw-URL `Display` interpolations in `rdlp-api` (`RdlpApiError::UnsupportedUrl.url`, `OrchestratorError::NoDownloader` → `format!`) on the no-extractor/no-downloader paths — tracked in **#427**.

Closes #422
