### PR TITLE
chore(dedup): resolve advisory high-similarity pairs (#464, #466, #467, #469)

### DIFF
--- a/crates/rdlp-api/src/handle.rs
+++ b/crates/rdlp-api/src/handle.rs
@@ -44,6 +44,17 @@ impl fmt::Display for DownloadId {
     }
 }
 
+/// The shared keep-then-cancel interrupt sequence (#413), used by both
+/// [`DownloadHandle::interrupt`] and [`InterruptHandle::interrupt`].
+///
+/// Ordering is load-bearing: the "keep the resumable partial" disposition MUST
+/// be set *before* the token is cancelled, so the download task cannot observe
+/// cancellation (and discard the partial) before the keep intent is visible.
+fn request_interrupt(disposition: &CancelDisposition, token: &CancellationToken) {
+    disposition.set_keep();
+    token.cancel();
+}
+
 /// Handle to a running download.
 ///
 /// Provides access to the event stream, cancellation, and final result.
@@ -114,8 +125,7 @@ impl DownloadHandle {
     /// Interrupt the download (Ctrl+C / SIGINT semantics): KEEP the resumable
     /// `.rdlp-part` for resume, then cancel. Non-blocking, idempotent. #413.
     pub fn interrupt(&self) {
-        self.cancel_disposition.set_keep();
-        self.cancel_token.cancel();
+        request_interrupt(&self.cancel_disposition, &self.cancel_token);
     }
 
     /// A detachable interrupt trigger that can be moved into a signal-handler
@@ -158,8 +168,7 @@ pub struct InterruptHandle {
 impl InterruptHandle {
     /// Interrupt: KEEP the resumable partial, then cancel. Idempotent.
     pub fn interrupt(&self) {
-        self.disposition.set_keep();
-        self.token.cancel();
+        request_interrupt(&self.disposition, &self.token);
     }
 }
 
@@ -215,6 +224,33 @@ mod tests {
         );
         let ih = handle.interrupt_handle();
         ih.interrupt();
+        assert!(token.is_cancelled(), "interrupt cancels the token");
+        assert!(disposition.should_keep(), "interrupt sets Keep");
+    }
+
+    #[tokio::test]
+    async fn test_download_handle_interrupt_sets_keep_and_cancels() {
+        // Directly exercises DownloadHandle::interrupt (the InterruptHandle path
+        // is covered above); both route through the shared request_interrupt.
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let token = CancellationToken::new();
+        let disposition = crate::cancel::CancelDisposition::new();
+        let jh = tokio::spawn(async {
+            Ok(crate::result::DownloadResult {
+                id: DownloadId::next(),
+                output_files: vec![],
+                info: rdlp_types::InfoDict::new("id", "title", "ext", "url"),
+                stats: rdlp_core::DownloadStats::new(0, std::time::Duration::ZERO, 0),
+            })
+        });
+        let handle = DownloadHandle::new(
+            DownloadId::next(),
+            rx,
+            token.clone(),
+            disposition.clone(),
+            jh,
+        );
+        handle.interrupt();
         assert!(token.is_cancelled(), "interrupt cancels the token");
         assert!(disposition.should_keep(), "interrupt sets Keep");
     }

--- a/crates/rdlp-downloader/src/dash/download.rs
+++ b/crates/rdlp-downloader/src/dash/download.rs
@@ -720,6 +720,17 @@ async fn download_one(
     }
 }
 
