### PR TITLE
refactor(extractor): unify retry-fetch into BaseExtractor::fetch_webpage_with_retry

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -7,10 +7,6 @@ fingerprint = "8c6b8e22faf810b1"
 reason = "Acceptable test boilerplate (build_*_plugin x3 in plugin golden tests)"
 
 [[ignore]]
-fingerprint = "e79a123cf3c33161"
-reason = "Initiative #5: InfoExtractorExt — fetch_api/html_search_page shared across PornHub+RedTube (tracking issue)"
-
-[[ignore]]
 fingerprint = "36dd26d02f5ee08b"
 reason = "Intentional single-call vs paginated twin (Orchestrator::search vs search_page; matches RdlpClient pair)"
 

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -45,8 +45,12 @@ mod string_utils;
 #[cfg(test)]
 mod tests;
 
+use std::time::Duration;
+
 use log::debug;
-use rdlp_core::{ExtractionContext, RdlpError, Result, check_http_response};
+use rdlp_core::{
+    ExponentialBuilder, ExtractionContext, RdlpError, Result, Retryable, check_http_response,
+};
 use rdlp_types::Codec;
 use rdlp_types::Format;
 use regex::Regex;
@@ -67,6 +71,21 @@ pub(crate) use rdlp_security::MAX_URL_LENGTH;
 /// the entire body and OOM the host. 50 MB covers any realistic HTML +
 /// JSON-LD payload with multiple orders of magnitude of headroom.
 pub(crate) const MAX_WEBPAGE_BYTES: usize = 50 * 1024 * 1024;
+
+/// Transient-failure retry budget for `fetch_webpage_with_retry`.
+///
+/// 2 retries (3 attempts total) with a 500 ms exponential base back off. This
+/// is the exact policy the four site extractors (pornhub ×2, redtube,
+/// xhamster) each hand-rolled for their search/pagination fetches before it
+/// was unified here — enough to ride out a brief CDN hiccup without stalling a
+/// pagination loop. Only timeout/connect errors are retried (see the `.when`
+/// predicate); a returned HTTP error status is not a transient fault and is
+/// failed fast by `check_http_response`.
+const FETCH_RETRY_MAX_TIMES: usize = 2;
+
+/// Base back-off delay between retry attempts, in milliseconds.
+/// See [`FETCH_RETRY_MAX_TIMES`] for the rationale of the shared policy.
+const FETCH_RETRY_MIN_DELAY_MS: u64 = 500;
 
 // ============================================================================
 // Base Extractor
