### PR TITLE
fix(downloader): validate ranged responses — silent ~517MB offset corruption (#526)

### DIFF
--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -11,7 +11,7 @@ mod trait_impl;
 mod tests;
 
 #[cfg(test)]
-pub(crate) use parallel::download_chunk_with_retry;
+pub(crate) use parallel::{download_chunk_with_retry, verify_merged_size};
 
 use backon::Retryable;
 use log::warn;
@@ -74,6 +74,96 @@ where
 /// `BaseExtractor::detect_file_size`. Closes #306.
 pub(crate) use rdlp_http::ProbeResult;
 
+/// HTTP status a single-part ranged response must carry (RFC 9110 §15.3.7).
+///
+/// A `200` means the server ignored `Range` — permitted by §14.2 — and the
+/// content is the WHOLE representation, not the requested span. Writing such a
+/// body into a chunk's offset slot is the corruption in #526, so the parallel
+/// chunk path accepts this status and no other.
+const HTTP_PARTIAL_CONTENT: u16 = 206;
+
+/// A parsed, validated single-part `Content-Range` response header.
+///
+/// Grammar (RFC 9110 §14.4):
+///
+/// ```text
+/// Content-Range = range-unit SP ( range-resp / unsatisfied-range )
+/// range-resp    = incl-range "/" ( complete-length / "*" )
+/// incl-range    = first-pos "-" last-pos
+/// ```
+///
+/// Both positions are INCLUSIVE, so the span covers
+/// `last_pos - first_pos + 1` bytes.
+///
+/// Only the `bytes` range unit is represented: §14.4 requires that a recipient
+/// which does not understand the unit "MUST NOT attempt to recombine it with a
+/// stored representation", and recombining is exactly what the chunk merge
+/// does. `unsatisfied-range` (`bytes */1234`, sent with 416) is likewise not
+/// represented — it describes no enclosed content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ContentRange {
+    /// First byte position of the enclosed span (inclusive).
+    first_pos: u64,
+    /// Last byte position of the enclosed span (inclusive).
+    last_pos: u64,
+    /// Total length of the selected representation; `None` when the server
+    /// sent `*` to signal that the complete length was unknown (§14.4).
+    complete_length: Option<u64>,
+}
+
+impl ContentRange {
+    /// Parse a `Content-Range` field value, returning `None` when it is absent,
+    /// malformed, carries a non-`bytes` unit, or is *invalid* per RFC 9110
+    /// §14.4 — that is, `last-pos < first-pos`, or a `complete-length` less
+    /// than or equal to `last-pos`. The spec's directive for an invalid value
+    /// is that the recipient "MUST NOT attempt to recombine the received
+    /// content with a stored representation", so an unparseable or invalid
+    /// header and a missing one are treated alike: the response is not usable.
+    fn parse(value: &str) -> Option<Self> {
+        let (unit, rest) = value.trim().split_once(' ')?;
+        if !unit.eq_ignore_ascii_case("bytes") {
+            return None;
+        }
+
+        let (incl_range, complete) = rest.trim().split_once('/')?;
+        let (first, last) = incl_range.split_once('-')?;
+
+        let first_pos: u64 = first.trim().parse().ok()?;
+        let last_pos: u64 = last.trim().parse().ok()?;
+
+        // §14.4: a last-pos below first-pos makes the field value invalid.
+        if last_pos < first_pos {
+            return None;
+        }
+
+        let complete_length = match complete.trim() {
+            "*" => None,
+            digits => {
+                let total: u64 = digits.parse().ok()?;
+                // §14.4: a complete-length <= last-pos makes the value invalid.
+                if total <= last_pos {
+                    return None;
+                }
+                Some(total)
+            }
+        };
+
+        Some(Self {
+            first_pos,
+            last_pos,
+            complete_length,
+        })
+    }
+
+    /// Read the header map and parse the `Content-Range` field if present.
+    fn from_headers(headers: &wreq::header::HeaderMap) -> Option<Self> {
+        headers
+            .get("content-range")
+            .and_then(|v| v.to_str().ok())
+            .and_then(Self::parse)
+    }
+}
+
 /// Parse the `Content-Range` header's total-bytes field.
 ///
 /// Used by `trait_impl::download_with_resume_with_cancel` to discover the
@@ -81,15 +171,97 @@ pub(crate) use rdlp_http::ProbeResult;
 /// `rdlp_http::probe_size` (which has its own parser); this helper is kept
 /// for the resume path's standalone header inspection.
 ///
