### PR TITLE
fix: single-pass HTML entity decode (html_escape), yt-dlp parity + filename hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,6 +6165,7 @@ dependencies = [
  "dash-mpd",
  "futures",
  "hex",
+ "html-escape",
  "inventory",
  "lazy-regex",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "fs", "proc
 tokio-util = { version = "0.7", features = ["rt"] }
 async-trait = "0.1"
 
+# HTML entity decoding (single-pass, WHATWG-complete) — shared by rdlp-extractor + rdlp-plugin
+html-escape = "0.2.13"
+
 # HTTP and networking
 # wreq features:
 # - cookies, json, stream: 1:1 with reqwest's feature set pre-migration

--- a/crates/rdlp-api/src/orchestrator/paths.rs
+++ b/crates/rdlp-api/src/orchestrator/paths.rs
@@ -136,6 +136,13 @@ impl Orchestrator {
                 if c == '\0' || (c.is_control() && c != ' ') {
                     return None;
                 }
+                // Normalize non-ASCII whitespace (e.g. U+00A0 NO-BREAK SPACE from
+                // a decoded `&nbsp;`, or other Unicode Zs/Zl/Zp separators) to a
+                // plain ASCII space, so it renders and trims like ordinary
+                // whitespace instead of persisting as an invisible non-space.
+                if c.is_whitespace() {
+                    return Some(' ');
+                }
                 // Replace invalid filesystem characters with underscore
                 Some(match c {
                     '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
@@ -230,6 +237,26 @@ mod sanitize_marker_tests {
         assert_eq!(
             Orchestrator::sanitize_filename("Normal Title"),
             "Normal Title"
+        );
+    }
+
+    /// A non-breaking space (U+00A0) — e.g. from a decoded `&nbsp;` title — is
+    /// normalized to a plain ASCII space so it renders and trims like ordinary
+    /// whitespace. Fails against the old code, which preserved U+00A0 verbatim
+    /// (it is category Zs, not a control char, and the trim only matched 0x20).
+    #[test]
+    fn normalizes_non_breaking_space_to_ascii_space() {
+        assert_eq!(Orchestrator::sanitize_filename("a\u{00A0}b"), "a b");
+    }
+
+    /// Leading/trailing Unicode whitespace is normalized first, so the existing
+    /// dot/space trim then strips it. Fails against the old code, which left the
+    /// U+00A0 padding in place.
+    #[test]
+    fn trims_leading_trailing_unicode_whitespace() {
+        assert_eq!(
+            Orchestrator::sanitize_filename("\u{00A0}Title\u{00A0}"),
+            "Title"
         );
     }
 

--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -31,7 +31,7 @@ base64 = { workspace = true }
 m3u8-rs = { workspace = true }
 futures = { workspace = true }
 urlencoding = "2"
-html-escape = "0.2.13"
+html-escape = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -31,6 +31,7 @@ base64 = { workspace = true }
 m3u8-rs = { workspace = true }
 futures = { workspace = true }
 urlencoding = "2"
+html-escape = "0.2.13"
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
@@ -101,18 +101,14 @@ pub(super) fn scrape_durations_from_html(
     map
 }
 
-/// Decode basic HTML entities in WP REST API title (e.g., `&#8211;` → `–`).
+/// Decode HTML entities in a WP REST API title in a single pass.
+///
+/// Delegates to [`html_escape::decode_html_entities`] (full WHATWG named set +
+/// numeric/hex references), so entities like `&#8211;` → `–` and `&#8217;` →
+/// `’` decode to their true code points without the double-decoding the former
+/// hand-rolled sequential `.replace()` chain was prone to.
 pub(super) fn html_entities_decode(s: &str) -> String {
-    s.replace("&#8211;", "–")
-        .replace("&#8212;", "—")
-        .replace("&#8216;", "'")
-        .replace("&#8217;", "'")
-        .replace("&#8220;", "\u{201c}")
-        .replace("&#8221;", "\u{201d}")
-        .replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
+    html_escape::decode_html_entities(s).into_owned()
 }
 
 // ============================================================================
@@ -288,4 +284,37 @@ pub(super) fn meta_content(html: &Html, selector: &Selector) -> Option<String> {
         .and_then(|el| el.value().attr("content"))
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::html_entities_decode;
+
+    /// Positive: the WP-REST punctuation entities this decoder was written for
+    /// still decode to the same characters (en/em dash, ampersand, plain text).
+    #[test]
+    fn decodes_wp_rest_punctuation_entities() {
+        assert_eq!(html_entities_decode("A &#8211; B"), "A \u{2013} B");
+        assert_eq!(html_entities_decode("A &#8212; B"), "A \u{2014} B");
+        assert_eq!(html_entities_decode("Tom &amp; Jerry"), "Tom & Jerry");
+        assert_eq!(html_entities_decode("plain title"), "plain title");
+    }
+
+    /// Curly-quote entities now decode to their true WHATWG code points (U+2019
+    /// RIGHT SINGLE QUOTATION MARK) rather than the old ASCII-apostrophe
+    /// approximation. Fails against the old decoder (`&#8217;`→`'` 0x27).
+    #[test]
+    fn decodes_curly_quotes_to_true_code_points() {
+        assert_eq!(html_entities_decode("it&#8217;s"), "it\u{2019}s");
+        assert_eq!(html_entities_decode("&#8216;q&#8217;"), "\u{2018}q\u{2019}");
+    }
+
+    /// Regression: single-pass decode — an already-escaped `&amp;lt;` must stay
+    /// `&lt;`, not collapse to `<`. Fails against the old sequential-`.replace()`
+    /// decoder (`&amp;`→`&` ran before `&lt;`→`<`, double-decoding to `<`).
+    #[test]
+    fn does_not_double_decode() {
+        assert_eq!(html_entities_decode("&amp;lt;"), "&lt;");
+        assert_eq!(html_entities_decode("&amp;#8211;"), "&#8211;");
+    }
 }

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
@@ -107,6 +107,7 @@ pub(super) fn scrape_durations_from_html(
 /// numeric/hex references), so entities like `&#8211;` → `–` and `&#8217;` →
 /// `’` decode to their true code points without the double-decoding the former
 /// hand-rolled sequential `.replace()` chain was prone to.
+#[must_use]
 pub(super) fn html_entities_decode(s: &str) -> String {
     html_escape::decode_html_entities(s).into_owned()
 }

--- a/crates/rdlp-extractor/src/utils.rs
+++ b/crates/rdlp-extractor/src/utils.rs
@@ -409,6 +409,14 @@ mod tests {
         assert_eq!(decode_html_entities("wait&hellip;"), "wait\u{2026}");
     }
 
+    /// Unknown/malformed entities are left verbatim (no decode, no panic) — pins
+    /// passthrough behavior against a future decoder swap.
+    #[test]
+    fn test_decode_html_entities_unknown_left_verbatim() {
+        assert_eq!(decode_html_entities("a &bogus; b"), "a &bogus; b");
+        assert_eq!(decode_html_entities("bare & amp"), "bare & amp");
+    }
+
     // ========================================================================
     // URL Handling Tests
     // ========================================================================

--- a/crates/rdlp-extractor/src/utils.rs
+++ b/crates/rdlp-extractor/src/utils.rs
@@ -22,9 +22,6 @@ use log::trace;
 // Static Patterns for Utility Functions
 // ============================================================================
 
-/// Pattern for HTML entity references (e.g., &amp; &#39; &#x27;)
-static HTML_ENTITY_PATTERN: Lazy<Regex> = lazy_regex!(r"&(#?[a-zA-Z0-9]+);");
-
 /// Pattern for whitespace normalization
 static WHITESPACE_PATTERN: Lazy<Regex> = lazy_regex!(r"\s+");
 
@@ -127,12 +124,16 @@ pub fn clean_html_text(text: &str) -> String {
         .to_string()
 }
 
-/// Decode common HTML entities
+/// Decode HTML entities in a single left-to-right pass.
 ///
-/// Handles:
-/// - Named entities: `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&nbsp;`
-/// - Numeric entities: `&#39;`, `&#34;`
-/// - Hex entities: `&#x27;`, `&#x22;`
+/// Delegates to [`html_escape::decode_html_entities`], which decodes the full
+/// WHATWG named-character-reference set plus decimal (`&#39;`) and hex
+/// (`&#x3C;`) numeric references. Decoding is single-pass, so an already-escaped
+/// input like `&amp;lt;` stays the literal `&lt;` rather than collapsing to `<`
+/// — matching yt-dlp / CPython `html.unescape` and avoiding the OWASP
+/// double-encoding class. `&nbsp;` decodes to U+00A0 (NO-BREAK SPACE); any
+/// ASCII-space normalization for filenames is the sanitizer's concern, not the
+/// decoder's.
 ///
 /// # Arguments
 /// * `text` - Text containing HTML entities
@@ -148,46 +149,9 @@ pub fn clean_html_text(text: &str) -> String {
 /// let decoded = decode_html_entities("Tom &amp; Jerry");
 /// assert_eq!(decoded, "Tom & Jerry");
 /// ```
+#[must_use]
 pub fn decode_html_entities(text: &str) -> String {
-    let mut result = text.to_string();
-
-    // Common named entities
-    result = result.replace("&amp;", "&");
-    result = result.replace("&lt;", "<");
-    result = result.replace("&gt;", ">");
-    result = result.replace("&quot;", "\"");
-    result = result.replace("&apos;", "'");
-    result = result.replace("&#39;", "'");
-    result = result.replace("&#34;", "\"");
-    result = result.replace("&nbsp;", " ");
-
-    // Handle numeric/hex entities
-    HTML_ENTITY_PATTERN
-        .replace_all(&result, |caps: &regex::Captures| {
-            let entity = &caps[1];
-            if let Some(stripped) = entity.strip_prefix('#') {
-                // Numeric entity
-                let code = if let Some(hex) = stripped
-                    .strip_prefix('x')
-                    .or_else(|| stripped.strip_prefix('X'))
-                {
-                    // Hex entity
-                    u32::from_str_radix(hex, 16).ok()
-                } else {
-                    // Decimal entity
-                    stripped.parse::<u32>().ok()
-                };
-
-                if let Some(code) = code
-                    && let Some(ch) = char::from_u32(code)
-                {
-                    return ch.to_string();
-                }
-            }
-            // Return original if can't decode
-            caps[0].to_string()
-        })
-        .to_string()
+    html_escape::decode_html_entities(text).into_owned()
 }
 
 // ============================================================================
@@ -415,6 +379,34 @@ mod tests {
         assert_eq!(decode_html_entities("it&#39;s"), "it's");
         assert_eq!(decode_html_entities("&#60;"), "<");
         assert_eq!(decode_html_entities("&#x3C;"), "<");
+    }
+
+    /// Regression: entities must be decoded in a single pass. An already-escaped
+    /// input like `&amp;lt;` (literal text `&lt;`) must NOT be recursively
+    /// re-decoded into `<` — that is the OWASP double-encoding class and diverges
+    /// from yt-dlp / CPython `html.unescape`. Fails against the old sequential
+    /// `.replace()` decoder, which yielded `<`.
+    #[test]
+    fn test_decode_html_entities_no_double_decode() {
+        assert_eq!(decode_html_entities("&amp;lt;"), "&lt;");
+        assert_eq!(decode_html_entities("&amp;amp;"), "&amp;");
+        assert_eq!(decode_html_entities("&amp;#39;"), "&#39;");
+    }
+
+    /// `&nbsp;` decodes to U+00A0 NO-BREAK SPACE (WHATWG / yt-dlp parity), not an
+    /// ASCII space. Fails against the old decoder, which emitted `0x20`.
+    #[test]
+    fn test_decode_html_entities_nbsp_is_no_break_space() {
+        assert_eq!(decode_html_entities("a&nbsp;b"), "a\u{00A0}b");
+    }
+
+    /// The full WHATWG named-entity set is decoded, not just the old 8-entity
+    /// subset. Fails against the old decoder, which left `&mdash;`/`&hellip;`
+    /// untouched.
+    #[test]
+    fn test_decode_html_entities_full_named_set() {
+        assert_eq!(decode_html_entities("a &mdash; b"), "a \u{2014} b");
+        assert_eq!(decode_html_entities("wait&hellip;"), "wait\u{2026}");
     }
 
     // ========================================================================

--- a/crates/rdlp-plugin/Cargo.toml
+++ b/crates/rdlp-plugin/Cargo.toml
@@ -48,7 +48,7 @@ hex = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
 percent-encoding = "2"
-html-escape = "0.2.13"
+html-escape = { workspace = true }
 rdlp-extractor = { version = "0.1.0", path = "../rdlp-extractor" }
 rdlp-redact = { workspace = true }
 


### PR DESCRIPTION
## Summary

Closes #481.

`rdlp-extractor` hand-rolled two HTML-entity decoders that **double-unescaped** and diverged from yt-dlp / CPython `html.unescape`. Both ran sequential `String::replace()` with `&amp;`→`&` first, so an already-escaped input `&amp;lt;` decoded to `<` instead of the literal `&lt;` — the OWASP double-encoding class. They also decoded only a small named-entity subset and mapped `&nbsp;` to an ASCII space.

## Changes

- **`utils::decode_html_entities`** and **`koreanpornmovie::html_entities_decode`** now delegate to `html_escape::decode_html_entities` — single-pass, full WHATWG named + numeric/hex set, `Cow<str>` zero-copy. Already a workspace dependency, already used in `rdlp-plugin`.
- **`&nbsp;` → U+00A0** (NO-BREAK SPACE) for true yt-dlp/WHATWG parity (was ASCII `0x20`).
- **`sanitize_filename`** (`rdlp-api`) normalizes Unicode whitespace (U+00A0 and other Zs/Zl/Zp separators) → ASCII space, so a decoded non-breaking space renders/trims like ordinary whitespace and never persists into a filename. Decode-vs-filename-normalization kept as separate concerns at their proper layers.
- Removed the now-dead `HTML_ENTITY_PATTERN` regex; promoted `html-escape` to `[workspace.dependencies]` (single version source across both consuming crates).

## Tests (failing-first)

Negative/regression tests that each fail against the unpatched decoders, plus positives for unchanged behavior:
- no double-decode (`&amp;lt;` → `&lt;`), both decoders
- `&nbsp;` → U+00A0
- full WHATWG named set (`&mdash;`, `&hellip;`)
- curly-quote true code points (`&#8217;` → U+2019, was ASCII `'`)
- unknown/malformed entity left verbatim (`&bogus;`)
- `sanitize_filename` NBSP → space + leading/trailing Unicode-whitespace trim

Full gate green: `cargo fmt --check && cargo check && cargo clippy --all-targets -D warnings && cargo test` + `cargo check -p rdlp-desktop` + all repo `check-*.sh` (dedup, url/log-redaction, no-cli, wit-drift).

## Reviews

- **security-reviewer** — **Approve**. No Critical/High/Medium. Verified double-decode elimination, no new filename-injection bypass (char-level sanitizer absorbs the expanded entity set), bounded allocation. One LOW note (terminal escape-sequence output of untrusted titles) is pre-existing → tracked in #482.
- **code-reviewer** — **Approve**. No Critical/Important. Confirmed `.into_owned()` matches in-tree idiom (no perf regression vs the old always-allocating path), test coverage proportionate, sanitizer ordering correct, dead-code removal clean. Optional nits applied.

## Follow-up

- #482 — sanitize terminal/log output of extractor-sourced titles (pre-existing ANSI-escape concern).
