### PR TITLE
feat(postprocess): widen thumbnail discovery to gif/bmp/tiff (#521)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-api/src/orchestrator/thumbnail.rs
@@ -8,6 +8,33 @@ use log::{debug, info, warn};
 use rdlp_redact::RedactedUrl;
 use std::path::{Path, PathBuf};
 
+/// Derive the on-disk sidecar extension for a downloaded thumbnail from its URL.
+///
+/// Preserves the URL's trailing extension only when it is a recognized raster
+/// thumbnail format (see [`rdlp_types::THUMBNAIL_EXTENSIONS`]); any query string
+/// is stripped first. An unrecognized or absent extension defaults to `jpg`,
+/// matching yt-dlp's behavior for extensionless thumbnail URLs.
+///
+/// This whitelist MUST stay aligned with the post-process discovery gate (both
+/// draw from `THUMBNAIL_EXTENSIONS`): a format saved here that discovery does not
+/// look for — or vice versa — silently drops the thumbnail.
+fn thumbnail_extension_from_url(thumbnail_url: &str) -> String {
+    thumbnail_url
+        .rsplit('/')
+        .next()
+        .and_then(|filename| {
+            // Strip query string, then take the trailing extension token.
+            let filename = filename.split('?').next().unwrap_or(filename);
+            filename.rsplit('.').next()
+        })
+        .filter(|ext| {
+            rdlp_types::THUMBNAIL_EXTENSIONS
+                .iter()
+                .any(|known| ext.eq_ignore_ascii_case(known))
+        })
+        .map_or_else(|| "jpg".to_owned(), str::to_lowercase)
+}
+
 impl Orchestrator {
     /// Download thumbnail image from URL and save alongside media file.
     ///
@@ -42,20 +69,7 @@ impl Orchestrator {
         debug!(url = RedactedUrl::new(thumbnail_url); "Downloading thumbnail");
 
         // Determine extension from URL (default to jpg)
-        let ext = thumbnail_url
-            .rsplit('/')
-            .next()
-            .and_then(|filename| {
-                // Strip query string
-                let filename = filename.split('?').next().unwrap_or(filename);
-                filename.rsplit('.').next()
-            })
-            .filter(|ext| {
-                ["jpg", "jpeg", "png", "webp"]
-                    .iter()
-                    .any(|known| ext.eq_ignore_ascii_case(known))
-            })
-            .map_or_else(|| "jpg".to_owned(), str::to_lowercase);
+        let ext = thumbnail_extension_from_url(thumbnail_url);
 
         // Build output path: {media_stem}.{ext}
         let thumbnail_path = super::container_resolver::sidecar_path(media_file, &ext);
@@ -136,5 +150,92 @@ impl Orchestrator {
         );
 
         Some(thumbnail_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::thumbnail_extension_from_url;
+
+    #[test]
+    fn preserves_original_baseline_extensions() {
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.jpg"),
+            "jpg"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.jpeg"),
+            "jpeg"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.png"),
+            "png"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.webp"),
+            "webp"
+        );
+    }
+
+    /// #521: the widened raster formats must be preserved on disk, not defaulted
+    /// to `jpg`. Fails against the pre-#521 whitelist (`jpg/jpeg/png/webp`),
+    /// which rejected these and saved e.g. GIF bytes under a `.jpg` name — the
+    /// codec/extension mislabel that then breaks embedding.
+    #[test]
+    fn preserves_widened_raster_extensions() {
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.gif"),
+            "gif"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.bmp"),
+            "bmp"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.tiff"),
+            "tiff"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.tif"),
+            "tif"
+        );
+    }
+
+    #[test]
+    fn lowercases_recognized_uppercase_extension() {
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/COVER.GIF"),
+            "gif"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/COVER.WEBP"),
+            "webp"
+        );
+    }
+
+    #[test]
+    fn strips_query_string_before_extension() {
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.png?w=640&sig=abc"),
+            "png"
+        );
+    }
+
+    /// Negative: an extension we cannot decode (avif) or no extension at all
+    /// defaults to `jpg` — never saved under its own unrecognized extension.
+    #[test]
+    fn defaults_unrecognized_or_missing_extension_to_jpg() {
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/cover.avif"),
+            "jpg"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/thumb?w=640"),
+            "jpg"
+        );
+        assert_eq!(
+            thumbnail_extension_from_url("https://cdn/x/coverfile"),
+            "jpg"
+        );
     }
 }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -16,11 +16,9 @@ use async_trait::async_trait;
 use log::{debug, info, warn};
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
+use rdlp_types::THUMBNAIL_EXTENSIONS;
 
 use crate::pipeline::{PipelineMessage, PipelineStage};
