### PR TITLE
refactor(rdlp-extractor): unify search pagination onto PagedSearch trait (Stage 3a)

### DIFF
--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -58,7 +58,7 @@ use regex::Regex;
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
 pub(crate) use search::{
-    FilterValidationError, KeyValidation, PaginatedSearch, SearchPageSpec, SearchParse,
+    FilterValidationError, KeyValidation, PagedSearch, SearchPage, SearchPageSpec, SearchParse,
     Termination, append_search_filters, run_search_page, validate_against_descriptors,
 };
 pub(crate) use selectors::*;

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -954,3 +954,138 @@ mod tests {
         }
     }
 }
+
+/// Static regression guard for issue #457 (Refs).
+///
+/// PornHub and RedTube each implement `PagedSearch::fetch_page` (loop
+/// semantics) and `PagedSearch::search_page_response` (single-page
+/// semantics) with deliberately DIVERGENT fallback logic — see the doc
+/// comments on those methods in `extractors/pornhub/mod.rs` and
+/// `extractors/redtube/mod.rs`. A real end-to-end behavioral test (mockito
+/// driving `search_page_response`/`fetch_page` and asserting which URLs were
+/// hit) is infeasible today: the per-site URL builders hardcode `https://`
+/// with no injectable base, `mockito` is HTTP-only (cannot terminate TLS),
+/// and `ExtractionContext.http_client` is a concrete `Arc<wreq::Client>`
+/// with no mock seam — a documented, deliberate project limitation (see
+/// `extractors/pornhub/tests/fetch.rs:1-7`, PR #231). A real golden test
+/// needs an injectable base-URL seam, deferred to follow-up issue **#457**.
+///
+/// Until that seam lands, this textual guard is the cheapest deterministic
+/// regression protection available: it `include_str!`s each site's source
+/// (so cargo recompiles this test whenever the extractor file changes — no
+/// runtime `fs` access) and asserts the token that makes each method's
+/// fallback behavior diverge from its sibling. If the two paths were ever
+/// accidentally unified (e.g. `fetch_page` made to page the fallback on
+/// every page, or `search_page_response` stopped paging it), the relevant
+/// token moves into the wrong method span and this test fails.
+///
+/// A future refactor that extracts `fetch_page` / `search_page_response`
+/// into shared helpers must update the anchors below (the `find` calls
+/// `unwrap_or_else`-panic loudly rather than silently no-op'ing), mirroring
+/// `test_extractor_call_order_expand_before_detect` in
+/// `hls/expand_in_place.rs`.
+#[cfg(test)]
+mod fallback_divergence_guard {
+    /// Split `src` into the `fetch_page` and `search_page_response` method
+    /// spans, using the sibling method / trailing `#[async_trait]` as the
+    /// boundary. Panics loudly (naming `label`) if an anchor is missing —
+    /// a rename must fail this test, not silently pass it.
+    fn method_spans<'a>(label: &str, src: &'a str) -> (&'a str, &'a str) {
+        let fetch_start = src
+            .find("async fn fetch_page")
+            .unwrap_or_else(|| panic!("`async fn fetch_page` not found in {label}"));
+        let response_fn_start = src
+            .find("async fn search_page_response")
+            .unwrap_or_else(|| panic!("`async fn search_page_response` not found in {label}"));
+        assert!(
+            fetch_start < response_fn_start,
+            "{label}: expected `fetch_page` to appear before `search_page_response`"
+        );
+
+        // `search_page_response`'s own doc comment sits directly above its
+        // `async fn` line, with no blank line separating them from
+        // `fetch_page`'s closing brace — back up over that doc comment so
+        // its prose (which may itself mention the sibling method's token,
+        // e.g. "has_more" wording) is attributed to the RIGHT span. The
+        // blank line right before the doc comment is the real boundary.
+        let response_start = src[fetch_start..response_fn_start]
+            .rfind("\n\n")
+            .map(|offset| fetch_start + offset + 2)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no blank line found between `fetch_page` and `search_page_response`'s \
+                     doc comment in {label}"
+                )
+            });
+
+        // Search for `#[async_trait]` starting AFTER `search_page_response` —
+        // an earlier `#[async_trait]` (e.g. on a helper trait impl) would
+        // wrongly truncate the span before it began.
+        let trait_boundary = src[response_fn_start..]
+            .find("#[async_trait]")
+            .map(|offset| response_fn_start + offset)
+            .unwrap_or_else(|| panic!("`#[async_trait]` (impl SearchExtractor) not found in {label} after search_page_response"));
+
+        (
+            &src[fetch_start..response_start],
+            &src[response_start..trait_boundary],
+        )
+    }
+
+    /// PornHub: `fetch_page` only falls back to the API on page 1, using the
+    /// BASE url builder (`build_api_search_url`, no `_page` suffix).
+    /// `search_page_response` falls back to the API on ANY page, using the
+    /// PAGED url builder (`build_api_search_url_page`) once `page > 1`. If
+    /// the two paths were unified, `build_api_search_url_page` would appear
+    /// in (or disappear from) the wrong span.
+    #[test]
+    fn pornhub_paged_api_fallback_url_builder_stays_in_search_page_response_only() {
+        let src = include_str!("../../extractors/pornhub/mod.rs");
+        let (fetch_page, search_page_response) = method_spans("extractors/pornhub/mod.rs", src);
+
+        assert!(
+            !fetch_page.contains("build_api_search_url_page"),
+            "PornHub `fetch_page` (loop) must NOT call the paged API url builder — \
+             its API fallback only ever targets page 1 (issue #457). If this fires, the \
+             loop and single-page fallback paths have likely been unified."
+        );
+        assert!(
+            search_page_response.contains("build_api_search_url_page"),
+            "PornHub `search_page_response` (single-page) must call \
+             `build_api_search_url_page` for its any-page API fallback (issue #457)."
+        );
+    }
+
+    /// RedTube: `fetch_page` computes `has_more` via
+    /// `termination_from_count(count).has_more(page)`; `search_page_response`
+    /// instead computes it via the `fetched_through < total` window. If the
+    /// two paths were unified onto one `has_more` strategy, one of these four
+    /// assertions fails.
+    #[test]
+    fn redtube_has_more_strategy_diverges_between_loop_and_single_page() {
+        let src = include_str!("../../extractors/redtube/mod.rs");
+        let (fetch_page, search_page_response) = method_spans("extractors/redtube/mod.rs", src);
+
+        assert!(
+            fetch_page.contains("termination_from_count"),
+            "RedTube `fetch_page` (loop) must compute `has_more` via \
+             `termination_from_count` (issue #457)."
+        );
+        assert!(
+            !fetch_page.contains("fetched_through"),
+            "RedTube `fetch_page` (loop) must NOT use the `fetched_through` window — \
+             that strategy belongs to `search_page_response` only (issue #457)."
+        );
+        assert!(
+            search_page_response.contains("fetched_through"),
+            "RedTube `search_page_response` (single-page) must compute `has_more` via \
+             the `fetched_through < total` window (issue #457)."
+        );
+        assert!(
+            !search_page_response.contains("termination_from_count"),
+            "RedTube `search_page_response` (single-page) must NOT use \
+             `termination_from_count` — that strategy belongs to `fetch_page` only \
+             (issue #457)."
+        );
+    }
+}

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -18,27 +18,38 @@ use url::form_urlencoded;
 use super::MAX_PLAYLIST_SIZE;
 use crate::base::common::BaseExtractor;
 
