### PR TITLE
refactor(extractor): PaginatedSearch trait — dedup search_all_pages across 4 sites

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -11,10 +11,6 @@ fingerprint = "e79a123cf3c33161"
 reason = "Initiative #5: InfoExtractorExt — fetch_api/html_search_page shared across PornHub+RedTube (tracking issue)"
 
 [[ignore]]
-fingerprint = "0b7f365890f934cb"
-reason = "Initiative #5: InfoExtractorExt — XHamster+TNAFlix search_all_pages share pagination scaffold (tracking issue)"
-
-[[ignore]]
 fingerprint = "36dd26d02f5ee08b"
 reason = "Intentional single-call vs paginated twin (Orchestrator::search vs search_page; matches RdlpClient pair)"
 

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -53,7 +53,7 @@ use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
-pub(crate) use search::append_search_filters;
+pub(crate) use search::{PaginatedSearch, append_search_filters};
 pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -7,8 +7,18 @@
 //! `ordering` / `period` / `category` / `tags[]` filter vocabulary (PornHub,
 //! RedTube) delegate that appending here.
 
-use rdlp_types::SearchFilter;
+use async_trait::async_trait;
+use log::debug;
+use rdlp_core::{ExtractionContext, Result};
+use rdlp_types::{SearchFilter, SearchQuery, SearchResultPreview};
+use std::time::Duration;
 use url::form_urlencoded;
+
+use super::MAX_PLAYLIST_SIZE;
+
+/// Delay between successive search-page fetches. All API-paginated sites that
+/// share the [`PaginatedSearch`] scaffold rate-limit at this interval.
+pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// Append the standard API search filters to an in-progress search URL.
 ///
@@ -51,6 +61,89 @@ pub(crate) fn append_search_filters(url: &mut String, filters: &[SearchFilter]) 
             }
             _ => {}
         }
+    }
+}
+
+/// Shared multi-page search pagination for API-style search extractors.
+///
+/// Sites whose search fetches page N and learns the total page count from the
+/// same response (XHamster, TNAFlix, EMPFlix, MovieFap) share one pagination
+/// loop: fetch pages in order, accumulate previews, and stop at the first of —
+/// `max_results` reached, `max_pages` reached, an empty page, or a fetch error
+/// (returning the partial results gathered so far). Implementors supply only
+/// the per-site pieces (a single-page fetch, a log tag, filter validation);
+/// [`search_all_pages`](Self::search_all_pages) is the shared default and
+/// should not be overridden.
+///
+/// Sites with a different pagination shape (e.g. PornHub/RedTube, which chain
+/// an HTML-vs-API fallback per page) intentionally do NOT implement this trait.
+#[async_trait]
+pub(crate) trait PaginatedSearch: Send + Sync {
+    /// Bracketed site tag used in log lines, e.g. `"[XHamster]"`.
+    fn search_log_tag(&self) -> &'static str;
+
+    /// Validate the query's filters against this site's supported filter set.
+    fn validate_search_filters(&self, filters: &[SearchFilter]) -> Result<()>;
+
+    /// Fetch a single search page, returning `(results, max_pages)`.
+    async fn fetch_search_page(
+        &self,
+        query: &SearchQuery,
+        page: usize,
+        ctx: &ExtractionContext,
+    ) -> Result<(Vec<SearchResultPreview>, usize)>;
+
+    /// Delay between successive page fetches. Defaults to [`PAGE_RATE_LIMIT_MS`].
+    fn page_rate_limit(&self) -> Duration {
+        Duration::from_millis(PAGE_RATE_LIMIT_MS)
+    }
+
+    /// Collect results across pages until `max_results` / `max_pages` / an empty
+    /// page / a fetch error. Shared scaffold — do not override.
+    async fn search_all_pages(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        self.validate_search_filters(&query.filters)?;
+
+        let tag = self.search_log_tag();
+        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
+        let mut all_results = Vec::new();
+        let mut page = 1usize;
+
+        loop {
+            let (page_results, max_pages) = match self.fetch_search_page(query, page, ctx).await {
+                Ok(result) => result,
+                Err(e) => {
+                    debug!(page; "{tag} Failed to fetch search page, returning partial results: {e}");
+                    break;
+                }
+            };
+
+            if page_results.is_empty() {
+                debug!(page; "{tag} No results on page, stopping pagination");
+                break;
+            }
+
+            all_results.extend(page_results);
+
+            if all_results.len() >= max_results {
+                all_results.truncate(max_results);
+                break;
+            }
+
+            if page >= max_pages {
+                break;
+            }
+
+            page += 1;
+            tokio::time::sleep(self.page_rate_limit()).await;
+        }
+
+        debug!(count = all_results.len(), pages = page; "{tag} Search complete");
+
+        Ok(all_results)
     }
 }
 
