### PR TITLE
perf(rdlp-extractor): drop BaseURL clones in DASH resolve_chain

### DIFF
--- a/crates/rdlp-extractor/src/base/common/dash/baseurl.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/baseurl.rs
@@ -3,29 +3,28 @@
 use url::Url;
 
 /// Resolve a BaseURL chain. Each level (MPD, AdaptationSet, Representation)
-/// may add zero or more `<BaseURL>` entries. Each is joined against the
-/// previous endpoint via RFC 3986. Returns the final base URL the
-/// segment URLs should be resolved against.
+/// contributes at most one `<BaseURL>` — the first entry, since the DASH spec
+/// lets a level carry several for CDN failover and CDN-rotation is not in
+/// scope. Picking that first entry is the *caller's* responsibility: each
+/// level is passed as an `Option<&str>` (`None` = the level adds no BaseURL),
+/// so no owned copies of the unused failover entries are ever made. Each
+/// present entry is joined against the previous endpoint via RFC 3986.
+/// Returns the final base URL the segment URLs should be resolved against.
 ///
 /// `mpd_url` is the URL the MPD itself was fetched from (the implicit
 /// "level 0" BaseURL).
 pub fn resolve_chain<'a, I>(mpd_url: &Url, levels: I) -> Url
 where
-    I: IntoIterator<Item = &'a [String]>,
+    I: IntoIterator<Item = Option<&'a str>>,
 {
     let mut current = mpd_url.clone();
-    for level in levels {
-        // DASH spec: each level may have multiple <BaseURL> entries
-        // (CDN failover). We pick the first; CDN-rotation is not in scope.
-        if let Some(first) = level.first() {
-            match current.join(first) {
-                Ok(joined) => current = joined,
-                Err(e) => {
-                    log::warn!(
-                        "DASH BaseURL chain: failed to resolve {first:?} against {current}: {e}; skipping this level"
-                    );
-                    continue;
-                }
+    for first in levels.into_iter().flatten() {
+        match current.join(first) {
+            Ok(joined) => current = joined,
+            Err(e) => {
+                log::warn!(
+                    "DASH BaseURL chain: failed to resolve {first:?} against {current}: {e}; skipping this level"
+                );
             }
         }
     }
@@ -39,59 +38,48 @@ mod tests {
     #[test]
     fn empty_chain_returns_mpd_url() {
         let mpd = Url::parse("https://cdn.example.com/manifest.mpd").unwrap();
-        let resolved = resolve_chain(&mpd, std::iter::empty());
+        let resolved = resolve_chain(&mpd, std::iter::empty::<Option<&str>>());
         assert_eq!(resolved.as_str(), "https://cdn.example.com/manifest.mpd");
     }
 
     #[test]
     fn mpd_level_baseurl_replaces() {
         let mpd = Url::parse("https://cdn.example.com/manifest.mpd").unwrap();
-        let mpd_levels: Vec<String> = vec!["https://cdn.example.com/segments/".into()];
-        let resolved = resolve_chain(&mpd, [mpd_levels.as_slice()]);
+        let resolved = resolve_chain(&mpd, [Some("https://cdn.example.com/segments/")]);
         assert_eq!(resolved.as_str(), "https://cdn.example.com/segments/");
     }
 
     #[test]
     fn relative_baseurl_resolves_against_mpd() {
         let mpd = Url::parse("https://cdn.example.com/path/manifest.mpd").unwrap();
-        let mpd_levels: Vec<String> = vec!["segments/".into()];
-        let resolved = resolve_chain(&mpd, [mpd_levels.as_slice()]);
+        let resolved = resolve_chain(&mpd, [Some("segments/")]);
         assert_eq!(resolved.as_str(), "https://cdn.example.com/path/segments/");
     }
 
     #[test]
     fn three_level_chain() {
         let mpd = Url::parse("https://a.com/m.mpd").unwrap();
-        let mpd_lvl: Vec<String> = vec!["base/".into()];
-        let adapt_lvl: Vec<String> = vec!["video/".into()];
-        let repr_lvl: Vec<String> = vec!["1080p/".into()];
-        let resolved = resolve_chain(
-            &mpd,
-            [
-                mpd_lvl.as_slice(),
-                adapt_lvl.as_slice(),
-                repr_lvl.as_slice(),
-            ],
-        );
+        let resolved = resolve_chain(&mpd, [Some("base/"), Some("video/"), Some("1080p/")]);
         assert_eq!(resolved.as_str(), "https://a.com/base/video/1080p/");
     }
 
     #[test]
     fn empty_inner_level_is_skipped() {
         let mpd = Url::parse("https://a.com/m.mpd").unwrap();
-        let empty: Vec<String> = vec![];
-        let with_value: Vec<String> = vec!["video/".into()];
-        let resolved = resolve_chain(&mpd, [empty.as_slice(), with_value.as_slice()]);
-        // Empty level adds nothing; chain proceeds with second level.
+        // `None` level adds nothing; chain proceeds with the next level.
+        let resolved = resolve_chain(&mpd, [None, Some("video/")]);
         assert_eq!(resolved.as_str(), "https://a.com/video/");
     }
 
     #[test]
-    fn multi_entry_level_only_first_consumed() {
+    fn caller_selects_first_entry_of_multi_baseurl_level() {
         let mpd = Url::parse("https://a.com/m.mpd").unwrap();
-        // Two CDN-failover entries; spec lets us pick any, we pick first.
-        let cdn_failover: Vec<String> = vec!["primary/".into(), "fallback/".into()];
-        let resolved = resolve_chain(&mpd, [cdn_failover.as_slice()]);
+        // A level may carry several <BaseURL> entries (CDN failover). The
+        // caller selects the first via `.first()` — mirroring the exact
+        // expression used in expand.rs — and resolve_chain resolves that one;
+        // the fallback entry is never touched (and never cloned).
+        let cdn_failover = ["primary/".to_string(), "fallback/".to_string()];
+        let resolved = resolve_chain(&mpd, [cdn_failover.first().map(String::as_str)]);
         assert_eq!(resolved.as_str(), "https://a.com/primary/");
     }
 }

--- a/crates/rdlp-extractor/src/base/common/dash/expand.rs
+++ b/crates/rdlp-extractor/src/base/common/dash/expand.rs
@@ -308,7 +308,6 @@ pub fn expand_dash_representations(
         return Err(DashExpandError::NoUsableReps);
     };
 
-    let mpd_baseurls: Vec<String> = mpd.base_url.iter().map(|b| b.base.clone()).collect();
     let period_duration_seconds = period
         .duration
         .as_ref()
@@ -325,7 +324,6 @@ pub fn expand_dash_representations(
             continue;
         }
 
-        let adapt_baseurls: Vec<String> = adapt.BaseURL.iter().map(|b| b.base.clone()).collect();
         let adapt_lang = adapt.lang.clone();
 
         for (repr_idx, repr) in adapt.representations.iter().enumerate() {
@@ -334,14 +332,15 @@ pub fn expand_dash_representations(
                 continue;
             }
 
-            let repr_baseurls: Vec<String> = repr.BaseURL.iter().map(|b| b.base.clone()).collect();
-
+            // Each level contributes only its first <BaseURL> (CDN-failover
+            // rotation is out of scope); pass borrowed &str so the unused
+            // failover entries are never cloned. See resolve_chain.
             let final_base = resolve_chain(
                 base_url,
                 [
-                    mpd_baseurls.as_slice(),
-                    adapt_baseurls.as_slice(),
-                    repr_baseurls.as_slice(),
+                    mpd.base_url.first().map(|b| b.base.as_str()),
+                    adapt.BaseURL.first().map(|b| b.base.as_str()),
+                    repr.BaseURL.first().map(|b| b.base.as_str()),
                 ],
             );
 


### PR DESCRIPTION
## What

`resolve_chain` (DASH `<BaseURL>` chain resolution) only ever consumes the **first** `<BaseURL>` of each level, but the call sites in `expand_dash_representations` cloned **every** entry into a `Vec<String>` per Representation just to hand over a `&[String]` slice. Every clone past index 0 was dead; even the first was needless.

This narrows `resolve_chain`'s input to `Item = Option<&'a str>` (the pre-selected first, borrowed from the parsed MPD). The `.first()` selection moves to the visible call site, and the failover entries are never materialised.

**Effect:** eliminates 3 `Vec<String>` allocations + N `String` clones **per Representation** in the DASH expansion path (`mpd`/`adapt` hoisted, `repr` in the inner loop). Net −13 lines.

## Behavior

Preserving. Same first-entry selection, same `mpd → adapt → repr` join order, same RFC 3986 `Url::join` semantics, same downstream `validate_resolved_url` SSRF gate. The 6 characterization tests keep identical assertions (the `None`-skip and first-of-multi cases re-spelled for the new signature).

## Verification

- Full gate green: `cargo fmt --check` → `check` → `clippy --all-targets -D warnings` → `test`, plus all repo `check-*.sh` (dedup, url/log redaction, no-CLI, WIT parity).

## Reviews

- **security-reviewer**: Approve — no findings. SSRF boundary, first-entry selection, join order, and log redaction all confirmed unchanged.
- **code-reviewer**: Approve — `levels.into_iter().flatten()` verified an exact match for the old skip-empty/take-first logic; dropped `continue` confirmed a no-op; lifetime minimal/correct. One non-blocking nit (the multi-BaseURL test is a caller-expression mirror), no change requested.

## Issue

No issue — this is a self-directed optimization found during an allocation-avoidance audit of iterator/collect usage across the workspace. A tracking issue was attempted but blocked locally; happy to link one if desired.


Closes #447
