### PR TITLE
refactor(rdlp-extractor): PaginatedSearch native async-fn-in-trait (#450 Stage 2)

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -45,7 +45,7 @@ This document establishes the core coding standards for the rdlp video downloade
 - Prefer `eq_ignore_ascii_case()` over `to_lowercase()` comparisons (avoids allocation)
 
 ### Async Patterns
-- Use `async_trait` for async trait methods
+- Use `async_trait` for async trait methods — **except** a `pub(crate)`/private trait with no `dyn`/`Box<dyn>`/generic-bound use (every call is `self.method().await` on a concrete `Self`), which should use native async-fn-in-trait (AFIT, stable since Rust 1.75) to avoid the per-call `Box<dyn Future>`. Native AFIT is not dyn-compatible and the `async_fn_in_trait` lint fires only on `pub` traits, so this exception is safe exactly for non-`pub`, non-`dyn` traits (e.g. `base::common::PaginatedSearch`).
 - Prefer `tokio::select!` for cancellation handling
 - Use `Arc<AtomicU64>` for shared progress counters
 - Apply `buffer_unordered` for bounded parallelism

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -7,7 +7,6 @@
 //! `ordering` / `period` / `category` / `tags[]` filter vocabulary (PornHub,
 //! RedTube) delegate that appending here.
 
-use async_trait::async_trait;
 use log::debug;
 use rdlp_core::{ExtractionContext, Result};
 use rdlp_types::{
@@ -253,7 +252,6 @@ pub(crate) fn append_search_filters(url: &mut String, filters: &[SearchFilter]) 
 /// with no reliable total (they paginate until an empty page) return
 /// `Termination::UntilEmpty`. Per-page primary↔fallback fetching is a private
 /// concern of each site's `fetch_search_page` implementation.
-#[async_trait]
 pub(crate) trait PaginatedSearch: Send + Sync {
     /// Bracketed site tag used in log lines, e.g. `"[XHamster]"`.
     fn search_log_tag(&self) -> &'static str;
@@ -475,7 +473,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl PaginatedSearch for MockSearch {
         fn search_log_tag(&self) -> &'static str {
             "[Mock]"
@@ -616,6 +613,26 @@ mod tests {
             0,
             "must not fetch any page when validation fails"
         );
+    }
+
+    #[test]
+    fn paginated_search_futures_are_send() {
+        // Guards the native-AFIT migration's correctness contract: the outer
+        // `#[async_trait] SearchExtractor::search` future must be `Send`, which
+        // requires the `PaginatedSearch` futures it awaits at the concrete call
+        // site to be `Send`. Under `#[async_trait]` this was guaranteed by the
+        // boxed `dyn Future + Send`; under native AFIT it is inferred, so pin it
+        // here. If a future ever goes non-`Send`, this fails at compile time
+        // instead of cryptically deep inside a site's `SearchExtractor::search`.
+        fn assert_send<T: Send>(_: T) {}
+
+        let mock = MockSearch::new(Vec::new());
+        let q = query(None);
+        let ctx = test_ctx();
+
+        assert_send(mock.fetch_search_page(&q, 1, &ctx));
+        assert_send(mock.search_all_pages(&q, &ctx));
+        assert_send(mock.search_page_response(&q, &ctx));
     }
 
     // ---- Termination::should_stop ----

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -108,7 +108,6 @@ impl PornHubExtractor {
     }
 }
 
-#[async_trait]
 impl PaginatedSearch for PornHubExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[PornHub]"

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -333,7 +333,6 @@ impl RedTubeExtractor {
     }
 }
 
-#[async_trait]
 impl PaginatedSearch for RedTubeExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[RedTube]"

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -38,7 +38,6 @@ impl EMPFlixSearchExtractor {
     }
 }
 
-#[async_trait]
 impl PaginatedSearch for EMPFlixSearchExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[EMPFlix]"

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -24,7 +24,6 @@ impl MovieFapSearchExtractor {
     }
 }
 
-#[async_trait]
 impl PaginatedSearch for MovieFapSearchExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[MovieFap]"

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -44,7 +44,6 @@ impl TNAFlixSearchExtractor {
     }
 }
 
-#[async_trait]
 impl PaginatedSearch for TNAFlixSearchExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[TNAFlix]"

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -250,7 +250,6 @@ impl XHamsterExtractor {
     }
 }
 
-#[async_trait]
 impl PaginatedSearch for XHamsterExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[XHamster]"


### PR DESCRIPTION
## Summary

Stage 2 of the search-pagination unification (meta #450, follow-up to #440).
Migrates the `pub(crate)` `PaginatedSearch` trait (in
`crates/rdlp-extractor/src/base/common/search.rs`) off `#[async_trait]` to
native async-fn-in-trait (AFIT, stable since Rust 1.75; MSRV 1.85), eliminating
the per-page `Box<dyn Future>` heap allocation in favor of static, inlinable
dispatch. **Mechanism-only and behavior-preserving** — no renames, no signature
changes, no new hooks (those are Stage 3).

## Changes

- Remove `#[async_trait]` from the trait def, its 6 production impls (XHamster,
  TNAFlix, MovieFap, EMPFlix, PornHub, RedTube), and the `MockSearch` test impl.
- Drop the now-dead `use async_trait::async_trait;` import in `search.rs` (the
  import is **retained** in the 6 site files — each still uses it for
  `InfoExtractor`/`SearchExtractor`).
- Add a `Send` static-assertion guard test (`paginated_search_futures_are_send`)
  pinning that the trait's three async methods stay `Send`.
- Document the native-AFIT exception in `CODING_RULES.md`'s async-patterns rule.

## Why it's safe

- No `dyn`/`Box<dyn>`/generic `T: PaginatedSearch` bound anywhere — 7 concrete
  impls only; every call is `self.method().await` on a concrete `Self`, so
  native AFIT's non-dyn-compatibility is inert.
- The trait stays `pub(crate)`, so the `async_fn_in_trait` lint does not fire
  (empirically verified under `-D warnings`: a `pub` trait trips it; `pub(crate)`
  is clean) — no `#[allow]` and no manual `impl Future + Send` desugaring needed.
- `Send` is inferred structurally at the concrete call site inside the outer
  `#[async_trait] SearchExtractor::search`; the new guard test pins that contract.

## Tests

Zero assertion edits to existing search tests; added one `Send` guard. Full gate
green: `fmt --check` / `check` / `clippy --all-targets -D warnings` / `test`
(workspace, 0 failed) + `check-dedup` + `check-url-redaction`.

## Reviews

- **security-reviewer:** Approve — no findings; no new attack surface; `Send`
  guard covers the three async methods awaited by the outer `SearchExtractor::search`.
- **code-reviewer:** Approve — no Critical/Important; verified all 8 attribute
  removals complete, 0 `dyn PaginatedSearch`, the 6 retained imports still live,
  and the guard test/`CODING_RULES` exception accurate. One non-blocking Minor
  (doc line length) left as-is, consistent with the file's existing style.

Closes #454
Refs #440
Refs #450