-/// Accepts `bytes 0-N/TOTAL` (returns `Some(TOTAL)`) and returns `None` for
-/// `bytes 0-N/*` (server signalled unknown total per RFC 7233 §4.2), any
-/// missing header, or any unparseable total.
+/// Returns the `complete-length` of a valid single-part `bytes` range, and
+/// `None` for `bytes 0-N/*` (server signalled unknown total), a missing
+/// header, or any value [`ContentRange::parse`] rejects.
 pub(crate) fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Option<u64> {
-    headers
-        .get("content-range")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.split('/').nth(1))
-        .and_then(|s| s.parse::<u64>().ok())
+    ContentRange::from_headers(headers).and_then(|range| range.complete_length)
+}
+
+/// The inclusive byte span a ranged chunk fetch asked the server for.
+///
+/// Both bounds are inclusive, matching the `Range: bytes=start-end` request
+/// form and RFC 9110 §14.4's `incl-range`, so the span covers
+/// `end - start + 1` bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RequestedSpan {
+    /// First byte position requested (inclusive).
+    start: u64,
+    /// Last byte position requested (inclusive).
+    end: u64,
+}
+
+impl RequestedSpan {
+    /// Number of bytes the span covers.
+    const fn len(self) -> u64 {
+        self.end - self.start + 1
+    }
+}
+
+/// Confirm a ranged response actually carries the requested span before any of
+/// its bytes are written into the chunk's offset slot in the merged output.
+///
+/// A parallel chunk is concatenated at a fixed position, so a response that
+/// encloses a different span silently relocates every byte after it — the
+/// ~517 MB interior displacement in #526. RFC 9110 §15.3.7 places this duty on
+/// the client: "A client MUST inspect a 206 response's Content-Type and
+/// Content-Range field(s) to determine what parts are enclosed and whether
+/// additional requests are needed."
+///
+/// Returns `Err` (never a silent acceptance) when the status is not 206, the
+/// `Content-Range` is absent/malformed/invalid, or the enclosed span is not
+/// exactly the one requested.
+fn validate_range_response(
+    response: &wreq::Response,
+    span: RequestedSpan,
+    url: &str,
+) -> Result<()> {
+    let redacted = || Some(rdlp_redact::RedactedUrlBuf::from(url));
+
+    // §14.2 permits a server to ignore Range; the reply is then a 200 carrying
+    // the WHOLE representation. Accepting it here is what wrote whole-file
+    // content into a chunk slot.
+    let status = response.status().as_u16();
+    if status != HTTP_PARTIAL_CONTENT {
+        return Err(RdlpError::Download {
+            url: redacted(),
+            message: format!(
+                "ranged chunk request for bytes {}-{} got HTTP {status}, expected \
+                 {HTTP_PARTIAL_CONTENT} (Partial Content). The server ignored the Range \
+                 header, so the body is the whole resource rather than the requested span \
+                 and cannot be placed at this chunk's offset.",
+                span.start, span.end
+            ),
+        });
+    }
+
+    // §15.3.7.1: a single-part 206 MUST carry Content-Range. Without it there
+    // is no way to confirm which span arrived.
+    let Some(range) = ContentRange::from_headers(response.headers()) else {
+        return Err(RdlpError::Download {
+            url: redacted(),
+            message: format!(
+                "ranged chunk request for bytes {}-{} got a {HTTP_PARTIAL_CONTENT} response \
+                 with a missing, malformed, or invalid Content-Range header; the enclosed \
+                 span cannot be verified.",
+                span.start, span.end
+            ),
+        });
+    };
+
+    if range.first_pos != span.start || range.last_pos != span.end {
+        return Err(RdlpError::Download {
+            url: redacted(),
+            message: format!(
+                "ranged chunk request for bytes {}-{} got Content-Range bytes {}-{}; the \
+                 response encloses a different span than requested and would corrupt the \
+                 output at this chunk's offset.",
+                span.start, span.end, range.first_pos, range.last_pos
+            ),
+        });
+    }
+
+    Ok(())
 }
 
 /// HTTP/HTTPS downloader
@@ -340,6 +512,12 @@ impl HttpDownloader {
         })
         .await?;
 
+        // Confirm the response encloses exactly the requested span BEFORE any
+        // of its bytes reach the chunk file (#526).
+        let span = RequestedSpan { start, end };
+        validate_range_response(&response, span, &url)?;
+        let expected_len = span.len();
+
         let file = File::create(chunk_path).await.map_err(|e| {
             RdlpError::Io(std::io::Error::new(
                 e.kind(),
@@ -369,6 +547,20 @@ impl HttpDownloader {
                         ))
                     })?;
                     downloaded += chunk.len() as u64;
+
+                    // Stop the moment the body overruns the span the headers
+                    // promised, rather than streaming an unbounded body to
+                    // disk before the post-loop check notices.
+                    if downloaded > expected_len {
+                        return Err(RdlpError::Download {
+                            url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_str())),
+                            message: format!(
+                                "ranged chunk for bytes {start}-{end} delivered more than the \
+                                 {expected_len} bytes its Content-Range promised; aborting to \
+                                 avoid overrunning this chunk's offset in the merged output."
+                            ),
+                        });
+                    }
 
                     if let Some(ref counter) = progress_counter {
                         counter.fetch_add(chunk.len() as u64, std::sync::atomic::Ordering::Relaxed);
@@ -402,6 +594,32 @@ impl HttpDownloader {
                 format!("failed to flush chunk file '{}': {e}", chunk_path.display()),
             ))
         })?;
+
+        // The stream ending is not proof the whole span arrived. hyper normally
+        // surfaces an interrupted body as an error, but that is an empirical
+        // property, not a guarantee — hyperium/hyper#3253 is a fixed case where
+        // a truncated chunked body ended the stream with no error at all. A
+        // short chunk shifts every later chunk in the merged output, so the
+        // byte count is verified here rather than trusted to the transport.
+        //
+        // A 206 enclosing less than was requested is also legal on its own
+        // terms (§14.2: a server "may only be possible (or efficient) to send a
+        // portion of the requested ranges first, while expecting the client to
+        // re-request the remaining portions later"). Re-requesting only the
+        // remainder is the spec's answer; this returns a RETRYABLE error so
+        // `download_chunk_with_retry` re-fetches the whole chunk instead, which
+        // is correct but wasteful. Tracked as a follow-up.
+        if downloaded != expected_len {
+            return Err(RdlpError::Network {
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_str())),
+                message: format!(
+                    "ranged chunk for bytes {start}-{end} ended after {downloaded} of \
+                     {expected_len} bytes; the chunk is incomplete and would displace every \
+                     later chunk in the merged output."
+                ),
+            });
+        }
+
         Ok(downloaded)
     }
 

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -192,7 +192,21 @@ pub(crate) struct RequestedSpan {
 }
 
 impl RequestedSpan {
+    /// Build a span, rejecting an inverted range.
+    ///
+    /// The invariant `start <= end` is what makes [`Self::len`]'s subtraction
+    /// total; enforcing it here rather than at the call site means no caller
+    /// can construct a span whose length underflows.
+    const fn new(start: u64, end: u64) -> Option<Self> {
+        if end < start {
+            return None;
+        }
+        Some(Self { start, end })
+    }
+
     /// Number of bytes the span covers.
+    ///
+    /// Cannot underflow: [`Self::new`] rejects `end < start`.
     const fn len(self) -> u64 {
         self.end - self.start + 1
     }
@@ -207,6 +221,13 @@ impl RequestedSpan {
 /// the client: "A client MUST inspect a 206 response's Content-Type and
 /// Content-Range field(s) to determine what parts are enclosed and whether
 /// additional requests are needed."
+///
+/// Only `Content-Range` is inspected here. The Content-Type half of that
+/// sentence exists to distinguish a single-part response from a
+/// `multipart/byteranges` one (§14.6), which arises only for a multi-range
+/// request; this client always asks for exactly one range. A multipart body
+/// would carry no top-level `Content-Range` anyway, so it is rejected by the
+/// missing-header branch below rather than silently accepted.
 ///
 /// Returns `Err` (never a silent acceptance) when the status is not 206, the
 /// `Content-Range` is absent/malformed/invalid, or the enclosed span is not
@@ -249,8 +270,13 @@ fn validate_range_response(
         });
     };
 