@@ -128,5 +221,178 @@ mod tests {
         let out = append(&[filter("bogus", "value"), filter("ordering", "top")]);
         assert!(!out.contains("bogus"), "got {out}");
         assert!(out.ends_with("&ordering=top"), "got {out}");
+    }
+
+    // ---- PaginatedSearch scaffold ----
+
+    use crate::hls::test_support::test_ctx;
+    use rdlp_core::RdlpError;
+    use rdlp_types::SearchQuery;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn preview(i: usize) -> SearchResultPreview {
+        SearchResultPreview {
+            video_url: format!("https://x.test/v{i}"),
+            title: format!("v{i}"),
+            thumbnail_url: None,
+            duration: None,
+            uploader: None,
+            uploader_url: None,
+            actors: Vec::new(),
+            view_count: None,
+            upload_date: None,
+        }
+    }
+
+    fn previews(n: usize) -> Vec<SearchResultPreview> {
+        (0..n).map(preview).collect()
+    }
+
+    enum Page {
+        Ok(Vec<SearchResultPreview>, usize),
+        Fail,
+    }
+
+    struct MockSearch {
+        script: Vec<Page>,
+        validation_fails: bool,
+        fetches: AtomicUsize,
+    }
+
+    impl MockSearch {
+        fn new(script: Vec<Page>) -> Self {
+            Self {
+                script,
+                validation_fails: false,
+                fetches: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PaginatedSearch for MockSearch {
+        fn search_log_tag(&self) -> &'static str {
+            "[Mock]"
+        }
+        fn validate_search_filters(&self, _filters: &[SearchFilter]) -> Result<()> {
+            if self.validation_fails {
+                Err(RdlpError::extraction(
+                    "mock validation failure",
+                    "https://x.test",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        // No real sleeps in tests.
+        fn page_rate_limit(&self) -> Duration {
+            Duration::ZERO
+        }
+        async fn fetch_search_page(
+            &self,
+            _query: &SearchQuery,
+            page: usize,
+            _ctx: &ExtractionContext,
+        ) -> Result<(Vec<SearchResultPreview>, usize)> {
+            self.fetches.fetch_add(1, Ordering::SeqCst);
+            match self.script.get(page - 1) {
+                Some(Page::Ok(results, max_pages)) => Ok((results.clone(), *max_pages)),
+                Some(Page::Fail) => Err(RdlpError::extraction(
+                    "mock fetch failure",
+                    "https://x.test",
+                )),
+                None => Ok((Vec::new(), page)), // past the script → empty page
+            }
+        }
+    }
+
+    fn query(max_results: Option<usize>) -> SearchQuery {
+        SearchQuery {
+            query: "q".to_string(),
+            filters: Vec::new(),
+            max_results,
+            page: None,
+        }
+    }
+
+    async fn run(script: Vec<Page>, max_results: Option<usize>) -> Vec<SearchResultPreview> {
+        MockSearch::new(script)
+            .search_all_pages(&query(max_results), &test_ctx())
+            .await
+            .expect("scaffold returns partial results, never errors")
+    }
+
+    #[tokio::test]
+    async fn accumulates_across_pages_then_truncates_to_max_results() {
+        // page1: 3, page2: 3, cap 4 → extend to 6, truncate to 4.
+        let out = run(
+            vec![Page::Ok(previews(3), 10), Page::Ok(previews(3), 10)],
+            Some(4),
+        )
+        .await;
+        assert_eq!(out.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn stops_at_max_pages_without_fetching_beyond() {
+        // page1 reports max_pages=1; page2 (if fetched) would add 5 — must not.
+        let out = run(
+            vec![Page::Ok(previews(2), 1), Page::Ok(previews(5), 1)],
+            None,
+        )
+        .await;
+        assert_eq!(out.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn stops_on_empty_page() {
+        let out = run(
+            vec![Page::Ok(previews(2), 10), Page::Ok(Vec::new(), 10)],
+            None,
+        )
+        .await;
+        assert_eq!(out.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_error_returns_partial_results() {
+        let out = run(vec![Page::Ok(previews(2), 10), Page::Fail], None).await;
+        assert_eq!(out.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn truncates_within_a_single_page() {
+        let out = run(vec![Page::Ok(previews(5), 10)], Some(3)).await;
+        assert_eq!(out.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn accumulates_all_pages_when_uncapped() {
+        // 2 pages, no result cap; max_pages=2 stops the loop naturally → all 5,
+        // no truncation (the one path the other multi-page tests don't cover).
+        let out = run(
+            vec![Page::Ok(previews(3), 2), Page::Ok(previews(2), 2)],
+            None,
+        )
+        .await;
+        assert_eq!(out.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn validation_error_returns_err_without_fetching() {
+        // The only scaffold path that returns Err (not partial results): a
+        // failed filter validation must short-circuit BEFORE any page fetch.
+        let mock = MockSearch {
+            script: vec![Page::Ok(previews(3), 10)],
+            validation_fails: true,
+            fetches: AtomicUsize::new(0),
+        };
+        let result = mock.search_all_pages(&query(None), &test_ctx()).await;
+        assert!(result.is_err(), "validation failure must propagate as Err");
+        assert_eq!(
+            mock.fetches.load(Ordering::SeqCst),
+            0,
+            "must not fetch any page when validation fails"
+        );
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -3,12 +3,9 @@
 use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result};
-use std::time::Duration;
 
 use super::{search_patterns, tnaflix_search_helpers};
-
-/// Rate limit delay between search page fetches (500 ms)
-const PAGE_RATE_LIMIT_MS: u64 = 500;
+use crate::base::common::PaginatedSearch;
 
 /// EMPFlix search extractor
 ///
@@ -39,6 +36,17 @@ impl EMPFlixSearchExtractor {
             search_patterns::build_search_url_page_for(Self::BASE_URL, query, page)
         }
     }
+}
+
+#[async_trait]
+impl PaginatedSearch for EMPFlixSearchExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[EMPFlix]"
+    }
+
+    fn validate_search_filters(&self, filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        tnaflix_search_helpers::validate_search_filters(filters)
+    }
 
     /// Fetch a single search results page and return `(results, max_page_number)`.
     async fn fetch_search_page(
@@ -62,55 +70,6 @@ impl EMPFlixSearchExtractor {
         );
 
         Ok((page_results, max_pages))
-    }
-
-    /// Collect all pages up to `MAX_PLAYLIST_SIZE` results.
-    async fn search_all_pages(
-        &self,
-        query: &rdlp_types::SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        tnaflix_search_helpers::validate_search_filters(&query.filters)?;
-
-        let max_results = query
-            .max_results
-            .unwrap_or(crate::base::common::MAX_PLAYLIST_SIZE);
-
-        let mut all_results = Vec::new();
-        let mut page = 1usize;
-
-        loop {
-            let (page_results, max_pages) = match self.fetch_search_page(query, page, ctx).await {
-                Ok(r) => r,
-                Err(e) => {
-                    debug!(page; "[EMPFlix] Failed to fetch search page, returning partial results: {e}");
-                    break;
-                }
-            };
-
-            if page_results.is_empty() {
-                debug!(page; "[EMPFlix] No results on page, stopping pagination");
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if page >= max_pages {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(count = all_results.len(), pages = page; "[EMPFlix] Search complete");
-
-        Ok(all_results)
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -6,12 +6,9 @@
 use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result};
-use std::time::Duration;
 
 use super::{moviefap_search_helpers, moviefap_search_patterns};
-
-/// Rate limit delay between search page fetches (500 ms)
-const PAGE_RATE_LIMIT_MS: u64 = 500;
+use crate::base::common::PaginatedSearch;
 
 /// MovieFap search extractor
 ///
@@ -24,6 +21,17 @@ impl MovieFapSearchExtractor {
     #[must_use]
     pub fn new() -> Self {
         Self
+    }
+}
+
+#[async_trait]
+impl PaginatedSearch for MovieFapSearchExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[MovieFap]"
+    }
+
+    fn validate_search_filters(&self, filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        moviefap_search_helpers::validate_search_filters(filters)
     }
 
     /// Fetch a single search results page and return `(results, max_page_number)`.
@@ -48,55 +56,6 @@ impl MovieFapSearchExtractor {
         );
 
         Ok((page_results, max_pages))
-    }
-
-    /// Collect all pages up to `MAX_PLAYLIST_SIZE` results.
-    async fn search_all_pages(
-        &self,
-        query: &rdlp_types::SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        moviefap_search_helpers::validate_search_filters(&query.filters)?;
-
-        let max_results = query
-            .max_results
-            .unwrap_or(crate::base::common::MAX_PLAYLIST_SIZE);
-
-        let mut all_results = Vec::new();
-        let mut page = 1usize;
-
-        loop {
-            let (page_results, max_pages) = match self.fetch_search_page(query, page, ctx).await {
-                Ok(r) => r,
-                Err(e) => {
-                    debug!(page; "[MovieFap] Failed to fetch search page, returning partial results: {e}");
-                    break;
-                }
-            };
-
-            if page_results.is_empty() {
-                debug!(page; "[MovieFap] No results on page, stopping pagination");
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if page >= max_pages {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(count = all_results.len(), pages = page; "[MovieFap] Search complete");
-
-        Ok(all_results)
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -4,15 +4,11 @@ use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::SearchPageResponse;
-use std::time::Duration;
 
-use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
+use crate::base::common::{BaseExtractor, PaginatedSearch};
 
 use super::search_patterns;
 use super::tnaflix_search_helpers;
-
-/// Rate limit delay between search page fetches (500 ms)
-const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// TNAFlix search extractor
 ///
@@ -46,6 +42,17 @@ impl TNAFlixSearchExtractor {
             search_patterns::build_search_url_page(query, page)
         }
     }
+}
+
+#[async_trait]
+impl PaginatedSearch for TNAFlixSearchExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[TNAFlix]"
+    }
+
+    fn validate_search_filters(&self, filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        tnaflix_search_helpers::validate_search_filters(filters)
+    }
 
     /// Fetch a single search results page and return `(results, max_page_number)`.
     async fn fetch_search_page(
@@ -69,53 +76,6 @@ impl TNAFlixSearchExtractor {
         );
 
         Ok((page_results, max_pages))
-    }
-
-    /// Collect all pages up to `MAX_PLAYLIST_SIZE` results.
-    async fn search_all_pages(
-        &self,
-        query: &rdlp_types::SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        tnaflix_search_helpers::validate_search_filters(&query.filters)?;
-
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-
-        let mut all_results = Vec::new();
-        let mut page = 1usize;
-
-        loop {
-            let (page_results, max_pages) = match self.fetch_search_page(query, page, ctx).await {
-                Ok(r) => r,
-                Err(e) => {
-                    debug!(page; "[TNAFlix] Failed to fetch search page, returning partial results: {e}");
-                    break;
-                }
-            };
-
-            if page_results.is_empty() {
-                debug!(page; "[TNAFlix] No results on page, stopping pagination");
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if page >= max_pages {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(count = all_results.len(), pages = page; "[TNAFlix] Search complete");
-
-        Ok(all_results)
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -32,7 +32,7 @@ use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtra
 use rdlp_types::{InfoDict, SearchPageResponse};
 use std::time::Duration;
 
-use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
+use crate::base::common::{BaseExtractor, PaginatedSearch};
 use crate::hls::detect_format_sizes_lazy;
 
 pub use patterns::{XHAMSTER_EMBED_PATTERN, XHAMSTER_VIDEO_PATTERN};
@@ -40,7 +40,8 @@ pub use patterns::{XHAMSTER_EMBED_PATTERN, XHAMSTER_VIDEO_PATTERN};
 /// Timeout for extracting a single video in playlist mode (30 seconds)
 const VIDEO_EXTRACTION_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Rate limit delay between user page fetches (500ms)
+/// Rate limit delay between playlist page fetches (500ms). Search pagination
+/// uses the shared `PaginatedSearch` default instead.
 const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// Number of concurrent video extractions
@@ -247,6 +248,17 @@ impl XHamsterExtractor {
             url: Some(url.to_string().into()),
         })
     }
+}
+
+#[async_trait]
+impl PaginatedSearch for XHamsterExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[XHamster]"
+    }
+
+    fn validate_search_filters(&self, filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        search::validate_search_filters(filters)
+    }
 
     /// Fetch a single search page, returning its results and the max page count.
     async fn fetch_search_page(
@@ -269,52 +281,6 @@ impl XHamsterExtractor {
         let max_pages = search::parse_max_pages(&initials).unwrap_or(1);
 
         Ok((page_results, max_pages))
-    }
-
-    /// Perform a paginated search, collecting results across all pages.
-    async fn search_all_pages(
-        &self,
-        query: &rdlp_types::SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        search::validate_search_filters(&query.filters)?;
-
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 1_usize;
-
-        loop {
-            let (page_results, max_pages) = match self.fetch_search_page(query, page, ctx).await {
-                Ok(result) => result,
-                Err(e) => {
-                    debug!(page; "[XHamster] Failed to fetch search page, returning partial results: {e}");
-                    break;
-                }
-            };
-
-            if page_results.is_empty() {
-                debug!(page; "[XHamster] No results on page, stopping pagination");
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if page >= max_pages {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(count = all_results.len(), pages = page; "[XHamster] Search complete");
-
-        Ok(all_results)
     }
 }
 


### PR DESCRIPTION
Initiative #5 (InfoExtractorExt) from `.dupes-ignore.toml`.

## What
The multi-page search pagination loop `search_all_pages` was **byte-identical** in **4 extractors** (XHamster, TNAFlix, EMPFlix, MovieFap) — 4 copies of a ~35-line loop differing only in a log tag and the `validate_search_filters` namespace. That loop is one piece of knowledge (change the pagination policy → all four must change), so it becomes the **default method of a new `#[async_trait] trait PaginatedSearch`** in `base/common/search.rs`.

- Required (per-site) methods: `fetch_search_page`, `search_log_tag`, `validate_search_filters`.
- Defaulted (shared): `page_rate_limit` (500ms) + `search_all_pages` (the scaffold).
- `#[async_trait]` matches the codebase idiom; default-method-calls-required-method is a supported pattern.

## Gate-1 / scope
- **Extracted**: the scaffold is genuine same-knowledge duplication across **4 sites** (Rule of Three well satisfied).
- **Excluded**: PornHub and RedTube have a *different* pagination shape (per-page HTML↔API fallback) and intentionally do **not** implement the trait.
- **XHamster** keeps its own `PAGE_RATE_LIMIT_MS` — used by the *unrelated* playlist path; search now uses the trait default. Two independent knobs, not a false coupling.
- Removed the resolved `0b7f3658` grandfather entry from `.dupes-ignore.toml` — the dedup gate stays green **without** it (duplication genuinely gone, not re-suppressed).

## Tests
7 scaffold tests via a scripted mock impl: accumulate+truncate across pages, `max_pages` stop, empty-page stop, fetch-error→partial, single-page truncate, **pure accumulation (uncapped)**, and **validation-error → `Err` without fetching** (the one scaffold path that returns `Err` not partial — added per code review). Stronger coverage than the 4 copies ever had.

Behavior-preserving: log tags/messages, structured-kv fields, and rate limit unchanged. All **1039** `rdlp-extractor` lib tests green.

## Verification
Full rust-pro gate: `fmt --check`, `check`, `clippy --all-targets -D warnings`, tests, all CI check-scripts (dedup / url-redaction / no-cli / wit-drift / log-redaction) ✅.

## Reviews
- **security-reviewer**: PASS — shared default logically identical to all 4 removed copies (diffed line-by-line); log tag is a hardcoded `&'static str` (no injection); redaction preserved; DoS caps intact; PornHub/RedTube correctly excluded.
- **code-reviewer**: Approve — idiomatic trait design, `Send + Sync` correct, no drift, grandfather removal correct. Flagged the `validate_search_filters`-error coverage gap → test added.