### PR TITLE
refactor(rdlp-extractor): fold 7 #440 search sites onto PagedSearch; delete run_search_page (Stage 3b)

### DIFF
--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -58,9 +58,15 @@ use regex::Regex;
 // Re-export selectors, patterns, and constants from submodule
 pub(crate) use protocol::protocol_for_url;
 pub(crate) use search::{
-    FilterValidationError, KeyValidation, PagedSearch, SearchPage, SearchPageSpec, SearchParse,
-    Termination, append_search_filters, run_search_page, validate_against_descriptors,
+    FilterValidationError, KeyValidation, PagedSearch, SearchPage, SearchPageSpec, Termination,
+    append_search_filters, validate_against_descriptors,
 };
+// Transitional re-export: no site imports these through this path as of
+// sub-PR 3b-7 (spankbang, the last `run_search_page` caller, moved onto
+// `PagedSearch::fetch_via_spec`). Deleted alongside `run_search_page` and
+// `SearchParse` in sub-PR 3b-8; `#[expect]` is self-cleaning.
+#[expect(unused_imports, reason = "deleted in Stage 3b-8, #450")]
+pub(crate) use search::{SearchParse, run_search_page};
 pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -61,12 +61,6 @@ pub(crate) use search::{
     FilterValidationError, KeyValidation, PagedSearch, SearchPage, SearchPageSpec, Termination,
     append_search_filters, validate_against_descriptors,
 };
