### PR TITLE
refactor(search): dedup Family-1 filter errors into format_std_filter_error

### DIFF
--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -61,7 +61,7 @@ pub(crate) use protocol::protocol_for_url;
 pub(crate) use search::SearchOrigin;
 pub(crate) use search::{
     FilterValidationError, KeyValidation, PagedSearch, SearchPage, SearchPageSpec, Termination,
-    append_search_filters, validate_against_descriptors,
+    append_search_filters, format_std_filter_error, validate_against_descriptors,
 };
 pub(crate) use selectors::*;
 

--- a/crates/rdlp-extractor/src/base/common/search.rs
+++ b/crates/rdlp-extractor/src/base/common/search.rs
@@ -8,7 +8,7 @@
 //! RedTube) delegate that appending here.
 
 use log::debug;
-use rdlp_core::{ExtractionContext, Result};
+use rdlp_core::{ExtractionContext, RdlpError, Result};
 use rdlp_types::{
     SearchFilter, SearchFilterDescriptor, SearchPageResponse, SearchQuery, SearchResultPreview,
 };
@@ -231,6 +231,35 @@ pub(crate) fn validate_against_descriptors(
         }
     }
     Ok(())
+}
+
+/// Format a [`FilterValidationError`] into an `RdlpError::Extraction` using the
+/// shared "Family-1" wording, where the site name is the **only** per-site
+/// variant. Used by PornHub / RedTube / XHamster, whose three validator error
+/// arms are byte-identical apart from that literal.
+///
+/// Family-2 sites (TNAFlix / MovieFap) phrase these errors differently
+/// (`Unknown {Site} search filter key '{key}'`, etc.) and MUST NOT use this
+/// helper — their wording legitimately diverges (see #442).
+pub(crate) fn format_std_filter_error(site: &str, error: FilterValidationError) -> RdlpError {
+    let message = match error {
+        FilterValidationError::UnknownKey { key, available } => format!(
+            "Unknown filter '{key}' for {site}. Available: {}",
+            available.join(", ")
+        ),
+        FilterValidationError::InvalidValue {
+            key,
+            value,
+            allowed,
+        } => format!(
+            "Invalid value '{value}' for filter '{key}'. Allowed: {}",
+            allowed.join(", ")
+        ),
+        FilterValidationError::NonNumeric { key, value } => {
+            format!("Invalid value '{value}' for filter '{key}'. Must be a number.")
+        }
+    };
+    RdlpError::Extraction { message, url: None }
 }
 
 /// Delay between successive search-page fetches. All API-paginated sites that
@@ -1080,6 +1109,89 @@ mod tests {
                     key: "dur".into(),
                     value: "x".into()
                 }
