### PR TITLE
refactor(rdlp-extractor): fold ABXXX + KoreanPornMovie search onto PagedSearch (Stage 3c, close #450)

### DIFF
--- a/crates/rdlp-extractor/src/extractors/abxxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/abxxx/search.rs
@@ -13,8 +13,10 @@
 //! a `videos[]` array with full metadata (title, duration `MM:SS`, view count,
 //! thumbnail, models, post date, …) so no per-result page fetch is needed.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
-use log::{debug, warn};
+use log::warn;
 use rdlp_core::{ExtractionContext, Result, SearchExtractor};
 use rdlp_types::{
     SearchFilter, SearchFilterDescriptor, SearchFilterValue, SearchPageResponse, SearchQuery,
@@ -23,7 +25,7 @@ use rdlp_types::{
 use serde_json::Value;
 
 use super::{ABXXX_BASE_URL, AbxxxExtractor};
-use crate::base::common::BaseExtractor;
+use crate::base::common::{PagedSearch, SearchPage, SearchPageSpec};
 use crate::base::kvs::api as kvs_api;
 
 const SEARCH_REFERER: &str = "https://abxxx.com/";
@@ -198,6 +200,75 @@ fn parse_response(body: &str) -> Result<(Vec<SearchResultPreview>, Option<u64>, 
     Ok((previews, total, max_page))
 }
 
+impl PagedSearch for AbxxxExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[ABXXX]"
+    }
+
+    // ABXXX has no filter validation today: the bespoke search()/search_page() never
+    // validated — resolved_sort tolerates any value (falls back to "relevance"), no reject
+    // path. Ok(()) is the only value that preserves that.
+    fn validate_search_filters(&self, _filters: &[SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    fn first_page_index(&self) -> u32 {
+        1
+    }
+
+    // The `.max(1)` clamp from the old search_page: one clamped value feeds BOTH the URL
+    // page and the echoed SearchPageResponse.page. Diverges from identity only at
+    // page=Some(0)->1. Opt-in per site (a universal .max(first_page_index()) would break
+    // 1-indexed sites at Some(0)).
+    fn clamp_page(&self, page: u32) -> u32 {
+        page.max(1)
+    }
+
+    // The old search() loop has NO inter-page sleep; inheriting the default 500ms would
+    // add latency (a behavior change). Preserve zero throttle.
+    fn page_rate_limit(&self) -> Duration {
+        Duration::ZERO
+    }
+
+    fn max_results_default(&self) -> usize {
+        MAX_PLAYLIST_SIZE
+    }
+
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
+        let spec = SearchPageSpec {
+            headers: &[
+                ("X-Requested-With", "XMLHttpRequest"),
+                ("Accept", "application/json"),
+                ("Referer", SEARCH_REFERER),
+            ],
+            build_url: |query, page| {
+                let sort = resolved_sort(&query.filters);
+                kvs_api::videos2_search_endpoint(
+                    ABXXX_BASE_URL,
+                    &query.query,
+                    sort,
+                    page,
+                    kvs_api::KVS_VIDEOS2_DEFAULT_PAGE_SIZE,
+                )
+            },
+            parse: |body, _query, page| {
+                let (results, total_estimate, max_page) = parse_response(body)?;
+                Ok(SearchPage {
+                    results,
+                    has_more: page < max_page,
+                    total_estimate,
+                })
+            },
+        };
+        self.fetch_via_spec(spec, query, page, ctx).await
+    }
+}
+
 #[async_trait]
 impl SearchExtractor for AbxxxExtractor {
     fn name(&self) -> &str {
@@ -224,47 +295,7 @@ impl SearchExtractor for AbxxxExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let cap = query.max_results.unwrap_or(MAX_PLAYLIST_SIZE);
-        let sort = resolved_sort(&query.filters);
-        let mut out: Vec<SearchResultPreview> = Vec::new();
-        let mut page: u32 = 1;
-
-        while out.len() < cap {
-            let url = kvs_api::videos2_search_endpoint(
-                ABXXX_BASE_URL,
-                &query.query,
-                sort,
-                page,
-                kvs_api::KVS_VIDEOS2_DEFAULT_PAGE_SIZE,
-            );
-            debug!(
-                "[ABXXX] search page {page}: {}",
-                rdlp_security::sanitize_for_logging(&url)
-            );
-            let body = BaseExtractor::fetch_webpage_with_headers(
-                &url,
-                &[
-                    ("X-Requested-With", "XMLHttpRequest"),
-                    ("Accept", "application/json"),
-                    ("Referer", SEARCH_REFERER),
-                ],
-                ctx,
-            )
-            .await?;
-
-            let (mut previews, _total, max_page) = parse_response(&body)?;
-            if previews.is_empty() {
-                break;
-            }
-            out.append(&mut previews);
-            if page >= max_page {
-                break;
-            }
-            page += 1;
-        }
-
-        out.truncate(cap);
-        Ok(out)
+        self.search_all_pages(query, ctx).await
     }
 
     async fn search_page(
@@ -272,39 +303,7 @@ impl SearchExtractor for AbxxxExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        // Bespoke: the `.max(1)` clamp is reflected in the returned SearchPageResponse.page.
-        // The shared PagedSearch skeleton exposes a `clamp_page` hook for exactly this;
-        // ABXXX is folded onto it in Stage 3c. See #450.
-        let page = query.page.unwrap_or(1).max(1);
-        let sort = resolved_sort(&query.filters);
-        let url = kvs_api::videos2_search_endpoint(
-            ABXXX_BASE_URL,
-            &query.query,
-            sort,
-            page,
-            kvs_api::KVS_VIDEOS2_DEFAULT_PAGE_SIZE,
-        );
-        debug!(
-            "[ABXXX] search_page page {page}: {}",
-            rdlp_security::sanitize_for_logging(&url)
-        );
-        let body = BaseExtractor::fetch_webpage_with_headers(
-            &url,
-            &[
-                ("X-Requested-With", "XMLHttpRequest"),
-                ("Accept", "application/json"),
-                ("Referer", SEARCH_REFERER),
-            ],
-            ctx,
-        )
-        .await?;
-        let (results, total_estimate, max_page) = parse_response(&body)?;
-        Ok(SearchPageResponse {
-            results,
-            page,
-            has_more: page < max_page,
-            total_estimate,
-        })
+        self.search_page_response(query, ctx).await
     }
 }
 

--- a/crates/rdlp-extractor/src/extractors/abxxx/search.rs
+++ b/crates/rdlp-extractor/src/extractors/abxxx/search.rs
@@ -290,6 +290,10 @@ impl SearchExtractor for AbxxxExtractor {
         }]
     }
 