@@ -180,6 +199,70 @@ impl BaseExtractor {
         let webpage = fetch_capped_text(response, url).await?;
 
         // Debug output if verbose
+        if ctx.config.verbose {
+            crate::utils::debug_print_webpage_sample(&webpage, DEFAULT_DEBUG_SAMPLE_SIZE);
+        }
+
+        Ok(webpage)
+    }
+
+    /// Fetch a webpage like [`fetch_webpage`](Self::fetch_webpage), but retry
+    /// transient timeout/connect failures with exponential back off.
+    ///
+    /// This is the retry-aware sibling of `fetch_webpage`. It applies the
+    /// **same safety guards** — the [`MAX_URL_LENGTH`] check and the
+    /// [`fetch_capped_text`] streaming body cap ([`MAX_WEBPAGE_BYTES`]) — and
+    /// additionally wraps the GET in a `backon` exponential retry
+    /// ([`FETCH_RETRY_MAX_TIMES`] attempts, [`FETCH_RETRY_MIN_DELAY_MS`] base
+    /// delay). Only timeout/connect errors are retried; a non-2xx status is a
+    /// definitive result and is surfaced immediately by `check_http_response`.
+    ///
+    /// Use this for search/pagination fetches against CDNs prone to transient
+    /// resets. The four site extractors that previously hand-rolled this
+    /// GET-retry-read block (pornhub, redtube, xhamster) dropped the URL and
+    /// body-size guards in the process; routing them through this helper
+    /// restores safety parity with `fetch_webpage`.
+    ///
+    /// # Arguments
+    /// * `url` - The URL to fetch
+    /// * `ctx` - Extraction context with HTTP client and config
+    ///
+    /// # Returns
+    /// The webpage content as a string
+    ///
+    /// # Errors
+    /// - `RdlpError::Extraction` if the URL exceeds [`MAX_URL_LENGTH`]
+    /// - `RdlpError::Network` if the request fails (after retries), the status
+    ///   is non-2xx, or the body exceeds [`MAX_WEBPAGE_BYTES`]
+    pub(crate) async fn fetch_webpage_with_retry(
+        url: &str,
+        ctx: &ExtractionContext,
+    ) -> Result<String> {
+        // Security: Validate URL length (parity with `fetch_webpage`).
+        if url.len() > MAX_URL_LENGTH {
+            return Err(RdlpError::Extraction {
+                message: format!("URL too long: {} bytes (max: {MAX_URL_LENGTH})", url.len()),
+                url: Some(url.to_string().into()),
+            });
+        }
+
+        let response = (|| async { ctx.http_client.get(url).send().await })
+            .retry(
+                ExponentialBuilder::default()
+                    .with_max_times(FETCH_RETRY_MAX_TIMES)
+                    .with_min_delay(Duration::from_millis(FETCH_RETRY_MIN_DELAY_MS)),
+            )
+            .when(|e| e.is_timeout() || e.is_connect())
+            .await
+            .map_err(|e| RdlpError::Network {
+                message: format!("Failed to fetch webpage: {e}"),
+                url: Some(url.to_string().into()),
+            })?;
+
+        check_http_response(&response)?;
+
+        let webpage = fetch_capped_text(response, url).await?;
+
         if ctx.config.verbose {
             crate::utils::debug_print_webpage_sample(&webpage, DEFAULT_DEBUG_SAMPLE_SIZE);
         }

--- a/crates/rdlp-extractor/src/base/common/tests.rs
+++ b/crates/rdlp-extractor/src/base/common/tests.rs
@@ -352,3 +352,110 @@ fn webpage_cap_documented_value() {
     // Pin the documented cap. Bumping is fine but should be intentional.
     assert_eq!(super::MAX_WEBPAGE_BYTES, 50 * 1024 * 1024);
 }
+
+// ========================================================================
+// fetch_webpage_with_retry
+// ========================================================================
+//
+// The retry-aware fetch helper unifies the hand-rolled
+// "GET-with-backon-retry → check status → read body" blocks that four
+// site extractors had each re-implemented (pornhub ×2, redtube, xhamster).
+// Those copies ADDED retry but DROPPED the URL-length check and the
+// `fetch_capped_text` body cap that `fetch_webpage` enforces — reading
+// bodies with an uncapped `response.text()`. This helper restores
+// safety parity: same URL-length guard and same streaming body cap as
+// `fetch_webpage`, PLUS transient-failure retry.
+//
+// These tests assert the two safety guards fire on the retry path (the
+// exact behavior the hand-rolled copies lacked) alongside the happy path
+// and status propagation.
+
+#[tokio::test]
+async fn fetch_webpage_with_retry_returns_body_on_200() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", mockito::Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "text/html; charset=utf-8")
+        .with_body("<html>ok</html>")
+        .create_async()
+        .await;
+
+    let ctx = crate::hls::test_support::test_ctx();
+    let body = BaseExtractor::fetch_webpage_with_retry(&server.url(), &ctx)
+        .await
+        .expect("200 response must yield the body");
+
+    assert_eq!(body, "<html>ok</html>");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_webpage_with_retry_propagates_5xx_as_error() {
+    // A 5xx is a *successful* HTTP exchange returning a bad status — it is
+    // NOT a timeout/connect error, so the backon `.when(...)` predicate must
+    // not retry it; it should fail fast via `check_http_response`.
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", mockito::Matcher::Any)
+        .with_status(503)
+        .with_body("service unavailable")
+        .expect(1) // proves 5xx is not retried by the transient-error predicate
+        .create_async()
+        .await;
+
+    let ctx = crate::hls::test_support::test_ctx();
+    let result = BaseExtractor::fetch_webpage_with_retry(&server.url(), &ctx).await;
+
+    assert!(result.is_err(), "503 must propagate as an error");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_webpage_with_retry_rejects_overlong_url() {
+    // The URL-length guard `fetch_webpage` has — which the hand-rolled
+    // retry copies dropped. An over-cap URL must be rejected as an
+    // `Extraction` error BEFORE any network call. The URL points at an
+    // unroutable loopback path: if the guard failed to fire, the attempted
+    // fetch would surface as a `Network` error instead, so asserting the
+    // `Extraction` variant proves the guard short-circuited pre-network.
+    let overlong = format!("http://127.0.0.1/{}", "a".repeat(MAX_URL_LENGTH));
+    assert!(overlong.len() > MAX_URL_LENGTH);
+
+    let ctx = crate::hls::test_support::test_ctx();
+    let err = BaseExtractor::fetch_webpage_with_retry(&overlong, &ctx)
+        .await
+        .expect_err("an over-cap URL must be rejected");
+
+    assert!(
+        matches!(err, RdlpError::Extraction { .. }),
+        "expected Extraction (URL too long), got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn fetch_webpage_with_retry_enforces_body_cap() {
+    // The body cap `fetch_webpage` enforces via `fetch_capped_text` — which
+    // the hand-rolled retry copies dropped in favour of an uncapped
+    // `response.text()`. A body one byte over `MAX_WEBPAGE_BYTES` must abort
+    // mid-stream with a Network error rather than buffer to completion.
+    // Intentionally large (~50 MB) — the sole functional guard that the
+    // retry path routes through the streaming cap; freed immediately.
+    let mut server = mockito::Server::new_async().await;
+    let oversized = vec![b'a'; MAX_WEBPAGE_BYTES + 1];
+    let mock = server
+        .mock("GET", mockito::Matcher::Any)
+        .with_status(200)
+        .with_body(oversized)
+        .create_async()
+        .await;
+
+    let ctx = crate::hls::test_support::test_ctx();
+    let result = BaseExtractor::fetch_webpage_with_retry(&server.url(), &ctx).await;
+
+    assert!(
+        matches!(result, Err(RdlpError::Network { .. })),
+        "a body over the cap must be rejected as a Network error, got: {result:?}"
+    );
+    mock.assert_async().await;
+}

--- a/crates/rdlp-extractor/src/base/common/tests.rs
+++ b/crates/rdlp-extractor/src/base/common/tests.rs
@@ -459,3 +459,72 @@ async fn fetch_webpage_with_retry_enforces_body_cap() {
     );
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn fetch_webpage_with_retry_recovers_after_a_transient_timeout() {
+    // Proves the retry machinery itself recovers a *transient* failure — the
+    // feature the helper is named for. Deterministic (no wall-clock race): a
+    // raw-TCP server accepts the first attempt and never responds, so that
+    // attempt can ONLY end via the client-side timeout (a retryable
+    // `is_timeout()` error); the server's second `accept()` then blocks until
+    // backon actually retries, and serves a 200. mockito can't express this —
+    // a returned HTTP status is not a timeout/connect error, so the retry
+    // predicate would skip it.
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    // Client timeout well below the (unbounded) stall on attempt 1, and the
+    // second attempt responds immediately, so neither bound is timing-fragile.
+    const CLIENT_TIMEOUT_MS: u64 = 400;
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let url = format!("http://{addr}/");
+
+    let server = tokio::spawn(async move {
+        let mut scratch = [0u8; 1024];
+
+        // Attempt 1: read the request, then hold the connection WITHOUT
+        // responding. The client's per-request timeout is the only way out.
+        let (mut first, _) = listener.accept().await.expect("accept attempt 1");
+        let _ = first.read(&mut scratch).await;
+
+        // Attempt 2 (the retry): blocks here until backon reconnects, so the
+        // sequencing is driven by the client, not a sleep.
+        let (mut second, _) = listener.accept().await.expect("accept attempt 2");
+        let _ = second.read(&mut scratch).await;
+        second
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n\r\nrecovered!!",
+            )
+            .await
+            .expect("write 200 on retry");
+        let _ = second.shutdown().await;
+    });
+
+    // A dedicated client with a short per-request timeout so attempt 1's stall
+    // surfaces as `is_timeout()` (the retry predicate's trigger).
+    let client = wreq::Client::builder()
+        .redirect(wreq::redirect::Policy::none())
+        .timeout(std::time::Duration::from_millis(CLIENT_TIMEOUT_MS))
+        .build()
+        .expect("client build must succeed in tests");
+    let ctx = rdlp_core::ExtractionContext::new(
+        std::sync::Arc::new(client),
+        std::sync::Arc::new(crate::hls::test_support::NoOpJsEngine),
+        std::sync::Arc::new(crate::hls::test_support::NoOpCookieJar),
+        std::sync::Arc::new(rdlp_types::Config {
+            verbose: false,
+            ..rdlp_types::Config::default()
+        }),
+    );
+
+    let body = BaseExtractor::fetch_webpage_with_retry(&url, &ctx)
+        .await
+        .expect("a transient first-attempt timeout must be retried, then succeed");
+
+    assert_eq!(body, "recovered!!");
+    server.await.expect("server task must not panic");
+}

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -33,10 +33,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use log::{debug, warn};
-use rdlp_core::{
-    ExponentialBuilder, ExtractionContext, InfoExtractor, RdlpError, Result, Retryable,
-    SearchExtractor,
-};
+use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtractor};
 use rdlp_types::{InfoDict, SearchPageResponse, SearchQuery, SearchResultPreview};
 use scraper::Html;
 
@@ -97,26 +94,7 @@ impl PornHubExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let response = (|| async { ctx.http_client.get(url).send().await })
-            .retry(
-                ExponentialBuilder::default()
-                    .with_max_times(2)
-                    .with_min_delay(Duration::from_millis(500)),
-            )
-            .when(|e| e.is_timeout() || e.is_connect())
-            .await
-            .map_err(|e| RdlpError::Network {
-                message: format!("Failed to fetch PornHub search API: {e}"),
-                url: Some(url.to_string().into()),
-            })?;
-
-        rdlp_core::check_http_response(&response)?;
-
-        let body = response.text().await.map_err(|e| RdlpError::Network {
-            message: format!("Failed to read PornHub API response: {e}"),
-            url: Some(url.to_string().into()),
-        })?;
-
+        let body = BaseExtractor::fetch_webpage_with_retry(url, ctx).await?;
         search::parse_api_search_results(&body)
     }
 
