### PR TITLE
fix(extractor): cap remaining uncapped response.text() reads (#438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Check no CLI FFmpeg usage
         run: bash scripts/check-no-cli.sh
 
+      - name: Check no uncapped response.text() reads
+        # Fails if any HTTP response body in rdlp-extractor is read via a bare,
+        # uncapped `.text().await` instead of the 50 MiB streaming cap
+        # `fetch_capped_text` — an adversarial/compromised CDN could otherwise
+        # OOM the host with an unbounded body (#438). Multiline-aware; a
+        # genuinely-safe test-only loopback read carries an inline
+        # `// uncapped-ok: <reason>` marker.
+        run: bash scripts/check-no-bare-response-text.sh
+
       - name: Check URL log redaction
         # Fails if any raw URL is interpolated into an operator-visible string in
         # rdlp-extractor (RdlpError message/reason fields, ctor message-args, log

--- a/crates/rdlp-extractor/src/base/common/mod.rs
+++ b/crates/rdlp-extractor/src/base/common/mod.rs
@@ -122,7 +122,7 @@ pub struct BaseExtractor;
 /// bytes exceed `MAX_WEBPAGE_BYTES`. The previous `response.text()` path
 /// buffered the entire response before any check, allowing an
 /// adversarial server to OOM the host with a 10 GB body.
-async fn fetch_capped_text(response: wreq::Response, url: &str) -> Result<String> {
+pub(crate) async fn fetch_capped_text(response: wreq::Response, url: &str) -> Result<String> {
     use futures::StreamExt;
     let mut stream = response.bytes_stream();
     let mut buf: Vec<u8> = Vec::new();

--- a/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
+++ b/crates/rdlp-extractor/src/extractors/hqporner/mydaddy.rs
@@ -127,10 +127,7 @@ async fn fetch_embed(url: &str, ctx: &ExtractionContext) -> Result<String> {
 
     rdlp_core::check_http_response(&response)?;
 
-    response.text().await.map_err(|e| RdlpError::Network {
-        message: format!("Failed to read mydaddy.cc response: {e}"),
-        url: Some(url.to_string().into()),
-    })
+    crate::base::common::fetch_capped_text(response, url).await
 }
 
 /// Parse MP4 format URLs from the embed HTML.

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/html.rs
@@ -61,9 +61,12 @@ pub(super) fn extract_total_pages(response: &wreq::Response) -> u32 {
 /// Scrape durations from an HTML listing response (best-effort, non-fatal).
 pub(super) async fn scrape_durations_from_html_response(
     result: std::result::Result<wreq::Response, wreq::Error>,
+    url: &str,
 ) -> std::collections::HashMap<String, f64> {
     let text = match result {
-        Ok(resp) => resp.text().await.unwrap_or_default(),
+        Ok(resp) => crate::base::common::fetch_capped_text(resp, url)
+            .await
+            .unwrap_or_default(),
         Err(e) => {
             // Network failure was previously indistinguishable from "page
             // had no durations" — surface it at debug so investigators

--- a/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/koreanpornmovie/mod.rs
@@ -381,7 +381,7 @@ impl KoreanPornMovieExtractor {
         })?;
 
         // Parse HTML for durations (best-effort, non-fatal)
-        let durations = scrape_durations_from_html_response(html_result).await;
+        let durations = scrape_durations_from_html_response(html_result, &html_url).await;
 
         let results = posts
             .into_iter()
@@ -457,7 +457,7 @@ impl KoreanPornMovieExtractor {
             .await
             .map_err(|e| RdlpError::extraction(format!("failed to parse posts: {e}"), &api_url))?;
 
-        let durations = scrape_durations_from_html_response(html_result).await;
+        let durations = scrape_durations_from_html_response(html_result, &html_url).await;
 
         let results = posts
             .into_iter()

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/client_key.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/client_key.rs
@@ -61,9 +61,11 @@ async fn extract_client_key_impl(
             format!("failed to fetch megacloud v3 embed page for source_id={source_id}")
         })?;
 
-    let html = response.text().await.with_context(|| {
-        format!("failed to read megacloud v3 embed body for source_id={source_id}")
-    })?;
+    let html = crate::base::common::fetch_capped_text(response, &url)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("failed to read megacloud v3 embed body for source_id={source_id}: {e}")
+        })?;
 
     parse_client_key(&html)
 }

--- a/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/nine_anime/megacloud/mod.rs
@@ -246,10 +246,7 @@ async fn fetch_get_sources(
         })?;
 
     let status = response.status();
-    let body = response.text().await.map_err(|e| RdlpError::Network {
-        message: format!("Failed to read getSources body: {e}"),
-        url: Some(url.to_string().into()),
-    })?;
+    let body = crate::base::common::fetch_capped_text(response, url).await?;
 
     if !status.is_success() {
         return Err(RdlpError::Extraction {

--- a/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/formats.rs
@@ -141,7 +141,9 @@ async fn fetch_media_formats(
         return None;
     }
 
-    let json_text = response.text().await.ok()?;
+    let json_text = crate::base::common::fetch_capped_text(response, url)
+        .await
+        .ok()?;
     let media_array: Value = serde_json::from_str(&json_text).ok()?;
 
     let mut formats = Vec::new();

--- a/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
+++ b/crates/rdlp-extractor/src/extractors/pornhub/playlist.rs
@@ -75,10 +75,7 @@ pub async fn extract_playlist(
 
     check_http_response(&response)?;
 
-    let webpage = response.text().await.map_err(|e| RdlpError::Network {
-        message: format!("Failed to read response: {e}"),
-        url: Some(url.to_string().into()),
-    })?;
+    let webpage = crate::base::common::fetch_capped_text(response, url).await?;
 
     // Extract metadata
     let (playlist_title, pagination_info, mut all_video_urls) = {
@@ -352,10 +349,7 @@ async fn download_page(
 
     check_http_response(&response)?;
 
-    response.text().await.map_err(|e| RdlpError::Network {
-        message: format!("Failed to read page {page_num}: {e}"),
-        url: Some(url.into()),
-    })
+    crate::base::common::fetch_capped_text(response, &url).await
 }
 
 #[cfg(test)]

--- a/crates/rdlp-extractor/src/extractors/redtube/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/formats.rs
@@ -438,7 +438,7 @@ async fn fetch_formats_from_endpoint(
         return None;
     }
 
-    let json_text = match response.text().await {
+    let json_text = match crate::base::common::fetch_capped_text(response, &absolute_url).await {
         Ok(t) => t,
         Err(e) => {
             BaseExtractor::log_if_verbose(

--- a/crates/rdlp-extractor/src/extractors/redtube/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/redtube/mod.rs
@@ -102,10 +102,7 @@ impl RedTubeExtractor {
 
         rdlp_core::check_http_response(&response)?;
 
-        let body = response.text().await.map_err(|e| RdlpError::Network {
-            message: format!("Failed to read RedTube video API response: {e}"),
-            url: Some(api_url.into()),
-        })?;
+        let body = crate::base::common::fetch_capped_text(response, &api_url).await?;
 
         BaseExtractor::log_content_if_verbose(ctx, "RedTube", "API video response", &body, 500);
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/ajax.rs
@@ -36,10 +36,7 @@ pub async fn parse_empflix_ajax(
 
     check_http_response(&response)?;
 
-    let json_text = response.text().await.map_err(|e| RdlpError::Network {
-        message: format!("Failed to read AJAX response: {e}"),
-        url: Some(ajax_url.clone().into()),
-    })?;
+    let json_text = crate::base::common::fetch_capped_text(response, &ajax_url).await?;
 
     BaseExtractor::log_content_if_verbose(ctx, "EMPFlix", "AJAX Response", &json_text, 500);
 
@@ -96,10 +93,7 @@ pub async fn parse_moviefap_xml(
 
     check_http_response(&response)?;
 
-    let xml_text = response.text().await.map_err(|e| RdlpError::Network {
-        message: format!("Failed to read XML response: {e}"),
-        url: Some(cdn_url.to_string().into()),
-    })?;
+    let xml_text = crate::base::common::fetch_capped_text(response, cdn_url).await?;
 
     BaseExtractor::log_content_if_verbose(ctx, "MovieFap", "XML Response", &xml_text, 1000);
 

--- a/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/tnaflix/mod.rs
@@ -498,10 +498,10 @@ mod async_tests {
             .get(format!("{}/search?what=test&tab=&page=1", server.url()))
             .send()
             .await
-            .unwrap()
-            .text()
+            .expect("mock search request should succeed")
+            .text() // uncapped-ok: mockito loopback test body (trusted, small)
             .await
-            .unwrap();
+            .expect("mock search body should read as UTF-8");
         let results = tnaflix_search_helpers::parse_search_results(&webpage);
 
         assert_eq!(results.len(), 1);

--- a/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
@@ -129,7 +129,7 @@ pub async fn fetch_player_js(
             .await
         {
             Ok(resp) if resp.status().is_success() => {
-                if let Ok(body) = resp.text().await {
+                if let Ok(body) = crate::base::common::fetch_capped_text(resp, &full_url).await {
                     // Verify it contains decryption-related code
                     if body.contains("1664525")
                         || body.contains("0x85ebca77")

--- a/crates/rdlp-extractor/src/extractors/xvideos/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xvideos/mod.rs
@@ -298,10 +298,10 @@ mod tests {
             .get(format!("{}/video.ooumovia9b7/slug", server.url()))
             .send()
             .await
-            .unwrap()
-            .text()
+            .expect("mock video request should succeed")
+            .text() // uncapped-ok: mockito loopback test body (trusted, small)
             .await
-            .unwrap();
+            .expect("mock video body should read as UTF-8");
 
         let info = XVideosExtractor::build_info(
             &html,

--- a/crates/rdlp-extractor/src/hls/detector.rs
+++ b/crates/rdlp-extractor/src/hls/detector.rs
@@ -277,10 +277,7 @@ impl HlsSizeDetector {
             });
         }
 
-        response.text().await.map_err(|e| RdlpError::Network {
-            message: format!("Failed to read playlist response: {e}"),
-            url: Some(m3u8_url.to_string().into()),
-        })
+        crate::base::common::fetch_capped_text(response, m3u8_url).await
     }
 
     /// Fetch a media playlist and extract its metadata

--- a/scripts/check-no-bare-response-text.sh
+++ b/scripts/check-no-bare-response-text.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check-no-bare-response-text.sh — CI gate: verify every HTTP response body read in
+# rdlp-extractor goes through the byte-capped `fetch_capped_text` helper
+# (crates/rdlp-extractor/src/base/common/mod.rs), not a bare `.text().await`.
+#
+# Exit 0 = PASS (no offenders found).
+# Exit 1 = FAIL (an uncapped response body read remains).
+#
+# Usage: bash scripts/check-no-bare-response-text.sh
+#
+# Rationale (#438): a bare `wreq::Response::text().await` buffers the entire body
+# before any size check runs — an adversarial/compromised CDN can stream an
+# unbounded payload and OOM the host. `fetch_capped_text` streams via
+# `bytes_stream()` and aborts once `MAX_WEBPAGE_BYTES` is exceeded. This gate
+# prevents a future call site from reintroducing the uncapped read.
+#
+# Detection is MULTILINE-aware (`rg -U`), like check-url-redaction.sh: a `.text()`
+# followed by `.await` across a rustfmt-split chain
+#     .text()
+#     .await
+# is caught exactly as the single-line `.text().await` form is — a split chain
+# cannot evade the gate. Each match is reduced to its `.text()` anchor line.
+#
+# Scope: only `.text()` immediately followed by `.await` (the async HTTP-body
+# read). `scraper`'s synchronous `element.text().collect()` has no `.await` and
+# never matches.
+#
+# Escape hatch: a genuinely-safe raw read (e.g. a mockito loopback body inside a
+# `#[cfg(test)]` module) carries an inline `// uncapped-ok: <reason>` marker on
+# its `.text()` line, which this gate skips. Production reads MUST NOT use it —
+# route them through `crate::base::common::fetch_capped_text(response, url)`.
+
+set -euo pipefail
+
+TARGET="crates/rdlp-extractor/src"
+
+# 1. `rg -U --pcre2` matches `.text()` + `.await` across optional whitespace/newlines.
+# 2. Reduce to the `.text()` anchor line (drops the trailing `.await` line of a
+#    multiline match).
+# 3. Drop pure comment lines (the helper's own docstring references the pattern).
+# 4. Drop lines carrying the explicit `uncapped-ok:` allow-marker.
+hits=$(
+    rg -Un --pcre2 '\.text\(\)\s*\.await' "$TARGET" 2>/dev/null \
+        | rg '\.text\(\)' \
+        | grep -vE ':[0-9]+:[[:space:]]*//' \
+        | grep -v 'uncapped-ok:' \
+        || true
+)
+
+if [[ -n "$hits" ]]; then
+    echo "FAIL — bare (uncapped) response body read(s) found:"
+    echo "$hits" | sed 's/^/  /'
+    echo ""
+    echo "FIX: route the read through crate::base::common::fetch_capped_text(response, url)."
+    echo "     For a genuinely-safe test-only loopback read, add an inline"
+    echo "     '// uncapped-ok: <reason>' marker on the .text() line."
+    exit 1
+fi
+
+echo "PASS — no bare .text().await response reads found in $TARGET"
+exit 0


### PR DESCRIPTION
## Resolves
Closes #438

## Summary
13 production HTTP-body reads across 11 extractor files still read bodies with a bare, uncapped `response.text().await` — the unbounded-memory / OOM exposure against an adversarial or compromised CDN that `fetch_capped_text` (50 MiB streaming cap) exists to prevent (follow-up to PR #437, which only covered the retry fetchers).

- Expose `fetch_capped_text` as `pub(crate)`; route each site through it, preserving each site's error shape (`RdlpError::Network`, anyhow `with_context`, `.ok()?`, `.unwrap_or_default()`, `if let`, `match`). Capping is byte-level/format-agnostic — JSON/XML/HTML/POST parse identically after the cap, so no per-format variant is needed.
- `koreanpornmovie::scrape_durations_from_html_response` gains a `url: &str` param (had no URL in scope); both call sites pass the request URL.

## CI gate
New `scripts/check-no-bare-response-text.sh` bans new bare `.text().await` reads, **wired into `ci.yml`'s lint job + the pre-PR gate command**. Multiline-aware (`rg -U`) so a rustfmt-split chain can't evade; honors an inline `// uncapped-ok: <reason>` marker for genuinely-safe test-only loopback reads (the two mockito test chains carry it, tidied from `.unwrap()` → descriptive `.expect()`). Canary-verified: single-line + multiline production offenders both fail; markered/comment lines and scraper `element.text().collect()` do not.

## Tests
`fetch_capped_text`'s cap is already exercised (`base/common/tests.rs`: over-cap body → `Err(Network)`); the gate guards the no-regression invariant. Full gate green: fmt, clippy `--all-targets`, `cargo test --workspace` (3591 passed), all 6 check scripts.

## Reviews
- security-reviewer: **Approve-with-fixes** — the one blocker (gate not wired into CI) is fixed in this PR; completeness / gate soundness / URL-redaction / behavioral-parity all verified clean.
- code-reviewer: **Approve-with-minor** — same CI-wiring finding (fixed); all 13 routings + signature change verified error-preserving.

## Follow-up
Same-threat-class uncapped `.json().await` reads + an rdlp-downloader DASH manifest read tracked in #508 (out of scope here).