### PR TITLE
chore(extractor): dedup search-filter construction + validation (#440)

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -51,10 +51,6 @@ fingerprint = "9b402eaf0837811d"
 reason = "False positive: HLS format-detection and DASH download closures share structural shape but operate on incompatible segment-type streams"
 
 [[ignore]]
-fingerprint = "c280dd2ab56d298f"
-reason = "Initiative #5: InfoExtractorExt — search_filter_descriptors duplicated across PornHub+RedTube (#440)"
-
-[[ignore]]
 fingerprint = "3b98ca18011a1100"
 reason = "Same domain-separation rationale (list_available_audio_codecs vs list_available_codecs for video)"
 
@@ -78,6 +74,3 @@ reason = "False positive: FFmpegRunner::merge and embed_thumbnail wrap the same 
 fingerprint = "40cd6e66253b577b"
 reason = "Acceptable test redundancy; round-trip pattern for two distinct serializable session-state shapes (playlist vs merge_plan)"
 
-[[ignore]]
-fingerprint = "b1f95f057f50ca9e"
-reason = "Initiative #5: InfoExtractorExt — category_values (PornHub) and tag_values (RedTube) share filter-value enumeration scaffold (#440)"

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -57,10 +57,6 @@ use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
-// `FilterValidationError`/`KeyValidation`/`validate_against_descriptors` have
-// no production call site yet — Task 5/6 of the search-filter-dedup sprint
-// migrate per-site validators to use them via this re-export.
-#[allow(unused_imports)]
 pub(crate) use search::{
     FilterValidationError, KeyValidation, PaginatedSearch, Termination, append_search_filters,
     validate_against_descriptors,

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -57,7 +57,14 @@ use regex::Regex;
 
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
-pub(crate) use search::{PaginatedSearch, Termination, append_search_filters};
+// `FilterValidationError`/`KeyValidation`/`validate_against_descriptors` have
+// no production call site yet — Task 5/6 of the search-filter-dedup sprint
+// migrate per-site validators to use them via this re-export.
+#[allow(unused_imports)]
+pub(crate) use search::{
+    FilterValidationError, KeyValidation, PaginatedSearch, Termination, append_search_filters,
+    validate_against_descriptors,
+};
 pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -10,11 +10,112 @@
 use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result};
-use rdlp_types::{SearchFilter, SearchQuery, SearchResultPreview};
+use rdlp_types::{SearchFilter, SearchFilterDescriptor, SearchQuery, SearchResultPreview};
 use std::time::Duration;
 use url::form_urlencoded;
 
 use super::MAX_PLAYLIST_SIZE;
+
+/// How one filter key's value is validated by [`validate_against_descriptors`].
+///
+/// `#[allow(dead_code)]`: only exercised by `validator_tests` until Task 5/6
+/// of the search-filter-dedup sprint migrate per-site validators to call
+/// `validate_against_descriptors` — not a speculative future-use allowance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum KeyValidation {
+    /// Value must be one of the descriptor's `allowed_values` (the default).
+    AllowedValues,
+    /// Any value accepted (the site's API validates server-side); skip the check.
+    FreeText,
+    /// Value must parse as `u32`.
+    NumericU32,
+}
+
+/// A filter-validation failure — data only, no baked-in wording. Each call site
+/// maps this to its own exact `RdlpError` message (producer returns data,
+/// consumer formats). `NonNumeric` is distinct from `InvalidValue` because the
+/// numeric path's message ("Must be a number.") differs from the allowed-values
+/// message ("Allowed: …").
+/// `#[allow(dead_code)]`: same rationale as [`KeyValidation`] — consumed by
+/// Task 5/6, not yet by production call sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum FilterValidationError {
+    UnknownKey {
+        key: String,
+        available: Vec<String>,
+    },
+    InvalidValue {
+        key: String,
+        value: String,
+        allowed: Vec<String>,
+    },
+    NonNumeric {
+        key: String,
+        value: String,
+    },
+}
+
+/// Validate `filters` against a site's `descriptors`. Unknown keys and
+/// out-of-set values are rejected. `overrides` lists keys whose value check
+/// differs from the default `AllowedValues` (keys absent default to it).
+///
+/// Returns a typed error; the caller formats it. NOTE the explicit
+/// `std::result::Result` — `Result` is shadowed here by `rdlp_core::Result`.
+///
+/// `#[allow(dead_code)]`: same rationale as [`KeyValidation`] — consumed by
+/// Task 5/6, not yet by production call sites.
+#[allow(dead_code)]
+pub(crate) fn validate_against_descriptors(
+    filters: &[SearchFilter],
+    descriptors: &[SearchFilterDescriptor],
+    overrides: &[(&str, KeyValidation)],
+) -> std::result::Result<(), FilterValidationError> {
+    for filter in filters {
+        let Some(descriptor) = descriptors.iter().find(|d| d.key == filter.key) else {
+            return Err(FilterValidationError::UnknownKey {
+                key: filter.key.clone(),
+                available: descriptors.iter().map(|d| d.key.clone()).collect(),
+            });
+        };
+
+        let policy = overrides
+            .iter()
+            .find(|(k, _)| *k == filter.key)
+            .map_or(KeyValidation::AllowedValues, |(_, p)| *p);
+
+        match policy {
+            KeyValidation::FreeText => {}
+            KeyValidation::NumericU32 => {
+                if filter.value.parse::<u32>().is_err() {
+                    return Err(FilterValidationError::NonNumeric {
+                        key: filter.key.clone(),
+                        value: filter.value.clone(),
+                    });
+                }
+            }
+            KeyValidation::AllowedValues => {
+                let ok = descriptor
+                    .allowed_values
+                    .iter()
+                    .any(|v| v.value == filter.value);
+                if !ok {
+                    return Err(FilterValidationError::InvalidValue {
+                        key: filter.key.clone(),
+                        value: filter.value.clone(),
+                        allowed: descriptor
+                            .allowed_values
+                            .iter()
+                            .map(|v| v.value.clone())
+                            .collect(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
 /// Delay between successive search-page fetches. All API-paginated sites that
 /// share the [`PaginatedSearch`] scaffold rate-limit at this interval.
@@ -530,5 +631,83 @@ mod tests {
         )
         .await;
         assert_eq!(out.len(), 6, "all 3 pages fetched (latest count = 3)");
+    }
+
+    mod validator_tests {
+        use super::super::{FilterValidationError, KeyValidation, validate_against_descriptors};
+        use rdlp_types::{SearchFilter, SearchFilterDescriptor, SearchFilterValue};
+
+        fn descriptors() -> Vec<SearchFilterDescriptor> {
+            vec![
+                SearchFilterDescriptor::new(
+                    "ordering",
+                    "Sort by",
+                    SearchFilterValue::list([("newest", "Newest"), ("rating", "Top")]),
+                    Some("newest"),
+                ),
+                SearchFilterDescriptor::new("category", "Category", vec![], None),
+                SearchFilterDescriptor::new("dur", "Duration", vec![], None),
+            ]
+        }
+        fn f(k: &str, v: &str) -> SearchFilter {
+            SearchFilter {
+                key: k.into(),
+                value: v.into(),
+            }
+        }
+
+        #[test]
+        fn ok_when_value_allowed() {
+            let r = validate_against_descriptors(&[f("ordering", "rating")], &descriptors(), &[]);
+            assert!(r.is_ok());
+        }
+
+        #[test]
+        fn unknown_key() {
+            let r = validate_against_descriptors(&[f("bogus", "x")], &descriptors(), &[]);
+            assert_eq!(
+                r.unwrap_err(),
+                FilterValidationError::UnknownKey {
+                    key: "bogus".into(),
+                    available: vec!["ordering".into(), "category".into(), "dur".into()],
+                }
+            );
+        }
+
+        #[test]
+        fn invalid_value_reports_allowed() {
+            let r = validate_against_descriptors(&[f("ordering", "nope")], &descriptors(), &[]);
+            assert_eq!(
+                r.unwrap_err(),
+                FilterValidationError::InvalidValue {
+                    key: "ordering".into(),
+                    value: "nope".into(),
+                    allowed: vec!["newest".into(), "rating".into()],
+                }
+            );
+        }
+
+        #[test]
+        fn free_text_skips_check() {
+            let r = validate_against_descriptors(
+                &[f("category", "anything-goes")],
+                &descriptors(),
+                &[("category", KeyValidation::FreeText)],
+            );
+            assert!(r.is_ok());
+        }
+
+        #[test]
+        fn numeric_accepts_digits_rejects_non_digits() {
+            let ov = &[("dur", KeyValidation::NumericU32)];
+            assert!(validate_against_descriptors(&[f("dur", "42")], &descriptors(), ov).is_ok());
+            assert_eq!(
+                validate_against_descriptors(&[f("dur", "x")], &descriptors(), ov).unwrap_err(),
+                FilterValidationError::NonNumeric {
+                    key: "dur".into(),
+                    value: "x".into()
+                }
+            );
+        }
     }
 }

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -17,12 +17,7 @@ use url::form_urlencoded;
 use super::MAX_PLAYLIST_SIZE;
 
 /// How one filter key's value is validated by [`validate_against_descriptors`].
-///
-/// `#[allow(dead_code)]`: only exercised by `validator_tests` until Task 5/6
-/// of the search-filter-dedup sprint migrate per-site validators to call
-/// `validate_against_descriptors` — not a speculative future-use allowance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum KeyValidation {
     /// Value must be one of the descriptor's `allowed_values` (the default).
     AllowedValues,
@@ -37,10 +32,7 @@ pub(crate) enum KeyValidation {
 /// consumer formats). `NonNumeric` is distinct from `InvalidValue` because the
 /// numeric path's message ("Must be a number.") differs from the allowed-values
 /// message ("Allowed: …").
-/// `#[allow(dead_code)]`: same rationale as [`KeyValidation`] — consumed by
-/// Task 5/6, not yet by production call sites.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum FilterValidationError {
     UnknownKey {
         key: String,
@@ -63,10 +55,6 @@ pub(crate) enum FilterValidationError {
 ///
 /// Returns a typed error; the caller formats it. NOTE the explicit
 /// `std::result::Result` — `Result` is shadowed here by `rdlp_core::Result`.
-///
-/// `#[allow(dead_code)]`: same rationale as [`KeyValidation`] — consumed by
-/// Task 5/6, not yet by production call sites.
-#[allow(dead_code)]
 pub(crate) fn validate_against_descriptors(
     filters: &[SearchFilter],
     descriptors: &[SearchFilterDescriptor],

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search_patterns.rs
@@ -71,41 +71,20 @@ fn resolve_sort(query: &SearchQuery) -> &str {
 
 /// Return filter descriptors for NineAnime search.
 pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
-    vec![SearchFilterDescriptor {
-        key: "ordering".to_string(),
-        display_name: "Sort By".to_string(),
-        default: Some("default".to_string()),
-        allowed_values: vec![
-            SearchFilterValue {
-                value: "default".to_string(),
-                label: "Default".to_string(),
-            },
-            SearchFilterValue {
-                value: "updated".to_string(),
-                label: "Recently Updated".to_string(),
-            },
-            SearchFilterValue {
-                value: "added".to_string(),
-                label: "Recently Added".to_string(),
-            },
-            SearchFilterValue {
-                value: "name".to_string(),
-                label: "Name A-Z".to_string(),
-            },
-            SearchFilterValue {
-                value: "mostwatched".to_string(),
-                label: "Most Watched".to_string(),
-            },
-            SearchFilterValue {
-                value: "score".to_string(),
-                label: "Score".to_string(),
-            },
-            SearchFilterValue {
-                value: "released".to_string(),
-                label: "Released Date".to_string(),
-            },
-        ],
-    }]
+    vec![SearchFilterDescriptor::new(
+        "ordering",
+        "Sort By",
+        SearchFilterValue::list([
+            ("default", "Default"),
+            ("updated", "Recently Updated"),
+            ("added", "Recently Added"),
+            ("name", "Name A-Z"),
+            ("mostwatched", "Most Watched"),
+            ("score", "Score"),
+            ("released", "Released Date"),
+        ]),
+        Some("default"),
+    )]
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -6,7 +6,7 @@
 use anyhow::Context as _;
 use log::debug;
 use rdlp_core::{RdlpError, Result};
-use rdlp_types::{SearchFilter, SearchFilterDescriptor, SearchResultPreview};
+use rdlp_types::{SearchFilter, SearchResultPreview};
 use serde::Deserialize;
 
 use super::search_patterns;
@@ -178,51 +178,41 @@ pub(crate) fn parse_duration_string(duration: &str) -> Option<u64> {
 /// # Returns
 /// `Ok(())` on success, `Err` describing the first invalid filter.
 pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
-    let descriptors: Vec<SearchFilterDescriptor> = search_patterns::search_filter_descriptors();
+    use crate::base::common::{FilterValidationError, KeyValidation, validate_against_descriptors};
 
-    for filter in filters {
-        let descriptor = descriptors.iter().find(|d| d.key == filter.key);
-
-        match descriptor {
-            None => {
-                let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
-                return Err(RdlpError::Extraction {
-                    message: format!(
-                        "Unknown filter '{}' for PornHub. Available: {}",
-                        filter.key,
-                        valid_keys.join(", ")
-                    ),
-                    url: None,
-                });
-            }
-            Some(desc) => {
-                // category and tags accept free-text — API validates server-side
-                if filter.key == "category" || filter.key == "tags" {
-                    continue;
-                }
-
-                let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
-                if !valid {
-                    let allowed: Vec<&str> = desc
-                        .allowed_values
-                        .iter()
-                        .map(|v| v.value.as_str())
-                        .collect();
-                    return Err(RdlpError::Extraction {
-                        message: format!(
-                            "Invalid value '{}' for filter '{}'. Allowed: {}",
-                            filter.value,
-                            filter.key,
-                            allowed.join(", ")
-                        ),
-                        url: None,
-                    });
-                }
-            }
-        }
-    }
-
-    Ok(())
+    let descriptors = search_patterns::search_filter_descriptors();
+    validate_against_descriptors(
+        filters,
+        &descriptors,
+        &[
+            ("category", KeyValidation::FreeText),
+            ("tags", KeyValidation::FreeText),
+        ],
+    )
+    .map_err(|e| match e {
+        FilterValidationError::UnknownKey { key, available } => RdlpError::Extraction {
+            message: format!(
+                "Unknown filter '{key}' for PornHub. Available: {}",
+                available.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } => RdlpError::Extraction {
+            message: format!(
+                "Invalid value '{value}' for filter '{key}'. Allowed: {}",
+                allowed.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
+            message: format!("Invalid value '{value}' for filter '{key}'. Must be a number."),
+            url: None,
+        },
+    })
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
@@ -135,60 +135,29 @@ fn category_values() -> Vec<SearchFilterValue> {
 /// Vector of filter descriptors.
 pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
     vec![
-        SearchFilterDescriptor {
-            key: "ordering".to_string(),
-            display_name: "Sort by".to_string(),
-            allowed_values: vec![
-                SearchFilterValue {
-                    value: "featured".to_string(),
-                    label: "Featured".to_string(),
-                },
-                SearchFilterValue {
-                    value: "newest".to_string(),
-                    label: "Newest".to_string(),
-                },
-                SearchFilterValue {
-                    value: "mostviewed".to_string(),
-                    label: "Most viewed".to_string(),
-                },
-                SearchFilterValue {
-                    value: "rating".to_string(),
-                    label: "Top rated".to_string(),
-                },
-            ],
-            default: Some("featured".to_string()),
-        },
-        SearchFilterDescriptor {
-            key: "period".to_string(),
-            display_name: "Time period".to_string(),
-            allowed_values: vec![
-                SearchFilterValue {
-                    value: "alltime".to_string(),
-                    label: "All time".to_string(),
-                },
-                SearchFilterValue {
-                    value: "weekly".to_string(),
-                    label: "This week".to_string(),
-                },
-                SearchFilterValue {
-                    value: "monthly".to_string(),
-                    label: "This month".to_string(),
-                },
-            ],
-            default: Some("alltime".to_string()),
-        },
-        SearchFilterDescriptor {
-            key: "category".to_string(),
-            display_name: "Category".to_string(),
-            allowed_values: category_values(),
-            default: None,
-        },
-        SearchFilterDescriptor {
-            key: "tags".to_string(),
-            display_name: "Tags".to_string(),
-            allowed_values: vec![],
-            default: None,
-        },
+        SearchFilterDescriptor::new(
+            "ordering",
+            "Sort by",
+            SearchFilterValue::list([
+                ("featured", "Featured"),
+                ("newest", "Newest"),
+                ("mostviewed", "Most viewed"),
+                ("rating", "Top rated"),
+            ]),
+            Some("featured"),
+        ),
+        SearchFilterDescriptor::new(
+            "period",
+            "Time period",
+            SearchFilterValue::list([
+                ("alltime", "All time"),
+                ("weekly", "This week"),
+                ("monthly", "This month"),
+            ]),
+            Some("alltime"),
+        ),
+        SearchFilterDescriptor::new("category", "Category", category_values(), None),
+        SearchFilterDescriptor::new("tags", "Tags", vec![], None),
     ]
 }
 

--- a/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search_patterns.rs
@@ -55,7 +55,7 @@ pub(crate) fn build_html_search_url(query: &str, page: u32) -> String {
 /// Only the most common/useful categories are included in the dropdown.
 /// Free-text is also accepted — the API validates server-side.
 fn category_values() -> Vec<SearchFilterValue> {
-    [
+    SearchFilterValue::list([
         ("amateur", "Amateur"),
         ("anal", "Anal"),
         ("arab", "Arab"),
@@ -120,13 +120,7 @@ fn category_values() -> Vec<SearchFilterValue> {
         ("transgender", "Transgender"),
         ("vintage", "Vintage"),
         ("webcam", "Webcam"),
-    ]
-    .into_iter()
-    .map(|(value, label)| SearchFilterValue {
-        value: value.to_string(),
-        label: label.to_string(),
-    })
-    .collect()
+    ])
 }
 
 /// Return the static filter descriptors for PornHub search.

--- a/crates/rdlp-extractor/src/extractors/redtube/filters.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/filters.rs
@@ -171,64 +171,30 @@ fn tag_values() -> Vec<SearchFilterValue> {
 /// - `tags`: comma-separated tags (enum with free-text bypass)
 pub fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
     vec![
-        SearchFilterDescriptor {
-            key: "ordering".to_string(),
-            display_name: "Sort by".to_string(),
-            allowed_values: vec![
-                SearchFilterValue {
-                    value: "relevance".to_string(),
-                    label: "Relevance".to_string(),
-                },
-                SearchFilterValue {
-                    value: "newest".to_string(),
-                    label: "Newest".to_string(),
-                },
-                SearchFilterValue {
-                    value: "mostviewed".to_string(),
-                    label: "Most viewed".to_string(),
-                },
-                SearchFilterValue {
-                    value: "rating".to_string(),
-                    label: "Top rated".to_string(),
-                },
-                SearchFilterValue {
-                    value: "mostfavoured".to_string(),
-                    label: "Most favoured".to_string(),
-                },
-            ],
-            default: Some("relevance".to_string()),
-        },
-        SearchFilterDescriptor {
-            key: "period".to_string(),
-            display_name: "Time period".to_string(),
-            allowed_values: vec![
-                SearchFilterValue {
-                    value: "alltime".to_string(),
-                    label: "All time".to_string(),
-                },
-                SearchFilterValue {
-                    value: "weekly".to_string(),
-                    label: "This week".to_string(),
-                },
-                SearchFilterValue {
-                    value: "monthly".to_string(),
-                    label: "This month".to_string(),
-                },
-            ],
-            default: Some("alltime".to_string()),
-        },
-        SearchFilterDescriptor {
-            key: "category".to_string(),
-            display_name: "Category".to_string(),
-            allowed_values: category_values(),
-            default: None,
-        },
-        SearchFilterDescriptor {
-            key: "tags".to_string(),
-            display_name: "Tags".to_string(),
-            allowed_values: tag_values(),
-            default: None,
-        },
+        SearchFilterDescriptor::new(
+            "ordering",
+            "Sort by",
+            SearchFilterValue::list([
+                ("relevance", "Relevance"),
+                ("newest", "Newest"),
+                ("mostviewed", "Most viewed"),
+                ("rating", "Top rated"),
+                ("mostfavoured", "Most favoured"),
+            ]),
+            Some("relevance"),
+        ),
+        SearchFilterDescriptor::new(
+            "period",
+            "Time period",
+            SearchFilterValue::list([
+                ("alltime", "All time"),
+                ("weekly", "This week"),
+                ("monthly", "This month"),
+            ]),
+            Some("alltime"),
+        ),
+        SearchFilterDescriptor::new("category", "Category", category_values(), None),
+        SearchFilterDescriptor::new("tags", "Tags", tag_values(), None),
     ]
 }
 

--- a/crates/rdlp-extractor/src/extractors/redtube/filters.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/filters.rs
@@ -10,7 +10,7 @@ use rdlp_types::{SearchFilterDescriptor, SearchFilterValue};
 /// Sourced from the `redtube.Categories.getCategoriesList` API endpoint.
 /// Test/spam entries and non-adult categories are excluded.
 fn category_values() -> Vec<SearchFilterValue> {
-    [
+    SearchFilterValue::list([
         ("Amateur", "Amateur"),
         ("Anal", "Anal"),
         ("Arab", "Arab"),
@@ -94,13 +94,7 @@ fn category_values() -> Vec<SearchFilterValue> {
         ("Virtual Reality", "Virtual Reality"),
         ("Webcam", "Webcam"),
         ("Young and Old", "Young and Old"),
-    ]
-    .into_iter()
-    .map(|(value, label)| SearchFilterValue {
-        value: value.to_string(),
-        label: label.to_string(),
-    })
-    .collect()
+    ])
 }
 
 /// Build the list of common RedTube tag filter values.
@@ -110,7 +104,7 @@ fn category_values() -> Vec<SearchFilterValue> {
 /// non-English text, and overly-specific compound tags are excluded.
 /// Users can still type custom tags not in this list (free-text bypass).
 fn tag_values() -> Vec<SearchFilterValue> {
-    [
+    SearchFilterValue::list([
         ("18 year old", "18 Year Old"),
         ("amateur", "Amateur"),
         ("amateur couple", "Amateur Couple"),
@@ -165,13 +159,7 @@ fn tag_values() -> Vec<SearchFilterValue> {
         ("trans", "Trans"),
         ("vr", "VR"),
         ("yoga", "Yoga"),
-    ]
-    .into_iter()
-    .map(|(value, label)| SearchFilterValue {
-        value: value.to_string(),
-        label: label.to_string(),
-    })
-    .collect()
+    ])
 }
 
 /// Return the static filter descriptors for RedTube search.

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -226,50 +226,40 @@ pub(crate) fn validate_search_filters(
     filters: &[SearchFilter],
     descriptors: &[SearchFilterDescriptor],
 ) -> Result<()> {
-    for filter in filters {
-        let descriptor = descriptors.iter().find(|d| d.key == filter.key);
+    use crate::base::common::{FilterValidationError, KeyValidation, validate_against_descriptors};
 
-        match descriptor {
-            None => {
-                let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
-                return Err(RdlpError::Extraction {
-                    message: format!(
-                        "Unknown filter '{}' for RedTube. Available: {}",
-                        filter.key,
-                        valid_keys.join(", ")
-                    ),
-                    url: None,
-                });
-            }
-            Some(desc) => {
-                // "category" and "tags" have suggested values for UI display,
-                // but the API accepts arbitrary strings, so bypass strict validation.
-                if filter.key == "category" || filter.key == "tags" {
-                    continue;
-                }
-
-                let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
-                if !valid {
-                    let allowed: Vec<&str> = desc
-                        .allowed_values
-                        .iter()
-                        .map(|v| v.value.as_str())
-                        .collect();
-                    return Err(RdlpError::Extraction {
-                        message: format!(
-                            "Invalid value '{}' for filter '{}'. Allowed: {}",
-                            filter.value,
-                            filter.key,
-                            allowed.join(", ")
-                        ),
-                        url: None,
-                    });
-                }
-            }
-        }
-    }
-
-    Ok(())
+    validate_against_descriptors(
+        filters,
+        descriptors,
+        &[
+            ("category", KeyValidation::FreeText),
+            ("tags", KeyValidation::FreeText),
+        ],
+    )
+    .map_err(|e| match e {
+        FilterValidationError::UnknownKey { key, available } => RdlpError::Extraction {
+            message: format!(
+                "Unknown filter '{key}' for RedTube. Available: {}",
+                available.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } => RdlpError::Extraction {
+            message: format!(
+                "Invalid value '{value}' for filter '{key}'. Allowed: {}",
+                allowed.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
+            message: format!("Invalid value '{value}' for filter '{key}'. Must be a number."),
+            url: None,
+        },
+    })
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_helpers.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_helpers.rs
@@ -144,30 +144,30 @@ pub(crate) fn parse_pagination(html: &str) -> Option<usize> {
 /// # Errors
 /// Returns [`RdlpError::Extraction`] if an unrecognised key or value is encountered.
 pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
-    for filter in filters {
-        match filter.key.as_str() {
-            "ordering" => {
-                if !moviefap_search_patterns::VALID_ORDERINGS.contains(&filter.value.as_str()) {
-                    return Err(RdlpError::Extraction {
-                        message: format!(
-                            "Invalid MovieFap ordering value '{}'. Valid values: {}",
-                            filter.value,
-                            moviefap_search_patterns::VALID_ORDERINGS.join(", ")
-                        ),
-                        url: None,
-                    });
-                }
-            }
-            other => {
-                return Err(RdlpError::Extraction {
-                    message: format!("Unknown MovieFap search filter key '{other}'"),
-                    url: None,
-                });
-            }
-        }
-    }
+    use crate::base::common::{FilterValidationError, validate_against_descriptors};
 
-    Ok(())
+    let descriptors = moviefap_search_patterns::search_filter_descriptors();
+    validate_against_descriptors(filters, &descriptors, &[]).map_err(|e| match e {
+        FilterValidationError::UnknownKey { key, .. } => RdlpError::Extraction {
+            message: format!("Unknown MovieFap search filter key '{key}'"),
+            url: None,
+        },
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } => RdlpError::Extraction {
+            message: format!(
+                "Invalid MovieFap {key} value '{value}'. Valid values: {}",
+                allowed.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
+            message: format!("Invalid MovieFap {key} value '{value}'. Valid values: "),
+            url: None,
+        },
+    })
 }
 
 /// Parse the `.videoleft` element to extract duration and upload date strings.

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
@@ -37,33 +37,18 @@ pub fn build_search_url(query: &rdlp_types::SearchQuery, page: usize) -> String 
 /// # Supported Filters
 /// - `ordering` - Sort order (relevance, adddate, viewnum, rate, duration)
 pub fn search_filter_descriptors() -> Vec<rdlp_types::SearchFilterDescriptor> {
-    vec![rdlp_types::SearchFilterDescriptor {
-        key: "ordering".to_string(),
-        display_name: "Sort by".to_string(),
-        allowed_values: vec![
-            rdlp_types::SearchFilterValue {
-                value: "relevance".to_string(),
-                label: "Relevance".to_string(),
-            },
-            rdlp_types::SearchFilterValue {
-                value: "adddate".to_string(),
-                label: "Newest".to_string(),
-            },
-            rdlp_types::SearchFilterValue {
-                value: "viewnum".to_string(),
-                label: "Most Viewed".to_string(),
-            },
-            rdlp_types::SearchFilterValue {
-                value: "rate".to_string(),
-                label: "Top Rated".to_string(),
-            },
-            rdlp_types::SearchFilterValue {
-                value: "duration".to_string(),
-                label: "Duration".to_string(),
-            },
-        ],
-        default: Some("relevance".to_string()),
-    }]
+    vec![rdlp_types::SearchFilterDescriptor::new(
+        "ordering",
+        "Sort by",
+        rdlp_types::SearchFilterValue::list([
+            ("relevance", "Relevance"),
+            ("adddate", "Newest"),
+            ("viewnum", "Most Viewed"),
+            ("rate", "Top Rated"),
+            ("duration", "Duration"),
+        ]),
+        Some("relevance"),
+    )]
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search_patterns.rs
@@ -6,9 +6,6 @@
 /// MovieFap base URL.
 pub const MOVIEFAP_BASE_URL: &str = "https://www.moviefap.com";
 
-/// Valid sort options for MovieFap search.
-pub const VALID_ORDERINGS: &[&str] = &["relevance", "adddate", "viewnum", "rate", "duration"];
-
 /// Build a MovieFap search URL for a specific page.
 ///
 /// Format: `https://www.moviefap.com/search/{encoded_query}/{sort}/{page}`

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -272,42 +272,22 @@ pub fn search_filter_descriptors() -> Vec<rdlp_types::SearchFilterDescriptor> {
     let category_values: Vec<rdlp_types::SearchFilterValue> = BROWSE_SECTIONS
         .iter()
         .chain(BROWSE_CATEGORIES.iter())
-        .map(|&slug| rdlp_types::SearchFilterValue {
-            value: slug.to_string(),
-            label: slug_to_label(slug),
-        })
+        .map(|&slug| rdlp_types::SearchFilterValue::new(slug, slug_to_label(slug)))
         .collect();
 
     vec![
-        rdlp_types::SearchFilterDescriptor {
-            key: "ordering".to_string(),
-            display_name: "Sort by".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "featured".to_string(),
-                    label: "Featured".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "newest".to_string(),
-                    label: "Newest".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "duration".to_string(),
-                    label: "Longest".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "rating".to_string(),
-                    label: "Top rated".to_string(),
-                },
-            ],
-            default: Some("featured".to_string()),
-        },
-        rdlp_types::SearchFilterDescriptor {
-            key: "category".to_string(),
-            display_name: "Category".to_string(),
-            allowed_values: category_values,
-            default: None,
-        },
+        rdlp_types::SearchFilterDescriptor::new(
+            "ordering",
+            "Sort by",
+            rdlp_types::SearchFilterValue::list([
+                ("featured", "Featured"),
+                ("newest", "Newest"),
+                ("duration", "Longest"),
+                ("rating", "Top rated"),
+            ]),
+            Some("featured"),
+        ),
+        rdlp_types::SearchFilterDescriptor::new("category", "Category", category_values, None),
     ]
 }
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search_patterns.rs
@@ -163,17 +163,6 @@ pub fn build_search_url_page(query: &rdlp_types::SearchQuery, page: usize) -> St
     url
 }
 
-/// Check whether a value is a valid browse section or category slug.
-///
-/// # Arguments
-/// * `value` - The slug to validate.
-///
-/// # Returns
-/// `true` if the value matches a known browse section or category slug.
-pub fn is_valid_category(value: &str) -> bool {
-    BROWSE_SECTIONS.contains(&value) || BROWSE_CATEGORIES.contains(&value)
-}
-
 /// Build a browse URL for page 1 of a section or category for the given base URL.
 ///
 /// # Arguments
@@ -393,30 +382,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_valid_category_sections() {
-        assert!(is_valid_category("new"));
-        assert!(is_valid_category("toprated"));
-        assert!(is_valid_category("featured"));
-    }
-
-    #[test]
-    fn test_is_valid_category_slugs() {
-        assert!(is_valid_category("teen-porn"));
-        assert!(is_valid_category("milf-porn"));
-        assert!(is_valid_category("hd-videos"));
-        assert!(is_valid_category("threesome-sex"));
-        assert!(is_valid_category("webcam-shows"));
-        assert!(is_valid_category("big-boobs"));
-    }
-
-    #[test]
-    fn test_is_valid_category_rejects_unknown() {
-        assert!(!is_valid_category("unknown"));
-        assert!(!is_valid_category(""));
-        assert!(!is_valid_category("not-a-category"));
-    }
-
-    #[test]
     fn test_build_browse_url() {
         assert_eq!(build_browse_url("new"), "https://www.tnaflix.com/new");
         assert_eq!(
@@ -590,19 +555,6 @@ mod tests {
         let url = build_search_url_for("https://www.empflix.com", &query);
         assert!(url.contains("&ordering=newest"));
         assert!(url.contains("&other=val"));
-    }
-
-    // is_valid_category negative (renamed to avoid duplicate)
-
-    #[test]
-    fn test_is_valid_category_rejects_empty() {
-        assert!(!is_valid_category(""));
-    }
-
-    #[test]
-    fn test_is_valid_category_case_sensitive() {
-        assert!(!is_valid_category("New"));
-        assert!(!is_valid_category("TEEN-PORN"));
     }
 
     // slug_to_label edge cases

--- a/crates/rdlp-extractor/src/extractors/tnaflix/tnaflix_search_helpers.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/tnaflix_search_helpers.rs
@@ -495,6 +495,25 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_search_filters_category_case_sensitive() {
+        // Category matching is case-sensitive: a differently-cased form of a
+        // valid slug/section must be rejected (regression guard for the removed
+        // is_valid_category case-sensitivity check, now enforced via the
+        // descriptor-driven AllowedValues path).
+        let upper_section = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "New".to_string(), // valid slug is "new"
+        }];
+        assert!(validate_search_filters(&upper_section).is_err());
+
+        let upper_slug = vec![SearchFilter {
+            key: "category".to_string(),
+            value: "TEEN-PORN".to_string(), // valid slug is "teen-porn"
+        }];
+        assert!(validate_search_filters(&upper_slug).is_err());
+    }
+
+    #[test]
     fn test_validate_search_filters_invalid_category() {
         let filters = vec![SearchFilter {
             key: "category".to_string(),

--- a/crates/rdlp-extractor/src/extractors/tnaflix/tnaflix_search_helpers.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/tnaflix_search_helpers.rs
@@ -176,43 +176,43 @@ pub fn parse_pagination(html: &str) -> Option<usize> {
 /// # Errors
 /// Returns [`RdlpError::Extraction`] if an unrecognised key or value is encountered.
 pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
-    const VALID_ORDERINGS: &[&str] = &["featured", "newest", "duration", "rating"];
+    use crate::base::common::{FilterValidationError, validate_against_descriptors};
 
-    for filter in filters {
-        match filter.key.as_str() {
-            "ordering" => {
-                if !VALID_ORDERINGS.contains(&filter.value.as_str()) {
-                    return Err(RdlpError::Extraction {
-                        message: format!(
-                            "Invalid TNAFlix ordering value '{}'. Valid values: {}",
-                            filter.value,
-                            VALID_ORDERINGS.join(", ")
-                        ),
-                        url: None,
-                    });
-                }
-            }
-            "category" => {
-                if !search_patterns::is_valid_category(&filter.value) {
-                    return Err(RdlpError::Extraction {
-                        message: format!(
-                            "Invalid TNAFlix category '{}'. Use search_filters() to see valid values.",
-                            filter.value
-                        ),
-                        url: None,
-                    });
-                }
-            }
-            other => {
-                return Err(RdlpError::Extraction {
-                    message: format!("Unknown TNAFlix search filter key '{other}'"),
-                    url: None,
-                });
+    let descriptors = search_patterns::search_filter_descriptors();
+    validate_against_descriptors(filters, &descriptors, &[]).map_err(|e| match e {
+        FilterValidationError::UnknownKey { key, .. } => RdlpError::Extraction {
+            message: format!("Unknown TNAFlix search filter key '{key}'"),
+            url: None,
+        },
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } if key == "category" => {
+            let _ = allowed;
+            RdlpError::Extraction {
+                message: format!(
+                    "Invalid TNAFlix category '{value}'. Use search_filters() to see valid values."
+                ),
+                url: None,
             }
         }
-    }
-
-    Ok(())
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } => RdlpError::Extraction {
+            message: format!(
+                "Invalid TNAFlix {key} value '{value}'. Valid values: {}",
+                allowed.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
+            message: format!("Invalid TNAFlix {key} value '{value}'. Valid values: "),
+            url: None,
+        },
+    })
 }
 
 /// Parse a duration string like `"12:34"` or `"1:23:45"` into seconds.

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -99,60 +99,41 @@ pub fn parse_max_pages(initials: &Value) -> Option<usize> {
 
 /// Validate search filters against the known xHamster filter descriptors.
 pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
+    use crate::base::common::{FilterValidationError, KeyValidation, validate_against_descriptors};
+
     let descriptors = patterns::search_filter_descriptors();
-
-    for filter in filters {
-        let descriptor = descriptors.iter().find(|d| d.key == filter.key);
-
-        match descriptor {
-            None => {
-                let valid_keys: Vec<&str> = descriptors.iter().map(|d| d.key.as_str()).collect();
-                return Err(RdlpError::Extraction {
-                    message: format!(
-                        "Unknown filter '{}' for XHamster. Available: {}",
-                        filter.key,
-                        valid_keys.join(", ")
-                    ),
-                    url: None,
-                });
-            }
-            Some(desc) => {
-                // Duration min/max are numeric, allow any reasonable value
-                if filter.key == "min-duration" || filter.key == "max-duration" {
-                    if filter.value.parse::<u32>().is_err() {
-                        return Err(RdlpError::Extraction {
-                            message: format!(
-                                "Invalid value '{}' for filter '{}'. Must be a number.",
-                                filter.value, filter.key
-                            ),
-                            url: None,
-                        });
-                    }
-                    continue;
-                }
-
-                let valid = desc.allowed_values.iter().any(|v| v.value == filter.value);
-                if !valid {
-                    let allowed: Vec<&str> = desc
-                        .allowed_values
-                        .iter()
-                        .map(|v| v.value.as_str())
-                        .collect();
-                    return Err(RdlpError::Extraction {
-                        message: format!(
-                            "Invalid value '{}' for filter '{}'. Allowed: {}",
-                            filter.value,
-                            filter.key,
-                            allowed.join(", ")
-                        ),
-                        url: None,
-                    });
-                }
-            }
-        }
-    }
-
-    Ok(())
+    validate_against_descriptors(
+        filters,
+        &descriptors,
+        &[
+            ("min-duration", KeyValidation::NumericU32),
+            ("max-duration", KeyValidation::NumericU32),
+        ],
+    )
+    .map_err(|e| match e {
+        FilterValidationError::UnknownKey { key, available } => RdlpError::Extraction {
+            message: format!(
+                "Unknown filter '{key}' for XHamster. Available: {}",
+                available.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } => RdlpError::Extraction {
+            message: format!(
+                "Invalid value '{value}' for filter '{key}'. Allowed: {}",
+                allowed.join(", ")
+            ),
+            url: None,
+        },
+        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
+            message: format!("Invalid value '{value}' for filter '{key}'. Must be a number."),
+            url: None,
+        },
+    })
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/xhamster/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search_patterns.rs
@@ -57,140 +57,71 @@ pub fn build_search_url_page(query: &rdlp_types::SearchQuery, page: usize) -> St
 /// Return the static filter descriptors for xHamster search.
 pub fn search_filter_descriptors() -> Vec<rdlp_types::SearchFilterDescriptor> {
     vec![
-        rdlp_types::SearchFilterDescriptor {
-            key: "quality".to_string(),
-            display_name: "Minimum quality".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "720p".to_string(),
-                    label: "720p+".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "1080p".to_string(),
-                    label: "1080p+".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "2160p".to_string(),
-                    label: "4K+".to_string(),
-                },
-            ],
-            default: None,
-        },
-        rdlp_types::SearchFilterDescriptor {
-            key: "sort".to_string(),
-            display_name: "Sort by".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "relevance".to_string(),
-                    label: "Relevance".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "newest".to_string(),
-                    label: "Newest".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "views".to_string(),
-                    label: "Most viewed".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "best".to_string(),
-                    label: "Top rated".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "longest".to_string(),
-                    label: "Longest".to_string(),
-                },
-            ],
-            default: Some("relevance".to_string()),
-        },
-        rdlp_types::SearchFilterDescriptor {
-            key: "orientations".to_string(),
-            display_name: "Orientation".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "straight".to_string(),
-                    label: "Straight".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "gay".to_string(),
-                    label: "Gay".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "shemale".to_string(),
-                    label: "Transgender".to_string(),
-                },
-            ],
-            default: None,
-        },
-        rdlp_types::SearchFilterDescriptor {
-            key: "date".to_string(),
-            display_name: "Upload date".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "daily".to_string(),
-                    label: "Last 24 hours".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "weekly".to_string(),
-                    label: "This week".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "monthly".to_string(),
-                    label: "This month".to_string(),
-                },
-            ],
-            default: None,
-        },
-        rdlp_types::SearchFilterDescriptor {
-            key: "min-duration".to_string(),
-            display_name: "Min duration".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "2".to_string(),
-                    label: "2 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "5".to_string(),
-                    label: "5 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "10".to_string(),
-                    label: "10 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "30".to_string(),
-                    label: "30 min".to_string(),
-                },
-            ],
-            default: None,
-        },
-        rdlp_types::SearchFilterDescriptor {
-            key: "max-duration".to_string(),
-            display_name: "Max duration".to_string(),
-            allowed_values: vec![
-                rdlp_types::SearchFilterValue {
-                    value: "2".to_string(),
-                    label: "2 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "5".to_string(),
-                    label: "5 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "10".to_string(),
-                    label: "10 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "30".to_string(),
-                    label: "30 min".to_string(),
-                },
-                rdlp_types::SearchFilterValue {
-                    value: "40".to_string(),
-                    label: "40+ min".to_string(),
-                },
-            ],
-            default: None,
-        },
+        rdlp_types::SearchFilterDescriptor::new(
+            "quality",
+            "Minimum quality",
+            rdlp_types::SearchFilterValue::list([
+                ("720p", "720p+"),
+                ("1080p", "1080p+"),
+                ("2160p", "4K+"),
+            ]),
+            None,
+        ),
+        rdlp_types::SearchFilterDescriptor::new(
+            "sort",
+            "Sort by",
+            rdlp_types::SearchFilterValue::list([
+                ("relevance", "Relevance"),
+                ("newest", "Newest"),
+                ("views", "Most viewed"),
+                ("best", "Top rated"),
+                ("longest", "Longest"),
+            ]),
+            Some("relevance"),
+        ),
+        rdlp_types::SearchFilterDescriptor::new(
+            "orientations",
+            "Orientation",
+            rdlp_types::SearchFilterValue::list([
+                ("straight", "Straight"),
+                ("gay", "Gay"),
+                ("shemale", "Transgender"),
+            ]),
+            None,
+        ),
+        rdlp_types::SearchFilterDescriptor::new(
+            "date",
+            "Upload date",
+            rdlp_types::SearchFilterValue::list([
+                ("daily", "Last 24 hours"),
+                ("weekly", "This week"),
+                ("monthly", "This month"),
+            ]),
+            None,
+        ),
+        rdlp_types::SearchFilterDescriptor::new(
+            "min-duration",
+            "Min duration",
+            rdlp_types::SearchFilterValue::list([
+                ("2", "2 min"),
+                ("5", "5 min"),
+                ("10", "10 min"),
+                ("30", "30 min"),
+            ]),
+            None,
+        ),
+        rdlp_types::SearchFilterDescriptor::new(
+            "max-duration",
+            "Max duration",
+            rdlp_types::SearchFilterValue::list([
+                ("2", "2 min"),
+                ("5", "5 min"),
+                ("10", "10 min"),
+                ("30", "30 min"),
+                ("40", "40+ min"),
+            ]),
+            None,
+        ),
     ]
 }
 

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -81,52 +81,28 @@ fn resolve_sort_by(query: &SearchQuery) -> String {
 /// Return the filter descriptors for XTits search.
 pub(crate) fn search_filter_descriptors() -> Vec<SearchFilterDescriptor> {
     vec![
-        SearchFilterDescriptor {
-            key: "ordering".to_string(),
-            display_name: "Sort By".to_string(),
-            default: Some("relevance".to_string()),
-            allowed_values: vec![
-                SearchFilterValue {
-                    value: "relevance".to_string(),
-                    label: "Relevance".to_string(),
-                },
-                SearchFilterValue {
-                    value: "newest".to_string(),
-                    label: "Newest".to_string(),
-                },
-                SearchFilterValue {
-                    value: "rating".to_string(),
-                    label: "Top Rated".to_string(),
-                },
-                SearchFilterValue {
-                    value: "mostviewed".to_string(),
-                    label: "Most Viewed".to_string(),
-                },
-            ],
-        },
-        SearchFilterDescriptor {
-            key: "period".to_string(),
-            display_name: "Time Period".to_string(),
-            default: Some("alltime".to_string()),
-            allowed_values: vec![
-                SearchFilterValue {
-                    value: "alltime".to_string(),
-                    label: "All Time".to_string(),
-                },
-                SearchFilterValue {
-                    value: "monthly".to_string(),
-                    label: "This Month".to_string(),
-                },
-                SearchFilterValue {
-                    value: "weekly".to_string(),
-                    label: "This Week".to_string(),
-                },
-                SearchFilterValue {
-                    value: "today".to_string(),
-                    label: "Today".to_string(),
-                },
-            ],
-        },
+        SearchFilterDescriptor::new(
+            "ordering",
+            "Sort By",
+            SearchFilterValue::list([
+                ("relevance", "Relevance"),
+                ("newest", "Newest"),
+                ("rating", "Top Rated"),
+                ("mostviewed", "Most Viewed"),
+            ]),
+            Some("relevance"),
+        ),
+        SearchFilterDescriptor::new(
+            "period",
+            "Time Period",
+            SearchFilterValue::list([
+                ("alltime", "All Time"),
+                ("monthly", "This Month"),
+                ("weekly", "This Week"),
+                ("today", "Today"),
+            ]),
+            Some("alltime"),
+        ),
     ]
 }
 

--- a/crates/rdlp-types/src/search.rs
+++ b/crates/rdlp-types/src/search.rs
@@ -46,6 +46,48 @@ pub struct SearchFilterValue {
     pub label: String,
 }
 
+impl SearchFilterValue {
+    /// Construct a filter value from a machine value and human-readable label.
+    #[must_use]
+    pub fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+        }
+    }
+
+    /// Build a value list from a `(value, label)` pair table.
+    ///
+    /// The per-site *data* stays at the call site; this removes only the
+    /// repeated `SearchFilterValue { value: ….to_string(), … }` construction
+    /// mechanic shared across every site's filter table.
+    #[must_use]
+    pub fn list<'a>(pairs: impl IntoIterator<Item = (&'a str, &'a str)>) -> Vec<Self> {
+        pairs.into_iter().map(|(v, l)| Self::new(v, l)).collect()
+    }
+}
+
+impl SearchFilterDescriptor {
+    /// Construct a filter descriptor.
+    ///
+    /// `default` is `Option<&str>` (not `impl Into<Option<String>>`, which would
+    /// reject `Some("x")` and reintroduce `.to_string()` boilerplate at callers).
+    #[must_use]
+    pub fn new(
+        key: impl Into<String>,
+        display_name: impl Into<String>,
+        allowed_values: Vec<SearchFilterValue>,
+        default: Option<&str>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            display_name: display_name.into(),
+            allowed_values,
+            default: default.map(str::to_string),
+        }
+    }
+}
+
 /// A lightweight preview of a single search result.
 ///
 /// Does NOT contain full format/download information. Callers that need
@@ -160,5 +202,61 @@ mod tests {
             value: "newest".to_string(),
         };
         assert_eq!(f1, f2);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)] // test assertions index short, known-length Vecs
+mod filter_ctor_tests {
+    use super::{SearchFilterDescriptor, SearchFilterValue};
+
+    #[test]
+    fn value_new_from_str_and_string() {
+        let a = SearchFilterValue::new("v", "L");
+        assert_eq!(a.value, "v");
+        assert_eq!(a.label, "L");
+        let b = SearchFilterValue::new(String::from("v2"), String::from("L2"));
+        assert_eq!(
+            b,
+            SearchFilterValue {
+                value: "v2".into(),
+                label: "L2".into()
+            }
+        );
+    }
+
+    #[test]
+    fn value_list_maps_table() {
+        let out = SearchFilterValue::list([("a", "A"), ("b", "B")]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], SearchFilterValue::new("a", "A"));
+        assert_eq!(out[1].label, "B");
+    }
+
+    #[test]
+    fn value_list_empty_is_empty() {
+        let out = SearchFilterValue::list([]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn descriptor_new_some_default() {
+        let d = SearchFilterDescriptor::new(
+            "ordering",
+            "Sort by",
+            SearchFilterValue::list([("newest", "Newest")]),
+            Some("newest"),
+        );
+        assert_eq!(d.key, "ordering");
+        assert_eq!(d.display_name, "Sort by");
+        assert_eq!(d.allowed_values.len(), 1);
+        assert_eq!(d.default, Some("newest".to_string()));
+    }
+
+    #[test]
+    fn descriptor_new_none_default() {
+        let d = SearchFilterDescriptor::new("tags", "Tags", vec![], None);
+        assert_eq!(d.default, None);
+        assert!(d.allowed_values.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Behavior-preserving dedup of `rdlp-extractor`'s per-site **search-filter** code onto shared, idiomatic constructors + one typed-error validator. Refs #440 (Initiative #5).

Three overlapping duplication surfaces collapsed:
- **Descriptor construction** (7 sites) → `SearchFilterDescriptor::new` + `SearchFilterValue::list`
- **Value tables** (`category_values`/`tag_values`) → `SearchFilterValue::list`
- **Validators** (5 sites, 2 families) → one shared `validate_against_descriptors` returning a data-only `FilterValidationError`; each site maps it to its exact `RdlpError` string at the boundary (producer returns data, consumer formats)

The Family-2 (TNAFlix/MovieFap) migration also removes a genuine DRY defect: their `VALID_ORDERINGS` consts and `is_valid_category` duplicated the descriptor data those same sites already build. The descriptors are now the single source of truth for valid filter values.

## What changed

- **`rdlp-types`** (pure-data foundation, additive only): `SearchFilterValue::new`/`::list`, `SearchFilterDescriptor::new`. No field-layout / serde / wire-format change.
- **`rdlp-extractor`**: shared `validate_against_descriptors(filters, descriptors, overrides) -> std::result::Result<(), FilterValidationError>` + `FilterValidationError`/`KeyValidation` in `base::common::search`; 7 descriptor builders + 3 value tables + 5 validators migrated; `VALID_ORDERINGS` ×2 and `is_valid_category` deleted.
- **`.dupes-ignore.toml`**: dropped the two now-collapsed #440 fingerprints (`c280dd2ab56d298f` descriptors, `b1f95f057f50ca9e` value tables). Kept `c779eff5aef82766` (XNXX↔SpankBang `search_page`, still deferred).

## Behavior preservation

Every existing per-site error string is reproduced **byte-for-byte**; no existing test was edited. The per-site `test_search_filter_descriptors_*` and exact-string validator tests are the regression guard and stay green. One test was **added** — a TNAFlix category case-sensitivity guard on the public validator path — to restore coverage lost when `is_valid_category`'s direct unit tests were deleted alongside the helper.

## Verification

Full pre-push gate green:
`cargo fmt --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo check -p rdlp-desktop && bash scripts/check-dedup.sh && bash scripts/check-url-redaction.sh && bash scripts/check-no-cli.sh && bash scripts/check-wit-drift.sh && bash scripts/check-log-redaction.sh`

The dedup gate confirms **no new fingerprint fires** for the collapsed builders (they fall below the similarity threshold).

## Reviews

- **security-reviewer** (Opus): **Approve** — validation-parity verified equivalent for all 5 migrated validators; no validation loosening, no info disclosure (`url: None` everywhere), no injection/panic/DoS surface.
- **code-reviewer** (Opus): **Approve** — byte-exact strings verified all 5 sites; deletions unreferenced; imports clean; cross-task consistency OK. 3 Minor non-blocking notes.

## Follow-up

- The 3 shared-family `.map_err` blocks (PornHub/RedTube/XHamster) could optionally collapse into a `format_std_filter_error(site, e)` helper (~40 lines, zero wording change). Deferred as a follow-up per the design's deliberate consumer-formats split.
- Remaining #440 deferral unchanged: XNXX↔SpankBang `search_page` (`c779eff5aef82766`) — a genuine 2-instance pair with load-bearing behavioral divergence (per-request `Cookie` header), kept deferred per the design.

Refs #440
