### PR TITLE
test(spankbang): pin the stream_data main/mpd skip with negative tests

### DIFF
--- a/crates/rdlp-extractor/src/extractors/spankbang/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/formats.rs
@@ -49,18 +49,23 @@ pub(super) fn parse_streamkey(html: &str) -> Option<String> {
 /// Convert a SpankBang `stream_data` / API JSON object to `Vec<Format>`.
 /// Skips empty arrays. Sets `vcodec=h264`, `acodec=aac`, `container=mp4`
 /// for direct MP4s; HLS rows get `protocol = M3u8`.
+///
+/// Rows are built from explicit label allow-lists. Two `stream_data` keys are
+/// deliberately excluded, and the allow-lists are what make that correct:
+///
+/// - **`main`** aliases the highest available progressive rendition — live
+///   probing (n=5, 2026-07-17) found it byte-identical to the top MP4 modulo
+///   the per-request `secure=` token. Emitting it would duplicate that row.
+/// - **`mpd`** is the DASH manifest key. It was empty in every video sampled
+///   and in both fixtures; wiring an unexercised DASH path would contradict
+///   the project's no-dead-code-for-future stance. Deferred until a video
+///   with a populated `mpd` turns up (issue #500).
 pub(super) fn build_formats(data: &Value) -> Vec<Format> {
     let mut formats = Vec::new();
     let Value::Object(map) = data else {
         return formats;
     };
 
-    // `main` and `mpd` are deliberately NOT in this allow-list. `main` is an
-    // alias for the highest available progressive rendition (verified via
-    // live probe: byte-identical to the top MP4 rendition modulo the
-    // per-request `secure=` token) — including it would duplicate that row.
-    // `mpd` is SpankBang's (always-empty, in every observed fixture) DASH
-    // key; there is no DASH path for this site today.
     // Direct MP4 progressive.
     for label in ["240p", "320p", "480p", "720p", "1080p", "4k"] {
         if let Some(arr) = map.get(label).and_then(Value::as_array)
@@ -199,23 +204,32 @@ mod tests {
         );
     }
 
-    // `mpd` is SpankBang's DASH key; it is empty in every observed fixture
-    // and there is no DASH path for this site. Cover both fixture shapes:
-    // the HTML page has `'mpd': []`, the API JSON omits the key entirely.
+    // `mpd` (DASH) is deliberately unwired for SpankBang: it was empty in all
+    // 5 videos sampled live and in BOTH fixtures, and building an unexercised
+    // code path contradicts the no-dead-code-for-future stance (issue #500).
+    //
+    // The fixtures cannot pin that decision. An empty array is dropped by the
+    // `arr.first()` guard no matter what the allow-list says, so a
+    // fixture-driven `mpd` assertion passes even with `mpd` in the allow-list
+    // — it would test the empty-array skip (already covered by the 320p/4k
+    // assertions above) while appearing to test the DASH decision. Feed a
+    // synthetic POPULATED `mpd` instead, so the test actually fails if someone
+    // starts emitting DASH rows without a real fixture to justify them.
     #[test]
-    fn mpd_key_produces_no_row_on_either_fixture() {
-        let inline = parse_inline_stream_data(PAGE).expect("inline parse");
-        let inline_formats = build_formats(&inline);
-        assert!(
-            inline_formats.iter().all(|f| f.format_id != "mpd"),
-            "empty 'mpd' array in HTML fixture must not produce a row"
-        );
+    fn populated_mpd_still_produces_no_row() {
+        let data = serde_json::json!({
+            "1080p": ["https://example.invalid/v-1080p.mp4"],
+            "mpd": ["https://example.invalid/v.mpd"],
+        });
 
-        let api: Value = serde_json::from_str(API).expect("API JSON parse");
-        let api_formats = build_formats(&api);
+        let formats = build_formats(&data);
         assert!(
-            api_formats.iter().all(|f| f.format_id != "mpd"),
-            "absent 'mpd' key in API fixture must not produce a row"
+            !formats.is_empty(),
+            "guard: the synthetic 1080p row must still be built, or this test proves nothing"
+        );
+        assert!(
+            formats.iter().all(|f| f.format_id != "mpd"),
+            "DASH is deliberately unwired; a populated 'mpd' must not produce a row"
         );
     }
 
@@ -243,8 +257,13 @@ mod tests {
 
     // Height legitimately repeats ACROSS protocols today (a progressive MP4
     // row and its HLS-variant sibling both carry `height = Some(1080)`), so
-    // this only pins uniqueness WITHIN the progressive (Https) rows — the
-    // failure mode a widened `main`/`mpd` allow-list would introduce.
+    // uniqueness is pinned only WITHIN the progressive (Https) rows — i.e.
+    // that `height_for_label` stays injective over the allow-list.
+    //
+    // Scope note: this does NOT catch a bare `main` added to the allow-list
+    // (`height_for_label("main")` is `None`, which is unique among the real
+    // heights) — `main_key_populated_but_produces_no_row` is what catches
+    // that. This one catches an alias mapped ONTO an existing height.
     #[test]
     fn no_duplicate_height_among_progressive_rows() {
         for (label, data) in [

--- a/crates/rdlp-extractor/src/extractors/spankbang/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/spankbang/formats.rs
@@ -55,6 +55,12 @@ pub(super) fn build_formats(data: &Value) -> Vec<Format> {
         return formats;
     };
 
+    // `main` and `mpd` are deliberately NOT in this allow-list. `main` is an
+    // alias for the highest available progressive rendition (verified via
+    // live probe: byte-identical to the top MP4 rendition modulo the
+    // per-request `secure=` token) — including it would duplicate that row.
+    // `mpd` is SpankBang's (always-empty, in every observed fixture) DASH
+    // key; there is no DASH path for this site today.
     // Direct MP4 progressive.
     for label in ["240p", "320p", "480p", "720p", "1080p", "4k"] {
         if let Some(arr) = map.get(label).and_then(Value::as_array)
@@ -166,5 +172,102 @@ mod tests {
         assert!(!formats.is_empty(), "API path also produces formats");
         assert!(formats.iter().any(|f| f.format_id == "1080p"));
         assert!(formats.iter().any(|f| f.format_id == "hls"));
+    }
+
+    // `main` is an alias for the highest-available progressive rendition
+    // (verified live: byte-identical URL to the top MP4 rendition, modulo
+    // the per-request `secure=` token). It is deliberately skipped by
+    // `build_formats` — including it would emit a duplicate row. The
+    // fixture MUST keep `main` populated, or this test would pass
+    // vacuously; assert the precondition alongside the behaviour.
+    #[test]
+    fn main_key_populated_but_produces_no_row() {
+        let data = parse_inline_stream_data(PAGE).expect("inline parse");
+        let main = data
+            .get("main")
+            .and_then(Value::as_array)
+            .expect("fixture precondition: 'main' key must be a populated array");
+        assert!(
+            !main.is_empty(),
+            "fixture precondition: 'main' must be non-empty for this test to be meaningful"
+        );
+
+        let formats = build_formats(&data);
+        assert!(
+            formats.iter().all(|f| f.format_id != "main"),
+            "'main' is an alias for the top progressive rendition; must not produce its own row"
+        );
+    }
+
+    // `mpd` is SpankBang's DASH key; it is empty in every observed fixture
+    // and there is no DASH path for this site. Cover both fixture shapes:
+    // the HTML page has `'mpd': []`, the API JSON omits the key entirely.
+    #[test]
+    fn mpd_key_produces_no_row_on_either_fixture() {
+        let inline = parse_inline_stream_data(PAGE).expect("inline parse");
+        let inline_formats = build_formats(&inline);
+        assert!(
+            inline_formats.iter().all(|f| f.format_id != "mpd"),
+            "empty 'mpd' array in HTML fixture must not produce a row"
+        );
+
+        let api: Value = serde_json::from_str(API).expect("API JSON parse");
+        let api_formats = build_formats(&api);
+        assert!(
+            api_formats.iter().all(|f| f.format_id != "mpd"),
+            "absent 'mpd' key in API fixture must not produce a row"
+        );
+    }
+
+    #[test]
+    fn no_duplicate_format_ids_on_either_fixture() {
+        for (label, data) in [
+            (
+                "inline",
+                parse_inline_stream_data(PAGE).expect("inline parse"),
+            ),
+            ("api", serde_json::from_str(API).expect("API JSON parse")),
+        ] {
+            let formats = build_formats(&data);
+            let mut ids: Vec<&str> = formats.iter().map(|f| f.format_id.as_str()).collect();
+            let before = ids.len();
+            ids.sort_unstable();
+            ids.dedup();
+            assert_eq!(
+                ids.len(),
+                before,
+                "{label} fixture: duplicate format_id among emitted rows"
+            );
+        }
+    }
+
+    // Height legitimately repeats ACROSS protocols today (a progressive MP4
+    // row and its HLS-variant sibling both carry `height = Some(1080)`), so
+    // this only pins uniqueness WITHIN the progressive (Https) rows — the
+    // failure mode a widened `main`/`mpd` allow-list would introduce.
+    #[test]
+    fn no_duplicate_height_among_progressive_rows() {
+        for (label, data) in [
+            (
+                "inline",
+                parse_inline_stream_data(PAGE).expect("inline parse"),
+            ),
+            ("api", serde_json::from_str(API).expect("API JSON parse")),
+        ] {
+            let formats = build_formats(&data);
+            let mut heights: Vec<Option<u32>> = formats
+                .iter()
+                .filter(|f| f.protocol == DownloadProtocol::Https)
+                .map(|f| f.height)
+                .collect();
+            let before = heights.len();
+            heights.sort_unstable();
+            heights.dedup();
+            assert_eq!(
+                heights.len(),
+                before,
+                "{label} fixture: duplicate height among progressive (Https) rows"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Resolves

Closes #500.

## Summary

`build_formats` builds rows from explicit label allow-lists, so `stream_data`'s `main` and `mpd` keys are excluded by construction. That is **correct** — this PR changes no behavior. It pins the skip, which nothing did.

The gap mattered asymmetrically. `320p`/`4k` are empty, so even a naive "iterate every key" refactor skips them harmlessly — and their skips were already asserted. **`main` is populated on every page sampled.** The same refactor, or anyone widening the allow-list, would emit a second 1080p row and the suite would stay green. A duplicate best-quality row surfaces as a confusing `-f best` selection, not a crash.

Live probe (n=5, 2026-07-17, via stealth browser — Cloudflare 403s plain clients) confirmed `main` is byte-identical to the top progressive rendition in 5/5, differing only in the per-request `secure=` token. It is an **alias**, not a stream.

## Tests

- `main_key_populated_but_produces_no_row` — asserts the fixture precondition (`main` present and non-empty) *and* the behavior, so it can't rot into a vacuous pass if the fixture changes.
- `populated_mpd_still_produces_no_row` — pins the deferred-DASH decision.
- `no_duplicate_format_ids_on_either_fixture`
- `no_duplicate_height_among_progressive_rows`

## Two places the issue's own acceptance criteria were wrong

Both were caught by verifying against the code rather than implementing to the text.

**1. "Exactly one format has height 1080" would have failed against correct code.** `build_formats` sets `height` on HLS variant rows as well as progressive MP4s, so height 1080 legitimately appears twice today (`1080p` + `m3u8_1080p`) in both fixtures. The assertion is scoped to progressive (`Https`) rows instead — which is what actually catches the duplicate-emission failure mode, and stays robust to the issue's noted 4k caveat (an assertion hardcoding `main == 1080p` would not).

**2. The proposed `mpd` test could never fail.** `mpd` is an empty array in **both** fixtures (the issue and an intermediate commit both claimed the API fixture omits the key — it does not), and `build_formats` drops empty arrays at the `arr.first()` guard regardless of the allow-list. A fixture-driven `mpd` assertion therefore passes even with `mpd` *in* the allow-list: it re-tests the empty-array skip already covered by the 320p/4k assertions, while appearing to pin the DASH decision. It now feeds a synthetic **populated** `mpd`, so it fails if someone starts emitting DASH rows without a fixture to justify them.

## Failing-first

Each negative test was confirmed RED against a deliberately-widened allow-list, then the probe reverted:

| Test | Under `+main` | Under `+mpd` |
|---|---|---|
| `main_key_populated_but_produces_no_row` | **RED** | — |
| `populated_mpd_still_produces_no_row` | — | **RED** |
| `no_duplicate_height_among_progressive_rows` | green* | — |
| `no_duplicate_format_ids_on_either_fixture` | green | green |

\* Deliberately recorded rather than papered over: a bare `main` leaves `height_for_label("main") == None`, which is unique among the real heights, so the height test does not catch that widen — `main_key_populated_but_produces_no_row` does. The height test catches an alias mapped *onto* an existing height. Both scopes are now stated in-code so the next reader doesn't over-trust either. `no_duplicate_format_ids` is a cheap cross-cutting invariant that can genuinely fail (a duplicated label, or an `m3u8_{label}` key colliding with a progressive id); it is kept as a decision-pin.

## Deliberately out of scope

DASH support. `mpd` was empty in 5/5 sampled videos and in both fixtures; rdlp has DASH support so wiring it would be mechanical, but there is no evidence SpankBang ever populates the key, and building an unexercised path contradicts the project's no-dead-code-for-future stance. If a video with a non-empty `mpd` turns up, that is a separate issue with a fixture attached.

## Reviews

Both pre-push reviewers ran over the full `develop...HEAD` diff.

- **security-reviewer: Approve**, no findings. Confirmed no URL is interpolated into any assertion message (the `check-url-redaction.sh` gate is a non-issue here), `.expect` usage matches crate convention, and no existing guarantee was weakened.
- **code-reviewer: Request changes → fixed.** It caught the vacuous `mpd` test, the false "API fixture omits the key" claim, and an overstated comment about the height test's reach — all corrected in the second commit. It independently verified the height-scoping deviation was correct.

## Verification

`cargo fmt --check` · `cargo clippy -p rdlp-extractor --all-targets -D warnings` (0 issues) · **1102 tests, 0 failures** · `check-dedup.sh` · `check-url-redaction.sh` · `check-no-cli.sh` · `check-log-redaction.sh` — all pass.

Note: `cargo test --workspace` cannot link `rdlp-api`'s test binaries on this machine right now (`mold: fatal: library not found: caca` — a missing system lib the local custom FFmpeg build references), and GitHub Actions is intentionally disabled on this repo, so the local gate above is the only gate. That gap is narrow for this diff: it touches nothing but `rdlp-extractor` test code, and that crate's full suite passes. No `rdlp-api` behavior is reachable from these changes.
