### PR TITLE
chore(tooling): PR-template Resolves section + audit-issues.sh (#443)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,21 @@
 
 <!-- 1–3 sentences: what changed and why. -->
 
+## Resolves
+
+<!--
+Link the issue(s) this PR touches. Pick ONE per issue and put the keyword line
+below (GitHub auto-closes `Closes`/`Fixes`/`Resolves #N` on merge to `develop`,
+the default branch). If the PR touches NO issue, say so explicitly.
+-->
+
+- [ ] **Fully resolves** an issue's core acceptance → use `Closes #NNN` (auto-closes on merge)
+- [ ] **Partial / tracking** issue that must stay open → use `Refs #NNN` **and** note what remains + a follow-up issue number
+- [ ] **No issue** — self-directed / trivial (state why below)
+
+<!-- Keyword line(s) — required unless "No issue" is checked: -->
+Closes #
+
 ## Type of change
 
 <!-- Mark with [x] -->

--- a/scripts/audit-issues.sh
+++ b/scripts/audit-issues.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Issue-hygiene reconciliation report (read-only; makes no changes).
+#
+# Surfaces the rot patterns that let issues drift out of sync with the code,
+# per issue-tracking-discipline. Run it on demand, or before declaring a sprint
+# complete:
+#
+#   1a. A PR said `Closes/Fixes/Resolves #N` but #N is STILL OPEN — a real bug:
+#       auto-close failed (wrong base branch, or manually reopened). Investigate.
+#   1b. A PR said `Refs #N` (non-closing) and #N is open — usually intentional
+#       (partial/tracking); listed so you can confirm it's still meant to stay open.
+#       This is the #390/#391 rot bucket when the work actually shipped.
+#   2.  Merged PRs with NO issue keyword at all — the #435 rot: scope merged
+#       without ever linking an issue. Link scope going forward.
+#   3.  Open issues with no activity in a while — candidates to close or split.
+#
+# It does NOT close anything — closure is a human/agent judgement call (verify
+# the acceptance criteria against the code first). It only points at candidates.
+#
+# Usage:
+#   scripts/audit-issues.sh                 # defaults: 40 recent merged PRs, 90-day stale
+#   PR_SCAN=80 STALE_DAYS=60 scripts/audit-issues.sh
+#
+# Requires: gh (authenticated), jq.
+
+set -euo pipefail
+
+PR_SCAN="${PR_SCAN:-40}"       # how many recently-merged PRs to scan
+STALE_DAYS="${STALE_DAYS:-90}" # open-issue inactivity threshold (days)
+
+# Auto-closing keywords (fire on merge to the default branch) vs the linking-
+# but-non-closing `Refs`. GitHub's recognized closing verbs: close/closes/closed,
+# fix/fixes/fixed, resolve/resolves/resolved.
+CLOSING_RE='[Cc]los(e|es|ed)|[Ff]ix(es|ed)?|[Rr]esolv(e|es|ed)'
+REFS_RE='[Rr]efs?'
+
+for bin in gh jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "error: '$bin' is required but not on PATH." >&2
+    exit 1
+  fi
+done
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: 'gh' is not authenticated. Run 'gh auth login'." >&2
+  exit 1
+fi
+
+echo "=== Issue-hygiene reconciliation (read-only) ==="
+echo "Scanning the $PR_SCAN most recently-merged PRs; stale threshold ${STALE_DAYS}d."
+echo
+
+# Set of currently-open issue numbers (one lookup, reused below).
+open_issues="$(gh issue list --state open --limit 300 --json number --jq '.[].number')"
+is_open() { grep -qxF "$1" <<<"$open_issues"; }
+
+# Pull issue numbers that follow a keyword class in a PR body.
+refs_for() { grep -oiE "($1)[[:space:]]+#[0-9]+" <<<"$2" | grep -oE '[0-9]+' | sort -u || true; }
+
+bug_lines=""      # 1a: Closes-but-still-open
+refs_lines=""     # 1b: Refs-and-open
+unlinked_lines="" # 2:  no keyword
+
+while IFS=$'\t' read -r pr_num pr_title pr_body; do
+  closing="$(refs_for "$CLOSING_RE" "$pr_body")"
+  refs="$(refs_for "$REFS_RE" "$pr_body")"
+
+  if [[ -z "$closing" && -z "$refs" ]]; then
+    unlinked_lines+="   PR #${pr_num}  ${pr_title}"$'\n'
+    continue
+  fi
+  while read -r n; do
+    [[ -z "$n" ]] && continue
+    is_open "$n" && bug_lines+="   PR #${pr_num} said Closes #${n} but #${n} is OPEN  —  ${pr_title}"$'\n'
+  done <<<"$closing"
+  while read -r n; do
+    [[ -z "$n" ]] && continue
+    is_open "$n" && refs_lines+="   PR #${pr_num} → Refs #${n} (OPEN)  —  ${pr_title}"$'\n'
+  done <<<"$refs"
+done < <(gh pr list --state merged --limit "$PR_SCAN" \
+           --json number,title,body \
+           --jq '.[] | [(.number|tostring), .title, (.body // "" | gsub("[\t\n]"; " "))] | @tsv')
+
+echo "## 1a. PR said Closes/Fixes/Resolves but the issue is STILL OPEN (real bug — investigate)"
+echo
+[[ -n "$bug_lines" ]] && printf '%s' "$bug_lines" || echo "   (none — every auto-close keyword resolved)"
+echo
+echo "## 1b. PR said Refs (non-closing) and the issue is open (confirm still meant to stay open)"
+echo "   (this is the #390/#391 rot bucket when the work actually shipped)"
+echo
+[[ -n "$refs_lines" ]] && printf '%s' "$refs_lines" || echo "   (none)"
+echo
+echo "## 2. Merged PRs with NO issue keyword (the #435 pattern — link scope going forward)"
+echo
+[[ -n "$unlinked_lines" ]] && printf '%s' "$unlinked_lines" || echo "   (none — every scanned merged PR links an issue)"
+echo
+
+echo "## 3. Open issues with no activity in > ${STALE_DAYS} days (review: close, split, or ping)"
+echo
+gh issue list --state open --limit 300 --json number,title,updatedAt \
+  | jq -r --arg days "$STALE_DAYS" '
+      (now - ($days | tonumber) * 86400) as $cutoff
+      | map(select((.updatedAt | fromdateiso8601) < $cutoff))
+      | sort_by(.updatedAt)
+      | .[]
+      | "   #\(.number)  (\(.updatedAt[0:10]))  \(.title)"
+    '
+[[ "${PIPESTATUS[1]}" -eq 0 ]] || true
+echo
+echo "=== end ==="
+echo "Note: this report only flags candidates. Verify each issue's acceptance"
+echo "criteria against the current code before closing (see issue-tracking-discipline)."


### PR DESCRIPTION
## Summary

Repo-side issue-discipline tooling, from the 2026-07-10 stale-issue audit that found #390/#391 had shipped but never closed. Leverages the fact that the default branch is `develop`, so `Closes/Fixes/Resolves #N` already auto-closes on merge — the gap was habit + reconciliation, not mechanism.

## Resolves

- [x] **Fully resolves** an issue's core acceptance → `Closes #443`

Closes #443

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — new `## Resolves` section forcing the `Closes` (auto-close) vs `Refs` (partial/tracking) vs `No issue` choice per PR.
- **`scripts/audit-issues.sh`** — read-only `gh`-based reconciliation report: (1a) PRs that said `Closes` but the issue is still open (real auto-close failure), (1b) `Refs`-and-open (confirm intent — the #390/#391 rot bucket), (2) merged PRs with no issue keyword (the #435 pattern), (3) open issues stale > N days. Closes nothing; flags candidates only.

## Test plan

- [x] `scripts/audit-issues.sh` validated live: correctly reports the 4 unlinked merged PRs, flags #440 as intentional-`Refs`, and 1a/3 empty (no failed auto-close, nothing >90d stale).
- [x] `cargo fmt --check` + all 5 `scripts/check-*.sh` gate scripts pass (no Rust touched — dev-only script + template).

No Rust/build changes; the cargo compile/test state is unchanged from the just-merged #441 full-green gate.

Closes #443
