### PR TITLE
chore(sanitize): tidy text-sanitization sites (dead wrapper + desktop bidi)

### DIFF
--- a/crates/rdlp-desktop/src-tauri/src/commands/search.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/search.rs
@@ -15,14 +15,18 @@ use crate::state::AppState;
 
 /// Sanitize a user-provided query string.
 ///
-/// Trims whitespace, strips control characters, and limits length to
-/// 500 characters to prevent oversized or malformed queries from
+/// Trims whitespace, strips control and bidi-control characters, and limits
+/// length to 500 characters to prevent oversized or malformed queries from
 /// reaching the backend.
+///
+/// Bidi-control stripping ([`rdlp_security::text::is_bidi_control`]) keeps this
+/// boundary consistent with the terminal and filesystem sanitizers; the
+/// zero-width joiner `U+200D` that legitimate emoji depend on is preserved.
 fn sanitize_query(input: &str) -> String {
     input
         .trim()
         .chars()
-        .filter(|c| !c.is_control())
+        .filter(|c| !c.is_control() && !rdlp_security::text::is_bidi_control(*c))
         .take(500)
         .collect()
 }
@@ -203,6 +207,21 @@ mod tests {
     fn test_sanitize_query_strips_control_chars() {
         assert_eq!(sanitize_query("hello\x00\x01world"), "helloworld");
         assert_eq!(sanitize_query("tab\there"), "tabhere");
+    }
+
+    #[test]
+    fn test_sanitize_query_strips_bidi_control() {
+        // Consistency with the other sanitization boundaries (#490): bidi-control
+        // chars are category `Cf`, not `Cc`, so the control-char filter does not
+        // catch U+202E RIGHT-TO-LEFT OVERRIDE. Fails against the pre-#490 code,
+        // which left it intact.
+        assert_eq!(sanitize_query("a\u{202e}b\u{2066}c"), "abc");
+        // The zero-width joiner U+200D (also `Cf`) must survive — legitimate
+        // emoji depend on it.
+        assert_eq!(
+            sanitize_query("\u{1f468}\u{200d}\u{1f469}"),
+            "\u{1f468}\u{200d}\u{1f469}"
+        );
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/base/common/string_utils.rs
+++ b/crates/rdlp-extractor/src/base/common/string_utils.rs
@@ -102,21 +102,4 @@ impl BaseExtractor {
             .take(max)
             .collect()
     }
-
-    /// Sanitize a string for safe logging (redact sensitive data)
-    ///
-    /// **Note**: This function delegates to [`rdlp_security::sanitize_for_logging`].
-    ///
-    /// Redacts common sensitive patterns like tokens, keys, passwords.
-    ///
-    /// # Arguments
-    /// * `s` - String to sanitize
-    ///
-    /// # Returns
-    /// Sanitized string with sensitive data redacted
-    #[must_use]
-    #[allow(dead_code)]
-    pub(crate) fn sanitize_for_logging(s: &str) -> String {
-        rdlp_security::sanitize_for_logging(s)
-    }
 }

--- a/crates/rdlp-extractor/src/base/common/tests.rs
+++ b/crates/rdlp-extractor/src/base/common/tests.rs
@@ -279,18 +279,6 @@ fn test_truncate_string() {
     );
 }
 
-#[test]
-fn test_sanitize_for_logging() {
-    assert_eq!(
-        BaseExtractor::sanitize_for_logging("url?token=secret123&other=value"),
-        "url?token=***&other=value"
-    );
-    assert_eq!(
-        BaseExtractor::sanitize_for_logging("url?key=abc&password=xyz"),
-        "url?key=***&password=***"
-    );
-}
-
 // ========================================================================
 // Format Building Tests
 // ========================================================================


### PR DESCRIPTION
## Resolves

Closes #490 (follow-up to #487).

## Changes

Two small tidy-ups surfaced while consolidating text sanitization:

1. **Remove dead `BaseExtractor::sanitize_for_logging` wrapper.** It was `#[allow(dead_code)]` and merely re-wrapped `rdlp_security::sanitize_for_logging`. Every production caller (12+ sites across hls/dash expand, tnaflix/spankbang/xhamster/hqporner search) already calls `rdlp_security::` directly; only the wrapper's own test referenced it. Removed the wrapper + its orphaned test — aligns with the "no dead `#[allow(dead_code)]` for future use" discipline.

2. **Apply the shared `is_bidi_control` predicate to desktop `sanitize_query`.** Query sanitization now strips the bidi-control block in addition to `Cc` controls, keeping it consistent with the terminal and filesystem boundaries. The query is the user's own input (not extractor-sourced), so this is a consistency fix rather than a security gap. ZWJ `U+200D` is preserved (guarded by a positive test).

## Tests

- New failing-first `test_sanitize_query_strips_bidi_control` (U+202E/U+2066 stripped; ZWJ emoji survives) — fails against pre-change code.
- Existing `sanitize_query` and `string_utils` tests unchanged/green.

## Gate

`cargo fmt --check` · `cargo check` · `cargo clippy --all-targets -D warnings` · full `cargo test` · `cargo check -p rdlp-desktop` · all repo `check-*.sh` — all pass.

## Reviews

- **security-reviewer**: Approve, no findings (wrapper removal drops no redaction — verified no remaining callers; `sanitize_query` change is strictly narrowing, no bypass).
- **code-reviewer**: Approve, no findings (fails-first test confirmed, ZWJ guard load-bearing, doc accurate, no dangling references).