### PR TITLE
fix(generic): og secure_url/type collapse, JSON-LD ext, RTA age_limit (#495–#498)

### DIFF
--- a/crates/rdlp-extractor/src/base/common/age_rating.rs
+++ b/crates/rdlp-extractor/src/base/common/age_rating.rs
@@ -1,0 +1,159 @@
+//! RTA (Restricted to Adults) age-rating detection.
+//!
+//! Mirrors yt-dlp's `InfoExtractor._rta_search` (`common.py:1520-1539`,
+//! <https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/common.py>).
+//! RTA labeling (<https://www.rtalabel.org/>) is a self-declared adult-content
+//! tag still deployed in the wild as of 2026-07-17 (live-verified on
+//! pornhub.com and xhamster.com, which serve the meta tag with differing
+//! `name` casing — `rating` vs `RATING` — hence the case-insensitive match).
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+
+/// Age (in years) implied by a bare RTA/2257 marker with no explicit number
+/// captured. RTA labeling and 18 U.S.C. §2257 record-keeping both denote
+/// adult (18+) content; this is the fixed default yt-dlp's `_rta_search`
+/// uses when a marker's capture group is absent.
+const DEFAULT_ADULT_AGE: u8 = 18;
+
+/// The canonical RTA meta tag content value, registered by rtalabel.org.
+/// Kept as an exact-string match (not a fuzzy pattern) so that a future
+/// change to the RTA scheme fails safe — no match, no `age_limit` — rather
+/// than misclassifying an unrelated `rating` meta tag.
+///
+/// Deliberately NOT anchored to the tag's closing `>`: yt-dlp's `_rta_search`
+/// stops at the closing quote, and a real tag may carry further attributes
+/// after `content=` (`<meta name="rating" content="RTA-…" data-nosnippet="1">`).
+/// Requiring the terminator here silently dropped those pages.
+///
+/// Attribute ORDER (`name` before `content`) is required, matching upstream —
+/// a reordered tag is missed by yt-dlp too, so this is parity, not a gap we
+/// introduce.
+static RTA_META_TAG: Lazy<Regex> =
+    lazy_regex!(r#"(?i)<meta\s+name="rating"\s+content="RTA-5042-1996-1400-1577-RTA""#);
+
+/// RTA-label anchor marker: the rtalabel.org attribution link some sites
+/// embed instead of (or alongside) the meta tag.
+static RTA_LABEL_MARKER: Lazy<Regex> = lazy_regex!(
+    r#"Proudly Labeled <a href="http://www\.rtalabel\.org/" title="Restricted to Adults">RTA</a>"#
+);
+
+/// Age-acknowledgment marker; captures an explicit age in group 1.
+static RTA_AGE_ACK_MARKER: Lazy<Regex> =
+    lazy_regex!(r">[^<]*you acknowledge you are at least (\d+) years old");
+
+/// The 18 U.S.C. §2257 record-keeping marker, matched separately since it
+/// has no capture group and always implies [`DEFAULT_ADULT_AGE`].
+static RTA_2257_MARKER: Lazy<Regex> =
+    lazy_regex!(r">\s*(?:18\s+U(?:\.S\.C\.|SC)\s+)?(?:§+\s*)?2257\b");
+
+/// Detect a self-declared age restriction from RTA labeling or adjacent
+/// adult-content markers in an HTML page.
+///
+/// Returns the highest age implied across all matched markers, or `None`
+/// when none match (an *unknown* age limit — distinct from "no restriction",
+/// which would be `Some(0)`).
+#[must_use]
+pub fn rta_search(html: &str) -> Option<u8> {
+    if RTA_META_TAG.is_match(html) {
+        return Some(DEFAULT_ADULT_AGE);
+    }
+
+    let mut age_limit: Option<u8> = None;
+
+    for re in [&*RTA_LABEL_MARKER, &*RTA_AGE_ACK_MARKER] {
+        if let Some(cap) = re.captures(html) {
+            let val = cap
+                .get(1)
+                .and_then(|g| g.as_str().parse::<u8>().ok())
+                .unwrap_or(DEFAULT_ADULT_AGE);
+            age_limit = Some(age_limit.map_or(val, |x| x.max(val)));
+        }
+    }
+
+    if RTA_2257_MARKER.is_match(html) {
+        age_limit = Some(age_limit.map_or(DEFAULT_ADULT_AGE, |x| x.max(DEFAULT_ADULT_AGE)));
+    }
+
+    age_limit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rta_meta_tag_lowercase_name_yields_18() {
+        let html = r#"<html><head><meta name="rating" content="RTA-5042-1996-1400-1577-RTA"></head></html>"#;
+        assert_eq!(rta_search(html), Some(18));
+    }
+
+    /// xhamster serves `name="RATING"` (uppercase) — the match must be
+    /// case-insensitive, unlike a naive exact-string port would be.
+    #[test]
+    fn rta_meta_tag_uppercase_name_yields_18() {
+        let html = r#"<html><head><meta name="RATING" content="RTA-5042-1996-1400-1577-RTA"></head></html>"#;
+        assert_eq!(rta_search(html), Some(18));
+    }
+
+    /// The tag may carry further attributes after `content=`. An earlier draft
+    /// anchored the pattern to the closing `>` and silently dropped these —
+    /// yt-dlp's `_rta_search` stops at the closing quote, so anchoring was a
+    /// false-negative we invented rather than inherited.
+    #[test]
+    fn rta_meta_tag_with_trailing_attribute_yields_18() {
+        let html =
+            r#"<meta name="rating" content="RTA-5042-1996-1400-1577-RTA" data-nosnippet="1">"#;
+        assert_eq!(rta_search(html), Some(18));
+    }
+
+    /// Self-closing form, as served by xhamster (`…-RTA"/>`).
+    #[test]
+    fn rta_meta_tag_self_closing_yields_18() {
+        let html = r#"<meta name="RATING" content="RTA-5042-1996-1400-1577-RTA"/>"#;
+        assert_eq!(rta_search(html), Some(18));
+    }
+
+    #[test]
+    fn no_tag_and_no_markers_yields_none() {
+        let html = r#"<html><head><title>Just a page</title></head></html>"#;
+        assert_eq!(rta_search(html), None);
+    }
+
+    #[test]
+    fn section_2257_marker_yields_18() {
+        let html = r#"<html><body><footer>See our >18 USC 2257 statement</footer></body></html>"#;
+        assert_eq!(rta_search(html), Some(18));
+    }
+
+    #[test]
+    fn age_acknowledgment_marker_parses_captured_number() {
+        let html = r#"<html><body><p>By entering >you acknowledge you are at least 21 years old</p></body></html>"#;
+        assert_eq!(rta_search(html), Some(21));
+    }
+
+    #[test]
+    fn multiple_markers_max_wins() {
+        let html = r#"<html><body>
+            <p>>you acknowledge you are at least 18 years old</p>
+            <footer>>2257</footer>
+        </body></html>"#;
+        assert_eq!(rta_search(html), Some(18));
+    }
+
+    #[test]
+    fn higher_acknowledged_age_beats_bare_2257_default() {
+        let html = r#"<html><body>
+            <p>>you acknowledge you are at least 21 years old</p>
+            <footer>>2257</footer>
+        </body></html>"#;
+        assert_eq!(rta_search(html), Some(21));
+    }
+
+    /// An unrelated `rating` meta tag with a different content value must
+    /// not false-positive as RTA (exact-string match, not fuzzy).
+    #[test]
+    fn unrelated_rating_meta_tag_yields_none() {
+        let html = r#"<html><head><meta name="rating" content="general"></head></html>"#;
+        assert_eq!(rta_search(html), None);
+    }
+}

--- a/crates/rdlp-extractor/src/base/common/json_ld.rs
+++ b/crates/rdlp-extractor/src/base/common/json_ld.rs
@@ -63,6 +63,13 @@ pub struct JsonLdVideo {
     #[serde(rename = "contentUrl")]
     pub content_url: Option<String>,
 
+    /// MIME type of `contentUrl` (e.g. `"video/webm"`).
+    ///
+    /// Used as a fallback to derive the file extension when `contentUrl`
+    /// itself has no recognizable extension (issue #496).
+    #[serde(rename = "encodingFormat")]
+    pub encoding_format: Option<String>,
+
     /// Embed/player URL (often an iframe, not direct media)
     #[serde(rename = "embedUrl")]
     pub embed_url: Option<String>,

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -33,6 +33,7 @@
 //! let size = BaseExtractor::detect_file_size(&video_url, &ctx.http_client, None, std::time::Duration::from_secs(5)).await;
 //! ```
 
+pub mod age_rating;
 pub mod dash;
 pub mod json_ld;
 mod metadata;

--- a/crates/rdlp-extractor/src/extractors/generic/json_ld.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/json_ld.rs
@@ -67,8 +67,28 @@ impl DetectionStrategy for JsonLdStrategy {
                 .as_deref()
                 .and_then(|u| resolve_url(ctx.base_url, u))
             {
+                // URL extension wins; `encodingFormat` is only a fallback for an
+                // extensionless URL (mirrors #494's OpenGraph precedence and
+                // yt-dlp's `_parse_jwplayer_formats` idiom:
+                // `determine_ext(url, default_ext=mimetype2ext(type))`).
+                //
+                // This deliberately diverges from yt-dlp's own
+                // `extract_video_object`, which is `encodingFormat`-only with no
+                // URL fallback and whose `mimetype2ext` falls through to a
+                // garbage subtype string (`application/octet-stream` ->
+                // `"octet-stream"`) instead of `None` on no match — that is
+                // upstream's weaker outlier. Our `content_type_to_ext` returns
+                // `Option` and yields `None` on no match, so an unrecognized
+                // `encodingFormat` leaves ext unset rather than inventing one.
+                let ext = ext_from_url(&url).or_else(|| {
+                    video
+                        .encoding_format
+                        .as_deref()
+                        .and_then(super::content_type_to_ext)
+                        .map(str::to_owned)
+                });
                 formats.push(DetectedFormat {
-                    ext: ext_from_url(&url),
+                    ext,
                     url,
                     quality: None,
                     confidence: Confidence::High,
@@ -250,5 +270,90 @@ mod tests {
         let ctx = make_ctx(&html, raw, &url);
 
         assert!(JsonLdStrategy.detect(&ctx).is_empty());
+    }
+
+    /// #496: an extensionless `contentUrl` should fall back to `encodingFormat`
+    /// rather than defaulting to `mp4` downstream.
+    #[test]
+    fn json_ld_extensionless_url_uses_encoding_format() {
+        let raw = r#"<html><head><script type="application/ld+json">
+        {
+            "@type": "VideoObject",
+            "name": "Test Video",
+            "contentUrl": "https://cdn.example.com/video/stream",
+            "encodingFormat": "video/webm"
+        }
+        </script></head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = JsonLdStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].ext.as_deref(), Some("webm"));
+    }
+
+    /// A recognizable URL extension always wins over `encodingFormat`, mirroring
+    /// #494's OpenGraph precedence.
+    #[test]
+    fn json_ld_url_extension_wins_over_encoding_format() {
+        let raw = r#"<html><head><script type="application/ld+json">
+        {
+            "@type": "VideoObject",
+            "name": "Test Video",
+            "contentUrl": "https://cdn.example.com/video.mp4",
+            "encodingFormat": "video/webm"
+        }
+        </script></head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = JsonLdStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].ext.as_deref(), Some("mp4"));
+    }
+
+    /// No `encodingFormat` present — unchanged behavior (ext derived from URL
+    /// alone, `None` when the URL has no recognizable extension).
+    #[test]
+    fn json_ld_no_encoding_format_unchanged() {
+        let raw = r#"<html><head><script type="application/ld+json">
+        {
+            "@type": "VideoObject",
+            "name": "Test Video",
+            "contentUrl": "https://cdn.example.com/video/stream"
+        }
+        </script></head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = JsonLdStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].ext, None);
+    }
+
+    /// An unrecognized `encodingFormat` must leave ext unset rather than invent
+    /// one — `content_type_to_ext` returns `None` on no match, deliberately
+    /// diverging from yt-dlp's `mimetype2ext`, which falls through to a garbage
+    /// subtype string (`application/octet-stream` -> `"octet-stream"`).
+    #[test]
+    fn json_ld_unrecognized_encoding_format_leaves_ext_unset() {
+        let raw = r#"<html><head><script type="application/ld+json">
+        {
+            "@type": "VideoObject",
+            "name": "Test Video",
+            "contentUrl": "https://cdn.example.com/video/stream",
+            "encodingFormat": "application/octet-stream"
+        }
+        </script></head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = JsonLdStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].ext, None);
     }
 }