+            );
+        }
+    }
+
+    /// Byte-exact wording guard for the shared Family-1 formatter. The per-site
+    /// validator tests only assert `.contains(substr)`, so these exact-string
+    /// checks are the sole guard that PornHub / RedTube / XHamster error
+    /// messages are reproduced verbatim across the dedup.
+    mod format_std_filter_error_tests {
+        use super::super::{FilterValidationError, format_std_filter_error};
+        use rdlp_core::RdlpError;
+
+        fn extraction_message(site: &str, error: FilterValidationError) -> String {
+            match format_std_filter_error(site, error) {
+                RdlpError::Extraction { message, url } => {
+                    assert!(url.is_none(), "Family-1 filter errors carry no URL");
+                    message
+                }
+                other => panic!("expected RdlpError::Extraction, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn unknown_key_arm_exact_wording() {
+            let error = FilterValidationError::UnknownKey {
+                key: "bogus".into(),
+                available: vec!["ordering".into(), "category".into()],
+            };
+            assert_eq!(
+                extraction_message("PornHub", error),
+                "Unknown filter 'bogus' for PornHub. Available: ordering, category"
+            );
+        }
+
+        #[test]
+        fn invalid_value_arm_exact_wording() {
+            let error = FilterValidationError::InvalidValue {
+                key: "ordering".into(),
+                value: "nope".into(),
+                allowed: vec!["newest".into(), "rating".into()],
+            };
+            assert_eq!(
+                extraction_message("RedTube", error),
+                "Invalid value 'nope' for filter 'ordering'. Allowed: newest, rating"
+            );
+        }
+
+        #[test]
+        fn non_numeric_arm_exact_wording() {
+            let error = FilterValidationError::NonNumeric {
+                key: "dur".into(),
+                value: "x".into(),
+            };
+            assert_eq!(
+                extraction_message("XHamster", error),
+                "Invalid value 'x' for filter 'dur'. Must be a number."
+            );
+        }
+
+        /// The site name is the ONLY per-site variant: the same `UnknownKey`
+        /// input yields wording that differs only in the interpolated site.
+        #[test]
+        fn site_name_is_the_only_variant() {
+            let mk = |site| {
+                extraction_message(
+                    site,
+                    FilterValidationError::UnknownKey {
+                        key: "k".into(),
+                        available: vec!["a".into()],
+                    },
+                )
+            };
+            assert_eq!(
+                mk("PornHub"),
+                "Unknown filter 'k' for PornHub. Available: a"
+            );
+            assert_eq!(
+                mk("RedTube"),
+                "Unknown filter 'k' for RedTube. Available: a"
+            );
+            assert_eq!(
+                mk("XHamster"),
+                "Unknown filter 'k' for XHamster. Available: a"
             );
         }
     }

--- a/crates/rdlp-extractor/src/extractors/pornhub/search.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/search.rs
@@ -178,7 +178,9 @@ pub(crate) fn parse_duration_string(duration: &str) -> Option<u64> {
 /// # Returns
 /// `Ok(())` on success, `Err` describing the first invalid filter.
 pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
-    use crate::base::common::{FilterValidationError, KeyValidation, validate_against_descriptors};
+    use crate::base::common::{
+        KeyValidation, format_std_filter_error, validate_against_descriptors,
+    };
 
     let descriptors = search_patterns::search_filter_descriptors();
     validate_against_descriptors(
@@ -189,30 +191,7 @@ pub(crate) fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
             ("tags", KeyValidation::FreeText),
         ],
     )
-    .map_err(|e| match e {
-        FilterValidationError::UnknownKey { key, available } => RdlpError::Extraction {
-            message: format!(
-                "Unknown filter '{key}' for PornHub. Available: {}",
-                available.join(", ")
-            ),
-            url: None,
-        },
-        FilterValidationError::InvalidValue {
-            key,
-            value,
-            allowed,
-        } => RdlpError::Extraction {
-            message: format!(
-                "Invalid value '{value}' for filter '{key}'. Allowed: {}",
-                allowed.join(", ")
-            ),
-            url: None,
-        },
-        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
-            message: format!("Invalid value '{value}' for filter '{key}'. Must be a number."),
-            url: None,
-        },
-    })
+    .map_err(|e| format_std_filter_error("PornHub", e))
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/redtube/search.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/search.rs
@@ -226,7 +226,9 @@ pub(crate) fn validate_search_filters(
     filters: &[SearchFilter],
     descriptors: &[SearchFilterDescriptor],
 ) -> Result<()> {
-    use crate::base::common::{FilterValidationError, KeyValidation, validate_against_descriptors};
+    use crate::base::common::{
+        KeyValidation, format_std_filter_error, validate_against_descriptors,
+    };
 
     validate_against_descriptors(
         filters,
@@ -236,30 +238,7 @@ pub(crate) fn validate_search_filters(
             ("tags", KeyValidation::FreeText),
         ],
     )
-    .map_err(|e| match e {
-        FilterValidationError::UnknownKey { key, available } => RdlpError::Extraction {
-            message: format!(
-                "Unknown filter '{key}' for RedTube. Available: {}",
-                available.join(", ")
-            ),
-            url: None,
-        },
-        FilterValidationError::InvalidValue {
-            key,
-            value,
-            allowed,
-        } => RdlpError::Extraction {
-            message: format!(
-                "Invalid value '{value}' for filter '{key}'. Allowed: {}",
-                allowed.join(", ")
-            ),
-            url: None,
-        },
-        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
-            message: format!("Invalid value '{value}' for filter '{key}'. Must be a number."),
-            url: None,
-        },
-    })
+    .map_err(|e| format_std_filter_error("RedTube", e))
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/xhamster/search.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/search.rs
@@ -99,7 +99,9 @@ pub fn parse_max_pages(initials: &Value) -> Option<usize> {
 
 /// Validate search filters against the known xHamster filter descriptors.
 pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
-    use crate::base::common::{FilterValidationError, KeyValidation, validate_against_descriptors};
+    use crate::base::common::{
+        KeyValidation, format_std_filter_error, validate_against_descriptors,
+    };
 
     let descriptors = patterns::search_filter_descriptors();
     validate_against_descriptors(
@@ -110,30 +112,7 @@ pub fn validate_search_filters(filters: &[SearchFilter]) -> Result<()> {
             ("max-duration", KeyValidation::NumericU32),
         ],
     )
-    .map_err(|e| match e {
-        FilterValidationError::UnknownKey { key, available } => RdlpError::Extraction {
-            message: format!(
-                "Unknown filter '{key}' for XHamster. Available: {}",
-                available.join(", ")
-            ),
-            url: None,
-        },
-        FilterValidationError::InvalidValue {
-            key,
-            value,
-            allowed,
-        } => RdlpError::Extraction {
-            message: format!(
-                "Invalid value '{value}' for filter '{key}'. Allowed: {}",
-                allowed.join(", ")
-            ),
-            url: None,
-        },
-        FilterValidationError::NonNumeric { key, value } => RdlpError::Extraction {
-            message: format!("Invalid value '{value}' for filter '{key}'. Must be a number."),
-            url: None,
-        },
-    })
+    .map_err(|e| format_std_filter_error("XHamster", e))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Resolves
Closes #442

## Summary
PornHub / RedTube / XHamster each hand-wrote the same three-arm `match` mapping a typed `FilterValidationError` to `RdlpError::Extraction`, differing only by the interpolated site name (~40 duplicated lines). This adds one shared `format_std_filter_error(site, error) -> RdlpError` in `base::common::search` and collapses each call site to `.map_err(|e| format_std_filter_error("<Site>", e))`.

- Error strings reproduced **byte-for-byte** (verified by new exact-string tests — the pre-existing per-site tests only `.contains(substr)`).
- Family-2 sites (TNAFlix/MovieFap) keep their divergent wording and do **not** use the helper.
- Argument count 2 (≤3 ceiling); `pub(crate)` + re-export mirrors sibling helpers.

## Tests
Exact-wording guards for all three arms + a `site_name_is_the_only_variant` test. Full pre-push gate green (fmt/clippy `-D warnings`/`cargo test` 3587 passed; check-dedup + check-url-redaction pass).

## Reviews
- security-reviewer: **Approve** (no info-disclosure change; `url: None` preserved; redaction gate N/A).
- code-reviewer: **Approve** (byte-exact strings, no dangling imports, Family-2 excluded, tests adequate).