### PR TITLE
chore(cli): fix clippy too_long_first_doc_paragraph in sanitize.rs

### DIFF
--- a/crates/rdlp-cli/src/sanitize.rs
+++ b/crates/rdlp-cli/src/sanitize.rs
@@ -35,9 +35,10 @@
 //! cannot. CWE-150 endorses this "restrict to printable" approach over matching
 //! known-bad sequences. (Verdict from a cited multi-source survey, 2026-07-14.)
 
-/// Return a copy of `s` with hostile control and bidi-formatting characters
-/// removed, rendering any embedded terminal escape sequence or visual-reorder
-/// spoof inert before the text is written to a TTY or log.
+/// Return a copy of `s` with hostile control and bidi-formatting characters removed.
+///
+/// This renders any embedded terminal escape sequence or visual-reorder spoof
+/// inert before the text is written to a TTY or log.
 ///
 /// Two independent filters run in one pass:
 ///


### PR DESCRIPTION
## Resolves
Closes #506

## Summary
`cargo clippy --workspace` was red on develop: `too_long_first_doc_paragraph` on `sanitize_for_terminal`'s doc comment (rustc 1.97.0), pre-existing since commit 30697591. Invisible to the documented gate because it runs clippy `--all-targets` without `--workspace` and rdlp-cli is excluded from default-members.

Split the 3-line first doc paragraph into a one-line summary + elaboration paragraph. Pure doc change, no behavior change.

## Verification
`cargo clippy --workspace --all-targets -- -D warnings` now clean (rdlp-cli + rdlp-desktop included); `cargo fmt --check` clean.