### PR TITLE
refactor(rdlp-extractor): dedup termination-cluster search_page (#450 phase 1)

### DIFF
--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -321,6 +321,36 @@ pub(crate) trait PaginatedSearch: Send + Sync {
 
         Ok(all_results)
     }
+
+    /// Assemble a single-page `SearchPageResponse` from one `fetch_search_page`.
+    ///
+    /// Shared default for `PaginatedSearch` adopters whose per-site
+    /// `SearchExtractor::search_page` was byte-identical (XHamster, TNAFlix,
+    /// MovieFap, EMPFlix): validate filters, derive the 1-based page, fetch it,
+    /// and report `has_more` only when the page was non-empty AND the site's
+    /// `Termination` says another page exists. `total_estimate` is `None` for
+    /// these sites (they report a page count, not a result total). Adopters with
+    /// divergent single-page semantics (PornHub, RedTube) override
+    /// `SearchExtractor::search_page` and do not call this.
+    async fn search_page_response(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        self.validate_search_filters(&query.filters)?;
+
+        let page = query.page.unwrap_or(1) as usize;
+        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
+
+        let has_more = !page_results.is_empty() && termination.has_more(page);
+
+        Ok(SearchPageResponse {
+            results: page_results,
+            page: page as u32,
+            has_more,
+            total_estimate: None,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -670,6 +700,83 @@ mod tests {
         )
         .await;
         assert_eq!(out.len(), 6, "all 3 pages fetched (latest count = 3)");
+    }
+
+    // ---- PaginatedSearch::search_page_response ----
+
+    fn query_with_page(page: Option<u32>) -> SearchQuery {
+        SearchQuery {
+            query: "q".to_string(),
+            filters: Vec::new(),
+            max_results: None,
+            page,
+        }
+    }
+
+    #[tokio::test]
+    async fn search_page_response_reports_has_more_when_more_pages() {
+        let mock = MockSearch::new(vec![Page::Ok(previews(3), Termination::Pages(5))]);
+        let resp = mock
+            .search_page_response(&query_with_page(None), &test_ctx())
+            .await
+            .expect("ok");
+        assert_eq!(resp.results.len(), 3);
+        assert_eq!(resp.page, 1);
+        assert!(resp.has_more);
+        assert_eq!(resp.total_estimate, None);
+    }
+
+    #[tokio::test]
+    async fn search_page_response_no_more_on_last_page() {
+        let mock = MockSearch::new(vec![Page::Ok(previews(3), Termination::Pages(1))]);
+        let resp = mock
+            .search_page_response(&query_with_page(None), &test_ctx())
+            .await
+            .expect("ok");
+        assert!(!resp.has_more);
+    }
+
+    #[tokio::test]
+    async fn search_page_response_empty_results_forces_has_more_false() {
+        let mock = MockSearch::new(vec![Page::Ok(previews(0), Termination::Pages(5))]);
+        let resp = mock
+            .search_page_response(&query_with_page(None), &test_ctx())
+            .await
+            .expect("ok");
+        assert!(resp.results.is_empty());
+        assert!(!resp.has_more);
+    }
+
+    #[tokio::test]
+    async fn search_page_response_honors_query_page() {
+        let mock = MockSearch::new(vec![
+            Page::Ok(previews(2), Termination::Pages(5)),
+            Page::Ok(previews(4), Termination::Pages(5)),
+        ]);
+        let resp = mock
+            .search_page_response(&query_with_page(Some(2)), &test_ctx())
+            .await
+            .expect("ok");
+        assert_eq!(resp.page, 2);
+        assert_eq!(resp.results.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn search_page_response_validation_error_does_not_fetch() {
+        let mock = MockSearch {
+            script: vec![Page::Ok(previews(3), Termination::Pages(5))],
+            validation_fails: true,
+            fetches: AtomicUsize::new(0),
+        };
+        let result = mock
+            .search_page_response(&query_with_page(None), &test_ctx())
+            .await;
+        assert!(result.is_err(), "validation failure must propagate as Err");
+        assert_eq!(
+            mock.fetches.load(Ordering::SeqCst),
+            0,
+            "must not fetch when validation fails"
+        );
     }
 
     mod validator_tests {

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -103,18 +103,6 @@ impl rdlp_core::SearchExtractor for EMPFlixSearchExtractor {
         query: &rdlp_types::SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<rdlp_types::SearchPageResponse> {
-        tnaflix_search_helpers::validate_search_filters(&query.filters)?;
-
-        let page = query.page.unwrap_or(1) as usize;
-        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
-
-        let has_more = !page_results.is_empty() && termination.has_more(page);
-
-        Ok(rdlp_types::SearchPageResponse {
-            results: page_results,
-            page: page as u32,
-            has_more,
-            total_estimate: None,
-        })
+        self.search_page_response(query, ctx).await
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -88,18 +88,6 @@ impl rdlp_core::SearchExtractor for MovieFapSearchExtractor {
         query: &rdlp_types::SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<rdlp_types::SearchPageResponse> {
-        moviefap_search_helpers::validate_search_filters(&query.filters)?;
-
-        let page = query.page.unwrap_or(1) as usize;
-        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
-
-        let has_more = !page_results.is_empty() && termination.has_more(page);
-
-        Ok(rdlp_types::SearchPageResponse {
-            results: page_results,
-            page: page as u32,
-            has_more,
-            total_estimate: None,
-        })
+        self.search_page_response(query, ctx).await
     }
 }

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -108,18 +108,6 @@ impl SearchExtractor for TNAFlixSearchExtractor {
         query: &rdlp_types::SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        tnaflix_search_helpers::validate_search_filters(&query.filters)?;
-
-        let page = query.page.unwrap_or(1) as usize;
-        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
-
-        let has_more = !page_results.is_empty() && termination.has_more(page);
-
-        Ok(SearchPageResponse {
-            results: page_results,
-            page: page as u32,
-            has_more,
-            total_estimate: None,
-        })
+        self.search_page_response(query, ctx).await
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -348,19 +348,7 @@ impl SearchExtractor for XHamsterExtractor {
         query: &rdlp_types::SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        search::validate_search_filters(&query.filters)?;
-
-        let page = query.page.unwrap_or(1) as usize;
-        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
-
-        let has_more = !page_results.is_empty() && termination.has_more(page);
-
-        Ok(SearchPageResponse {
-            results: page_results,
-            page: page as u32,
-            has_more,
-            total_estimate: None,
-        })
+        self.search_page_response(query, ctx).await
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the search-pagination convergence (meta #450, staged A→B→C). Lifts the **4× byte-identical** `SearchExtractor::search_page` bodies in the termination cluster (XHamster, TNAFlix, MovieFap, EMPFlix) into a single provided default method on the internal `#[async_trait] PaginatedSearch` trait, and collapses each site to a one-line delegation. Behavior is byte-for-byte preserved.

The API↔HTML fallback pair (PornHub, RedTube) is **untouched** — it keeps its divergent two-fetch `search_page`. Native-AFIT migration (Stage 2) and the broader `run_search_page` convergence (Stage 3) are deferred to their own plans.

## Changes

- **`base/common/search.rs`** — new `PaginatedSearch::search_page_response` provided default: validate filters → derive 1-based page → `fetch_search_page` once → `has_more = !empty && termination.has_more(page)` → `SearchPageResponse{…, total_estimate: None}`. Placed alongside the existing `search_all_pages` scaffold. 5 new unit tests via the `MockSearch` harness (has_more true/false, empty-forces-false boundary, page-echo, validation-short-circuits-before-fetch).
- **4 termination extractors** (`xhamster/mod.rs`, `tnaflix/search.rs`, `tnaflix/empflix_search.rs`, `tnaflix/moviefap_search.rs`) — `search_page` body → `self.search_page_response(query, ctx).await`. Net −52/+4 across the four.

## Verification

- Behavior-preserving: existing search tests green with **zero assertion edits** (incl. `test_tnaflix_search_page_returns_results`).
- Full pre-PR gate green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `scripts/check-dedup.sh` (reduced duplication), `scripts/check-url-redaction.sh`.
- Validation-equivalence confirmed: each type's trait `validate_search_filters` resolves to the same site-specific helper the removed inline body called — so `self.validate_search_filters(...)` in the default is behavior-identical, and still runs before any fetch.

## Reviews

- **security-reviewer**: PASS, no findings. Pure refactor — no new URL construction, no new fetch/loop/allocation, validation-before-fetch preserved on all 4 paths.
- **code-reviewer** (whole-diff, `develop..HEAD`): Approve. Trait default well-placed/documented, all 4 delegations identical, no orphaned helpers, net coverage increases. One non-blocking cosmetic note (a `has_more` doc-comment rationale is now slightly stale) — left for a future touch to keep this diff minimal.

Closes #452
Refs #440
Refs #450
