### PR TITLE
fix(generic): drop HTML embed pages wrongly emitted as mp4 formats

### DIFF
--- a/crates/rdlp-extractor/src/extractors/generic/json_ld.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/json_ld.rs
@@ -75,19 +75,29 @@ impl DetectionStrategy for JsonLdStrategy {
                     source: "json-ld:contentUrl",
                 });
             }
+            // `embedUrl` is advisory only — never a format.
+            //
+            // schema.org defines it as "A URL pointing to a player for a specific
+            // video" (the `src` of an embed tag), against `contentUrl` = "Actual
+            // bytes of the media object". A player page is not a downloadable
+            // stream, so emitting it as one produced an HTML page labelled `mp4`
+            // (issue #493). It was previously demoted to `Confidence::Low` in the
+            // belief that suppressed it, but confidence only orders dedup
+            // candidates (see `detection::run_detection_pipeline`) and never
+            // filters — the entry shipped regardless.
+            //
+            // Mirrors `IframeEmbedStrategy`, which logs embedded players without
+            // emitting formats. yt-dlp's shared JSON-LD parser likewise reads only
+            // `contentUrl`; every upstream use of `embedUrl` is a recursion target.
             if let Some(url) = video
                 .embed_url
                 .as_deref()
                 .and_then(|u| resolve_url(ctx.base_url, u))
             {
-                // embedUrl is often an iframe, not a direct media link
-                formats.push(DetectedFormat {
-                    ext: ext_from_url(&url),
-                    url,
-                    quality: None,
-                    confidence: Confidence::Low,
-                    source: "json-ld:embedUrl",
-                });
+                log::info!(
+                    "JSON-LD declares an embedded player — try that URL directly (embedUrl: {})",
+                    rdlp_redact::RedactedUrl::new(&url)
+                );
             }
         }
 
@@ -130,8 +140,20 @@ mod tests {
         assert_eq!(formats[0].source, "json-ld:contentUrl");
     }
 
+    /// `embedUrl` is a player page, never media, so it yields no format.
+    ///
+    /// This previously asserted `embedUrl` became a `Confidence::Low` format —
+    /// encoding the same defect as the OpenGraph Flash branch: `Confidence` only
+    /// orders dedup candidates and never filters, so the "low confidence" entry
+    /// was emitted as a real downloadable format with a guessed `mp4` extension
+    /// (issue #493).
+    ///
+    /// schema.org defines `embedUrl` as "A URL pointing to a player for a
+    /// specific video", against `contentUrl` = "Actual bytes of the media
+    /// object". yt-dlp's shared JSON-LD parser reads `contentUrl` only and never
+    /// reads `embedUrl` at all.
     #[test]
