### PR TITLE
refactor(rdlp-ffmpeg): iterator/borrow/alloc cleanups (#473–477)

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -245,19 +245,15 @@ pub fn resolve_audio_encoder(input: &str) -> Option<&'static str> {
         return Some(enc);
     }
 
-    // Otherwise treat as a direct encoder name — find matching static str
-    for entry in AUDIO_CODEC_PREFERENCES {
-        for (enc, _) in entry.encoders {
-            if enc.eq_ignore_ascii_case(input) {
-                if is_audio_encoder_available(enc) {
-                    return Some(enc);
-                }
-                return None;
-            }
-        }
-    }
-
-    None
+    // Otherwise treat as a direct encoder name — find the matching static str,
+    // then gate on availability. Short-circuits on the first name match exactly
+    // like the prior nested-loop search (duplicate names occur only across
+    // byte-identical codec-alias rows), so the verdict is unchanged.
+    AUDIO_CODEC_PREFERENCES
+        .iter()
+        .flat_map(|entry| entry.encoders)
+        .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
+        .and_then(|(enc, _)| is_audio_encoder_available(enc).then_some(*enc))
 }
 
 /// Returns all available encoders for a given audio codec name, in preference order.
@@ -512,5 +508,19 @@ mod tests {
     #[test]
     fn unknown_codec_resolve_returns_none() {
         assert!(resolve_audio_encoder("nonexistent_codec_xyz").is_none());
+    }
+
+    #[test]
+    fn registered_but_unavailable_encoder_resolves_none() {
+        // `libfdk_aac` is registered in AUDIO_CODEC_PREFERENCES but is a nonfree
+        // encoder usually absent from a stock ffmpeg build. When present it
+        // resolves to itself; when absent the name matches yet the availability
+        // gate rejects it → None. Pins the `.and_then(is_available.then_some(..))`
+        // unavailable branch of the iterator chain.
+        if is_audio_encoder_available("libfdk_aac") {
+            assert_eq!(resolve_audio_encoder("libfdk_aac"), Some("libfdk_aac"));
+        } else {
+            assert_eq!(resolve_audio_encoder("libfdk_aac"), None);
+        }
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/log_capture.rs
@@ -405,17 +405,32 @@ unsafe extern "C" fn capture_callback(
         .to_string_lossy()
         .to_string();
 
-    if has_capture {
+    let push_to_capture = |line: String| {
         CAPTURE_STACK.with(|stack| {
             if let Some(top) = stack.borrow().last()
                 && let Ok(mut v) = top.lock()
             {
-                v.push(msg.clone());
+                v.push(line);
             }
         });
-    }
-    if let Some(forwarder) = forwarder {
-        forwarder(level, msg);
+    };
+
+    // Clone only when BOTH sinks are live (the message is consumed twice). On
+    // the common capture-only path — the integrity scan and loudnorm capture
+    // run with no forwarder — move `msg` into the buffer instead of cloning,
+    // saving one allocation per captured log line.
+    match forwarder {
+        Some(forwarder) => {
+            if has_capture {
+                push_to_capture(msg.clone());
+            }
+            forwarder(level, msg);
+        }
+        None => {
+            if has_capture {
+                push_to_capture(msg);
+            }
+        }
     }
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/probe.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/probe.rs
@@ -147,10 +147,13 @@ impl FFmpegRunner {
             m.ok().map(|m| m.len())
         };
 
-        // Format-level metadata
-        for (key, value) in ictx.metadata().iter() {
-            info.metadata.insert(key.to_lowercase(), value.to_string());
-        }
+        // Format-level metadata. `collect` into the fresh default map keeps
+        // last-wins on duplicate keys exactly as repeated `insert` would.
+        info.metadata = ictx
+            .metadata()
+            .iter()
+            .map(|(key, value)| (key.to_lowercase(), value.to_string()))
+            .collect();
 
         // Parse streams
         info.stream_count = ictx.streams().count();
@@ -168,23 +171,23 @@ impl FFmpegRunner {
                 _ => "unknown",
             };
 
+            // Stream-level metadata, built directly into the struct below.
+            let stream_metadata = stream
+                .metadata()
+                .iter()
+                .map(|(key, value)| (key.to_lowercase(), value.to_string()))
+                .collect();
+
             let mut stream_info = StreamInfo {
                 index: stream.index(),
                 codec_type: codec_type_str.to_string(),
                 codec_name: Some(codec_name),
-                metadata: HashMap::new(),
+                metadata: stream_metadata,
                 duration: None,
                 sar_num: None,
                 sar_den: None,
                 nb_frames: None,
             };
-
-            // Stream-level metadata
-            for (key, value) in stream.metadata().iter() {
-                stream_info
-                    .metadata
-                    .insert(key.to_lowercase(), value.to_string());
-            }
 
             // Per-stream duration
             let stream_duration_ts = stream.duration();

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -142,6 +142,32 @@ pub fn check_matroska_integrity(input: &Path) -> Result<()> {
     }
 }
 
+/// Maximum number of `.salvageN.` disambiguation slots probed before giving up.
+///
+/// Bounds the collision search so a directory already full of salvage files
+/// cannot spin unbounded; when every slot is occupied the last slot is reused
+/// (matching the historical `attempt >= 99` cap).
+const MAX_SALVAGE_ATTEMPTS: u32 = 99;
+
+/// Pick the salvage output path for `input`, avoiding collisions with existing
+/// files so a previous partial salvage is never overwritten.
+///
+/// Returns `stem.salvage.ext` when that slot is free; otherwise the first free
+/// `stem.salvageN.ext` for `N` in `1..=MAX_SALVAGE_ATTEMPTS`. If every slot is
+/// occupied, falls back to the last slot (`MAX_SALVAGE_ATTEMPTS`).
+fn next_salvage_path(input: &Path, stem: &str, ext: &str) -> PathBuf {
+    let base = input.with_file_name(format!("{stem}.salvage.{ext}"));
+    if !base.exists() {
+        return base;
+    }
+    (1..=MAX_SALVAGE_ATTEMPTS)
+        .map(|n| input.with_file_name(format!("{stem}.salvage{n}.{ext}")))
+        .find(|candidate| !candidate.exists())
+        .unwrap_or_else(|| {
+            input.with_file_name(format!("{stem}.salvage{MAX_SALVAGE_ATTEMPTS}.{ext}"))
+        })
+}
+
 /// Salvage a corrupt Matroska/WebM container by remuxing with stream copy.
 ///
 /// Reads all recoverable packets from the corrupt input and writes them into
@@ -161,22 +187,7 @@ pub fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("salvage");
-    let salvage_path = {
-        let base = input.with_file_name(format!("{stem}.salvage.{ext}"));
-        if base.exists() {
-            // Find unique path to avoid reusing partially written files
-            let mut attempt = 1u32;
-            loop {
-                let candidate = input.with_file_name(format!("{stem}.salvage{attempt}.{ext}"));
-                if !candidate.exists() || attempt >= 99 {
-                    break candidate;
-                }
-                attempt += 1;
-            }
-        } else {
-            base
-        }
-    };
+    let salvage_path = next_salvage_path(input, stem, ext);
 
     info!(
         "Salvage remuxing corrupt input: {} -> {}",
@@ -408,5 +419,52 @@ mod tests {
         }
         let result = check_matroska_integrity(Path::new("/nonexistent/file.mkv"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn next_salvage_path_uses_base_when_free() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("movie.mkv");
+        // Nothing occupies the base slot yet → the un-numbered path is chosen.
+        assert_eq!(
+            next_salvage_path(&input, "movie", "mkv"),
+            dir.path().join("movie.salvage.mkv")
+        );
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)] // test fixture: create sync files to occupy salvage slots
+    fn next_salvage_path_skips_occupied_slots() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("movie.mkv");
+        // Base + first numbered slot are already taken by prior salvage runs;
+        // the next free slot is salvage2 — a previous partial file is never reused.
+        for name in ["movie.salvage.mkv", "movie.salvage1.mkv"] {
+            std::fs::File::create(dir.path().join(name)).expect("create fixture");
+        }
+        assert_eq!(
+            next_salvage_path(&input, "movie", "mkv"),
+            dir.path().join("movie.salvage2.mkv")
+        );
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)] // test fixture: occupy every salvage slot
+    fn next_salvage_path_reuses_last_slot_when_all_occupied() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("movie.mkv");
+        // Occupy the base slot and every numbered slot 1..=MAX.
+        std::fs::File::create(dir.path().join("movie.salvage.mkv")).expect("create base");
+        for n in 1..=MAX_SALVAGE_ATTEMPTS {
+            std::fs::File::create(dir.path().join(format!("movie.salvage{n}.mkv")))
+                .expect("create slot");
+        }
+        // No free slot remains → fall back to the last slot, matching the old
+        // loop's `attempt >= 99` cap that returned salvage99 even when occupied.
+        assert_eq!(
+            next_salvage_path(&input, "movie", "mkv"),
+            dir.path()
+                .join(format!("movie.salvage{MAX_SALVAGE_ATTEMPTS}.mkv"))
+        );
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
@@ -86,7 +86,7 @@ pub enum SpeedControlError {
 
 fn check_knob(
     field: KnobField,
-    value: Option<String>,
+    value: Option<&str>,
     encoder: &str,
 ) -> Result<(), SpeedControlError> {
     let Some(val) = value else {
@@ -101,12 +101,12 @@ fn check_knob(
         })?;
     match def.kind {
         KnobKindDef::Choice { choices, .. } => {
-            if choices.contains(&val.as_str()) {
+            if choices.contains(&val) {
                 Ok(())
             } else {
                 Err(SpeedControlError::NotInChoices {
                     knob: field,
-                    value: val,
+                    value: val.to_string(),
                     choices: choices.iter().map(|s| (*s).to_string()).collect(),
                 })
             }
@@ -114,7 +114,7 @@ fn check_knob(
         KnobKindDef::Int { min, max, .. } => {
             let n: i32 = val.parse().map_err(|_| SpeedControlError::NotInteger {
                 knob: field,
-                value: val.clone(),
+                value: val.to_string(),
             })?;
             if (min..=max).contains(&n) {
                 Ok(())
@@ -150,14 +150,15 @@ pub fn validate_speed_controls(
     let Some(enc) = encoder else {
         return Ok(());
     };
-    check_knob(KnobField::Preset, preset.map(str::to_string), enc)?;
-    check_knob(KnobField::Deadline, deadline.map(str::to_string), enc)?;
-    check_knob(KnobField::CpuUsed, cpu_used.map(|n| n.to_string()), enc)?;
-    check_knob(
-        KnobField::SpeedLevel,
-        speed_level.map(|n| i32::try_from(n).unwrap_or(i32::MAX).to_string()),
-        enc,
-    )?;
+    // The numeric knobs bind their owned strings first so `.as_deref()` can
+    // borrow them; `preset`/`deadline` are already `&str` and pass through with
+    // no allocation on the happy path.
+    let cpu = cpu_used.map(|n| n.to_string());
+    let spd = speed_level.map(|n| i32::try_from(n).unwrap_or(i32::MAX).to_string());
+    check_knob(KnobField::Preset, preset, enc)?;
+    check_knob(KnobField::Deadline, deadline, enc)?;
+    check_knob(KnobField::CpuUsed, cpu.as_deref(), enc)?;
+    check_knob(KnobField::SpeedLevel, spd.as_deref(), enc)?;
     Ok(())
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -435,20 +435,16 @@ pub fn resolve_encoder(input: &str) -> Option<&'static str> {
         return Some(enc);
     }
 
-    // Otherwise treat as a direct encoder name — check if it's available
-    // and find the matching static str in our table
-    for entry in CODEC_PREFERENCES {
-        for (enc, _) in entry.encoders {
-            if enc.eq_ignore_ascii_case(input) {
-                if is_encoder_available(enc) {
-                    return Some(enc);
-                }
-                return None;
-            }
-        }
-    }
-
-    None
+    // Otherwise treat as a direct encoder name — find the matching static str
+    // in our table, then gate on availability. Short-circuits on the first
+    // name match exactly like the prior nested-loop search: duplicate encoder
+    // names occur only across byte-identical codec-alias rows, so the verdict
+    // (available → Some, unavailable → None) is unchanged.
+    CODEC_PREFERENCES
+        .iter()
+        .flat_map(|entry| entry.encoders)
+        .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
+        .and_then(|(enc, _)| is_encoder_available(enc).then_some(*enc))
 }
 
 /// Returns all available encoders for a given codec name, in preference order.
@@ -558,9 +554,16 @@ mod tests {
         if is_encoder_available("libxeve") {
             assert_eq!(resolve_encoder("evc"), Some("libxeve"));
             assert_eq!(resolve_encoder("libxeve"), Some("libxeve"));
+        } else {
+            // Registered in the table but not built into this ffmpeg: the
+            // name matches yet the availability gate rejects it → None. Pins
+            // the `.and_then(is_available.then_some(..))` unavailable branch.
+            assert_eq!(resolve_encoder("libxeve"), None);
         }
         if is_encoder_available("libxavs2") {
             assert_eq!(resolve_encoder("avs2"), Some("libxavs2"));
+        } else {
+            assert_eq!(resolve_encoder("libxavs2"), None);
         }
         // APV must NOT be registered (intentionally excluded).
         assert_eq!(resolve_encoder("apv"), None);

--- a/crates/rdlp-ffmpeg/tests/probe_metadata.rs
+++ b/crates/rdlp-ffmpeg/tests/probe_metadata.rs
@@ -1,0 +1,164 @@
+//! Fixture-backed coverage for `FFmpegRunner::probe` metadata extraction.
+//!
+//! `probe_sync`'s format- and stream-level metadata parsing has no in-crate
+//! unit coverage (its only unit test exercises `StreamInfo::default`). This
+//! integration test generates a minimal MKV *with* format- and stream-level
+//! metadata tags using FFmpeg library bindings (no CLI spawning), then probes
+//! it through the public async API and asserts the tags land in the returned
+//! `MediaInfo`. It guards the `.map().collect()` metadata rewrite (issue #475):
+//! a regression that dropped the maps would surface here as empty metadata.
+
+// This test directly accesses raw FFmpeg FFI to copy encoder params onto the
+// output stream — there is no safe abstraction for it in ffmpeg-the-third v4.1.
+#![allow(unsafe_code)]
+// expect()/unwrap() are intentional in tests — panics surface failures.
+// Integration tests aren't seen as #[cfg(test)] by clippy, so the file-scope
+// allow is required (see clippy.toml, rust-clippy#13981).
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+
+use rdlp_ffmpeg::FFmpegRunner;
+
+/// Generate a minimal 5-frame MKV (mpeg4 video) carrying format- and
+/// stream-level `title` metadata tags.
+fn generate_fixture_with_metadata(path: &Path) {
+    use ffmpeg_the_third::ffi;
+
+    let mut octx = ffmpeg_the_third::format::output(path).expect("failed to create output format");
+
+    // mpeg4 is a built-in encoder, needs no external library.
+    let mpeg4 = ffmpeg_the_third::encoder::find_by_name("mpeg4").expect("mpeg4 encoder not found");
+    let v_ost = octx.add_stream(mpeg4).expect("failed to add video stream");
+    let v_ost_idx = v_ost.index();
+    let v_enc_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(v_ost.parameters())
+        .expect("failed to create video encoder context");
+    let mut v_enc = v_enc_ctx
+        .encoder()
+        .video()
+        .expect("failed to open video encoder context");
+    v_enc.set_width(320);
+    v_enc.set_height(240);
+    v_enc.set_format(ffmpeg_the_third::format::Pixel::YUV420P);
+    v_enc.set_time_base(ffmpeg_the_third::Rational(1, 25));
+    v_enc.set_bit_rate(400_000);
+    unsafe {
+        let ptr = v_enc.as_mut_ptr();
+        (*ptr).gop_size = 12;
+        (*ptr).max_b_frames = 0;
+    }
+
+    let needs_global = octx
+        .format()
+        .flags()
+        .contains(ffmpeg_the_third::format::Flags::GLOBAL_HEADER);
+    if needs_global {
+        unsafe {
+            (*v_enc.as_mut_ptr()).flags |= ffi::AV_CODEC_FLAG_GLOBAL_HEADER as i32;
+        }
+    }
+
+    let mut v_enc = v_enc.open_as(mpeg4).expect("failed to open mpeg4 encoder");
+
+    // Copy encoder params onto the output stream.
+    unsafe {
+        let ost_ptr = (*octx.as_mut_ptr()).streams.add(v_ost_idx);
+        ffi::avcodec_parameters_from_context((**ost_ptr).codecpar, v_enc.as_ptr());
+    }
+
+    // Format-level metadata (Matroska SegmentInfo Title).
+    let mut fmeta = ffmpeg_the_third::Dictionary::new();
+    fmeta.set("title", "Rdlp Probe Fixture");
+    octx.set_metadata(fmeta);
+
+    // Stream-level metadata (Matroska track Name).
+    let mut smeta = ffmpeg_the_third::Dictionary::new();
+    smeta.set("title", "green-test-track");
+    octx.stream_mut(v_ost_idx)
+        .expect("output stream exists")
+        .set_metadata(smeta);
+
+    octx.write_header().expect("failed to write output header");
+
+    // 5 frames of solid green is enough for a valid, probeable container.
+    for i in 0..5u32 {
+        let mut frame =
+            ffmpeg_the_third::frame::Video::new(ffmpeg_the_third::format::Pixel::YUV420P, 320, 240);
+        frame.set_pts(Some(i64::from(i)));
+        for byte in frame.data_mut(0).iter_mut() {
+            *byte = 149; // Y
+        }
+        for byte in frame.data_mut(1).iter_mut() {
+            *byte = 43; // U
+        }
+        for byte in frame.data_mut(2).iter_mut() {
+            *byte = 21; // V
+        }
+        v_enc.send_frame(&frame).expect("failed to send frame");
+        drain(&mut v_enc, &mut octx, v_ost_idx);
+    }
+    v_enc.send_eof().expect("failed to send eof");
+    drain(&mut v_enc, &mut octx, v_ost_idx);
+
+    octx.write_trailer()
+        .expect("failed to write output trailer");
+}
+
+fn drain(
+    encoder: &mut ffmpeg_the_third::encoder::video::Video,
+    octx: &mut ffmpeg_the_third::format::context::Output,
+    ost_idx: usize,
+) {
+    let mut packet = ffmpeg_the_third::Packet::empty();
+    while encoder.receive_packet(&mut packet).is_ok() {
+        packet.set_stream(ost_idx);
+        packet.write_interleaved(octx).ok();
+    }
+}
+
+#[tokio::test]
+async fn probe_extracts_format_and_stream_metadata() {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let video_path = dir.path().join("meta.mkv");
+    generate_fixture_with_metadata(&video_path);
+
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+    let info = runner.probe(&video_path).await.expect("probe failed");
+
+    // Format-level metadata round-trips into the map (guards the collect
+    // rewrite — a broken collect would leave this empty).
+    assert!(
+        !info.metadata.is_empty(),
+        "expected format metadata, got none"
+    );
+    assert_eq!(
+        info.metadata.get("title").map(String::as_str),
+        Some("Rdlp Probe Fixture"),
+        "format-level title tag missing or wrong: {:?}",
+        info.metadata,
+    );
+    assert!(
+        info.metadata.keys().all(|k| k == &k.to_lowercase()),
+        "format metadata keys must be lowercased: {:?}",
+        info.metadata.keys().collect::<Vec<_>>(),
+    );
+
+    // Stream-level metadata round-trips into the per-stream map.
+    let video = info
+        .streams
+        .iter()
+        .find(|s| s.codec_type == "video")
+        .expect("expected a video stream");
+    assert_eq!(
+        video.metadata.get("title").map(String::as_str),
+        Some("green-test-track"),
+        "stream-level title tag missing or wrong: {:?}",
+        video.metadata,
+    );
+    assert!(
+        video.metadata.keys().all(|k| k == &k.to_lowercase()),
+        "stream metadata keys must be lowercased: {:?}",
+        video.metadata.keys().collect::<Vec<_>>(),
+    );
+}


### PR DESCRIPTION
## Summary

Whole-crate iterator/HOF/allocation audit follow-ups for `rdlp-ffmpeg`. All five changes are **behavior-preserving** refactors plus test-coverage backfill — no public API or behavioral change.

- **#473** — `resolve_encoder` (video_codecs.rs) + its twin `resolve_audio_encoder` (audio_encoder_registry.rs): nested `for` loops → `flat_map`/`find`/`and_then` iterator chains (the lone imperative outliers among iterator-composing accessors). Added registered-but-unavailable → `None` branch assertions on both sides.
- **#474** — `log_capture.rs` `capture_callback`: clone the message only when a forwarder **and** a capture sink are both live; move on the common capture-only path (integrity scan / loudnorm), saving one allocation per captured line.
- **#475** — `probe.rs` format + per-stream metadata `insert`-loops → `.map().collect()` (stream map folded into the struct literal). Backfilled with a fixture-backed integration test (`tests/probe_metadata.rs`) that generates an MKV via FFmpeg library bindings (no CLI) and asserts format- and stream-level metadata round-trip through the public `FFmpegRunner::probe`.
- **#476** — `speed_controls.rs` `check_knob`: `Option<String>` → `Option<&str>`; `preset`/`deadline` pass through with zero allocation, numeric knobs via `.as_deref()`; allocation now only on the error arms.
- **#477** — `salvage.rs`: extracted a testable `next_salvage_path` helper using `(1..=MAX_SALVAGE_ATTEMPTS).find(...)`; lifted the `99` cap to a named const. Added deterministic tests for base-free, skip-to-`salvage2`, and all-slots-occupied → reuse-last-slot fallback.

## Testing

`cargo fmt --check` · `cargo check` · `cargo clippy --all-targets -- -D warnings` · `cargo test -p rdlp-ffmpeg` (189 lib + integration) · `cargo test -p rdlp-postprocess` · all five `scripts/check-*.sh` gates — all green.

## Reviews

- **security-reviewer**: Approve (PASS) — behavior-preserving; salvage path semantics, log-capture delivery, and bounded allocations all unchanged; no new log/URL/PII surface; test-only `unsafe` confined to the fixture.
- **code-reviewer**: Approve — verified per-change semantic equivalence; one *Important* coverage gap (all-slots-occupied salvage fallback) surfaced and **fixed in this PR** before push.

Closes #473
Closes #474
Closes #475
Closes #476
Closes #477