### PR TITLE
refactor(extractor): PornHub + RedTube adopt PaginatedSearch via Termination enum

### DIFF
--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -57,7 +57,7 @@ use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
-pub(crate) use search::{PaginatedSearch, append_search_filters};
+pub(crate) use search::{PaginatedSearch, Termination, append_search_filters};
 pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -28,8 +28,8 @@ pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 pub(crate) enum Termination {
     Pages(usize),
     /// Constructed by `PaginatedSearch` adopters that paginate until an empty
-    /// page (PornHub, RedTube once Task 3 lands — #436). No reliable total
-    /// page count is available from these sites' responses.
+    /// page (PornHub, RedTube). No reliable total page count is available from
+    /// these sites' responses.
     UntilEmpty,
 }
 

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -20,6 +20,35 @@ use super::MAX_PLAYLIST_SIZE;
 /// share the [`PaginatedSearch`] scaffold rate-limit at this interval.
 pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 
+/// How a paginated search knows when to stop.
+///
+/// `Pages(n)` — the site reports a known page count; stop once `page >= n`.
+/// `UntilEmpty` — no reliable total; stop only when a page comes back empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Termination {
+    Pages(usize),
+    /// Constructed by `PaginatedSearch` adopters that paginate until an empty
+    /// page (PornHub/RedTube — Tasks 2-3 of this refactor, #436). This task
+    /// only wires the enum through the 4 existing `Pages`-only adopters, so
+    /// `UntilEmpty` has no production constructor yet; silence the transient
+    /// dead-code false positive rather than leaving the gate unclean.
+    #[allow(dead_code)]
+    UntilEmpty,
+}
+
+impl Termination {
+    /// True once the loop should stop, given the 1-based page just fetched.
+    /// `n.max(1)` treats a zero total as one page (`Pages(0)` == `Pages(1)`);
+    /// count==0 is normally caught by the empty-page break first, so do not
+    /// "simplify" away the `.max(1)`.
+    fn should_stop(self, page: usize) -> bool {
+        match self {
+            Termination::Pages(n) => page >= n.max(1),
+            Termination::UntilEmpty => false,
+        }
+    }
+}
+
 /// Append the standard API search filters to an in-progress search URL.
 ///
 /// Recognizes four filter keys; unknown keys are silently ignored (value
@@ -75,8 +104,10 @@ pub(crate) fn append_search_filters(url: &mut String, filters: &[SearchFilter]) 
 /// [`search_all_pages`](Self::search_all_pages) is the shared default and
 /// should not be overridden.
 ///
