### PR TITLE
refactor: iterator/idiom cleanups tail across 5 crates (#479)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/subtitle/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/subtitle/mod.rs
@@ -199,16 +199,17 @@ impl Orchestrator {
         }
 
         // Map selected indices back to (lang, best_subtitle) pairs
-        let mut result = Vec::new();
-        for &idx in &selected_indices {
-            #[allow(clippy::indexing_slicing)]
-            // idx comes from interactive selection bounded by items.len()
-            let item = &items[idx];
-            // Find the best subtitle entry for this language
-            if let Some(sub) = self.pick_best_subtitle_for_lang(info, &item.lang, item.is_auto) {
-                result.push((item.lang.clone(), sub));
-            }
-        }
+        let result: Vec<_> = selected_indices
+            .iter()
+            .filter_map(|&idx| {
+                #[allow(clippy::indexing_slicing)]
+                // idx comes from interactive selection bounded by items.len()
+                let item = &items[idx];
+                // Find the best subtitle entry for this language
+                self.pick_best_subtitle_for_lang(info, &item.lang, item.is_auto)
+                    .map(|sub| (item.lang.clone(), sub))
+            })
+            .collect();
 
         info!(
             "Selected {} subtitle language(s): {}",

--- a/crates/rdlp-api/src/orchestrator/template/render.rs
+++ b/crates/rdlp-api/src/orchestrator/template/render.rs
@@ -75,10 +75,11 @@ impl OutputTemplate {
         ctx: &RenderContext,
     ) -> Result<String, TemplateError> {
         // Try each field in the fallback chain
-        for field_ref in &spec.names {
-            if let Some(val) = Self::lookup_field(field_ref, info_json, format_json, ext, ctx) {
-                return Ok(Self::format_value(&val, &spec.format));
-            }
+        if let Some(rendered) = spec.names.iter().find_map(|field_ref| {
+            Self::lookup_field(field_ref, info_json, format_json, ext, ctx)
+                .map(|val| Self::format_value(&val, &spec.format))
+        }) {
+            return Ok(rendered);
         }
 
         // All fields missed — try conditional replacement

--- a/crates/rdlp-downloader/src/dash/manifest.rs
+++ b/crates/rdlp-downloader/src/dash/manifest.rs
@@ -132,25 +132,17 @@ pub fn parse_mpd(body: &str, base_url: &Url) -> Result<ParsedManifest, DashError
 /// Returns true if any `ContentProtection` element appears at MPD, Period,
 /// AdaptationSet, or Representation scope.
 fn mpd_has_drm(mpd: &dash_mpd::MPD) -> bool {
-    if !mpd.ContentProtection.is_empty() {
-        return true;
-    }
-    for period in &mpd.periods {
-        if !period.ContentProtection.is_empty() {
-            return true;
-        }
-        for aset in &period.adaptations {
-            if !aset.ContentProtection.is_empty() {
-                return true;
-            }
-            for repr in &aset.representations {
-                if !repr.ContentProtection.is_empty() {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    !mpd.ContentProtection.is_empty()
+        || mpd.periods.iter().any(|period| {
+            !period.ContentProtection.is_empty()
+                || period.adaptations.iter().any(|aset| {
+                    !aset.ContentProtection.is_empty()
+                        || aset
+                            .representations
+                            .iter()
+                            .any(|repr| !repr.ContentProtection.is_empty())
+                })
+        })
 }
 
 /// Resolve a list of `<BaseURL>` elements against a parent URL. When the

--- a/crates/rdlp-extractor/src/base/common/json_ld.rs
+++ b/crates/rdlp-extractor/src/base/common/json_ld.rs
@@ -249,13 +249,8 @@ pub enum JsonLdGenre {
 /// `VideoObject`, including inside `@graph` arrays.
 #[must_use]
 pub fn extract_json_ld(html: &Html) -> Option<JsonLdVideo> {
-    for script_elem in html.select(&JSONLD_SELECTOR) {
-        let json_text = script_elem.text().collect::<String>();
-        if let Some(video) = parse_video_object(&json_text) {
-            return Some(video);
-        }
-    }
-    None
+    html.select(&JSONLD_SELECTOR)
+        .find_map(|script_elem| parse_video_object(&script_elem.text().collect::<String>()))
 }
 
 /// Parse a JSON-LD text block and extract the first `VideoObject`.
@@ -266,11 +261,10 @@ fn parse_video_object(json_text: &str) -> Option<JsonLdVideo> {
                 return Some(obj);
             }
             JsonLdRoot::Graph(graph) => {
-                for obj in graph.graph {
-                    if obj.json_type.as_ref().is_some_and(|t| t.is_video()) {
-                        return Some(obj);
-                    }
-                }
+                return graph
+                    .graph
+                    .into_iter()
+                    .find(|obj| obj.json_type.as_ref().is_some_and(|t| t.is_video()));
             }
             _ => {}
         }

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -429,15 +429,12 @@ impl BaseExtractor {
         group_indices: &[usize],
     ) -> Option<String> {
         pattern.captures(url).and_then(|cap| {
-            for &idx in group_indices {
-                if let Some(m) = cap.get(idx) {
-                    let value = m.as_str();
-                    if !value.is_empty() {
-                        return Some(value.to_string());
-                    }
-                }
-            }
-            None
+            group_indices.iter().find_map(|&idx| {
+                cap.get(idx)
+                    .map(|m| m.as_str())
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+            })
         })
     }
 

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
@@ -234,15 +234,11 @@ pub(super) fn decode_player_iframe(iframe_src: &str) -> Option<String> {
         base64::Engine::decode(&base64::engine::general_purpose::STANDARD, q.as_bytes()).ok()?;
     let decoded = String::from_utf8(decoded_bytes).ok()?;
 
-    // URL-decode the tag parameter
-    let params: Vec<(String, String)> = url::form_urlencoded::parse(decoded.as_bytes())
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect();
-
-    params
-        .iter()
+    // URL-decode the tag parameter — read the first `tag` pair directly instead
+    // of collecting every param into a Vec<(String, String)> just to scan it.
+    url::form_urlencoded::parse(decoded.as_bytes())
         .find(|(k, _)| k == "tag")
-        .map(|(_, v)| v.clone())
+        .map(|(_, v)| v.into_owned())
 }
 
 /// Extract media URLs from the decoded player tag HTML.

--- a/crates/rdlp-extractor/src/extractors/nine_anime/episodes.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/episodes.rs
@@ -123,33 +123,27 @@ fn parse_episode_info(html: &str, episode_data_id: &str) -> Option<EpisodeInfo> 
 /// Returns every `ep-item` block as an `EpisodeListEntry` with data-id,
 /// episode number, and title.
 pub fn parse_all_episodes(html: &str) -> Vec<EpisodeListEntry> {
-    let mut entries = Vec::new();
+    EP_ITEM_BLOCK
+        .find_iter(html)
+        .filter_map(|block_match| {
+            let block = block_match.as_str();
+            let id_caps = EP_ITEM_DATA_ID.captures(block)?;
+            let num_caps = EP_DATA_NUMBER.captures(block)?;
 
-    for block_match in EP_ITEM_BLOCK.find_iter(html) {
-        let block = block_match.as_str();
+            let title = EP_TITLE_ATTR
+                .captures(block)
+                .map(|c| decode_html_entities(&c[1]))
+                .filter(|t| !t.is_empty());
 
-        let Some(id_caps) = EP_ITEM_DATA_ID.captures(block) else {
-            continue;
-        };
-        let Some(num_caps) = EP_DATA_NUMBER.captures(block) else {
-            continue;
-        };
-
-        let title = EP_TITLE_ATTR
-            .captures(block)
-            .map(|c| decode_html_entities(&c[1]))
-            .filter(|t| !t.is_empty());
-
-        entries.push(EpisodeListEntry {
-            data_id: id_caps[1].to_string(),
-            info: EpisodeInfo {
-                number: num_caps[1].to_string(),
-                title,
-            },
-        });
-    }
-
-    entries
+            Some(EpisodeListEntry {
+                data_id: id_caps[1].to_string(),
+                info: EpisodeInfo {
+                    number: num_caps[1].to_string(),
+                    title,
+                },
+            })
+        })
+        .collect()
 }
 
 /// Fetch the full episode list for an anime.

--- a/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
@@ -39,15 +39,21 @@ pub fn fixup_formats(formats: &mut [Format]) {
 ///
 /// Returns a map of quality label (e.g. `"720p"`) to byte size.
 fn collect_download_sizes(sources: &serde_json::Map<String, Value>) -> HashMap<String, f64> {
-    let mut format_sizes: HashMap<String, f64> = HashMap::new();
-    if let Some(download) = sources.get("download").and_then(|v| v.as_object()) {
-        for (quality, format_dict) in download {
-            if let Some(size) = format_dict.get("size").and_then(|v| v.as_f64()) {
-                format_sizes.insert(quality.clone(), size);
-            }
-        }
-    }
-    format_sizes
+    sources
+        .get("download")
+        .and_then(|v| v.as_object())
+        .map(|download| {
+            download
+                .iter()
+                .filter_map(|(quality, format_dict)| {
+                    format_dict
+                        .get("size")
+                        .and_then(Value::as_f64)
+                        .map(|size| (quality.clone(), size))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Collect HLS formats from `xplayerSettings.sources.hls` (encrypted URLs).

--- a/crates/rdlp-extractor/src/extractors/xtits/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xtits/mod.rs
@@ -155,13 +155,9 @@ fn extract_info_bar_text(html: &Html, icon_class: &str) -> Option<String> {
     let item_selector = scraper::Selector::parse(".buttons-info .item").ok()?;
     let icon_selector = scraper::Selector::parse(icon_class).ok()?;
 
-    for item in html.select(&item_selector) {
-        if item.select(&icon_selector).next().is_some() {
-            return Some(item.text().collect());
-        }
-    }
-
-    None
+    html.select(&item_selector)
+        .find(|item| item.select(&icon_selector).next().is_some())
+        .map(|item| item.text().collect())
 }
 
 /// Extract view count from the page
@@ -428,5 +424,34 @@ mod tests {
             extract_model_url(&html),
             Some("https://www.xtits.com/models/jenni-lee/".to_string())
         );
+    }
+
+    #[test]
+    fn extract_info_bar_text_reads_matching_icon_item() {
+        let html_str = r#"
+        <div class="buttons-info">
+            <div class="item"><span class="icon-clock"></span> 12:34</div>
+            <div class="item"><span class="icon-eye"></span> 1 234</div>
+        </div>
+        "#;
+        let html = Html::parse_document(html_str);
+        // Returns the text of the `.item` whose icon matches, not the first item.
+        assert_eq!(
+            extract_info_bar_text(&html, ".icon-eye")
+                .as_deref()
+                .map(str::trim),
+            Some("1 234")
+        );
+    }
+
+    #[test]
+    fn extract_info_bar_text_returns_none_without_matching_icon() {
+        let html_str = r#"
+        <div class="buttons-info">
+            <div class="item"><span class="icon-clock"></span> 12:34</div>
+        </div>
+        "#;
+        let html = Html::parse_document(html_str);
+        assert_eq!(extract_info_bar_text(&html, ".icon-eye"), None);
     }
 }

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -183,12 +183,13 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
             else {
                 continue;
             };
-            if let Some(m) = re.captures(&html) {
-                for i in 1..m.len() {
-                    if let Some(g) = m.get(i) {
-                        return Some(html_escape::decode_html_entities(g.as_str()).into_owned());
-                    }
-                }
+            if let Some(m) = re.captures(&html)
+                && let Some(s) = (1..m.len()).find_map(|i| {
+                    m.get(i)
+                        .map(|g| html_escape::decode_html_entities(g.as_str()).into_owned())
+                })
+            {
+                return Some(s);
             }
         }
         None

--- a/crates/rdlp-plugin/src/host/js_eval.rs
+++ b/crates/rdlp-plugin/src/host/js_eval.rs
@@ -108,10 +108,10 @@ impl JsEvalCtx {
         // Build a JSON object from the string key-value pairs so we can use
         // eval_with_context, which injects each top-level key as a global.
         let ctx_json: serde_json::Value = {
-            let mut map = serde_json::Map::with_capacity(sandbox_globals.len());
-            for (k, v) in sandbox_globals {
-                map.insert(k.clone(), serde_json::Value::String(v.clone()));
-            }
+            let map: serde_json::Map<String, serde_json::Value> = sandbox_globals
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                .collect();
             serde_json::Value::Object(map)
         };
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -50,22 +50,21 @@ impl ThumbnailStage {
         let parent = media_file.parent()?;
 
         // Try original_stem first (most accurate after UUID renames).
-        for ext in THUMBNAIL_EXTENSIONS {
-            let path = parent.join(format!("{original_stem}.{ext}"));
-            if path.exists() {
-                return Some(path);
-            }
+        if let Some(path) = THUMBNAIL_EXTENSIONS
+            .iter()
+            .map(|ext| parent.join(format!("{original_stem}.{ext}")))
+            .find(|path| path.exists())
+        {
+            return Some(path);
         }
 
         // Fallback: try current file stem.
         let current_stem = media_file.file_stem()?.to_str()?;
         if current_stem != original_stem {
-            for ext in THUMBNAIL_EXTENSIONS {
-                let path = parent.join(format!("{current_stem}.{ext}"));
-                if path.exists() {
-                    return Some(path);
-                }
-            }
+            return THUMBNAIL_EXTENSIONS
+                .iter()
+                .map(|ext| parent.join(format!("{current_stem}.{ext}")))
+                .find(|path| path.exists());
         }
 
         None


### PR DESCRIPTION
## Summary

Follow-up to #473–477 (which cleaned rdlp-ffmpeg). Sweeps the same iterator/HOF/allocation pattern classes across the remaining crates. All changes are **behavior-preserving**; existing tests are the regression guard (plus one backfilled characterization test).

**Allocation wins**
- `rdlp-extractor` koreanpornmovie/html.rs — `collect()`-into-`Vec<(String,String)>`-then-`find` → `find` on the `form_urlencoded` parse iterator (drops a Vec + a `to_string()` pair per param to read one key).
- `rdlp-extractor` xhamster/formats.rs `collect_download_sizes` — insert-in-for → `filter_map().collect()`.
- `rdlp-api` subtitle/mod.rs — filter loop → `filter_map().collect()`.
- `rdlp-plugin` js_eval.rs — insert-in-for → `.map().collect()`; extract_helpers.rs — inner counter loop → `find_map`.

**Readability (`for … { if x { return } }` → `find`/`find_map`/`any`)**
- `rdlp-extractor` json_ld.rs ×2, common/mod.rs `extract_id_positional`, nine_anime `parse_all_episodes`, xtits `extract_info_bar_text`.
- `rdlp-api` template/render.rs `resolve_field`.
- `rdlp-downloader` dash/manifest.rs `mpd_has_drm` (triple-nested → `.any()`).
- `rdlp-postprocess` thumbnail.rs `find_thumbnail` (two loops → `find`).

**Deliberately excluded** (documented in #479): `HeaderMap` insert→`collect` (append-vs-replace semantics change) and `sanitise_for_path` `String`→`&str` (pedantic `needless_pass_by_value`, not in `-D warnings`).

## Testing

`cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` (workspace) · `cargo test` on all 5 touched crates (35 test groups, 0 failures) · `check-url-redaction` / `check-log-redaction` / `check-dedup` / `check-no-cli` — all green. Backfilled a positive+negative characterization test for the one previously-untested helper (`extract_info_bar_text`).

## Reviews

- **security-reviewer**: PASS — no findings. `mpd_has_drm` (the DRM-refusal gate) verified logically 1:1 with the old nested early-returns; no new URL/secret/PII interpolation.
- **code-reviewer**: Approve — all 12 refactors confirmed semantically equivalent; its one optional suggestion (test the untested `extract_info_bar_text`) was **added in this PR** before push.

Closes #479