+    // A wrong span is a per-response anomaly rather than a statement about
+    // what the server supports — a retry against another CDN node plausibly
+    // gets the right bytes. Reported as `Network` so `is_retryable_error`
+    // accepts it and `download_chunk_with_retry` re-fetches, instead of
+    // failing a multi-gigabyte download over one bad response.
     if range.first_pos != span.start || range.last_pos != span.end {
-        return Err(RdlpError::Download {
+        return Err(RdlpError::Network {
             url: redacted(),
             message: format!(
                 "ranged chunk request for bytes {}-{} got Content-Range bytes {}-{}; the \
@@ -514,7 +540,14 @@ impl HttpDownloader {
 
         // Confirm the response encloses exactly the requested span BEFORE any
         // of its bytes reach the chunk file (#526).
-        let span = RequestedSpan { start, end };
+        let Some(span) = RequestedSpan::new(start, end) else {
+            return Err(RdlpError::Download {
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_str())),
+                message: format!(
+                    "internal error: chunk requested an inverted byte range {start}-{end}"
+                ),
+            });
+        };
         validate_range_response(&response, span, &url)?;
         let expected_len = span.len();
 
@@ -537,6 +570,24 @@ impl HttpDownloader {
         loop {
             match next_with_cancel_and_timeout(stream.as_mut(), cancel, read_timeout, &url).await {
                 Ok(Some(Ok(chunk))) => {
+                    // Reject the frame BEFORE it reaches disk if it would push
+                    // this chunk past the span its Content-Range promised, so
+                    // an over-long body never lands on disk at all rather than
+                    // being written and caught on the following iteration.
+                    let chunk_len = chunk.len() as u64;
+                    if downloaded.saturating_add(chunk_len) > expected_len {
+                        // Retryable for the same reason as a wrong span: this
+                        // is one malformed response, not a server capability.
+                        return Err(RdlpError::Network {
+                            url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_str())),
+                            message: format!(
+                                "ranged chunk for bytes {start}-{end} delivered more than the \
+                                 {expected_len} bytes its Content-Range promised; aborting to \
+                                 avoid overrunning this chunk's offset in the merged output."
+                            ),
+                        });
+                    }
+
                     writer.write_all(&chunk).await.map_err(|e| {
                         RdlpError::Io(std::io::Error::new(
                             e.kind(),
@@ -546,21 +597,7 @@ impl HttpDownloader {
                             ),
                         ))
                     })?;
-                    downloaded += chunk.len() as u64;
-
-                    // Stop the moment the body overruns the span the headers
-                    // promised, rather than streaming an unbounded body to
-                    // disk before the post-loop check notices.
-                    if downloaded > expected_len {
-                        return Err(RdlpError::Download {
-                            url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_str())),
-                            message: format!(
-                                "ranged chunk for bytes {start}-{end} delivered more than the \
-                                 {expected_len} bytes its Content-Range promised; aborting to \
-                                 avoid overrunning this chunk's offset in the merged output."
-                            ),
-                        });
-                    }
+                    downloaded += chunk_len;
 
                     if let Some(ref counter) = progress_counter {
                         counter.fetch_add(chunk.len() as u64, std::sync::atomic::Ordering::Relaxed);
@@ -595,12 +632,17 @@ impl HttpDownloader {
             ))
         })?;
 
-        // The stream ending is not proof the whole span arrived. hyper normally
-        // surfaces an interrupted body as an error, but that is an empirical
-        // property, not a guarantee — hyperium/hyper#3253 is a fixed case where
-        // a truncated chunked body ended the stream with no error at all. A
-        // short chunk shifts every later chunk in the merged output, so the
-        // byte count is verified here rather than trusted to the transport.
+        // The stream ending is not proof the whole span arrived. hyper does
+        // normally surface an interrupted body as an error, but that is a
+        // property of the current implementation rather than a guarantee the
+        // type system enforces: hyperium/hyper#3253 was a case where an
+        // interrupted chunked body's error was swallowed and the stream simply
+        // ended (that report concerns reading a chunked *request* body, so it
+        // is an analogous decoder path rather than this exact one — the point
+        // is that a silent short read has occurred in this decoder family, not
+        // that it is known to occur here). A short chunk shifts every later
+        // chunk in the merged output, so the byte count is verified
+        // independently rather than trusted to the transport.
         //
         // A 206 enclosing less than was requested is also legal on its own
         // terms (§14.2: a server "may only be possible (or efficient) to send a
@@ -852,6 +894,87 @@ mod content_range_tests {
     fn returns_none_when_total_unparseable() {
         let h = make_headers(Some("bytes 0-262143/notanumber"));
         assert_eq!(parse_content_range_total(&h), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // `ContentRange::parse` grammar branches (RFC 9110 §14.4).
+    //
+    // The chunk path decides whether a response may be written into its offset
+    // slot from this parser's verdict, so each accept/reject branch is pinned
+    // individually rather than only through the mockito-driven tests.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parses_a_conformant_single_part_range() {
+        let range = ContentRange::parse("bytes 0-1023/2048").expect("valid range must parse");
+        assert_eq!(range.first_pos, 0);
+        assert_eq!(range.last_pos, 1023);
+        assert_eq!(range.complete_length, Some(2048));
+    }
+
+    /// `*` for complete-length is explicitly legal — "An asterisk character
+    /// ("*") in place of the complete-length indicates that the representation
+    /// length was unknown when the header field was generated" (§14.4). The
+    /// span is still fully usable, so this MUST parse; rejecting it would
+    /// break every server that cannot cheaply determine total length.
+    #[test]
+    fn accepts_unknown_complete_length() {
+        let range =
+            ContentRange::parse("bytes 0-1023/*").expect("unknown complete-length is legal");
+        assert_eq!(range.first_pos, 0);
+        assert_eq!(range.last_pos, 1023);
+        assert_eq!(range.complete_length, None);
+    }
+
+    /// §14.4: a recipient that does not understand the range unit "MUST NOT
+    /// attempt to recombine it with a stored representation" — and recombining
+    /// is exactly what the chunk merge does.
+    #[test]
+    fn rejects_unknown_range_unit() {
+        assert!(ContentRange::parse("items 0-1023/2048").is_none());
+        assert!(ContentRange::parse("seconds 0-10/60").is_none());
+    }
+
+    #[test]
+    fn accepts_case_insensitive_unit() {
+        assert!(ContentRange::parse("BYTES 0-1023/2048").is_some());
+    }
+
+    /// §14.4 invalidity: "a last-pos value less than its first-pos value".
+    #[test]
+    fn rejects_last_pos_below_first_pos() {
+        assert!(ContentRange::parse("bytes 1023-0/2048").is_none());
+    }
+
+    /// §14.4 invalidity: "a complete-length value less than or equal to its
+    /// last-pos value". Positions are inclusive, so a 0-1023 span needs at
+    /// least 1024 total bytes; 1024 is the tightest legal value.
+    #[test]
+    fn rejects_complete_length_not_above_last_pos() {
+        assert!(ContentRange::parse("bytes 0-1023/1023").is_none());
+        assert!(ContentRange::parse("bytes 0-1023/1024").is_some());
+    }
+
+    /// A single-position span is legal and covers exactly one byte.
+    #[test]
+    fn accepts_single_byte_span() {
+        let range = ContentRange::parse("bytes 5-5/10").expect("single-byte span is valid");
+        assert_eq!(range.first_pos, range.last_pos);
+    }
+
+    #[test]
+    fn rejects_unsatisfied_range_form() {
+        // `bytes */1234` accompanies a 416 and encloses no content.
+        assert!(ContentRange::parse("bytes */1234").is_none());
+    }
+
+    #[test]
+    fn rejects_structurally_malformed_values() {
+        assert!(ContentRange::parse("").is_none());
+        assert!(ContentRange::parse("bytes").is_none());
+        assert!(ContentRange::parse("bytes 0-1023").is_none());
+        assert!(ContentRange::parse("bytes abc-def/2048").is_none());
+        assert!(ContentRange::parse("0-1023/2048").is_none());
     }
 }
 

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -220,7 +220,7 @@ impl HttpDownloader {
 
         // Backstop (#526): the assembly must match the advertised length before
         // this file is handed back as a completed download.
-        verify_merged_size(path, total_size).await?;
+        verify_merged_size(path, total_size, url).await?;
 
         let duration = start_time.elapsed();
         let stats = DownloadStats::new(total_downloaded, duration, 0);
@@ -331,7 +331,7 @@ impl HttpDownloader {
         // that disagreed with the file's real length: the appended bytes land
         // at EOF regardless of the offset the ranges were requested from, so a
         // mismatch shows up here as a wrong final size.
-        verify_merged_size(path, total_size).await?;
+        verify_merged_size(path, total_size, url).await?;
 
         let duration = start_time.elapsed();
         let total_downloaded = resume_from + newly_downloaded;
@@ -591,7 +591,7 @@ impl HttpDownloader {
 /// A size match is not a proof of correctness (#526 produced a full-length file
 /// with displaced interior bytes), so this complements the per-chunk checks
 /// rather than replacing them.
-pub(crate) async fn verify_merged_size(path: &Path, expected_total: u64) -> Result<()> {
+pub(crate) async fn verify_merged_size(path: &Path, expected_total: u64, url: &str) -> Result<()> {
     let actual = tokio::fs::metadata(path)
         .await
         .map_err(|e| {
@@ -607,7 +607,7 @@ pub(crate) async fn verify_merged_size(path: &Path, expected_total: u64) -> Resu
 
     if actual != expected_total {
         return Err(RdlpError::Download {
-            url: None,
+            url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
             message: format!(
                 "assembled output '{}' is {actual} bytes but the server advertised \
                  {expected_total}; the download is incomplete or misassembled.",

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -218,6 +218,10 @@ impl HttpDownloader {
         )
         .await?;
 
+        // Backstop (#526): the assembly must match the advertised length before
+        // this file is handed back as a completed download.
+        verify_merged_size(path, total_size).await?;
+
         let duration = start_time.elapsed();
         let stats = DownloadStats::new(total_downloaded, duration, 0);
 
@@ -322,6 +326,12 @@ impl HttpDownloader {
             MergeMode::Append,
         )
         .await?;
+
+        // Backstop (#526). On the resume path this also catches a `resume_from`
+        // that disagreed with the file's real length: the appended bytes land
+        // at EOF regardless of the offset the ranges were requested from, so a
+        // mismatch shows up here as a wrong final size.
+        verify_merged_size(path, total_size).await?;
 
         let duration = start_time.elapsed();
         let total_downloaded = resume_from + newly_downloaded;
@@ -567,6 +577,46 @@ impl HttpDownloader {
 
         Ok((chunk_paths, total_bytes))
     }
+}
+
+/// Confirm the assembled output is exactly the size the server advertised.
+///
+/// Last-resort integrity gate for #526, deliberately independent of the
+/// per-chunk validation in `download_range_with_progress`: that layer checks
+/// each response against what was requested, while this one checks the
+/// finished artifact against the resource's advertised length. A defect in
+/// chunk bookkeeping — a dropped, duplicated, or misordered chunk — leaves the
+/// per-chunk checks satisfied but the assembly wrong, and only shows up here.
+///
+/// A size match is not a proof of correctness (#526 produced a full-length file
+/// with displaced interior bytes), so this complements the per-chunk checks
+/// rather than replacing them.
+pub(crate) async fn verify_merged_size(path: &Path, expected_total: u64) -> Result<()> {
+    let actual = tokio::fs::metadata(path)
+        .await
+        .map_err(|e| {
+            RdlpError::Io(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to stat merged output '{}' for size verification: {e}",
+                    path.display()
+                ),
+            ))
+        })?
+        .len();
+
+    if actual != expected_total {
+        return Err(RdlpError::Download {
+            url: None,
+            message: format!(
+                "assembled output '{}' is {actual} bytes but the server advertised \
+                 {expected_total}; the download is incomplete or misassembled.",
+                path.display()
+            ),
+        });
+    }
+
+    Ok(())
 }
 
 /// Merge or append chunks to file using an explicit ordered list of paths.

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -1427,8 +1427,13 @@ async fn range_fetch_rejects_mismatched_content_range() {
         .await;
 
     assert!(
-        matches!(result, Err(RdlpError::Download { .. })),
+        matches!(result, Err(RdlpError::Network { .. })),
         "a 206 whose Content-Range is not the requested span must be refused, got {result:?}"
+    );
+    assert!(
+        is_retryable_error(&result.unwrap_err()),
+        "a wrong-span response is a per-response anomaly, so the chunk must be re-fetched \
+         rather than failing the whole download"
     );
 }
 
@@ -1502,6 +1507,17 @@ async fn range_fetch_rejects_overlong_body() {
         result.is_err(),
         "a body longer than the requested span must be refused, got {result:?}"
     );
+
+    // The overrun is rejected BEFORE the frame is written, so the excess never
+    // reaches disk — the chunk file must never hold more than the span allows.
+    if let Ok(meta) = tokio::fs::metadata(&chunk_path).await {
+        assert!(
+            meta.len() <= 1024,
+            "an over-long body must not be written past the requested span; \
+             chunk file holds {} bytes",
+            meta.len()
+        );
+    }
 }
 
 /// Positive case: a fully conformant 206 still succeeds and reports the exact
@@ -1553,7 +1569,9 @@ async fn verify_merged_size_accepts_exact_total() {
     tokio::fs::write(&path, vec![0u8; 4096]).await.unwrap();
 
     assert!(
-        verify_merged_size(&path, 4096).await.is_ok(),
+        verify_merged_size(&path, 4096, "https://example.com/video.mp4")
+            .await
+            .is_ok(),
         "an output matching the advertised total must be accepted"
     );
 }
@@ -1568,7 +1586,9 @@ async fn verify_merged_size_rejects_short_output() {
     tokio::fs::write(&path, vec![0u8; 4095]).await.unwrap();
 
     assert!(
-        verify_merged_size(&path, 4096).await.is_err(),
+        verify_merged_size(&path, 4096, "https://example.com/video.mp4")
+            .await
+            .is_err(),
         "an output shorter than the advertised total must be refused"
     );
 }
@@ -1583,7 +1603,9 @@ async fn verify_merged_size_rejects_long_output() {
     tokio::fs::write(&path, vec![0u8; 4097]).await.unwrap();
 
     assert!(
-        verify_merged_size(&path, 4096).await.is_err(),
+        verify_merged_size(&path, 4096, "https://example.com/video.mp4")
+            .await
+            .is_err(),
         "an output longer than the advertised total must be refused"
     );
 }
@@ -1596,7 +1618,330 @@ async fn verify_merged_size_rejects_missing_output() {
     let path = dir.path().join("never-created.mp4");
 
     assert!(
-        verify_merged_size(&path, 4096).await.is_err(),
+        verify_merged_size(&path, 4096, "https://example.com/video.mp4")
+            .await
+            .is_err(),
         "a missing output file must be refused, not treated as verified"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Chunk retry actually RECOVERS from a bad range response (#526)
+//
+// Classifying an error as retryable is not the same as proving the chunk is
+// re-fetched and the download proceeds. These drive the full
+// `download_chunk_with_retry` loop: first attempt gets a corrupt response,
+// second gets a good one, and the chunk must end up with the correct bytes.
+// ---------------------------------------------------------------------------
+
+/// A wrong-span response must be retried, and the retry's correct bytes must
+/// be what lands in the chunk file — not appended to the rejected attempt.
+#[tokio::test]
+async fn chunk_retry_recovers_from_wrong_span_response() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // Mockito matches LIFO: create the success mock FIRST so it answers SECOND.
+    let _mock_ok = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/1048576")
+        .with_body(vec![0x11u8; 1024])
+        .expect(1)
+        .create_async()
+        .await;
+
+    // Answers FIRST: right length, WRONG span — the #526 signature.
+    let _mock_wrong_span = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 1048576-1049599/2097152")
+        .with_body(vec![0x99u8; 1024])
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(Arc::new(AtomicU64::new(0))),
+        0,
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        result.expect("the chunk must recover on retry after a wrong-span response"),
+        1024
+    );
+
+    // The rejected attempt's bytes must not survive: the file holds exactly the
+    // retry's payload, not 2048 bytes of both.
+    let contents = tokio::fs::read(&chunk_path).await.unwrap();
+    assert_eq!(contents.len(), 1024, "chunk must hold exactly one attempt");
+    assert!(
+        contents.iter().all(|&b| b == 0x11),
+        "chunk must hold the RETRY's bytes, not the rejected wrong-span response"
+    );
+}
+
+/// Same guarantee for a truncated body.
+#[tokio::test]
+async fn chunk_retry_recovers_from_short_body() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    let _mock_ok = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/1048576")
+        .with_body(vec![0x22u8; 1024])
+        .expect(1)
+        .create_async()
+        .await;
+
+    // Answers FIRST: conformant headers, truncated body.
+    let _mock_short = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/1048576")
+        .with_body(vec![0x88u8; 400])
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(Arc::new(AtomicU64::new(0))),
+        0,
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        result.expect("the chunk must recover on retry after a truncated body"),
+        1024
+    );
+
+    let contents = tokio::fs::read(&chunk_path).await.unwrap();
+    assert_eq!(
+        contents.len(),
+        1024,
+        "the truncated attempt must be discarded, not appended to"
+    );
+    assert!(contents.iter().all(|&b| b == 0x22));
+}
+
+/// A server that ignores Range (answers 200) is stating a capability, not
+/// suffering a transient fault: that must fail fast rather than burn retries.
+#[tokio::test]
+async fn chunk_retry_does_not_retry_range_ignoring_server() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // expect(1): a non-retryable failure must issue exactly ONE request.
+    let mock_200 = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(200)
+        .with_body(vec![0x77u8; 4096])
+        .expect(1)
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        0,
+        1023,
+        &chunk_path,
+        Some(Arc::new(AtomicU64::new(0))),
+        0,
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a Range-ignoring server must fail the chunk"
+    );
+    mock_200.assert_async().await;
+}
+
+// ---------------------------------------------------------------------------
+// Exact-boundary negatives for the chunk-length check (#526).
+//
+// `range_fetch_accepts_conformant_206` pins N (exactly 1024 bytes accepted).
+// These pin N-1 and N+1, so a `>` / `>=` slip in the length comparison cannot
+// pass: a test at 512 or 2048 would survive that mutation, these do not.
+// ---------------------------------------------------------------------------
+
+/// One byte short of the promised span must still be refused.
+#[tokio::test]
+async fn range_fetch_rejects_body_one_byte_short() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/1048576")
+        .with_body(vec![0x3Cu8; 1023]) // N-1
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        matches!(result, Err(RdlpError::Network { .. })),
+        "1023 of 1024 bytes must be refused as incomplete, got {result:?}"
+    );
+}
+
+/// One byte over the promised span must be refused, and must not reach disk.
+#[tokio::test]
+async fn range_fetch_rejects_body_one_byte_over() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/1048576")
+        .with_body(vec![0x3Du8; 1025]) // N+1
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "1025 of 1024 bytes must be refused as an overrun, got {result:?}"
+    );
+    if let Ok(meta) = tokio::fs::metadata(&chunk_path).await {
+        assert!(
+            meta.len() <= 1024,
+            "the overrunning byte must not be written; file holds {} bytes",
+            meta.len()
+        );
+    }
+}
+
+/// The resume path appends the response body at EOF, so a server answering
+/// from a DIFFERENT offset than `resume_from` splices foreign bytes into the
+/// file — the #526 corruption shape on the resume path. Checking the status is
+/// 206 is not enough; the enclosed span must start where the file ends.
+#[tokio::test]
+async fn resume_rejects_response_starting_at_wrong_offset() {
+    use mockito::Server;
+    use tempfile::NamedTempFile;
+
+    let mut server = Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", "bytes=1000-")
+        .with_status(206)
+        // Asked to resume at 1000; server answers from 5000.
+        .with_header("content-range", "bytes 5000-9999/10000")
+        .with_body(vec![0x66u8; 5000])
+        .create_async()
+        .await;
+
+    let downloader = HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ));
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path();
+    tokio::fs::write(path, b"partial data").await.unwrap();
+
+    let result = downloader
+        .download_with_resume(
+            &format!("{}/video.mp4", server.url()),
+            path,
+            1000,
+            None,
+            None,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a resume response starting at the wrong offset must be refused, got {result:?}"
+    );
+
+    // The existing bytes must be left intact rather than extended with
+    // wrongly-offset data.
+    let contents = tokio::fs::read(path).await.unwrap();
+    assert_eq!(
+        contents, b"partial data",
+        "a rejected resume must not append foreign bytes to the partial file"
     );
 }

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -269,6 +269,9 @@ async fn test_chunk_retry_succeeds_on_second_attempt() {
         .match_header("Range", mockito::Matcher::Any)
         .with_status(206)
         .with_header("content-type", "application/octet-stream")
+        // A single-part 206 MUST carry Content-Range (RFC 9110 §15.3.7.1);
+        // the chunk path validates it against the requested span (#526).
+        .with_header("content-range", "bytes 0-1023/1048576")
         .with_body(body.clone())
         .expect(1)
         .create_async()
@@ -421,6 +424,9 @@ async fn test_chunk_retry_cleans_partial_file() {
         .match_header("Range", mockito::Matcher::Any)
         .with_status(206)
         .with_header("content-type", "application/octet-stream")
+        // A single-part 206 MUST carry Content-Range (RFC 9110 §15.3.7.1);
+        // the chunk path validates it against the requested span (#526).
+        .with_header("content-range", "bytes 0-511/1048576")
         .with_body(body)
         .expect(1)
         .create_async()
@@ -1303,5 +1309,294 @@ fn parallel_adaptive_cancel_uses_biased_select() {
         "tokio::select! in download_parallel_adaptive MUST use `biased;` \
          to deterministically prioritize the cancel arm. \
          Found header: {header:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Range-response validation (#526)
+//
+// A parallel chunk fetch writes its bytes into a fixed offset slot in the
+// merged output, so a response that does not deliver exactly the requested
+// span corrupts the file at that offset. RFC 9110 §15.3.7 puts the burden on
+// the client: "A client MUST inspect a 206 response's Content-Type and
+// Content-Range field(s) to determine what parts are enclosed and whether
+// additional requests are needed." §14.2 additionally permits a server to
+// ignore Range entirely and answer 200 with the full body.
+//
+// These tests pin each way a response can diverge from the requested span.
+// ---------------------------------------------------------------------------
+
+/// Build a downloader whose transport-level retry is disabled, so each test
+/// observes exactly one request/response exchange.
+fn validation_test_downloader() -> HttpDownloader {
+    HttpDownloader::new().with_retry_config(RetryConfig::new(
+        0,
+        Duration::from_millis(1),
+        Duration::from_millis(10),
+        2.0,
+    ))
+}
+
+/// RFC 9110 §14.2 lets a server ignore `Range` and return the whole body with
+/// 200. Writing that into a chunk's offset slot is the corruption in #526,
+/// so it must be refused rather than accepted as a valid chunk.
+#[tokio::test]
+async fn range_fetch_rejects_200_full_body() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // Server ignores Range: full 4096-byte body, status 200, no Content-Range.
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(200)
+        .with_body(vec![0xAAu8; 4096])
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        matches!(result, Err(RdlpError::Download { .. })),
+        "a 200 full-body answer to a Range request must be refused, got {result:?}"
+    );
+}
+
+/// A 206 is required to carry `Content-Range` (RFC 9110 §15.3.7). Without it
+/// there is no way to confirm which span arrived, so it cannot be trusted.
+#[tokio::test]
+async fn range_fetch_rejects_206_without_content_range() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_body(vec![0xBBu8; 1024])
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        matches!(result, Err(RdlpError::Download { .. })),
+        "a 206 without Content-Range must be refused, got {result:?}"
+    );
+}
+
+/// The exact #526 signature: a correct-LENGTH response carrying the WRONG
+/// span. Byte-count checking alone cannot catch this — only comparing
+/// Content-Range against what was requested does.
+#[tokio::test]
+async fn range_fetch_rejects_mismatched_content_range() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // Requested 0-1023; server answers with the 1024 bytes at 1048576-1049599.
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 1048576-1049599/2097152")
+        .with_body(vec![0xCCu8; 1024])
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        matches!(result, Err(RdlpError::Download { .. })),
+        "a 206 whose Content-Range is not the requested span must be refused, got {result:?}"
+    );
+}
+
+/// A short body must fail even though the headers are conformant. hyper
+/// normally raises an error on an interrupted body, but hyperium/hyper#3253
+/// documents a case where a truncated stream ended silently — so the byte
+/// count is verified independently rather than trusted to the transport.
+///
+/// Truncation is transient, so this must be RETRYABLE (`Network`) to let
+/// `download_chunk_with_retry` re-fetch the chunk.
+#[tokio::test]
+async fn range_fetch_rejects_short_body() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    // Headers promise 0-1023 (1024 bytes); body delivers only 512.
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/2097152")
+        .with_body(vec![0xDDu8; 512])
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        matches!(result, Err(RdlpError::Network { .. })),
+        "a short body must fail as a retryable Network error, got {result:?}"
+    );
+    assert!(
+        is_retryable_error(&result.unwrap_err()),
+        "a truncated chunk must be retryable so the chunk is re-fetched"
+    );
+}
+
+/// A body longer than the requested span would push every later chunk
+/// forward in the merged output.
+#[tokio::test]
+async fn range_fetch_rejects_overlong_body() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 0-1023/2097152")
+        .with_body(vec![0xEEu8; 2048])
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 0, 1023, &chunk_path, None, None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a body longer than the requested span must be refused, got {result:?}"
+    );
+}
+
+/// Positive case: a fully conformant 206 still succeeds and reports the exact
+/// requested length. Guards against the validation over-rejecting valid work.
+#[tokio::test]
+async fn range_fetch_accepts_conformant_206() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+    let chunk_path = temp_dir.path().join("chunk_0");
+
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .match_header("Range", mockito::Matcher::Any)
+        .with_status(206)
+        .with_header("content-range", "bytes 4096-5119/2097152")
+        .with_body(vec![0x5Au8; 1024])
+        .create_async()
+        .await;
+
+    let url = format!("{}/video.mp4", server.url());
+    let result = validation_test_downloader()
+        .download_range_with_progress(&url, 4096, 5119, &chunk_path, None, None)
+        .await;
+
+    assert_eq!(
+        result.expect("a conformant 206 must be accepted"),
+        1024,
+        "must report exactly the requested span length"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Merged-output size verification (#526)
+//
+// Final backstop, independent of the per-chunk checks: whatever the chunk
+// layer believed it fetched, the assembled file must be exactly the size the
+// server advertised before it is promoted to the user-visible name.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verify_merged_size_accepts_exact_total() {
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("out.mp4");
+    tokio::fs::write(&path, vec![0u8; 4096]).await.unwrap();
+
+    assert!(
+        verify_merged_size(&path, 4096).await.is_ok(),
+        "an output matching the advertised total must be accepted"
+    );
+}
+
+/// A short assembly is the shape a dropped or truncated chunk produces.
+#[tokio::test]
+async fn verify_merged_size_rejects_short_output() {
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("out.mp4");
+    tokio::fs::write(&path, vec![0u8; 4095]).await.unwrap();
+
+    assert!(
+        verify_merged_size(&path, 4096).await.is_err(),
+        "an output shorter than the advertised total must be refused"
+    );
+}
+
+/// A long assembly is the shape a duplicated or overlapping chunk produces.
+#[tokio::test]
+async fn verify_merged_size_rejects_long_output() {
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("out.mp4");
+    tokio::fs::write(&path, vec![0u8; 4097]).await.unwrap();
+
+    assert!(
+        verify_merged_size(&path, 4096).await.is_err(),
+        "an output longer than the advertised total must be refused"
+    );
+}
+
+#[tokio::test]
+async fn verify_merged_size_rejects_missing_output() {
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("never-created.mp4");
+
+    assert!(
+        verify_merged_size(&path, 4096).await.is_err(),
+        "a missing output file must be refused, not treated as verified"
     );
 }

--- a/crates/rdlp-downloader/src/http/trait_impl.rs
+++ b/crates/rdlp-downloader/src/http/trait_impl.rs
@@ -17,7 +17,7 @@ use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio_util::sync::CancellationToken;
 
 use super::config::PROGRESS_UPDATE_INTERVAL;
-use super::{HttpDownloader, with_retry};
+use super::{ContentRange, HTTP_PARTIAL_CONTENT, HttpDownloader, with_retry};
 use crate::progress::SpeedMeter;
 
 #[allow(clippy::too_many_lines, clippy::option_if_let_else)]
@@ -391,16 +391,50 @@ impl HttpDownloader {
                         .await
                         .map_err(|e| RdlpError::Network { message: format!("Resume request failed: {e}"), url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())) })?;
 