-/// Sites with a different pagination shape (e.g. PornHub/RedTube, which chain
-/// an HTML-vs-API fallback per page) intentionally do NOT implement this trait.
+/// Sites that report a total page count return `Termination::Pages(n)`; sites
+/// with no reliable total (they paginate until an empty page) return
+/// `Termination::UntilEmpty`. Per-page primary↔fallback fetching is a private
+/// concern of each site's `fetch_search_page` implementation.
 #[async_trait]
 pub(crate) trait PaginatedSearch: Send + Sync {
     /// Bracketed site tag used in log lines, e.g. `"[XHamster]"`.
@@ -85,13 +116,13 @@ pub(crate) trait PaginatedSearch: Send + Sync {
     /// Validate the query's filters against this site's supported filter set.
     fn validate_search_filters(&self, filters: &[SearchFilter]) -> Result<()>;
 
-    /// Fetch a single search page, returning `(results, max_pages)`.
+    /// Fetch a single search page, returning `(results, termination)`.
     async fn fetch_search_page(
         &self,
         query: &SearchQuery,
         page: usize,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<SearchResultPreview>, usize)>;
+    ) -> Result<(Vec<SearchResultPreview>, Termination)>;
 
     /// Delay between successive page fetches. Defaults to [`PAGE_RATE_LIMIT_MS`].
     fn page_rate_limit(&self) -> Duration {
@@ -113,7 +144,7 @@ pub(crate) trait PaginatedSearch: Send + Sync {
         let mut page = 1usize;
 
         loop {
-            let (page_results, max_pages) = match self.fetch_search_page(query, page, ctx).await {
+            let (page_results, termination) = match self.fetch_search_page(query, page, ctx).await {
                 Ok(result) => result,
                 Err(e) => {
                     debug!(page; "{tag} Failed to fetch search page, returning partial results: {e}");
@@ -133,7 +164,7 @@ pub(crate) trait PaginatedSearch: Send + Sync {
                 break;
             }
 
-            if page >= max_pages {
+            if termination.should_stop(page) {
                 break;
             }
 
@@ -249,7 +280,7 @@ mod tests {
     }
 
     enum Page {
-        Ok(Vec<SearchResultPreview>, usize),
+        Ok(Vec<SearchResultPreview>, Termination),
         Fail,
     }
 
@@ -293,15 +324,15 @@ mod tests {
             _query: &SearchQuery,
             page: usize,
             _ctx: &ExtractionContext,
-        ) -> Result<(Vec<SearchResultPreview>, usize)> {
+        ) -> Result<(Vec<SearchResultPreview>, Termination)> {
             self.fetches.fetch_add(1, Ordering::SeqCst);
             match self.script.get(page - 1) {
-                Some(Page::Ok(results, max_pages)) => Ok((results.clone(), *max_pages)),
+                Some(Page::Ok(results, termination)) => Ok((results.clone(), *termination)),
                 Some(Page::Fail) => Err(RdlpError::extraction(
                     "mock fetch failure",
                     "https://x.test",
                 )),
-                None => Ok((Vec::new(), page)), // past the script → empty page
+                None => Ok((Vec::new(), Termination::UntilEmpty)), // past script → empty page
             }
         }
     }
@@ -326,7 +357,10 @@ mod tests {
     async fn accumulates_across_pages_then_truncates_to_max_results() {
         // page1: 3, page2: 3, cap 4 → extend to 6, truncate to 4.
         let out = run(
-            vec![Page::Ok(previews(3), 10), Page::Ok(previews(3), 10)],
+            vec![
+                Page::Ok(previews(3), Termination::Pages(10)),
+                Page::Ok(previews(3), Termination::Pages(10)),
+            ],
             Some(4),
         )
         .await;
@@ -337,7 +371,10 @@ mod tests {
     async fn stops_at_max_pages_without_fetching_beyond() {
         // page1 reports max_pages=1; page2 (if fetched) would add 5 — must not.
         let out = run(
-            vec![Page::Ok(previews(2), 1), Page::Ok(previews(5), 1)],
+            vec![
+                Page::Ok(previews(2), Termination::Pages(1)),
+                Page::Ok(previews(5), Termination::Pages(1)),
+            ],
             None,
         )
         .await;
@@ -347,7 +384,10 @@ mod tests {
     #[tokio::test]
     async fn stops_on_empty_page() {
         let out = run(
-            vec![Page::Ok(previews(2), 10), Page::Ok(Vec::new(), 10)],
+            vec![
+                Page::Ok(previews(2), Termination::Pages(10)),
+                Page::Ok(Vec::new(), Termination::Pages(10)),
+            ],
             None,
         )
         .await;
@@ -356,13 +396,17 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_error_returns_partial_results() {
-        let out = run(vec![Page::Ok(previews(2), 10), Page::Fail], None).await;
+        let out = run(
+            vec![Page::Ok(previews(2), Termination::Pages(10)), Page::Fail],
+            None,
+        )
+        .await;
         assert_eq!(out.len(), 2);
     }
 
     #[tokio::test]
     async fn truncates_within_a_single_page() {
-        let out = run(vec![Page::Ok(previews(5), 10)], Some(3)).await;
+        let out = run(vec![Page::Ok(previews(5), Termination::Pages(10))], Some(3)).await;
         assert_eq!(out.len(), 3);
     }
 
@@ -371,7 +415,10 @@ mod tests {
         // 2 pages, no result cap; max_pages=2 stops the loop naturally → all 5,
         // no truncation (the one path the other multi-page tests don't cover).
         let out = run(
-            vec![Page::Ok(previews(3), 2), Page::Ok(previews(2), 2)],
+            vec![
+                Page::Ok(previews(3), Termination::Pages(2)),
+                Page::Ok(previews(2), Termination::Pages(2)),
+            ],
             None,
         )
         .await;
@@ -383,7 +430,7 @@ mod tests {
         // The only scaffold path that returns Err (not partial results): a
         // failed filter validation must short-circuit BEFORE any page fetch.
         let mock = MockSearch {
-            script: vec![Page::Ok(previews(3), 10)],
+            script: vec![Page::Ok(previews(3), Termination::Pages(10))],
             validation_fails: true,
             fetches: AtomicUsize::new(0),
         };
@@ -394,5 +441,89 @@ mod tests {
             0,
             "must not fetch any page when validation fails"
         );
+    }
+
+    // ---- Termination::should_stop ----
+
+    #[test]
+    fn should_stop_pages_stops_at_or_past_n() {
+        assert!(
+            !Termination::Pages(3).should_stop(2),
+            "page 2 of 3: keep going"
+        );
+        assert!(Termination::Pages(3).should_stop(3), "page 3 of 3: stop");
+        assert!(Termination::Pages(3).should_stop(4), "past the end: stop");
+    }
+
+    #[test]
+    fn should_stop_pages_one_stops_after_page_1() {
+        // The common single-page case.
+        assert!(Termination::Pages(1).should_stop(1));
+    }
+
+    #[test]
+    fn should_stop_pages_zero_behaves_as_one() {
+        // `n.max(1)`: a zero total is treated as one page (page 1 is still fetched
+        // by the loop before this check; count==0 is normally caught by the
+        // empty-page break first). Documents Pages(0) == Pages(1).
+        assert!(Termination::Pages(0).should_stop(1));
+        assert_eq!(
+            Termination::Pages(0).should_stop(1),
+            Termination::Pages(1).should_stop(1)
+        );
+    }
+
+    #[test]
+    fn should_stop_until_empty_never_stops_on_count() {
+        assert!(!Termination::UntilEmpty.should_stop(1));
+        assert!(!Termination::UntilEmpty.should_stop(9_999));
+    }
+
+    #[tokio::test]
+    async fn until_empty_accumulates_until_empty_page() {
+        // No page-count bound; only the empty page stops it.
+        let out = run(
+            vec![
+                Page::Ok(previews(3), Termination::UntilEmpty),
+                Page::Ok(previews(2), Termination::UntilEmpty),
+                Page::Ok(Vec::new(), Termination::UntilEmpty),
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(out.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn until_empty_respects_max_results() {
+        // max_results caps before any empty page under UntilEmpty (all existing
+        // truncation tests use Pages).
+        let out = run(
+            vec![
+                Page::Ok(previews(4), Termination::UntilEmpty),
+                Page::Ok(previews(4), Termination::UntilEmpty),
+            ],
+            Some(6),
+        )
+        .await;
+        assert_eq!(out.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn pages_recompute_follows_latest_count() {
+        // The §4.1 accepted semantic: a later page reporting a LARGER page count
+        // (live-dataset drift) makes the loop follow the latest total. page-1 says
+        // Pages(2), page-2 says Pages(3) → page 3 IS fetched. Would fail against a
+        // freeze-first loop that locked max_pages=2 from page 1.
+        let out = run(
+            vec![
+                Page::Ok(previews(2), Termination::Pages(2)),
+                Page::Ok(previews(2), Termination::Pages(3)),
+                Page::Ok(previews(2), Termination::Pages(3)),
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(out.len(), 6, "all 3 pages fetched (latest count = 3)");
     }
 }

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -32,7 +32,7 @@ pub(crate) enum Termination {
     /// only wires the enum through the 4 existing `Pages`-only adopters, so
     /// `UntilEmpty` has no production constructor yet; silence the transient
     /// dead-code false positive rather than leaving the gate unclean.
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), allow(dead_code))]
     UntilEmpty,
 }
 
@@ -46,6 +46,14 @@ impl Termination {
             Termination::Pages(n) => page >= n.max(1),
             Termination::UntilEmpty => false,
         }
+    }
+
+    /// True while the loop/caller may fetch a further page after `page`
+    /// (the inverse of `should_stop`). `pub(crate)` so single-page
+    /// `search_page` callers can compute `has_more` without duplicating the
+    /// match; `should_stop` itself stays private.
+    pub(crate) fn has_more(self, page: usize) -> bool {
+        !self.should_stop(page)
     }
 }
 

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -28,11 +28,8 @@ pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 pub(crate) enum Termination {
     Pages(usize),
     /// Constructed by `PaginatedSearch` adopters that paginate until an empty
-    /// page (PornHub/RedTube — Tasks 2-3 of this refactor, #436). This task
-    /// only wires the enum through the 4 existing `Pages`-only adopters, so
-    /// `UntilEmpty` has no production constructor yet; silence the transient
-    /// dead-code false positive rather than leaving the gate unclean.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// page (PornHub, RedTube once Task 3 lands — #436). No reliable total
+    /// page count is available from these sites' responses.
     UntilEmpty,
 }
 

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -29,21 +29,16 @@ mod search_patterns;
 mod tests;
 mod utils;
 
-use std::time::Duration;
-
 use async_trait::async_trait;
 use log::{debug, warn};
 use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtractor};
 use rdlp_types::{InfoDict, SearchPageResponse, SearchQuery, SearchResultPreview};
 use scraper::Html;
 
-use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
+use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
 use crate::hls::detect_format_sizes_lazy;
 
 pub use patterns::{PORNHUB_PLAYLIST_URL_PATTERN, PORNHUB_VIDEO_URL_PATTERN};
-
-/// Rate limit between search page fetches (milliseconds).
-const SEARCH_RATE_LIMIT_MS: u64 = 500;
 
 /// Expected number of results per API page. Used to detect the last page:
 /// if a page returns fewer than this, there are no more pages.
@@ -111,74 +106,49 @@ impl PornHubExtractor {
         let body = BaseExtractor::fetch_webpage_with_retry(url, ctx).await?;
         search_html::parse_html_search_results(&body)
     }
+}
 
-    /// Paginated search across all pages, collecting up to `max_results` results.
-    ///
-    /// Uses the HTML search page as the primary source with a 500ms rate limit between pages.
-    /// Falls back to the JSON API on page 1 HTML failures or empty results.
-    ///
-    /// # Arguments
-    /// * `query` - Search query with optional filters and result cap.
-    /// * `ctx` - Extraction context with HTTP client.
-    async fn search_all_pages(
+#[async_trait]
+impl PaginatedSearch for PornHubExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[PornHub]"
+    }
+
+    fn validate_search_filters(&self, filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        search::validate_search_filters(filters)
+    }
+
+    async fn fetch_search_page(
         &self,
         query: &SearchQuery,
+        page: usize,
         ctx: &ExtractionContext,
-    ) -> Result<Vec<SearchResultPreview>> {
-        search::validate_search_filters(&query.filters)?;
-
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 1_u32;
-
-        loop {
-            let html_url = search_patterns::build_html_search_url(&query.query, page);
-            debug!(page, url:? = rdlp_security::sanitize_for_logging(&html_url); "[PornHub] Fetching HTML search page");
-
-            let page_results = match self.fetch_html_search_page(&html_url, ctx).await {
-                Ok(results) if !results.is_empty() => results,
-                outcome => {
-                    if page == 1 {
-                        let reason = match &outcome {
-                            Ok(_) => "HTML returned 0 results".to_string(),
-                            Err(e) => format!("{e}"),
-                        };
-                        debug!(
-                            "[PornHub] HTML search failed/empty on page 1, falling back to API: {reason}"
-                        );
-                        let base_url =
-                            search_patterns::build_api_search_url(&query.query, &query.filters);
-                        match self.fetch_api_search_page(&base_url, ctx).await {
-                            Ok(api_results) => api_results,
-                            Err(api_err) => {
-                                warn!("[PornHub] API fallback also failed on page 1: {api_err}");
-                                break;
-                            }
+    ) -> Result<(Vec<SearchResultPreview>, Termination)> {
+        let html_url = search_patterns::build_html_search_url(&query.query, page as u32);
+        match self.fetch_html_search_page(&html_url, ctx).await {
+            Ok(results) if !results.is_empty() => Ok((results, Termination::UntilEmpty)),
+            outcome => {
+                if page == 1 {
+                    let base_url =
+                        search_patterns::build_api_search_url(&query.query, &query.filters);
+                    match self.fetch_api_search_page(&base_url, ctx).await {
+                        Ok(api_results) => Ok((api_results, Termination::UntilEmpty)),
+                        Err(api_err) => {
+                            // Preserve the operator-visible WARN (never downgrade
+                            // to the shared loop's DEBUG). Then propagate → the
+                            // loop breaks with partial results, as today.
+                            warn!("[PornHub] API fallback also failed on page 1: {api_err}");
+                            Err(api_err)
                         }
-                    } else {
-                        debug!(page; "[PornHub] HTML search failed on later page, returning partial results");
-                        break;
+                    }
+                } else {
+                    match outcome {
+                        Ok(empty) => Ok((empty, Termination::UntilEmpty)),
+                        Err(e) => Err(e),
                     }
                 }
-            };
-
-            if page_results.is_empty() {
-                break;
             }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(SEARCH_RATE_LIMIT_MS)).await;
         }
-
-        debug!(count = all_results.len(), pages = page; "[PornHub] Search complete");
-        Ok(all_results)
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -27,16 +27,12 @@ use rdlp_types::{InfoDict, SearchPageResponse};
 use regex::Regex;
 use scraper::Html;
 use std::sync::LazyLock;
-use std::time::Duration;
 
-use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
+use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
 use crate::base::tnaflix_network::TnaFlixNetworkBase;
 use crate::hls::detect_format_sizes_lazy;
 use crate::utils::make_absolute_url;
 use patterns::REDTUBE_URL_PATTERN;
-
-/// Rate limit delay between search page fetches (500ms).
-const SEARCH_RATE_LIMIT_MS: u64 = 500;
 
 /// RedTube extractor
 pub struct RedTubeExtractor {
@@ -192,6 +188,17 @@ impl RedTubeExtractor {
     }
 }
 
+/// Map a RedTube API total-result `count` to a pagination terminator.
+/// `Some(total)` → `Pages(ceil(total / page_size))`; `None` → `UntilEmpty`.
+fn termination_from_count(count: Option<u64>) -> Termination {
+    match count {
+        Some(total) => {
+            Termination::Pages((total as usize).div_ceil(patterns::API_RESULTS_PER_PAGE as usize))
+        }
+        None => Termination::UntilEmpty,
+    }
+}
+
 /// Extract performer/pornstar names from RedTube video page HTML.
 ///
 /// Looks for `<a href="/pornstar/name">` links within the `.performers-list` section.
@@ -303,100 +310,6 @@ impl InfoExtractor for RedTubeExtractor {
 }
 
 impl RedTubeExtractor {
-    /// Perform paginated search across all pages, collecting results.
-    ///
-    /// Uses the JSON API as the primary source. Falls back to HTML scraping
-    /// if the API request fails. Rate-limits at 500ms between page fetches.
-    /// Caps results at `max_results` or `MAX_PLAYLIST_SIZE`.
-    async fn search_all_pages(
-        &self,
-        query: &rdlp_types::SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        let descriptors = patterns::search_filter_descriptors();
-        search::validate_search_filters(&query.filters, &descriptors)?;
-
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 1_u32;
-        let mut total_count: Option<u64> = None;
-
-        let base_url = patterns::build_api_search_url(&query.query, &query.filters);
-
-        loop {
-            let page_url = if page == 1 {
-                base_url.clone()
-            } else {
-                patterns::build_api_search_url_page(&base_url, page)
-            };
-
-            debug!(
-                page;
-                "[RedTube] Fetching search page"
-            );
-
-            // Try JSON API first
-            let page_results = match self.fetch_api_search_page(&page_url, ctx).await {
-                Ok((results, count)) => {
-                    if total_count.is_none() {
-                        total_count = count;
-                    }
-                    results
-                }
-                Err(e) => {
-                    if page == 1 {
-                        // First page failed, try HTML fallback
-                        debug!("[RedTube] API search failed, falling back to HTML: {e}");
-                        let html_url = patterns::build_html_search_url(&query.query);
-                        match self.fetch_html_search_page(&html_url, ctx).await {
-                            Ok(results) => results,
-                            Err(html_err) => {
-                                warn!("[RedTube] HTML fallback also failed: {html_err}");
-                                break;
-                            }
-                        }
-                    } else {
-                        debug!(
-                            page;
-                            "[RedTube] Failed to fetch search page, returning partial results: {e}"
-                        );
-                        break;
-                    }
-                }
-            };
-
-            if page_results.is_empty() {
-                debug!(page; "[RedTube] No results on page, stopping pagination");
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            // Check if we have more pages based on total count
-            if let Some(total) = total_count {
-                let fetched_so_far = page as u64 * u64::from(patterns::API_RESULTS_PER_PAGE);
-                if fetched_so_far >= total {
-                    break;
-                }
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(SEARCH_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(
-            count = all_results.len(), pages = page;
-            "[RedTube] Search complete"
-        );
-
-        Ok(all_results)
-    }
-
     /// Fetch and parse a single API search page.
     async fn fetch_api_search_page(
         &self,
@@ -417,6 +330,49 @@ impl RedTubeExtractor {
         // a transient CDN reset here should retry rather than abandon search.
         let webpage = BaseExtractor::fetch_webpage_with_retry(url, ctx).await?;
         search::parse_html_search_results(&webpage)
+    }
+}
+
+#[async_trait]
+impl PaginatedSearch for RedTubeExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[RedTube]"
+    }
+
+    fn validate_search_filters(&self, filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        let descriptors = patterns::search_filter_descriptors();
+        search::validate_search_filters(filters, &descriptors)
+    }
+
+    async fn fetch_search_page(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        page: usize,
+        ctx: &ExtractionContext,
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
+        let base_url = patterns::build_api_search_url(&query.query, &query.filters);
+        let page_url = if page == 1 {
+            base_url
+        } else {
+            patterns::build_api_search_url_page(&base_url, page as u32)
+        };
+        match self.fetch_api_search_page(&page_url, ctx).await {
+            Ok((results, count)) => Ok((results, termination_from_count(count))),
+            Err(e) => {
+                if page == 1 {
+                    let html_url = patterns::build_html_search_url(&query.query);
+                    match self.fetch_html_search_page(&html_url, ctx).await {
+                        Ok(results) => Ok((results, Termination::UntilEmpty)),
+                        Err(html_err) => {
+                            warn!("[RedTube] HTML fallback also failed: {html_err}");
+                            Err(html_err)
+                        }
+                    }
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 }
 
@@ -563,5 +519,25 @@ mod tests {
         let period = filters.iter().find(|f| f.key == "period");
         assert!(period.is_some());
         assert_eq!(period.unwrap().allowed_values.len(), 3);
+    }
+
+    #[test]
+    fn termination_from_count_maps_totals_to_page_counts() {
+        use super::termination_from_count;
+        use crate::base::common::Termination;
+        assert_eq!(termination_from_count(Some(0)), Termination::Pages(0));
+        assert_eq!(termination_from_count(Some(1)), Termination::Pages(1));
+        assert_eq!(termination_from_count(Some(19)), Termination::Pages(1));
+        assert_eq!(termination_from_count(Some(20)), Termination::Pages(1));
+        assert_eq!(termination_from_count(Some(21)), Termination::Pages(2));
+        assert_eq!(termination_from_count(Some(40)), Termination::Pages(2));
+        assert_eq!(termination_from_count(Some(41)), Termination::Pages(3));
+    }
+
+    #[test]
+    fn termination_from_count_none_is_until_empty() {
+        use super::termination_from_count;
+        use crate::base::common::Termination;
+        assert_eq!(termination_from_count(None), Termination::UntilEmpty);
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -108,14 +108,7 @@ impl rdlp_core::SearchExtractor for EMPFlixSearchExtractor {
         let page = query.page.unwrap_or(1) as usize;
         let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        // Mirrors `Termination::should_stop` (private to `base::common::search`)
-        // without calling it: a later page exists iff the page count hasn't
-        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
-        let has_more = !page_results.is_empty()
-            && match termination {
-                Termination::Pages(n) => page < n.max(1),
-                Termination::UntilEmpty => true,
-            };
+        let has_more = !page_results.is_empty() && termination.has_more(page);
 
         Ok(rdlp_types::SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -5,7 +5,7 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Result};
 
 use super::{search_patterns, tnaflix_search_helpers};
-use crate::base::common::PaginatedSearch;
+use crate::base::common::{PaginatedSearch, Termination};
 
 /// EMPFlix search extractor
 ///
@@ -54,7 +54,7 @@ impl PaginatedSearch for EMPFlixSearchExtractor {
         query: &rdlp_types::SearchQuery,
         page: usize,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, usize)> {
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
         let page_url = Self::build_page_url(query, page);
         debug!(page; "[EMPFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
@@ -69,7 +69,7 @@ impl PaginatedSearch for EMPFlixSearchExtractor {
             page_results.len()
         );
 
-        Ok((page_results, max_pages))
+        Ok((page_results, Termination::Pages(max_pages)))
     }
 }
 
@@ -106,9 +106,16 @@ impl rdlp_core::SearchExtractor for EMPFlixSearchExtractor {
         tnaflix_search_helpers::validate_search_filters(&query.filters)?;
 
         let page = query.page.unwrap_or(1) as usize;
-        let (page_results, max_pages) = self.fetch_search_page(query, page, ctx).await?;
+        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        let has_more = page < max_pages && !page_results.is_empty();
+        // Mirrors `Termination::should_stop` (private to `base::common::search`)
+        // without calling it: a later page exists iff the page count hasn't
+        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
+        let has_more = !page_results.is_empty()
+            && match termination {
+                Termination::Pages(n) => page < n.max(1),
+                Termination::UntilEmpty => true,
+            };
 
         Ok(rdlp_types::SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -48,7 +48,7 @@ impl PaginatedSearch for EMPFlixSearchExtractor {
         tnaflix_search_helpers::validate_search_filters(filters)
     }
 
-    /// Fetch a single search results page and return `(results, max_page_number)`.
+    /// Fetch a single search results page and return `(results, Termination)`.
     async fn fetch_search_page(
         &self,
         query: &rdlp_types::SearchQuery,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -34,7 +34,7 @@ impl PaginatedSearch for MovieFapSearchExtractor {
         moviefap_search_helpers::validate_search_filters(filters)
     }
 
-    /// Fetch a single search results page and return `(results, max_page_number)`.
+    /// Fetch a single search results page and return `(results, Termination)`.
     async fn fetch_search_page(
         &self,
         query: &rdlp_types::SearchQuery,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -8,7 +8,7 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Result};
 
 use super::{moviefap_search_helpers, moviefap_search_patterns};
-use crate::base::common::PaginatedSearch;
+use crate::base::common::{PaginatedSearch, Termination};
 
 /// MovieFap search extractor
 ///
@@ -40,7 +40,7 @@ impl PaginatedSearch for MovieFapSearchExtractor {
         query: &rdlp_types::SearchQuery,
         page: usize,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, usize)> {
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
         let page_url = moviefap_search_patterns::build_search_url(query, page);
         debug!(page; "[MovieFap] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
@@ -55,7 +55,7 @@ impl PaginatedSearch for MovieFapSearchExtractor {
             page_results.len()
         );
 
-        Ok((page_results, max_pages))
+        Ok((page_results, Termination::Pages(max_pages)))
     }
 }
 
@@ -91,9 +91,16 @@ impl rdlp_core::SearchExtractor for MovieFapSearchExtractor {
         moviefap_search_helpers::validate_search_filters(&query.filters)?;
 
         let page = query.page.unwrap_or(1) as usize;
-        let (page_results, max_pages) = self.fetch_search_page(query, page, ctx).await?;
+        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        let has_more = page < max_pages && !page_results.is_empty();
+        // Mirrors `Termination::should_stop` (private to `base::common::search`)
+        // without calling it: a later page exists iff the page count hasn't
+        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
+        let has_more = !page_results.is_empty()
+            && match termination {
+                Termination::Pages(n) => page < n.max(1),
+                Termination::UntilEmpty => true,
+            };
 
         Ok(rdlp_types::SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -93,14 +93,7 @@ impl rdlp_core::SearchExtractor for MovieFapSearchExtractor {
         let page = query.page.unwrap_or(1) as usize;
         let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        // Mirrors `Termination::should_stop` (private to `base::common::search`)
-        // without calling it: a later page exists iff the page count hasn't
-        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
-        let has_more = !page_results.is_empty()
-            && match termination {
-                Termination::Pages(n) => page < n.max(1),
-                Termination::UntilEmpty => true,
-            };
+        let has_more = !page_results.is_empty() && termination.has_more(page);
 
         Ok(rdlp_types::SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -113,14 +113,7 @@ impl SearchExtractor for TNAFlixSearchExtractor {
         let page = query.page.unwrap_or(1) as usize;
         let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        // Mirrors `Termination::should_stop` (private to `base::common::search`)
-        // without calling it: a later page exists iff the page count hasn't
-        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
-        let has_more = !page_results.is_empty()
-            && match termination {
-                Termination::Pages(n) => page < n.max(1),
-                Termination::UntilEmpty => true,
-            };
+        let has_more = !page_results.is_empty() && termination.has_more(page);
 
         Ok(SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -54,7 +54,7 @@ impl PaginatedSearch for TNAFlixSearchExtractor {
         tnaflix_search_helpers::validate_search_filters(filters)
     }
 
-    /// Fetch a single search results page and return `(results, max_page_number)`.
+    /// Fetch a single search results page and return `(results, Termination)`.
     async fn fetch_search_page(
         &self,
         query: &rdlp_types::SearchQuery,

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -5,7 +5,7 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::SearchPageResponse;
 
-use crate::base::common::{BaseExtractor, PaginatedSearch};
+use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
 
 use super::search_patterns;
 use super::tnaflix_search_helpers;
@@ -60,7 +60,7 @@ impl PaginatedSearch for TNAFlixSearchExtractor {
         query: &rdlp_types::SearchQuery,
         page: usize,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, usize)> {
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
         let page_url = Self::build_page_url(query, page);
         debug!(page; "[TNAFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
@@ -75,7 +75,7 @@ impl PaginatedSearch for TNAFlixSearchExtractor {
             page_results.len()
         );
 
-        Ok((page_results, max_pages))
+        Ok((page_results, Termination::Pages(max_pages)))
     }
 }
 
@@ -111,9 +111,16 @@ impl SearchExtractor for TNAFlixSearchExtractor {
         tnaflix_search_helpers::validate_search_filters(&query.filters)?;
 
         let page = query.page.unwrap_or(1) as usize;
-        let (page_results, max_pages) = self.fetch_search_page(query, page, ctx).await?;
+        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        let has_more = page < max_pages && !page_results.is_empty();
+        // Mirrors `Termination::should_stop` (private to `base::common::search`)
+        // without calling it: a later page exists iff the page count hasn't
+        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
+        let has_more = !page_results.is_empty()
+            && match termination {
+                Termination::Pages(n) => page < n.max(1),
+                Termination::UntilEmpty => true,
+            };
 
         Ok(SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -32,7 +32,7 @@ use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtra
 use rdlp_types::{InfoDict, SearchPageResponse};
 use std::time::Duration;
 
-use crate::base::common::{BaseExtractor, PaginatedSearch};
+use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
 use crate::hls::detect_format_sizes_lazy;
 
 pub use patterns::{XHAMSTER_EMBED_PATTERN, XHAMSTER_VIDEO_PATTERN};
@@ -266,7 +266,7 @@ impl PaginatedSearch for XHamsterExtractor {
         query: &rdlp_types::SearchQuery,
         page: usize,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, usize)> {
+    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
         let page_url = if page == 1 {
             patterns::build_search_url(query)
         } else {
@@ -280,7 +280,7 @@ impl PaginatedSearch for XHamsterExtractor {
         let page_results = search::parse_search_results_json(&initials)?;
         let max_pages = search::parse_max_pages(&initials).unwrap_or(1);
 
-        Ok((page_results, max_pages))
+        Ok((page_results, Termination::Pages(max_pages)))
     }
 }
 
@@ -351,9 +351,16 @@ impl SearchExtractor for XHamsterExtractor {
         search::validate_search_filters(&query.filters)?;
 
         let page = query.page.unwrap_or(1) as usize;
-        let (page_results, max_pages) = self.fetch_search_page(query, page, ctx).await?;
+        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        let has_more = page < max_pages && !page_results.is_empty();
+        // Mirrors `Termination::should_stop` (private to `base::common::search`)
+        // without calling it: a later page exists iff the page count hasn't
+        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
+        let has_more = !page_results.is_empty()
+            && match termination {
+                Termination::Pages(n) => page < n.max(1),
+                Termination::UntilEmpty => true,
+            };
 
         Ok(SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -353,14 +353,7 @@ impl SearchExtractor for XHamsterExtractor {
         let page = query.page.unwrap_or(1) as usize;
         let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
 
-        // Mirrors `Termination::should_stop` (private to `base::common::search`)
-        // without calling it: a later page exists iff the page count hasn't
-        // been reached yet (`Pages`), or the mode has no total (`UntilEmpty`).
-        let has_more = !page_results.is_empty()
-            && match termination {
-                Termination::Pages(n) => page < n.max(1),
-                Termination::UntilEmpty => true,
-            };
+        let has_more = !page_results.is_empty() && termination.has_more(page);
 
         Ok(SearchPageResponse {
             results: page_results,

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -260,7 +260,7 @@ impl PaginatedSearch for XHamsterExtractor {
         search::validate_search_filters(filters)
     }
 
-    /// Fetch a single search page, returning its results and the max page count.
+    /// Fetch a single search page, returning its results and a `Termination`.
     async fn fetch_search_page(
         &self,
         query: &rdlp_types::SearchQuery,


### PR DESCRIPTION
## Summary

Adoption, not a new abstraction. PornHub and RedTube now adopt the existing `PaginatedSearch` trait (the shared Template-Method search-pagination loop in `base/common/search.rs`, landed in #435) instead of each carrying a near-duplicate hand-rolled `search_all_pages` loop. The only thing crossing the hook boundary is the *termination signal*, modelled as a new enum:

```rust
pub(crate) enum Termination { Pages(usize), UntilEmpty }
```

Each site's primary↔fallback fetch lives entirely inside its own `fetch_search_page` hook (a private detail); the shared loop gains **zero** new conditionals. This is the same shape the 4 current adopters (TNAFlix, EMPFlix, MovieFap, XHamster) already use — deliberately **not** a shared fallback-orchestrator (that would be the wrong abstraction; Rule-of-Three decision, see spec §2).

## Changes

- **`Termination` enum + `should_stop`** (private) in `base/common/search.rs`; `Pages(n) => page >= n.max(1)`, `UntilEmpty => false`. A `pub(crate) has_more = !should_stop` dedups the 4 single-page `search_page` callers.
- **Trait flip:** `fetch_search_page` returns `(Vec<SearchResultPreview>, Termination)` (was a bare `usize`); the loop's stop check becomes `termination.should_stop(page)`.
- **4 existing adopters:** one-line `Termination::Pages(max_pages)` wrap each (behavior-preserving).
- **PornHub:** HTML-first / page-1-only API fallback moves into the hook; `UntilEmpty` (no total). Inherent loop deleted; `search()` uses the trait default.
- **RedTube:** API-first / page-1-only HTML fallback in the hook; `count → Termination` via a pure, unit-tested `termination_from_count` (`div_ceil(patterns::API_RESULTS_PER_PAGE)`, never a literal 20). Inherent loop deleted.
- Dead `SEARCH_RATE_LIMIT_MS` / `Duration` / `MAX_PLAYLIST_SIZE` imports removed.

## Behavior

PornHub + the 4 existing sites are **behavior-preserving**. RedTube carries **exactly one intentional, documented change** (spec §4.1): termination **recomputes** from each page's `count` (follows live-dataset drift, self-correcting) instead of freezing page-1's total. The empty-page break remains the authoritative terminator, so recompute never over-runs real results. Locked by a drift scaffold test.

**Log parity:** both hooks preserve the page-1 double-failure `warn!` (no WARN→DEBUG downgrade; never-hide-logs rule).

## Tests

- `should_stop` unit tests (incl. `Pages(0) == Pages(1)` `.max(1)` edge); `UntilEmpty` accumulate-until-empty + `max_results`-cap tests; a recompute/drift test (`pages_recompute_follows_latest_count`) that genuinely distinguishes recompute from freeze-first.
- `termination_from_count` boundary table (0/1/19/20/21/40/41 + None).
- The 8 pre-existing `MockSearch` scaffold tests migrated to `Termination` and green; existing PornHub/RedTube fetch-helper tests unchanged.

## Reviews

- **Pre-PR gate:** `cargo fmt --check` · `cargo check` · `clippy --all-targets -D warnings` · `cargo test` (workspace) · `cargo check -p rdlp-desktop` · `check-dedup` · `check-url-redaction` · `check-no-cli` · `check-wit-drift` · `check-log-redaction` — **all green**. The dedup AST gate passed with no new failing group (no `.dupes-ignore` entry needed).
- **Security review:** PASS (Approve) — zero findings. SSRF parity (same hardcoded-host URL builders), resource bounds intact (`MAX_PLAYLIST_SIZE` + empty-page break), log hygiene (warns interpolate only `RdlpError`, whose Display excludes the `RedactedUrlBuf` url field), validation preserved, div_ceil/cast safe.
- **Code review:** Approve — no High/Critical; control-flow translation faithful branch-for-branch to the deleted loops, arithmetic correct, tests assert real behavior. Doc-rot flagged by review folded in (final commit).

Refs #436