--- a/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
@@ -3,6 +3,7 @@
 use scraper::Selector;
 use std::collections::HashMap;
 use std::sync::LazyLock;
+use url::Url;
 
 use super::detection::{Confidence, DetectedFormat, DetectionStrategy, PageContext, resolve_url};
 
@@ -107,11 +108,22 @@ impl<'a> OgEntry<'a> {
         }
     }
 
-    /// The single URL this entry contributes as a candidate: `secure_url`
-    /// when declared (ogp.me: "use this if you need HTTPS" — and HTTPS is
-    /// the better default besides), else `root`. Never both.
-    fn url(&self) -> &'a str {
-        self.secure_url.unwrap_or(self.root)
+    /// The single URL this entry contributes as a candidate, resolved against
+    /// the page's base: `secure_url` when declared *and usable* (ogp.me: "use
+    /// this if you need HTTPS" — and HTTPS is the better default besides),
+    /// else `root`. Never both.
+    ///
+    /// The preference is resolution-aware on purpose. `resolve_url` rejects
+    /// empty, `data:`, and `javascript:` values, and real meta soup carries all
+    /// three — so preferring `secure_url` *blindly* would let a malformed
+    /// alternate take a legitimate stream down with it, turning a recoverable
+    /// bad tag into total extraction failure. That is the same rule the
+    /// `OgTag::Type` branch already states for an empty `content`: a malformed
+    /// sibling tag must not drop a real stream.
+    fn resolve(&self, base: &Url) -> Option<String> {
+        self.secure_url
+            .and_then(|raw| resolve_url(base, raw))
+            .or_else(|| resolve_url(base, self.root))
     }
 
     /// Whether this entry denotes a downloadable stream.