+    // Inherits the shared multi-page loop. Divergence from the old hand-rolled
+    // `search()`: a mid-pagination fetch error now returns `Ok(partial results)`
+    // instead of propagating `Err` (design-sanctioned convergence, #450). The
+    // single-page `search_page` below preserves the old `?`-error behavior exactly.
     async fn search(
         &self,
         query: &SearchQuery,

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -26,6 +26,7 @@ use rdlp_types::{
 };
 
 use crate::base::common::BaseExtractor;
+use crate::base::common::{PagedSearch, SearchPage};
 
 // ============================================================================
 // Selectors
@@ -244,17 +245,40 @@ impl SearchExtractor for KoreanPornMovieExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<Vec<SearchResultPreview>> {
-        let response = self.search_page(query, ctx).await?;
-        Ok(response.results)
+        // KPM is single-page: opt OUT of the shared multi-page loop (which would
+        // re-run the taxonomy term-lookup per page). Preserves the old single-call
+        // search() exactly.
+        Ok(self.search_page_response(query, ctx).await?.results)
     }
 
-    // Bespoke: multi-endpoint browse dispatch (the single-GET PagedSearch spec path does not fit); folded in Stage 3c. See #450.
     async fn search_page(
         &self,
         query: &SearchQuery,
         ctx: &ExtractionContext,
     ) -> Result<SearchPageResponse> {
-        let page = query.page.unwrap_or(1);
+        self.search_page_response(query, ctx).await
+    }
+}
+
+impl PagedSearch for KoreanPornMovieExtractor {
+    fn search_log_tag(&self) -> &'static str {
+        "[KoreanPornMovie]"
+    }
+
+    // KPM validates no filters today (the bespoke search_page never validated). Ok(()) preserves that.
+    fn validate_search_filters(&self, _filters: &[rdlp_types::SearchFilter]) -> Result<()> {
+        Ok(())
+    }
+
+    // Custom multi-endpoint hook (no SearchPageSpec): browse-mode dispatch → two concurrent
+    // ctx.http_client fetches + X-WP-TotalPages pagination. Opts out of the loop via the
+    // search() override above, so it is only ever called once per query.
+    async fn fetch_page(
+        &self,
+        query: &SearchQuery,
+        page: u32,
+        ctx: &ExtractionContext,
+    ) -> Result<SearchPage> {
         let browse_mode = query
             .filters
             .iter()
@@ -334,7 +358,7 @@ impl KoreanPornMovieExtractor {
         query: &SearchQuery,
         ctx: &ExtractionContext,
         page: u32,
-    ) -> Result<SearchPageResponse> {
+    ) -> Result<SearchPage> {
         let per_page = 20;
         let encoded_query = urlencoding::encode(&query.query);
         let api_url = format!(
@@ -367,9 +391,8 @@ impl KoreanPornMovieExtractor {
             })
             .collect();
 
-        Ok(SearchPageResponse {
+        Ok(SearchPage {
             results,
-            page,
             has_more: page < total_pages,
             total_estimate: None,
         })
@@ -382,7 +405,7 @@ impl KoreanPornMovieExtractor {
         ctx: &ExtractionContext,
         taxonomy: &str,
         page: u32,
-    ) -> Result<SearchPageResponse> {
+    ) -> Result<SearchPage> {
         let slug = query.query.to_lowercase().replace(' ', "-");
 
         // Step 1: Resolve slug to term ID
@@ -444,9 +467,8 @@ impl KoreanPornMovieExtractor {
             })
             .collect();
 
-        Ok(SearchPageResponse {
+        Ok(SearchPage {
             results,
-            page,
             has_more: page < total_pages,
             total_estimate: Some(term.count),
         })


### PR DESCRIPTION
## Summary

Final slice (Stage 3c) of the search-pagination unification (meta #450, follow-up to #440). Folds the last two bespoke search extractors onto the shared `PagedSearch` trait, completing the convergence begun in 3a (PR #458) and 3b (PR #460). Behavior-preserving; zero assertion edits to existing tests.

- **ABXXX** (`extractors/abxxx/search.rs`) — was fully bespoke (hand-rolled `search()` loop + `search_page()`, no trait). Now `impl PagedSearch`: single-GET `fetch_page` → provided `fetch_via_spec(SearchPageSpec)` with the KVS `videos2` endpoint spec built inline; `SearchExtractor::search`/`search_page` collapse to one-liner delegations. Hooks: `clamp_page(p)=p.max(1)` (preserves the `page=Some(0)→1` echo), `page_rate_limit()=Duration::ZERO` (its loop had no inter-page sleep), `max_results_default()=MAX_PLAYLIST_SIZE` (500), `validate_search_filters=Ok(())`.
- **KoreanPornMovie** (`extractors/koreanpornmovie/mod.rs`) — was bespoke multi-endpoint browse dispatch. Now `impl PagedSearch` with a **custom** `fetch_page` (browse-mode dispatch → `tokio::join!` two concurrent fetches + `X-WP-TotalPages` pagination); `search_api`/`search_api_taxonomy` return `SearchPage` (dropped the redundant `page` echo); `search()` overrides to a single call, opting out of the shared loop (never re-runs the taxonomy term-lookup per page).

With this, all 15 paginated search sites are on `PagedSearch`; no bespoke search skeletons remain.

## Behavior note (design-sanctioned)

ABXXX's multi-page `search()` now inherits the shared `search_all_pages` scaffold, which returns `Ok(partial results)` on a mid-pagination fetch error (the old hand-rolled loop propagated `Err` on any page failure). Single-page `search_page` error behavior is preserved exactly. This is the same design-sanctioned convergence the 6 Stage-3a and 5 Stage-3b looper sites already carry (design spec §2). KPM overrides `search()`→single, so no loop convergence there.

## Testing

- Full pre-PR gate green: `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (all suites), `cargo check -p rdlp-desktop`, and all `scripts/check-*.sh` (dedup, url-redaction, no-cli, wit-drift, log-redaction).
- Zero assertion edits; all pre-existing ABXXX (15) and KPM unit/HLS tests stay green as the regression guard.
- Golden mockito search tests remain infeasible for both sites (hardcoded-`https://` builders / raw `ctx.http_client` with no mock seam) — the pre-existing limitation tracked in #457. Not addressed here.

## Reviews

Both `security-reviewer` and `code-reviewer` ran over the full `develop..HEAD` diff before push (per-task spec + code-quality reviews also passed for each fold).

- **security-reviewer: Approve** — 0 Critical / 0 HIGH / 0 Medium. Every audited control (KVS `videos2` SSRF surface, `is_safe_path_segment` path-traversal guard, resource caps, log hygiene) byte-for-byte preserved; the ABXXX partial-on-error delta is benign (error-propagation only). Two pre-existing, out-of-scope posture notes (KPM slug not fully percent-encoded; transport-error Display) flagged as optional future defense-in-depth, not blockers.
- **code-reviewer: Approve** — no Critical/Important. ABXXX reads like the xnxx template; KPM matches the eporner single-page-override precedent; no dead code, no duplicated logic, zero test-assertion edits. One Minor (a parity breadcrumb on ABXXX `search()`) applied in commit `44fef914`.

Closes #461
Refs #440
Refs #450
