### PR TITLE
test+docs: incorporate @kingrubic's selector cleanup (#468) and add CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing to rdlp! We welcome contributions from everyone, whether you're fixing bugs, adding features, improving documentation, or adding support for new sites.
 
+Everyone who contributes is credited in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ## Ways to Contribute
 
 ### Report Bugs

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,22 @@
+# Contributors
+
+rdlp is built and maintained by the people listed here. Thank you to everyone
+who has contributed code, extractors, tests, documentation, bug reports, and
+ideas. 🩷
+
+Contributions of every size are valued — see [CONTRIBUTING.md](CONTRIBUTING.md)
+to get started.
+
+## Maintainer
+
+- **Mattias Carlsson** ([@crippledgeek](https://github.com/crippledgeek)) — project author and maintainer
+
+## Contributors
+
+- **Bao** ([@kingrubic](https://github.com/kingrubic)) — deduplicated the `make_format` format-selector test helper ([#468](https://github.com/crippledgeek/rdlp/pull/468))
+
+<!--
+Ordering: maintainer first, then contributors in order of first contribution.
+When adding yourself, keep one entry per person with a short note describing the
+contribution and a link to the relevant PR or issue.
+-->

--- a/crates/rdlp-types/src/format/selector/tests.rs
+++ b/crates/rdlp-types/src/format/selector/tests.rs
@@ -4281,7 +4281,6 @@ mod negative_eval_2 {
 
 mod negative_sort_2 {
     use super::*;
-    use crate::format::Format;
 
     // ---- Missing numeric fields sort as absent (tier -10) ----
 
@@ -4858,7 +4857,6 @@ mod negative_eval_3 {
 
 mod negative_sort_3 {
     use super::*;
-    use crate::format::Format;
 
     // ---- Empty codec string treated as missing ----
 


### PR DESCRIPTION
## Summary

Incorporates and credits **@kingrubic's contribution (#468)**, in two commits:

1. **`test(rdlp-types)`** — cherry-picked (`-x`, **authorship preserved**) from @kingrubic's #468: drops the two redundant `use crate::format::Format;` lines in the `negative_sort_2` / `negative_sort_3` selector submodules. Both #468 and the merged #470 hoisted the shared `make_format` helper (issue #464); #470 landed first and closed #464 but left those imports, which are redundant — `Format` already resolves via the existing `use super::*` (from the root's `use crate::format::{Codec, Format}`). Only this 2-line cleanup survives on top of #470.

2. **`docs`** — adds a root-level **`CONTRIBUTORS.md`** crediting the maintainer and @kingrubic, linked from `CONTRIBUTING.md`. Placed at root (not `docs/`, which is gitignored) so it's visible to GitHub readers — same rationale as `EXTRACTORS.md`.

## Provenance / credit

The code change keeps @kingrubic (Bao) as the commit author. #468 is the cleaner variant of the #464 extraction; this PR captures it and records the credit.

## Verification

- **Full workspace test suite** (`cargo test --workspace`, all crates incl. `rdlp-desktop`/`rdlp-cli`/`rdlp-probe`) ✓ green
- `cargo fmt --check` ✓ · `cargo clippy -p rdlp-types --all-targets -- -D warnings` ✓
- Code change is test-only; the docs change touches no source.

Refs #464, #468