@@ -210,7 +222,7 @@ impl DetectionStrategy for OpenGraphStrategy {
                 // A declared media type names the container even when the URL has
                 // no extension to sniff — better than guessing downstream.
                 let ext_from_mime = entry.mime.and_then(super::content_type_to_ext);
-                let url = resolve_url(ctx.base_url, entry.url())?;
+                let url = entry.resolve(ctx.base_url)?;
                 let ext = super::detection::ext_from_url(&url)
                     .or_else(|| ext_from_mime.map(str::to_owned));
                 Some(DetectedFormat {
@@ -312,6 +324,41 @@ mod tests {
         let formats = OpenGraphStrategy.detect(&ctx);
         assert_eq!(formats.len(), 1, "root + secure_url is one asset, not two");
         assert_eq!(formats[0].url, "https://cdn.example.com/video.mp4");
+    }
+
+    /// A `secure_url` that cannot resolve must fall back to the entry's root
+    /// rather than taking the whole entry down with it.
+    ///
+    /// `resolve_url` rejects empty, `data:`, and `javascript:` values, and real
+    /// meta soup carries all three. Preferring `secure_url` *blindly* turned a
+    /// recoverable bad tag into total extraction failure on an otherwise-fine
+    /// page — the preference has to be resolution-aware. This is the same rule
+    /// the `OgTag::Type` branch already states for an empty `content`: a
+    /// malformed sibling tag must not drop a legitimate stream.
+    #[test]
+    fn og_unresolvable_secure_url_falls_back_to_root() {
+        for bad in ["", "javascript:void(0)", "data:text/html,x"] {
+            let raw = format!(
+                r#"<html><head>
+                <meta property="og:video:url" content="http://cdn.example.com/video.mp4">
+                <meta property="og:video:secure_url" content="{bad}">
+                </head></html>"#
+            );
+            let html = Html::parse_document(&raw);
+            let url = Url::parse("https://example.com/page").unwrap();
+            let ctx = make_ctx(&html, &raw, &url);
+
+            let formats = OpenGraphStrategy.detect(&ctx);
+            assert_eq!(
+                formats.len(),
+                1,
+                "secure_url={bad:?} is unusable; the root must still be emitted"
+            );
+            assert_eq!(
+                formats[0].url, "http://cdn.example.com/video.mp4",
+                "secure_url={bad:?} is unusable; the candidate must fall back to the root"
+            );
+        }
     }
 
     /// A `secure_url` declared with no preceding root of its kind keeps

--- a/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
@@ -1,7 +1,6 @@
 //! OpenGraph and Twitter meta tag detection strategies.
 
 use scraper::Selector;
-use std::collections::HashMap;
 use std::sync::LazyLock;
 use url::Url;
 
@@ -62,13 +61,23 @@ impl OgTag {
 /// Load-bearing: a structured property binds to a root of its *own* namespace.
 /// `og:video:type` describes an `og:video` — never a neighbouring `og:audio`
 /// that merely happens to be the most recent tag.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum OgKind {
     Video,
     Audio,
 }
 
 impl OgKind {
+    /// Dense index into the fixed-size orphan-type table — there are exactly
+    /// two kinds, so a two-slot array indexed by this beats a `HashMap` (no
+    /// heap alloc, no hashing, no `Hash` derive) while staying just as clear.
+    const fn index(self) -> usize {
+        match self {
+            Self::Video => 0,
+            Self::Audio => 1,
+        }
+    }
+
     /// The `DetectedFormat::source` tag, which feeds the emitted `format_id`.
     const fn source(self) -> &'static str {
         match self {
@@ -78,7 +87,7 @@ impl OgKind {
     }
 }
 
-/// One OpenGraph media entry: a single asset (never two — see [`OgEntry::url`])
+/// One OpenGraph media entry: a single asset (never two — see [`OgEntry::resolve`])
 /// plus the MIME type declared for it.
 ///
 /// `root` is never optional: an [`OgEntry`] cannot exist without one, since it
@@ -168,7 +177,8 @@ impl DetectionStrategy for OpenGraphStrategy {
         // after the walk, to that kind's *first* root — fill-if-absent, so an
         // explicit in-block type always wins. A later same-kind orphan
         // overwrites an earlier one: the orphan nearest its eventual root wins.
-        let mut orphan_types: HashMap<OgKind, &str> = HashMap::new();
+        // Indexed by `OgKind::index` — two kinds, so a two-slot array suffices.
+        let mut orphan_types: [Option<&str>; 2] = [None, None];
 
         for elem in ctx.html.select(&OG_MEDIA_SELECTOR) {
             let (Some(property), Some(content)) =
@@ -199,15 +209,16 @@ impl DetectionStrategy for OpenGraphStrategy {
                     }
                     match Self::open_root(&mut entries, kind) {
                         Some(entry) => entry.mime = Some(content),
-                        None => {
-                            orphan_types.insert(kind, content);
-                        }
+                        None => orphan_types[kind.index()] = Some(content),
                     }
                 }
             }
         }
 
-        for (kind, mime) in orphan_types {
+        for kind in [OgKind::Video, OgKind::Audio] {
+            let Some(mime) = orphan_types[kind.index()] else {
+                continue;
+            };
             if let Some(entry) = entries.iter_mut().find(|entry| entry.kind == kind)
                 && entry.mime.is_none()
             {

--- a/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/meta_sources.rs
@@ -1,6 +1,7 @@
 //! OpenGraph and Twitter meta tag detection strategies.
 
 use scraper::Selector;
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use super::detection::{Confidence, DetectedFormat, DetectionStrategy, PageContext, resolve_url};
@@ -60,7 +61,7 @@ impl OgTag {
 /// Load-bearing: a structured property binds to a root of its *own* namespace.
 /// `og:video:type` describes an `og:video` — never a neighbouring `og:audio`
 /// that merely happens to be the most recent tag.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum OgKind {
     Video,
     Audio,
@@ -76,13 +77,23 @@ impl OgKind {
     }
 }
 
-/// One OpenGraph media entry: a root URL plus any `secure_url` alternate for the
-/// same resource, and the MIME type declared for it.
+/// One OpenGraph media entry: a single asset (never two — see [`OgEntry::url`])
+/// plus the MIME type declared for it.
+///
+/// `root` is never optional: an [`OgEntry`] cannot exist without one, since it
+/// is only ever constructed from a `Root` tag or a fallback orphan `SecureUrl`
+/// (see [`OgTag::SecureUrl`]) — both of which supply a URL up front. Making the
+/// no-URL state unrepresentable removes the need for any later "does this
+/// entry have a URL" check.
 struct OgEntry<'a> {
     kind: OgKind,
-    /// Root URL first, `secure_url` alternate (if any) after. Both are surfaced
-    /// as candidates; pipeline dedup collapses them when identical.
-    urls: Vec<&'a str>,
+    /// The tag's own URL.
+    root: &'a str,
+    /// The HTTPS alternate for the *same* resource, if declared. Per ogp.me,
+    /// `og:video:secure_url` is "an alternate url to use if the webpage
+    /// requires HTTPS" — not a second asset — so it replaces `root` as the
+    /// emitted candidate rather than joining it (issue #495).
+    secure_url: Option<&'a str>,
     mime: Option<&'a str>,
 }
 
@@ -90,9 +101,17 @@ impl<'a> OgEntry<'a> {
     fn new(kind: OgKind, url: &'a str) -> Self {
         Self {
             kind,
-            urls: vec![url],
+            root: url,
+            secure_url: None,
             mime: None,
         }
+    }
+
+    /// The single URL this entry contributes as a candidate: `secure_url`
+    /// when declared (ogp.me: "use this if you need HTTPS" — and HTTPS is
+    /// the better default besides), else `root`. Never both.
+    fn url(&self) -> &'a str {
+        self.secure_url.unwrap_or(self.root)
     }
 
     /// Whether this entry denotes a downloadable stream.
@@ -129,6 +148,16 @@ impl DetectionStrategy for OpenGraphStrategy {
         // that precedes it, per the OGP spec's array/structured-property rules.
         let mut entries: Vec<OgEntry<'_>> = Vec::new();
 
+        // A `:type` seen before any root of its kind has no entry to bind to
+        // yet. ogp.me (<https://ogp.me>) carries no RFC 2119 language and
+        // leaves out-of-order authoring undefined, so rather than discard it
+        // (which let a `text/html` embed ship as a format — issue #498, the
+        // #493 defect via malformed ordering) we hold it here and apply it,
+        // after the walk, to that kind's *first* root — fill-if-absent, so an
+        // explicit in-block type always wins. A later same-kind orphan
+        // overwrites an earlier one: the orphan nearest its eventual root wins.
+        let mut orphan_types: HashMap<OgKind, &str> = HashMap::new();
+
         for elem in ctx.html.select(&OG_MEDIA_SELECTOR) {
             let (Some(property), Some(content)) =
                 (elem.value().attr("property"), elem.value().attr("content"))
@@ -146,40 +175,50 @@ impl DetectionStrategy for OpenGraphStrategy {
                 // declare one before any root (or with none at all) — keep the URL
                 // as its own entry rather than discarding it.
                 OgTag::SecureUrl(kind) => match Self::open_root(&mut entries, kind) {
-                    Some(entry) => entry.urls.push(content),
+                    Some(entry) => entry.secure_url = Some(content),
                     None => entries.push(OgEntry::new(kind, content)),
                 },
                 // An empty `content` leaves the type unspecified rather than
                 // declaring a non-media one — real meta soup carries these, and
                 // they must not drop a legitimate stream.
                 OgTag::Type(kind) => {
-                    if !content.trim().is_empty()
-                        && let Some(entry) = Self::open_root(&mut entries, kind)
-                    {
-                        entry.mime = Some(content);
+                    if content.trim().is_empty() {
+                        continue;
+                    }
+                    match Self::open_root(&mut entries, kind) {
+                        Some(entry) => entry.mime = Some(content),
+                        None => {
+                            orphan_types.insert(kind, content);
+                        }
                     }
                 }
+            }
+        }
+
+        for (kind, mime) in orphan_types {
+            if let Some(entry) = entries.iter_mut().find(|entry| entry.kind == kind)
+                && entry.mime.is_none()
+            {
+                entry.mime = Some(mime);
             }
         }
 
         entries
             .into_iter()
             .filter(OgEntry::is_media)
-            .flat_map(|entry| {
+            .filter_map(|entry| {
                 // A declared media type names the container even when the URL has
                 // no extension to sniff — better than guessing downstream.
                 let ext_from_mime = entry.mime.and_then(super::content_type_to_ext);
-                entry.urls.into_iter().filter_map(move |raw| {
-                    let url = resolve_url(ctx.base_url, raw)?;
-                    let ext = super::detection::ext_from_url(&url)
-                        .or_else(|| ext_from_mime.map(str::to_owned));
-                    Some(DetectedFormat {
-                        url,
-                        ext,
-                        quality: None,
-                        confidence: Confidence::High,
-                        source: entry.kind.source(),
-                    })
+                let url = resolve_url(ctx.base_url, entry.url())?;
+                let ext = super::detection::ext_from_url(&url)
+                    .or_else(|| ext_from_mime.map(str::to_owned));
+                Some(DetectedFormat {
+                    url,
+                    ext,
+                    quality: None,
+                    confidence: Confidence::High,
+                    source: entry.kind.source(),
                 })
             })
             .collect()
@@ -249,24 +288,116 @@ mod tests {
         assert_eq!(formats[0].confidence, Confidence::High);
     }
 
+    /// Canonical order (root → secure_url): ogp.me defines `secure_url` as
+    /// "an alternate url to use if the webpage requires HTTPS" for the SAME
+    /// asset, not a second asset — so the entry yields exactly one candidate,
+    /// and it is the HTTPS one.
+    ///
+    /// This test previously asserted `formats.len() == 2`, which encoded the
+    /// #495 defect (both URLs surfaced as separate formats for one video),
+    /// and it declared the tags in *reverse* order — secure_url before root —
+    /// so it actually exercised the orphan-secure_url fallback path (see
+    /// `og_video_secure_url_without_root_becomes_own_entry` below) rather
+    /// than the canonical root-then-secure_url path it claimed to test.
     #[test]
-    fn og_video_secure_url_extracted() {
+    fn og_video_secure_url_shares_entry_with_root() {
         let raw = r#"<html><head>
-            <meta property="og:video:secure_url" content="https://cdn.example.com/secure.mp4">
             <meta property="og:video:url" content="http://cdn.example.com/video.mp4">
+            <meta property="og:video:secure_url" content="https://cdn.example.com/video.mp4">
         </head></html>"#;
         let html = Html::parse_document(raw);
         let url = Url::parse("https://example.com/page").unwrap();
         let ctx = make_ctx(&html, raw, &url);
 
         let formats = OpenGraphStrategy.detect(&ctx);
-        assert_eq!(formats.len(), 2);
-        // Both are extracted; dedup happens at pipeline level
+        assert_eq!(formats.len(), 1, "root + secure_url is one asset, not two");
+        assert_eq!(formats[0].url, "https://cdn.example.com/video.mp4");
+    }
+
+    /// A `secure_url` declared with no preceding root of its kind keeps
+    /// today's fallback: it becomes its own entry rather than being dropped.
+    #[test]
+    fn og_video_secure_url_without_root_becomes_own_entry() {
+        let raw = r#"<html><head>
+            <meta property="og:video:secure_url" content="https://cdn.example.com/secure.mp4">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1);
+        assert_eq!(formats[0].url, "https://cdn.example.com/secure.mp4");
+    }
+
+    /// Two distinct roots each with their own `secure_url` yield two
+    /// candidates — one per asset — not four.
+    #[test]
+    fn og_video_multiple_entries_each_collapse_secure_url() {
+        let raw = r#"<html><head>
+            <meta property="og:video:url" content="http://cdn.example.com/a.mp4">
+            <meta property="og:video:secure_url" content="https://cdn.example.com/a.mp4">
+            <meta property="og:video:url" content="http://cdn.example.com/b.mp4">
+            <meta property="og:video:secure_url" content="https://cdn.example.com/b.mp4">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 2, "one candidate per asset, not per URL tag");
         assert!(
             formats
                 .iter()
-                .any(|f| f.url == "https://cdn.example.com/secure.mp4")
+                .any(|f| f.url == "https://cdn.example.com/a.mp4")
         );
+        assert!(
+            formats
+                .iter()
+                .any(|f| f.url == "https://cdn.example.com/b.mp4")
+        );
+    }
+
+    /// `og:video:type` declared *before* any `og:video` root: ogp.me
+    /// (<https://ogp.me>) carries no RFC 2119 language and leaves out-of-order
+    /// authoring undefined, so an orphaned type binds to the kind's first
+    /// root (fill-if-absent) rather than being discarded — matching yt-dlp's
+    /// whole-document first-match regex and open-graph-scraper's
+    /// collect-then-zip, both of which would catch this ordering. Pre-fix
+    /// this dropped the type and let a `text/html` embed page ship as a
+    /// format (issue #498, the #493 defect via malformed ordering).
+    #[test]
+    fn og_video_type_before_root_still_gates() {
+        let raw = r#"<html><head>
+            <meta property="og:video:type" content="text/html">
+            <meta property="og:video" content="https://example.com/embed/353006/">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        assert!(
+            OpenGraphStrategy.detect(&ctx).is_empty(),
+            "an orphaned :type binds to the kind's first root"
+        );
+    }
+
+    /// An orphaned type binds only when the root it lands on has no type of
+    /// its own — an explicit in-block type always wins over an orphan.
+    #[test]
+    fn og_video_orphan_type_does_not_clobber_explicit_type() {
+        let raw = r#"<html><head>
+            <meta property="og:video:type" content="text/html">
+            <meta property="og:video" content="https://cdn.example.com/real.mp4">
+            <meta property="og:video:type" content="video/mp4">
+        </head></html>"#;
+        let html = Html::parse_document(raw);
+        let url = Url::parse("https://example.com/page").unwrap();
+        let ctx = make_ctx(&html, raw, &url);
+
+        let formats = OpenGraphStrategy.detect(&ctx);
+        assert_eq!(formats.len(), 1, "explicit video/mp4 type wins over orphan");
+        assert_eq!(formats[0].url, "https://cdn.example.com/real.mp4");
     }
 
     /// A Flash object is a plugin embed, not a stream, so it is dropped.

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -481,18 +481,76 @@ mod tests {
         assert_eq!(format.format_note, Some("720p".to_string()));
     }
 
-    /// Verifies the Generic extractor wires `rta_search` against the fetched
-    /// webpage (issue #497). `extract()` itself needs a live HTTP fetch for
-    /// Phase 2, so this exercises the same shared helper the wiring calls
-    /// directly against representative page bodies instead of driving a full
-    /// network-backed `extract()` call.
-    #[test]
-    fn rta_search_wiring_detects_age_restriction() {
-        let restricted = r#"<html><head><meta name="rating" content="RTA-5042-1996-1400-1577-RTA"></head></html>"#;
-        assert_eq!(rta_search(restricted), Some(18));
+    /// End-to-end guard for the #497 wiring: the Generic extractor must set
+    /// `InfoDict::age_limit` from an RTA label on the *fetched* page.
+    ///
+    /// This drives the full `extract()` path on purpose. `rta_search`'s own
+    /// behaviour is already covered exhaustively in `base::common::age_rating`;
+    /// what a helper-only test cannot pin is the single wiring line
+    /// (`info.age_limit = rta_search(&webpage)`). Deleting that line leaves
+    /// every `age_rating` test green while age-gated sites silently lose their
+    /// rating — so the guard has to observe `age_limit` coming out of
+    /// `extract()`, not out of the helper.
+    ///
+    /// Feasible without a real network because `prefetch`/`fetch_webpage` issue
+    /// a plain `ctx.http_client.get(url)` with no SSRF/loopback gate, so a
+    /// mockito loopback URL is fetched directly. The `og:video` tag is present
+    /// only so `formats` is non-empty (an empty page is an `Err`, which would
+    /// mask the assertion); its plain-mp4 URL is never fetched.
+    #[tokio::test]
+    async fn extract_sets_age_limit_from_rta_label() {
+        let mut server = mockito::Server::new_async().await;
+        let page = r#"<html><head>
+            <meta name="rating" content="RTA-5042-1996-1400-1577-RTA">
+            <meta property="og:video" content="https://cdn.example.com/v.mp4">
+            </head><body></body></html>"#;
+        let _m = server
+            .mock("GET", "/watch")
+            .with_header("content-type", "text/html")
+            .with_body(page)
+            .create_async()
+            .await;
 
-        let unrestricted = r#"<html><head><title>No adult content here</title></head></html>"#;
-        assert_eq!(rta_search(unrestricted), None);
+        let url = format!("{}/watch", server.url());
+        let ctx = crate::hls::test_support::test_ctx();
+        let info = GenericExtractor::new().extract(&url, &ctx).await.unwrap();
+
+        assert!(
+            !info.formats.is_empty(),
+            "the og:video must yield a format — an empty page would Err and mask the age_limit check"
+        );
+        assert_eq!(
+            info.age_limit,
+            Some(18),
+            "an RTA label on the fetched page must set age_limit via the extract() wiring"
+        );
+    }
+
+    /// Negative companion to [`extract_sets_age_limit_from_rta_label`]: a page
+    /// with no age signal must leave `age_limit` unset (not defaulted to 18).
+    #[tokio::test]
+    async fn extract_leaves_age_limit_unset_without_rta_label() {
+        let mut server = mockito::Server::new_async().await;
+        let page = r#"<html><head>
+            <title>All ages</title>
+            <meta property="og:video" content="https://cdn.example.com/v.mp4">
+            </head><body></body></html>"#;
+        let _m = server
+            .mock("GET", "/watch")
+            .with_header("content-type", "text/html")
+            .with_body(page)
+            .create_async()
+            .await;
+
+        let url = format!("{}/watch", server.url());
+        let ctx = crate::hls::test_support::test_ctx();
+        let info = GenericExtractor::new().extract(&url, &ctx).await.unwrap();
+
+        assert!(!info.formats.is_empty(), "the og:video must yield a format");
+        assert_eq!(
+            info.age_limit, None,
+            "a page with no RTA/age signal must not set age_limit"
+        );
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -22,6 +22,7 @@ use rdlp_core::{ExtractionContext, InfoExtractor, Result};
 use rdlp_types::{DownloadProtocol, Format, InfoDict};
 
 use crate::base::common::BaseExtractor;
+use crate::base::common::age_rating::rta_search;
 
 use self::detection::{
     DetectedFormat, DetectionStrategy, PageContext, ext_from_url, run_detection_pipeline,
@@ -178,6 +179,7 @@ impl InfoExtractor for GenericExtractor {
         let mut info = InfoDict::new(&video_id, &title, "Generic", url);
         info.description = description;
         info.thumbnail = thumbnail;
+        info.age_limit = rta_search(&webpage);
 
         if let Some(secs) = json_ld_meta.duration_seconds {
             info.duration = Some(secs);
@@ -477,6 +479,20 @@ mod tests {
         assert_eq!(format.url, "https://cdn.example.com/video.mp4");
         assert_eq!(format.ext, "mp4");
         assert_eq!(format.format_note, Some("720p".to_string()));
+    }
+
+    /// Verifies the Generic extractor wires `rta_search` against the fetched
+    /// webpage (issue #497). `extract()` itself needs a live HTTP fetch for
+    /// Phase 2, so this exercises the same shared helper the wiring calls
+    /// directly against representative page bodies instead of driving a full
+    /// network-backed `extract()` call.
+    #[test]
+    fn rta_search_wiring_detects_age_restriction() {
+        let restricted = r#"<html><head><meta name="rating" content="RTA-5042-1996-1400-1577-RTA"></head></html>"#;
+        assert_eq!(rta_search(restricted), Some(18));
+
+        let unrestricted = r#"<html><head><title>No adult content here</title></head></html>"#;
+        assert_eq!(rta_search(unrestricted), None);
     }
 
     #[test]

--- a/crates/rdlp-extractor/src/extractors/generic/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/generic/mod.rs
@@ -358,21 +358,31 @@ fn protocol_from_url(url: &str, ext: Option<&str>) -> DownloadProtocol {
 }
 
 /// Map Content-Type to a file extension.
+///
+/// Media type/subtype names are case-insensitive (RFC 6838 §4.2, RFC 9110
+/// §8.3.1). Comparisons case-fold via `eq_ignore_ascii_case` — mirroring the
+/// zero-allocation idiom in `generic::patterns` — rather than `to_lowercase`,
+/// which would allocate a `String` on every call (PR #494 deliberately removed
+/// those allocations).
 fn content_type_to_ext(ct: &str) -> Option<&'static str> {
     let ct = ct.split(';').next().unwrap_or(ct).trim();
-    match ct {
-        "video/mp4" => Some("mp4"),
-        "video/webm" => Some("webm"),
-        "video/x-flv" => Some("flv"),
-        "video/quicktime" => Some("mov"),
-        "video/x-matroska" => Some("mkv"),
-        "audio/mpeg" => Some("mp3"),
-        "audio/mp4" => Some("m4a"),
-        "audio/ogg" => Some("ogg"),
-        "application/vnd.apple.mpegurl" | "application/x-mpegurl" => Some("m3u8"),
-        "application/dash+xml" => Some("mpd"),
-        _ => None,
-    }
+    const TABLE: &[(&str, &str)] = &[
+        ("video/mp4", "mp4"),
+        ("video/webm", "webm"),
+        ("video/x-flv", "flv"),
+        ("video/quicktime", "mov"),
+        ("video/x-matroska", "mkv"),
+        ("audio/mpeg", "mp3"),
+        ("audio/mp4", "m4a"),
+        ("audio/ogg", "ogg"),
+        ("application/vnd.apple.mpegurl", "m3u8"),
+        ("application/x-mpegurl", "m3u8"),
+        ("application/dash+xml", "mpd"),
+    ];
+    TABLE
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(ct))
+        .map(|(_, ext)| *ext)
 }
 
 #[cfg(test)]
@@ -443,6 +453,15 @@ mod tests {
             Some("m3u8")
         );
         assert_eq!(content_type_to_ext("text/html"), None);
+    }
+
+    /// Media type/subtype names are case-insensitive (RFC 6838 §4.2, RFC 9110
+    /// §8.3.1) — a publisher-authored `encodingFormat` or `og:video:type` value
+    /// with unconventional casing must still resolve.
+    #[test]
+    fn content_type_to_ext_is_case_insensitive() {
+        assert_eq!(content_type_to_ext("VIDEO/WEBM"), Some("webm"));
+        assert_eq!(content_type_to_ext("Video/MP4; codecs=avc1"), Some("mp4"));
     }
 
     #[test]

--- a/crates/rdlp-plugin/src/host/extract_helpers.rs
+++ b/crates/rdlp-plugin/src/host/extract_helpers.rs
@@ -196,36 +196,9 @@ impl crate::bindings::rdlp::plugin::host_extract_helpers::Host for PluginStoreDa
     }
 
     async fn rta_search(&mut self, html: String) -> Option<u8> {
-        // Mirrors yt-dlp's `_rta_search` (common.py:1525-1543).
-        let official = regex::RegexBuilder::new(
-            r#"<meta\s+name="rating"\s+content="RTA-5042-1996-1400-1577-RTA""#,
-        )
-        .case_insensitive(true)
-        .ignore_whitespace(true)
-        .build()
-        .ok()?;
-        if official.is_match(&html) {
-            return Some(18);
-        }
-        let markers = [
-            r#"Proudly Labeled <a href="http://www\.rtalabel\.org/" title="Restricted to Adults">RTA</a>"#,
-            r">[^<]*you acknowledge you are at least (\d+) years old",
-            r">\s*(?:18\s+U(?:\.S\.C\.|SC)\s+)?(?:§+\s*)?2257\b",
-        ];
-        let mut age_limit: Option<u8> = None;
-        for m in markers {
-            let Some(re) = regex::Regex::new(m).ok() else {
-                continue;
-            };
-            if let Some(cap) = re.captures(&html) {
-                let val: u8 = cap
-                    .get(1)
-                    .and_then(|g| g.as_str().parse().ok())
-                    .unwrap_or(18);
-                age_limit = Some(age_limit.map_or(val, |x| x.max(val)));
-            }
-        }
-        age_limit
+        // Delegates to the shared host+generic-extractor RTA detector (#497)
+        // — mirrors yt-dlp's `_rta_search` (common.py:1520-1539).
+        rdlp_extractor::base::common::age_rating::rta_search(&html)
     }
 
     async fn search_json(


### PR DESCRIPTION
## Resolves

Closes #495
Closes #496
Closes #497
Closes #498

## Summary

Fixes four defects in the Generic fallback extractor's OpenGraph / JSON-LD / age-rating handling, all surfaced from the same cluster of malformed-metadata reports.

- **#495 — duplicate `secure_url` format.** `og:video:secure_url` was emitted as a *second* `Format` for the same asset. `OgEntry` now collapses `secure_url` into its root entry, preferring `secure_url` **only when it actually resolves**, else falling back to the root. `resolve_url` rejects empty/`data:`/`javascript:` values, and real meta soup carries all three, so a blind preference turned a recoverable bad tag into total extraction failure — the preference is now resolution-aware.
- **#496 — wrong extension guess.** JSON-LD `contentUrl` with no path extension guessed `mp4`; it now derives the extension from the sibling `encodingFormat` MIME (RFC 6838/9110), falling back to the URL extension where present.
- **#497 — age gate never set.** Age-restricted sites routed through the fallback never had `age_limit` set. New `base::common::age_rating::rta_search` ports yt-dlp's `_rta_search()` (RTA label / 2257 / age-acknowledgment markers); `extract()` now wires it against the fetched page. The duplicate per-call regex block in the plugin host now delegates to the shared helper.
- **#498 — orphaned `og:video:type` discarded.** An `og:video:type` declared *before* any root of its kind was dropped, letting a `text/html` embed ship as a downloadable format. Out-of-order types are now held and bound to that kind's first root (fill-if-absent, so an explicit in-block type always wins).

## Tests

Each fix ships positive + negative coverage; `age_rating.rs` has 10 direct cases. The #497 wiring is guarded **end-to-end** through `extract()` (mockito), verified failing-first — neutralizing the wiring line fails the guard (`left: None, right: Some(18)`). Boundaries covered on both sides: unresolvable `secure_url` (empty/`data:`/`javascript:`) falls back to root; extensionless `contentUrl` → `encodingFormat`; type-before-root gating; orphan type does not clobber an explicit type.

Full gate green: `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -D warnings`, `cargo test` (3586 tests, 0 failures), `cargo check -p rdlp-desktop`, and all repo `check-*.sh` gates (dedup, url-redaction, log-redaction, no-cli, wit-drift).

## Reviews

- **security-reviewer** — **PASS / Approve**, no CRITICAL/HIGH/MEDIUM findings. All new URL-resolution paths still route through the unchanged `resolve_url()` SSRF gate; RTA regexes are linear-time (Rust `regex`, no ReDoS); `u8` age parsing fails safe to `None`/default (no panic/overflow on hostile input); no unredacted URLs in logs.
- **code-reviewer** — **Approve-with-minor-fixes**. Both minor findings addressed in the final commit: (1) the #497 wiring test was helper-only and didn't guard the wiring line — replaced with the end-to-end `extract()` guard above; (2) the two-variant orphan-type `HashMap` was over-engineered — swapped for an allocation-free `[Option<&str>; 2]`, dropping the `Hash` derive.