-/// One parsed search page: the rows, an optional total-result estimate, and
-/// whether another page exists. Produced by a site's `parse` hook in a single
-/// pass (no re-scan of the body).
-pub(crate) struct SearchParse {
+/// One parsed search page: the rows, whether another page exists, and an
+/// optional total-result estimate. Produced by a site's `parse` hook in a
+/// single pass (no re-scan of the body).
+pub(crate) struct SearchPage {
     pub results: Vec<SearchResultPreview>,
-    pub total_estimate: Option<u64>,
     pub has_more: bool,
+    pub total_estimate: Option<u64>,
 }
 
-/// Per-site configuration for [`run_search_page`]. All behavioral variation is
-/// a `fn` pointer (zero-alloc, `Copy`); config is plain data. Sites pass bare
-/// `fn` items or non-capturing closures (which coerce to `fn`).
+/// Transitional alias for [`SearchPage`], kept only while [`run_search_page`]
+/// and the 7 single-GET `#440` sites that still call it (XNXX, XVideos, XTits,
+/// NineAnime, EPorner, SpankBang, HQPorner) reference the old name. Removed in
+/// sub-PR 3b together with `run_search_page` and `SearchPageSpec::first_page_index`.
+pub(crate) type SearchParse = SearchPage;
+
+/// Per-site configuration for the default [`PagedSearch::fetch_page`] (via
+/// [`PagedSearch::fetch_via_spec`]) and the legacy [`run_search_page`]. All
+/// behavioral variation is a `fn` pointer (zero-alloc, `Copy`); config is plain
+/// data. Sites pass bare `fn` items or non-capturing closures (which coerce to `fn`).
 pub(crate) struct SearchPageSpec {
     /// The page a `None` `SearchQuery::page` defaults to (0 or 1 per site).
+    ///
+    /// Read only by [`run_search_page`]; `fetch_via_spec` takes `page` as an
+    /// argument (the first-page index is [`PagedSearch::first_page_index`] there).
+    /// Transitional — removed in sub-PR 3b with `run_search_page`.
     pub first_page_index: u32,
     /// Extra request headers; `&[]` for none.
     pub headers: &'static [(&'static str, &'static str)],
     /// Build the page URL from the query and the (site-convention) page number.
     pub build_url: fn(&SearchQuery, u32) -> String,
     /// Parse the fetched body into results + pagination in one pass.
-    pub parse: fn(&str, &SearchQuery, u32) -> Result<SearchParse>,
+    pub parse: fn(&str, &SearchQuery, u32) -> Result<SearchPage>,
 }
 
 /// Shared single-GET search-page skeleton: derive the page, build the URL,
@@ -156,7 +167,7 @@ pub(crate) fn validate_against_descriptors(
 }
 
 /// Delay between successive search-page fetches. All API-paginated sites that
-/// share the [`PaginatedSearch`] scaffold rate-limit at this interval.
+/// share the [`PagedSearch`] scaffold rate-limit at this interval.
 pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// How a paginated search knows when to stop.
@@ -166,7 +177,7 @@ pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Termination {
     Pages(usize),
-    /// Constructed by `PaginatedSearch` adopters that paginate until an empty
+    /// Constructed by `PagedSearch` adopters that paginate until an empty
     /// page (PornHub, RedTube). No reliable total page count is available from
     /// these sites' responses.
     UntilEmpty,
@@ -239,41 +250,96 @@ pub(crate) fn append_search_filters(url: &mut String, filters: &[SearchFilter]) 
 
 /// Shared multi-page search pagination for API-style search extractors.
 ///
-/// Sites whose search fetches page N and learns the total page count from the
-/// same response (XHamster, TNAFlix, EMPFlix, MovieFap) share one pagination
-/// loop: fetch pages in order, accumulate previews, and stop at the first of —
-/// `max_results` reached, `max_pages` reached, an empty page, or a fetch error
-/// (returning the partial results gathered so far). Implementors supply only
-/// the per-site pieces (a single-page fetch, a log tag, filter validation);
+/// Sites whose search fetches page N and learns whether another page exists
+/// from the same response share one pagination loop: fetch pages in order,
+/// accumulate previews, and stop at the first of — `max_results` reached, an
+/// empty page, `!has_more`, or a fetch error (returning the partial results
+/// gathered so far). Implementors supply only the per-site pieces (a single
+/// [`fetch_page`](Self::fetch_page), a log tag, filter validation);
 /// [`search_all_pages`](Self::search_all_pages) is the shared default and
 /// should not be overridden.
 ///
-/// Sites that report a total page count return `Termination::Pages(n)`; sites
-/// with no reliable total (they paginate until an empty page) return
-/// `Termination::UntilEmpty`. Per-page primary↔fallback fetching is a private
-/// concern of each site's `fetch_search_page` implementation.
-pub(crate) trait PaginatedSearch: Send + Sync {
+/// Each `fetch_page` computes its own `has_more` (from a site page count via
+/// the [`Termination`] helper, or from result-emptiness). Per-page
+/// primary↔fallback fetching is a private concern of each site's `fetch_page`.
+pub(crate) trait PagedSearch: Send + Sync {
     /// Bracketed site tag used in log lines, e.g. `"[XHamster]"`.
     fn search_log_tag(&self) -> &'static str;
 
     /// Validate the query's filters against this site's supported filter set.
     fn validate_search_filters(&self, filters: &[SearchFilter]) -> Result<()>;
 
-    /// Fetch a single search page, returning `(results, termination)`.
-    async fn fetch_search_page(
+    /// Fetch + parse ONE page — the single behavioral hook. REQUIRED (no default).
+    /// Single-GET sites implement it as a one-liner delegating to [`fetch_via_spec`];
+    /// exotic sites (two-GET fallback, multi-endpoint) implement a custom body.
+    /// Requiring it makes "forgot to implement" a compile error, not a runtime panic —
+    /// which also lets the crate keep `expect_used`/`unwrap_used` clean (no `.expect()`).
+    ///
+    /// [`fetch_via_spec`]: Self::fetch_via_spec
+    async fn fetch_page(
         &self,
         query: &SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<SearchResultPreview>, Termination)>;
+    ) -> Result<SearchPage>;
+
+    /// Drive a single-GET [`SearchPageSpec`]: build URL → fetch (± headers) → parse.
+    /// This is today's `run_search_page` body minus the response assembly (which
+    /// lives in [`search_page_response`](Self::search_page_response)). Provided
+    /// method — single-GET sites call `self.fetch_via_spec(SPEC, query, page, ctx)`
+    /// from their `fetch_page`. `SearchPageSpec` is `Copy`, taken by value.
+    ///
+    // No caller yet in sub-PR 3a (the 6 migrated sites implement `fetch_page`
+    // directly). The first callers land in sub-PR 3b (the single-GET #440
+    // sites). `expect` (not `allow`) is deliberate: it is self-cleaning —
+    // the moment 3b adds a caller the lint stops firing and `-D warnings`
+    // turns the now-unfulfilled expectation into an error, forcing this
+    // attribute's removal. See `run_search_page` (deleted in 3b) for today's
+    // equivalent body.
+    #[expect(dead_code, reason = "first caller lands in Stage 3b, #450")]
+    async fn fetch_via_spec(
+        &self,
+        spec: SearchPageSpec,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let url = (spec.build_url)(query, page);
+        let body = if spec.headers.is_empty() {
+            BaseExtractor::fetch_webpage(&url, ctx).await?
+        } else {
+            BaseExtractor::fetch_webpage_with_headers(&url, spec.headers, ctx).await?
+        };
+        (spec.parse)(&body, query, page)
+    }
+
+    /// The page a `None` `SearchQuery::page` defaults to (0 or 1 per site).
+    fn first_page_index(&self) -> u32 {
+        1
+    }
+
+    /// Clamp the derived single-page number before it is used for BOTH the fetch
+    /// URL and the echoed `SearchPageResponse.page`. Default identity. A site with
+    /// a floor (ABXXX: `page.max(1)`) overrides this; a universal
+    /// `.max(first_page_index())` is WRONG — it would clamp 1-indexed sites at
+    /// `page = Some(0)`, changing their echoed page. Opt-in per site only.
+    fn clamp_page(&self, page: u32) -> u32 {
+        page
+    }
 
     /// Delay between successive page fetches. Defaults to [`PAGE_RATE_LIMIT_MS`].
     fn page_rate_limit(&self) -> Duration {
         Duration::from_millis(PAGE_RATE_LIMIT_MS)
     }
 
-    /// Collect results across pages until `max_results` / `max_pages` / an empty
-    /// page / a fetch error. Shared scaffold — do not override.
+    /// The `max_results` cap when the query does not specify one. Defaults to
+    /// [`MAX_PLAYLIST_SIZE`]; #440 single-GET sites override to their file-local 500.
+    fn max_results_default(&self) -> usize {
+        MAX_PLAYLIST_SIZE
+    }
+
+    /// Collect results across pages until `max_results` / an empty page / `!has_more`
+    /// / a fetch error (returning partials). Shared scaffold — do not override.
     async fn search_all_pages(
         &self,
         query: &SearchQuery,
@@ -282,32 +348,38 @@ pub(crate) trait PaginatedSearch: Send + Sync {
         self.validate_search_filters(&query.filters)?;
 
         let tag = self.search_log_tag();
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 1usize;
+        let max_results = query.max_results.unwrap_or(self.max_results_default());
+        let mut all_results: Vec<SearchResultPreview> = Vec::new();
+        let mut page = self.first_page_index();
 
         loop {
-            let (page_results, termination) = match self.fetch_search_page(query, page, ctx).await {
-                Ok(result) => result,
+            let SearchPage {
+                results, has_more, ..
+            } = match self.fetch_page(query, page, ctx).await {
+                Ok(p) => p,
                 Err(e) => {
                     debug!(page; "{tag} Failed to fetch search page, returning partial results: {e}");
                     break;
                 }
             };
 
-            if page_results.is_empty() {
+            if results.is_empty() {
                 debug!(page; "{tag} No results on page, stopping pagination");
                 break;
             }
 
-            all_results.extend(page_results);
+            if all_results.is_empty() {
+                all_results = results;
+            } else {
+                all_results.extend(results);
+            }
 
             if all_results.len() >= max_results {
                 all_results.truncate(max_results);
                 break;
             }
 
-            if termination.should_stop(page) {
+            if !has_more {
                 break;
             }
 
@@ -320,16 +392,11 @@ pub(crate) trait PaginatedSearch: Send + Sync {
         Ok(all_results)
     }
 
-    /// Assemble a single-page `SearchPageResponse` from one `fetch_search_page`.
+    /// Assemble a single-page `SearchPageResponse` from one [`fetch_page`]. Shared
+    /// default; the fallback pair (PornHub, RedTube) override this to keep their
+    /// divergent single-page API-fallback semantics.
     ///
-    /// Shared default for `PaginatedSearch` adopters whose per-site
-    /// `SearchExtractor::search_page` was byte-identical (XHamster, TNAFlix,
-    /// MovieFap, EMPFlix): validate filters, derive the 1-based page, fetch it,
-    /// and report `has_more` only when the page was non-empty AND the site's
-    /// `Termination` says another page exists. `total_estimate` is `None` for
-    /// these sites (they report a page count, not a result total). Adopters with
-    /// divergent single-page semantics (PornHub, RedTube) override
-    /// `SearchExtractor::search_page` and do not call this.
+    /// [`fetch_page`]: Self::fetch_page
     async fn search_page_response(
         &self,
         query: &SearchQuery,
@@ -337,16 +404,18 @@ pub(crate) trait PaginatedSearch: Send + Sync {
     ) -> Result<SearchPageResponse> {
         self.validate_search_filters(&query.filters)?;
 
-        let page = query.page.unwrap_or(1) as usize;
-        let (page_results, termination) = self.fetch_search_page(query, page, ctx).await?;
-
-        let has_more = !page_results.is_empty() && termination.has_more(page);
+        let page = self.clamp_page(query.page.unwrap_or(self.first_page_index()));
+        let SearchPage {
+            results,
+            has_more,
+            total_estimate,
+        } = self.fetch_page(query, page, ctx).await?;
 
         Ok(SearchPageResponse {
-            results: page_results,
-            page: page as u32,
+            results,
+            page,
             has_more,
-            total_estimate: None,
+            total_estimate,
         })
     }
 }
@@ -473,7 +542,7 @@ mod tests {
         }
     }
 
-    impl PaginatedSearch for MockSearch {
+    impl PagedSearch for MockSearch {
         fn search_log_tag(&self) -> &'static str {
             "[Mock]"
         }
@@ -491,20 +560,31 @@ mod tests {
         fn page_rate_limit(&self) -> Duration {
             Duration::ZERO
         }
-        async fn fetch_search_page(
+        async fn fetch_page(
             &self,
             _query: &SearchQuery,
-            page: usize,
+            page: u32,
             _ctx: &ExtractionContext,
-        ) -> Result<(Vec<SearchResultPreview>, Termination)> {
+        ) -> Result<SearchPage> {
             self.fetches.fetch_add(1, Ordering::SeqCst);
-            match self.script.get(page - 1) {
-                Some(Page::Ok(results, termination)) => Ok((results.clone(), *termination)),
+            match self.script.get((page - 1) as usize) {
+                Some(Page::Ok(results, termination)) => {
+                    let has_more = !results.is_empty() && termination.has_more(page as usize);
+                    Ok(SearchPage {
+                        results: results.clone(),
+                        has_more,
+                        total_estimate: None,
+                    })
+                }
                 Some(Page::Fail) => Err(RdlpError::extraction(
                     "mock fetch failure",
                     "https://x.test",
                 )),
-                None => Ok((Vec::new(), Termination::UntilEmpty)), // past script → empty page
+                None => Ok(SearchPage {
+                    results: Vec::new(),
+                    has_more: false,
+                    total_estimate: None,
+                }), // past script → empty page
             }
         }
     }
@@ -616,10 +696,10 @@ mod tests {
     }
 
     #[test]
-    fn paginated_search_futures_are_send() {
+    fn paged_search_futures_are_send() {
         // Guards the native-AFIT migration's correctness contract: the outer
         // `#[async_trait] SearchExtractor::search` future must be `Send`, which
-        // requires the `PaginatedSearch` futures it awaits at the concrete call
+        // requires the `PagedSearch` futures it awaits at the concrete call
         // site to be `Send`. Under `#[async_trait]` this was guaranteed by the
         // boxed `dyn Future + Send`; under native AFIT it is inferred, so pin it
         // here. If a future ever goes non-`Send`, this fails at compile time
@@ -630,7 +710,7 @@ mod tests {
         let q = query(None);
         let ctx = test_ctx();
 
-        assert_send(mock.fetch_search_page(&q, 1, &ctx));
+        assert_send(mock.fetch_page(&q, 1, &ctx));
         assert_send(mock.search_all_pages(&q, &ctx));
         assert_send(mock.search_page_response(&q, &ctx));
     }

--- a/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/mod.rs
@@ -35,7 +35,7 @@ use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtra
 use rdlp_types::{InfoDict, SearchPageResponse, SearchQuery, SearchResultPreview};
 use scraper::Html;
 
-use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
+use crate::base::common::{BaseExtractor, PagedSearch, SearchPage};
 use crate::hls::detect_format_sizes_lazy;
 
 pub use patterns::{PORNHUB_PLAYLIST_URL_PATTERN, PORNHUB_VIDEO_URL_PATTERN};
@@ -108,7 +108,7 @@ impl PornHubExtractor {
     }
 }
 
-impl PaginatedSearch for PornHubExtractor {
+impl PagedSearch for PornHubExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[PornHub]"
     }
@@ -117,21 +117,36 @@ impl PaginatedSearch for PornHubExtractor {
         search::validate_search_filters(filters)
     }
 
-    async fn fetch_search_page(
+    /// Fetch + parse ONE search page (loop semantics): HTML-primary, with an
+    /// API fallback ONLY on page 1. `has_more` folds the old
+    /// `Termination::UntilEmpty` — a non-empty page keeps the loop going; an
+    /// empty page breaks in the shared loop before `has_more` is consulted.
+    async fn fetch_page(
         &self,
         query: &SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<SearchResultPreview>, Termination)> {
-        let html_url = search_patterns::build_html_search_url(&query.query, page as u32);
+    ) -> Result<SearchPage> {
+        let html_url = search_patterns::build_html_search_url(&query.query, page);
         match self.fetch_html_search_page(&html_url, ctx).await {
-            Ok(results) if !results.is_empty() => Ok((results, Termination::UntilEmpty)),
+            Ok(results) if !results.is_empty() => Ok(SearchPage {
+                results,
+                has_more: true,
+                total_estimate: None,
+            }),
             outcome => {
                 if page == 1 {
                     let base_url =
                         search_patterns::build_api_search_url(&query.query, &query.filters);
                     match self.fetch_api_search_page(&base_url, ctx).await {
-                        Ok(api_results) => Ok((api_results, Termination::UntilEmpty)),
+                        Ok(api_results) => {
+                            let has_more = !api_results.is_empty();
+                            Ok(SearchPage {
+                                results: api_results,
+                                has_more,
+                                total_estimate: None,
+                            })
+                        }
                         Err(api_err) => {
                             // Preserve the operator-visible WARN (never downgrade
                             // to the shared loop's DEBUG). Then propagate → the
@@ -142,34 +157,22 @@ impl PaginatedSearch for PornHubExtractor {
                     }
                 } else {
                     match outcome {
-                        Ok(empty) => Ok((empty, Termination::UntilEmpty)),
+                        Ok(empty) => Ok(SearchPage {
+                            results: empty,
+                            has_more: false,
+                            total_estimate: None,
+                        }),
                         Err(e) => Err(e),
                     }
                 }
             }
         }
     }
-}
 
-#[async_trait]
-impl SearchExtractor for PornHubExtractor {
-    fn name(&self) -> &str {
-        "PornHub"
-    }
-
-    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
-        search_patterns::search_filter_descriptors()
-    }
-
-    async fn search(
-        &self,
-        query: &SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<SearchResultPreview>> {
-        self.search_all_pages(query, ctx).await
-    }
-
-    async fn search_page(
+    /// Single-page semantics differ from the loop: the API fallback runs on
+    /// ANY page (with a paged API URL), and `has_more` derives from the API
+    /// page-size heuristic. Overrides the shared assembler to preserve this.
+    async fn search_page_response(
         &self,
         query: &SearchQuery,
         ctx: &ExtractionContext,
@@ -206,6 +209,33 @@ impl SearchExtractor for PornHubExtractor {
             has_more,
             total_estimate: None,
         })
+    }
+}
+
+#[async_trait]
+impl SearchExtractor for PornHubExtractor {
+    fn name(&self) -> &str {
+        "PornHub"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
+        search_patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -28,7 +28,7 @@ use regex::Regex;
 use scraper::Html;
 use std::sync::LazyLock;
 
-use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
+use crate::base::common::{BaseExtractor, PagedSearch, SearchPage, Termination};
 use crate::base::tnaflix_network::TnaFlixNetworkBase;
 use crate::hls::detect_format_sizes_lazy;
 use crate::utils::make_absolute_url;
@@ -333,7 +333,7 @@ impl RedTubeExtractor {
     }
 }
 
-impl PaginatedSearch for RedTubeExtractor {
+impl PagedSearch for RedTubeExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[RedTube]"
     }
@@ -343,25 +343,44 @@ impl PaginatedSearch for RedTubeExtractor {
         search::validate_search_filters(filters, &descriptors)
     }
 
-    async fn fetch_search_page(
+    /// Fetch + parse ONE search page (loop semantics): API-primary, with an
+    /// HTML fallback ONLY on page 1. `has_more` folds `termination_from_count`
+    /// (the count-derived predicate, byte-identical to the old loop) on the API
+    /// path, and the old `Termination::UntilEmpty` (result-emptiness) on HTML.
+    async fn fetch_page(
         &self,
         query: &rdlp_types::SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
+    ) -> Result<SearchPage> {
         let base_url = patterns::build_api_search_url(&query.query, &query.filters);
         let page_url = if page == 1 {
             base_url
         } else {
-            patterns::build_api_search_url_page(&base_url, page as u32)
+            patterns::build_api_search_url_page(&base_url, page)
         };
         match self.fetch_api_search_page(&page_url, ctx).await {
-            Ok((results, count)) => Ok((results, termination_from_count(count))),
+            Ok((results, count)) => {
+                let has_more =
+                    !results.is_empty() && termination_from_count(count).has_more(page as usize);
+                Ok(SearchPage {
+                    results,
+                    has_more,
+                    total_estimate: count,
+                })
+            }
             Err(e) => {
                 if page == 1 {
                     let html_url = patterns::build_html_search_url(&query.query);
                     match self.fetch_html_search_page(&html_url, ctx).await {
-                        Ok(results) => Ok((results, Termination::UntilEmpty)),
+                        Ok(results) => {
+                            let has_more = !results.is_empty(); // UntilEmpty
+                            Ok(SearchPage {
+                                results,
+                                has_more,
+                                total_estimate: None,
+                            })
+                        }
                         Err(html_err) => {
                             warn!("[RedTube] HTML fallback also failed: {html_err}");
                             Err(html_err)
@@ -373,27 +392,11 @@ impl PaginatedSearch for RedTubeExtractor {
             }
         }
     }
-}
 
-#[async_trait]
-impl SearchExtractor for RedTubeExtractor {
-    fn name(&self) -> &str {
-        "RedTube"
-    }
-
-    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
-        patterns::search_filter_descriptors()
-    }
-
-    async fn search(
-        &self,
-        query: &rdlp_types::SearchQuery,
-        ctx: &ExtractionContext,
-    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
-        self.search_all_pages(query, ctx).await
-    }
-
-    async fn search_page(
+    /// Single-page semantics diverge: the HTML fallback carries `None` for
+    /// `total_estimate`, and `has_more` uses the `fetched_through < total`
+    /// window. Overrides the shared assembler verbatim to preserve this.
+    async fn search_page_response(
         &self,
         query: &rdlp_types::SearchQuery,
         ctx: &ExtractionContext,
@@ -437,6 +440,33 @@ impl SearchExtractor for RedTubeExtractor {
             has_more,
             total_estimate: total_count,
         })
+    }
+}
+
+#[async_trait]
+impl SearchExtractor for RedTubeExtractor {
+    fn name(&self) -> &str {
+        "RedTube"
+    }
+
+    fn supported_filters(&self) -> Vec<rdlp_types::SearchFilterDescriptor> {
+        patterns::search_filter_descriptors()
+    }
+
+    async fn search(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<Vec<rdlp_types::SearchResultPreview>> {
+        self.search_all_pages(query, ctx).await
+    }
+
+    async fn search_page(
+        &self,
+        query: &rdlp_types::SearchQuery,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPageResponse> {
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/empflix_search.rs
@@ -5,7 +5,7 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Result};
 
 use super::{search_patterns, tnaflix_search_helpers};
-use crate::base::common::{PaginatedSearch, Termination};
+use crate::base::common::{PagedSearch, SearchPage, Termination};
 
 /// EMPFlix search extractor
 ///
@@ -38,7 +38,7 @@ impl EMPFlixSearchExtractor {
     }
 }
 
-impl PaginatedSearch for EMPFlixSearchExtractor {
+impl PagedSearch for EMPFlixSearchExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[EMPFlix]"
     }
@@ -47,14 +47,16 @@ impl PaginatedSearch for EMPFlixSearchExtractor {
         tnaflix_search_helpers::validate_search_filters(filters)
     }
 
-    /// Fetch a single search results page and return `(results, Termination)`.
-    async fn fetch_search_page(
+    /// Fetch + parse ONE search page. `has_more` is computed here from the
+    /// site's reported page count (the `Termination` helper), so the shared
+    /// loop stays conditional-free.
+    async fn fetch_page(
         &self,
         query: &rdlp_types::SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
-        let page_url = Self::build_page_url(query, page);
+    ) -> Result<SearchPage> {
+        let page_url = Self::build_page_url(query, page as usize);
         debug!(page; "[EMPFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
         let webpage = crate::base::common::BaseExtractor::fetch_webpage(&page_url, ctx).await?;
@@ -68,7 +70,13 @@ impl PaginatedSearch for EMPFlixSearchExtractor {
             page_results.len()
         );
 
-        Ok((page_results, Termination::Pages(max_pages)))
+        let has_more =
+            !page_results.is_empty() && Termination::Pages(max_pages).has_more(page as usize);
+        Ok(SearchPage {
+            results: page_results,
+            has_more,
+            total_estimate: None,
+        })
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/moviefap_search.rs
@@ -8,7 +8,7 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Result};
 
 use super::{moviefap_search_helpers, moviefap_search_patterns};
-use crate::base::common::{PaginatedSearch, Termination};
+use crate::base::common::{PagedSearch, SearchPage, Termination};
 
 /// MovieFap search extractor
 ///
@@ -24,7 +24,7 @@ impl MovieFapSearchExtractor {
     }
 }
 
-impl PaginatedSearch for MovieFapSearchExtractor {
+impl PagedSearch for MovieFapSearchExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[MovieFap]"
     }
@@ -33,14 +33,16 @@ impl PaginatedSearch for MovieFapSearchExtractor {
         moviefap_search_helpers::validate_search_filters(filters)
     }
 
-    /// Fetch a single search results page and return `(results, Termination)`.
-    async fn fetch_search_page(
+    /// Fetch + parse ONE search page. `has_more` is computed here from the
+    /// site's reported page count (the `Termination` helper), so the shared
+    /// loop stays conditional-free.
+    async fn fetch_page(
         &self,
         query: &rdlp_types::SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
-        let page_url = moviefap_search_patterns::build_search_url(query, page);
+    ) -> Result<SearchPage> {
+        let page_url = moviefap_search_patterns::build_search_url(query, page as usize);
         debug!(page; "[MovieFap] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
         let webpage = crate::base::common::BaseExtractor::fetch_webpage(&page_url, ctx).await?;
@@ -54,7 +56,13 @@ impl PaginatedSearch for MovieFapSearchExtractor {
             page_results.len()
         );
 
-        Ok((page_results, Termination::Pages(max_pages)))
+        let has_more =
+            !page_results.is_empty() && Termination::Pages(max_pages).has_more(page as usize);
+        Ok(SearchPage {
+            results: page_results,
+            has_more,
+            total_estimate: None,
+        })
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/search.rs
@@ -5,7 +5,7 @@ use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::SearchPageResponse;
 
-use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
+use crate::base::common::{BaseExtractor, PagedSearch, SearchPage, Termination};
 
 use super::search_patterns;
 use super::tnaflix_search_helpers;
@@ -44,7 +44,7 @@ impl TNAFlixSearchExtractor {
     }
 }
 
-impl PaginatedSearch for TNAFlixSearchExtractor {
+impl PagedSearch for TNAFlixSearchExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[TNAFlix]"
     }
@@ -53,14 +53,16 @@ impl PaginatedSearch for TNAFlixSearchExtractor {
         tnaflix_search_helpers::validate_search_filters(filters)
     }
 
-    /// Fetch a single search results page and return `(results, Termination)`.
-    async fn fetch_search_page(
+    /// Fetch + parse ONE search page. `has_more` is computed here from the
+    /// site's reported page count (the `Termination` helper), so the shared
+    /// loop stays conditional-free.
+    async fn fetch_page(
         &self,
         query: &rdlp_types::SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
-        let page_url = Self::build_page_url(query, page);
+    ) -> Result<SearchPage> {
+        let page_url = Self::build_page_url(query, page as usize);
         debug!(page; "[TNAFlix] Fetching search page: {}", rdlp_security::sanitize_for_logging(&page_url));
 
         let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
@@ -74,7 +76,13 @@ impl PaginatedSearch for TNAFlixSearchExtractor {
             page_results.len()
         );
 
-        Ok((page_results, Termination::Pages(max_pages)))
+        let has_more =
+            !page_results.is_empty() && Termination::Pages(max_pages).has_more(page as usize);
+        Ok(SearchPage {
+            results: page_results,
+            has_more,
+            total_estimate: None,
+        })
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -32,7 +32,7 @@ use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtra
 use rdlp_types::{InfoDict, SearchPageResponse};
 use std::time::Duration;
 
-use crate::base::common::{BaseExtractor, PaginatedSearch, Termination};
+use crate::base::common::{BaseExtractor, PagedSearch, SearchPage, Termination};
 use crate::hls::detect_format_sizes_lazy;
 
 pub use patterns::{XHAMSTER_EMBED_PATTERN, XHAMSTER_VIDEO_PATTERN};
@@ -41,7 +41,7 @@ pub use patterns::{XHAMSTER_EMBED_PATTERN, XHAMSTER_VIDEO_PATTERN};
 const VIDEO_EXTRACTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Rate limit delay between playlist page fetches (500ms). Search pagination
-/// uses the shared `PaginatedSearch` default instead.
+/// uses the shared `PagedSearch` default instead.
 const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// Number of concurrent video extractions
@@ -250,7 +250,7 @@ impl XHamsterExtractor {
     }
 }
 
-impl PaginatedSearch for XHamsterExtractor {
+impl PagedSearch for XHamsterExtractor {
     fn search_log_tag(&self) -> &'static str {
         "[XHamster]"
     }
@@ -259,17 +259,19 @@ impl PaginatedSearch for XHamsterExtractor {
         search::validate_search_filters(filters)
     }
 
-    /// Fetch a single search page, returning its results and a `Termination`.
-    async fn fetch_search_page(
+    /// Fetch + parse ONE search page. `has_more` is computed here from the
+    /// site's reported page count (the `Termination` helper), so the shared
+    /// loop stays conditional-free.
+    async fn fetch_page(
         &self,
         query: &rdlp_types::SearchQuery,
-        page: usize,
+        page: u32,
         ctx: &ExtractionContext,
-    ) -> Result<(Vec<rdlp_types::SearchResultPreview>, Termination)> {
+    ) -> Result<SearchPage> {
         let page_url = if page == 1 {
             patterns::build_search_url(query)
         } else {
-            patterns::build_search_url_page(query, page)
+            patterns::build_search_url_page(query, page as usize)
         };
 
         debug!(page, url:? = rdlp_security::sanitize_for_logging(&page_url); "[XHamster] Fetching search page");
@@ -279,7 +281,13 @@ impl PaginatedSearch for XHamsterExtractor {
         let page_results = search::parse_search_results_json(&initials)?;
         let max_pages = search::parse_max_pages(&initials).unwrap_or(1);
 
-        Ok((page_results, Termination::Pages(max_pages)))
+        let has_more =
+            !page_results.is_empty() && Termination::Pages(max_pages).has_more(page as usize);
+        Ok(SearchPage {
+            results: page_results,
+            has_more,
+            total_estimate: None,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Stage 3a of the search-pagination unification (meta #450, follow-up to #440). **Behavior-preserving** trait unification — no site behavior changes.

Introduces the unified `pub(crate)` native-AFIT trait `PagedSearch` in `base/common/search.rs`, replacing `PaginatedSearch`, and migrates the 6 already-AFIT sites onto it. `run_search_page` and the 7 #440 single-GET sites are **untouched** (folded in the follow-up 3b).

### Changes
- Rename `PaginatedSearch → PagedSearch`, `SearchParse → SearchPage` (kept as a transitional `type SearchParse = SearchPage;` alias — removed in 3b), hook `fetch_search_page → fetch_page` (returns `SearchPage`; `has_more` computed *inside* the hook, subsuming `Termination`).
- `fetch_page` is a **required** method (no default, no `Option`) + a **provided** `fetch_via_spec` helper holding the future single-GET fetch body. Design decision: making `fetch_page` required turns "forgot to implement" into a compile error, keeping the crate's `expect_used`/`unwrap_used = "warn"` gate clean (a defaulted `.expect()` hook would fail `-D warnings`). Research-backed (Rust Book ch.9.3 make-illegal-states-unrepresentable; clippy `expect_used`; RFC 2383).
- Add config hooks with behavior-preserving defaults: `first_page_index()`, `clamp_page()`, `page_rate_limit()`, `max_results_default()`. `search_all_pages` + `search_page_response` are the two shared defaults.
- Migrate 6 sites: **4 termination** (XHamster, TNAFlix, MovieFap, EMPFlix — `has_more` via the shared `pub(crate) Termination` helper, `total_estimate: None`) + **2 API-fallback** (PornHub, RedTube — override `search_page_response` to preserve their divergent single-page fallback verbatim; `fetch_page` carries loop semantics).
- Page type unifies to `u32` (`as usize` only at `Termination::has_more`).
- `fetch_via_spec` is `#[expect(dead_code, reason = "first caller lands in Stage 3b, #450")]` — self-cleaning: its first caller in 3b turns the unfulfilled expectation into a `-D warnings` error, forcing the attribute's removal. (Chosen over `#[allow]` per the no-dead-code-for-future rule's rationale.)

### Tests
- Behavior-preserving: **zero assertion edits** to existing search tests. The `MockSearch` suite + all 6 sites' tests stay green unchanged (regression guard). Native-AFIT `Send` guard renamed `paged_search_futures_are_send`.
- Adds a compile-time `include_str!` **fallback-divergence guard** (`fallback_divergence_guard` in `search.rs`) pinning the PornHub (`build_api_search_url_page` present-in-single/absent-in-loop) and RedTube (`termination_from_count` loop vs `fetched_through` single) divergences. This is the crate's sanctioned zero-seam substitute for a mockito golden test, which is **infeasible** here (hardcoded `https://` builders, mockito HTTP-only, concrete `http_client` — documented in `pornhub/tests/fetch.rs:1-7`, PR #231). The real end-to-end golden test (injectable base-URL seam) is deferred to #457.

### Reviews
- **security-reviewer**: PASS — no High/Critical/Medium. SSRF surface unchanged, pagination bound preserved (`has_more(page) == !should_stop(page)` verified), log hygiene intact, no `has_more` runaway.
- **code-reviewer**: Approve-with-minor — no Critical/Important. All 6 migrations verified byte-equivalent; override bodies verbatim; field-reorder safe; `#[expect]` correct. Deferred Minors: `fetch_via_spec` arg-count rationale + `UntilEmpty` doc refresh (both folded into 3b when that code is next touched).

### Gate
`cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test` (workspace, 0 failed) · `check-dedup` · `check-url-redaction` · `check-no-cli` · `check-wit-drift` · `check-log-redaction` · `cargo check -p rdlp-desktop` — all green.

Closes #456
Refs #440
Refs #450
Refs #457
