### PR TITLE
perf(extractor): skip boa decrypt for sub-header-length xHamster fields (#514)

### DIFF
--- a/crates/rdlp-crypto/src/xhamster.rs
+++ b/crates/rdlp-crypto/src/xhamster.rs
@@ -39,6 +39,14 @@ use url::Url;
 
 use crate::prng::ByteGenerator;
 
+/// Minimum decoded length of a valid ciphertext payload: a 1-byte algorithm ID
+/// plus a 4-byte little-endian seed (the header) plus at least one ciphertext
+/// byte. Inputs that hex-decode to fewer bytes cannot be valid ciphertext for
+/// *any* algorithm — there is no room for the header — so decryption rejects
+/// them before an algorithm is ever selected. A bare-hex string therefore needs
+/// at least `MIN_CIPHERTEXT_BYTES * 2` hex characters.
+const MIN_CIPHERTEXT_BYTES: usize = 6;
+
 /// Pattern to extract hex-encoded ciphertext and remainder from URL path.
 ///
 /// The path starts with `/{hex}{remainder}` where hex is 12+ hex chars
@@ -84,6 +92,35 @@ pub fn decipher_format_url(format_url: &str) -> Option<String> {
     decipher_bare_hex(format_url)
 }
 
+/// Returns `true` if `format_url` is *structurally* capable of being valid
+/// `XHamster` ciphertext.
+///
+/// Plausible means it carries a hex payload that decodes to at least
+/// [`MIN_CIPHERTEXT_BYTES`] bytes (algorithm ID + seed + ≥1 ciphertext byte),
+/// via either accepted input form (full URL with hex path, or bare hex).
+///
+/// This is deliberately weaker than [`decipher_format_url`]: it does **not**
+/// inspect the algorithm ID, so a genuinely-rotated ciphertext whose algorithm
+/// this port does not yet know still returns `true`. It exists so callers can
+/// cheaply skip an expensive JS-engine decrypt fallback for inputs too short to
+/// be ciphertext under *any* algorithm — e.g. the malformed sub-header
+/// `fallback` fields in `xplayerSettings.sources` (issue #514) — where the JS
+/// path would only fail after evaluating a large player bundle.
+#[must_use]
+pub fn could_be_ciphertext(format_url: &str) -> bool {
+    // Path 1: a full URL whose path carries a hex segment (12+ hex chars, i.e.
+    // ≥ MIN_CIPHERTEXT_BYTES bytes) — the rotated-algorithm URL a JS fallback
+    // could still self-heal.
+    if let Ok(parsed) = Url::parse(format_url)
+        && HEX_PATH_PATTERN.is_match(parsed.path())
+    {
+        return true;
+    }
+
+    // Path 2: a bare hex string long enough to carry the algo+seed header.
+    is_plausible_bare_hex(format_url)
+}
+
 /// Decipher a full URL that contains a hex-encoded path segment.
 ///
 /// The URL path has the form `/{hex_string}/{remainder}` where the hex portion
@@ -110,11 +147,7 @@ fn decipher_url_with_hex_path(parsed: &Url) -> Option<String> {
 /// The entire string is hex, and the deciphered plaintext is returned directly
 /// (typically a full URL).
 fn decipher_bare_hex(hex_str: &str) -> Option<String> {
-    // Quick check: must be all hex chars and even length
-    if hex_str.len() < 12 || !hex_str.len().is_multiple_of(2) {
-        return None;
-    }
-    if !hex_str.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if !is_plausible_bare_hex(hex_str) {
         return None;
     }
 
@@ -124,13 +157,24 @@ fn decipher_bare_hex(hex_str: &str) -> Option<String> {
     Some(deciphered)
 }
 
+/// Structural check for a bare hex ciphertext string: long enough to carry the
+/// algo+seed header ([`MIN_CIPHERTEXT_BYTES`]), even length (whole bytes), and
+/// all ASCII hex digits. Shared by [`decipher_bare_hex`] (the decrypt path) and
+/// [`could_be_ciphertext`] (the plausibility gate) so both agree on exactly what
+/// counts as a decodable bare-hex payload.
+fn is_plausible_bare_hex(hex_str: &str) -> bool {
+    hex_str.len() >= MIN_CIPHERTEXT_BYTES * 2
+        && hex_str.len().is_multiple_of(2)
+        && hex_str.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// Core decryption: decode hex to bytes, extract algorithm + seed, XOR with PRNG stream.
-// The `byte_data.len() < 6` guard above each index/slice makes these infallible;
-// `indexing_slicing` cannot see through the early-return guard.
+// The `byte_data.len() < MIN_CIPHERTEXT_BYTES` guard above each index/slice makes
+// these infallible; `indexing_slicing` cannot see through the early-return guard.
 #[allow(clippy::indexing_slicing)]
 fn decipher_hex_bytes(hex_str: &str) -> Option<String> {
     let byte_data = hex::decode(hex_str).ok()?;
-    if byte_data.len() < 6 {
+    if byte_data.len() < MIN_CIPHERTEXT_BYTES {
         trace!("[XHamster] Hex data too short: {} bytes", byte_data.len());
         return None;
     }
@@ -199,5 +243,51 @@ mod tests {
         assert!(HEX_PATH_PATTERN.is_match("/ABCDEF123456789012/path,extra"));
         assert!(!HEX_PATH_PATTERN.is_match("/abc/something")); // Too short
         assert!(!HEX_PATH_PATTERN.is_match("/abcdef12345g/something")); // Non-hex char
+    }
+
+    // =========================================================================
+    // could_be_ciphertext — plausibility gate for the JS decrypt fallback (#514)
+    // =========================================================================
+
+    #[test]
+    fn test_could_be_ciphertext_rejects_sub_header_fallback_field() {
+        // The real malformed `fallback` field this gate targets: 10 hex chars =
+        // 5 bytes, one short of the 6-byte algo+seed+cipher minimum. No algorithm
+        // can decrypt it, so the JS fallback must be skipped.
+        assert!(!could_be_ciphertext("02e7b7d11b"));
+    }
+
+    #[test]
+    fn test_could_be_ciphertext_boundary_five_vs_six_bytes() {
+        // Boundary of MIN_CIPHERTEXT_BYTES (6). 5 bytes (10 hex) is rejected;
+        // exactly 6 bytes (12 hex) is accepted — a `>=`/`>` off-by-one flips one.
+        assert!(!could_be_ciphertext("0011223344")); // 10 hex chars = 5 bytes
+        assert!(could_be_ciphertext("001122334455")); // 12 hex chars = 6 bytes
+    }
+
+    #[test]
+    fn test_could_be_ciphertext_unknown_algo_still_plausible() {
+        // Algorithm ID 0 is unknown to this port, so decipher_format_url returns
+        // None — but the input IS structurally valid ciphertext (9 bytes), so the
+        // gate keeps the JS self-heal path open. Fallback must stay intact.
+        assert!(decipher_format_url("000000000041424344").is_none());
+        assert!(could_be_ciphertext("000000000041424344"));
+    }
+
+    #[test]
+    fn test_could_be_ciphertext_rejects_odd_length_and_non_hex() {
+        assert!(!could_be_ciphertext("00112233445")); // 11 chars = odd, not whole bytes
+        assert!(!could_be_ciphertext("001122334z55")); // non-hex digit
+        assert!(!could_be_ciphertext("")); // empty
+    }
+
+    #[test]
+    fn test_could_be_ciphertext_full_url_with_hex_path() {
+        // A rotated-algorithm URL form (12+ hex path segment) stays plausible.
+        assert!(could_be_ciphertext(
+            "https://cdn.example.com/000000000041424344/,720p.mp4"
+        ));
+        // A plain URL with no hex path segment is not ciphertext.
+        assert!(!could_be_ciphertext("https://example.com/video.mp4"));
     }
 }

--- a/crates/rdlp-crypto/src/xhamster.rs
+++ b/crates/rdlp-crypto/src/xhamster.rs
@@ -50,11 +50,18 @@ const MIN_CIPHERTEXT_BYTES: usize = 6;
 /// Pattern to extract hex-encoded ciphertext and remainder from URL path.
 ///
 /// The path starts with `/{hex}{remainder}` where hex is 12+ hex chars
-/// and remainder starts with `/` or `,`.
+/// and remainder starts with `/` or `,`. The `{12,}` minimum is
+/// `MIN_CIPHERTEXT_BYTES * 2` (a regex literal cannot reference the const);
+/// the static assertion below keeps the two in lock-step so the URL-path and
+/// bare-hex arms of [`could_be_ciphertext`] stay a faithful mirror.
 #[allow(clippy::expect_used)] // LazyLock<Regex>: hardcoded literal, panic = programming error caught at first use
 static HEX_PATH_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^/(?P<hex>[0-9a-fA-F]{12,})(?P<rem>[/,].+)$").expect("Valid hex path pattern")
 });
+
+// If MIN_CIPHERTEXT_BYTES changes, the `{12,}` in HEX_PATH_PATTERN above must
+// change with it — this trips a compile error to force that.
+const _: () = assert!(MIN_CIPHERTEXT_BYTES * 2 == 12);
 
 /// Decipher an encrypted `XHamster` format URL.
 ///
@@ -289,5 +296,18 @@ mod tests {
         ));
         // A plain URL with no hex path segment is not ciphertext.
         assert!(!could_be_ciphertext("https://example.com/video.mp4"));
+    }
+
+    #[test]
+    fn test_could_be_ciphertext_url_hex_path_boundary() {
+        // Same MIN_CIPHERTEXT_BYTES boundary via the URL-path arm: an 11-hex
+        // segment (< 12 = < 6 bytes) fails HEX_PATH_PATTERN and is rejected;
+        // exactly 12 hex chars is accepted.
+        assert!(!could_be_ciphertext(
+            "https://cdn.example.com/0011223344a/,720p.mp4" // 11 hex chars
+        ));
+        assert!(could_be_ciphertext(
+            "https://cdn.example.com/001122334455/,720p.mp4" // 12 hex chars
+        ));
     }
 }