-
-/// Supported thumbnail image formats.
-const THUMBNAIL_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
 
 /// Containers that support thumbnail embedding via `FFmpeg`.
 const SUPPORTED_CONTAINERS: &[&str] = &[
@@ -61,8 +59,9 @@ impl ThumbnailStage {
 
     /// Find a thumbnail file using `original_stem` for discovery.
     ///
-    /// Searches `{parent}/{original_stem}.{jpg|jpeg|png|webp}`.
-    /// Also tries the current file's stem as a fallback.
+    /// Searches `{parent}/{original_stem}.{ext}` for each `ext` in
+    /// [`rdlp_types::THUMBNAIL_EXTENSIONS`]. Also tries the current file's stem
+    /// as a fallback.
     fn find_thumbnail(media_file: &Path, original_stem: &str) -> Option<PathBuf> {
         let parent = media_file.parent()?;
 
@@ -461,6 +460,30 @@ mod tests {
             "original-title",
         );
         assert!(result.is_none());
+    }
+
+    /// #521: discovery must locate the widened raster formats
+    /// (`gif`/`bmp`/`tiff`), not only the original `jpg`/`jpeg`/`png`/`webp`.
+    /// Fails against the pre-#521 list, which stopped at `webp` and so returned
+    /// `None` for a `gif`/`bmp`/`tiff` sidecar (silent thumbnail skip).
+    #[test]
+    fn find_thumbnail_finds_widened_raster_formats() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        for ext in ["gif", "bmp", "tiff", "tif"] {
+            let dir = TempDir::new().unwrap();
+            let thumb = dir.path().join(format!("clip.{ext}"));
+            fs::write(&thumb, b"fake-image").unwrap();
+
+            let media = dir.path().join("clip.rdlp-tmp-abc123.mp4");
+            let result = ThumbnailStage::find_thumbnail(&media, "clip");
+            assert_eq!(
+                result,
+                Some(thumb),
+                "find_thumbnail must discover a .{ext} sidecar via original_stem"
+            );
+        }
     }
 
     #[test]

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -43,6 +43,7 @@ pub mod subtitle_format;
 pub mod subtitle_kind;
 pub mod subtitle_selection;
 pub mod subtitle_track;
+pub mod thumbnail;
 pub mod vpx_deadline;
 
 // Re-export main types
@@ -72,4 +73,5 @@ pub use subtitle_track::{
     SubtitleDiagnostic, SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack,
     normalize_from_info_dict,
 };
+pub use thumbnail::THUMBNAIL_EXTENSIONS;
 pub use vpx_deadline::VpxDeadline;

--- a/crates/rdlp-types/src/thumbnail.rs
+++ b/crates/rdlp-types/src/thumbnail.rs
@@ -1,0 +1,87 @@
+//! Thumbnail sidecar format policy.
+//!
+//! A single source of truth for the raster image extensions rdlp treats as
+//! embeddable thumbnail sidecars. It is shared by two layers that MUST agree,
+//! or a downloaded thumbnail is saved under one name and never found under
+//! another (the discovery/download drift this const exists to prevent):
+//!
+//! - the **download layer** (`rdlp-api`), which chooses the on-disk extension
+//!   for a fetched thumbnail — an extension not listed here is not trusted from
+//!   the URL and the file is saved as `jpg`; and
+//! - the **post-process discovery gate** (`rdlp-postprocess`), which locates the
+//!   sidecar next to the media file before embedding it.
+
+/// Raster image extensions rdlp discovers as thumbnail sidecars and preserves
+/// when naming a downloaded thumbnail.
+///
+/// Every extension here is decodable by `rdlp_ffmpeg::FFmpegRunner::transcode_image`,
+/// which normalizes any non-`jpg`/`png` sidecar to baseline JPEG before
+/// MP4-family embedding (MP4/MOV/M4A/M4V have no muxer tag for `webp`, `gif`,
+/// `bmp`, or `tiff`). `jpg`/`jpeg`/`png` embed without transcoding; the rest
+/// flow through `transcode_image`. Matroska attaches the source codec natively
+/// and needs no normalization.
+///
+/// `jpeg`/`jpg` and `tiff`/`tif` are the two standard extension spellings of the
+/// same format, so both are listed — omitting an alias would save a `.tif` URL
+/// as `.jpg` with TIFF bytes (a codec/extension mislabel).
+///
+/// `avif` is intentionally excluded: the still-image codecs above are
+/// `FFmpeg`-core demuxers present in every build, whereas AVIF decoding requires
+/// an AVIF *demuxer* that the current `FFmpeg` build does not ship (it can only
+/// mux/write AVIF). An `.avif` sidecar would therefore fail to normalize and be
+/// gracefully skipped; keeping it out of discovery avoids saving AVIF bytes
+/// under an extension we cannot decode. Re-add it here once the linked `FFmpeg`
+/// gains AVIF demux support.
+pub const THUMBNAIL_EXTENSIONS: &[&str] =
+    &["jpg", "jpeg", "png", "webp", "gif", "bmp", "tiff", "tif"];
+
+#[cfg(test)]
+mod tests {
+    use super::THUMBNAIL_EXTENSIONS;
+
+    #[test]
+    fn includes_the_widened_decodable_formats() {
+        // The formats #521 added: FFmpeg-core still-image decoders that
+        // `transcode_image` can normalize. Guards against a silent narrowing.
+        for ext in ["gif", "bmp", "tiff", "tif"] {
+            assert!(
+                THUMBNAIL_EXTENSIONS.contains(&ext),
+                "{ext} must be a discoverable thumbnail extension"
+            );
+        }
+    }
+
+    #[test]
+    fn retains_the_original_baseline_formats() {
+        for ext in ["jpg", "jpeg", "png", "webp"] {
+            assert!(
+                THUMBNAIL_EXTENSIONS.contains(&ext),
+                "{ext} is a load-bearing baseline thumbnail extension"
+            );
+        }
+    }
+
+    /// avif has an `FFmpeg` muxer but no demuxer in the current build, so it
+    /// cannot be decoded/normalized — it must NOT be advertised as discoverable
+    /// or the download layer would save undecodable AVIF bytes to disk.
+    #[test]
+    fn excludes_undecodable_avif() {
+        assert!(
+            !THUMBNAIL_EXTENSIONS.contains(&"avif"),
+            "avif is not decodable by the current FFmpeg build; keep it out of discovery"
+        );
+    }
+
+    /// All entries are lowercase, bare (no leading dot) extensions — callers
+    /// compare case-insensitively against a URL/path extension token that has no
+    /// dot, so a stray `.jpg` or `JPG` entry here would silently never match.
+    #[test]
+    fn entries_are_lowercase_and_dotless() {
+        for ext in THUMBNAIL_EXTENSIONS {
+            assert!(
+                !ext.starts_with('.') && ext.chars().all(|c| c.is_ascii_lowercase()),
+                "extension {ext:?} must be a bare lowercase token"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #521.

## What
Widens the thumbnail sidecar format set from `jpg/jpeg/png/webp` to also include the FFmpeg-core still-image formats `FFmpegRunner::transcode_image` can already normalize: **gif, bmp, tiff** (+ the `tif` alias). Introduces a single source of truth `rdlp_types::THUMBNAIL_EXTENSIONS` shared by the two layers that previously each hardcoded the same four-format list:

- **download layer** (`rdlp-api` `orchestrator/thumbnail.rs`) — names the on-disk sidecar from the (attacker-controllable) thumbnail URL; extension logic extracted into a pure, unit-tested `thumbnail_extension_from_url` helper.
- **discovery gate** (`rdlp-postprocess` `stages/thumbnail.rs` `find_thumbnail`) — locates the sidecar; widened non-jpg/png formats flow through `transcode_image` → baseline JPEG before MP4-family embed.

## Why
The two layers were duplicated literals. A site serving a gif/bmp/tiff thumbnail had it saved under a `.jpg` name with foreign bytes (codec/extension mislabel) and was never discovered → cover silently skipped. One shared const closes the drift.

`EMBEDDABLE_RASTER_EXTENSIONS` (jpg/jpeg/png — the "skip normalization" set) is intentionally **not** widened; widening it would reintroduce the webp-as-jpeg covr mislabel (#519).

## avif
Deliberately excluded and test-locked: the current FFmpeg build ships an AVIF muxer but **no demuxer**, so `.avif` cannot be decoded/normalized. Documented for re-add once the linked FFmpeg gains AVIF demux support.

## Tests
- `rdlp-types`: const contract (widened formats present, baseline retained, avif excluded, lowercase/dotless).
- discovery: `find_thumbnail` locates `.gif/.bmp/.tiff/.tif` (failing-first against the old list — verified).
- download helper: preserves gif/bmp/tiff, lowercases uppercase, strips query string, defaults unrecognized/avif/extensionless → jpg (failing-first verified).

## Gate
`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, full test suite, and all 6 repo check-*.sh scripts — green.

## Reviews
- **security-reviewer**: Approve. Path-injection surface, decompression-bomb guard (8192px, applies uniformly), codec/extension mislabel protection, avif exclusion, and SSRF gate all sound. One non-blocking MEDIUM (unbounded frame/page count for animated GIF / multi-page TIFF) → filed as **#522**.
- **code-reviewer**: Approve, no changes required. Confirmed cross-layer drift closed, no other discovery list in-tree, `EMBEDDABLE_RASTER_EXTENSIONS` correctly narrow, test coverage adequate.

## Follow-up
- #522 — cap frame/page count in `transcode_image` (first-frame-only).