@@ -130,26 +108,7 @@ impl PornHubExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let response = (|| async { ctx.http_client.get(url).send().await })
-            .retry(
-                ExponentialBuilder::default()
-                    .with_max_times(2)
-                    .with_min_delay(Duration::from_millis(500)),
-            )
-            .when(|e| e.is_timeout() || e.is_connect())
-            .await
-            .map_err(|e| RdlpError::Network {
-                message: format!("Failed to fetch PornHub HTML search page: {e}"),
-                url: Some(url.to_string().into()),
-            })?;
-
-        rdlp_core::check_http_response(&response)?;
-
-        let body = response.text().await.map_err(|e| RdlpError::Network {
-            message: format!("Failed to read PornHub HTML search response: {e}"),
-            url: Some(url.to_string().into()),
-        })?;
-
+        let body = BaseExtractor::fetch_webpage_with_retry(url, ctx).await?;
         search_html::parse_html_search_results(&body)
     }
 

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -22,10 +22,7 @@ mod search;
 
 use async_trait::async_trait;
 use log::{debug, warn};
-use rdlp_core::{
-    ExponentialBuilder, ExtractionContext, InfoExtractor, RdlpError, Result, Retryable,
-    SearchExtractor,
-};
+use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtractor};
 use rdlp_types::{InfoDict, SearchPageResponse};
 use regex::Regex;
 use scraper::Html;
