### PR TITLE
refactor(rdlp-extractor): unify single-GET search_page onto shared run_search_page skeleton

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -59,10 +59,6 @@ fingerprint = "2171a47deb213f3b"
 reason = "Same domain-separation rationale (closures inside list_*_codecs helpers iterate distinct codec tables)"
 
 [[ignore]]
-fingerprint = "c779eff5aef82766"
-reason = "Initiative #5: InfoExtractorExt — XNXX+SpankBang SearchExtractor::search_page share pagination scaffold (#440)"
-
-[[ignore]]
 fingerprint = "d1fae871b2e72790"
 reason = "Acceptable test redundancy; two related assertions on Orchestrator::select merge-selector behaviour (explicit vs derived merge selection)"
 

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -58,8 +58,8 @@ use regex::Regex;
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
 pub(crate) use search::{
-    FilterValidationError, KeyValidation, PaginatedSearch, Termination, append_search_filters,
-    validate_against_descriptors,
+    FilterValidationError, KeyValidation, PaginatedSearch, SearchPageSpec, SearchParse,
+    Termination, append_search_filters, run_search_page, validate_against_descriptors,
 };
 pub(crate) use selectors::*;
 

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -10,11 +10,62 @@
 use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result};
-use rdlp_types::{SearchFilter, SearchFilterDescriptor, SearchQuery, SearchResultPreview};
+use rdlp_types::{
+    SearchFilter, SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchResultPreview,
+};
 use std::time::Duration;
 use url::form_urlencoded;
 
 use super::MAX_PLAYLIST_SIZE;
+use crate::base::common::BaseExtractor;
+
+/// One parsed search page: the rows, an optional total-result estimate, and
+/// whether another page exists. Produced by a site's `parse` hook in a single
+/// pass (no re-scan of the body).
+pub(crate) struct SearchParse {
+    pub results: Vec<SearchResultPreview>,
+    pub total_estimate: Option<u64>,
+    pub has_more: bool,
+}
+
+/// Per-site configuration for [`run_search_page`]. All behavioral variation is
+/// a `fn` pointer (zero-alloc, `Copy`); config is plain data. Sites pass bare
+/// `fn` items or non-capturing closures (which coerce to `fn`).
+pub(crate) struct SearchPageSpec {
+    /// The page a `None` `SearchQuery::page` defaults to (0 or 1 per site).
+    pub first_page_index: u32,
+    /// Extra request headers; `&[]` for none.
+    pub headers: &'static [(&'static str, &'static str)],
+    /// Build the page URL from the query and the (site-convention) page number.
+    pub build_url: fn(&SearchQuery, u32) -> String,
+    /// Parse the fetched body into results + pagination in one pass.
+    pub parse: fn(&str, &SearchQuery, u32) -> Result<SearchParse>,
+}
+
+/// Shared single-GET search-page skeleton: derive the page, build the URL,
+/// fetch once (with optional headers), parse, and assemble the response. Sites
+/// with genuinely divergent shapes (two-fetch fallback, termination-based
+/// pagination) keep their own `search_page` and do not use this.
+pub(crate) async fn run_search_page(
+    query: &SearchQuery,
+    ctx: &ExtractionContext,
+    spec: SearchPageSpec,
+) -> Result<SearchPageResponse> {
+    let page = query.page.unwrap_or(spec.first_page_index);
+    let url = (spec.build_url)(query, page);
+    let body = if spec.headers.is_empty() {
+        BaseExtractor::fetch_webpage(&url, ctx).await?
+    } else {
+        BaseExtractor::fetch_webpage_with_headers(&url, spec.headers, ctx).await?
+    };
+    let parsed = (spec.parse)(&body, query, page)?;
+    Ok(SearchPageResponse {
+        results: parsed.results,
+        page,
+        has_more: parsed.has_more,
+        total_estimate: parsed.total_estimate,
+    })
+}
 
 /// How one filter key's value is validated by [`validate_against_descriptors`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rdlp-extractor/src/extractors/abxxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/abxxx/search.rs