-// Transitional re-export: no site imports these through this path as of
-// sub-PR 3b-7 (spankbang, the last `run_search_page` caller, moved onto
-// `PagedSearch::fetch_via_spec`). Deleted alongside `run_search_page` and
-// `SearchParse` in sub-PR 3b-8; `#[expect]` is self-cleaning.
-#[expect(unused_imports, reason = "deleted in Stage 3b-8, #450")]
-pub(crate) use search::{SearchParse, run_search_page};
 pub(crate) use selectors::*;
 
 /// Maximum URL length to prevent memory exhaustion attacks

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -288,15 +288,6 @@ pub(crate) trait PagedSearch: Send + Sync {
     /// lives in [`search_page_response`](Self::search_page_response)). Provided
     /// method — single-GET sites call `self.fetch_via_spec(SPEC, query, page, ctx)`
     /// from their `fetch_page`. `SearchPageSpec` is `Copy`, taken by value.
-    ///
-    // No caller yet in sub-PR 3a (the 6 migrated sites implement `fetch_page`
-    // directly). The first callers land in sub-PR 3b (the single-GET #440
-    // sites). `expect` (not `allow`) is deliberate: it is self-cleaning —
-    // the moment 3b adds a caller the lint stops firing and `-D warnings`
-    // turns the now-unfulfilled expectation into an error, forcing this
-    // attribute's removal. See `run_search_page` (deleted in 3b) for today's
-    // equivalent body.
-    #[expect(dead_code, reason = "first caller lands in Stage 3b, #450")]
     async fn fetch_via_spec(
         &self,
         spec: SearchPageSpec,

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -27,10 +27,14 @@ pub(crate) struct SearchPage {
     pub total_estimate: Option<u64>,
 }
 
-/// Transitional alias for [`SearchPage`], kept only while [`run_search_page`]
-/// and the 7 single-GET `#440` sites that still call it (XNXX, XVideos, XTits,
-/// NineAnime, EPorner, SpankBang, HQPorner) reference the old name. Removed in
-/// sub-PR 3b together with `run_search_page` and `SearchPageSpec::first_page_index`.
+/// Transitional alias for [`SearchPage`], kept only until sub-PR 3b-8 deletes
+/// it together with `run_search_page` and `SearchPageSpec::first_page_index`.
+/// As of 3b-7 (spankbang, the last of the 7 single-GET `#440` sites) no site
+/// still calls `run_search_page`, so this is genuinely unused — `#[expect]`
+/// (not `#[allow]`) is deliberate: it is self-cleaning, matching the pattern
+/// used for `PagedSearch::fetch_via_spec` in sub-PR 3a. The moment 3b-8
+/// deletes the alias the expectation is fulfilled and removed alongside it.
+#[expect(dead_code, reason = "deleted in Stage 3b-8, #450")]
 pub(crate) type SearchParse = SearchPage;
 
 /// Per-site configuration for the default [`PagedSearch::fetch_page`] (via
@@ -42,7 +46,9 @@ pub(crate) struct SearchPageSpec {
     ///
     /// Read only by [`run_search_page`]; `fetch_via_spec` takes `page` as an
     /// argument (the first-page index is [`PagedSearch::first_page_index`] there).
-    /// Transitional — removed in sub-PR 3b with `run_search_page`.
+    /// Transitional — deleted in sub-PR 3b-8 with `run_search_page`. As of
+    /// 3b-7 no call site reads this field; `#[expect]` is self-cleaning.
+    #[expect(dead_code, reason = "deleted in Stage 3b-8, #450")]
     pub first_page_index: u32,
     /// Extra request headers; `&[]` for none.
     pub headers: &'static [(&'static str, &'static str)],
@@ -56,6 +62,13 @@ pub(crate) struct SearchPageSpec {
 /// fetch once (with optional headers), parse, and assemble the response. Sites
 /// with genuinely divergent shapes (two-fetch fallback, termination-based
 /// pagination) keep their own `search_page` and do not use this.
+///
+/// As of sub-PR 3b-7 (spankbang) every former caller has moved onto
+/// [`PagedSearch::fetch_via_spec`]; this function is genuinely unused and
+/// kept only until 3b-8 deletes it. `#[expect]` (not `#[allow]`) so the
+/// unfulfilled-expectation lint forces removal of this attribute the moment
+/// the function is deleted.
+#[expect(dead_code, reason = "deleted in Stage 3b-8, #450")]
 pub(crate) async fn run_search_page(
     query: &SearchQuery,
     ctx: &ExtractionContext,

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -27,67 +27,17 @@ pub(crate) struct SearchPage {
     pub total_estimate: Option<u64>,
 }
 
-/// Transitional alias for [`SearchPage`], kept only until sub-PR 3b-8 deletes
-/// it together with `run_search_page` and `SearchPageSpec::first_page_index`.
-/// As of 3b-7 (spankbang, the last of the 7 single-GET `#440` sites) no site
-/// still calls `run_search_page`, so this is genuinely unused — `#[expect]`
-/// (not `#[allow]`) is deliberate: it is self-cleaning, matching the pattern
-/// used for `PagedSearch::fetch_via_spec` in sub-PR 3a. The moment 3b-8
-/// deletes the alias the expectation is fulfilled and removed alongside it.
-#[expect(dead_code, reason = "deleted in Stage 3b-8, #450")]
-pub(crate) type SearchParse = SearchPage;
-
 /// Per-site configuration for the default [`PagedSearch::fetch_page`] (via
-/// [`PagedSearch::fetch_via_spec`]) and the legacy [`run_search_page`]. All
-/// behavioral variation is a `fn` pointer (zero-alloc, `Copy`); config is plain
-/// data. Sites pass bare `fn` items or non-capturing closures (which coerce to `fn`).
+/// [`PagedSearch::fetch_via_spec`]). All behavioral variation is a `fn`
+/// pointer (zero-alloc, `Copy`); config is plain data. Sites pass bare `fn`
+/// items or non-capturing closures (which coerce to `fn`).
 pub(crate) struct SearchPageSpec {
-    /// The page a `None` `SearchQuery::page` defaults to (0 or 1 per site).
-    ///
-    /// Read only by [`run_search_page`]; `fetch_via_spec` takes `page` as an
-    /// argument (the first-page index is [`PagedSearch::first_page_index`] there).
-    /// Transitional — deleted in sub-PR 3b-8 with `run_search_page`. As of
-    /// 3b-7 no call site reads this field; `#[expect]` is self-cleaning.
-    #[expect(dead_code, reason = "deleted in Stage 3b-8, #450")]
-    pub first_page_index: u32,
     /// Extra request headers; `&[]` for none.
     pub headers: &'static [(&'static str, &'static str)],
     /// Build the page URL from the query and the (site-convention) page number.
     pub build_url: fn(&SearchQuery, u32) -> String,
     /// Parse the fetched body into results + pagination in one pass.
     pub parse: fn(&str, &SearchQuery, u32) -> Result<SearchPage>,
-}
-
-/// Shared single-GET search-page skeleton: derive the page, build the URL,
-/// fetch once (with optional headers), parse, and assemble the response. Sites
-/// with genuinely divergent shapes (two-fetch fallback, termination-based
-/// pagination) keep their own `search_page` and do not use this.
-///
-/// As of sub-PR 3b-7 (spankbang) every former caller has moved onto
-/// [`PagedSearch::fetch_via_spec`]; this function is genuinely unused and
-/// kept only until 3b-8 deletes it. `#[expect]` (not `#[allow]`) so the
-/// unfulfilled-expectation lint forces removal of this attribute the moment
-/// the function is deleted.
-#[expect(dead_code, reason = "deleted in Stage 3b-8, #450")]
-pub(crate) async fn run_search_page(
-    query: &SearchQuery,
-    ctx: &ExtractionContext,
-    spec: SearchPageSpec,
-) -> Result<SearchPageResponse> {
-    let page = query.page.unwrap_or(spec.first_page_index);
-    let url = (spec.build_url)(query, page);
-    let body = if spec.headers.is_empty() {
-        BaseExtractor::fetch_webpage(&url, ctx).await?
-    } else {
-        BaseExtractor::fetch_webpage_with_headers(&url, spec.headers, ctx).await?
-    };
-    let parsed = (spec.parse)(&body, query, page)?;
-    Ok(SearchPageResponse {
-        results: parsed.results,
-        page,
-        has_more: parsed.has_more,
-        total_estimate: parsed.total_estimate,
-    })
 }
 
 /// How one filter key's value is validated by [`validate_against_descriptors`].
@@ -190,9 +140,13 @@ pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Termination {
     Pages(usize),
-    /// Constructed by `PagedSearch` adopters that paginate until an empty
-    /// page (PornHub, RedTube). No reliable total page count is available from
-    /// these sites' responses.
+    /// Used when no reliable total page count is available from a site's
+    /// response, so pagination stops only on an empty page. RedTube's
+    /// `termination_from_count` constructs this variant (via its `fetch_page`)
+    /// when the API response carries no `count`. PornHub folds the same
+    /// semantic inline in `fetch_page` (`has_more: true` on any non-empty
+    /// page) rather than constructing this variant. Otherwise reachable via
+    /// unit tests in this module.
     UntilEmpty,
 }
 
@@ -297,10 +251,13 @@ pub(crate) trait PagedSearch: Send + Sync {
     ) -> Result<SearchPage>;
 
     /// Drive a single-GET [`SearchPageSpec`]: build URL → fetch (± headers) → parse.
-    /// This is today's `run_search_page` body minus the response assembly (which
-    /// lives in [`search_page_response`](Self::search_page_response)). Provided
-    /// method — single-GET sites call `self.fetch_via_spec(SPEC, query, page, ctx)`
-    /// from their `fetch_page`. `SearchPageSpec` is `Copy`, taken by value.
+    /// Provided method — single-GET sites call
+    /// `self.fetch_via_spec(SPEC, query, page, ctx)` from their `fetch_page`.
+    /// `SearchPageSpec` is `Copy`, taken by value.
+    ///
+    /// 4 params: `spec` is a parameter-object, `ctx` the threaded extraction
+    /// context, `(query, page)` the trait's established pair — no same-type
+    /// ambiguity.
     async fn fetch_via_spec(
         &self,
         spec: SearchPageSpec,

--- a/crates/rdlp-extractor/src/extractors/abxxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/abxxx/search.rs
@@ -272,8 +272,9 @@ impl SearchExtractor for AbxxxExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        // Bespoke: the `.max(1)` clamp is reflected in the returned SearchPageResponse.page,
-        // which run_search_page cannot reproduce (it drives page from an unclamped unwrap_or). See #450.
+        // Bespoke: the `.max(1)` clamp is reflected in the returned SearchPageResponse.page.
+        // The shared PagedSearch skeleton exposes a `clamp_page` hook for exactly this;
+        // ABXXX is folded onto it in Stage 3c. See #450.
         let page = query.page.unwrap_or(1).max(1);
         let sort = resolved_sort(&query.filters);
         let url = kvs_api::videos2_search_endpoint(

--- a/crates/rdlp-extractor/src/extractors/eporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/eporner/search.rs
@@ -246,7 +246,6 @@ impl PagedSearch for EPornerExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 0, // struct field exists until 3b-8; fetch_via_spec ignores it
             headers: &[],
             build_url: build_search_url,
             parse: |body, _query, page| {

--- a/crates/rdlp-extractor/src/extractors/eporner/search.rs
+++ b/crates/rdlp-extractor/src/extractors/eporner/search.rs
@@ -12,7 +12,7 @@ use scraper::{Html, Selector};
 use std::sync::LazyLock;
 
 use super::EPornerExtractor;
-use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{BaseExtractor, PagedSearch, SearchPage, SearchPageSpec};
 
 const EPORNER_ROOT: &str = "https://www.eporner.com";
 
@@ -225,6 +225,44 @@ fn parse_results(html: &str) -> Vec<SearchResultPreview> {
     out
 }
 
+impl PagedSearch for EPornerExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[EPorner]"
+    }
+
+    // EPorner has no filter validation today; Ok(()) preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        0
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 0, // struct field exists until 3b-8; fetch_via_spec ignores it
+            headers: &[],
+            build_url: build_search_url,
+            parse: |body, _query, page| {
+                let results = parse_results(body);
+                let has_more = body.contains(&format!("/{}/", page + 2));
+                Ok(SearchPage {
+                    results,
+                    total_estimate: None,
+                    has_more,
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for EPornerExtractor {
     fn name(&self) -> &str {
@@ -254,8 +292,7 @@ impl SearchExtractor for EPornerExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let page_resp = self.search_page(query, ctx).await?;
-        Ok(page_resp.results)
+        Ok(self.search_page_response(query, ctx).await?.results)
     }
 
     async fn search_page(
@@ -263,26 +300,7 @@ impl SearchExtractor for EPornerExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 0,
-                headers: &[],
-                build_url: build_search_url,
-                parse: |body, _query, page| {
-                    let results = parse_results(body);
-                    // next-page probe: a "/{page+2}/" link in the pagination
-                    let has_more = body.contains(&format!("/{}/", page + 2));
-                    Ok(SearchParse {
-                        results,
-                        total_estimate: None,
-                        has_more,
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -30,14 +30,14 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use lazy_regex::{Lazy, Regex, lazy_regex};
-use log::{debug, warn};
+use log::warn;
 use rdlp_core::{ExtractionContext, InfoExtractor, RdlpError, Result, SearchExtractor};
 use rdlp_types::{InfoDict, SearchPageResponse, SearchQuery, SearchResultPreview};
 use scraper::Html;
 use std::sync::LazyLock;
 
 use crate::base::common::{
-    BaseExtractor, MAX_PLAYLIST_SIZE, SearchPageSpec, SearchParse, run_search_page,
+    BaseExtractor, MAX_PLAYLIST_SIZE, PagedSearch, SearchPage, SearchPageSpec,
 };
 use crate::hls::detect_format_sizes_lazy;
 
@@ -342,6 +342,42 @@ impl InfoExtractor for HQPornerExtractor {
     }
 }
 
+impl PagedSearch for HQPornerExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[HQPorner]"
+    }
+
+    // HQPorner has no filter validation today; Ok(()) preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        1
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 1, // struct field exists until 3b-8; fetch_via_spec ignores it
+            headers: &[("Referer", "https://hqporner.com/")],
+            build_url: |query, page| search_patterns::build_search_url(&query.query, page),
+            parse: |body, _query, _page| {
+                Ok(SearchPage {
+                    results: search::parse_search_results(body),
+                    total_estimate: search::extract_total_count(body),
+                    has_more: search::has_next_page(body),
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for HQPornerExtractor {
     fn name(&self) -> &str {
@@ -358,47 +394,7 @@ impl SearchExtractor for HQPornerExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 1_u32;
-
-        loop {
-            let page_url = search_patterns::build_search_url(&query.query, page);
-            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
-            debug!("[HQPorner] Fetching search page {page}: {sanitized}");
-
-            let webpage = BaseExtractor::fetch_webpage_with_headers(
-                &page_url,
-                &[("Referer", "https://hqporner.com/")],
-                ctx,
-            )
-            .await?;
-            let page_results = search::parse_search_results(&webpage);
-
-            if page_results.is_empty() {
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if !search::has_next_page(&webpage) {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(
-            "[HQPorner] Search complete: {} results across {page} pages",
-            all_results.len()
-        );
-        Ok(all_results)
+        self.search_all_pages(query, ctx).await
     }
 
     async fn search_page(
@@ -406,23 +402,7 @@ impl SearchExtractor for HQPornerExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 1,
-                headers: &[("Referer", "https://hqporner.com/")],
-                build_url: |query, page| search_patterns::build_search_url(&query.query, page),
-                parse: |body, _query, _page| {
-                    Ok(SearchParse {
-                        results: search::parse_search_results(body),
-                        total_estimate: search::extract_total_count(body),
-                        has_more: search::has_next_page(body),
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mod.rs
@@ -363,7 +363,6 @@ impl PagedSearch for HQPornerExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 1, // struct field exists until 3b-8; fetch_via_spec ignores it
             headers: &[("Referer", "https://hqporner.com/")],
             build_url: |query, page| search_patterns::build_search_url(&query.query, page),
             parse: |body, _query, _page| {

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -248,7 +248,7 @@ impl SearchExtractor for KoreanPornMovieExtractor {
         Ok(response.results)
     }
 
-    // Bespoke: multi-endpoint browse dispatch (single-GET run_search_page skeleton does not fit); see #450.
+    // Bespoke: multi-endpoint browse dispatch (the single-GET PagedSearch spec path does not fit); folded in Stage 3c. See #450.
     async fn search_page(
         &self,
         query: &SearchQuery,

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
@@ -4,16 +4,16 @@
 //! (`?page=N`, 0-based). No AJAX needed — standard HTML scraping.
 
 use async_trait::async_trait;
-use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{SearchPageResponse, SearchQuery, SearchResultPreview};
-use std::time::Duration;
 
 use super::NineAnimeExtractor;
 use super::search_patterns;
-use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{PagedSearch, SearchPage, SearchPageSpec};
 
 const BASE_URL: &str = "https://9animetv.to";
+
+/// Maximum results cap for a full search (matches the pre-refactor loop's cap).
 const MAX_PLAYLIST_SIZE: usize = 500;
 
 /// Parse search result items from 9anime search page HTML.
@@ -72,6 +72,52 @@ pub(crate) fn extract_total_pages(html: &str) -> Option<u32> {
         .and_then(|m| m.as_str().parse().ok())
 }
 
+impl PagedSearch for NineAnimeExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[NineAnime]"
+    }
+
+    // NineAnime has no filter validation today; Ok(()) preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        1
+    }
+
+    fn max_results_default(&self) -> usize {
+        MAX_PLAYLIST_SIZE
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 1, // struct field exists until 3b-8; fetch_via_spec ignores it
+            headers: &[("Referer", "https://9animetv.to/")],
+            build_url: |query, page| {
+                let url_page = if page > 0 { page - 1 } else { 0 };
+                search_patterns::build_search_url(query, url_page)
+            },
+            parse: |body, _query, _page| {
+                let results = parse_search_results(body);
+                let total_estimate = extract_total_pages(body)
+                    .map(|tp| tp as u64 * search_patterns::RESULTS_PER_PAGE);
+                Ok(SearchPage {
+                    has_more: has_next_page(body) && !results.is_empty(),
+                    total_estimate,
+                    results,
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for NineAnimeExtractor {
     fn name(&self) -> &str {
@@ -87,48 +133,7 @@ impl SearchExtractor for NineAnimeExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 0_u32; // 0-based pagination
-
-        loop {
-            let page_url = search_patterns::build_search_url(query, page);
-            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
-            debug!("[NineAnime] Fetching search page {}: {sanitized}", page + 1);
-
-            let webpage = BaseExtractor::fetch_webpage_with_headers(
-                &page_url,
-                &[("Referer", "https://9animetv.to/")],
-                ctx,
-            )
-            .await?;
-
-            let page_results = parse_search_results(&webpage);
-            if page_results.is_empty() {
-                break;
-            }
-
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if !has_next_page(&webpage) {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(search_patterns::PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(
-            "[NineAnime] Search complete: {} results across {} pages",
-            all_results.len(),
-            page + 1
-        );
-        Ok(all_results)
+        self.search_all_pages(query, ctx).await
     }
 
     async fn search_page(
@@ -136,29 +141,7 @@ impl SearchExtractor for NineAnimeExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 1,
-                headers: &[("Referer", "https://9animetv.to/")],
-                build_url: |query, page| {
-                    let url_page = if page > 0 { page - 1 } else { 0 };
-                    search_patterns::build_search_url(query, url_page)
-                },
-                parse: |body, _query, _page| {
-                    let results = parse_search_results(body);
-                    let total_estimate = extract_total_pages(body)
-                        .map(|tp| tp as u64 * search_patterns::RESULTS_PER_PAGE);
-                    Ok(SearchParse {
-                        has_more: has_next_page(body) && !results.is_empty(),
-                        total_estimate,
-                        results,
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search.rs
@@ -97,7 +97,6 @@ impl PagedSearch for NineAnimeExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 1, // struct field exists until 3b-8; fetch_via_spec ignores it
             headers: &[("Referer", "https://9animetv.to/")],
             build_url: |query, page| {
                 let url_page = if page > 0 { page - 1 } else { 0 };

--- a/crates/rdlp-extractor/src/extractors/nine_anime/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/search_patterns.rs
@@ -9,9 +9,6 @@ const BASE_URL: &str = "https://9animetv.to";
 /// Approximate results per page.
 pub(crate) const RESULTS_PER_PAGE: u64 = 30;
 
-/// Rate limit between page fetches (milliseconds).
-pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
-
 /// Extract film-name links from 9anime search results.
 /// Captures: (1) href, (2) title.
 pub(crate) static FILM_NAME_PATTERN: Lazy<Regex> = lazy_regex!(

--- a/crates/rdlp-extractor/src/extractors/spankbang/search.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/search.rs
@@ -237,7 +237,7 @@ impl PagedSearch for SpankBangExtractor {
     }
 
     // SpankBang advertises an `ordering` filter but has never validated it
-    // (the pre-refactor `run_search_page` path never checked); `Ok(())` is
+    // (the pre-refactor single-GET search path never checked); `Ok(())` is
     // the only value that preserves that.
     fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
         Ok(())

--- a/crates/rdlp-extractor/src/extractors/spankbang/search.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/search.rs
@@ -258,7 +258,6 @@ impl PagedSearch for SpankBangExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 0, // struct field exists until 3b-8; fetch_via_spec ignores it
             headers: &[("Cookie", "country=US")],
             build_url: build_search_url,
             parse: |body, query, page| {

--- a/crates/rdlp-extractor/src/extractors/spankbang/search.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/search.rs
@@ -19,7 +19,7 @@ use rdlp_types::{
 use super::SpankBangExtractor;
 use super::{metadata, patterns};
 use crate::base::common::BaseExtractor;
-use crate::base::common::{SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{PagedSearch, SearchPage, SearchPageSpec};
 
 const SPANKBANG_BASE_URL: &str = "https://spankbang.com";
 const SPANKBANG_NAME_STR: &str = "SpankBang";
@@ -231,6 +231,48 @@ fn has_more_pages(html: &str, query: &SearchQuery, page: u32) -> bool {
     parse_results(html).len() as u64 >= RESULTS_PER_PAGE
 }
 
+impl PagedSearch for SpankBangExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[spankbang]"
+    }
+
+    // SpankBang advertises an `ordering` filter but has never validated it
+    // (the pre-refactor `run_search_page` path never checked); `Ok(())` is
+    // the only value that preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        0
+    }
+
+    // NOTE: `max_results_default` is intentionally NOT overridden here — the
+    // 500-result cap lives in the hand-rolled `search()` loop below, which
+    // this trait impl does not drive (only `search_page`/`fetch_page` does).
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 0, // struct field exists until 3b-8; fetch_via_spec ignores it
+            headers: &[("Cookie", "country=US")],
+            build_url: build_search_url,
+            parse: |body, query, page| {
+                Ok(SearchPage {
+                    results: parse_results(body),
+                    total_estimate: Some(RESULTS_PER_PAGE * 100),
+                    has_more: has_more_pages(body, query, page),
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for SpankBangExtractor {
     fn name(&self) -> &str {
@@ -372,23 +414,7 @@ impl SearchExtractor for SpankBangExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 0,
-                headers: &[("Cookie", "country=US")],
-                build_url: build_search_url,
-                parse: |body, query, page| {
-                    Ok(SearchParse {
-                        results: parse_results(body),
-                        total_estimate: Some(RESULTS_PER_PAGE * 100),
-                        has_more: has_more_pages(body, query, page),
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 
@@ -603,5 +629,45 @@ mod tests {
         // case-insensitive lookup routes correctly.
         let ext = SpankBangExtractor::new();
         assert_eq!(SearchExtractor::name(&ext), "SpankBang");
+    }
+
+    /// Static regression guard for #450/3b-7: SpankBang's `search()` MUST
+    /// keep its hand-rolled cross-page video-ID dedup loop — it is the one
+    /// #440 site that does NOT fold `search()` onto the shared
+    /// `PagedSearch::search_all_pages` scaffold (that scaffold has no
+    /// cross-page dedup; folding onto it would silently reintroduce
+    /// duplicate rows from SpankBang's recommendation/editor's-pick rails
+    /// that repeat across pages). Only `search_page`/`fetch_page` moved onto
+    /// the trait. Pinned textually (like
+    /// `hls::expand_in_place::test_extractor_call_order_expand_before_detect`)
+    /// because there's no mockito-observable way to distinguish "dedup loop
+    /// present" from "dedup loop silently deleted" — both can return
+    /// duplicate-free results on the small fixture pages used elsewhere in
+    /// this suite.
+    #[test]
+    fn search_keeps_hand_rolled_dedup_loop() {
+        let src = include_str!("search.rs");
+        // Scope the scan to the production code that precedes this test
+        // module, so the guard cannot match against its own assertion
+        // strings below (self-inclusion via `include_str!` embeds the
+        // whole file, tests included).
+        let production_src = src
+            .split("#[cfg(test)]")
+            .next()
+            .expect("file always has a preamble before the first split marker");
+
+        assert!(
+            production_src.contains("let mut seen_ids: HashSet<String> = HashSet::new();"),
+            "SpankBang's search() must keep its cross-page seen_ids HashSet dedup"
+        );
+        assert!(
+            production_src.contains("if !seen_ids.insert(id_seg) {"),
+            "SpankBang's search() must keep de-duplicating by video ID across pages"
+        );
+        assert!(
+            !production_src.contains("search_all_pages("),
+            "SpankBang must NOT fold search() onto the shared PagedSearch::search_all_pages \
+             scaffold — that scaffold has no cross-page dedup"
+        );
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xnxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/search.rs
@@ -228,7 +228,6 @@ impl PagedSearch for XNXXExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 0,
             headers: &[],
             build_url: build_search_url,
             parse: |body, query, page| {

--- a/crates/rdlp-extractor/src/extractors/xnxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/search.rs
@@ -4,26 +4,21 @@
 //! is **1-indexed** (page 0 externally → path segment `1`).
 
 use async_trait::async_trait;
-use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{
     SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery, SearchResultPreview,
 };
 use scraper::Html;
-use std::time::Duration;
 
 use super::XNXXExtractor;
 use crate::base::common::BaseExtractor;
-use crate::base::common::{SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{PagedSearch, SearchPage, SearchPageSpec};
 
 /// Base URL for search requests.
 const XNXX_BASE_URL: &str = "https://www.xnxx.com";
 
 /// Number of results per page (XNXX default).
 const RESULTS_PER_PAGE: u64 = 36;
-
-/// Delay between paginated requests (ms).
-const PAGE_RATE_LIMIT_MS: u64 = 500;
 
 /// Maximum results cap for a full search.
 const MAX_PLAYLIST_SIZE: usize = 500;
@@ -207,6 +202,47 @@ pub(crate) fn has_more_pages(html: &str, query: &SearchQuery, page: u32) -> bool
     html.contains(&needle)
 }
 
+impl PagedSearch for XNXXExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[xnxx]"
+    }
+
+    // XNXX has no filter validation today (the pre-refactor `run_search_page`
+    // path never validated); `Ok(())` is the only value that preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        0
+    }
+
+    fn max_results_default(&self) -> usize {
+        MAX_PLAYLIST_SIZE
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 0,
+            headers: &[],
+            build_url: build_search_url,
+            parse: |body, query, page| {
+                Ok(SearchPage {
+                    results: parse_results(body),
+                    has_more: has_more_pages(body, query, page),
+                    total_estimate: Some(RESULTS_PER_PAGE * 100),
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for XNXXExtractor {
     fn name(&self) -> &str {
@@ -230,44 +266,7 @@ impl SearchExtractor for XNXXExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 0_u32;
-
-        loop {
-            let page_url = build_search_url(query, page);
-            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
-            debug!("[xnxx] Fetching search page {}: {sanitized}", page + 1);
-
-            let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
-
-            let page_results = parse_results(&webpage);
-            if page_results.is_empty() {
-                break;
-            }
-
-            let more = has_more_pages(&webpage, query, page);
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if !more {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(
-            "[xnxx] Search complete: {} results across {} pages",
-            all_results.len(),
-            page + 1
-        );
-        Ok(all_results)
+        self.search_all_pages(query, ctx).await
     }
 
     async fn search_page(
@@ -275,23 +274,7 @@ impl SearchExtractor for XNXXExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 0,
-                headers: &[],
-                build_url: build_search_url,
-                parse: |body, query, page| {
-                    Ok(SearchParse {
-                        results: parse_results(body),
-                        total_estimate: Some(RESULTS_PER_PAGE * 100),
-                        has_more: has_more_pages(body, query, page),
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xnxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xnxx/search.rs
@@ -207,8 +207,8 @@ impl PagedSearch for XNXXExtractor {
         "[xnxx]"
     }
 
-    // XNXX has no filter validation today (the pre-refactor `run_search_page`
-    // path never validated); `Ok(())` is the only value that preserves that.
+    // XNXX has no filter validation today (the pre-refactor single-GET
+    // search path never validated); `Ok(())` is the only value that preserves that.
     fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
         Ok(())
     }

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -4,15 +4,15 @@
 //! from the same async endpoint that returns HTML fragments.
 
 use async_trait::async_trait;
-use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{SearchPageResponse, SearchQuery, SearchResultPreview};
-use std::time::Duration;
 
 use super::XTitsExtractor;
 use super::search_patterns;
-use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{PagedSearch, SearchPage, SearchPageSpec};
 
+/// Maximum results cap for a full search (matches the pre-refactor
+/// `unwrap_or(500)`; mirrors the xnxx/xvideos siblings' named cap).
 const MAX_PLAYLIST_SIZE: usize = 500;
 
 /// Parse search result items from KVS AJAX response HTML.
@@ -67,6 +67,52 @@ pub(crate) fn detect_max_page(html: &str) -> u32 {
         .unwrap_or(1)
 }
 
+impl PagedSearch for XTitsExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[XTits]"
+    }
+
+    // XTits has no filter validation today (the pre-refactor `run_search_page`
+    // path never validated); `Ok(())` is the only value that preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        1
+    }
+
+    fn max_results_default(&self) -> usize {
+        MAX_PLAYLIST_SIZE
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 1, // struct field exists until 3b-8; fetch_via_spec ignores it
+            headers: &[
+                ("X-Requested-With", "XMLHttpRequest"),
+                ("Referer", "https://www.xtits.com/search/"),
+            ],
+            build_url: search_patterns::build_search_url,
+            parse: |body, _query, page| {
+                let results = parse_search_results(body);
+                let max_page = detect_max_page(body);
+                Ok(SearchPage {
+                    has_more: page < max_page && !results.is_empty(),
+                    total_estimate: Some(max_page as u64 * search_patterns::RESULTS_PER_PAGE),
+                    results,
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for XTitsExtractor {
     fn name(&self) -> &str {
@@ -82,51 +128,7 @@ impl SearchExtractor for XTitsExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let max_results = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let mut all_results = Vec::new();
-        let mut page = 1_u32;
-
-        loop {
-            let page_url = search_patterns::build_search_url(query, page);
-            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
-            debug!("[XTits] Fetching search page {page}: {sanitized}");
-
-            let webpage = BaseExtractor::fetch_webpage_with_headers(
-                &page_url,
-                &[
-                    ("X-Requested-With", "XMLHttpRequest"),
-                    ("Referer", "https://www.xtits.com/search/"),
-                ],
-                ctx,
-            )
-            .await?;
-
-            let page_results = parse_search_results(&webpage);
-            if page_results.is_empty() {
-                break;
-            }
-
-            let max_page = detect_max_page(&webpage);
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            if page >= max_page {
-                break;
-            }
-
-            page += 1;
-            tokio::time::sleep(Duration::from_millis(search_patterns::PAGE_RATE_LIMIT_MS)).await;
-        }
-
-        debug!(
-            "[XTits] Search complete: {} results across {page} pages",
-            all_results.len()
-        );
-        Ok(all_results)
+        self.search_all_pages(query, ctx).await
     }
 
     async fn search_page(
@@ -134,28 +136,7 @@ impl SearchExtractor for XTitsExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 1,
-                headers: &[
-                    ("X-Requested-With", "XMLHttpRequest"),
-                    ("Referer", "https://www.xtits.com/search/"),
-                ],
-                build_url: search_patterns::build_search_url,
-                parse: |body, _query, page| {
-                    let results = parse_search_results(body);
-                    let max_page = detect_max_page(body);
-                    Ok(SearchParse {
-                        has_more: page < max_page && !results.is_empty(),
-                        total_estimate: Some(max_page as u64 * search_patterns::RESULTS_PER_PAGE),
-                        results,
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -93,7 +93,6 @@ impl PagedSearch for XTitsExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 1, // struct field exists until 3b-8; fetch_via_spec ignores it
             headers: &[
                 ("X-Requested-With", "XMLHttpRequest"),
                 ("Referer", "https://www.xtits.com/search/"),

--- a/crates/rdlp-extractor/src/extractors/xtits/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search.rs
@@ -72,8 +72,8 @@ impl PagedSearch for XTitsExtractor {
         "[XTits]"
     }
 
-    // XTits has no filter validation today (the pre-refactor `run_search_page`
-    // path never validated); `Ok(())` is the only value that preserves that.
+    // XTits has no filter validation today (the pre-refactor single-GET
+    // search path never validated); `Ok(())` is the only value that preserves that.
     fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
         Ok(())
     }

--- a/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/search_patterns.rs
@@ -7,9 +7,6 @@ use url::form_urlencoded;
 /// Results per page (XTits KVS default).
 pub(crate) const RESULTS_PER_PAGE: u64 = 100;
 
-/// Rate limit between page fetches (milliseconds).
-pub(crate) const PAGE_RATE_LIMIT_MS: u64 = 500;
-
 /// Regex to extract video items from KVS AJAX response HTML.
 ///
 /// Captures: (1) video URL, (2) title, (3) thumbnail URL.

--- a/crates/rdlp-extractor/src/extractors/xvideos/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/search.rs
@@ -4,7 +4,6 @@
 //! where `p` is 0-indexed. Adding `&top` sorts by most-viewed.
 
 use async_trait::async_trait;
-use log::debug;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{
     SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery, SearchResultPreview,
@@ -12,9 +11,13 @@ use rdlp_types::{
 use scraper::Html;
 
 use super::XVideosExtractor;
-use crate::base::common::{BaseExtractor, SearchPageSpec, SearchParse, run_search_page};
+use crate::base::common::{BaseExtractor, PagedSearch, SearchPage, SearchPageSpec};
 
 const XVIDEOS_BASE_URL: &str = "https://www.xvideos.com";
+
+/// Maximum results cap for a full search (matches the pre-refactor
+/// `unwrap_or(500)`; mirrors the xnxx sibling's named cap).
+const MAX_PLAYLIST_SIZE: usize = 500;
 
 /// Build the search URL for a given query and 0-indexed page number.
 fn build_search_url(query: &SearchQuery, page: u32) -> String {
@@ -179,6 +182,52 @@ pub(crate) fn parse_search_results(html: &str) -> Vec<SearchResultPreview> {
     results
 }
 
+impl PagedSearch for XVideosExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[XVideos]"
+    }
+
+    // XVideos has no filter validation today (the pre-refactor `run_search_page`
+    // path never validated); `Ok(())` is the only value that preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        1
+    }
+
+    fn max_results_default(&self) -> usize {
+        MAX_PLAYLIST_SIZE
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            first_page_index: 1, // struct field still exists until 3b-8; fetch_via_spec ignores it
+            headers: &[],
+            // XVideos is 0-indexed internally; external page is 1-indexed.
+            build_url: |query, page| build_search_url(query, page.saturating_sub(1)),
+            parse: |body, _query, page| {
+                let results = parse_search_results(body);
+                // Reproduce the original arg exactly: has_next_page(webpage, page_0indexed + 1),
+                // where page_0indexed = page.saturating_sub(1). Equal to page for page>=1; correct at page 0.
+                Ok(SearchPage {
+                    has_more: has_next_page(body, page.saturating_sub(1) + 1)
+                        && !results.is_empty(),
+                    total_estimate: None,
+                    results,
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for XVideosExtractor {
     fn name(&self) -> &str {
@@ -202,42 +251,7 @@ impl SearchExtractor for XVideosExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let max_results = query.max_results.unwrap_or(500);
-        let mut all_results = Vec::new();
-        let mut page = 0_u32;
-
-        loop {
-            let page_url = build_search_url(query, page);
-            let sanitized = rdlp_security::sanitize_for_logging(&page_url);
-            debug!("[XVideos] Fetching search page {page}: {sanitized}");
-
-            let webpage = BaseExtractor::fetch_webpage(&page_url, ctx).await?;
-            let page_results = parse_search_results(&webpage);
-
-            if page_results.is_empty() {
-                break;
-            }
-
-            let next_page = page + 1;
-            let more = has_next_page(&webpage, next_page);
-            all_results.extend(page_results);
-
-            if all_results.len() >= max_results || !more {
-                all_results.truncate(max_results);
-                break;
-            }
-
-            page = next_page;
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        }
-
-        debug!(
-            "[XVideos] Search complete: {} results across {} pages",
-            all_results.len(),
-            page + 1
-        );
-
-        Ok(all_results)
+        self.search_all_pages(query, ctx).await
     }
 
     async fn search_page(
@@ -245,28 +259,7 @@ impl SearchExtractor for XVideosExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        run_search_page(
-            query,
-            ctx,
-            SearchPageSpec {
-                first_page_index: 1,
-                headers: &[],
-                // XVideos is 0-indexed internally; external page is 1-indexed.
-                build_url: |query, page| build_search_url(query, page.saturating_sub(1)),
-                parse: |body, _query, page| {
-                    let results = parse_search_results(body);
-                    // Reproduce the original arg exactly: has_next_page(webpage, page_0indexed + 1),
-                    // where page_0indexed = page.saturating_sub(1). Equal to page for page>=1; correct at page 0.
-                    Ok(SearchParse {
-                        has_more: has_next_page(body, page.saturating_sub(1) + 1)
-                            && !results.is_empty(),
-                        total_estimate: None,
-                        results,
-                    })
-                },
-            },
-        )
-        .await
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/xvideos/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/search.rs
@@ -187,8 +187,8 @@ impl PagedSearch for XVideosExtractor {
         "[XVideos]"
     }
 
-    // XVideos has no filter validation today (the pre-refactor `run_search_page`
-    // path never validated); `Ok(())` is the only value that preserves that.
+    // XVideos has no filter validation today (the pre-refactor single-GET
+    // search path never validated); `Ok(())` is the only value that preserves that.
     fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
         Ok(())
     }

--- a/crates/rdlp-extractor/src/extractors/xvideos/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/search.rs
@@ -208,7 +208,6 @@ impl PagedSearch for XVideosExtractor {
         ctx: &ExtractionContext,
     ) -> Result<SearchPage> {
         let spec = SearchPageSpec {
-            first_page_index: 1, // struct field still exists until 3b-8; fetch_via_spec ignores it
             headers: &[],
             // XVideos is 0-indexed internally; external page is 1-indexed.
             build_url: |query, page| build_search_url(query, page.saturating_sub(1)),
@@ -437,9 +436,9 @@ mod tests {
     /// identical to passing `page` directly, but at the out-of-contract
     /// `page == 0` boundary the original computes `0.saturating_sub(1) + 1 == 1`,
     /// NOT `0`. Pin both sides of that boundary directly against `has_next_page`
-    /// (the closure itself is only reachable via `run_search_page`, which
-    /// performs a network fetch, so this exercises the restored arithmetic
-    /// rather than the full search_page path).
+    /// (the closure itself is only reachable via `PagedSearch::fetch_via_spec`,
+    /// which performs a network fetch, so this exercises the restored
+    /// arithmetic rather than the full search_page path).
     #[test]
     fn has_next_page_boundary_matches_original_arg_computation() {
         let html = "...p=1...";


### PR DESCRIPTION
## Summary

Stage 3b of the search-pagination convergence ([META] #450, follows Stage 3a #458). Folds the 7 `#440` single-GET search sites onto the unified `PagedSearch` trait introduced in 3a, and **deletes the now-redundant `run_search_page` free function** plus the two 3a transitional shims.

Behavior-preserving; one sub-PR.

## What changed

- **5 loopers** (xnxx, xvideos, xtits, nine_anime, hqporner) implement the required `fetch_page` (a one-liner delegating to the provided `fetch_via_spec` with an inline `SearchPageSpec`) and **delete their hand-rolled `search()` loops** → inherit the shared `search_all_pages`.
- **eporner** overrides `search()` to a single `search_page_response` (it was already single-page).
- **spankbang KEEPS its custom `search()`** (cross-page video-ID dedup + `new_this_page == 0` stop — genuine per-site state a stateless `fetch_page` hook can't hold); only its single-page `search_page` moves onto the trait. A new `include_str!` regression guard pins that the dedup loop is retained and never regresses to `search_all_pages`.
- All 7: `SearchExtractor::search_page → self.search_page_response(query, ctx)`.
- **Deleted** `run_search_page`, the `type SearchParse = SearchPage` alias, and the `SearchPageSpec::first_page_index` field (the trait method `first_page_index()` stays); updated all 7 sites' inline SPEC literals accordingly.
- Removed the now-fulfilled `#[expect(dead_code)]` on `fetch_via_spec` (3b is its first caller) and added a one-line arg-count rationale; refreshed the stale `Termination::UntilEmpty` doc-comment.
- Updated `.claude/rules/crate-extractor.md` (Search section describes the unified `PagedSearch`).

## Behavior preservation

- **ZERO assertion edits** to existing search tests (the #440/#451 byte-exact discipline). Per-site SPECs (headers / `build_url` / `parse` / `has_more` / `total_estimate` / `first_page_index` / cap) reproduced verbatim — incl. the xvideos page-0 `saturating_sub(1)` boundary (#451 regression) and nine_anime's `if p>0 {p-1} else {0}` mapping.
- **`validate_search_filters → Ok(())` for all 7** — verified against the actual code: none of these sites validated filters before (`run_search_page` never did), so `Ok(())` is the only value that preserves the old no-validation behavior.
- **Known, design-sanctioned convergence:** the 5 loopers' multi-page `search()` now returns `Ok(partial-results)` on a mid-pagination fetch error instead of `Err` (they inherit the shared `search_all_pages` scaffold, which the design spec documents and the 6 Stage-3a sites already used). Single-page `search_page` error behavior is preserved exactly. No security implication (validation still runs first; only page-number/tag logged, no URL).
- **Golden mockito search tests are infeasible** for these sites (URL builders hardcode `https://…`, no injectable base — the documented 3a limitation, tracked in #457); the preserved #451 free-function tests + the spankbang dedup guard are the regression coverage.

## Verification

Full pre-PR gate green: `cargo fmt --check` · `cargo check` · `cargo clippy --all-targets -- -D warnings` · `cargo test` (workspace) · `cargo check -p rdlp-desktop` · `check-dedup` · `check-url-redaction` · `check-no-cli` · `check-wit-drift` · `check-log-redaction`. Dedup gate unchanged (no new fingerprint).

## Reviews

Each of the 8 tasks: `rust-engineer` implementer → spec-compliance review → code-quality review (all green). Whole-branch pre-push:
- **security-reviewer: PASS / Approve** — SSRF surface unchanged (same `build_*_url` helpers, same `BaseExtractor::fetch_webpage`), bounded loops with preserved caps, redaction intact.
- **code-reviewer: Approve-with-minor** — only comment-only ghost references to the deleted `run_search_page`; all refreshed in the final commit.

Closes #459
Refs #440
Refs #450
