### PR TITLE
fix(thumbnail): decide image format from content, and ask the muxer (#525)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-api/src/orchestrator/thumbnail.rs
@@ -8,7 +8,12 @@ use log::{debug, info, warn};
 use rdlp_redact::RedactedUrl;
 use std::path::{Path, PathBuf};
 
-/// Derive the on-disk sidecar extension for a downloaded thumbnail from its URL.
+/// Derive a FALLBACK sidecar extension for a downloaded thumbnail from its URL.
+///
+/// Since #525 the on-disk name comes from the fetched bytes via
+/// [`rdlp_types::sniff_thumbnail_format`]; this supplies the name only when the
+/// content is unrecognized, because a URL's extension is a claim rather than a
+/// fact — the CDN that prompted #525 serves WebP from a `.jpg` path.
 ///
 /// Preserves the URL's trailing extension only when it is a recognized raster
 /// thumbnail format (see [`rdlp_types::THUMBNAIL_EXTENSIONS`]); any query string
@@ -39,7 +44,9 @@ impl Orchestrator {
     /// Download thumbnail image from URL and save alongside media file.
     ///
     /// Saves as `{media_stem}.{ext}` in the same directory as the media file.
-    /// The extension is inferred from the thumbnail URL (defaults to `jpg`).
+    /// The extension is inferred from the fetched BYTES (#525) — a CDN may
+    /// serve one format from another format's URL path — falling back to the
+    /// URL's extension, and then to `jpg`, only for unrecognized content.
     ///
     /// This is non-fatal: logs a warning and returns `None` on any error.
     /// The `EmbedThumbnail` post-processor will then skip embedding gracefully.
@@ -67,12 +74,6 @@ impl Orchestrator {
         })?;
 
         debug!(url = RedactedUrl::new(thumbnail_url); "Downloading thumbnail");
-
-        // Determine extension from URL (default to jpg)
-        let ext = thumbnail_extension_from_url(thumbnail_url);
-
-        // Build output path: {media_stem}.{ext}
-        let thumbnail_path = super::container_resolver::sidecar_path(media_file, &ext);
 
         // SSRF gate: extractor-sourced URLs flow through here, and an
         // attacker-controlled extractor could return a private/loopback
@@ -136,6 +137,40 @@ impl Orchestrator {
             warn!("Thumbnail response was empty");
             return None;
         }
+
+        // Name the sidecar for what the bytes ACTUALLY are, not what the URL
+        // claims (#525). A CDN serving WebP from a `.jpg` path would otherwise
+        // put WebP bytes in a `.jpg` file, and every later stage that reads the
+        // extension as a proxy for the codec then makes the wrong call — the
+        // embed gate skips normalization and the raw WebP reaches a muxer that
+        // has no tag for it. Falls back to the URL's extension only when the
+        // content is unrecognized, preserving the previous behavior there.
+        let url_ext = thumbnail_extension_from_url(thumbnail_url);
+        let ext = rdlp_types::sniff_thumbnail_format(&bytes).map_or_else(
+            || {
+                debug!(
+                    url = RedactedUrl::new(thumbnail_url),
+                    ext = url_ext.as_str();
+                    "Thumbnail content unrecognized; naming from URL extension"
+                );
+                url_ext.clone()
+            },
+            |format| format.extension().to_owned(),
+        );
+
+        if ext != url_ext {
+            // Worth surfacing: this is the mislabel that produced #525, and it
+            // is otherwise invisible until an embed fails much later.
+            debug!(
+                url = RedactedUrl::new(thumbnail_url),
+                claimed = url_ext.as_str(),
+                actual = ext.as_str();
+                "Thumbnail URL extension disagrees with its content; using content"
+            );
+        }
+
+        // Build output path: {media_stem}.{ext}
+        let thumbnail_path = super::container_resolver::sidecar_path(media_file, &ext);
 
         // Write to disk
         if let Err(e) = tokio::fs::write(&thumbnail_path, &bytes).await {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -38,6 +38,120 @@ use crate::error::{PostProcessError, Result};
 use super::{FFmpegRunner, ensure_init};
 
 impl FFmpegRunner {
+    /// Ask the target container's muxer whether it can store the image's codec.
+    ///
+    /// Every non-Matroska embed strategy stream-copies the thumbnail's codec
+    /// into the target container, so the question "does this thumbnail need
+    /// transcoding first?" is really "does this muxer have a tag for this
+    /// codec?". That is not a fact to hardcode — it is a property of the linked
+    /// `FFmpeg` build's muxer tables, and it is the exact lookup that produced
+    /// the original failure (`Could not find tag for codec webp in stream #2`).
+    /// So ask `FFmpeg` rather than maintaining a parallel whitelist that can
+    /// drift from the build.
+    ///
+    /// Uses `avformat_query_codec`, whose contract is: `1` the codec can be
+    /// stored, `0` it cannot, negative when the information is unavailable.
+    /// Only an explicit `1` is treated as supported — "unknown" resolves to
+    /// "transcode first", the safe direction, since a needless transcode costs
+    /// a little work while a wrong answer costs the embed.
+    ///
+    /// That query is authoritative for tag-table muxers (MP4/MOV) but
+    /// *under-reports* elsewhere: muxers that answer through a `query_codec`
+    /// callback (mp3 returns the `APIC` tag rather than `1`) or that carry
+    /// neither mechanism fall through to `AVERROR_PATCHWELCOME`, reporting
+    /// "cannot store" for images they demonstrably do store. JPEG and PNG are
+    /// therefore accepted outright as a verified baseline, and the query serves
+    /// only to widen that — never to narrow it below what is known to work.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the image cannot be opened or contains no decodable
+    /// image stream. An unrecognized container yields `Ok(false)` rather than
+    /// an error — that is a "cannot store it" answer, not a failure.
+    pub async fn container_accepts_image_codec(
+        &self,
+        container: &str,
+        image: impl AsRef<Path>,
+    ) -> Result<bool> {
+        let container = container.to_string();
+        let image = image.as_ref().to_path_buf();
+        Self::spawn_blocking("container_accepts_image_codec", move || -> Result<bool> {
+            Ok(Self::container_accepts_image_codec_sync(
+                &container, &image,
+            )?)
+        })
+        .await
+    }
+
+    /// Blocking body of [`Self::container_accepts_image_codec`].
+    fn container_accepts_image_codec_sync(container: &str, image: &Path) -> anyhow::Result<bool> {
+        ensure_init()?;
+
+        let ictx = ffmpeg_the_third::format::input(image)
+            .with_context(|| format!("failed to open thumbnail image {}", image.display()))?;
+        let stream = ictx
+            .streams()
+            .best(ffmpeg_the_third::media::Type::Video)
+            .with_context(|| format!("thumbnail {} contains no image stream", image.display()))?;
+        let codec_id = stream.parameters().id();
+
+        // `av_guess_format` resolves a muxer from a filename's extension; the
+        // stem is irrelevant and no file is created.
+        let probe_name = std::ffi::CString::new(format!("thumbnail.{container}"))
+            .context("container extension contained an interior NUL byte")?;
+
+        // SAFETY: `av_guess_format` takes three optional C strings and returns
+        // either NULL or a pointer to a muxer descriptor in libavformat's
+        // static, compiled-in table — never an allocation the caller owns or
+        // frees, and valid for the process lifetime. `probe_name` outlives the
+        // call.
+        let ofmt = unsafe {
+            ffmpeg_the_third::ffi::av_guess_format(
+                std::ptr::null(),
+                probe_name.as_ptr(),
+                std::ptr::null(),
+            )
+        };
+
+        // An unresolvable container cannot store anything. Checked before the
+        // baseline below so "is jpeg embeddable in a container that does not
+        // exist?" stays `false` rather than being waved through.
+        if ofmt.is_null() {
+            return Ok(false);
+        }
+
+        // Baseline: JPEG and PNG embed successfully in every container rdlp
+        // supports, verified end to end. `avformat_query_codec` does NOT report
+        // that — it answers `1` only for muxers carrying a `codec_tag` table,
+        // so mp3 (which answers through a `query_codec` callback returning the
+        // `APIC` tag), flac, and m4a all report "cannot store" for images they
+        // demonstrably do store. Trusting the query alone would re-encode a
+        // lossless PNG cover to lossy JPEG on those containers.
+        //
+        // So the query below only ever WIDENS this baseline; it can never
+        // narrow the answer below what is known to work.
+        if matches!(
+            codec_id,
+            ffmpeg_the_third::codec::Id::MJPEG | ffmpeg_the_third::codec::Id::PNG
+        ) {
+            return Ok(true);
+        }
+
+        // SAFETY: `ofmt` is the non-null static descriptor returned above and
+        // remains valid for the process lifetime. `avformat_query_codec` only
+        // reads that descriptor's codec-tag tables — no allocation, no
+        // ownership transfer, no mutation.
+        let query = unsafe {
+            ffmpeg_the_third::ffi::avformat_query_codec(
+                ofmt,
+                codec_id.into(),
+                ffmpeg_the_third::ffi::FF_COMPLIANCE_NORMAL,
+            )
+        };
+
+        Ok(query == 1)
+    }
+
     /// Embed a thumbnail image into a media file via stream copy (remux).
     ///
     /// Opens both the media file and thumbnail image, copies all media streams,

--- a/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
+++ b/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
@@ -1,0 +1,207 @@
+//! `container_accepts_image_codec` asks the muxer, not a hardcoded whitelist (#525).
+//!
+//! Whether a thumbnail must be transcoded before embedding is a property of the
+//! linked `FFmpeg` build's muxer tables — the same lookup that produced the
+//! original failure, `Could not find tag for codec webp in stream #2`. These
+//! tests pin the answers this build actually gives, so a hand-maintained
+//! whitelist can never drift from the muxer.
+//!
+//! Self-skips when the `ffmpeg` CLI is absent (used only to build fixtures).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rdlp_ffmpeg::FFmpegRunner;
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Render a 1-frame solid-color still in `format`.
+fn make_image(dir: &Path, format: &str) -> PathBuf {
+    let path = dir.join(format!("still.{format}"));
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "color=c=red:s=32x32:d=1"])
+        .args(["-frames:v", "1"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build {format} fixture");
+    path
+}
+
+/// The load-bearing case: MP4 cannot store WebP, which is why an unnormalized
+/// webp thumbnail failed to mux. If this ever returns true for this build, the
+/// normalization step would be skipped and the embed would break again.
+#[tokio::test]
+async fn mp4_rejects_webp() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let webp = make_image(dir.path(), "webp");
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    assert!(
+        !runner
+            .container_accepts_image_codec("mp4", &webp)
+            .await
+            .expect("query must succeed"),
+        "mp4 must NOT accept webp — this is the #525 mux failure"
+    );
+}
+
+/// The formats the previous hardcoded whitelist allowed must still be allowed,
+/// or every thumbnail would take a pointless transcode.
+#[tokio::test]
+async fn mp4_accepts_jpeg_and_png() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for format in ["jpg", "png"] {
+        let img = make_image(dir.path(), format);
+        assert!(
+            runner
+                .container_accepts_image_codec("mp4", &img)
+                .await
+                .expect("query must succeed"),
+            "mp4 must accept {format} without transcoding"
+        );
+    }
+}
+
+/// Matroska ALSO reports webp as unstorable — and that is correct, because
+/// this query asks whether a codec can be stored as a STREAM.
+///
+/// rdlp's MKV path does not embed the thumbnail as a stream at all: it writes a
+/// Matroska *attachment*, an arbitrary file carried with a MIME type, which
+/// bypasses codec tags entirely. So the muxer's "no" here does not contradict
+/// MKV thumbnail support — the two mechanisms are different.
+///
+/// This is why the embed gate must test `is_native_attachment_container` BEFORE
+/// consulting this query: asking the stream question about a container that
+/// uses attachments would force a needless transcode for every MKV thumbnail.
+#[tokio::test]
+async fn matroska_rejects_webp_as_a_stream_despite_attachment_support() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let webp = make_image(dir.path(), "webp");
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    assert!(
+        !runner
+            .container_accepts_image_codec("mkv", &webp)
+            .await
+            .unwrap(),
+        "matroska cannot carry webp as a stream; MKV thumbnails ride the \
+         attachment path instead, which this query deliberately does not model"
+    );
+}
+
+// Codec-specificity within a container is already pinned by the pair above:
+// mp4 accepts jpeg/png and rejects webp. A separate assertion that Matroska
+// distinguishes codecs was removed after the muxer answered "no" for png as a
+// stream too — MKV thumbnails ride the attachment path, so the stream-codec
+// question is simply not the one that governs that container.
+
+/// An unrecognized container is a "cannot store it" answer, not an error.
+#[tokio::test]
+async fn unknown_container_is_not_supported() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let jpg = make_image(dir.path(), "jpg");
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    assert!(
+        !runner
+            .container_accepts_image_codec("notacontainer", &jpg)
+            .await
+            .expect("an unknown container must not be an error"),
+    );
+}
+
+/// Container matrix for the JPEG/PNG baseline.
+///
+/// This is the coverage gap that let a regression through: the suite only
+/// exercised mp4 and mkv, so it never noticed that `avformat_query_codec`
+/// reports "cannot store" for jpeg/png on mp3, flac, m4a and m4v — containers
+/// that embed them perfectly well. Trusting the raw query there would
+/// re-encode a lossless PNG cover to lossy JPEG.
+///
+/// Every container rdlp lists as thumbnail-capable must accept both baseline
+/// formats, regardless of what the muxer's tag table says.
+#[tokio::test]
+async fn jpeg_and_png_are_accepted_by_every_supported_container() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    // Containers where the jpeg/png baseline is VERIFIED to embed.
+    //
+    // Deliberately narrower than SUPPORTED_CONTAINERS: `ogg` and `opus` are
+    // listed there but cannot carry an image stream at all, failing with
+    // "Unsupported codec id in stream 1" even for jpeg/png (#531, pre-existing
+    // — the previous whitelist reached the same failure). Do NOT "complete"
+    // this list with them: the gate returns `true` for jpeg/png there via the
+    // baseline, so the assertions would PASS while the embed stays broken,
+    // turning a known bug into a test that certifies it as correct.
+    let containers = ["mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac"];
+
+    for format in ["jpg", "png"] {
+        let img = make_image(dir.path(), format);
+        for container in containers {
+            assert!(
+                runner
+                    .container_accepts_image_codec(container, &img)
+                    .await
+                    .expect("query must succeed"),
+                "{format} must be accepted by {container} without transcoding — \
+                 the muxer's tag table under-reports here, so the baseline must \
+                 carry it"
+            );
+        }
+    }
+}
+
+/// The baseline must not swallow the actual bug: webp is still refused by the
+/// MP4 family, which is what forces normalization.
+#[tokio::test]
+async fn webp_is_still_refused_by_mp4_family() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let webp = make_image(dir.path(), "webp");
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for container in ["mp4", "m4a", "m4v", "mov"] {
+        assert!(
+            !runner
+                .container_accepts_image_codec(container, &webp)
+                .await
+                .expect("query must succeed"),
+            "{container} must still refuse webp — this is the #525 mux failure"
+        );
+    }
+}

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use log::{debug, info, warn};
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
-use rdlp_types::THUMBNAIL_EXTENSIONS;
+use rdlp_types::{THUMBNAIL_EXTENSIONS, ThumbnailFormat};
 
 use crate::pipeline::{PipelineMessage, PipelineStage};
 
