### PR TITLE
perf(extractor): native-first xHamster decrypt + lazy player-JS fetch (#510)

### DIFF
--- a/crates/rdlp-extractor/Cargo.toml
+++ b/crates/rdlp-extractor/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 dash-mpd = { workspace = true, default-features = false }
 log = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 wreq = { workspace = true }
 scraper = { workspace = true }
 serde = { workspace = true }

--- a/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/formats.rs
@@ -16,6 +16,7 @@ use rdlp_core::JsEngine;
 
 use crate::base::common::BaseExtractor;
 
+use super::js_extract::PlayerJsSource;
 use super::patterns;
 
 /// Detect vcodec from URL by checking for `.av1.` or `.h264.` in the path.
@@ -67,7 +68,7 @@ async fn collect_hls_formats(
     hls: &serde_json::Map<String, Value>,
     page_url: &str,
     js_engine: &dyn JsEngine,
-    player_decrypt_js: Option<&str>,
+    player_js: &PlayerJsSource<'_>,
     seen_urls: &mut HashSet<String>,
 ) -> Vec<Format> {
     let mut formats = Vec::new();
@@ -107,7 +108,7 @@ async fn collect_hls_formats(
 
     for (format_id, hls_url) in hls_urls {
         let Some(deciphered) =
-            super::js_extract::decipher_url_via_boa(&hls_url, js_engine, player_decrypt_js).await
+            super::js_extract::decipher_url(&hls_url, js_engine, player_js).await
         else {
             debug!(format_id:?; "[XHamster] Failed to decipher HLS URL");
             continue;
@@ -137,7 +138,7 @@ async fn collect_standard_formats(
     standard: &serde_json::Map<String, Value>,
     page_url: &str,
     js_engine: &dyn JsEngine,
-    player_decrypt_js: Option<&str>,
+    player_js: &PlayerJsSource<'_>,
     seen_urls: &mut HashSet<String>,
 ) -> Vec<Format> {
     let mut formats = Vec::new();
@@ -182,8 +183,7 @@ async fn collect_standard_formats(
                 };
 
                 let Some(deciphered) =
-                    super::js_extract::decipher_url_via_boa(std_url, js_engine, player_decrypt_js)
-                        .await
+                    super::js_extract::decipher_url(std_url, js_engine, player_js).await
                 else {
                     debug!(format_id:?; "[XHamster] Failed to decipher standard URL");
                     continue;
@@ -251,7 +251,7 @@ pub async fn extract_from_initials(
     initials: &Value,
     page_url: &str,
     js_engine: &dyn JsEngine,
-    player_decrypt_js: Option<&str>,
+    player_js: &PlayerJsSource<'_>,
 ) -> Vec<Format> {
     let mut formats = Vec::new();
     let mut seen_urls: HashSet<String> = HashSet::new();
@@ -297,21 +297,15 @@ pub async fn extract_from_initials(
         // Phase 2: HLS sources (encrypted)
         if let Some(hls) = xplayer_sources.get("hls").and_then(|v| v.as_object()) {
             let hls_formats =
-                collect_hls_formats(hls, page_url, js_engine, player_decrypt_js, &mut seen_urls)
-                    .await;
+                collect_hls_formats(hls, page_url, js_engine, player_js, &mut seen_urls).await;
             formats.extend(hls_formats);
         }
 
         // Phase 3: Standard sources (encrypted)
         if let Some(standard) = xplayer_sources.get("standard").and_then(|v| v.as_object()) {
-            let std_formats = collect_standard_formats(
-                standard,
-                page_url,
-                js_engine,
-                player_decrypt_js,
-                &mut seen_urls,
-            )
-            .await;
+            let std_formats =
+                collect_standard_formats(standard, page_url, js_engine, player_js, &mut seen_urls)
+                    .await;
             formats.extend(std_formats);
         }
     } else {
@@ -475,7 +469,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
         assert_eq!(formats.len(), 2);
@@ -529,7 +523,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
         // Same URL should be deduped
@@ -568,7 +562,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
         assert_eq!(formats.len(), 2);
@@ -612,7 +606,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
         assert_eq!(

--- a/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
@@ -1,16 +1,18 @@
-//! Boa-based JS extraction module for XHamster.
+//! JS extraction module for XHamster.
 //!
-//! Provides three public functions for boa-based extraction:
+//! Public entry points:
 //! - [`extract_initials`] — parses `window.initials` (serde-first, boa fallback)
 //! - [`find_player_script_urls`] — discovers player JS URLs from HTML
-//! - [`decipher_url_via_boa`] — decrypts an encrypted URL using boa
+//! - [`decipher_url`] — decrypts a format URL (native fast-path, boa fallback)
+//! - [`PlayerJsSource`] — lazily fetches the player-JS decrypt bundle on demand
 //!
-//! And one async helper:
-//! - [`fetch_player_js`] — downloads player JS bundle from discovered URLs
+//! Crate-internal helpers (reached only via the entry points above):
+//! [`decipher_url_via_boa`] and [`fetch_player_js`].
 
 use lazy_regex::{Lazy, Regex, lazy_regex};
 use log::debug;
 use rdlp_core::JsEngine;
+use tokio::sync::OnceCell;
 
 /// Bundled JS decryption code (port of rdlp-crypto PRNG algorithms).
 const BUNDLED_DECRYPT_JS: &str = include_str!("decrypt.js");
@@ -85,12 +87,94 @@ pub fn find_player_script_urls(webpage: &str) -> Vec<String> {
         .collect()
 }
 
+/// Decipher an encrypted xHamster format URL.
+///
+/// Fast path: the native Rust PRNG port (`rdlp_crypto::xhamster`) decrypts
+/// algorithms 1–7 — the current, stable algorithm set, unchanged since
+/// 2025-11-08 — in microseconds without any JS engine. This is the dominant
+/// on-CPU extraction cost when done through boa (issue #510): the boa path
+/// evaluates the site's ~656 KB player bundle once per encrypted URL.
+///
+/// Only when native decryption returns `None` (an unknown/rotated algorithm ID
+/// or malformed input) does it fall back to boa via [`decipher_url_via_boa`],
+/// which evaluates the site's live player JS (self-healing if xHamster adds a
+/// new algorithm) and then the bundled `decrypt.js`. The native port is
+/// cross-validated against that bundled JS for all 7 algorithms (see the parity
+/// tests), so the fast path is result-identical for the algorithms it handles.
+pub async fn decipher_url(
+    encrypted_url: &str,
+    js_engine: &dyn JsEngine,
+    player_js: &PlayerJsSource<'_>,
+) -> Option<String> {
+    if let Some(decrypted) = rdlp_crypto::xhamster::decipher_format_url(encrypted_url) {
+        return Some(decrypted);
+    }
+    debug!("[XHamster] Native decrypt returned None; falling back to boa");
+    // Only here — the rare unknown/rotated algorithm — is the player bundle
+    // actually needed, so this is where the lazy fetch is triggered (once).
+    decipher_url_via_boa(encrypted_url, js_engine, player_js.get().await).await
+}
+
+/// Source of the site's player-JS decrypt bundle, resolved lazily.
+///
+/// With native-first decryption ([`decipher_url`]) the ~656 KB player bundle is
+/// only needed when the native port cannot handle an algorithm — the rare
+/// rotation case. This defers (and caches) the fetch so the common path pays no
+/// network cost for a bundle it never evaluates (issue #510).
+pub enum PlayerJsSource<'a> {
+    /// Already-resolved bundle (or none). Test-only constructor — production
+    /// always resolves lazily via [`PlayerJsSource::lazy`].
+    #[cfg(test)]
+    Resolved(Option<&'a str>),
+    /// Fetched from the page's player-script URLs on first need, then cached.
+    Lazy {
+        http_client: &'a wreq::Client,
+        page_url: &'a str,
+        script_urls: Vec<String>,
+        cache: OnceCell<Option<String>>,
+    },
+}
+
+impl<'a> PlayerJsSource<'a> {
+    /// Build a lazy source from discovered player-script URLs (no fetch yet).
+    #[must_use]
+    pub fn lazy(
+        http_client: &'a wreq::Client,
+        page_url: &'a str,
+        script_urls: Vec<String>,
+    ) -> Self {
+        Self::Lazy {
+            http_client,
+            page_url,
+            script_urls,
+            cache: OnceCell::new(),
+        }
+    }
+
+    /// Resolve the player JS, fetching (and caching) once on first need.
+    async fn get(&self) -> Option<&str> {
+        match self {
+            #[cfg(test)]
+            Self::Resolved(v) => *v,
+            Self::Lazy {
+                http_client,
+                page_url,
+                script_urls,
+                cache,
+            } => cache
+                .get_or_init(|| fetch_player_js(script_urls, http_client, page_url))
+                .await
+                .as_deref(),
+        }
+    }
+}
+
 /// Decipher an encrypted XHamster URL using boa.
 ///
 /// If `player_decrypt_js` is provided, tries to find and call the site's own
 /// decryption function first. Falls back to the bundled `decrypt.js` (loaded
 /// via `include_str!`). Returns the decrypted URL or `None`.
-pub async fn decipher_url_via_boa(
+pub(crate) async fn decipher_url_via_boa(
     encrypted_url: &str,
     js_engine: &dyn JsEngine,
     player_decrypt_js: Option<&str>,
@@ -111,7 +195,7 @@ pub async fn decipher_url_via_boa(
 ///
 /// Tries each URL in order, returning the first response body that contains
 /// known decryption-related constants. Returns `None` if no suitable JS is found.
-pub async fn fetch_player_js(
+pub(crate) async fn fetch_player_js(
     script_urls: &[String],
     http_client: &wreq::Client,
     page_url: &str,
@@ -475,6 +559,103 @@ mod tests {
     }
 
     // =========================================================================
+    // native-first decrypt fast path (issue #510, Finding B)
+    // =========================================================================
+
+    /// Test engine returning a fixed sentinel from every eval — proves the boa
+    /// fallback path was actually reached (native decrypt returned `None`).
+    struct SentinelEngine;
+
+    #[async_trait::async_trait]
+    impl rdlp_core::JsEngine for SentinelEngine {
+        async fn eval(&self, _code: &str) -> rdlp_core::Result<serde_json::Value> {
+            Ok(serde_json::Value::String(
+                "SENTINEL://decrypted".to_string(),
+            ))
+        }
+
+        async fn eval_with_context(
+            &self,
+            _code: &str,
+            _context: &serde_json::Value,
+        ) -> rdlp_core::Result<serde_json::Value> {
+            unreachable!("decipher_url does not call eval_with_context")
+        }
+
+        async fn call_function(
+            &self,
+            _function_name: &str,
+            _args: &[serde_json::Value],
+        ) -> rdlp_core::Result<serde_json::Value> {
+            unreachable!("decipher_url does not call call_function")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decipher_url_native_fast_path_skips_boa() {
+        // A known-algorithm (1-7) ciphertext must decrypt via the native Rust
+        // port WITHOUT invoking boa. NeverEvalEngine errors on any eval, so if
+        // control reaches boa the result is None and this assertion fails.
+        let hex = encrypt_test_vector(1, 42, "https://cdn.example.com/media=hls4/video.m3u8");
+        let result = decipher_url(&hex, &NeverEvalEngine, &PlayerJsSource::Resolved(None)).await;
+        assert_eq!(
+            result.as_deref(),
+            Some("https://cdn.example.com/media=hls4/video.m3u8"),
+            "native port must decrypt algo 1-7 without touching boa"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decipher_url_unknown_algo_falls_back_to_boa() {
+        // Algorithm id 0 is unknown to the native port (returns None) — control
+        // must fall back to boa. SentinelEngine returns a fixed string from
+        // eval, proving the boa fallback was actually reached.
+        let result = decipher_url(
+            "000000000041424344",
+            &SentinelEngine,
+            &PlayerJsSource::Resolved(None),
+        )
+        .await;
+        assert_eq!(
+            result.as_deref(),
+            Some("SENTINEL://decrypted"),
+            "unknown algorithm must fall back to the boa path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decipher_url_native_success_skips_lazy_fetch() {
+        // The core #510 invariant: when native decryption succeeds, the ~656 KB
+        // player-JS bundle must NOT be fetched. Uses a real `Lazy` source (not
+        // `Resolved`) so a future refactor that eagerly fetches would fail here.
+        let mut server = mockito::Server::new_async().await;
+        let player_endpoint = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("charCodeAt 1664525")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let client = wreq::Client::new();
+        let script_url = format!("{}/xplayer.js", server.url());
+        let player_js =
+            PlayerJsSource::lazy(&client, "https://xhamster.com/videos/x", vec![script_url]);
+
+        // Valid algo-1 ciphertext: native decrypts it, so neither boa nor the
+        // lazy fetch is reached.
+        let hex = encrypt_test_vector(1, 42, "https://cdn.example.com/media=hls4/v.m3u8");
+        let result = decipher_url(&hex, &NeverEvalEngine, &player_js).await;
+
+        assert_eq!(
+            result.as_deref(),
+            Some("https://cdn.example.com/media=hls4/v.m3u8")
+        );
+        // expect(0): the player-JS endpoint must not have been requested.
+        player_endpoint.assert_async().await;
+    }
+
+    // =========================================================================
     // Bundled JS unit tests
     // =========================================================================
 
@@ -598,7 +779,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
 
@@ -638,7 +819,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
 
@@ -677,7 +858,7 @@ mod tests {
             &initials,
             "https://xhamster.com/videos/test-123",
             &engine,
-            None,
+            &PlayerJsSource::Resolved(None),
         )
         .await;
 

--- a/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/mod.rs
@@ -112,10 +112,12 @@ impl XHamsterExtractor {
             }
         };
 
-        // Discover and fetch player JS for decryption
+        // Discover player-JS script URLs. The ~656 KB bundle itself is fetched
+        // lazily — only if native decryption fails for some URL (rare rotated
+        // algorithm), so the common path pays no fetch cost (issue #510).
         let player_script_urls = js_extract::find_player_script_urls(&webpage);
         let player_js =
-            js_extract::fetch_player_js(&player_script_urls, &ctx.http_client, &url).await;
+            js_extract::PlayerJsSource::lazy(&ctx.http_client, &url, player_script_urls);
 
         // Try modern layout: window.initials JSON
         let (mut info, formats) = if let Some(initials) = initials {
@@ -142,13 +144,9 @@ impl XHamsterExtractor {
                 )
             };
 
-            let formats = formats::extract_from_initials(
-                &initials,
-                &url,
-                ctx.js_engine.as_ref(),
-                player_js.as_deref(),
-            )
-            .await;
+            let formats =
+                formats::extract_from_initials(&initials, &url, ctx.js_engine.as_ref(), &player_js)
+                    .await;
             (info, formats)
         } else {
             // Legacy fallback


### PR DESCRIPTION
## Summary

The #510 profiling showed the dominant boa cost is xHamster's decrypt path evaluating the site's **~656 KB `xplayer.js` bundle once per encrypted format URL**. This adds the native Rust PRNG port (`rdlp_crypto::xhamster::decipher_format_url`, already cross-validated against the bundled JS for all 7 algorithms) as a **fast-path before boa**:

- `decipher_url` tries native first — algorithms 1–7 (the stable set, unchanged since 2025-11-08) decrypt in microseconds with no JS engine.
- On native `None` (an unknown/rotated algorithm ID or malformed input), it falls back to `decipher_url_via_boa` (live player JS → bundled `decrypt.js`). **boa stays** as the dynamic-dispatch fallback — other extractors (EPorner `calc_hash`, generic deobfuscation) still need it.
- The 656 KB player bundle is now fetched **lazily** (`PlayerJsSource` + tokio `OnceCell`) only when native fails for some URL, so the common path pays neither the eval nor the fetch cost.

## Measured (real-URL flamegraph, same 1.595 GB video, identical download)

| | boa self-time |
|---|---|
| Baseline (all-boa) | 41.6% |
| After serde `window.initials` (#512) | 36.1% |
| **After this PR** | **18.49%** |

~56% total reduction in boa on-CPU time from baseline; B alone more than halved the residual (36.1% → 18.5%). The same video downloaded correctly end-to-end, confirming native-first yields working URLs. The native port was also verified current against the live 2026-07-18 ciphertexts (algos 1/3/5 → valid `xhcdn` URLs).

**Remaining 18.5% residual:** boa still evaluates the bundle for the malformed short `fallback` fields (e.g. `02e7b7d11b`, 10 hex chars) — native correctly returns `None` (too short to be valid ciphertext), so they fall to boa, which also fails. Eliminating those wasted evals is a distinct, follow-up optimization (a "skip boa for sub-ciphertext-length input" guard) tracked separately — see the follow-up issue.

## Design research (cited)

- yt-dlp decrypts this exact cipher **100% natively in Python** — no JS fetch/eval anywhere — i.e. native-first is the upstream-accepted approach.
- The algorithm set has been stable at 7 IDs for ~8.3 months; the boa fallback is a rare path (site *adds* IDs, historically ~once), not a routine one.
- Fallback contract: native `None` is the sole boa trigger (no per-request boa re-verification — that would reintroduce the cost). Constant-drift on a supported ID is guarded by the existing cross-validation parity tests.

## Reviews

- **security-reviewer: Approve** — native path fails safe on all malformed/attacker input; algos 1–7 parity means no silent divergence; trust boundary + SSRF gate untouched; `OnceCell` sequential use correct; no info disclosure.
- **code-reviewer: Approve** (with the tokio-audit lens) — `OnceCell` is the correct primitive, no double-fetch/deadlock, negative caching correct. All three of its non-blocking findings are fixed in this PR:
  1. Added `test_decipher_url_native_success_skips_lazy_fetch` (mockito `expect(0)`) guarding the "native success ⇒ no 656 KB fetch" invariant using the real `Lazy` path.
  2. Tightened `decipher_url_via_boa` / `fetch_player_js` to `pub(crate)`; refreshed the module doc.
  3. Fixed the local `crate-infra.md` doc drift.

## Tests

- `test_decipher_url_native_fast_path_skips_boa` — `NeverEvalEngine` proves native skips boa (failing-first).
- `test_decipher_url_unknown_algo_falls_back_to_boa` — `SentinelEngine` proves the boa fallback is reached.
- `test_decipher_url_native_success_skips_lazy_fetch` — mockito `expect(0)` proves no player-JS fetch on the common path.
- Pre-existing algo 1–7 parity tests back the native/boa result-identity.

Gate green: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, all 6 CI check scripts.

Closes #510
