### PR TITLE
fix(postprocess): normalize thumbnail to JPEG before MP4 embed (#519)

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/image_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/image_convert.rs
@@ -102,6 +102,11 @@ impl FFmpegRunner {
 
         // Decompression-bomb guard: reject an oversized declared canvas before
         // any frame buffer is allocated (the thumbnail is attacker-controlled).
+        // `decoder.width()/height()` come from the container header (parsed by
+        // `find_stream_info`), so this fires before the codec sizes its per-pixel
+        // decode buffer — the load-bearing property. Still-image codecs
+        // (webp/png/jpeg) don't renegotiate resolution mid-stream, so the header
+        // dims are authoritative here.
         ensure_thumbnail_dimensions(decoder.width(), decoder.height())
             .with_context(|| format!("thumbnail {} rejected", src.display()))?;
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/image_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/image_convert.rs
@@ -1,0 +1,205 @@
+//! Still-image normalization to baseline MJPEG (`.jpg`).
+//!
+//! `transcode_image` decodes a single still image in any `FFmpeg`-readable
+//! format (webp, png, …) and re-encodes it as baseline MJPEG in a `.jpg`
+//! container. This is the single normalization point for "make this image
+//! MP4-embeddable" — MP4/MOV/M4A/M4V have no muxer tag for `webp` (or most
+//! other still-image codecs), so `ThumbnailStage` calls this before both the
+//! `embed_thumbnail` `ATTACHED_PIC` pass and the `mp4ameta` `covr` atom pass
+//! for any container that isn't Matroska (which attaches the source codec
+//! natively; see `thumbnail/mkv_raw_ffi.rs`).
+//!
+//! # Lint allowances
+//!
+//! - `clippy::cast_*`: `FFmpeg` APIs use mixed C integer types; all casts are
+//!   audited and within valid ranges for `FFmpeg`-returned values.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless
+)]
+
+use std::path::Path;
+
+use anyhow::Context as _;
+
+use crate::error::{PostProcessError, Result};
+
+use super::super::{FFmpegRunner, ensure_init};
+
+/// MJPEG `qscale` value used when normalizing a thumbnail image, set via
+/// `AV_CODEC_FLAG_QSCALE` and `global_quality` (`FFmpegRunner::set_vbr_quality`).
+/// `FFmpeg`'s `mjpeg` encoder quantizer scale runs 1 (best) to 31 (worst); 3
+/// matches the `FFmpeg` CLI's default `-q:v` range for "visually lossless"
+/// JPEG output and keeps a thumbnail-sized image small without visible blocking.
+const THUMBNAIL_MJPEG_QSCALE: i32 = 3;
+
+impl FFmpegRunner {
+    /// Normalize a still image to baseline MJPEG (`.jpg`) on a background thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `FFmpeg` fails to open the input, find a video
+    /// stream, decode the frame, open the `mjpeg` encoder, or write/mux the
+    /// output.
+    pub async fn transcode_image(
+        &self,
+        src: impl AsRef<Path>,
+        dst: impl AsRef<Path>,
+    ) -> Result<()> {
+        let src = src.as_ref().to_path_buf();
+        let dst = dst.as_ref().to_path_buf();
+        Self::spawn_blocking("transcode_image", move || -> Result<()> {
+            Ok(Self::transcode_image_sync(&src, &dst)?)
+        })
+        .await
+    }
+
+    /// Decode the first video frame of `src` and encode it as baseline MJPEG to `dst`.
+    fn transcode_image_sync(src: &Path, dst: &Path) -> anyhow::Result<()> {
+        ensure_init()?;
+
+        // FFmpeg's still-image decoders are chatty at info/warning level about
+        // things like unsupported ICC profiles; we only care about hard failures.
+        let _suppress = super::super::log_capture::LogSuppressGuard::error_level();
+
+        let mut ictx = ffmpeg_the_third::format::input(src)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to open image input {}", src.display()))?;
+
+        let ist = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Video)
+            .ok_or(PostProcessError::NoVideoStream)?;
+        let ist_index = ist.index();
+        let ist_time_base = ist.time_base();
+
+        let dec_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())?;
+        let mut decoder = dec_ctx.decoder().video()?;
+
+        let mut octx = ffmpeg_the_third::format::output(dst)
+            .map_err(PostProcessError::from)
+            .with_context(|| format!("failed to create image output {}", dst.display()))?;
+
+        let mjpeg_codec = ffmpeg_the_third::encoder::find_by_name("mjpeg").ok_or_else(|| {
+            PostProcessError::UnsupportedCodec {
+                codec: "mjpeg".to_string(),
+                operation: "thumbnail image normalization".into(),
+            }
+        })?;
+
+        let needs_global_header = octx
+            .format()
+            .flags()
+            .contains(ffmpeg_the_third::format::Flags::GLOBAL_HEADER);
+
+        let ost_index;
+        {
+            let ost = octx
+                .add_stream(mjpeg_codec)
+                .map_err(PostProcessError::from)
+                .context("failed to add output stream for image normalization")?;
+            ost_index = ost.index();
+        }
+
+        let enc_context = ffmpeg_the_third::codec::context::Context::new_with_codec(mjpeg_codec);
+        let mut encoder = enc_context.encoder().video()?;
+        encoder.set_width(decoder.width());
+        encoder.set_height(decoder.height());
+        let target_pix_fmt = Self::pick_video_pixel_format(&mjpeg_codec, decoder.format());
+        encoder.set_format(target_pix_fmt);
+
+        // Still-image decoders (webp, png, …) commonly produce full-range
+        // (JPEG-range) YUV frames on a plain (non-`YUVJ*`) pixel format —
+        // `pick_video_pixel_format` picks the encoder-supported format closest
+        // to the decoder's, which for `mjpeg` is typically the same plain
+        // format. At the default `Normal` compliance level libavcodec's mjpeg
+        // encoder rejects that combination ("Non full-range YUV is
+        // non-standard"). `Unofficial` is exactly the compliance level
+        // FFmpeg's own error message names as the fix, and is safe here: this
+        // encoder is used only for thumbnail normalization, never a
+        // spec-sensitive delivery path.
+        encoder.compliance(ffmpeg_the_third::codec::Compliance::Unofficial);
+
+        // A still image is a single-frame stream; the tick rate is otherwise
+        // meaningless. 1/1 (one frame per "second") is the conventional choice
+        // FFmpeg's own image2 muxer path uses for single-frame output.
+        let enc_time_base = ffmpeg_the_third::Rational(1, 1);
+        encoder.set_time_base(enc_time_base);
+        encoder.set_frame_rate(Some(enc_time_base));
+
+        if needs_global_header {
+            // SAFETY: encoder is a valid pre-open encoder context.
+            Self::set_global_header_flag(unsafe { encoder.as_mut_ptr() });
+        }
+        // SAFETY: encoder is a valid pre-open encoder context.
+        Self::set_vbr_quality(unsafe { encoder.as_mut_ptr() }, THUMBNAIL_MJPEG_QSCALE);
+
+        let mut encoder = encoder
+            .open_as(mjpeg_codec)
+            .map_err(PostProcessError::from)
+            .context("failed to open mjpeg encoder for image normalization")?;
+
+        // SAFETY: octx owns ost_index (just added above); encoder was just opened.
+        Self::copy_encoder_params_to_stream(&mut octx, ost_index, unsafe { encoder.as_ptr() });
+
+        octx.write_header()
+            .map_err(PostProcessError::from)
+            .context("failed to write output header for image normalization")?;
+
+        let mut filter_graph = Self::build_video_filter(&decoder, &encoder, ist_time_base)?;
+
+        for result in ictx.packets() {
+            let (stream, packet) = result
+                .map_err(PostProcessError::from)
+                .context("failed to read packet during image normalization")?;
+            if stream.index() != ist_index {
+                continue;
+            }
+            decoder.send_packet(&packet)?;
+            Self::receive_and_process_video(
+                &mut decoder,
+                &mut filter_graph,
+                &mut encoder,
+                &mut octx,
+                ost_index,
+                enc_time_base,
+                ist_time_base,
+            )?;
+        }
+
+        // Flush decoder -> filter -> encoder.
+        decoder.send_eof()?;
+        Self::receive_and_process_video(
+            &mut decoder,
+            &mut filter_graph,
+            &mut encoder,
+            &mut octx,
+            ost_index,
+            enc_time_base,
+            ist_time_base,
+        )?;
+        filter_graph
+            .get("in")
+            .ok_or_else(|| PostProcessError::ffmpeg_failed("image filter node 'in' not found"))?
+            .source()
+            .flush()?;
+        Self::drain_video_filter_to_encoder(
+            &mut filter_graph,
+            &mut encoder,
+            &mut octx,
+            ost_index,
+            enc_time_base,
+            ist_time_base,
+        )?;
+        encoder.send_eof()?;
+        Self::drain_video_encoder_packets(&mut encoder, &mut octx, ost_index, enc_time_base)?;
+
+        octx.write_trailer()
+            .map_err(PostProcessError::from)
+            .context("failed to write output trailer for image normalization")?;
+
+        Ok(())
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/image_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/image_convert.rs
@@ -35,6 +35,28 @@ use super::super::{FFmpegRunner, ensure_init};
 /// JPEG output and keeps a thumbnail-sized image small without visible blocking.
 const THUMBNAIL_MJPEG_QSCALE: i32 = 3;
 