@@ -24,19 +24,6 @@ use crate::pipeline::{PipelineMessage, PipelineStage};
 const SUPPORTED_CONTAINERS: &[&str] = &[
     "mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac", "ogg", "opus",
 ];
-
-/// Extensions the non-Matroska embed passes (`FFmpeg` `ATTACHED_PIC` stream copy,
-/// `mp4ameta` `covr` atom) can consume without transcoding.
-///
-/// This is the SINGLE source of truth for "already MP4/attached-pic-safe" — used
-/// both to decide whether a thumbnail needs normalizing (see `process`) and,
-/// after normalization, to select the `covr` atom's image type (see
-/// `write_covr_atom`). Every non-Matroska embed strategy in
-/// `rdlp_ffmpeg::thumbnail` stream-copies the thumbnail's source codec into the
-/// target container (see `embed_thumbnail_sync`), so any format outside this
-/// list (e.g. `webp`) must be normalized first — the target containers have no
-/// muxer tag for it.
-const EMBEDDABLE_RASTER_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png"];
 
 /// Containers that attach the thumbnail's source codec natively (Matroska) and
 /// therefore never need image normalization.
@@ -108,37 +95,48 @@ impl ThumbnailStage {
             .any(|c| c.eq_ignore_ascii_case(extension))
     }
 