--- a/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
+++ b/crates/rdlp-extractor/src/extractors/xhamster/js_extract.rs
@@ -95,12 +95,17 @@ pub fn find_player_script_urls(webpage: &str) -> Vec<String> {
 /// on-CPU extraction cost when done through boa (issue #510): the boa path
 /// evaluates the site's ~656 KB player bundle once per encrypted URL.
 ///
-/// Only when native decryption returns `None` (an unknown/rotated algorithm ID
-/// or malformed input) does it fall back to boa via [`decipher_url_via_boa`],
-/// which evaluates the site's live player JS (self-healing if xHamster adds a
-/// new algorithm) and then the bundled `decrypt.js`. The native port is
-/// cross-validated against that bundled JS for all 7 algorithms (see the parity
-/// tests), so the fast path is result-identical for the algorithms it handles.
+/// When native decryption returns `None`, boa is used as a fallback via
+/// [`decipher_url_via_boa`] — but only if the input is still *structurally*
+/// plausible ciphertext (`rdlp_crypto::xhamster::could_be_ciphertext`): a
+/// full-length unknown/rotated-algorithm URL boa might self-heal by evaluating
+/// the site's live player JS, then the bundled `decrypt.js`. Inputs too short to
+/// carry the algo+seed header (e.g. the malformed sub-header `fallback` fields
+/// in `xplayerSettings.sources`) are rejected without invoking boa — no
+/// algorithm could decrypt them, so a bundle eval would be pure wasted work
+/// (issue #514). The native port is cross-validated against the bundled JS for
+/// all 7 algorithms (see the parity tests), so the fast path is result-identical
+/// for the algorithms it handles.
 pub async fn decipher_url(
     encrypted_url: &str,
     js_engine: &dyn JsEngine,
@@ -108,6 +113,17 @@ pub async fn decipher_url(
 ) -> Option<String> {
     if let Some(decrypted) = rdlp_crypto::xhamster::decipher_format_url(encrypted_url) {
         return Some(decrypted);
+    }
+    // Native returned None. Only fall back to the expensive boa path (which
+    // evaluates the ~656 KB player bundle) when the input is *structurally*
+    // plausible ciphertext for some algorithm — i.e. a rotated/unknown-algorithm
+    // URL boa might self-heal. Inputs too short to carry the algo+seed header —
+    // e.g. the malformed `fallback` fields in `xplayerSettings.sources` — cannot
+    // decrypt under any algorithm, so boa would only waste a bundle eval on them
+    // (issue #514). Skipping them is behavior-preserving for the output.
+    if !rdlp_crypto::xhamster::could_be_ciphertext(encrypted_url) {
+        debug!("[XHamster] Input too short to be ciphertext; skipping boa fallback");
+        return None;
     }
     debug!("[XHamster] Native decrypt returned None; falling back to boa");
     // Only here — the rare unknown/rotated algorithm — is the player bundle
@@ -651,6 +667,37 @@ mod tests {
             result.as_deref(),
             Some("https://cdn.example.com/media=hls4/v.m3u8")
         );
+        // expect(0): the player-JS endpoint must not have been requested.
+        player_endpoint.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_decipher_url_short_fallback_field_skips_boa() {
+        // Issue #514: xplayerSettings.sources carries malformed `fallback` fields
+        // shorter than the 6-byte algo+seed header (e.g. "02e7b7d11b" = 5 bytes).
+        // Native decrypt returns None on these, but so would boa — they aren't
+        // valid ciphertext for any algorithm. The gate must skip the boa fallback
+        // entirely, so neither the ~656 KB player-JS fetch nor an eval happens.
+        let mut server = mockito::Server::new_async().await;
+        let player_endpoint = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("charCodeAt 1664525")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let client = wreq::Client::new();
+        let script_url = format!("{}/xplayer.js", server.url());
+        let player_js =
+            PlayerJsSource::lazy(&client, "https://xhamster.com/videos/x", vec![script_url]);
+
+        // NeverEvalEngine errors on any eval, so reaching boa would also be
+        // observable as a failure — but the expect(0) fetch guard is the load-
+        // bearing proof the boa path was never entered.
+        let result = decipher_url("02e7b7d11b", &NeverEvalEngine, &player_js).await;
+
+        assert_eq!(result, None, "sub-header-length field must not decrypt");
         // expect(0): the player-JS endpoint must not have been requested.
         player_endpoint.assert_async().await;
     }


### PR DESCRIPTION
## Resolves

Closes #514.

## What

After #513 shipped native-first xHamster decrypt, a real-URL flamegraph showed a **residual ~18.5% boa self-time**: for each malformed short `fallback` field in `xplayerSettings.sources` (e.g. `02e7b7d11b` — 10 hex chars = 5 bytes, below the 6-byte algo+seed header), native `decipher_format_url` correctly returns `None`, and the code then falls back to boa — which evaluates the ~656 KB `xplayer.js` bundle and *also* fails. Pure wasted work, ~5 such fields per extraction.

This adds a structural plausibility gate so those inputs never reach boa.

## How

- **`rdlp_crypto::xhamster::could_be_ciphertext(&str) -> bool`** — returns `true` only if the input can structurally carry the algo+seed header (hex-decodes to ≥ `MIN_CIPHERTEXT_BYTES` bytes), via either accepted input form: full-URL-with-hex-path (shared `HEX_PATH_PATTERN`) or bare hex (shared `is_plausible_bare_hex`). It deliberately **ignores the algorithm ID**, so a genuinely-rotated/unknown-algorithm URL still returns `true` and boa's self-heal path stays intact.
- **`decipher_url`** (js_extract.rs) — after native returns `None`, returns `None` (skipping both the boa eval *and* the lazy 656 KB player-JS fetch) when `!could_be_ciphertext(input)`. Behavior-preserving for the output: an input too short for any algorithm could never have decrypted via boa either.
- Lifts the `< 6` bytes / `< 12` hex-chars magic numbers into one `MIN_CIPHERTEXT_BYTES` const; extracts `is_plausible_bare_hex` shared by `decipher_bare_hex` and the new gate (single source of truth — no duplicated hex/length logic). A `const _` static assertion pins `HEX_PATH_PATTERN`'s `{12,}` to `MIN_CIPHERTEXT_BYTES * 2`.

## Tests

- Failing-first integration test (`test_decipher_url_short_fallback_field_skips_boa`): a 5-byte field skips boa — proven by mockito `expect(0)` on the player-JS endpoint + `NeverEvalEngine`. Verified RED against unpatched (1 fetch → assert fails), GREEN after.
- Boundary pinned on both sides of `MIN_CIPHERTEXT_BYTES` (5 vs 6 bytes) for both the bare-hex and URL-path arms; unknown-algo input asserted to keep the fallback reachable (`decipher_format_url` None **and** `could_be_ciphertext` true); odd-length / non-hex / empty negatives.
- Existing `test_decipher_url_unknown_algo_falls_back_to_boa` still passes (self-heal intact).

## Acceptance (#514)

- ✅ Malformed sub-ciphertext-length fields no longer trigger a boa eval (test-proven).
- ✅ Genuinely-rotated full-length ciphertext still reaches boa.
- ⏳ Re-measure of boa self-time on the #510 reference video deferred to a follow-up profiling note (the eval is now unreachable for those fields by construction + test proof).

## Reviews

- **security-reviewer**: PASS / Approve — no blocking findings. Verified the gate is a permissive superset of `decipher_format_url`'s structural acceptance (cannot wrongly drop valid ciphertext), panic-free on adversarial input, net-negative resource use, no raw-URL logging, no change to the downstream SSRF gate.
- **code-reviewer**: Approve with minor fixes — both Low findings applied in this PR (const/regex static-assert linkage; URL-path boundary test).

## Gate

`cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test`, and the repo `check-*.sh` scripts (url-redaction, no-bare-response-text, dedup, log-redaction) all pass.