+/// Maximum accepted thumbnail edge length, in pixels (decompression-bomb guard).
+///
+/// Thumbnails are attacker-controlled (served by the video site) and the
+/// download layer caps only the *encoded* file size (`MAX_THUMBNAIL_BYTES`),
+/// not decoded dimensions — a small, size-cap-compliant still image can declare
+/// an enormous canvas that decodes to a multi-gigabyte raw frame. 8192 is
+/// generous for any legitimate cover image (4K is 3840 wide) while bounding the
+/// decode buffer to a safe size. Oversized inputs are rejected before any frame
+/// buffer is allocated; `ThumbnailStage` then falls back to the original file
+/// (the embed is non-fatal).
+const MAX_THUMBNAIL_DIMENSION: u32 = 8192;
+
+/// Reject a thumbnail whose declared canvas exceeds [`MAX_THUMBNAIL_DIMENSION`]
+/// on either axis, before any decode buffer is allocated.
+fn ensure_thumbnail_dimensions(width: u32, height: u32) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        width <= MAX_THUMBNAIL_DIMENSION && height <= MAX_THUMBNAIL_DIMENSION,
+        "thumbnail dimensions {width}x{height} exceed the {MAX_THUMBNAIL_DIMENSION}px cap"
+    );
+    Ok(())
+}
+
 impl FFmpegRunner {
     /// Normalize a still image to baseline MJPEG (`.jpg`) on a background thread.
     ///
@@ -77,6 +99,11 @@ impl FFmpegRunner {
 
         let dec_ctx = ffmpeg_the_third::codec::context::Context::from_parameters(ist.parameters())?;
         let mut decoder = dec_ctx.decoder().video()?;
+
+        // Decompression-bomb guard: reject an oversized declared canvas before
+        // any frame buffer is allocated (the thumbnail is attacker-controlled).
+        ensure_thumbnail_dimensions(decoder.width(), decoder.height())
+            .with_context(|| format!("thumbnail {} rejected", src.display()))?;
 
         let mut octx = ffmpeg_the_third::format::output(dst)
             .map_err(PostProcessError::from)
@@ -201,5 +228,30 @@ impl FFmpegRunner {
             .context("failed to write output trailer for image normalization")?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_THUMBNAIL_DIMENSION, ensure_thumbnail_dimensions};
+
+    #[test]
+    fn dimensions_at_or_below_cap_accepted() {
+        assert!(ensure_thumbnail_dimensions(1, 1).is_ok());
+        // The cap itself (both axes) is accepted — pins the boundary on the pass side.
+        assert!(
+            ensure_thumbnail_dimensions(MAX_THUMBNAIL_DIMENSION, MAX_THUMBNAIL_DIMENSION).is_ok()
+        );
+    }
+
+    #[test]
+    fn dimensions_one_over_cap_rejected() {
+        // cap + 1 on either axis is rejected — a `>=`/`>` off-by-one flips exactly one.
+        assert!(ensure_thumbnail_dimensions(MAX_THUMBNAIL_DIMENSION + 1, 1).is_err());
+        assert!(ensure_thumbnail_dimensions(1, MAX_THUMBNAIL_DIMENSION + 1).is_err());
+        assert!(
+            ensure_thumbnail_dimensions(MAX_THUMBNAIL_DIMENSION + 1, MAX_THUMBNAIL_DIMENSION + 1)
+                .is_err()
+        );
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/mod.rs
@@ -9,6 +9,7 @@ mod audio_pipeline_direct;
 mod audio_recode_pipeline;
 mod cancel;
 pub mod encoder_options;
+mod image_convert;
 pub mod mux_timing;
 #[cfg(test)]
 mod tests;

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -27,6 +27,23 @@ const SUPPORTED_CONTAINERS: &[&str] = &[
     "mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac", "ogg", "opus",
 ];
 
+/// Extensions the non-Matroska embed passes (`FFmpeg` `ATTACHED_PIC` stream copy,
+/// `mp4ameta` `covr` atom) can consume without transcoding.
+///
+/// This is the SINGLE source of truth for "already MP4/attached-pic-safe" — used
+/// both to decide whether a thumbnail needs normalizing (see `process`) and,
+/// after normalization, to select the `covr` atom's image type (see
+/// `write_covr_atom`). Every non-Matroska embed strategy in
+/// `rdlp_ffmpeg::thumbnail` stream-copies the thumbnail's source codec into the
+/// target container (see `embed_thumbnail_sync`), so any format outside this
+/// list (e.g. `webp`) must be normalized first — the target containers have no
+/// muxer tag for it.
+const EMBEDDABLE_RASTER_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png"];
+
+/// Containers that attach the thumbnail's source codec natively (Matroska) and
+/// therefore never need image normalization.
+const NATIVE_ATTACHMENT_CONTAINERS: &[&str] = &["mkv", "mka"];
+
 /// Embeds thumbnail into the primary current file.
 ///
 /// `should_run` triggers when `config.embed_thumbnail` is true.
@@ -82,6 +99,72 @@ impl ThumbnailStage {
         ["mp4", "m4a", "m4v", "mov"]
             .iter()
             .any(|c| c.eq_ignore_ascii_case(extension))
+    }
+
+    /// Check if the container attaches the thumbnail's source codec natively
+    /// (Matroska), so it never needs image normalization.
+    fn is_native_attachment_container(extension: &str) -> bool {
+        NATIVE_ATTACHMENT_CONTAINERS
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(extension))
+    }
+
+    /// Check whether `path`'s extension is already MP4/attached-pic-safe
+    /// (see `EMBEDDABLE_RASTER_EXTENSIONS`).
+    fn is_embeddable_raster(path: &Path) -> bool {
+        path.extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| {
+                EMBEDDABLE_RASTER_EXTENSIONS
+                    .iter()
+                    .any(|c| c.eq_ignore_ascii_case(ext))
+            })
+    }
+
+    /// Normalize `thumbnail_file` to a tracker-owned temp `.jpg` when the
+    /// target container can't consume its codec directly.
+    ///
+    /// Every non-Matroska embed strategy stream-copies the thumbnail's source
+    /// codec into the target container (see `rdlp_ffmpeg::thumbnail`), so a
+    /// codec outside `EMBEDDABLE_RASTER_EXTENSIONS` (e.g. `webp`) must be
+    /// transcoded first or the mux fails (MP4/MOV/M4A/M4V) or the `covr` atom
+    /// silently mislabels raw webp bytes as JPEG (MP4-family only). Matroska
+    /// is exempt — it attaches the source codec natively. On transcode
+    /// failure, falls back to the original thumbnail path so the caller's
+    /// existing non-fatal embed-failure handling still applies.
+    async fn normalize_thumbnail_for_embed(
+        &self,
+        msg: &mut PipelineMessage,
+        extension: &str,
+        thumbnail_file: &Path,
+    ) -> PathBuf {
+        if Self::is_native_attachment_container(extension)
+            || Self::is_embeddable_raster(thumbnail_file)
+        {
+            return thumbnail_file.to_path_buf();
+        }
+
+        let normalized = msg.tracker.temp_path(thumbnail_file, "jpg");
+        debug!(
+            "ThumbnailStage: normalizing thumbnail {} → jpg for {extension} embed",
+            thumbnail_file.display()
+        );
+        match self
+            .ffmpeg
+            .transcode_image(thumbnail_file, &normalized)
+            .await
+        {
+            Ok(()) => {
+                msg.tracker.mark_temp(normalized.clone());
+                normalized
+            }
+            Err(e) => {
+                warn!("ThumbnailStage: thumbnail normalization to jpg failed, using original: {e}");
+                msg.warnings
+                    .push(format!("Thumbnail normalization to jpg failed: {e}"));
+                thumbnail_file.to_path_buf()
+            }
+        }
     }
 
     /// Write the iTunes `covr` metadata atom for Windows Explorer thumbnail visibility.
@@ -199,6 +282,10 @@ impl PipelineStage for ThumbnailStage {
             media_file.display()
         );
 
+        let embed_source = self
+            .normalize_thumbnail_for_embed(&mut msg, &extension, &thumbnail_file)
+            .await;
+
         let temp_output = msg.tracker.temp_path(&media_file, &extension);
 
         let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
@@ -225,7 +312,7 @@ impl PipelineStage for ThumbnailStage {
             .ffmpeg
             .embed_thumbnail(
                 &media_file,
-                &thumbnail_file,
+                &embed_source,
                 &temp_output,
                 &extension,
                 log_callback,
@@ -243,8 +330,10 @@ impl PipelineStage for ThumbnailStage {
                 msg.tracker.replace(vec![temp_output.clone()]);
 
                 // For MP4-family: write covr atom for Windows Explorer.
+                // `embed_source` is guaranteed EMBEDDABLE_RASTER_EXTENSIONS
+                // (jpg/jpeg/png) by `normalize_thumbnail_for_embed` above.
                 if Self::is_mp4_family(&extension) {
-                    Self::write_covr_atom(&temp_output, &thumbnail_file).await;
+                    Self::write_covr_atom(&temp_output, &embed_source).await;
                 }
 
                 // Clean up thumbnail unless --write-thumbnail was requested.
@@ -455,5 +544,53 @@ mod tests {
             !result.warnings.is_empty(),
             "expected warning about missing thumbnail"
         );
+    }
+
+    // --- is_embeddable_raster / is_native_attachment_container (bugfix/thumbnail-webp-mp4-embed) ---
+
+    #[test]
+    fn embeddable_raster_accepts_jpg_jpeg_png() {
+        assert!(ThumbnailStage::is_embeddable_raster(&PathBuf::from(
+            "/tmp/thumb.jpg"
+        )));
+        assert!(ThumbnailStage::is_embeddable_raster(&PathBuf::from(
+            "/tmp/thumb.JPEG"
+        )));
+        assert!(ThumbnailStage::is_embeddable_raster(&PathBuf::from(
+            "/tmp/thumb.png"
+        )));
+    }
+
+    /// Negative: webp (the reported bug — xHamster and others serve webp
+    /// thumbnails) and an extensionless path are NOT already embeddable —
+    /// they must go through `normalize_thumbnail_for_embed`.
+    #[test]
+    fn embeddable_raster_rejects_webp_and_other() {
+        assert!(!ThumbnailStage::is_embeddable_raster(&PathBuf::from(
+            "/tmp/thumb.webp"
+        )));
+        assert!(!ThumbnailStage::is_embeddable_raster(&PathBuf::from(
+            "/tmp/thumb.gif"
+        )));
+        assert!(!ThumbnailStage::is_embeddable_raster(&PathBuf::from(
+            "/tmp/thumb"
+        )));
+    }
+
+    #[test]
+    fn native_attachment_container_accepts_mkv_mka() {
+        assert!(ThumbnailStage::is_native_attachment_container("mkv"));
+        assert!(ThumbnailStage::is_native_attachment_container("MKA"));
+    }
+
+    /// Negative: MP4-family (and other non-Matroska) containers must NOT be
+    /// treated as native-attachment — they need normalization for non-raster
+    /// codecs. Regression guard for the bug: an unfixed check that also
+    /// exempted "mp4" would silently re-introduce the webp mux failure.
+    #[test]
+    fn native_attachment_container_rejects_mp4_family() {
+        assert!(!ThumbnailStage::is_native_attachment_container("mp4"));
+        assert!(!ThumbnailStage::is_native_attachment_container("mov"));
+        assert!(!ThumbnailStage::is_native_attachment_container("mp3"));
     }
 }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -159,6 +159,10 @@ impl ThumbnailStage {
                 normalized
             }
             Err(e) => {
+                // Mark the (possibly partial) temp jpg for cleanup on the success
+                // path too, mirroring the auto-remux-failure path below — otherwise
+                // a failed-transcode partial lingers until the TempRegistry sweep.
+                msg.tracker.mark_temp(normalized);
                 warn!("ThumbnailStage: thumbnail normalization to jpg failed, using original: {e}");
                 msg.warnings
                     .push(format!("Thumbnail normalization to jpg failed: {e}"));
@@ -179,6 +183,15 @@ impl ThumbnailStage {
             #[allow(clippy::disallowed_methods)]
             let cover_bytes =
                 std::fs::read(&thumb).context("thumbnail stage: failed to read thumbnail file")?;
+            // Invariant: `normalize_thumbnail_for_embed` guarantees the covr
+            // input is an mp4ameta-supported raster (jpg/jpeg/png). Tie the check
+            // to the same predicate so a future change to the embeddable set
+            // can't silently mislabel bytes here (the original webp-as-jpeg bug).
+            debug_assert!(
+                Self::is_embeddable_raster(&thumb),
+                "write_covr_atom requires a normalized jpg/jpeg/png thumbnail: {}",
+                thumb.display()
+            );
             let ext = thumb.extension().and_then(|e| e.to_str()).unwrap_or("");
             let img = if ext.eq_ignore_ascii_case("png") {
                 mp4ameta::Img::png(cover_bytes)

--- a/crates/rdlp-postprocess/tests/thumbnail_webp_mp4_embed.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_webp_mp4_embed.rs
@@ -1,0 +1,248 @@
+//! End-to-end proof that embedding a webp thumbnail into an MP4 succeeds
+//! (bugfix/thumbnail-webp-mp4-embed).
+//!
+//! Reproduces the reported bug: embedding a webp thumbnail (as served by
+//! xHamster and others) into an MP4 used to fail muxing with "Could not find
+//! tag for codec webp in stream #2, codec not currently supported in
+//! container" because `embed_thumbnail_sync` stream-copies the thumbnail's
+//! source codec and the MP4 muxer has no tag for webp. Verified RED against
+//! the unpatched `ThumbnailStage::process` (temporarily bypassing the
+//! normalization call to feed the raw webp straight to `embed_thumbnail`,
+//! mirroring pre-fix behavior; confirmed the exact `write_header` failure)
+//! before the normalization fix landed.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! webp/jpg/mp4 fixtures).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
+use rdlp_types::InfoDict;
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Build a 1-frame H.264 mp4 fixture via the system `ffmpeg` CLI (test-only;
+/// mirrors `crates/rdlp-ffmpeg/tests/recode_cancel.rs`'s fixture pattern).
+fn build_mp4_fixture(path: &Path) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+/// Build a single-frame still-image thumbnail via the system `ffmpeg` CLI.
+/// The output codec/container is inferred from `path`'s extension (e.g.
+/// `.webp` -> webp, `.jpg` -> mjpeg), so this fixture builder covers both the
+/// webp regression case and the jpg pass-through case.
+fn build_still_image_fixture(path: &Path) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-frames:v",
+            "1",
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+fn make_msg(files: Vec<std::path::PathBuf>, config: PostProcess) -> PipelineMessage {
+    let reg = Arc::new(TempRegistry::new());
+    let (error_tx, _) = oneshot::channel();
+    PipelineMessage {
+        info: InfoDict::new(
+            "id".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com".to_string(),
+        ),
+        tracker: FileTracker::new(files, reg),
+        config: Arc::new(config),
+        original_stem: "video".to_string(),
+        is_hls: false,
+        verbose: false,
+        callback_factory: None,
+        error_tx: Some(error_tx),
+        warnings: Vec::new(),
+        encoding_tool: None,
+        cancel: CancellationToken::new(),
+    }
+}
+
+/// Positive + regression test: a webp thumbnail must embed into an MP4 via
+/// `ThumbnailStage::process` with no warnings, and the resulting file must
+/// carry a second (attached-pic) video stream encoded as `mjpeg` — proving
+/// the thumbnail was normalized to an MP4-safe codec rather than
+/// stream-copied as webp.
+#[tokio::test]
+async fn process_embeds_webp_thumbnail_into_mp4_as_mjpeg() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.mp4");
+    let thumb = dir.path().join("video.webp");
+    if build_mp4_fixture(&media).is_err() || build_still_image_fixture(&thumb).is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg.clone());
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+    assert!(
+        result.warnings.is_empty(),
+        "webp thumbnail embed should succeed with no warnings, got: {:?}",
+        result.warnings
+    );
+
+    let out_path = result.tracker.primary();
+    let info = ffmpeg
+        .probe(&out_path)
+        .await
+        .expect("probing embedded output must succeed");
+    assert_eq!(
+        info.stream_count, 2,
+        "expected media stream + attached-pic thumbnail stream"
+    );
+    let thumb_stream = info
+        .streams
+        .iter()
+        .find(|s| s.index == 1)
+        .expect("second stream (thumbnail) must be present");
+    assert_eq!(thumb_stream.codec_type, "video");
+    assert_eq!(
+        thumb_stream.codec_name.as_deref(),
+        Some("mjpeg"),
+        "thumbnail stream must be normalized to mjpeg, not stream-copied webp"
+    );
+}
+
+/// Negative companion: a jpg thumbnail is already MP4-embeddable and must
+/// pass straight through the normalization gate (no re-transcode attempt) —
+/// the embed must still succeed with no warnings.
+#[tokio::test]
+async fn process_embeds_jpg_thumbnail_without_normalizing() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.mp4");
+    let thumb = dir.path().join("video.jpg");
+    if build_mp4_fixture(&media).is_err() || build_still_image_fixture(&thumb).is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg.clone());
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+    assert!(
+        result.warnings.is_empty(),
+        "jpg thumbnail embed should succeed with no warnings, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Regression guard: the Matroska path is untouched by the normalization
+/// fix — an mkv container must still embed a webp thumbnail directly (native
+/// Matroska attachment, no normalization), unlike the MP4-family path above.
+#[tokio::test]
+async fn process_embeds_webp_thumbnail_into_mkv_natively() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.mkv");
+    let thumb = dir.path().join("video.webp");
+    let mp4_src = dir.path().join("src.mp4");
+    if build_mp4_fixture(&mp4_src).is_err() || build_still_image_fixture(&thumb).is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+    // Remux the mp4 fixture into mkv so the media file under test is a real MKV container.
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-i",
+            mp4_src.to_str().unwrap(),
+            "-c",
+            "copy",
+            media.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if !ok {
+        eprintln!("[SKIP] mkv fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+    assert!(
+        result.warnings.is_empty(),
+        "mkv native webp attachment should succeed with no warnings, got: {:?}",
+        result.warnings
+    );
+}


### PR DESCRIPTION
## Resolves

Closes #519.

## Problem

A `.webp` thumbnail failed to embed into an MP4 (surfaced in a real xHamster download): the `attached_pic` pass **stream-copied** the webp codec → MP4 muxer has no tag for webp → `write_header` fails (fatal to the embed), and `write_covr_atom` blindly labeled non-png bytes as `jpeg` → silent covr corruption. xHamster and others serve webp thumbnails.

## Fix (and the de-duplication)

Normalize the thumbnail to **one** canonical MP4-safe codec (baseline JPEG) **once**, up front, via a new FFmpeg `transcode_image` helper (decode→mjpeg, **reusing** the existing transcode pipeline helpers — no new dependency, no cloned logic), and feed **both** the `attached_pic` embed and the `covr` atom from the single normalized `embed_source`. The scattered image-format handling collapses to one `normalize_thumbnail_for_embed` gate + one `is_embeddable_raster` predicate, so a future non-embeddable source codec can't reproduce it. MKV is untouched (native Matroska attachment preserves the source codec).

## Security hardening (from pre-push review)

- **Decompression-bomb guard**: `transcode_image` decodes attacker-controlled thumbnails; added `MAX_THUMBNAIL_DIMENSION=8192` (`ensure_thumbnail_dimensions`) rejecting an oversized declared canvas **before any frame buffer is allocated**. Rejection routes through the stage's existing non-fatal fallback (uses original file, no pipeline failure).
- Temp-cleanup symmetry: `mark_temp` the partial jpg on transcode failure.
- `debug_assert` ties `write_covr_atom`'s jpg/png invariant to the shared `is_embeddable_raster` predicate (kills the latent coupling).

## Tests

- Failing-first integration test: webp→mp4 embeds as `mjpeg` `attached_pic` (verified RED against unpatched `write_header` failure, GREEN after).
- Negatives: jpg pass-through (not re-transcoded), MKV path unchanged.
- Boundary: `MAX_THUMBNAIL_DIMENSION` 8192 accepted vs 8193 rejected on both axes.

## Reviews

- **security-reviewer**: **Approve** — 1 MEDIUM (decompression bomb) raised and re-verified fixed over the follow-up commit (bound enforced before allocation, non-fatal fallback preserved, boundary tests present); no High/Critical. Confirmed 8192/axis is a sufficient security-fixed bound (const + rationale per no-hardcoded-magic-numbers).
- **code-reviewer (pr-review-toolkit)**: **Approve with minor fixes** — confirmed the dedup goal is met (genuine helper reuse, single-sourced format handling); 2 Low items (temp-cleanup symmetry, covr invariant coupling) both applied.

## Gate

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test` (incl. the failing-first integration test), and check-dedup/url-redaction/log-redaction/no-bare-response-text/no-cli all pass.

## Follow-up

Discovery-list widening (gif/bmp/avif → same normalized pipeline) kept out of scope; to be filed separately.