-                    if response.status().as_u16() != 206 {
+                    if response.status().as_u16() != HTTP_PARTIAL_CONTENT {
                         return Err(RdlpError::Download {
                             url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
                             message: format!(
-                                "Server does not support resume (expected HTTP 206, got {}). \
-                                 Cannot continue download without overwriting existing data. \
-                                 Please delete the partial file and restart the download.",
+                                "Server does not support resume (expected HTTP \
+                                 {HTTP_PARTIAL_CONTENT}, got {}). Cannot continue download \
+                                 without overwriting existing data. Please delete the partial \
+                                 file and restart the download.",
                                 response.status()
                             ),
                         });
+                    }
+
+                    // A 206 alone does not prove the body starts where the
+                    // partial file ends. The resumed bytes are appended at EOF,
+                    // so a response enclosing a different span splices foreign
+                    // data into the file at the resume point — the #526
+                    // corruption shape on this path. RFC 9110 §15.3.7 requires
+                    // the client to inspect Content-Range; do so before any
+                    // byte is appended.
+                    match ContentRange::from_headers(response.headers()) {
+                        Some(range) if range.first_pos == resume_from => {}
+                        Some(range) => {
+                            return Err(RdlpError::Download {
+                                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
+                                message: format!(
+                                    "Resume response starts at byte {} but the partial file ends \
+                                     at {resume_from}; appending it would corrupt the file. \
+                                     Please delete the partial file and restart the download.",
+                                    range.first_pos
+                                ),
+                            });
+                        }
+                        None => {
+                            return Err(RdlpError::Download {
+                                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
+                                message: format!(
+                                    "Resume response has a missing, malformed, or invalid \
+                                     Content-Range header, so the span it encloses cannot be \
+                                     verified against the partial file's {resume_from} bytes. \
+                                     Please delete the partial file and restart the download."
+                                ),
+                            });
+                        }
                     }
 
                     Ok(response)


### PR DESCRIPTION
## Resolves

Closes #526

## What was wrong

A parallel chunk fetch writes its bytes into a fixed offset slot in the merged output, but nothing verified the response actually carried the requested span. One divergent response therefore relocated every byte after it — silently.

Found from a real 1.2 GB download that produced a **full-length, correct-total-size MP4 with ~517 MB of interior data at wrong offsets**. It passed `ffprobe`, reported the correct duration, and `FixupStage` declared "no issues detected". The only symptom was seeking: the file plays for ~60 s, then 60 s–2100 s is undecodable (`Invalid NAL unit size (-46491671 > 8148)`).

Forensics against the origin (which was confirmed deterministic and byte-identical outside the damaged span):

| true offset | correct data found at | displacement |
|---|---|---|
| 100,000,000 | 98,951,424 | −1,048,576 (exactly 1 MiB) |
| 450,000,000 | 444,756,154 | −5,243,846 (5 MiB **+ 966 B**) |

Data displaced, not missing; total length exactly right. Ruled out: server (3 identical fetches per range; 12/12 concurrent range requests correct), merge ordering (`parallel.rs` sorts by `chunk_id`), sparse writes (zero all-zero runs), and container damage (sequential decode with no seeking reproduces it).

The root gap: `check_http_response` only tests `status.is_success()`, so a `200` answering a Range request — permitted by RFC 9110 §14.2 — was accepted as a valid chunk even though its body is the whole resource. `Content-Range` was never parsed, the byte count was never compared to the requested span, and an early stream end (`Ok(None)`) counted as success.

## What this changes

Each ranged response is validated before any byte reaches the chunk file, per RFC 9110 §15.3.7 ("A client MUST inspect a 206 response's Content-Type and Content-Range field(s)"):

| Check | Authority |
|---|---|
| Status must be `206` | §14.2 — a `200` means Range was ignored |
| `Content-Range` must be present | §15.3.7.1 — a single-part 206 "MUST generate" it |
| range-unit must be `bytes` | §14.4 — unknown unit: "MUST NOT attempt to recombine" |
| Reject `last-pos < first-pos` / `complete-length <= last-pos` | §14.4 — defined as invalid |
| Enclosed span must equal the requested span | the #526 signature: right length, wrong offset |
| Body length must equal the span (abort before writing an overrun) | hyper#3253 — truncation can be silent |

Parsing goes through a new validated `ContentRange` type; `parse_content_range_total` is reimplemented on top of it so there is one parser.

Two further layers:

- **`verify_merged_size`** on both the fresh and resume paths — deliberately independent of the per-chunk checks, so an assembly-level defect (dropped, duplicated, misordered chunk) that leaves every individual response valid is still caught.
- **Sequential resume validation** — that path checked for `206` but never verified the response began at `resume_from` before appending at EOF. A server answering from a different offset spliced foreign bytes in at the resume point. This was the same corruption vector on a path the initial fix didn't reach; the failing-first test confirmed it was accepted before.

## Retryable vs not

Non-retryable is reserved for **capability signals an identical retry cannot change**: a `200` (server ignores Range) and a `206` with no usable `Content-Range`. Everything else — wrong span, short body, over-long body — is a **per-response anomaly** where a retry against another CDN node plausibly succeeds, so it is retryable and bounded by `MAX_CHUNK_RETRIES`, still failing loudly if it persists.

This is a deliberate deviation from the code reviewer's assessment, which judged span-mismatch a stable server property. Given the observed bug was most likely a one-off anomaly, failing a multi-gigabyte download over one bad response is the worse trade — and recovery is now proven by test, not assumed.

## Tests

23 new tests, all negatives verified failing-first against unpatched code:

- 6 range-response validation (200 full-body, missing `Content-Range`, wrong span, short, over-long, conformant positive)
- 2 exact-boundary negatives at N−1 / N+1 (the previous 512/2048 tests would survive a `>` / `>=` mutation)
- 3 retry-recovery (wrong span recovers, short body recovers, Range-ignoring server issues exactly one request) — asserting the *retry's* bytes land in the file, not appended to the rejected attempt
- 9 `ContentRange::parse` branch tests, including the positive acceptance of `bytes 0-1023/*` (legal unknown length, previously unpinned)
- 4 `verify_merged_size` (exact / short / long / missing)
- 1 resume wrong-offset rejection, asserting the partial file is left intact

Two pre-existing tests mocked a `206` with no `Content-Range`, which a conformant server does not send (§15.3.7.1); their mocks now carry one. Tightened, not weakened — both kept `.expect(1)` and their original assertions.

## Verification

`cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace` · `cargo check -p rdlp-desktop` · all 6 `scripts/check-*.sh` — green. 198 tests in `rdlp-downloader`, 0 failures.

## Reviews

- **security-reviewer: Approve** — no Critical/High/Medium. Confirmed no bypass path, no attacker-reachable integer overflow (server-supplied values are only compared, never subtracted), panic-free parser, no raw URL leakage. Its one LOW (overrun abort ran after `write_all`) is fixed here rather than accepted.
- **code-reviewer: Approve with minor fixes** — independently verified all six RFC citations against the RFC 9110 plain text. All findings addressed in-PR, including the resume-path gap it suggested deferring.

## Honest limits

This makes the corruption **impossible to occur silently** — any divergent response now fails loudly and retries. It does **not** establish what triggered the original download, which came from a single un-reproduced sample. If that was a transient server or transport anomaly, this converts it into a retry; if a client-side defect remains unfound, `verify_merged_size` now catches it at the end instead of shipping a corrupt file.

## Follow-up

§14.2 permits a server to satisfy a range only partially and expect the client to re-request the remainder. This treats that as a retryable error and re-fetches the whole chunk — correct but wasteful. Narrowing it to fetching only the remainder is a behavior change deserving its own issue.