+/// 0-retry `RetryConfig` so failing tests fail immediately rather than
+/// exercising backoff loops. Shared by the `cancel_tests` and
+/// `same_origin_gate_tests` submodules (both reach it via `use super::*`).
+#[cfg(test)]
+fn fast_retry() -> Arc<RetryConfig> {
+    Arc::new(RetryConfig {
+        max_retries: 0,
+        ..RetryConfig::default()
+    })
+}
+
 #[cfg(test)]
 mod cancel_tests {
     //! Issue #347: the DASH static-VoD resume path (`run` → segment fetch →
@@ -728,16 +739,8 @@ mod cancel_tests {
     //! the top of the segment loop). A pre-cancelled token must abort
     //! `download_representation` BEFORE any segment is fetched.
     use super::*;
-    use rdlp_core::RetryConfig;
     use std::sync::atomic::AtomicU64;
     use tokio_util::sync::CancellationToken;
-
-    fn fast_retry() -> Arc<RetryConfig> {
-        Arc::new(RetryConfig {
-            max_retries: 0,
-            ..RetryConfig::default()
-        })
-    }
 
     /// Negative (regression guard for #347): a pre-cancelled token makes
     /// `download_representation` return `RdlpError::Cancelled` WITHOUT fetching
@@ -868,23 +871,12 @@ mod same_origin_gate_tests {
     //! from the MPD URL's origin, operator-set `Format.http_headers` are
     //! stripped to prevent header exfiltration to a redirected CDN.
     use super::*;
-    use rdlp_core::RetryConfig;
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     fn make_downloader_with_header(name: &str, value: &str) -> HttpDownloader {
         let mut headers = HashMap::new();
         headers.insert(name.to_string(), value.to_string());
         HttpDownloader::with_client(wreq::Client::new()).with_extra_headers(Some(&headers))
-    }
-
-    fn fast_retry() -> Arc<RetryConfig> {
-        // 0-retry config so failing tests fail immediately rather than
-        // exercising backoff loops.
-        Arc::new(RetryConfig {
-            max_retries: 0,
-            ..RetryConfig::default()
-        })
     }
 
     /// Positive: same-origin segment URL DOES receive `Format.http_headers`.

--- a/crates/rdlp-redact/src/lib.rs
+++ b/crates/rdlp-redact/src/lib.rs
@@ -150,6 +150,38 @@ pub fn redact_str(s: &str) -> String {
     result.into_owned()
 }
 
+/// Generate the redacting `Display` / `Debug` / (feature-gated) `ToValue`
+/// impls for a URL wrapper type.
+///
+/// Both wrappers ([`RedactedUrl`], [`RedactedUrlBuf`]) share one source of
+/// truth for the redaction wiring: `Display` always routes the raw value
+/// (`self.expose()`) through [`redact_str`] — no wrapper may bypass redaction —
+/// `Debug` delegates to `Display`, and `ToValue` renders via `from_display`.
+/// The single `expose() -> &str` accessor is what lets one macro cover both the
+/// borrowed (`&str`) and owned (`String`) representations.
+macro_rules! impl_redacting_traits {
+    ($ty:ty) => {
+        impl fmt::Display for $ty {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&redact_str(self.expose()))
+            }
+        }
+
+        impl fmt::Debug for $ty {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(self, f)
+            }
+        }
+
+        #[cfg(feature = "log-kv")]
+        impl log::kv::ToValue for $ty {
+            fn to_value(&self) -> log::kv::Value<'_> {
+                log::kv::Value::from_display(self)
+            }
+        }
+    };
+}
+
 /// Borrowed wrapper around a URL string whose [`Display`](fmt::Display) and
 /// [`Debug`](fmt::Debug) automatically redact credentials.
 ///
@@ -172,17 +204,7 @@ impl<'a> RedactedUrl<'a> {
     }
 }
 
-impl fmt::Display for RedactedUrl<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&redact_str(self.0))
-    }
-}
-
-impl fmt::Debug for RedactedUrl<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
+impl_redacting_traits!(RedactedUrl<'_>);
 
 /// Owned wrapper around a URL string whose [`Display`](fmt::Display) and
 /// [`Debug`](fmt::Debug) automatically redact credentials.
@@ -215,31 +237,7 @@ impl From<&str> for RedactedUrlBuf {
     }
 }
 
-impl fmt::Display for RedactedUrlBuf {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&redact_str(&self.0))
-    }
-}
-
-impl fmt::Debug for RedactedUrlBuf {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-#[cfg(feature = "log-kv")]
-impl log::kv::ToValue for RedactedUrl<'_> {
-    fn to_value(&self) -> log::kv::Value<'_> {
-        log::kv::Value::from_display(self)
-    }
-}
-
-#[cfg(feature = "log-kv")]
-impl log::kv::ToValue for RedactedUrlBuf {
-    fn to_value(&self) -> log::kv::Value<'_> {
-        log::kv::Value::from_display(self)
-    }
-}
+impl_redacting_traits!(RedactedUrlBuf);
 
 #[cfg(test)]
 mod tests;

--- a/crates/rdlp-redact/src/tests.rs
+++ b/crates/rdlp-redact/src/tests.rs
@@ -106,6 +106,16 @@ fn to_value_serializes_redacted_for_log_kv() {
     assert_eq!(r.to_value().to_string(), "u?token=***");
 }
 