@@ -272,6 +272,8 @@ impl SearchExtractor for AbxxxExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
+        // Bespoke: the `.max(1)` clamp is reflected in the returned SearchPageResponse.page,
+        // which run_search_page cannot reproduce (it drives page from an unclamped unwrap_or). See #450.
         let page = query.page.unwrap_or(1).max(1);
         let sort = resolved_sort(&query.filters);
         let url = kvs_api::videos2_search_endpoint(

--- a/crates/rdlp-extractor/src/extractors/eporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/eporner/search.rs
@@ -4,7 +4,7 @@
 //! Filter key: `sort` ∈ {`top-rated`, `longest`}.
 
 use async_trait::async_trait;
-use rdlp_core::{ExtractionContext, RdlpError, Result, SearchExtractor};
+use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{
     SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery, SearchResultPreview,
 };
@@ -12,7 +12,7 @@ use scraper::{Html, Selector};
 use std::sync::LazyLock;
 
 use super::EPornerExtractor;
-use crate::base::common::BaseExtractor;
+use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
 
 const EPORNER_ROOT: &str = "https://www.eporner.com";
 
@@ -263,25 +263,26 @@ impl SearchExtractor for EPornerExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        let page = query.page.unwrap_or(0);
-        let url = build_search_url(query, page);
-        let html =
-            BaseExtractor::fetch_webpage(&url, ctx)
-                .await
-                .map_err(|e| RdlpError::Network {
-                    message: format!("eporner search: fetch failed: {e:#}"),
-                    url: Some(url.clone().into()),
-                })?;
-        let results = parse_results(&html);
-        // Detect if a next page exists by checking for a page+2 link in pagination
-        let next_page_str = format!("/{}/", page + 2);
-        let has_more = html.contains(&next_page_str);
-        Ok(SearchPageResponse {
-            results,
-            page,
-            has_more,
-            total_estimate: None,
-        })
+        run_search_page(
+            query,
+            ctx,
+            SearchPageSpec {
+                first_page_index: 0,
+                headers: &[],
+                build_url: build_search_url,
+                parse: |body, _query, page| {
+                    let results = parse_results(body);
+                    // next-page probe: a "/{page+2}/" link in the pagination
+                    let has_more = body.contains(&format!("/{}/", page + 2));
+                    Ok(SearchParse {
+                        results,
+                        total_estimate: None,
+                        has_more,
+                    })
+                },
+            },
+        )
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -36,7 +36,9 @@ use rdlp_types::{InfoDict, SearchPageResponse, SearchQuery, SearchResultPreview}
 use scraper::Html;
 use std::sync::LazyLock;
 
-use crate::base::common::{BaseExtractor, MAX_PLAYLIST_SIZE};
+use crate::base::common::{
+    BaseExtractor, MAX_PLAYLIST_SIZE, SearchPageSpec, SearchParse, run_search_page,
+};
 use crate::hls::detect_format_sizes_lazy;
 
 pub use patterns::HQPORNER_VIDEO_PATTERN;
@@ -404,25 +406,23 @@ impl SearchExtractor for HQPornerExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        let page = query.page.unwrap_or(1);
-        let page_url = search_patterns::build_search_url(&query.query, page);
-
-        let webpage = BaseExtractor::fetch_webpage_with_headers(
-            &page_url,
-            &[("Referer", "https://hqporner.com/")],
+        run_search_page(
+            query,
             ctx,
+            SearchPageSpec {
+                first_page_index: 1,
+                headers: &[("Referer", "https://hqporner.com/")],
+                build_url: |query, page| search_patterns::build_search_url(&query.query, page),
+                parse: |body, _query, _page| {
+                    Ok(SearchParse {
+                        results: search::parse_search_results(body),
+                        total_estimate: search::extract_total_count(body),
+                        has_more: search::has_next_page(body),
+                    })
+                },
+            },
         )
-        .await?;
-        let page_results = search::parse_search_results(&webpage);
-        let has_more = search::has_next_page(&webpage);
-        let total_estimate = search::extract_total_count(&webpage);
-
-        Ok(SearchPageResponse {
-            results: page_results,
-            page,
-            has_more,
-            total_estimate,
-        })
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -248,6 +248,7 @@ impl SearchExtractor for KoreanPornMovieExtractor {
         Ok(response.results)
     }
 
+    // Bespoke: multi-endpoint browse dispatch (single-GET run_search_page skeleton does not fit); see #450.
     async fn search_page(
         &self,
         query: &SearchQuery,

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use super::NineAnimeExtractor;
 use super::search_patterns;
-use crate::base::common::BaseExtractor;
+use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
 
 const BASE_URL: &str = "https://9animetv.to";
 const MAX_PLAYLIST_SIZE: usize = 500;
@@ -136,30 +136,29 @@ impl SearchExtractor for NineAnimeExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        // Convert 1-based user page to 0-based URL page
-        let user_page = query.page.unwrap_or(1);
-        let url_page = if user_page > 0 { user_page - 1 } else { 0 };
-
-        let page_url = search_patterns::build_search_url(query, url_page);
-
-        let webpage = BaseExtractor::fetch_webpage_with_headers(
-            &page_url,
-            &[("Referer", "https://9animetv.to/")],
+        run_search_page(
+            query,
             ctx,
+            SearchPageSpec {
+                first_page_index: 1,
+                headers: &[("Referer", "https://9animetv.to/")],
+                build_url: |query, page| {
+                    let url_page = if page > 0 { page - 1 } else { 0 };
+                    search_patterns::build_search_url(query, url_page)
+                },
+                parse: |body, _query, _page| {
+                    let results = parse_search_results(body);
+                    let total_estimate = extract_total_pages(body)
+                        .map(|tp| tp as u64 * search_patterns::RESULTS_PER_PAGE);
+                    Ok(SearchParse {
+                        has_more: has_next_page(body) && !results.is_empty(),
+                        total_estimate,
+                        results,
+                    })
+                },
+            },
         )
-        .await?;
-
-        let page_results = parse_search_results(&webpage);
-        let has_more = has_next_page(&webpage) && !page_results.is_empty();
-        let total_pages = extract_total_pages(&webpage);
-        let total_estimate = total_pages.map(|tp| tp as u64 * search_patterns::RESULTS_PER_PAGE);
-
-        Ok(SearchPageResponse {
-            results: page_results,
-            page: user_page,
-            has_more,
-            total_estimate,
-        })
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/spankbang/search.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/search.rs
@@ -19,6 +19,7 @@ use rdlp_types::{
 use super::SpankBangExtractor;
 use super::{metadata, patterns};
 use crate::base::common::BaseExtractor;
+use crate::base::common::{SearchPageSpec, SearchParse, run_search_page};
 
 const SPANKBANG_BASE_URL: &str = "https://spankbang.com";
 const SPANKBANG_NAME_STR: &str = "SpankBang";
@@ -371,22 +372,23 @@ impl SearchExtractor for SpankBangExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        let page = query.page.unwrap_or(0);
-        let page_url = build_search_url(query, page);
-
-        let webpage =
-            BaseExtractor::fetch_webpage_with_headers(&page_url, &[("Cookie", "country=US")], ctx)
-                .await?;
-
-        let results = parse_results(&webpage);
-        let more = has_more_pages(&webpage, query, page);
-
-        Ok(SearchPageResponse {
-            results,
-            page,
-            has_more: more,
-            total_estimate: Some(RESULTS_PER_PAGE * 100),
-        })
+        run_search_page(
+            query,
+            ctx,
+            SearchPageSpec {
+                first_page_index: 0,
+                headers: &[("Cookie", "country=US")],
+                build_url: build_search_url,
+                parse: |body, query, page| {
+                    Ok(SearchParse {
+                        results: parse_results(body),
+                        total_estimate: Some(RESULTS_PER_PAGE * 100),
+                        has_more: has_more_pages(body, query, page),
+                    })
+                },
+            },
+        )
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xnxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/search.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use super::XNXXExtractor;
 use crate::base::common::BaseExtractor;
+use crate::base::common::{SearchPageSpec, SearchParse, run_search_page};
 
 /// Base URL for search requests.
 const XNXX_BASE_URL: &str = "https://www.xnxx.com";
@@ -274,21 +275,23 @@ impl SearchExtractor for XNXXExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        // External `page` is 0-indexed; display page in URL is 1-indexed
-        let page = query.page.unwrap_or(0);
-        let page_url = build_search_url(query, page);
-
-        let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
-
-        let results = parse_results(&webpage);
-        let more = has_more_pages(&webpage, query, page);
-
-        Ok(SearchPageResponse {
-            results,
-            page,
-            has_more: more,
-            total_estimate: Some(RESULTS_PER_PAGE * 100),
-        })
+        run_search_page(
+            query,
+            ctx,
+            SearchPageSpec {
+                first_page_index: 0,
+                headers: &[],
+                build_url: build_search_url,
+                parse: |body, query, page| {
+                    Ok(SearchParse {
+                        results: parse_results(body),
+                        total_estimate: Some(RESULTS_PER_PAGE * 100),
+                        has_more: has_more_pages(body, query, page),
+                    })
+                },
+            },
+        )
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use super::XTitsExtractor;
 use super::search_patterns;
-use crate::base::common::BaseExtractor;
+use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
 
 const MAX_PLAYLIST_SIZE: usize = 500;
 
@@ -134,30 +134,28 @@ impl SearchExtractor for XTitsExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        let page = query.page.unwrap_or(1);
-        let page_url = search_patterns::build_search_url(query, page);
-
-        let webpage = BaseExtractor::fetch_webpage_with_headers(
-            &page_url,
-            &[
-                ("X-Requested-With", "XMLHttpRequest"),
-                ("Referer", "https://www.xtits.com/search/"),
-            ],
+        run_search_page(
+            query,
             ctx,
+            SearchPageSpec {
+                first_page_index: 1,
+                headers: &[
+                    ("X-Requested-With", "XMLHttpRequest"),
+                    ("Referer", "https://www.xtits.com/search/"),
+                ],
+                build_url: search_patterns::build_search_url,
+                parse: |body, _query, page| {
+                    let results = parse_search_results(body);
+                    let max_page = detect_max_page(body);
+                    Ok(SearchParse {
+                        has_more: page < max_page && !results.is_empty(),
+                        total_estimate: Some(max_page as u64 * search_patterns::RESULTS_PER_PAGE),
+                        results,
+                    })
+                },
+            },
         )
-        .await?;
-
-        let page_results = parse_search_results(&webpage);
-        let max_page = detect_max_page(&webpage);
-        let has_more = page < max_page && !page_results.is_empty();
-        let total_estimate = Some(max_page as u64 * search_patterns::RESULTS_PER_PAGE);
-
-        Ok(SearchPageResponse {
-            results: page_results,
-            page,
-            has_more,
-            total_estimate,
-        })
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xvideos/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/search.rs
@@ -13,6 +13,7 @@ use scraper::Html;
 
 use super::XVideosExtractor;
 use crate::base::common::BaseExtractor;
+use crate::base::common::{SearchPageSpec, SearchParse, run_search_page};
 
 const XVIDEOS_BASE_URL: &str = "https://www.xvideos.com";
 
@@ -245,23 +246,26 @@ impl SearchExtractor for XVideosExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        // page in SearchQuery is 1-indexed per convention; XVideos uses 0-indexed internally
-        let page_1indexed = query.page.unwrap_or(1);
-        let page_0indexed = page_1indexed.saturating_sub(1);
-
-        let page_url = build_search_url(query, page_0indexed);
-        let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
-
-        let results = parse_search_results(&webpage);
-        let has_more = has_next_page(&webpage, page_0indexed + 1) && !results.is_empty();
-        let total_estimate = None;
-
-        Ok(SearchPageResponse {
-            results,
-            page: page_1indexed,
-            has_more,
-            total_estimate,
-        })
+        run_search_page(
+            query,
+            ctx,
+            SearchPageSpec {
+                first_page_index: 1,
+                headers: &[],
+                // XVideos is 0-indexed internally; external page is 1-indexed.
+                build_url: |query, page| build_search_url(query, page.saturating_sub(1)),
+                parse: |body, _query, page| {
+                    let results = parse_search_results(body);
+                    // `page` is 1-indexed here == the old `page_0indexed + 1`.
+                    Ok(SearchParse {
+                        has_more: has_next_page(body, page) && !results.is_empty(),
+                        total_estimate: None,
+                        results,
+                    })
+                },
+            },
+        )
+        .await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xvideos/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/search.rs
@@ -12,8 +12,7 @@ use rdlp_types::{
 use scraper::Html;
 
 use super::XVideosExtractor;
-use crate::base::common::BaseExtractor;
-use crate::base::common::{SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
 
 const XVIDEOS_BASE_URL: &str = "https://www.xvideos.com";
 
@@ -256,9 +255,11 @@ impl SearchExtractor for XVideosExtractor {
                 build_url: |query, page| build_search_url(query, page.saturating_sub(1)),
                 parse: |body, _query, page| {
                     let results = parse_search_results(body);
-                    // `page` is 1-indexed here == the old `page_0indexed + 1`.
+                    // Reproduce the original arg exactly: has_next_page(webpage, page_0indexed + 1),
+                    // where page_0indexed = page.saturating_sub(1). Equal to page for page>=1; correct at page 0.
                     Ok(SearchParse {
-                        has_more: has_next_page(body, page) && !results.is_empty(),
+                        has_more: has_next_page(body, page.saturating_sub(1) + 1)
+                            && !results.is_empty(),
                         total_estimate: None,
                         results,
                     })
@@ -434,6 +435,30 @@ mod tests {
         // Spot-check: every parsed view count must be > 0
         for v in results.iter().filter_map(|r| r.view_count) {
             assert!(v > 0, "view_count of zero should be None, not Some(0)");
+        }
+    }
+
+    /// Regression: `search_page`'s `parse` closure must reproduce the original
+    /// pre-refactor `has_next_page(webpage, page_0indexed + 1)` call exactly,
+    /// where `page_0indexed = page.saturating_sub(1)`. For `page >= 1` this is
+    /// identical to passing `page` directly, but at the out-of-contract
+    /// `page == 0` boundary the original computes `0.saturating_sub(1) + 1 == 1`,
+    /// NOT `0`. Pin both sides of that boundary directly against `has_next_page`
+    /// (the closure itself is only reachable via `run_search_page`, which
+    /// performs a network fetch, so this exercises the restored arithmetic
+    /// rather than the full search_page path).
+    #[test]
+    fn has_next_page_boundary_matches_original_arg_computation() {
+        let html = "...p=1...";
+        // page == 0: original arg is 0.saturating_sub(1) + 1 == 1, not 0.
+        let page = 0_u32;
+        assert_eq!(page.saturating_sub(1) + 1, 1);
+        assert!(has_next_page(html, page.saturating_sub(1) + 1));
+        assert!(!has_next_page(html, page));
+
+        // page >= 1: the restored computation equals `page` directly.
+        for page in 1_u32..=3 {
+            assert_eq!(page.saturating_sub(1) + 1, page);
         }
     }
 


### PR DESCRIPTION
## Summary

Collapses the hand-rolled `SearchExtractor::search_page` bodies across the single-GET search family onto one shared, allocation-free `run_search_page` skeleton parameterized by a `fn`-pointer spec.

A new free `async fn run_search_page(query, ctx, spec)` in `base/common/search.rs` owns the fetch→parse→assemble skeleton. Per-site variation is supplied via `SearchPageSpec` — a plain-data struct of `fn` pointers (`Copy`, zero-alloc) plus `&'static` header slices — producing a `SearchParse { results, total_estimate, has_more }`. Each migrated site's `search_page` becomes a one-line delegation with a spec literal. The three new items are re-exported from `base/common/mod.rs` (the `search` submodule is private).

This satisfies the Rule-of-Three trigger for the deferred XNXX↔SpankBang dedup (#440) and generalizes it to the whole single-GET family.

## Migrated (byte-exact, 7 sites)

XNXX, XVideos, SpankBang, XTits, EPorner, HQPorner, NineAnime — each one commit. Same URLs built, same parse, same `has_more` / `total_estimate` / `page`. Every existing per-site search test stays green with **no assertion edits** (regression guard).

## The one deliberate exception — EPorner

EPorner's redundant `.map_err(RdlpError::Network { "eporner search: fetch failed" })` fetch-wrap is **dropped**; a fetch failure now surfaces the shared skeleton's standard fetch error. This is the only non-byte-exact change. No test pinned that string. The security review confirmed it is **posture-neutral**: the skeleton path wraps the same URL in `RedactedUrlBuf` exactly as the dropped wrap did (equal credential/URL-disclosure posture).

## Deferred (evaluated, kept bespoke — tracked under #450)

- **ABXXX** — its `.max(1)` page clamp is reflected in `SearchPageResponse.page`, which `run_search_page` cannot reproduce (it drives the response page from an unclamped `unwrap_or`). Folding would need a conditional in shared code.
- **KoreanPornMovie** — multi-endpoint browse dispatch: `search_api` fires two concurrent fetches via `ctx.http_client`, `search_api_taxonomy` is a three-step flow with an early return, and pagination comes from response headers. The single-GET skeleton does not fit.

Both carry a breadcrumb doc-comment referencing #450. The termination cluster (XHamster/TNAFlix/MovieFap/EMPFlix) and the fallback pair (PornHub/RedTube) remain out of scope, tracked by #450.

The stale `.dupes-ignore.toml` entry (`c779eff5`, the XNXX↔SpankBang scaffold) is removed; the dedup gate confirms no new fingerprint fires for the collapsed one-line bodies.

## Reviews

- **security-reviewer** (opus): **APPROVE** — no HIGH/Critical. Attacker-controlled bodies still flow through the unchanged per-site `parse_*` fns; URL/header/pagination math byte-exact; body-size (`fetch_capped_text`) and URL-length caps preserved; no new panic/alloc surface; EPorner drop confirmed security-neutral.
- **code-reviewer** (opus): **Approve** (after fix). Found one Important byte-exactness gap in XVideos `has_more` at the out-of-contract `page=0` boundary (`has_next_page(body, page)` vs the original `page.saturating_sub(1) + 1`) — **fixed** in `47dbc8d7`, which restores the exact original arithmetic, corrects the comment, merges the split import, and adds a boundary regression test (20/20 green). Re-review confirmed byte-exact and no new issue.

Whole-branch gate green: `fmt --check`, `check`, `clippy --all-targets -D warnings`, `test`, `check -p rdlp-desktop`, and all repo `check-*.sh` (dedup / url-redaction / no-cli / wit-drift / log-redaction).

Closes #440
Refs #450