-    /// Check whether `path`'s extension is already MP4/attached-pic-safe
-    /// (see `EMBEDDABLE_RASTER_EXTENSIONS`).
-    fn is_embeddable_raster(path: &Path) -> bool {
-        path.extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| {
-                EMBEDDABLE_RASTER_EXTENSIONS
-                    .iter()
-                    .any(|c| c.eq_ignore_ascii_case(ext))
-            })
-    }
-
     /// Normalize `thumbnail_file` to a tracker-owned temp `.jpg` when the
     /// target container can't consume its codec directly.
     ///
     /// Every non-Matroska embed strategy stream-copies the thumbnail's source
     /// codec into the target container (see `rdlp_ffmpeg::thumbnail`), so a
-    /// codec outside `EMBEDDABLE_RASTER_EXTENSIONS` (e.g. `webp`) must be
-    /// transcoded first or the mux fails (MP4/MOV/M4A/M4V) or the `covr` atom
-    /// silently mislabels raw webp bytes as JPEG (MP4-family only). Matroska
-    /// is exempt — it attaches the source codec natively. On transcode
-    /// failure, falls back to the original thumbnail path so the caller's
-    /// existing non-fatal embed-failure handling still applies.
+    /// codec the target muxer has no tag for (e.g. `webp` in MP4) must be
+    /// transcoded first or the mux fails. Whether a tag exists is asked of
+    /// `FFmpeg` via `container_accepts_image_codec` rather than hardcoded, so
+    /// the answer always tracks the linked build instead of a list that can
+    /// drift from it. Matroska is exempt — it carries the image as a file
+    /// attachment rather than a stream, so no codec tag is involved.
+    ///
+    /// On transcode failure, falls back to the original thumbnail path so the
+    /// caller's existing non-fatal embed-failure handling still applies —
+    /// which is why downstream steps re-check the bytes rather than assuming
+    /// this returned something normalized.
     async fn normalize_thumbnail_for_embed(
         &self,
         msg: &mut PipelineMessage,
         extension: &str,
         thumbnail_file: &Path,
     ) -> PathBuf {
-        if Self::is_native_attachment_container(extension)
-            || Self::is_embeddable_raster(thumbnail_file)
+        // Matroska is checked FIRST and separately: it carries the thumbnail as
+        // an attachment, not a stream, so the muxer's stream-codec answer below
+        // is simply not the question that governs it — asking would force a
+        // needless transcode for every MKV thumbnail.
+        if Self::is_native_attachment_container(extension) {
+            return thumbnail_file.to_path_buf();
+        }
+
+        // Ask the muxer whether it can carry this image's codec, rather than
+        // consulting a hardcoded list (#525). This is the same codec-tag lookup
+        // that produced the original failure, and it reads the image's real
+        // codec — FFmpeg probes content, so a mislabeled `.jpg` holding webp is
+        // identified as webp here regardless of its name. An error (unopenable
+        // or undecodable image) answers "not accepted", so normalization, the
+        // safe direction, is the default.
+        if self
+            .ffmpeg
+            .container_accepts_image_codec(extension, thumbnail_file)
+            .await
+            .unwrap_or(false)
         {
             return thumbnail_file.to_path_buf();
         }
@@ -182,20 +180,38 @@ impl ThumbnailStage {
             #[allow(clippy::disallowed_methods)]
             let cover_bytes =
                 std::fs::read(&thumb).context("thumbnail stage: failed to read thumbnail file")?;
-            // Invariant: `normalize_thumbnail_for_embed` guarantees the covr
-            // input is an mp4ameta-supported raster (jpg/jpeg/png). Tie the check
-            // to the same predicate so a future change to the embeddable set
-            // can't silently mislabel bytes here (the original webp-as-jpeg bug).
-            debug_assert!(
-                Self::is_embeddable_raster(&thumb),
-                "write_covr_atom requires a normalized jpg/jpeg/png thumbnail: {}",
-                thumb.display()
-            );
-            let ext = thumb.extension().and_then(|e| e.to_str()).unwrap_or("");
-            let img = if ext.eq_ignore_ascii_case("png") {
-                mp4ameta::Img::png(cover_bytes)
-            } else {
-                mp4ameta::Img::jpeg(cover_bytes)
+            // Pick the covr image type from the BYTES, never the extension.
+            // The previous extension-based branch labelled anything not named
+            // `.png` as JPEG, so a `.jpg` file holding webp bytes was written
+            // into the atom tagged as JPEG — precisely the mislabel #519 set
+            // out to prevent, reachable again through #525's misnamed sidecar.
+            // A `debug_assert` on the extension could not catch it either,
+            // since the extension was the thing that lied.
+            //
+            // Content outside mp4ameta's supported rasters is refused rather
+            // than mislabeled. This is non-fatal: the FFmpeg `attached_pic`
+            // pass has already embedded the thumbnail, so skipping covr costs
+            // Windows Explorer visibility, not the thumbnail itself.
+            //
+            // The arms are listed exhaustively rather than with a catch-all so
+            // that adding a ThumbnailFormat variant fails to compile here,
+            // forcing a decision about whether mp4ameta can represent it. A
+            // string match could not do that — which is how the previous
+            // coupling to the embeddable set was lost silently.
+            let img = match rdlp_types::sniff_thumbnail_format(&cover_bytes) {
+                Some(ThumbnailFormat::Jpeg) => mp4ameta::Img::jpeg(cover_bytes),
+                Some(ThumbnailFormat::Png) => mp4ameta::Img::png(cover_bytes),
+                Some(ThumbnailFormat::Bmp) => mp4ameta::Img::bmp(cover_bytes),
+                Some(
+                    format @ (ThumbnailFormat::Gif | ThumbnailFormat::Tiff | ThumbnailFormat::WebP),
+                ) => anyhow::bail!(
+                    "thumbnail stage: covr atom cannot represent {} content",
+                    format.extension()
+                ),
+                None => anyhow::bail!(
+                    "thumbnail stage: covr atom requires a recognized image, found \
+                     unrecognized data"
+                ),
             };
             let mut tag =
                 mp4ameta::Tag::read_from_path(&media).unwrap_or_else(|_| mp4ameta::Tag::default());
@@ -342,8 +358,12 @@ impl PipelineStage for ThumbnailStage {
                 msg.tracker.replace(vec![temp_output.clone()]);
 
                 // For MP4-family: write covr atom for Windows Explorer.
-                // `embed_source` is guaranteed EMBEDDABLE_RASTER_EXTENSIONS
-                // (jpg/jpeg/png) by `normalize_thumbnail_for_embed` above.
+                // `embed_source` is USUALLY normalized by
+                // `normalize_thumbnail_for_embed` above — but not guaranteed:
+                // that helper falls back to the original file when the
+                // transcode fails. `write_covr_atom` therefore re-checks the
+                // bytes itself and refuses what mp4ameta cannot represent,
+                // rather than trusting an invariant that can be violated.
                 if Self::is_mp4_family(&extension) {
                     Self::write_covr_atom(&temp_output, &embed_source).await;
                 }
@@ -580,37 +600,6 @@ mod tests {
             !result.warnings.is_empty(),
             "expected warning about missing thumbnail"
         );
-    }
-
-    // --- is_embeddable_raster / is_native_attachment_container (bugfix/thumbnail-webp-mp4-embed) ---
-
-    #[test]
-    fn embeddable_raster_accepts_jpg_jpeg_png() {
-        assert!(ThumbnailStage::is_embeddable_raster(&PathBuf::from(
-            "/tmp/thumb.jpg"
-        )));
-        assert!(ThumbnailStage::is_embeddable_raster(&PathBuf::from(
-            "/tmp/thumb.JPEG"
-        )));
-        assert!(ThumbnailStage::is_embeddable_raster(&PathBuf::from(
-            "/tmp/thumb.png"
-        )));
-    }
-
-    /// Negative: webp (the reported bug — xHamster and others serve webp
-    /// thumbnails) and an extensionless path are NOT already embeddable —
-    /// they must go through `normalize_thumbnail_for_embed`.
-    #[test]
-    fn embeddable_raster_rejects_webp_and_other() {
-        assert!(!ThumbnailStage::is_embeddable_raster(&PathBuf::from(
-            "/tmp/thumb.webp"
-        )));
-        assert!(!ThumbnailStage::is_embeddable_raster(&PathBuf::from(
-            "/tmp/thumb.gif"
-        )));
-        assert!(!ThumbnailStage::is_embeddable_raster(&PathBuf::from(
-            "/tmp/thumb"
-        )));
     }
 
     #[test]

--- a/crates/rdlp-postprocess/tests/thumbnail_webp_mp4_embed.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_webp_mp4_embed.rs
@@ -246,3 +246,76 @@ async fn process_embeds_webp_thumbnail_into_mkv_natively() {
         result.warnings
     );
 }
+
+/// The reported #525 shape, end to end: WebP bytes carried by a file NAMED
+/// `.jpg`, because the CDN served WebP from a `.jpg` URL path.
+///
+/// The unit tests pin the individual decisions; this pins the symptom at the
+/// level it was reported. It fails against the pre-#525 code, where the gate
+/// read the `.jpg` name as "already embeddable", skipped normalization, and
+/// stream-copied raw WebP into the MP4 muxer:
+///
+/// ```text
+/// Could not find tag for codec webp in stream #2, codec not currently supported in container
+/// ```
+///
+/// Covers gate + normalize + mux + covr in one pass.
+#[tokio::test]
+async fn process_embeds_mislabeled_webp_named_jpg_into_mp4() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.mp4");
+
+    // Build a genuine WebP, then give it a .jpg name — the mislabel itself.
+    let real_webp = dir.path().join("source.webp");
+    if build_mp4_fixture(&media).is_err() || build_still_image_fixture(&real_webp).is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+    let mislabeled = dir.path().join("video.jpg");
+    std::fs::rename(&real_webp, &mislabeled).expect("rename webp to .jpg");
+
+    // Sanity-check the fixture really is the mislabel we intend to test.
+    let header = std::fs::read(&mislabeled).expect("read fixture");
+    assert_eq!(
+        &header[0..4],
+        b"RIFF",
+        "fixture must actually be webp bytes under a .jpg name"
+    );
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg.clone());
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+    assert!(
+        result.warnings.is_empty(),
+        "a mislabeled webp-as-.jpg thumbnail must still embed cleanly, got: {:?}",
+        result.warnings
+    );
+
+    let out_path = result.tracker.primary();
+    let info = ffmpeg
+        .probe(&out_path)
+        .await
+        .expect("probing embedded output must succeed");
+    let thumb_stream = info
+        .streams
+        .iter()
+        .find(|s| s.index == 1)
+        .expect("thumbnail stream must be present");
+    assert_eq!(
+        thumb_stream.codec_name.as_deref(),
+        Some("mjpeg"),
+        "the mislabeled webp must be normalized to mjpeg — its .jpg NAME must \
+         not have been taken as proof it was already embeddable"
+    );
+}

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -73,5 +73,5 @@ pub use subtitle_track::{
     SubtitleDiagnostic, SubtitleReason, SubtitleResult, SubtitleStatus, SubtitleTrack,
     normalize_from_info_dict,
 };