@@ -406,26 +403,7 @@ impl RedTubeExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Option<u64>)> {
-        let response = (|| async { ctx.http_client.get(url).send().await })
-            .retry(
-                ExponentialBuilder::default()
-                    .with_max_times(2)
-                    .with_min_delay(Duration::from_millis(500)),
-            )
-            .when(|e| e.is_timeout() || e.is_connect())
-            .await
-            .map_err(|e| RdlpError::Network {
-                message: format!("Failed to fetch search API: {e}"),
-                url: Some(url.to_string().into()),
-            })?;
-
-        rdlp_core::check_http_response(&response)?;
-
-        let body = response.text().await.map_err(|e| RdlpError::Network {
-            message: format!("Failed to read search API response: {e}"),
-            url: Some(url.to_string().into()),
-        })?;
-
+        let body = BaseExtractor::fetch_webpage_with_retry(url, ctx).await?;
         search::parse_api_search_results(&body)
     }
 
@@ -435,7 +413,9 @@ impl RedTubeExtractor {
         url: &str,
         ctx: &ExtractionContext,
     ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        let webpage = BaseExtractor::fetch_webpage(url, ctx).await?;
+        // Retry-aware sibling: the HTML path is a fallback for a flaky API, so
+        // a transient CDN reset here should retry rather than abandon search.
+        let webpage = BaseExtractor::fetch_webpage_with_retry(url, ctx).await?;
         search::parse_html_search_results(&webpage)
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/playlist.rs
@@ -4,13 +4,11 @@
 
 use super::XHamsterExtractor;
 use super::patterns;
-use crate::base::common::MAX_PLAYLIST_SIZE;
+use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
 use futures::stream::{self, StreamExt};
 use lazy_regex::{Lazy, Regex, lazy_regex};
 use log::{debug, info, warn};
-use rdlp_core::{
-    ExponentialBuilder, ExtractionContext, RdlpError, Result, Retryable, check_http_response,
-};
+use rdlp_core::{ExtractionContext, RdlpError, Result};
 use rdlp_types::InfoDict;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -51,25 +49,7 @@ impl XHamsterExtractor {
 
             debug!(page, url:? = rdlp_redact::RedactedUrl::new(&page_url); "[XHamster] Fetching user page");
 
-            let response = (|| async { ctx.http_client.get(&page_url).send().await })
-                .retry(
-                    ExponentialBuilder::default()
-                        .with_max_times(2)
-                        .with_min_delay(Duration::from_millis(500)),
-                )
-                .when(|e| e.is_timeout() || e.is_connect())
-                .await
-                .map_err(|e| RdlpError::Network {
-                    message: format!("Failed to fetch user page {page}: {e}"),
-                    url: Some(page_url.clone().into()),
-                })?;
-
-            check_http_response(&response)?;
-
-            let webpage = response.text().await.map_err(|e| RdlpError::Network {
-                message: format!("Failed to read user page {page}: {e}"),
-                url: Some(page_url.clone().into()),
-            })?;
+            let webpage = BaseExtractor::fetch_webpage_with_retry(&page_url, ctx).await?;
 
             // Extract video URLs from the page
             let page_urls = extract_user_video_urls(&webpage);


### PR DESCRIPTION
## Summary

Extracts the hand-rolled **"HTTP GET with `backon` exponential retry → check status → read body"** block that four site extractors each re-implemented into one shared helper `BaseExtractor::fetch_webpage_with_retry(url, ctx) -> Result<String>` (sibling to the existing `fetch_webpage`), and migrates all call sites to it.

This is **Initiative #5's first-half sibling** (the `search_all_pages` half shipped in #435). It resolves the `e79a123c` `.dupes-ignore.toml` entry — the dedup gate now passes **without** it.

### Why this half extracts now (and the other half stays deferred)

Two duplication targets lived inside these functions. This PR draws the line where the authorities do:

- **Target A — the fetch/retry/read-body boilerplate (this PR):** 3–4 near-identical copies (two PornHub fetchers measured 96.95% similar). Fowler/Roberts' *Rule of Three* counts occurrences of the block (met), and *The Pragmatic Programmer*'s DRY chapter treats mechanical scaffolding wrapping a parameterized downstream call as the textbook **safe** extraction — pull out the mechanism, keep each caller's parser separate. No internal conditionals → not a Metz "wrong abstraction."
- **Target B — the `search_all_pages` fallback *orchestration* (stays deferred, tracked in #436):** 2 sites, **opposite** control flow (HTML-first↔API-first) + one tracks a result count. Forcing one shape now is the parameter-and-conditional-laden abstraction Metz/AHA warn against. Re-evaluate at a real 3rd instance.

### Security parity restored (real fix, not just dedup)

The hand-rolled copies **added** retry but **dropped** the `MAX_URL_LENGTH` check and the `fetch_capped_text` streaming body cap (`MAX_WEBPAGE_BYTES` = 50 MiB) that `fetch_webpage` enforces — reading bodies with an **uncapped `response.text()`** (unbounded-memory exposure against adversarial CDNs). Routing every site through the helper restores that parity.

## Call sites migrated (5)

| Site | Fn | Note |
|------|----|------|
| PornHub | `fetch_api_search_page` | |
| PornHub | `fetch_html_search_page` | |
| RedTube | `fetch_api_search_page` | tuple return preserved |
| RedTube | `fetch_html_search_page` | **now retries** (was non-retry `fetch_webpage`) — intended, commented |
| XHamster | user-page pagination loop | inline block |

Backoff literals (`2` / `500ms`) lifted to named consts (`FETCH_RETRY_MAX_TIMES` / `FETCH_RETRY_MIN_DELAY_MS`) with rationale.

## Tests

4 new mockito cases on the retry path: 200-body (positive); 503 **not** retried (`.expect(1)` proves the transient-error predicate skips HTTP statuses); over-`MAX_URL_LENGTH` rejected **pre-network** (`Extraction`); body over cap aborts mid-stream (`Network`).

**Deliberately not added:** a retry-then-success test. The predicate retries only `is_timeout()`/`is_connect()`, so a mockito "503-then-200" wouldn't trigger a retry; a genuine transient-connect/timeout recovery needs transport-level fault injection or wall-clock racing against the 500ms backoff (flaky). The retry machinery is `backon`'s (independently tested); our predicate's non-retry of 503 + happy path are covered.

## Verification

`cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test` (workspace, incl. rdlp-extractor 1045) · `check-dedup.sh` (PASS **without** `e79a123c`) · `check-url-redaction.sh` · `check-log-redaction.sh` · `check-no-cli.sh` · `check-wit-drift.sh` · `cargo check -p rdlp-desktop` — all green.

## Reviews

- **security-reviewer:** Approve — no findings at Medium+. Confirms a genuine resource-exhaustion improvement across 4 sites; SSRF/redaction posture preserved exactly (re-ran `check-url-redaction.sh`).
- **code-reviewer:** Approve — no findings at/above bar. Faithful mirror of `fetch_webpage`, correct `backon` idiom, magic-number rule satisfied.

## Follow-ups (out of scope)

- `redtube/mod.rs:76-92` (video-info API) still uses an uncapped `response.text()` — same dropped-cap class, but never one of the four *retry* blocks this PR targets. Tracking issue to file.

Refs #436