### PR TITLE
chore(deps): drop tabled derive feature to remove archived proc-macro-error2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7704,21 +7704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck 0.5.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,14 @@ clap = { version = "4.5", features = ["derive", "cargo"] }
 indicatif = "0.18.3"
 inquire = "0.9"
 
-# Table rendering
-tabled = "0.20"
+# Table rendering.
+# default-features = false drops the `derive` feature (the `Tabled` proc-macro),
+# which is the sole path pulling in `tabled_derive` -> the archived, unmaintained
+# `proc-macro-error2` crate (future-incompat E0365, rust-lang/rust#127909).
+# rdlp-table builds tables at runtime via `Builder` and never uses `#[derive(Tabled)]`,
+# so only the `std` feature is needed (Builder + settings::{Style,Alignment,Columns}).
+# Revisit if a future tabled release drops proc-macro-error2 upstream (zhiburt/tabled#584).
+tabled = { version = "0.20", default-features = false, features = ["std"] }
 console = "0.16"
 terminal_size = "0.4"
 


### PR DESCRIPTION
## Resolves
Closes #503

## Summary
`tabled`'s default `derive` feature is the only *active* path pulling `tabled_derive` → the archived, unmaintained `proc-macro-error2 2.0.1`, which emits a future-incompat warning (E0365, `pub use proc_macro`; rust-lang/rust#127909).

No version bump fixes it today: proc-macro-error2's repo is archived (fix stranded in unmerged PR #14), and tabled's own fix (zhiburt/tabled#584, drops the dep) is merged to master but unreleased.

`rdlp-table` — the sole `tabled` consumer — builds tables at runtime via `Builder` and never uses `#[derive(Tabled)]`, so the `derive` feature is dead weight. Setting `default-features = false, features = ["std"]` keeps `Builder` + `settings::{Style,Alignment,Columns}` and drops `tabled_derive` + `proc-macro-error2` from the build entirely.

## Verification
`cargo build --workspace` emits **no future-incompat warning** and neither crate is compiled. Full gate green: fmt/clippy `-D warnings`/`cargo test` (3587 passed), check-dedup + check-url-redaction. rdlp-table renders identically (37 tests).

## Notes
An inert `getset → proc-macro-error2` chain remains in Cargo.lock via sigstore's optional `oci-client` path — feature-gated off, never compiled. Revisit to re-enable `derive` once a `tabled` release ships #584.

## Reviews
- code-reviewer: **Approve** — all four claims verified against tabled 0.20 source + lockfile; feature set correct and minimal.