### PR TITLE
fix(api): type-level URL redaction for rdlp-api error types (#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,15 @@ jobs:
 
       - name: Check URL log redaction
         # Fails if any raw URL is interpolated into an operator-visible string in
-        # rdlp-extractor (RdlpError message/reason fields, RdlpError ctor message-args,
-        # positional log macros, structured-kv log fields) OR in the rdlp-postprocess
-        # pipeline (fatal-stage `.context(...)` / error / log macros that reach
-        # Event::Failed via classify_pipeline_err's `{e:#}` flatten — #422).
+        # rdlp-extractor (RdlpError message/reason fields, ctor message-args, log
+        # macros, structured-kv fields), the rdlp-postprocess pipeline (fatal-stage
+        # `.context(...)` reaching Event::Failed — #422), OR rdlp-api structured-kv
+        # log fields (the .expose()-then-log surface — #427). NOTE: rdlp-api error
+        # `#[error]`/`format!` `{url}` sites are guarded by the RedactedUrlBuf TYPE
+        # + unit tests, NOT by grep (a grep can't tell redacted {url} from raw) —
+        # see CODING_RULES.md "URL Redaction — Two Controls".
         # Multiline-aware; credential URLs must be wrapped in
-        # rdlp_redact::RedactedUrl / rdlp_security::sanitize_for_logging (#328/#392/#422).
+        # rdlp_redact::RedactedUrl / rdlp_security::sanitize_for_logging (#328/#392/#422/#427).
         run: bash scripts/check-url-redaction.sh
 
       - name: Check WIT vendor drift

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -287,6 +287,37 @@ let data = fetch_url(&url)
     .context("Failed to fetch playlist")?;
 ```
 
+### URL Redaction — Two Controls
+
+URLs may carry credentials (signed CDN tokens, OAuth, AWS SigV4) in userinfo/query.
+Two complementary controls keep them out of logs and error messages
+(CWE-532 / OWASP "redact at source"). **Each catches what the other cannot.**
+
+1. **The type system is the PRIMARY guard.** A URL that can reach operator-visible
+   output (an error `Display`, `user_message()`, a `format!`, a log field) must be
+   stored as `rdlp_redact::RedactedUrlBuf` (or borrowed `RedactedUrl<'_>`), whose
+   `Display`/`Debug` redact via `redact_str`. Then `#[error("…{url}")]` and
+   `format!("…{url}")` auto-redact — the raw value can only escape via an explicit
+   `.expose()`. This is "secrets-as-types": redaction is compiler-enforced, not a
+   convention a future call site can forget. Mirror the precedents
+   `RdlpError::Extraction.url: Option<RedactedUrlBuf>` and
+   `RdlpApiError::UnsupportedUrl.url: RedactedUrlBuf` (#427). **Never** store a raw
+   `String` URL in an error field that a Display/format interpolates, and never
+   store a "pre-redacted `String`" (the type must carry the guarantee).
+
+2. **`scripts/check-url-redaction.sh` is the SECONDARY guard (defense-in-depth).**
+   It greps for raw URL interpolation idioms in `rdlp-extractor`, `rdlp-postprocess`,
+   and `rdlp-api`. **It deliberately does NOT gate error-`Display`/`format!` `{url}`
+   sites in `rdlp-api`** — a grep cannot distinguish a redacted `{url}`
+   (`RedactedUrlBuf`) from a raw one (`String`); both are the same token in source,
+   and it would false-positive on the compliant `{source_url}` precedent. That
+   surface is the type system's job (control 1). The grep's residual role is the
+   surface the type cannot cover: a raw URL passed to a structured-kv log field
+   (`url:? = some_string`) — i.e. an `.expose()`-then-log bypass.
+
+When you add a new URL-bearing error variant or log a URL: pick the field type
+(`RedactedUrlBuf`) first; the grep gate is the backstop, not the design.
+
 ## Code Reuse
 
 ### Extractor Format Building

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -5,6 +5,7 @@
 
 use crate::orchestrator::OrchestratorError;
 use rdlp_core::RdlpError;
+use rdlp_redact::RedactedUrlBuf;
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -22,10 +23,15 @@ pub enum RdlpApiError {
     },
 
     /// No extractor found for the given URL.
+    ///
+    /// `url` is stored as [`RedactedUrlBuf`] so that `#[error("…{url}")]`
+    /// Display and `user_message()` automatically strip credentials — the type
+    /// system enforces this at every construction site.
     #[error("Unsupported URL: {url}")]
     UnsupportedUrl {
-        /// The URL that no extractor was found for.
-        url: String,
+        /// The URL that no extractor was found for. Credentials are redacted
+        /// in all Display / Debug output.
+        url: RedactedUrlBuf,
     },
 
     /// Extraction failed (metadata retrieval).
@@ -176,7 +182,9 @@ impl From<RdlpError> for RdlpApiError {
                 message,
                 source_url: url.map(|u| u.to_string()).unwrap_or_default(),
             },
-            RdlpError::NoExtractor(url) => Self::UnsupportedUrl { url },
+            RdlpError::NoExtractor(url) => Self::UnsupportedUrl {
+                url: RedactedUrlBuf::from(url),
+            },
             RdlpError::InvalidUrl(msg) | RdlpError::FormatSelection(msg) => {
                 Self::InvalidInput { message: msg }
             }
@@ -218,12 +226,7 @@ impl From<RdlpError> for RdlpApiError {
 impl From<OrchestratorError> for RdlpApiError {
     fn from(err: OrchestratorError) -> Self {
         match err {
-            // Phase 1 bridge: `url` is now `RedactedUrlBuf`; `UnsupportedUrl.url` is still
-            // `String` (changed to `RedactedUrlBuf` in Phase 2). Use `.expose()` to produce
-            // the raw string temporarily — Phase 2 removes this conversion entirely.
-            OrchestratorError::NoExtractor { url } => Self::UnsupportedUrl {
-                url: url.expose().to_owned(),
-            },
+            OrchestratorError::NoExtractor { url } => Self::UnsupportedUrl { url },
             OrchestratorError::ExtractionFailed(rdlp_err)
             | OrchestratorError::DownloadFailed(rdlp_err) => Self::from(rdlp_err),
             OrchestratorError::UserCancelled => Self::UserCancelled,
@@ -451,7 +454,8 @@ mod tests {
         let err: RdlpApiError = RdlpError::NoExtractor("http://unknown.com".into()).into();
         match err {
             RdlpApiError::UnsupportedUrl { url } => {
-                assert_eq!(url, "http://unknown.com");
+                // `url` is now `RedactedUrlBuf`; use `.expose()` to check the raw value.
+                assert_eq!(url.expose(), "http://unknown.com");
             }
             other => panic!("Expected UnsupportedUrl, got: {other:?}"),
         }
@@ -544,6 +548,73 @@ mod tests {
             );
         } else {
             panic!("expected ExtractError");
+        }
+    }
+
+    // ── Phase 2 redaction tests ────────────────────────────────────────────────
+    // Failing-first: these tests reference `RedactedUrlBuf` in the `UnsupportedUrl`
+    // field, which is still `String` until the Phase 2 type change below. The first
+    // two tests (unsupported_url_*) fail with a type-mismatch compile error before
+    // the change; `from_rdlp_no_extractor_redacts` fails at runtime because the raw
+    // `String` still contains "SECRET"; `no_downloader_invalid_input_redacts` already
+    // passes (Phase 1 made NoDownloader.url `RedactedUrlBuf`).
+
+    #[test]
+    fn unsupported_url_display_redacts() {
+        use rdlp_redact::RedactedUrlBuf;
+        let err = RdlpApiError::UnsupportedUrl {
+            url: RedactedUrlBuf::from("https://x.com/v?token=SECRET"),
+        };
+        let s = err.to_string();
+        assert!(!s.contains("SECRET"), "raw token must not leak: {s}");
+        assert!(s.contains("token=***"), "redacted form expected: {s}");
+    }
+
+    #[test]
+    fn unsupported_url_user_message_redacts() {
+        use rdlp_redact::RedactedUrlBuf;
+        let err = RdlpApiError::UnsupportedUrl {
+            url: RedactedUrlBuf::from("https://x.com/v?token=SECRET"),
+        };
+        let msg = err.user_message();
+        assert!(!msg.contains("SECRET"), "raw token must not leak: {msg}");
+        assert!(msg.contains("token=***"), "redacted form expected: {msg}");
+    }
+
+    #[test]
+    fn from_rdlp_no_extractor_redacts() {
+        let api: RdlpApiError =
+            RdlpError::NoExtractor("https://x.com/v?token=SECRET".to_owned()).into();
+        match api {
+            RdlpApiError::UnsupportedUrl { url } => {
+                let s = url.to_string();
+                assert!(!s.contains("SECRET"), "raw token must not leak: {s}");
+                assert!(s.contains("token=***"), "redacted form expected: {s}");
+            }
+            other => panic!("expected UnsupportedUrl, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_downloader_invalid_input_redacts() {
+        use crate::orchestrator::OrchestratorError;
+        use rdlp_redact::RedactedUrlBuf;
+        let api: RdlpApiError = OrchestratorError::NoDownloader {
+            url: RedactedUrlBuf::from("https://cdn.example.com/seg.ts?token=SECRET"),
+        }
+        .into();
+        match api {
+            RdlpApiError::InvalidInput { message } => {
+                assert!(
+                    !message.contains("SECRET"),
+                    "raw token must not leak: {message}"
+                );
+                assert!(
+                    message.contains("token=***"),
+                    "redacted form expected: {message}"
+                );
+            }
+            other => panic!("expected InvalidInput, got: {other:?}"),
         }
     }
 

--- a/crates/rdlp-api/src/errors.rs
+++ b/crates/rdlp-api/src/errors.rs
@@ -218,7 +218,12 @@ impl From<RdlpError> for RdlpApiError {
 impl From<OrchestratorError> for RdlpApiError {
     fn from(err: OrchestratorError) -> Self {
         match err {
-            OrchestratorError::NoExtractor { url } => Self::UnsupportedUrl { url },
+            // Phase 1 bridge: `url` is now `RedactedUrlBuf`; `UnsupportedUrl.url` is still
+            // `String` (changed to `RedactedUrlBuf` in Phase 2). Use `.expose()` to produce
+            // the raw string temporarily — Phase 2 removes this conversion entirely.
+            OrchestratorError::NoExtractor { url } => Self::UnsupportedUrl {
+                url: url.expose().to_owned(),
+            },
             OrchestratorError::ExtractionFailed(rdlp_err)
             | OrchestratorError::DownloadFailed(rdlp_err) => Self::from(rdlp_err),
             OrchestratorError::UserCancelled => Self::UserCancelled,

--- a/crates/rdlp-api/src/orchestrator/download.rs
+++ b/crates/rdlp-api/src/orchestrator/download.rs
@@ -157,7 +157,7 @@ impl Orchestrator {
             .downloader_registry
             .find_downloader_with_headers(&format.url, format.http_headers.as_ref())
             .ok_or_else(|| OrchestratorError::NoDownloader {
-                url: format.url.clone(),
+                url: RedactedUrlBuf::from(format.url.clone()),
             })?;
 
         // Validate CDN token expiry
@@ -371,7 +371,7 @@ impl Orchestrator {
             .downloader_registry
             .find_downloader_with_headers(&format.url, format.http_headers.as_ref())
             .ok_or_else(|| OrchestratorError::NoDownloader {
-                url: format.url.clone(),
+                url: RedactedUrlBuf::from(format.url.clone()),
             })?;
 
         Self::check_cdn_token_expiry(&format.url)?;

--- a/crates/rdlp-api/src/orchestrator/errors.rs
+++ b/crates/rdlp-api/src/orchestrator/errors.rs
@@ -9,6 +9,7 @@
 //! - I/O errors are preserved directly via `#[from]`.
 
 use rdlp_core::RdlpError;
+use rdlp_redact::RedactedUrlBuf;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -19,7 +20,7 @@ pub enum OrchestratorError {
     #[error("No extractor found for URL: {url}")]
     NoExtractor {
         /// The URL that no extractor was found for
-        url: String,
+        url: RedactedUrlBuf,
     },
 
     /// Video extraction failed (wraps domain `RdlpError`)
@@ -42,7 +43,7 @@ pub enum OrchestratorError {
     #[error("No downloader found for URL: {url}")]
     NoDownloader {
         /// The URL that no downloader was found for
-        url: String,
+        url: RedactedUrlBuf,
     },
 
     /// Download failed (wraps domain `RdlpError`)
@@ -121,3 +122,49 @@ pub fn is_reextractable_error(err: &OrchestratorError) -> bool {
 
 /// Result type for orchestrator operations
 pub type Result<T> = std::result::Result<T, OrchestratorError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rdlp_redact::RedactedUrlBuf;
+
+    /// `NoExtractor` display must redact credentials in the URL.
+    ///
+    /// Failing-first: with `url: String`, `to_string()` would produce the raw
+    /// URL including "SECRET", causing `!contains("SECRET")` to fail.
+    #[test]
+    fn no_extractor_display_redacts() {
+        let err = OrchestratorError::NoExtractor {
+            url: RedactedUrlBuf::from("https://x.example.com/v?token=SECRET"),
+        };
+        let display = err.to_string();
+        assert!(
+            !display.contains("SECRET"),
+            "Display must not contain raw credential; got: {display}"
+        );
+        assert!(
+            display.contains("token=***"),
+            "Display must contain redacted placeholder; got: {display}"
+        );
+    }
+
+    /// `NoDownloader` display must redact credentials in the URL.
+    ///
+    /// Failing-first: with `url: String`, `to_string()` would produce the raw
+    /// URL including "SECRET", causing `!contains("SECRET")` to fail.
+    #[test]
+    fn no_downloader_display_redacts() {
+        let err = OrchestratorError::NoDownloader {
+            url: RedactedUrlBuf::from("https://cdn.example.com/v?token=SECRET"),
+        };
+        let display = err.to_string();
+        assert!(
+            !display.contains("SECRET"),
+            "Display must not contain raw credential; got: {display}"
+        );
+        assert!(
+            display.contains("token=***"),
+            "Display must contain redacted placeholder; got: {display}"
+        );
+    }
+}

--- a/crates/rdlp-api/src/orchestrator/extraction.rs
+++ b/crates/rdlp-api/src/orchestrator/extraction.rs
@@ -5,6 +5,7 @@ use super::{
     errors::{OrchestratorError, Result},
 };
 use log::{debug, info};
+use rdlp_redact::RedactedUrlBuf;
 use rdlp_types::{SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchResultPreview};
 use tracing::instrument;
 
@@ -24,7 +25,7 @@ impl Orchestrator {
 
         let extractor = self.extractor_registry.find_extractor(url).ok_or_else(|| {
             OrchestratorError::NoExtractor {
-                url: url.to_owned(),
+                url: RedactedUrlBuf::from(url),
             }
         })?;
 
@@ -92,7 +93,7 @@ impl Orchestrator {
     pub(super) async fn extract_lazy_formats(&self, url: &str) -> Result<rdlp_types::InfoDict> {
         let extractor = self.extractor_registry.find_extractor(url).ok_or_else(|| {
             OrchestratorError::NoExtractor {
-                url: url.to_owned(),
+                url: RedactedUrlBuf::from(url),
             }
         })?;
 
@@ -138,7 +139,7 @@ impl Orchestrator {
 
         let extractor = self.extractor_registry.find_extractor(url).ok_or_else(|| {
             OrchestratorError::NoExtractor {
-                url: url.to_owned(),
+                url: RedactedUrlBuf::from(url),
             }
         })?;
 

--- a/scripts/check-url-redaction.sh
+++ b/scripts/check-url-redaction.sh
@@ -31,6 +31,7 @@ set -euo pipefail
 
 EXTRACTOR_TARGET="crates/rdlp-extractor/src"
 PIPELINE_TARGET="crates/rdlp-postprocess/src"
+API_TARGET="crates/rdlp-api/src"
 FAIL=0
 
 # Helper: run rg -U (multiline), filter out already-compliant lines and test files,
@@ -105,8 +106,39 @@ check "pp:structured-kv:url_field" \
     '[a-z_]*url[a-z_]*:[?%]\s*=' \
     "$PIPELINE_TARGET"
 
+# ---------------------------------------------------------------------------
+# API layer (rdlp-api) — #427 defense-in-depth (DELIBERATELY NARROW).
+#
+# Two controls protect rdlp-api's URL surface; each catches what the other
+# cannot (see CODING_RULES.md "URL redaction — two controls"):
+#
+#   1. THE TYPE SYSTEM is the PRIMARY guard for error-enum URL fields. The
+#      `url` field of `RdlpApiError::UnsupportedUrl` / `OrchestratorError::
+#      {NoExtractor,NoDownloader}` is `rdlp_redact::RedactedUrlBuf`, whose
+#      `Display` redacts — so `#[error("…{url}")]` and `format!("…{url}")`
+#      auto-redact (#427). This grep CANNOT verify that surface: a redacted
+#      `{url}` (RedactedUrlBuf) and a raw `{url}` (String) are the SAME token
+#      in source. The compliant precedent `#[error("…{source_url}…")]`
+#      (errors.rs) would false-positive under an error-attr/format pattern.
+#      Industry standard: redact at source via a secret type (CWE-532;
+#      secrets-as-types). So we do NOT add a `{*url}` error-attr/format check
+#      here — the type + the unit tests guard it.
+#
+#   2. THIS GREP is the SECONDARY guard, for the one surface the type cannot
+#      cover: a raw URL passed to a STRUCTURED-KV log field (`url:? = <var>`).
+#      A `.expose()`-then-log bypass lands here. Only the `:?`/`:%` form is
+#      gated; the positional no-sigil `url = <var>` form is added by #428
+#      (after orchestrator/thumbnail.rs is wrapped — it is the one remaining
+#      raw `url = thumbnail_url` site today).
+# ---------------------------------------------------------------------------
+
+# A1. Structured-kv `:?`/`:%` url fields in rdlp-api (the .expose()-then-log surface).
+check "api:structured-kv:url_field" \
+    '[a-z_]*url[a-z_]*:[?%]\s*=' \
+    "$API_TARGET"
+
 if [[ $FAIL -eq 0 ]]; then
-    echo "PASS — no raw URL interpolations found in $EXTRACTOR_TARGET or $PIPELINE_TARGET"
+    echo "PASS — no raw URL interpolations found in $EXTRACTOR_TARGET, $PIPELINE_TARGET, or $API_TARGET"
     exit 0
 else
     echo ""


### PR DESCRIPTION
## Summary

Closes a credential-leak (CWE-532) class in rdlp-api error types: three raw `url: String` fields were interpolated into operator-visible `Display` / `user_message()` / `format!` output. URLs can carry credentials (signed CDN tokens, OAuth, AWS SigV4) in userinfo/query.

Fix is **type-level** (industry standard — secrets-as-types, redact-at-source): change the fields to `rdlp_redact::RedactedUrlBuf`, whose `Display`/`Debug` redact via `redact_str`. Then `#[error("…{url}")]` and `format!("…{url}")` auto-redact — compiler-enforced, mirroring the in-tree precedent `RdlpError::Extraction.url: Option<RedactedUrlBuf>`. Research (cited in the plan) confirmed this over the brittle "pre-redacted String" alternative.

Follow-up to #422 / PR #426.

## Changes

- **`OrchestratorError::NoExtractor.url` + `NoDownloader.url`** → `RedactedUrlBuf`; 5 construction sites wrapped (extraction.rs ×3, download.rs ×2).
- **`RdlpApiError::UnsupportedUrl.url`** → `RedactedUrlBuf`; `From<RdlpError>::NoExtractor(String)` arm wraps the raw rdlp-core String; the Tauri desktop error layer formats it via `Display` only, so it auto-redacts unchanged.
- **CI gate** (`check-url-redaction.sh`): a narrow `api:structured-kv:url_field` check over `crates/rdlp-api/src` — the `.expose()`-then-log surface the type can't cover. It **deliberately does not** gate rdlp-api error-`#[error]`/`format!` `{url}` sites: a grep can't distinguish a redacted `{url}` from a raw one, and would false-positive on the compliant `{source_url}` precedent. That surface is guarded by the type + unit tests.
- **`CODING_RULES.md`**: new "URL Redaction — Two Controls" section (type = primary guard, grep = secondary; what each can/cannot catch; CWE-532 / secrets-as-types).

## Design decisions (research-backed)

The decision to use type-level redaction (vs construction-time string redaction) and to NOT extend the grep gate to the error-attr surface was settled by industry research: `secrecy`/`redact`/`redactable` design rationale (secrets-as-types), OWASP Logging Cheat Sheet + CWE-532 (redact at source), and the structural fact that a textual gate cannot distinguish a redacting type from a raw one. Plan + citations: `docs/planning/427-rdlp-api-url-redaction-plan.md` (local).

## Verification

- Full `rust-gate` (fmt → check → clippy `-D warnings` → test) green; **473 tests pass**. `cargo check -p rdlp-desktop` green. All 4 gate scripts pass.
- **Failing-first tests** (both error modules): Display + `user_message()` + conversion-path redaction for all three variants; existing `extraction_error_source_url_is_redacted` precedent preserved.
- **Canary-verified** gate: a raw `master_url:? = raw_url` in a non-test rdlp-api file FAILS the new check; clean tree PASSES (3 targets).

## Reviews

- **Security review:** Approve / PASS. No residual leak path for the 3 fixed variants; the only production `.expose()` is gone (Phase 1 bridge removed in Phase 2); `redact_str` covers userinfo + SigV4 + token/sig query params; no Serde/DTO bypass. Flagged one **pre-existing MEDIUM** (not introduced here): `ExtractError.source_url: String` is the pre-redacted-String pattern (currently safe, not type-enforced) — tracked as a follow-up.
- **Code review:** Approve. Cross-commit seam clean (bridge removed), coherent, gate/doc accurate, #428 covers the deferred thumbnail surface.

## Follow-ups

- #428 — thumbnail.rs raw-URL log sites (positional `url = <var>`) + positional-form gate.
- #430 — migrate `RdlpApiError::ExtractError.source_url: String` → `RedactedUrlBuf` (security-review MEDIUM; the last raw-String URL field in operator-visible error output).

Closes #427
