### PR TITLE
refactor(extractor): extract shared append_search_filters helper (close #309)

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -47,10 +47,6 @@ fingerprint = "c724f5103213d974"
 reason = "Same domain-separation rationale (resolve_audio_encoder vs resolve_encoder for video)"
 
 [[ignore]]
-fingerprint = "e12f9e5e11985162"
-reason = "Rule of Three pending: build_api_search_url is duplicated in PornHub+RedTube; extract when a 3rd extractor needs the same pattern (tracking issue)"
-
-[[ignore]]
 fingerprint = "f07ba850fd9c6f4d"
 reason = "Acceptable test redundancy; two distinct retry scenarios (exhausted vs non-retryable) share assertion shape"
 

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -38,6 +38,7 @@ pub mod json_ld;
 mod metadata;
 mod parsing;
 pub(crate) mod protocol;
+mod search;
 pub mod selector_macro;
 mod selectors;
 mod string_utils;
@@ -52,6 +53,7 @@ use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
+pub(crate) use search::append_search_filters;
 pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -1,0 +1,132 @@
+//! Shared search-URL construction helpers for API-based search extractors.
+//!
+//! The *base* search URL (host, fixed query params, `search=` position) is
+//! per-site knowledge and stays in each extractor. What is genuinely shared —
+//! the same knowledge, changing together across sites — is how the standard
+//! filter set is appended to an API search URL. Sites whose API accepts the
+//! `ordering` / `period` / `category` / `tags[]` filter vocabulary (PornHub,
+//! RedTube) delegate that appending here.
+
+use rdlp_types::SearchFilter;
+use url::form_urlencoded;
+
+/// Append the standard API search filters to an in-progress search URL.
+///
+/// Recognizes four filter keys; unknown keys are silently ignored (value
+/// validation happens at the CLI/descriptor boundary, not here):
+/// - `ordering`, `period` — appended verbatim as `&{key}={value}`.
+/// - `category` — appended as `&category={encoded}` (form-urlencoded).
+/// - `tags` — comma-separated; each non-empty, trimmed tag is appended as a
+///   separate `&tags[]={encoded}` pair.
+///
+/// The URL must already contain a `?` and its base query params; this only
+/// appends `&`-prefixed pairs.
+pub(crate) fn append_search_filters(url: &mut String, filters: &[SearchFilter]) {
+    for filter in filters {
+        match filter.key.as_str() {
+            "ordering" => {
+                url.push_str("&ordering=");
+                url.push_str(&filter.value);
+            }
+            "period" => {
+                url.push_str("&period=");
+                url.push_str(&filter.value);
+            }
+            "category" => {
+                let encoded: String =
+                    form_urlencoded::byte_serialize(filter.value.as_bytes()).collect();
+                url.push_str("&category=");
+                url.push_str(&encoded);
+            }
+            "tags" => {
+                for tag in filter.value.split(',') {
+                    let trimmed = tag.trim();
+                    if !trimmed.is_empty() {
+                        let encoded: String =
+                            form_urlencoded::byte_serialize(trimmed.as_bytes()).collect();
+                        url.push_str("&tags[]=");
+                        url.push_str(&encoded);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filter(key: &str, value: &str) -> SearchFilter {
+        SearchFilter {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    fn append(filters: &[SearchFilter]) -> String {
+        let mut url = String::from("https://x.test/?output=json");
+        append_search_filters(&mut url, filters);
+        url
+    }
+
+    #[test]
+    fn no_filters_is_noop() {
+        assert_eq!(append(&[]), "https://x.test/?output=json");
+    }
+
+    #[test]
+    fn ordering_and_period_appended_verbatim() {
+        let out = append(&[filter("ordering", "newest"), filter("period", "weekly")]);
+        assert!(out.ends_with("&ordering=newest&period=weekly"), "got {out}");
+    }
+
+    #[test]
+    fn category_is_url_encoded() {
+        let out = append(&[filter("category", "big ass")]);
+        assert!(out.contains("&category=big+ass"), "got {out}");
+    }
+
+    #[test]
+    fn empty_category_value_appends_empty() {
+        let out = append(&[filter("category", "")]);
+        assert!(out.ends_with("&category="), "got {out}");
+    }
+
+    #[test]
+    fn ordering_and_period_are_not_encoded() {
+        // Asymmetry lock: ordering/period append VERBATIM (values are
+        // enum-constrained upstream), unlike category/tags which are
+        // form-urlencoded. A future "helpful" encode of these would be a
+        // behavior change — this pins it.
+        let out = append(&[filter("ordering", "a b&c"), filter("period", "x y")]);
+        assert!(out.contains("&ordering=a b&c"), "got {out}");
+        assert!(out.contains("&period=x y"), "got {out}");
+    }
+
+    #[test]
+    fn tags_split_trim_encode_each() {
+        let out = append(&[filter("tags", " red head , milf ")]);
+        assert!(out.contains("&tags[]=red+head"), "got {out}");
+        assert!(out.contains("&tags[]=milf"), "got {out}");
+    }
+
+    #[test]
+    fn empty_tag_entries_are_skipped() {
+        // Leading/trailing/double commas must not emit empty tags[] pairs.
+        let out = append(&[filter("tags", ",a,,b,")]);
+        assert_eq!(out.matches("&tags[]=").count(), 2, "got {out}");
+        assert!(
+            out.contains("&tags[]=a") && out.contains("&tags[]=b"),
+            "got {out}"
+        );
+    }
+
+    #[test]
+    fn unknown_filter_key_is_ignored() {
+        let out = append(&[filter("bogus", "value"), filter("ordering", "top")]);
+        assert!(!out.contains("bogus"), "got {out}");
+        assert!(out.ends_with("&ordering=top"), "got {out}");
+    }
+}

--- a/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
@@ -20,38 +20,7 @@ const HTML_SEARCH_BASE: &str = "https://www.pornhub.com/video/search";
 pub(crate) fn build_api_search_url(query: &str, filters: &[SearchFilter]) -> String {
     let encoded_query: String = form_urlencoded::byte_serialize(query.as_bytes()).collect();
     let mut url = format!("{API_BASE}?search={encoded_query}&output=json&thumbsize=large");
-
-    for filter in filters {
-        match filter.key.as_str() {
-            "ordering" => {
-                url.push_str("&ordering=");
-                url.push_str(&filter.value);
-            }
-            "period" => {
-                url.push_str("&period=");
-                url.push_str(&filter.value);
-            }
-            "category" => {
-                let encoded: String =
-                    form_urlencoded::byte_serialize(filter.value.as_bytes()).collect();
-                url.push_str("&category=");
-                url.push_str(&encoded);
-            }
-            "tags" => {
-                for tag in filter.value.split(',') {
-                    let trimmed = tag.trim();
-                    if !trimmed.is_empty() {
-                        let encoded: String =
-                            form_urlencoded::byte_serialize(trimmed.as_bytes()).collect();
-                        url.push_str("&tags[]=");
-                        url.push_str(&encoded);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
+    crate::base::common::append_search_filters(&mut url, filters);
     url
 }
 

--- a/crates/rdlp-extractor/src/extractors/redtube/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/patterns.rs
@@ -53,39 +53,7 @@ pub(crate) fn build_api_search_url(query: &str, filters: &[SearchFilter]) -> Str
         "https://api.redtube.com/?data=redtube.Videos.searchVideos\
          &output=json&search={encoded_query}&thumbsize=big"
     );
-
-    for filter in filters {
-        match filter.key.as_str() {
-            "ordering" => {
-                url.push_str("&ordering=");
-                url.push_str(&filter.value);
-            }
-            "period" => {
-                url.push_str("&period=");
-                url.push_str(&filter.value);
-            }
-            "category" => {
-                let encoded: String =
-                    form_urlencoded::byte_serialize(filter.value.as_bytes()).collect();
-                url.push_str("&category=");
-                url.push_str(&encoded);
-            }
-            "tags" => {
-                // Tags are comma-separated, each sent as tags[]
-                for tag in filter.value.split(',') {
-                    let trimmed = tag.trim();
-                    if !trimmed.is_empty() {
-                        let encoded: String =
-                            form_urlencoded::byte_serialize(trimmed.as_bytes()).collect();
-                        url.push_str("&tags[]=");
-                        url.push_str(&encoded);
-                    }
-                }
-            }
-            _ => {} // Unknown filters are silently ignored (validation is done elsewhere)
-        }
-    }
-
+    crate::base::common::append_search_filters(&mut url, filters);
     url
 }
 


### PR DESCRIPTION
Closes #309.

## What
The API search-filter loop (`ordering`/`period`/`category`/`tags[]`) was **byte-identical** in PornHub's and RedTube's `build_api_search_url`. That loop is a single piece of knowledge — a filter-encoding rule change must touch both — so it moves to a shared helper. Each site keeps its own divergent base URL (per-site knowledge, correctly not shared).

- **New** `base/common/search.rs::append_search_filters(&mut String, &[SearchFilter])`, re-exported `pub(crate)` (mirrors the `protocol_for_url` precedent).
- Rewire `pornhub/search_patterns.rs` + `redtube/patterns.rs` to call it.
- Remove the now-resolved grandfather entry `e12f9e5e` from `.dupes-ignore.toml`.

## Gate-1 / Gate-2 reasoning (why this and not more)
- **Extracted** the filter loop: genuine same-knowledge duplication (byte-identical; changes together).
- **Left per-site**: each base URL (host, fixed params, `search=` position) — different knowledge.
- **Deliberately NOT extracted** the trivial one-line `build_api_search_url_page` (`format!("{base}&page={n}")`) — a one-liner whose name restates its body is a **Lazy Element** (Fowler); shrinking the filter loop already resolves the cargo-dupes fingerprint.
- tnaflix/moviefap `ordering =>` arms are *validation* (return `Err`) — different knowledge, correctly out of scope.

Extracts at **2 instances** (early by Rule of Three) at maintainer request — justified because the shared part is an exact, stable operation with low wrong-abstraction risk.

## Tests
New helper has positive + negative coverage: no-op, verbatim ordering/period, **ordering/period-not-encoded asymmetry lock**, category encoding, empty category, tag split/trim/**empty-tag skip**, unknown-key ignore (8 tests). Existing 13 `build_api_search_url` tests unchanged and green → **behavior-preserving**.

## Verification
Full rust-pro gate green: `fmt --check`, `check`, `clippy --all-targets -D warnings`, tests, **and `check-dedup.sh` passes with the grandfather entry removed** — the duplication is genuinely gone, not re-suppressed.

## Reviews
- **security-reviewer**: PASS — helper byte-identical to both originals; no SSRF/injection change; verbatim `ordering`/`period` is pre-existing operator-supplied input.
- **code-reviewer**: Approve — idiomatic placement, no drift, grandfather removal correct. Suggested the ordering/period-no-encoding test, now added.

Refs the code-quality-sprint grandfather list.