### PR TITLE
fix(cli): sanitize extractor-sourced titles before terminal/log output (#482)

### DIFF
--- a/crates/rdlp-cli/src/commands.rs
+++ b/crates/rdlp-cli/src/commands.rs
@@ -68,7 +68,9 @@ pub fn print_fields(info: &InfoDict, fields: &str) -> Result<()> {
             continue;
         }
         match map.get(field) {
-            Some(serde_json::Value::String(s)) => println!("{field}: {s}"),
+            Some(serde_json::Value::String(s)) => {
+                println!("{field}: {}", rdlp_cli::sanitize::sanitize_for_terminal(s));
+            }
             Some(serde_json::Value::Null) => println!("{field}:"),
             Some(v) => println!("{field}: {v}"),
             None => {

--- a/crates/rdlp-cli/src/event_handler.rs
+++ b/crates/rdlp-cli/src/event_handler.rs
@@ -49,7 +49,11 @@ impl CliEventHandler {
             }
             Event::MetadataReady { info, .. } => {
                 if !self.quiet {
-                    info!("{} | {} format(s)", info.title, info.formats.len());
+                    info!(
+                        "{} | {} format(s)",
+                        crate::sanitize::sanitize_for_terminal(&info.title),
+                        info.formats.len()
+                    );
                 }
             }
             Event::FormatSelected {

--- a/crates/rdlp-cli/src/lib.rs
+++ b/crates/rdlp-cli/src/lib.rs
@@ -21,5 +21,8 @@ pub mod interactive;
 /// drive them without going through `clap`'s argument parsing.
 #[path = "plugin_cmd.rs"]
 pub mod plugin_cmd;
+/// Neutralize terminal control sequences in extractor-sourced text before it
+/// is written to a TTY or log (#482).
+pub mod sanitize;
 /// Cross-platform shutdown-signal handling and escalation state machine (#413).
 pub mod signal;

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -19,6 +19,7 @@ use rdlp_api::TempRegistry;
 use rdlp_api::{RdlpApiError, RdlpClient};
 use rdlp_cli::event_handler::CliEventHandler;
 use rdlp_cli::interactive::DialoguerCallback;
+use rdlp_cli::sanitize::sanitize_for_terminal;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use tracing::{debug, info, warn};
@@ -280,8 +281,8 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
                     };
                     eprintln!("Found {} results{}:\n", response.results.len(), page_info);
                     for (i, r) in response.results.iter().enumerate() {
-                        eprintln!("{:>3}. {}", i + 1, r.title);
-                        eprintln!("     {}", r.video_url);
+                        eprintln!("{:>3}. {}", i + 1, sanitize_for_terminal(&r.title));
+                        eprintln!("     {}", sanitize_for_terminal(&r.video_url));
                         if let Some(d) = r.duration {
                             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                             // d is a non-negative duration in seconds; values up to ~136 years fit u32
@@ -294,7 +295,7 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
                             eprint!("  Views: {views}");
                         }
                         if let Some(uploader) = &r.uploader {
-                            eprint!("  Uploader: {uploader}");
+                            eprint!("  Uploader: {}", sanitize_for_terminal(uploader));
                         }
                         eprintln!();
                     }
@@ -360,7 +361,7 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
                 let refs: Vec<&rdlp_api::Format> = info.formats.iter().collect();
                 let table =
                     rdlp_table::render_formats_table(&refs, &rdlp_table::TableOpts::default());
-                println!("{}", info.title);
+                println!("{}", sanitize_for_terminal(&info.title));
                 println!("{table}");
             }
         }
@@ -375,8 +376,8 @@ async fn async_main(exit_signal: Arc<AtomicU8>) -> Result<()> {
             for info in &infos {
                 debug!(
                     "[Simulate] {} | id={} | extractor={} | {} format(s)",
-                    info.title,
-                    info.id,
+                    sanitize_for_terminal(&info.title),
+                    sanitize_for_terminal(&info.id),
                     info.extractor,
                     info.formats.len()
                 );

--- a/crates/rdlp-cli/src/sanitize.rs
+++ b/crates/rdlp-cli/src/sanitize.rs
@@ -1,0 +1,102 @@
+//! Neutralize terminal control sequences in extractor-sourced text.
+//!
+//! Titles, uploader names, and other strings sourced from a remote site are
+//! attacker-controlled. Written **raw** to a TTY or a log they can smuggle in
+//! ANSI/terminal control sequences — a title containing an `ESC [ 2 J` clears
+//! the user's screen, `ESC ]` (OSC) can retitle the window, and a bare `CR`
+//! overwrites the current line to spoof output. Since #481 the full WHATWG
+//! entity set is decodable (`&#27;` → `ESC`) at more extractor call sites, so
+//! this boundary must be guarded.
+//!
+//! This mirrors `rdlp_api`'s `Orchestrator::sanitize_filename`, which already
+//! strips control characters at the filesystem boundary — here we guard the
+//! terminal/log boundary the same way.
+
+/// Return a copy of `s` with all Unicode control characters removed, rendering
+/// any embedded terminal escape sequence inert before the text is written to a
+/// TTY or log.
+///
+/// [`char::is_control`] is the Unicode general-category `Cc` set, i.e. the C0
+/// range `U+0000..=U+001F` (including `ESC` `U+001B`, `CR`, `BEL`, `BS`), the
+/// `DEL` `U+007F`, and the C1 range `U+0080..=U+009F` (which includes the
+/// single-byte `CSI` `U+009B` / `OSC` `U+009D` introducers). Stripping the
+/// introducer leaves the remaining bytes as harmless literal text
+/// (`"\x1b[31mX"` → `"[31mX"`). Ordinary printable text — including non-ASCII
+/// letters and spaces — passes through unchanged.
+///
+/// # Scope
+///
+/// This targets the ANSI/terminal-escape-injection threat (category `Cc`). It
+/// deliberately does **not** strip Unicode category `Cf` "format" characters
+/// such as `U+202E` RIGHT-TO-LEFT OVERRIDE or zero-width joiners — those are a
+/// separate display-spoofing class ("Trojan Source") outside this function's
+/// remit; add a dedicated pass if that threat model is ever brought in scope.
+#[must_use]
+pub fn sanitize_for_terminal(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_for_terminal;
+
+    #[test]
+    fn ordinary_title_passes_through_unchanged() {
+        let title = "Café — 日本語 Video (2024) [HD]";
+        assert_eq!(sanitize_for_terminal(title), title);
+    }
+
+    #[test]
+    fn ascii_space_and_punctuation_preserved() {
+        let s = "A B\tC"; // tab is a control char and is stripped
+        assert_eq!(sanitize_for_terminal(s), "A BC");
+    }
+
+    #[test]
+    fn esc_csi_sequence_is_rendered_inert() {
+        let malicious = "\u{1b}[31mHACKED\u{1b}[0m";
+        let out = sanitize_for_terminal(malicious);
+        assert!(!out.contains('\u{1b}'), "ESC must be stripped: {out:?}");
+        assert_eq!(out, "[31mHACKED[0m");
+    }
+
+    #[test]
+    fn decoded_numeric_entity_esc_is_neutralized() {
+        // Post-#481 an extractor can decode `&#27;` into a raw ESC; the decoded
+        // title reaching the terminal must be inert.
+        let decoded_title = "Watch \u{1b}]0;pwned\u{7}now";
+        let out = sanitize_for_terminal(decoded_title);
+        assert!(!out.chars().any(char::is_control), "no controls: {out:?}");
+        assert_eq!(out, "Watch ]0;pwnednow");
+    }
+
+    #[test]
+    fn carriage_return_is_stripped() {
+        let out = sanitize_for_terminal("real title\rFAKE STATUS");
+        assert!(!out.contains('\r'));
+        assert_eq!(out, "real titleFAKE STATUS");
+    }
+
+    #[test]
+    fn bel_backspace_del_and_nul_are_stripped() {
+        let out = sanitize_for_terminal("a\u{7}b\u{8}c\u{7f}d\0e");
+        assert_eq!(out, "abcde");
+    }
+
+    #[test]
+    fn c1_single_byte_csi_is_stripped() {
+        // U+009B is the single-byte CSI introducer; some terminals honor it.
+        let out = sanitize_for_terminal("x\u{9b}31mY");
+        assert!(!out.chars().any(char::is_control), "no controls: {out:?}");
+        assert_eq!(out, "x31mY");
+    }
+
+    #[test]
+    fn c1_upper_boundary_stops_at_nbsp() {
+        // Boundary: U+009F is the last C1 control (stripped); U+00A0 NO-BREAK
+        // SPACE is the first non-control after it (preserved). Guards against a
+        // future range refactor sliding the ceiling from 0x9F to 0xA0.
+        let out = sanitize_for_terminal("a\u{9f}\u{a0}b");
+        assert_eq!(out, "a\u{a0}b");
+    }
+}


### PR DESCRIPTION
## Resolves

Closes #482 (follow-up to #481).

## Problem

Extractor-sourced titles, uploader names, and ids were written **raw** to the terminal and logs. An attacker-controlled title containing ANSI/terminal control sequences — reachable now that #481 widened HTML-entity decoding to the full WHATWG set (a `&#27;` decodes to `ESC`) — could clear the user's screen (`ESC[2J`), rewrite the window title (OSC), or overwrite the current line to spoof output (`CR`). Filenames were already safe (`Orchestrator::sanitize_filename` strips control chars); the terminal/log output boundary was not.

## Fix

- New `rdlp_cli::sanitize::sanitize_for_terminal(&str) -> String` — strips all Unicode control characters (`char::is_control()` = category `Cc`: C0 `U+0000..=U+001F` incl. `ESC`, `DEL` `U+007F`, and C1 `U+0080..=U+009F` incl. the single-byte `CSI`/`OSC` introducers). Stripping the introducer leaves the remainder as inert literal text. Mirrors the existing filesystem-boundary guard; no new dependency (library-first).
- Applied at every CLI site printing extractor-sourced text: search results (title, **video_url**, uploader), `--list-formats` title, `--simulate` title/id, `print_fields` string values, and the `MetadataReady` log line. `extractor` (internal registry name) and already-`RedactedUrl`-wrapped lines are intentionally left as-is.

Out of scope (documented in the module doc-comment): Unicode `Cf` format/bidi characters (`U+202E` "Trojan Source" class) — a separate display-spoofing threat; file a dedicated pass if brought in scope.

## Tests

Test-first (`sanitize.rs`): positive passthrough (incl. non-ASCII), and negatives for ESC-CSI, decoded OSC+BEL (the #481 vector), CR, BEL/BS/DEL/NUL, single-byte C1 CSI, and the C1 upper boundary (`U+009F` stripped vs `U+00A0` NBSP preserved). All watched fail against an identity stub before implementing.

## Reviews

- **security-reviewer**: Approve with minor — surfaced the raw `video_url` site (MEDIUM), now fixed; C1 UTF-8 range confirmed unbypassable (valid-UTF-8 `&str`).
- **code-reviewer**: Approve with minor — module placement/import paths correct for a lib+bin crate; added the C1-boundary test and fixed a malformed intra-doc link.

Full gate green: `cargo fmt --check && cargo check && cargo clippy --all-targets -D warnings && cargo test` + all repo `check-*.sh`.