-    fn json_ld_embed_url_fallback() {
+    fn json_ld_embed_url_is_advisory_only() {
         let raw = r#"<html><head><script type="application/ld+json">
         {
             "@type": "VideoObject",
@@ -143,10 +165,33 @@ mod tests {
         let url = Url::parse("https://example.com/page").unwrap();
         let ctx = make_ctx(&html, raw, &url);
 
+        assert!(
+            JsonLdStrategy.detect(&ctx).is_empty(),
+            "embedUrl is a player page, not a downloadable stream"
+        );
+    }
+
+    /// When both are present, only the real media bytes become a format.
+    /// Mirrors yt-dlp's CI-enforced eporner fixture, which asserts `contentUrl`
+    /// wins and `embedUrl` never surfaces.
+    #[test]
+    fn json_ld_content_url_wins_over_embed_url() {
+        let raw = r#"<html><head><script type="application/ld+json">
+        {
+            "@type": "VideoObject",
+            "name": "Test Video",
+            "contentUrl": "https://cdn.example.com/real.mp4",
+            "embedUrl": "https://example.com/embed/123"
+        }
+        </script></head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
         let formats = JsonLdStrategy.detect(&ctx);
         assert_eq!(formats.len(), 1);
-        assert_eq!(formats[0].url, "https://example.com/embed/123");
-        assert_eq!(formats[0].confidence, Confidence::Low);
+        assert_eq!(formats[0].url, "https://cdn.example.com/real.mp4");
+        assert_eq!(formats[0].source, "json-ld:contentUrl");
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
@@ -9,16 +9,10 @@ use super::detection::{Confidence, DetectedFormat, DetectionStrategy, PageContex
 // Selectors
 // ============================================================================
 
-static OG_VIDEO_SELECTOR: LazyLock<Selector> = crate::static_selector!(
-    r#"meta[property="og:video"], meta[property="og:video:url"], meta[property="og:video:secure_url"]"#
-);
-
-static OG_AUDIO_SELECTOR: LazyLock<Selector> = crate::static_selector!(
-    r#"meta[property="og:audio"], meta[property="og:audio:url"], meta[property="og:audio:secure_url"]"#
-);
-
-static OG_VIDEO_TYPE_SELECTOR: LazyLock<Selector> =
-    crate::static_selector!(r#"meta[property="og:video:type"]"#);
+/// Every `og:video*` / `og:audio*` meta tag, yielded in document order — which is
+/// what binds a structured property to its root tag (see [`OgTag`]).
+static OG_MEDIA_SELECTOR: LazyLock<Selector> =
+    crate::static_selector!(r#"meta[property^="og:video"], meta[property^="og:audio"]"#);
 
 static TWITTER_PLAYER_STREAM_SELECTOR: LazyLock<Selector> = crate::static_selector!(
     r#"meta[name="twitter:player:stream"], meta[property="twitter:player:stream"]"#
@@ -28,6 +22,68 @@ static TWITTER_PLAYER_STREAM_SELECTOR: LazyLock<Selector> = crate::static_select
 // OpenGraph Strategy
 // ============================================================================
 
+/// The role a single `og:video*` / `og:audio*` meta tag plays while walking the
+/// document.
+///
+/// The OpenGraph spec (<https://ogp.me>) defines structured properties by
+/// position, not by name alone: "Put structured properties after you declare
+/// their root tag. Whenever another root element is parsed, that structured
+/// property is considered to be done and another one is started." So `:type`
+/// binds to the *most recently declared* root — never to the document at large.
+enum OgTag {
+    /// A root tag: begins a new entry.
+    Root(&'static str),
+    /// The HTTPS alternate of the current root's resource — not a new entry.
+    SecureUrl(&'static str),
+    /// The current root's MIME type.
+    Type,
+}
+
+impl OgTag {
+    /// Classify a `property` attribute. Returns `None` for tags that carry no
+    /// URL or type (`og:video:width`, `:height`, `:duration`, …).
+    fn classify(property: &str) -> Option<Self> {
+        match property {
+            "og:video" | "og:video:url" => Some(Self::Root("og:video")),
+            "og:audio" | "og:audio:url" => Some(Self::Root("og:audio")),
+            "og:video:secure_url" => Some(Self::SecureUrl("og:video")),
+            "og:audio:secure_url" => Some(Self::SecureUrl("og:audio")),
+            "og:video:type" | "og:audio:type" => Some(Self::Type),
+            _ => None,
+        }
+    }
+}
+
+/// One OpenGraph media entry: a root URL plus any `secure_url` alternate for the
+/// same resource, and the MIME type declared for it.
+struct OgEntry<'a> {
+    source: &'static str,
+    /// Root URL first, `secure_url` alternate (if any) after. Both are surfaced
+    /// as candidates; pipeline dedup collapses them when identical.
+    urls: Vec<&'a str>,
+    mime: Option<&'a str>,
+}
+
+impl<'a> OgEntry<'a> {
+    fn new(source: &'static str, url: &'a str) -> Self {
+        Self {
+            source,
+            urls: vec![url],
+            mime: None,
+        }
+    }
+
+    /// Whether this entry denotes a downloadable stream.
+    ///
+    /// An entry with no `:type` sibling is kept — the type is merely unspecified,
+    /// and pages that omit it must not regress. An entry that *declares* a
+    /// non-media type is an embed/player page (`text/html`) or a plugin object
+    /// (Flash), and is dropped: it is not a stream (issue #493).
+    fn is_media(&self) -> bool {
+        self.mime.is_none_or(super::patterns::is_media_content_type)
+    }
+}
+
 pub(crate) struct OpenGraphStrategy;
 
 impl DetectionStrategy for OpenGraphStrategy {
@@ -36,55 +92,56 @@ impl DetectionStrategy for OpenGraphStrategy {
     }
 
     fn detect(&self, ctx: &PageContext<'_>) -> Vec<DetectedFormat> {
-        let mut formats = Vec::new();
+        // Walk in document order, binding each structured property to the root
+        // that precedes it, per the OGP spec's array/structured-property rules.
+        let mut entries: Vec<OgEntry<'_>> = Vec::new();
 
-        // og:video:secure_url takes priority (listed first in selector)
-        for elem in ctx.html.select(&OG_VIDEO_SELECTOR) {
-            if let Some(content) = elem.value().attr("content")
-                && let Some(url) = resolve_url(ctx.base_url, content)
-            {
-                let ext = super::detection::ext_from_url(&url);
-                formats.push(DetectedFormat {
-                    url,
-                    ext,
-                    quality: None,
-                    confidence: Confidence::High,
-                    source: "og:video",
-                });
-            }
-        }
+        for elem in ctx.html.select(&OG_MEDIA_SELECTOR) {
+            let (Some(property), Some(content)) =
+                (elem.value().attr("property"), elem.value().attr("content"))
+            else {
+                continue;
+            };
 
-        // og:audio
-        for elem in ctx.html.select(&OG_AUDIO_SELECTOR) {
-            if let Some(content) = elem.value().attr("content")
-                && let Some(url) = resolve_url(ctx.base_url, content)
-            {
-                let ext = super::detection::ext_from_url(&url);
-                formats.push(DetectedFormat {
-                    url,
-                    ext,
-                    quality: None,
-                    confidence: Confidence::High,
-                    source: "og:audio",
-                });
-            }
-        }
-
-        // Check og:video:type for MIME hint
-        if let Some(type_elem) = ctx.html.select(&OG_VIDEO_TYPE_SELECTOR).next()
-            && let Some(mime) = type_elem.value().attr("content")
-        {
-            // If type indicates a Flash embed (not direct media), lower confidence
-            if mime.contains("flash") || mime.contains("shockwave") {
-                for f in &mut formats {
-                    if f.source == "og:video" {
-                        f.confidence = Confidence::Low;
+            match OgTag::classify(property) {
+                Some(OgTag::Root(source)) => entries.push(OgEntry::new(source, content)),
+                // A `secure_url` belongs to the open root. Should a page declare
+                // one with no preceding root, treat it as a root itself rather
+                // than discarding a usable URL.
+                Some(OgTag::SecureUrl(source)) => match entries.last_mut() {
+                    Some(entry) => entry.urls.push(content),
+                    None => entries.push(OgEntry::new(source, content)),
+                },
+                Some(OgTag::Type) => {
+                    if let Some(entry) = entries.last_mut() {
+                        entry.mime = Some(content);
                     }
                 }
+                None => {}
             }
         }
 
-        formats
+        entries
+            .into_iter()
+            .filter(OgEntry::is_media)
+            .flat_map(|entry| {
+                // A declared media type names the container even when the URL has
+                // no extension to sniff — better than guessing downstream.
+                let ext_from_mime = entry.mime.and_then(super::content_type_to_ext);
+                entry.urls.into_iter().filter_map(move |raw| {
+                    let url = resolve_url(ctx.base_url, raw)?;
+                    let ext = super::detection::ext_from_url(&url)
+                        .or_else(|| ext_from_mime.map(str::to_owned));
+                    Some(DetectedFormat {
+                        url,
+                        ext,
+                        quality: None,
+                        confidence: Confidence::High,
+                        source: entry.source,
+                    })
+                })
+            })
+            .collect()
     }
 }
 
@@ -171,8 +228,15 @@ mod tests {
         );
     }
 
+    /// A Flash object is a plugin embed, not a stream, so it is dropped.
+    ///
+    /// This previously asserted the entry survived at `Confidence::Low`. That
+    /// encoded a defect: `Confidence` only orders dedup candidates (see
+    /// `detection::run_detection_pipeline`) and never filters, so the demoted
+    /// entry was still emitted as a format. Skipping is the behavior the demotion
+    /// was reaching for (issue #493).
     #[test]
-    fn og_flash_type_lowers_confidence() {
+    fn og_flash_type_skipped() {
         let raw = r#"<html><head>
             <meta property="og:video" content="https://example.com/player.swf">
             <meta property="og:video:type" content="application/x-shockwave-flash">
@@ -181,9 +245,7 @@ mod tests {
         let url = Url::parse("https://example.com/page").unwrap();
         let ctx = make_ctx(&html, raw, &url);
 
-        let formats = OpenGraphStrategy.detect(&ctx);
-        assert_eq!(formats.len(), 1);
-        assert_eq!(formats[0].confidence, Confidence::Low);
+        assert!(OpenGraphStrategy.detect(&ctx).is_empty());
     }
 
     #[test]
@@ -214,6 +276,120 @@ mod tests {
         assert_eq!(formats.len(), 1);
         assert_eq!(formats[0].url, "https://cdn.example.com/video.mp4");
         assert_eq!(formats[0].confidence, Confidence::Medium);
+    }
+
+    // ------------------------------------------------------------------
+    // og:video:type media gating (issue #493)
+    //
+    // Per the OGP spec (https://ogp.me), `og:video` legitimately points at an
+    // HTML embed/player page, signalled by `og:video:type: text/html` — YouTube
+    // and friends do exactly this. Such an entry is not a downloadable stream
+    // and must not become a format.
+    // ------------------------------------------------------------------
+
+    /// The #493 regression guard: an `og:video` embed page declared `text/html`
+    /// must yield no format at all. Before the fix this emitted a High-confidence
+    /// `mp4` pointing at an HTML page.
+    #[test]
+    fn og_video_html_embed_type_skipped() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="https://example.com/embed/353006/">
+            <meta property="og:video:type" content="text/html">
+            <meta property="og:video:width" content="1920">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert!(
+            OpenGraphStrategy.detect(&ctx).is_empty(),
+            "og:video:type=text/html marks an embed page, not a stream"
+        );
+    }
+
+    /// Structured properties bind to the most recently declared root tag, so a
+    /// page mixing an embed entry with a real media entry must keep the media
+    /// one. Pre-fix, the first `og:video:type` was applied to every entry — so a
+    /// naive "skip on non-media" would have wrongly dropped the real MP4 here.
+    #[test]
+    fn og_video_type_pairs_per_entry_not_globally() {
+        let raw = r#"<html><head>
+            <meta property="og:video:url" content="https://example.com/embed/1">
+            <meta property="og:video:type" content="text/html">
+            <meta property="og:video:url" content="https://cdn.example.com/real.mp4">
+            <meta property="og:video:type" content="video/mp4">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1, "only the video/mp4 entry survives");
+        assert_eq!(formats[0].url, "https://cdn.example.com/real.mp4");
+    }
+
+    /// An entry with no `og:video:type` sibling keeps its unspecified type and is
+    /// still emitted — pages without the tag must not regress.
+    #[test]
+    fn og_video_without_type_still_extracted() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="https://cdn.example.com/video.mp4">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert_eq!(OpenGraphStrategy.detect(&ctx).len(), 1);
+    }
+
+    /// Boundary: a media type is accepted even when the URL carries no extension
+    /// to sniff, and the declared type supplies the ext instead of the `mp4` guess.
+    #[test]
+    fn og_video_media_type_accepted_without_url_extension() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="https://cdn.example.com/stream/1234">
+            <meta property="og:video:type" content="video/webm">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1);
+        assert_eq!(
+            formats[0].ext.as_deref(),
+            Some("webm"),
+            "ext comes from og:video:type, not the mp4 default"
+        );
+    }
+
+    /// MIME type/subtype are case-insensitive and may carry parameters
+    /// (RFC 9110 §8.3.1) — neither may cause a real stream to be dropped.
+    #[test]
+    fn og_video_type_is_case_insensitive_and_ignores_parameters() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="https://cdn.example.com/a.mp4">
+            <meta property="og:video:type" content="VIDEO/MP4; codecs=avc1.64001f">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert_eq!(OpenGraphStrategy.detect(&ctx).len(), 1);
+    }
+
+    /// `og:audio` carries the same structured `type` property and the same defect.
+    #[test]
+    fn og_audio_html_embed_type_skipped() {
+        let raw = r#"<html><head>
+            <meta property="og:audio" content="https://example.com/embed/audio">
+            <meta property="og:audio:type" content="text/html">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert!(OpenGraphStrategy.detect(&ctx).is_empty());
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
@@ -32,11 +32,11 @@ static TWITTER_PLAYER_STREAM_SELECTOR: LazyLock<Selector> = crate::static_select
 /// binds to the *most recently declared* root — never to the document at large.
 enum OgTag {
     /// A root tag: begins a new entry.
-    Root(&'static str),
-    /// The HTTPS alternate of the current root's resource — not a new entry.
-    SecureUrl(&'static str),
-    /// The current root's MIME type.
-    Type,
+    Root(OgKind),
+    /// The HTTPS alternate of the open root's resource — not a new entry.
+    SecureUrl(OgKind),
+    /// The open root's MIME type.
+    Type(OgKind),
 }
 
 impl OgTag {
@@ -44,12 +44,34 @@ impl OgTag {
     /// URL or type (`og:video:width`, `:height`, `:duration`, …).
     fn classify(property: &str) -> Option<Self> {
         match property {
-            "og:video" | "og:video:url" => Some(Self::Root("og:video")),
-            "og:audio" | "og:audio:url" => Some(Self::Root("og:audio")),
-            "og:video:secure_url" => Some(Self::SecureUrl("og:video")),
-            "og:audio:secure_url" => Some(Self::SecureUrl("og:audio")),
-            "og:video:type" | "og:audio:type" => Some(Self::Type),
+            "og:video" | "og:video:url" => Some(Self::Root(OgKind::Video)),
+            "og:audio" | "og:audio:url" => Some(Self::Root(OgKind::Audio)),
+            "og:video:secure_url" => Some(Self::SecureUrl(OgKind::Video)),
+            "og:audio:secure_url" => Some(Self::SecureUrl(OgKind::Audio)),
+            "og:video:type" => Some(Self::Type(OgKind::Video)),
+            "og:audio:type" => Some(Self::Type(OgKind::Audio)),
             _ => None,
+        }
+    }
+}
+
+/// Which OpenGraph media namespace a tag belongs to.
+///
+/// Load-bearing: a structured property binds to a root of its *own* namespace.
+/// `og:video:type` describes an `og:video` — never a neighbouring `og:audio`
+/// that merely happens to be the most recent tag.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OgKind {
+    Video,
+    Audio,
+}
+
+impl OgKind {
+    /// The `DetectedFormat::source` tag, which feeds the emitted `format_id`.
+    const fn source(self) -> &'static str {
+        match self {
+            Self::Video => "og:video",
+            Self::Audio => "og:audio",
         }
     }
 }
@@ -57,7 +79,7 @@ impl OgTag {
 /// One OpenGraph media entry: a root URL plus any `secure_url` alternate for the
 /// same resource, and the MIME type declared for it.
 struct OgEntry<'a> {
-    source: &'static str,
+    kind: OgKind,
     /// Root URL first, `secure_url` alternate (if any) after. Both are surfaced
     /// as candidates; pipeline dedup collapses them when identical.
     urls: Vec<&'a str>,
@@ -65,9 +87,9 @@ struct OgEntry<'a> {
 }
 
 impl<'a> OgEntry<'a> {
-    fn new(source: &'static str, url: &'a str) -> Self {
+    fn new(kind: OgKind, url: &'a str) -> Self {
         Self {
-            source,
+            kind,
             urls: vec![url],
             mime: None,
         }
@@ -86,6 +108,17 @@ impl<'a> OgEntry<'a> {
 
 pub(crate) struct OpenGraphStrategy;
 
+impl OpenGraphStrategy {
+    /// The entry a structured property binds to: the most recently declared root
+    /// **of the same kind**, per the OGP spec's document-order rule.
+    fn open_root<'e, 'a>(
+        entries: &'e mut [OgEntry<'a>],
+        kind: OgKind,
+    ) -> Option<&'e mut OgEntry<'a>> {
+        entries.iter_mut().rev().find(|entry| entry.kind == kind)
+    }
+}
+
 impl DetectionStrategy for OpenGraphStrategy {
     fn name(&self) -> &'static str {
         "OpenGraph"
@@ -103,21 +136,29 @@ impl DetectionStrategy for OpenGraphStrategy {
                 continue;
             };
 
-            match OgTag::classify(property) {
-                Some(OgTag::Root(source)) => entries.push(OgEntry::new(source, content)),
-                // A `secure_url` belongs to the open root. Should a page declare
-                // one with no preceding root, treat it as a root itself rather
-                // than discarding a usable URL.
-                Some(OgTag::SecureUrl(source)) => match entries.last_mut() {
+            let Some(tag) = OgTag::classify(property) else {
+                continue;
+            };
+
+            match tag {
+                OgTag::Root(kind) => entries.push(OgEntry::new(kind, content)),
+                // A `secure_url` belongs to its kind's open root. A page may also
+                // declare one before any root (or with none at all) — keep the URL
+                // as its own entry rather than discarding it.
+                OgTag::SecureUrl(kind) => match Self::open_root(&mut entries, kind) {
                     Some(entry) => entry.urls.push(content),
-                    None => entries.push(OgEntry::new(source, content)),
+                    None => entries.push(OgEntry::new(kind, content)),
                 },
-                Some(OgTag::Type) => {
-                    if let Some(entry) = entries.last_mut() {
+                // An empty `content` leaves the type unspecified rather than
+                // declaring a non-media one — real meta soup carries these, and
+                // they must not drop a legitimate stream.
+                OgTag::Type(kind) => {
+                    if !content.trim().is_empty()
+                        && let Some(entry) = Self::open_root(&mut entries, kind)
+                    {
                         entry.mime = Some(content);
                     }
                 }
-                None => {}
             }
         }
 
@@ -137,7 +178,7 @@ impl DetectionStrategy for OpenGraphStrategy {
                         ext,
                         quality: None,
                         confidence: Confidence::High,
-                        source: entry.source,
+                        source: entry.kind.source(),
                     })
                 })
             })
@@ -376,6 +417,86 @@ mod tests {
         let ctx = make_ctx(&html, raw, &url);
 
         assert_eq!(OpenGraphStrategy.detect(&ctx).len(), 1);
+    }
+
+    /// `og:video:type` binds to the most recent `og:video` root — not to whatever
+    /// entry happens to be last.
+    ///
+    /// With a bare "last entry" rule the `text/html` here would bind to the
+    /// *audio* entry, dropping the real mp3 and letting the video embed page ship
+    /// as a format — reintroducing issue #493.
+    #[test]
+    fn og_type_binds_to_root_of_matching_kind() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="https://example.com/embed/1">
+            <meta property="og:audio" content="https://cdn.example.com/song.mp3">
+            <meta property="og:video:type" content="text/html">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1, "the video embed is dropped, audio kept");
+        assert_eq!(formats[0].url, "https://cdn.example.com/song.mp3");
+        assert_eq!(formats[0].source, "og:audio");
+    }
+
+    /// A `secure_url` attaches to its own kind's root, never to an unrelated one.
+    #[test]
+    fn og_secure_url_attaches_to_root_of_matching_kind() {
+        let raw = r#"<html><head>
+            <meta property="og:audio" content="https://cdn.example.com/song.mp3">
+            <meta property="og:video:secure_url" content="https://cdn.example.com/movie.mp4">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        let movie = formats
+            .iter()
+            .find(|f| f.url == "https://cdn.example.com/movie.mp4")
+            .expect("video secure_url is still surfaced");
+        assert_eq!(
+            movie.source, "og:video",
+            "a video URL must not be labelled og:audio"
+        );
+    }
+
+    /// An empty `content=""` means the type is unspecified, not non-media — real
+    /// meta soup carries these, and they must not drop a legitimate stream.
+    #[test]
+    fn og_empty_type_treated_as_unspecified() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="https://cdn.example.com/video.mp4">
+            <meta property="og:video:type" content="">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert_eq!(OpenGraphStrategy.detect(&ctx).len(), 1);
+    }
+
+    /// Canonical OGP order (root → secure_url → type): the type gates both URLs
+    /// of the entry, and the `secure_url` collapses into the open root rather
+    /// than starting a new entry.
+    #[test]
+    fn og_secure_url_in_canonical_order_shares_entry_type() {
+        let raw = r#"<html><head>
+            <meta property="og:video" content="http://cdn.example.com/embed/1">
+            <meta property="og:video:secure_url" content="https://cdn.example.com/embed/1">
+            <meta property="og:video:type" content="text/html">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert!(
+            OpenGraphStrategy.detect(&ctx).is_empty(),
+            "the entry's text/html type gates its root AND its secure_url"
+        );
     }
 
     /// `og:audio` carries the same structured `type` property and the same defect.

--- a/crates/rdlp-extractor/src/extractors/generic/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/patterns.rs
@@ -25,26 +25,78 @@ pub(crate) fn has_media_extension(url: &str) -> bool {
     }
 }
 
+/// ASCII-case-insensitive prefix test that borrows instead of allocating.
+///
+/// Media type and subtype names are case-insensitive (RFC 6838 §4.2, RFC 9110
+/// §8.3.1), so comparisons must case-fold — but `to_lowercase` would allocate a
+/// `String` on every call. Mirrors the `eq_ignore_ascii_case` idiom already used
+/// by `PrefetchedResponse::is_dash_content_type`.
+fn starts_with_ignore_ascii_case(haystack: &str, prefix: &str) -> bool {
+    haystack
+        .as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(prefix.as_bytes()))
+}
+
+/// ASCII-case-insensitive substring test that borrows instead of allocating.
+///
+/// `needle` must be non-empty — `<[u8]>::windows` panics on a zero width. Every
+/// call site passes a non-empty literal.
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    debug_assert!(!needle.is_empty(), "windows(0) panics");
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
 /// Check if a Content-Type header indicates direct media.
+///
+/// Also the gate for the OpenGraph `og:video:type` / `og:audio:type` hint, which
+/// distinguishes a real stream from an embed/player page (issue #493). Parameters
+/// (`; codecs=…`) need no stripping here: every test is a prefix or substring
+/// match against the type/subtype, which precedes the first `;`.
 pub(crate) fn is_media_content_type(content_type: &str) -> bool {
-    let ct = content_type.to_lowercase();
-    ct.starts_with("video/")
-        || ct.starts_with("audio/")
-        || ct.contains("mpegurl")
-        || ct.contains("dash+xml")
-        || ct.contains("x-flv")
-        || ct.contains("mp2t")
+    starts_with_ignore_ascii_case(content_type, "video/")
+        || starts_with_ignore_ascii_case(content_type, "audio/")
+        || contains_ignore_ascii_case(content_type, "mpegurl")
+        || contains_ignore_ascii_case(content_type, "dash+xml")
+        || contains_ignore_ascii_case(content_type, "x-flv")
+        || contains_ignore_ascii_case(content_type, "mp2t")
 }
 
 /// Check if a Content-Type header indicates HTML.
 pub(crate) fn is_html_content_type(content_type: &str) -> bool {
-    let ct = content_type.to_lowercase();
-    ct.contains("text/html") || ct.contains("application/xhtml")
+    contains_ignore_ascii_case(content_type, "text/html")
+        || contains_ignore_ascii_case(content_type, "application/xhtml")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Type/subtype names are case-insensitive (RFC 6838 §4.2, RFC 9110 §8.3.1).
+    /// The zero-alloc rewrite must keep case-folding — a regression here would
+    /// silently drop real streams served with an uppercase Content-Type.
+    #[test]
+    fn media_content_type_is_case_insensitive() {
+        assert!(is_media_content_type("VIDEO/MP4"));
+        assert!(is_media_content_type("Video/MP4; codecs=avc1.64001f"));
+        assert!(is_media_content_type("Application/X-MPEGURL"));
+        assert!(is_media_content_type("APPLICATION/DASH+XML"));
+        assert!(is_html_content_type("TEXT/HTML; charset=UTF-8"));
+    }
+
+    /// Non-media types must not pass — `text/html` is the embed-page marker the
+    /// OpenGraph gate keys on (issue #493).
+    #[test]
+    fn non_media_content_type_rejected() {
+        assert!(!is_media_content_type("text/html"));
+        assert!(!is_media_content_type("text/html; charset=UTF-8"));
+        assert!(!is_media_content_type("application/x-shockwave-flash"));
+        assert!(!is_media_content_type("application/json"));
+        assert!(!is_media_content_type(""));
+    }
 
     #[test]
     fn media_extension_detected() {

--- a/crates/rdlp-extractor/src/extractors/generic/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/patterns.rs
@@ -40,35 +40,51 @@ fn starts_with_ignore_ascii_case(haystack: &str, prefix: &str) -> bool {
 
 /// ASCII-case-insensitive substring test that borrows instead of allocating.
 ///
-/// `needle` must be non-empty — `<[u8]>::windows` panics on a zero width. Every
-/// call site passes a non-empty literal.
+/// `needle` must be a non-empty literal — `<[u8]>::windows` panics on a zero
+/// width, and a panic in an extractor is a denial of service. The guard is a
+/// full `assert!`, not `debug_assert!`: the latter compiles out of release
+/// builds, which is exactly where such a panic would matter.
 fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
-    debug_assert!(!needle.is_empty(), "windows(0) panics");
+    assert!(!needle.is_empty(), "windows(0) panics");
     haystack
         .as_bytes()
         .windows(needle.len())
         .any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
 }
 
+/// The bare `type/subtype`, with any parameters and surrounding space removed.
+///
+/// `media-type = type "/" subtype *( OWS ";" OWS parameter )` (RFC 9110 §8.3.1),
+/// so only the span before the first `;` identifies the type. Stripping matters
+/// because the substring tests below would otherwise scan the parameters too, and
+/// `text/html; profile=mp2t` would answer as media.
+fn type_subtype(content_type: &str) -> &str {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+}
+
 /// Check if a Content-Type header indicates direct media.
 ///
 /// Also the gate for the OpenGraph `og:video:type` / `og:audio:type` hint, which
-/// distinguishes a real stream from an embed/player page (issue #493). Parameters
-/// (`; codecs=…`) need no stripping here: every test is a prefix or substring
-/// match against the type/subtype, which precedes the first `;`.
+/// distinguishes a real stream from an embed/player page (issue #493).
 pub(crate) fn is_media_content_type(content_type: &str) -> bool {
-    starts_with_ignore_ascii_case(content_type, "video/")
-        || starts_with_ignore_ascii_case(content_type, "audio/")
-        || contains_ignore_ascii_case(content_type, "mpegurl")
-        || contains_ignore_ascii_case(content_type, "dash+xml")
-        || contains_ignore_ascii_case(content_type, "x-flv")
-        || contains_ignore_ascii_case(content_type, "mp2t")
+    let ct = type_subtype(content_type);
+    starts_with_ignore_ascii_case(ct, "video/")
+        || starts_with_ignore_ascii_case(ct, "audio/")
+        || contains_ignore_ascii_case(ct, "mpegurl")
+        || contains_ignore_ascii_case(ct, "dash+xml")
+        || contains_ignore_ascii_case(ct, "x-flv")
+        || contains_ignore_ascii_case(ct, "mp2t")
 }
 
 /// Check if a Content-Type header indicates HTML.
 pub(crate) fn is_html_content_type(content_type: &str) -> bool {
-    contains_ignore_ascii_case(content_type, "text/html")
-        || contains_ignore_ascii_case(content_type, "application/xhtml")
+    let ct = type_subtype(content_type);
+    contains_ignore_ascii_case(ct, "text/html")
+        || contains_ignore_ascii_case(ct, "application/xhtml")
 }
 
 #[cfg(test)]
@@ -96,6 +112,23 @@ mod tests {
         assert!(!is_media_content_type("application/x-shockwave-flash"));
         assert!(!is_media_content_type("application/json"));
         assert!(!is_media_content_type(""));
+    }
+
+    /// Only the type/subtype decides — a parameter must never satisfy the match.
+    ///
+    /// The substring tests (`mpegurl`, `mp2t`, …) would otherwise scan the
+    /// parameters too, so `text/html; profile=mp2t` would pass as media and let
+    /// an embed page back through the OpenGraph gate (issue #493).
+    #[test]
+    fn media_content_type_ignores_parameters() {
+        assert!(!is_media_content_type("text/html; profile=mp2t"));
+        assert!(!is_media_content_type("text/html; codecs=mpegurl"));
+        assert!(!is_media_content_type("application/json; x=dash+xml"));
+        // …while a genuine media type with parameters still passes.
+        assert!(is_media_content_type("video/mp4; codecs=avc1.64001f"));
+        assert!(is_media_content_type(
+            "application/vnd.apple.mpegurl; charset=utf-8"
+        ));
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/generic/patterns.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/patterns.rs
@@ -40,10 +40,10 @@ fn starts_with_ignore_ascii_case(haystack: &str, prefix: &str) -> bool {
 
 /// ASCII-case-insensitive substring test that borrows instead of allocating.
 ///
-/// `needle` must be a non-empty literal — `<[u8]>::windows` panics on a zero
-/// width, and a panic in an extractor is a denial of service. The guard is a
-/// full `assert!`, not `debug_assert!`: the latter compiles out of release
-/// builds, which is exactly where such a panic would matter.
+/// `needle` must be non-empty — `<[u8]>::windows` panics on a zero width. That is
+/// unreachable by construction: every call site passes a non-empty literal, and
+/// the attacker-controlled string is always the `haystack`. The `assert!`
+/// documents the precondition and costs nothing for literal needles.
 fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     assert!(!needle.is_empty(), "windows(0) panics");
     haystack


### PR DESCRIPTION
## Summary

The generic fallback emitted HTML player/embed pages as downloadable `mp4` formats. Two independent strategies did it, both leaning on the same false belief.

Verified against the issue URL: **2 formats → 1**, the real MP4 only, title and duration unchanged.

```
before:  generic-og-video-video       ext=mp4  →  https://bigtitbitches.com/embed/353006/   (text/html)
         generic-video>source-mp4     ext=mp4  →  https://media.…/353006.mp4
after:   generic-video>source-mp4     ext=mp4  →  https://media.…/353006.mp4
```

## The root cause: `Confidence::Low` never filtered anything

Both sites believed demoting a candidate suppressed it. It doesn't — `run_detection_pipeline` (`detection.rs:99-101`) only sorts by `(url, confidence desc)` and dedups **by URL**. A `Low` entry with a unique URL always shipped. So both "mitigations" were no-ops, and today a Flash `.swf` `og:video` ships as a format too.

That single misconception appeared twice:

- **OpenGraph** (`meta_sources.rs`) — `og:video:type` was matched against an enumerated Flash/Shockwave denylist, so `text/html` (the far more common embed marker — YouTube emits it) fell through at `Confidence::High`.
- **JSON-LD** (`json_ld.rs`) — `embedUrl` was emitted as a format, commented "often an iframe, not a direct media link", demoted to `Low`. Dedup had been masking it *behind* the og:video entry; fixing OpenGraph alone unmasked it and the page was still wrong.

The fix skips non-media candidates instead of demoting them.

## Changes

**Gate on the existing predicate, don't fork a MIME table.** `patterns::is_media_content_type` is already the crate's media predicate (already used by the direct-link path, already returns `false` for `text/html`). The OpenGraph gate now reuses it — no second table for the dedup gate to flag.

**Bind the type per entry, per spec.** ogp.me: *"Put structured properties after you declare their root tag. Whenever another root element is parsed, that structured property is considered to be done and another one is started."* Reading only the first `og:video:type` and applying it document-wide violated that — and made the naive fix dangerous: on a YouTube-style page listing its `text/html` embed first, "skip on non-media" would have dropped the **real** stream. The walk now binds each structured property to the most recent root **of its own kind** (`OgKind`), so `og:video:type` can never describe a neighbouring `og:audio`.

**`embedUrl` is advisory, not a format.** schema.org defines it as *"A URL pointing to a player for a specific video"*, against `contentUrl` = *"Actual bytes of the media object"*. It now logs (redacted) and emits nothing, mirroring the existing `IframeEmbedStrategy`.

**The declared type supplies the ext**, replacing the `unwrap_or("mp4")` guess that produced the bogus label when a URL had no extension to sniff.

**Scout rule, in code already touched:** both content-type predicates drop a `to_lowercase()` allocation per call, case-folding via the zero-alloc `eq_ignore_ascii_case` idiom already used by `is_dash_content_type`, and now match the bare `type/subtype` (RFC 9110 §8.3.1) rather than scanning parameters.

## Research

Load-bearing facts were verified against primary sources, not recall:

- **ogp.me** — structured-property binding is positional; `text/html` is spec-sanctioned for embed entries, not malformed.
- **schema.org / Google Search Central** — `embedUrl` is a player page; Google: *"this must be the URL of the video player itself."*
- **RFC 9110 §8.3.1 / RFC 6838 §4.2** — type/subtype are case-insensitive; parameters follow the first `;`.
- **yt-dlp** (`common.py`, `generic.py`) — never reads `embedUrl`; only `contentUrl` becomes `info['url']`. Its CI-enforced fixture is an eporner `VideoObject` carrying **both**, asserting `contentUrl` wins and `embedUrl` never surfaces. Its own `og:video:type` guard (`if m_video_type is not None` against `re.findall`) is dead code — prior art to learn from, not copy.

## Two existing tests were rewritten because they encoded the defect

- `og_flash_type_lowers_confidence` asserted the Flash entry survived at `Confidence::Low` — green while the user-visible outcome (an HTML page offered as `mp4`) was broken.
- `json_ld_embed_url_fallback` asserted `embedUrl` became a format.

Both now assert the outcome, which is strictly stronger. The doc comments record why the old assertions were wrong, to defend against a "restore the fallback" PR.

## Tests

All negatives confirmed **RED against the unpatched code** first. New: `og_video_html_embed_type_skipped` (the #493 guard), `og_video_type_pairs_per_entry_not_globally`, `og_type_binds_to_root_of_matching_kind`, `og_secure_url_attaches_to_root_of_matching_kind`, `og_empty_type_treated_as_unspecified`, `og_secure_url_in_canonical_order_shares_entry_type`, `og_video_media_type_accepted_without_url_extension`, `og_video_type_is_case_insensitive_and_ignores_parameters`, `og_audio_html_embed_type_skipped`, `json_ld_embed_url_is_advisory_only`, `json_ld_content_url_wins_over_embed_url`, `media_content_type_ignores_parameters`, `media_content_type_is_case_insensitive`, `non_media_content_type_rejected`.

## Reviews

Both pre-push reviewers ran over the full `develop...HEAD` diff.

**security-reviewer: Approve.** No Critical/High/Medium. Confirmed no new SSRF surface (`validate_url_security` runs downstream regardless), no reachable panic path, correct `RedactedUrl` usage on the new log, and that removing candidates weakens no validation posture. Its one LOW note is folded in.

**code-reviewer: Request changes → Approve.** The first pass found **four real defects**, each reproduced under execution — most seriously, cross-kind type binding that **reintroduced #493 through the new mechanism** (a page with `og:video` embed + `og:audio` + `og:video:type: text/html` bound the type to the audio entry, dropped the real mp3, and shipped the embed page). Also: cross-kind `secure_url` mislabelling, empty `content=""` dropping a legitimate stream, and `text/html; profile=mp2t` passing the predicate because the substring tests scanned parameters. All fixed at the recommended layer, with regression tests confirmed RED-first, then re-reviewed to **Approve**.

## Deliberately out of scope

- `og:video:secure_url` is still surfaced as a separate candidate alongside its root (double-counts one asset); per spec it's an HTTPS alternate, not a second entry.
- JSON-LD `encodingFormat` (schema.org's MIME property) isn't on our struct; it would give `contentUrl` a real ext the way `og:video:type` now does.
- `age_limit` is unset for age-gated sites routed through the fallback (noted in #492).
- A `og:video:type` declared *before* any root is discarded — malformed per spec, matches prior behavior, would need a second pass.

## Verification

`cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · **3561 tests, 0 failures** · `cargo check -p rdlp-desktop` · all 5 repo `check-*.sh` gates pass · live re-probe of the #493 URL.

Closes #493
