### PR TITLE
chore(ffmpeg): compile-time + debug invariant guards for recode threads (#397)

### DIFF
--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -216,6 +216,9 @@ pub struct Args {
     #[arg(long, value_name = "MODE", default_value = "copy")]
     pub recode_audio: String,
 
+    // Help text hardcodes the bounds: keep `1-64` in sync with
+    // `rdlp_types::config::MAX_RECODE_THREADS` and `8` in sync with
+    // `rdlp_ffmpeg`'s `AUTO_RECODE_THREADS_CAP`.
     /// Encoder threads for video recode (1-64). Omit for auto (min(cores, 8)).
     #[arg(long, value_name = "N")]
     pub recode_threads: Option<u32>,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/encoder_options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/encoder_options.rs
@@ -27,6 +27,15 @@ pub fn build_video_encoder_options(
     opts: &VideoConvertOptions,
     encoder_name: &str,
 ) -> Vec<(&'static str, String)> {
+    // Precondition: only reached on the transcode path. `convert_video` routes
+    // `remux_only` to the stream-copy branch before any encoder is opened, so an
+    // encoder-option list is never built for a remux. The debug-only tripwire
+    // documents and enforces that in tests/dev.
+    debug_assert!(
+        !opts.remux_only,
+        "build_video_encoder_options reached on a remux_only path; the encode path is gated upstream"
+    );
+
     let mut kv: Vec<(&'static str, String)> = Vec::new();
 
     if let Some(ref preset) = opts.preset {
@@ -73,6 +82,20 @@ mod tests {
             threads,
             ..Default::default()
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "remux_only path")]
+    fn remux_only_trips_debug_assert() {
+        // Contract violation: the encode path is gated upstream, so a
+        // `remux_only` options struct must never reach the encoder-option
+        // builder. The debug-only tripwire fires in tests/dev.
+        let opts = VideoConvertOptions {
+            remux_only: true,
+            threads: Some(4),
+            ..Default::default()
+        };
+        let _ = build_video_encoder_options(&opts, "libx265");
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/thread_resolve.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/thread_resolve.rs
@@ -15,6 +15,20 @@ pub const AUTO_RECODE_THREADS_CAP: u32 = 8;
 /// extra threads. See `encoder_options::build_video_encoder_options`.
 pub const WIDE_PARALLELISM_THRESHOLD: u32 = 8;
 
+/// Compile-time coupling: the auto-default cap and the wide-parallelism
+/// threshold MUST stay equal. If they diverged, the auto path (`None`) could
+/// resolve to a count that silently trips the wide-parallelism encoder params
+/// (tiles/wavefront/row-mt) without the operator ever asking for them.
+///
+/// Uses `assert!(a == b)`, not `assert_eq!` — `assert_eq!` is not
+/// const-fn-compatible (it `Debug`-formats operands via a non-const panic
+/// path; rust-lang/rust#119826). Build fails here if the two ever diverge, so
+/// the invariant is enforced by construction, not by convention.
+const _: () = assert!(
+    AUTO_RECODE_THREADS_CAP == WIDE_PARALLELISM_THRESHOLD,
+    "AUTO_RECODE_THREADS_CAP must equal WIDE_PARALLELISM_THRESHOLD"
+);
+
 /// Fallback when `available_parallelism()` errors (e.g. sandboxed/seccomp).
 const PARALLELISM_FALLBACK: u32 = 4;
 
@@ -32,7 +46,18 @@ pub fn resolve_recode_threads(configured: Option<u32>) -> u32 {
             });
             cores.clamp(1, AUTO_RECODE_THREADS_CAP)
         },
-        |n| n.max(1),
+        |n| {
+            // Contract: `Config::validate` rejects an explicit 0 upstream, so a
+            // `Some(0)` never reaches here in production. The debug-only tripwire
+            // makes a contract violation loud in tests/dev; `.max(1)` stays as
+            // the production-safe fallback so release builds never emit `0`
+            // (libvvenc at 0 threads runs main-thread-only).
+            debug_assert!(
+                n != 0,
+                "resolve_recode_threads got Some(0); Config::validate must reject 0 upstream"
+            );
+            n.max(1)
+        },
     )
 }
 
@@ -48,13 +73,24 @@ mod tests {
     }
 
     #[test]
-    fn explicit_zero_is_floored_to_one() {
-        assert_eq!(resolve_recode_threads(Some(0)), 1);
+    #[should_panic(expected = "Config::validate must reject 0 upstream")]
+    fn explicit_zero_trips_debug_assert() {
+        // Contract violation: a `Some(0)` should never arrive (rejected by
+        // `Config::validate`). In debug/test builds the tripwire fires; in
+        // release builds `.max(1)` floors it to 1 as a production-safe fallback.
+        let _ = resolve_recode_threads(Some(0));
     }
 
     #[test]
     fn auto_is_within_one_to_cap() {
         let n = resolve_recode_threads(None);
         assert!((1..=AUTO_RECODE_THREADS_CAP).contains(&n), "got {n}");
+    }
+
+    #[test]
+    fn auto_cap_couples_to_wide_parallelism_threshold() {
+        // Runtime companion to the module-scope `const _` compile-time assert:
+        // documents the coupling as a named, discoverable test.
+        assert_eq!(AUTO_RECODE_THREADS_CAP, WIDE_PARALLELISM_THRESHOLD);
     }
 }


### PR DESCRIPTION
Retires the **Rust-polish items** from #397's deferred checklist. Compile-time + debug-only guards — no production runtime behavior change in release builds.

## Changes
- **Compile-time coupling** (`thread_resolve.rs`): `const _: () = assert!(AUTO_RECODE_THREADS_CAP == WIDE_PARALLELISM_THRESHOLD, ...)`. Build fails if the two ever diverge, so the auto path can never silently trip wide-parallelism encoder params. Uses `assert!(a == b)` not `assert_eq!` — the latter isn't const-fn-compatible (it `Debug`-formats operands via a non-const panic path, [rust-lang/rust#119826](https://github.com/rust-lang/rust/issues/119826)). No `static_assertions` dep (unmaintained since 2019; std const-eval supersedes it).
- **`debug_assert!(n != 0)`** in `resolve_recode_threads` — documents/enforces that `Config::validate` rejects an explicit `0` upstream; `.max(1)` stays as the release-mode production-safe fallback.
- **`debug_assert!(!opts.remux_only)`** in `build_video_encoder_options` — the encode path is gated upstream by `convert_video`'s `remux_only` branch.
- **CLI keep-in-sync comment** on `--recode-threads` tying the `1-64` / `8` help text to `MAX_RECODE_THREADS` / `AUTO_RECODE_THREADS_CAP`.

## Tests
- `explicit_zero_is_floored_to_one` → `#[should_panic]` tripwire `explicit_zero_trips_debug_assert` (the negative test — fails against unpatched code, which returned `1` with no panic).
- New `remux_only_trips_debug_assert` `#[should_panic]` tripwire.
- New runtime companion `auto_cap_couples_to_wide_parallelism_threshold`.
- **Verified the compile-time guard bites**: temporarily diverging the constants yields `error[E0080] ... AUTO_RECODE_THREADS_CAP must equal WIDE_PARALLELISM_THRESHOLD`, blocking the build.

## Verification
`cargo fmt --check`, `cargo check --workspace`, `cargo clippy --all-targets -D warnings`, transcode tests (47 pass), and all CI check scripts (dedup / url-redaction / no-cli / wit-drift / log-redaction) green.

## Reviews
- **security-reviewer**: PASS, no findings — `debug_assert!` conditions pure, neither `recode_threads=0` nor `remux_only` attacker-reachable in prod, all assert messages static.
- **code-reviewer**: Approve, clean — no findings above threshold; preconditions independently verified.

## Scope
Trims but does **not** close #397 — the frontend inline-form-error item (map `AppError::InvalidInput` → inline field error in `DownloadConfig.tsx`) remains. Tracked as a follow-up.

Refs #397