+#[cfg(feature = "log-kv")]
+#[test]
+fn buf_to_value_serializes_redacted_for_log_kv() {
+    // Guards the owned wrapper's macro-generated `ToValue`: it MUST redact
+    // (route through `redact_str` via Display), same as the borrowed wrapper.
+    use log::kv::ToValue as _;
+    let r = RedactedUrlBuf::new("u?token=abc");
+    assert_eq!(r.to_value().to_string(), "u?token=***");
+}
+
 #[test]
 fn acceptance_328_presigned_and_oauth_code_redacted_host_preserved() {
     let s = redact_str("https://cdn.example.com/seg.m4s?X-Amz-Signature=DEADBEEF");

--- a/crates/rdlp-types/src/format/selector/tests.rs
+++ b/crates/rdlp-types/src/format/selector/tests.rs
@@ -21,6 +21,12 @@ use crate::protocol::DownloadProtocol;
 
 // ---- Test helpers ----
 
+/// Minimal HTTPS mp4 `Format` keyed only by id. Shared by the `negative_sort_2`
+/// and `negative_sort_3` submodules (both reach it via `use super::*`).
+fn make_format(id: &str) -> Format {
+    Format::new(id, "https://example.com", "mp4", DownloadProtocol::Https)
+}
+
 fn make_combined(id: &str, ext: &str, height: u32, quality: i32) -> Format {
     let mut f = Format::new(id, format!("url_{id}"), ext, DownloadProtocol::Https);
     f.vcodec = Codec::Present("h264".to_string());
@@ -4276,11 +4282,6 @@ mod negative_eval_2 {
 mod negative_sort_2 {
     use super::*;
     use crate::format::Format;
-    use crate::protocol::DownloadProtocol;
-
-    fn make_format(id: &str) -> Format {
-        Format::new(id, "https://example.com", "mp4", DownloadProtocol::Https)
-    }
 
     // ---- Missing numeric fields sort as absent (tier -10) ----
 
@@ -4858,11 +4859,6 @@ mod negative_eval_3 {
 mod negative_sort_3 {
     use super::*;
     use crate::format::Format;
-    use crate::protocol::DownloadProtocol;
-
-    fn make_format(id: &str) -> Format {
-        Format::new(id, "https://example.com", "mp4", DownloadProtocol::Https)
-    }
 
     // ---- Empty codec string treated as missing ----
 


### PR DESCRIPTION
## Summary

Triage of the 6 advisory `similarity-rs --threshold 0.99 --skip-test` high-similarity pairs (the ADVISORY detector in `check-dedup.sh`, which has no allowlist by design). The `cargo dupes` gate already passed; this cleanup drops the **advisory count from 6 → 1**, where the remaining pair is a known-intentional test double.

Each real pair was extracted with **byte-identical behavior**; each intentional pair is closed with a rationale.

## Real extractions (deduped)

- **`make_format` test helper** (`rdlp-types` selector/tests.rs) — hoisted one shared helper to the module root; the two duplicate submodule copies (`negative_sort_2`, `negative_sort_3`) now reach it via `use super::*`. The third `make_format` in `sort_edge_cases` uses a *different* URL and is intentionally left alone. `Closes #464`
- **`fast_retry` test helper** (`rdlp-downloader` dash/download.rs) — hoisted one `#[cfg(test)]` helper to the file root (root already imports `Arc` + `RetryConfig` for production); deleted both submodule copies and their now-unused imports. `Closes #469`
- **Redaction trait impls** (`rdlp-redact`) — replaced the parallel `Display`/`Debug`/(`log-kv`)`ToValue` impls on `RedactedUrl<'_>` and `RedactedUrlBuf` with a single `impl_redacting_traits!` declarative macro — one source of truth for the redaction wiring. Both `Display` paths still route the raw value (`self.expose()`) through `redact_str` (no bypass); adds a `ToValue` redaction test for the owned wrapper (previously untested). `Closes #467`
- **`interrupt()` bodies** (`rdlp-api` handle.rs) — factored a shared `request_interrupt(disposition, token)` free fn; both `DownloadHandle::interrupt` and `InterruptHandle::interrupt` delegate. Centralizes the load-bearing set-keep-**before**-cancel ordering; adds a direct `DownloadHandle::interrupt` test. `Closes #466`

## Accepted as intentional (closed separately, not via this PR)

- **Pipeline mock `process()` twins** — `#465` closed won't-fix: `PassthroughStage` (fatal) and `NonFatalFailStage` (`is_fatal() == false`) are distinct stage-category test doubles; the `Ok(msg)` coincidence is incidental. Sharing a 1-line trait-method body across two structs would need a macro/blanket-impl more complex than the duplication (Fowler *Lazy Element*). `Refs #465`

## Verification

- Full pre-PR gate green: `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo check -p rdlp-desktop`, and all five `scripts/check-*.sh` (dedup gate PASS, advisory count = 1).
- Advisory similarity count: **6 → 1** (5 pairs extracted; the 1 remaining is the intentional #465 pair).

## Reviews

- **security-reviewer**: **Approve** — no findings. Confirmed the `#467` macro preserves the redaction invariant exactly (both `Display` paths → `redact_str`; `Debug` and `ToValue` delegate to `Display`; `expose()` remains the sole raw accessor), and the `#466` `request_interrupt` preserves set-keep-before-cancel ordering.
- **code-reviewer**: **Approve** — no Critical/High/Medium. Verified byte-equivalence of all four extractions, macro hygiene under the anonymous lifetime, and correct unused-import bookkeeping. One optional Low nit (test-boilerplate consistency) left as-is to match sibling tests.

Closes #464
Closes #466
Closes #467
Closes #469
Refs #465