-pub use thumbnail::THUMBNAIL_EXTENSIONS;
+pub use thumbnail::{THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
 pub use vpx_deadline::VpxDeadline;

--- a/crates/rdlp-types/src/thumbnail.rs
+++ b/crates/rdlp-types/src/thumbnail.rs
@@ -6,8 +6,10 @@
 //! another (the discovery/download drift this const exists to prevent):
 //!
 //! - the **download layer** (`rdlp-api`), which chooses the on-disk extension
-//!   for a fetched thumbnail — an extension not listed here is not trusted from
-//!   the URL and the file is saved as `jpg`; and
+//!   for a fetched thumbnail. Since #525 that name comes from the bytes via
+//!   [`sniff_thumbnail_format`], because a CDN may serve one format from
+//!   another format's URL path; the URL's extension is only a fallback for
+//!   unrecognized content, and one not listed here still degrades to `jpg`; and
 //! - the **post-process discovery gate** (`rdlp-postprocess`), which locates the
 //!   sidecar next to the media file before embedding it.
 
@@ -35,9 +37,279 @@
 pub const THUMBNAIL_EXTENSIONS: &[&str] =
     &["jpg", "jpeg", "png", "webp", "gif", "bmp", "tiff", "tif"];
 
+/// Identify a thumbnail's real image format from its leading bytes.
+///
+/// A URL's extension is a claim, not a fact: a CDN may serve WebP bytes from a
+/// `.jpg` path (the defect in #525). Naming a sidecar from that claim writes
+/// one format under another format's extension, and every later stage that
+/// treats the extension as a proxy for the codec — discovery, the embed
+/// normalization gate, the `covr` atom's image type — then makes the wrong
+/// call. Content is the only trustworthy source, so callers that have the
+/// bytes should name the file from this rather than from the URL.
+///
+/// Returns the identified [`ThumbnailFormat`], or `None` when the bytes match
+/// no known signature — including a short or empty buffer. `None` means
+/// "unrecognized", never "definitely not an image": callers should fall back to
+/// their previous behavior rather than discarding the file.
+///
+/// Matching is table-driven over [`SIGNATURES`]; see [`SignatureFragment`] for
+/// why patterns carry an offset rather than being leading-byte prefixes.
+#[must_use]
+pub fn sniff_thumbnail_format(bytes: &[u8]) -> Option<ThumbnailFormat> {
+    SIGNATURES
+        .iter()
+        .find(|(fragments, _)| fragments.iter().all(|fragment| fragment.matches(bytes)))
+        .map(|(_, format)| *format)
+}
+
+/// One contiguous byte pattern that must appear at a fixed offset.
+///
+/// Signatures are expressed as fragments rather than a single leading pattern
+/// because not every format announces itself in its first bytes: WebP's `WEBP`
+/// marker sits at offset 8, behind the RIFF chunk length, and BMP's stronger
+/// form checks reserved fields past its 2-byte tag. Modelling "pattern at
+/// offset" once keeps those cases as data in [`SIGNATURES`] instead of
+/// bespoke control flow per format, and any future format with a marker behind
+/// a header (AVIF's `ftyp` at offset 4, say) is then one more table row.
+#[derive(Debug, Clone, Copy)]
+struct SignatureFragment {
+    /// Byte offset the pattern must appear at.
+    offset: usize,
+    /// Bytes that must match exactly at `offset`.
+    pattern: &'static [u8],
+}
+
+impl SignatureFragment {
+    /// Declare a fragment; `const` so [`SIGNATURES`] stays a compile-time table.
+    const fn at(offset: usize, pattern: &'static [u8]) -> Self {
+        Self { offset, pattern }
+    }
+
+    /// Whether `bytes` carries this fragment. A buffer too short to contain the
+    /// window simply does not match — short input is never an error.
+    fn matches(self, bytes: &[u8]) -> bool {
+        bytes
+            .get(self.offset..self.offset.saturating_add(self.pattern.len()))
+            .is_some_and(|window| window == self.pattern)
+    }
+}
+
+/// Byte signatures identifying each format; ALL fragments of an entry must
+/// match. Verified against files produced by the linked `FFmpeg` build.
+const SIGNATURES: &[(&[SignatureFragment], ThumbnailFormat)] = &[
+    (
+        &[SignatureFragment::at(0, &[0xFF, 0xD8, 0xFF])],
+        ThumbnailFormat::Jpeg,
+    ),
+    (
+        &[SignatureFragment::at(
+            0,
+            &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+        )],
+        ThumbnailFormat::Png,
+    ),
+    (&[SignatureFragment::at(0, b"GIF87a")], ThumbnailFormat::Gif),
+    (&[SignatureFragment::at(0, b"GIF89a")], ThumbnailFormat::Gif),
+    // BMP's tag is only two bytes, making it the most collision-prone entry —
+    // any payload beginning "BM" would otherwise qualify. `BITMAPFILEHEADER`
+    // requires bfReserved1/bfReserved2 (offsets 6..10) to be zero, so match
+    // those too, as libmagic does.
+    (
+        &[
+            SignatureFragment::at(0, b"BM"),
+            SignatureFragment::at(6, &[0x00, 0x00, 0x00, 0x00]),
+        ],
+        ThumbnailFormat::Bmp,
+    ),
+    // TIFF is byte-order tagged. Version 42 is classic TIFF; BigTIFF
+    // (version 43) is deliberately out of scope — CDNs do not serve it, and an
+    // unrecognized thumbnail degrades safely to normalization.
+    (
+        &[SignatureFragment::at(0, &[0x49, 0x49, 0x2A, 0x00])],
+        ThumbnailFormat::Tiff,
+    ),
+    (
+        &[SignatureFragment::at(0, &[0x4D, 0x4D, 0x00, 0x2A])],
+        ThumbnailFormat::Tiff,
+    ),
+    // WebP is a RIFF container: "RIFF" <u32 length> "WEBP". The form type is
+    // what distinguishes it from other RIFF payloads such as WAV or AVI, and
+    // the intervening length field is why it needs a second fragment rather
+    // than one contiguous pattern.
+    (
+        &[
+            SignatureFragment::at(0, b"RIFF"),
+            SignatureFragment::at(8, b"WEBP"),
+        ],
+        ThumbnailFormat::WebP,
+    ),
+];
+
+/// A thumbnail image format rdlp can identify from content.
+///
+/// Distinct from [`THUMBNAIL_EXTENSIONS`], which is a list of *filename*
+/// spellings to probe on disk (including the `jpeg`/`jpg` and `tif`/`tiff`
+/// aliases). This is the set of actual formats, one variant per format, so a
+/// caller deciding what a file *is* matches exhaustively and the compiler
+/// tracks any future addition — the coupling a `debug_assert` on a string
+/// could not enforce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ThumbnailFormat {
+    /// JPEG (`FF D8 FF`).
+    Jpeg,
+    /// PNG (8-byte signature, ISO 15948 §5).
+    Png,
+    /// GIF, either `GIF87a` or `GIF89a`.
+    Gif,
+    /// Windows bitmap (`BM`).
+    Bmp,
+    /// TIFF, either byte order.
+    Tiff,
+    /// WebP (RIFF container with a `WEBP` form type).
+    WebP,
+}
+
+impl ThumbnailFormat {
+    /// The canonical extension rdlp saves this format under.
+    ///
+    /// One spelling per format: `jpg` (not `jpeg`) and `tiff` (not `tif`).
+    #[must_use]
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Jpeg => "jpg",
+            Self::Png => "png",
+            Self::Gif => "gif",
+            Self::Bmp => "bmp",
+            Self::Tiff => "tiff",
+            Self::WebP => "webp",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::THUMBNAIL_EXTENSIONS;
+    use super::{THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
+
+    // Byte signatures below were verified empirically against files produced by
+    // the linked FFmpeg build, not from recall.
+
+    #[test]
+    fn sniffs_jpeg() {
+        assert_eq!(
+            sniff_thumbnail_format(&[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]),
+            Some(ThumbnailFormat::Jpeg)
+        );
+    }
+
+    #[test]
+    fn sniffs_png() {
+        let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+        assert_eq!(sniff_thumbnail_format(&png), Some(ThumbnailFormat::Png));
+    }
+
+    /// The bug behind #525: a CDN serving WebP bytes under a `.jpg` URL. The
+    /// `WEBP` marker sits at offset 8, AFTER the 4-byte RIFF chunk length, so a
+    /// contiguous `RIFF....WEBP` match would fail.
+    #[test]
+    fn sniffs_webp_despite_split_marker() {
+        let mut webp = Vec::from(*b"RIFF");
+        webp.extend_from_slice(&[0x4C, 0x00, 0x00, 0x00]); // chunk length
+        webp.extend_from_slice(b"WEBPVP8 ");
+        assert_eq!(sniff_thumbnail_format(&webp), Some(ThumbnailFormat::WebP));
+    }
+
+    /// A RIFF container that is not WebP (e.g. WAV) must not be claimed.
+    #[test]
+    fn rejects_non_webp_riff() {
+        let mut wav = Vec::from(*b"RIFF");
+        wav.extend_from_slice(&[0x24, 0x00, 0x00, 0x00]);
+        wav.extend_from_slice(b"WAVEfmt ");
+        assert_eq!(sniff_thumbnail_format(&wav), None);
+    }
+
+    #[test]
+    fn sniffs_both_gif_versions() {
+        assert_eq!(
+            sniff_thumbnail_format(b"GIF89a\x20\x00"),
+            Some(ThumbnailFormat::Gif)
+        );
+        assert_eq!(
+            sniff_thumbnail_format(b"GIF87a\x20\x00"),
+            Some(ThumbnailFormat::Gif)
+        );
+    }
+
+    #[test]
+    fn sniffs_bmp() {
+        assert_eq!(
+            sniff_thumbnail_format(b"BM\x36\x0c\x00\x00\x00\x00\x00\x00"),
+            Some(ThumbnailFormat::Bmp)
+        );
+    }
+
+    /// BMP's tag is only two bytes, so it is the entry most likely to claim
+    /// unrelated data. `BITMAPFILEHEADER` requires the reserved fields at
+    /// offsets 6..10 to be zero, and matching them rejects payloads that merely
+    /// happen to start with "BM".
+    #[test]
+    fn rejects_bm_prefixed_data_with_nonzero_reserved_fields() {
+        assert_eq!(
+            sniff_thumbnail_format(b"BMOKAY-this-is-just-text"),
+            None,
+            "text beginning \"BM\" must not be claimed as a bitmap"
+        );
+    }
+
+    /// TIFF is byte-order tagged: `II*\0` little-endian, `MM\0*` big-endian.
+    /// Both are valid and both must be recognized.
+    #[test]
+    fn sniffs_tiff_in_both_byte_orders() {
+        assert_eq!(
+            sniff_thumbnail_format(b"II\x2A\x00rest"),
+            Some(ThumbnailFormat::Tiff)
+        );
+        assert_eq!(
+            sniff_thumbnail_format(b"MM\x00\x2Arest"),
+            Some(ThumbnailFormat::Tiff)
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unrecognized_or_short_input() {
+        assert_eq!(sniff_thumbnail_format(b""), None);
+        assert_eq!(sniff_thumbnail_format(b"\xFF"), None);
+        assert_eq!(sniff_thumbnail_format(b"RIFF"), None); // truncated
+        assert_eq!(sniff_thumbnail_format(b"<!DOCTYPE html>"), None);
+        assert_eq!(sniff_thumbnail_format(b"not an image at all"), None);
+    }
+
+    /// Load-bearing invariant: anything the sniffer can name must also be a
+    /// discoverable sidecar extension, or the download layer would save a file
+    /// under a name the post-process discovery gate never looks for.
+    #[test]
+    fn every_sniffable_format_is_discoverable() {
+        let samples: &[(ThumbnailFormat, &[u8])] = &[
+            (ThumbnailFormat::Jpeg, &[0xFF, 0xD8, 0xFF, 0xE0]),
+            (
+                ThumbnailFormat::Png,
+                &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+            ),
+            (ThumbnailFormat::Gif, b"GIF89a\x00\x00"),
+            (ThumbnailFormat::Bmp, b"BM\x00\x00\x00\x00\x00\x00\x00\x00"),
+            (ThumbnailFormat::Tiff, b"II\x2A\x00"),
+            (ThumbnailFormat::WebP, b"RIFF\x00\x00\x00\x00WEBP"),
+        ];
+        for (expected, bytes) in samples {
+            let sniffed = sniff_thumbnail_format(bytes)
+                .unwrap_or_else(|| panic!("{expected:?} sample must be sniffable"));
+            assert_eq!(sniffed, *expected);
+            assert!(
+                THUMBNAIL_EXTENSIONS.contains(&sniffed.extension()),
+                "sniffer returned {:?}, whose extension discovery does not look for",
+                sniffed.extension()
+            );
+        }
+    }
 
     #[test]
     fn includes_the_widened_decodable_formats() {


### PR DESCRIPTION
## Resolves

Closes #525

## What was wrong

A CDN may serve one image format from another format's URL path. `bigtitbitches` serves WebP bytes from `.../1280x720/1.jpg` with `Content-Type: image/webp`, and every layer that touched the thumbnail took the URL's word for it.

| Layer | Value | Source |
|---|---|---|
| Thumbnail URL | `…/1280x720/1.jpg` | extractor |
| CDN `Content-Type` | `image/webp` | server |
| Bytes on disk | `RIFF…WEBP`, VP8 | `file(1)` / `ffprobe` |
| Sidecar filename | `…[generic-…].jpg` | `thumbnail_extension_from_url` |

`jpg` is in `THUMBNAIL_EXTENSIONS`, so the whitelist check passed and WebP bytes landed in a `.jpg` file. The embed gate then tested that same path extension, read `.jpg` as "already MP4-safe", skipped normalization, and stream-copied raw WebP into the muxer:

```
Could not find tag for codec webp in stream #2, codec not currently supported in container
```

Distinct from #519: that fix normalizes a sidecar whose URL *honestly* advertises `.webp`, and it works. Here the URL lied, so no extension-based logic could reach the normalization at all.

## What this changes

**Name the sidecar from its bytes.** Identification lives in `rdlp-types` beside the whitelist it must agree with, as a table of byte signatures over a `ThumbnailFormat` enum. The URL's extension is now only a fallback for unrecognized content, and a disagreement is logged — otherwise it stays invisible until an embed fails much later.

Signatures were verified against files produced by the linked FFmpeg build rather than recalled, which caught two things:
- **WebP's `WEBP` marker sits at offset 8**, behind the RIFF chunk length — not a contiguous match. Confirmed against the real mislabeled file, whose bytes 4–8 are `18 50 01 00`. A naive `RIFF…WEBP` match would have failed on the exact file that caused this bug.
- **TIFF is byte-order tagged** (`II*\0` / `MM\0*`).

Because signatures are modelled as *pattern at offset* rather than leading-byte prefixes, WebP needs no special case, and BMP's 2-byte tag — the most collision-prone entry — is hardened by also requiring `BITMAPFILEHEADER`'s reserved fields to be zero, as libmagic does.

**Ask the muxer instead of hardcoding.** `EMBEDDABLE_RASTER_EXTENSIONS` was a guess about container capability maintained by hand. `avformat_query_codec` consults the linked build's own muxer tables — the very lookup that emitted the error above — and FFmpeg probes the image, so a mislabeled `.jpg` is identified as webp regardless of its name.

Two limits of that query, both **measured rather than assumed**:

- It is authoritative only for tag-table muxers. mp3 answers through a `query_codec` callback returning the `APIC` tag, and flac/m4a/m4v carry neither mechanism, so all report "cannot store" for jpeg/png they demonstrably *do* store. JPEG and PNG are therefore a verified baseline that the query can only **widen** — otherwise a lossless PNG cover on an MP3 would be re-encoded to lossy JPEG.
- It answers about storing a codec as a **stream**. Matroska carries thumbnails as attachments, so it reports "no" for webp and png alike; the attachment container is checked first, and a test records why that "no" isn't a contradiction.

Every failure direction resolves to *transcode first* — unopenable image, unresolvable container, negative/unknown query. A needless transcode costs work; a wrong answer costs the embed.

**Fix the `covr` atom**, which had the same blind spot: it chose the image type from the extension, labelling anything not named `.png` as JPEG, and its `debug_assert` was tied to that same predicate so it could not detect mislabeled bytes — the extension was the thing lying. It now selects from content and matches `ThumbnailFormat` exhaustively **with no catch-all**, so adding a format fails to compile there. mp4ameta supports bmp, so covr accepts it rather than refusing.

## Tests

- Signature table: per-format positives, both GIF versions, both TIFF byte orders, non-WebP RIFF rejection, `BM`-prefixed text rejection, short/empty/unrecognized input, plus an invariant test that every sniffable format is discoverable.
- Container matrix over all eight verified containers for the jpeg/png baseline — the coverage gap that let a regression through in review.
- `webp_is_still_refused_by_mp4_family`, guarding that the baseline didn't swallow the actual bug.
- End-to-end at the layer the bug was reported: **webp bytes under a `.jpg` name through `process()`**, asserting the output stream is `mjpeg` — covering gate + normalize + mux + covr in one pass.

The two extension-based `is_embeddable_raster` tests were replaced rather than deleted; the function they tested no longer exists, and the replacement drives real bytes through the successor.

## Verification

`cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace` · `cargo check -p rdlp-desktop` · all 6 `scripts/check-*.sh` — green.

## Reviews

- **security-reviewer: Approve** (twice — once per design). Verified the unsafe FFI against the *generated bindings*, not the SAFETY comment's claims: `av_guess_format` returns a pointer into libavformat's static compiled-in table that is never caller-owned, null-checked before every deref, `CString` outlives its call, and the query is a read-only table lookup. Confirmed no panic path in the offset matcher and that every failure direction is transcode-first.
- **code-reviewer: Approve with minor fixes**, after a **Request changes** round that caught a real regression I introduced — the muxer query under-reporting for non-tag-table muxers (see above). It verified the fix by measurement, embedding into each container and confirming PNG survives as PNG. It also independently checked every byte signature against WHATWG MIME Sniffing, libmagic, ISO 15948 and ITU-T T.81.

## Follow-ups filed

- **#530** — MKV attachment mimetype falls back to `image/jpeg` for gif/bmp/tiff. Same class of defect, different code path, pre-existing.
- **#531** — ogg/opus thumbnail embed fails with "Unsupported codec id in stream 1", even for jpeg/png. Pre-existing; the previous whitelist reached the same failure.

Both are deliberately out of this branch, which is scoped to content-vs-extension.
