### PR TITLE
fix(thumbnail): embed ogg/opus cover art via METADATA_BLOCK_PICTURE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6195,6 +6195,7 @@ name = "rdlp-ffmpeg"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "ffmpeg-the-third",
  "log",
  "openssl-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6302,6 +6302,7 @@ dependencies = [
  "rdlp-core",
  "rdlp-ffmpeg",
  "rdlp-types",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/rdlp-ffmpeg/Cargo.toml
+++ b/crates/rdlp-ffmpeg/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+base64 = { workspace = true }
 
 # FFmpeg library bindings (FFmpeg 5-8)
 ffmpeg-the-third = "4.1"

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -58,6 +58,7 @@ mod remux;
 pub(crate) mod salvage;
 pub mod speed_controls;
 mod thumbnail;
+pub use thumbnail::supports_thumbnail_embed;
 mod transcode;
 pub use speed_controls::{
     SpeedControlError, default_codec_for_container, resolve_recode_encoder, validate_speed_controls,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
@@ -83,8 +83,94 @@ impl ThumbnailEmbedStrategy {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr as _;
+
     use super::ThumbnailEmbedStrategy;
     use rdlp_types::ContainerFormat;
+
+    /// Mirrors `rdlp-postprocess`'s `SUPPORTED_CONTAINERS`
+    /// (`crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs`) — the two
+    /// lists are independent sources of truth for "can this container carry a
+    /// thumbnail" today (full consolidation tracked by #533). The two tests
+    /// below are the guardrail that keeps them from silently drifting apart
+    /// until that consolidation lands.
+    const MIRRORED_SUPPORTED_CONTAINERS: &[&str] = &[
+        "mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac", "ogg", "opus",
+    ];
+
+    /// Every `ContainerFormat` variant. Kept in step, by hand, with
+    /// `for_container`'s own exhaustive match (no catch-all, above) — that
+    /// match already fails to compile if a variant is added without a
+    /// decision, so a stale list here is a soft test gap, not a silently
+    /// wrong answer.
+    fn all_container_formats() -> Vec<ContainerFormat> {
+        vec![
+            ContainerFormat::Mp4,
+            ContainerFormat::Mkv,
+            ContainerFormat::WebM,
+            ContainerFormat::Mov,
+            ContainerFormat::M4v,
+            ContainerFormat::Ts,
+            ContainerFormat::Flv,
+            ContainerFormat::Avi,
+            ContainerFormat::ThreeGp,
+            ContainerFormat::Mpg,
+            ContainerFormat::F4v,
+            ContainerFormat::Asf,
+            ContainerFormat::Mxf,
+            ContainerFormat::Vob,
+            ContainerFormat::Dv,
+            ContainerFormat::Nut,
+            ContainerFormat::Ivf,
+            ContainerFormat::Ogg,
+            ContainerFormat::M4a,
+            ContainerFormat::Mp3,
+            ContainerFormat::Wav,
+            ContainerFormat::Flac,
+            ContainerFormat::Opus,
+            ContainerFormat::Aac,
+            ContainerFormat::Aiff,
+            ContainerFormat::Mka,
+            ContainerFormat::Wv,
+            ContainerFormat::Caf,
+            ContainerFormat::Ac3,
+        ]
+    }
+
+    /// Forward direction: every string `rdlp-postprocess` advertises as
+    /// thumbnail-capable must actually resolve to an embed strategy here.
+    #[test]
+    fn supported_containers_all_resolve_to_a_strategy() {
+        for container in MIRRORED_SUPPORTED_CONTAINERS {
+            let format = ContainerFormat::from_str(container)
+                .unwrap_or_else(|_| panic!("'{container}' must parse as a ContainerFormat"));
+            assert!(
+                ThumbnailEmbedStrategy::for_container(format).is_some(),
+                "'{container}' is listed in SUPPORTED_CONTAINERS but for_container returned None"
+            );
+        }
+    }
+
+    /// Reverse direction: every container this module resolves to a strategy
+    /// for must be advertised by `rdlp-postprocess` — otherwise
+    /// `ThumbnailStage` would never reach this code for that container at
+    /// all, and the two lists have quietly diverged.
+    #[test]
+    fn every_strategy_supported_format_is_in_supported_containers() {
+        for format in all_container_formats() {
+            if ThumbnailEmbedStrategy::for_container(format).is_some() {
+                // `as_ext()` (not `Display`/`to_string()`) is the canonical
+                // extension string: `ContainerFormat`'s `Display` impl does
+                // not necessarily print the same alias `SUPPORTED_CONTAINERS`
+                // uses (e.g. `Mkv`'s `Display` is "matroska", not "mkv").
+                let name = format.as_ext();
+                assert!(
+                    MIRRORED_SUPPORTED_CONTAINERS.contains(&name),
+                    "'{name}' resolves to a thumbnail strategy but is missing from SUPPORTED_CONTAINERS"
+                );
+            }
+        }
+    }
 
     #[test]
     fn matroska_containers_use_native_attachment() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
@@ -1,0 +1,165 @@
+//! How a thumbnail is carried into a given [`ContainerFormat`].
+//!
+//! `embed_thumbnail_sync` previously decided this with four independent
+//! `container.eq_ignore_ascii_case(...)` checks (`is_mkv`, `is_mp3`,
+//! `is_mp4_mov`, and the Ogg/Opus check added for #531) — the same decision
+//! expressed piecemeal, entirely in raw strings. This module collapses it
+//! into one typed decision made once, from [`ContainerFormat`] rather than a
+//! bare `&str` (per the workspace convention: container formats are never raw
+//! strings — see `CLAUDE.md`).
+
+use rdlp_types::ContainerFormat;
+
+/// The mechanism used to carry a thumbnail into a media container.
+///
+/// Constructed once per embed via [`Self::for_container`] and matched
+/// exhaustively at each decision point in `embed_thumbnail_sync`, replacing
+/// the four scattered string predicates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ThumbnailEmbedStrategy {
+    /// Native Matroska attachment (raw FFI), not a stream at all.
+    MatroskaAttachment,
+    /// `ATTACHED_PIC` video stream, only audio streams mapped from the
+    /// source, `ID3v2` title/comment tags on the picture stream.
+    Id3Apic,
+    /// `ATTACHED_PIC` video stream; the muxer converts it to a native FLAC
+    /// `PICTURE` block, which must be written to the picture stream BEFORE
+    /// the header (`write_header`) is written.
+    FlacAttachedPic,
+    /// `ATTACHED_PIC` video stream with `movflags=+faststart` (moov atom
+    /// first, for Windows Explorer thumbnail visibility); picture packet
+    /// written after the header, same as any other stream.
+    Mp4FamilyAttachedPic,
+    /// No stream at all — the cover rides a base64 `METADATA_BLOCK_PICTURE`
+    /// `VorbisComment` field set before the header is written (#531; see
+    /// `super::vorbis_picture`). `FFmpeg`'s Ogg muxer hard-rejects any stream
+    /// whose codec isn't Vorbis/Theora/Speex/FLAC/Opus/VP8, so an
+    /// `ATTACHED_PIC` image stream is not an option here.
+    VorbisComment,
+}
+
+impl ThumbnailEmbedStrategy {
+    /// Resolve the embed strategy for `format`, or `None` when `format`
+    /// cannot carry a thumbnail at all.
+    ///
+    /// Matched exhaustively over every [`ContainerFormat`] variant (no
+    /// catch-all arm) so that a newly-added container format fails to
+    /// compile here, forcing an explicit decision about its thumbnail
+    /// strategy — the same exhaustive-match discipline `vorbis_picture::
+    /// mime_type` uses for [`rdlp_types::ThumbnailFormat`] (#525).
+    #[must_use]
+    pub(super) const fn for_container(format: ContainerFormat) -> Option<Self> {
+        match format {
+            ContainerFormat::Mkv | ContainerFormat::Mka => Some(Self::MatroskaAttachment),
+            ContainerFormat::Mp3 => Some(Self::Id3Apic),
+            ContainerFormat::Flac => Some(Self::FlacAttachedPic),
+            ContainerFormat::Mp4
+            | ContainerFormat::Mov
+            | ContainerFormat::M4v
+            | ContainerFormat::M4a => Some(Self::Mp4FamilyAttachedPic),
+            ContainerFormat::Ogg | ContainerFormat::Opus => Some(Self::VorbisComment),
+            ContainerFormat::WebM
+            | ContainerFormat::Ts
+            | ContainerFormat::Flv
+            | ContainerFormat::Avi
+            | ContainerFormat::ThreeGp
+            | ContainerFormat::Mpg
+            | ContainerFormat::F4v
+            | ContainerFormat::Asf
+            | ContainerFormat::Mxf
+            | ContainerFormat::Vob
+            | ContainerFormat::Dv
+            | ContainerFormat::Nut
+            | ContainerFormat::Ivf
+            | ContainerFormat::Wav
+            | ContainerFormat::Aac
+            | ContainerFormat::Aiff
+            | ContainerFormat::Wv
+            | ContainerFormat::Caf
+            | ContainerFormat::Ac3 => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ThumbnailEmbedStrategy;
+    use rdlp_types::ContainerFormat;
+
+    #[test]
+    fn matroska_containers_use_native_attachment() {
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Mkv),
+            Some(ThumbnailEmbedStrategy::MatroskaAttachment)
+        );
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Mka),
+            Some(ThumbnailEmbedStrategy::MatroskaAttachment)
+        );
+    }
+
+    #[test]
+    fn mp3_uses_id3_apic() {
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Mp3),
+            Some(ThumbnailEmbedStrategy::Id3Apic)
+        );
+    }
+
+    #[test]
+    fn flac_uses_attached_pic_before_header() {
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Flac),
+            Some(ThumbnailEmbedStrategy::FlacAttachedPic)
+        );
+    }
+
+    /// The regression this module exists to prevent: Ogg and Opus must NOT
+    /// resolve to any `ATTACHED_PIC`-stream strategy (#531).
+    #[test]
+    fn ogg_and_opus_use_vorbis_comment_not_a_stream() {
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Ogg),
+            Some(ThumbnailEmbedStrategy::VorbisComment)
+        );
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Opus),
+            Some(ThumbnailEmbedStrategy::VorbisComment)
+        );
+    }
+
+    #[test]
+    fn mp4_family_uses_attached_pic_with_faststart() {
+        for format in [
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::M4v,
+            ContainerFormat::M4a,
+        ] {
+            assert_eq!(
+                ThumbnailEmbedStrategy::for_container(format),
+                Some(ThumbnailEmbedStrategy::Mp4FamilyAttachedPic)
+            );
+        }
+    }
+
+    /// Negative: a container `rdlp` never advertises as thumbnail-capable
+    /// (`SUPPORTED_CONTAINERS` in `rdlp-postprocess`) must resolve to `None`,
+    /// not silently fall through to a stream-based strategy that would fail
+    /// at mux time.
+    #[test]
+    fn unsupported_container_resolves_to_none() {
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::WebM),
+            None
+        );
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Wav),
+            None
+        );
+        assert_eq!(
+            ThumbnailEmbedStrategy::for_container(ContainerFormat::Avi),
+            None
+        );
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
@@ -81,96 +81,22 @@ impl ThumbnailEmbedStrategy {
     }
 }
 
+/// Whether `format` can carry an embedded thumbnail at all.
+///
+/// The public gateway to [`ThumbnailEmbedStrategy::for_container`] — exposed
+/// so `rdlp-postprocess`'s `SUPPORTED_CONTAINERS` can be asserted against the
+/// real strategy table instead of a hand-copied mirror of it (full
+/// consolidation of the two lists into one source of truth is tracked by
+/// #533).
+#[must_use]
+pub const fn supports_thumbnail_embed(format: ContainerFormat) -> bool {
+    ThumbnailEmbedStrategy::for_container(format).is_some()
+}
+
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr as _;
-
     use super::ThumbnailEmbedStrategy;
     use rdlp_types::ContainerFormat;
-
-    /// Mirrors `rdlp-postprocess`'s `SUPPORTED_CONTAINERS`
-    /// (`crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs`) — the two
-    /// lists are independent sources of truth for "can this container carry a
-    /// thumbnail" today (full consolidation tracked by #533). The two tests
-    /// below are the guardrail that keeps them from silently drifting apart
-    /// until that consolidation lands.
-    const MIRRORED_SUPPORTED_CONTAINERS: &[&str] = &[
-        "mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac", "ogg", "opus",
-    ];
-
-    /// Every `ContainerFormat` variant. Kept in step, by hand, with
-    /// `for_container`'s own exhaustive match (no catch-all, above) — that
-    /// match already fails to compile if a variant is added without a
-    /// decision, so a stale list here is a soft test gap, not a silently
-    /// wrong answer.
-    fn all_container_formats() -> Vec<ContainerFormat> {
-        vec![
-            ContainerFormat::Mp4,
-            ContainerFormat::Mkv,
-            ContainerFormat::WebM,
-            ContainerFormat::Mov,
-            ContainerFormat::M4v,
-            ContainerFormat::Ts,
-            ContainerFormat::Flv,
-            ContainerFormat::Avi,
-            ContainerFormat::ThreeGp,
-            ContainerFormat::Mpg,
-            ContainerFormat::F4v,
-            ContainerFormat::Asf,
-            ContainerFormat::Mxf,
-            ContainerFormat::Vob,
-            ContainerFormat::Dv,
-            ContainerFormat::Nut,
-            ContainerFormat::Ivf,
-            ContainerFormat::Ogg,
-            ContainerFormat::M4a,
-            ContainerFormat::Mp3,
-            ContainerFormat::Wav,
-            ContainerFormat::Flac,
-            ContainerFormat::Opus,
-            ContainerFormat::Aac,
-            ContainerFormat::Aiff,
-            ContainerFormat::Mka,
-            ContainerFormat::Wv,
-            ContainerFormat::Caf,
-            ContainerFormat::Ac3,
-        ]
-    }
-
-    /// Forward direction: every string `rdlp-postprocess` advertises as
-    /// thumbnail-capable must actually resolve to an embed strategy here.
-    #[test]
-    fn supported_containers_all_resolve_to_a_strategy() {
-        for container in MIRRORED_SUPPORTED_CONTAINERS {
-            let format = ContainerFormat::from_str(container)
-                .unwrap_or_else(|_| panic!("'{container}' must parse as a ContainerFormat"));
-            assert!(
-                ThumbnailEmbedStrategy::for_container(format).is_some(),
-                "'{container}' is listed in SUPPORTED_CONTAINERS but for_container returned None"
-            );
-        }
-    }
-
-    /// Reverse direction: every container this module resolves to a strategy
-    /// for must be advertised by `rdlp-postprocess` — otherwise
-    /// `ThumbnailStage` would never reach this code for that container at
-    /// all, and the two lists have quietly diverged.
-    #[test]
-    fn every_strategy_supported_format_is_in_supported_containers() {
-        for format in all_container_formats() {
-            if ThumbnailEmbedStrategy::for_container(format).is_some() {
-                // `as_ext()` (not `Display`/`to_string()`) is the canonical
-                // extension string: `ContainerFormat`'s `Display` impl does
-                // not necessarily print the same alias `SUPPORTED_CONTAINERS`
-                // uses (e.g. `Mkv`'s `Display` is "matroska", not "mkv").
-                let name = format.as_ext();
-                assert!(
-                    MIRRORED_SUPPORTED_CONTAINERS.contains(&name),
-                    "'{name}' resolves to a thumbnail strategy but is missing from SUPPORTED_CONTAINERS"
-                );
-            }
-        }
-    }
 
     #[test]
     fn matroska_containers_use_native_attachment() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -47,6 +47,7 @@ use rdlp_types::ContainerFormat;
 use crate::error::{PostProcessError, Result};
 
 use self::embed_strategy::ThumbnailEmbedStrategy;
+pub use self::embed_strategy::supports_thumbnail_embed;
 use super::{FFmpegRunner, ensure_init};
 
 impl FFmpegRunner {
@@ -377,14 +378,16 @@ impl FFmpegRunner {
         // which a stream-based ATTACHED_PIC would otherwise be rejected.
         if is_ogg_opus {
             // Deliberate second read of `thumbnail`, not an oversight: the
-            // `thumb_ictx`/`thumb_ist` probe above only demuxes the image to
-            // learn its dimensions and codec — `ffmpeg-the-third` exposes no
-            // way to recover the original whole-file encoded bytes from a
-            // decoded stream, so the raw bytes this branch embeds (MIME-sniffed
-            // and RFC 9639-framed below) have to come from a fresh read of the
-            // same path. Restructuring to share one read would mean threading
-            // raw bytes through the demux path for every other container's
-            // strategy too, for no benefit there.
+            // `thumb_ictx`/`thumb_ist` probe above exists only to learn the
+            // image's dimensions and codec (needed for the PICTURE block's
+            // width/height/MIME fields); its demuxed packets are never
+            // consumed here. Recovering the encoded bytes from those packets
+            // instead of re-reading the file is demuxer/format-dependent —
+            // "packet bytes equal the original file bytes" only holds for a
+            // single-frame image2-demuxed still, not in general — so relying
+            // on it would couple this Vorbis-comment path to the same
+            // packet-equals-file assumption `write_thumbnail_packets` makes
+            // for the stream-copy paths below, for no benefit here.
             //
             // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking
             // from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -376,23 +376,40 @@ impl FFmpegRunner {
         // the header it writes, and `avformat_write_header` is the point at
         // which a stream-based ATTACHED_PIC would otherwise be rejected.
         if is_ogg_opus {
+            // Deliberate second read of `thumbnail`, not an oversight: the
+            // `thumb_ictx`/`thumb_ist` probe above only demuxes the image to
+            // learn its dimensions and codec — `ffmpeg-the-third` exposes no
+            // way to recover the original whole-file encoded bytes from a
+            // decoded stream, so the raw bytes this branch embeds (MIME-sniffed
+            // and RFC 9639-framed below) have to come from a fresh read of the
+            // same path. Restructuring to share one read would mean threading
+            // raw bytes through the demux path for every other container's
+            // strategy too, for no benefit there.
+            //
             // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking
             // from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
             #[allow(clippy::disallowed_methods)]
             let image_bytes = std::fs::read(thumbnail)
                 .with_context(|| format!("failed to read thumbnail {}", thumbnail.display()))?;
-            let format = rdlp_types::sniff_thumbnail_format(&image_bytes).ok_or_else(|| {
-                PostProcessError::ffmpeg_failed(format!(
-                    "thumbnail {} is not a recognized image format",
-                    thumbnail.display()
-                ))
-            })?;
+            let image_format =
+                rdlp_types::sniff_thumbnail_format(&image_bytes).ok_or_else(|| {
+                    PostProcessError::ffmpeg_failed(format!(
+                        "thumbnail {} is not a recognized image format",
+                        thumbnail.display()
+                    ))
+                })?;
             let picture = vorbis_picture::build_metadata_block_picture(
-                vorbis_picture::mime_type(format),
+                vorbis_picture::mime_type(image_format),
                 thumb_width,
                 thumb_height,
                 &image_bytes,
-            );
+            )
+            .map_err(|e| {
+                PostProcessError::ffmpeg_failed(format!(
+                    "failed to build METADATA_BLOCK_PICTURE for thumbnail {}: {e:#}",
+                    thumbnail.display()
+                ))
+            })?;
             let mut meta = octx.metadata().to_owned();
             meta.set("METADATA_BLOCK_PICTURE", &picture);
             octx.set_metadata(meta);

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -325,10 +325,11 @@ impl FFmpegRunner {
                 .set_metadata(ist.metadata().to_owned());
         }
 
-        // Read the thumbnail's video stream up front: every strategy below
-        // needs its dimensions and/or codec, and the metadata-block-picture
-        // strategy needs its raw bytes read before `thumb_ictx` goes out of
-        // scope.
+        // Probe the thumbnail's video stream up front: every strategy below
+        // needs its dimensions and/or codec. Note this probe does NOT supply
+        // the metadata-block-picture strategy's raw bytes — those come from a
+        // separate `std::fs::read` further down, for the reason documented at
+        // that call site.
         let thumb_ist = thumb_ictx
             .streams()
             .best(ffmpeg_the_third::media::Type::Video)
@@ -379,8 +380,9 @@ impl FFmpegRunner {
         if is_ogg_opus {
             // Deliberate second read of `thumbnail`, not an oversight: the
             // `thumb_ictx`/`thumb_ist` probe above exists only to learn the
-            // image's dimensions and codec (needed for the PICTURE block's
-            // width/height/MIME fields); its demuxed packets are never
+            // image's dimensions (needed for the PICTURE block's width/height
+            // fields; the MIME comes from sniffing the bytes read below, not
+            // from the probe's codec); its demuxed packets are never
             // consumed here. Recovering the encoded bytes from those packets
             // instead of re-reading the file is demuxer/format-dependent —
             // "packet bytes equal the original file bytes" only holds for a

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -4,7 +4,14 @@
 //! - **MP4/MOV/M4A/M4V**: Map all streams + thumbnail as video with `ATTACHED_PIC`
 //! - **MKV/MKA**: Native Matroska attachment via raw FFI
 //! - **MP3**: Map audio only + thumbnail as video with `ID3v2` metadata
-//! - **FLAC/OGG/Opus**: Map all streams + thumbnail with `ATTACHED_PIC`
+//! - **FLAC**: Map all streams + thumbnail as video with `ATTACHED_PIC` (the
+//!   FLAC muxer accepts an attached-pic stream and converts it internally to
+//!   a native FLAC `PICTURE` block)
+//! - **OGG/Opus**: Map all streams; the thumbnail rides a base64
+//!   `METADATA_BLOCK_PICTURE` `VorbisComment` field (see [`vorbis_picture`])
+//!   instead of a stream — `FFmpeg`'s Ogg muxer hard-rejects any stream whose
+//!   codec isn't Vorbis/Theora/Speex/FLAC/Opus/VP8, so an `ATTACHED_PIC`
+//!   image stream fails with `Unsupported codec id in stream N` (#531)
 //!
 //! # Lint allowances
 //!
@@ -25,16 +32,21 @@
     clippy::option_if_let_else, // ok_or_else pattern with complex closures is clearer as if let
 )]
 
+mod embed_strategy;
 mod mkv_raw_ffi;
+mod vorbis_picture;
 
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Context as _;
 use rdlp_core::PostProcessCallback;
+use rdlp_types::ContainerFormat;
 
 use crate::error::{PostProcessError, Result};
 
+use self::embed_strategy::ThumbnailEmbedStrategy;
 use super::{FFmpegRunner, ensure_init};
 
 impl FFmpegRunner {
@@ -199,7 +211,9 @@ impl FFmpegRunner {
     /// - **MP4/MOV/M4A/M4V**: Map all streams + thumbnail as video with `ATTACHED_PIC`
     /// - **MKV/MKA**: Map all streams + thumbnail as attachment with mimetype metadata
     /// - **MP3**: Map audio only + thumbnail as video with `ID3v2` metadata
-    /// - **FLAC/OGG/Opus**: Map all streams + thumbnail with `ATTACHED_PIC`
+    /// - **FLAC**: Map all streams + thumbnail as video with `ATTACHED_PIC`
+    /// - **OGG/Opus**: Map all streams; thumbnail carried as a
+    ///   `METADATA_BLOCK_PICTURE` metadata field, no video stream added (#531)
     #[allow(clippy::too_many_lines)]
     fn embed_thumbnail_sync(
         media: &Path,
@@ -210,6 +224,20 @@ impl FFmpegRunner {
         encoding_tool_override: Option<&str>,
     ) -> anyhow::Result<()> {
         ensure_init()?;
+
+        // Parse the container ONCE, at the boundary, into the typed
+        // `ContainerFormat` + the strategy it implies — every downstream
+        // decision matches on `strategy`, never on a raw string.
+        let format = ContainerFormat::from_str(container).map_err(|_| {
+            PostProcessError::ffmpeg_failed(format!(
+                "unrecognized container '{container}' for thumbnail embed"
+            ))
+        })?;
+        let strategy = ThumbnailEmbedStrategy::for_container(format).ok_or_else(|| {
+            PostProcessError::ffmpeg_failed(format!(
+                "container '{container}' does not support thumbnail embedding"
+            ))
+        })?;
 
         // When a callback is provided, capture FFmpeg logs and forward them;
         // otherwise suppress muxer trace/debug spam.
@@ -225,8 +253,7 @@ impl FFmpegRunner {
         };
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility
-        let is_mkv = container.eq_ignore_ascii_case("mkv") || container.eq_ignore_ascii_case("mka");
-        if is_mkv {
+        if strategy == ThumbnailEmbedStrategy::MatroskaAttachment {
             let result =
                 Self::embed_thumbnail_mkv_raw_ffi(media, thumbnail, output, encoding_tool_override);
             // Forward captured logs before returning
@@ -259,7 +286,11 @@ impl FFmpegRunner {
                 )
             })?;
 
-        let is_mp3 = container.eq_ignore_ascii_case("mp3");
+        let is_mp3 = strategy == ThumbnailEmbedStrategy::Id3Apic;
+        // Ogg/Opus reject any stream whose codec isn't in a small fixed set
+        // (Vorbis/Theora/Speex/FLAC/Opus/VP8) at `write_header` time, so the
+        // thumbnail must NEVER become a stream for these containers (#531).
+        let is_ogg_opus = strategy == ThumbnailEmbedStrategy::VorbisComment;
 
         // Map media streams to output
         let stream_count = ictx.streams().count();
@@ -293,32 +324,44 @@ impl FFmpegRunner {
                 .set_metadata(ist.metadata().to_owned());
         }
 
-        // Add thumbnail stream
+        // Read the thumbnail's video stream up front: every strategy below
+        // needs its dimensions and/or codec, and the metadata-block-picture
+        // strategy needs its raw bytes read before `thumb_ictx` goes out of
+        // scope.
         let thumb_ist = thumb_ictx
             .streams()
             .best(ffmpeg_the_third::media::Type::Video)
             .ok_or_else(|| PostProcessError::ffmpeg_failed("no video stream found in thumbnail"))?;
         let thumb_ist_index = thumb_ist.index();
         let thumb_ist_time_base = thumb_ist.time_base();
-        let thumb_params = thumb_ist.parameters();
+        let thumb_width = thumb_ist.parameters().width();
+        let thumb_height = thumb_ist.parameters().height();
 
-        // Add thumbnail as video stream with ATTACHED_PIC disposition
-        let thumb_ost_index = Self::add_stream_copy(&mut octx, thumb_params, "for thumbnail")?;
-        {
-            let mut thumb_ost = octx
-                .stream_mut(thumb_ost_index)
-                .expect("just-added thumbnail stream");
-            // SAFETY: thumb_ost is a valid output stream in a live output context.
-            Self::set_attached_pic_disposition(unsafe { thumb_ost.as_mut_ptr() });
+        // Ogg/Opus: carry the cover as a `METADATA_BLOCK_PICTURE` VorbisComment
+        // field (see `vorbis_picture`) instead of an `ATTACHED_PIC` stream — no
+        // video stream is added for these containers at all (#531).
+        let thumb_ost_index = if is_ogg_opus {
+            None
+        } else {
+            let ost_idx =
+                Self::add_stream_copy(&mut octx, thumb_ist.parameters(), "for thumbnail")?;
+            {
+                let mut thumb_ost = octx
+                    .stream_mut(ost_idx)
+                    .expect("just-added thumbnail stream");
+                // SAFETY: thumb_ost is a valid output stream in a live output context.
+                Self::set_attached_pic_disposition(unsafe { thumb_ost.as_mut_ptr() });
 
-            // For MP3: set ID3v2 metadata on the thumbnail stream
-            if is_mp3 {
-                let mut dict = ffmpeg_the_third::Dictionary::new();
-                dict.set("title", "Album cover");
-                dict.set("comment", "Cover (Front)");
-                thumb_ost.set_metadata(dict);
+                // For MP3: set ID3v2 metadata on the thumbnail stream
+                if is_mp3 {
+                    let mut dict = ffmpeg_the_third::Dictionary::new();
+                    dict.set("title", "Album cover");
+                    dict.set("comment", "Cover (Front)");
+                    thumb_ost.set_metadata(dict);
+                }
             }
-        }
+            Some(ost_idx)
+        };
 
         // Copy format-level metadata from media input
         octx.set_metadata(ictx.metadata().to_owned());
@@ -328,15 +371,38 @@ impl FFmpegRunner {
             crate::ffmpeg::encoding_tag::set_encoding_tool_if_missing(&mut octx, "thumbnail");
         }
 
+        // Ogg/Opus: build and set the METADATA_BLOCK_PICTURE tag BEFORE
+        // `write_header` — the Ogg muxer copies format-level metadata into
+        // the header it writes, and `avformat_write_header` is the point at
+        // which a stream-based ATTACHED_PIC would otherwise be rejected.
+        if is_ogg_opus {
+            // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking
+            // from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
+            #[allow(clippy::disallowed_methods)]
+            let image_bytes = std::fs::read(thumbnail)
+                .with_context(|| format!("failed to read thumbnail {}", thumbnail.display()))?;
+            let format = rdlp_types::sniff_thumbnail_format(&image_bytes).ok_or_else(|| {
+                PostProcessError::ffmpeg_failed(format!(
+                    "thumbnail {} is not a recognized image format",
+                    thumbnail.display()
+                ))
+            })?;
+            let picture = vorbis_picture::build_metadata_block_picture(
+                vorbis_picture::mime_type(format),
+                thumb_width,
+                thumb_height,
+                &image_bytes,
+            );
+            let mut meta = octx.metadata().to_owned();
+            meta.set("METADATA_BLOCK_PICTURE", &picture);
+            octx.set_metadata(meta);
+        }
+
         // Build muxer options dictionary
         let mut dict = ffmpeg_the_third::Dictionary::new();
 
-        // MP4/MOV: enable faststart (moov atom at beginning) for Windows Explorer thumbnail visibility
-        let is_mp4_mov = container.eq_ignore_ascii_case("mp4")
-            || container.eq_ignore_ascii_case("m4a")
-            || container.eq_ignore_ascii_case("m4v")
-            || container.eq_ignore_ascii_case("mov");
-        if is_mp4_mov {
+        // MP4/MOV family: enable faststart (moov atom at beginning) for Windows Explorer thumbnail visibility
+        if strategy == ThumbnailEmbedStrategy::Mp4FamilyAttachedPic {
             dict.set("movflags", "+faststart");
         }
 
@@ -345,21 +411,22 @@ impl FFmpegRunner {
             .map_err(PostProcessError::from)
             .context("failed to write output header for thumbnail embed")?;
 
-        // For FLAC/OGG/Opus: write thumbnail packets BEFORE media packets.
-        // These formats store picture metadata in the file header (METADATA_BLOCK_PICTURE
-        // for FLAC, Vorbis comment for OGG/Opus), so the muxer needs picture data before
-        // audio frames are flushed. For other formats (MP4, MP3), order doesn't matter.
-        let is_header_picture_format = container.eq_ignore_ascii_case("flac")
-            || container.eq_ignore_ascii_case("ogg")
-            || container.eq_ignore_ascii_case("opus");
+        // FLAC: write the thumbnail packet BEFORE media packets. FLAC stores
+        // the ATTACHED_PIC stream as a native FLAC PICTURE block in the file
+        // header, so the muxer needs the picture data before audio frames are
+        // flushed. For other stream-based formats (MP4, MP3), order doesn't
+        // matter. Ogg/Opus need no packet at all — their picture already rode
+        // into the header as METADATA_BLOCK_PICTURE metadata above.
+        let needs_thumbnail_packet_before_header =
+            strategy == ThumbnailEmbedStrategy::FlacAttachedPic;
 
-        if is_header_picture_format {
+        if needs_thumbnail_packet_before_header && let Some(ost_idx) = thumb_ost_index {
             Self::write_thumbnail_packets(
                 &mut thumb_ictx,
                 &mut octx,
                 thumb_ist_index,
                 thumb_ist_time_base,
-                thumb_ost_index,
+                ost_idx,
             )?;
         }
 
@@ -390,14 +457,15 @@ impl FFmpegRunner {
         }
 
         // Copy thumbnail packet(s) for formats that don't need them in the header.
-        // MKV: handled by embed_thumbnail_mkv_raw_ffi. FLAC/OGG/Opus: already written above.
-        if !is_header_picture_format {
+        // MKV: handled by embed_thumbnail_mkv_raw_ffi. FLAC: already written above.
+        // Ogg/Opus: no stream was ever added, so there is no packet to write.
+        if !needs_thumbnail_packet_before_header && let Some(ost_idx) = thumb_ost_index {
             Self::write_thumbnail_packets(
                 &mut thumb_ictx,
                 &mut octx,
                 thumb_ist_index,
                 thumb_ist_time_base,
-                thumb_ost_index,
+                ost_idx,
             )?;
         }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/vorbis_picture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/vorbis_picture.rs
@@ -14,15 +14,17 @@
 //! directly against a known-good byte vector rather than through a mux/demux
 //! round trip.
 //!
-//! # Lint allowances
-//!
-//! - `clippy::cast_possible_truncation`: `mime`/`image_data` lengths are cast
-//!   to `u32` for the RFC 9639 wire format. Thumbnails are capped at 20 MiB
-//!   by the download layer (`MAX_THUMBNAIL_BYTES`,
-//!   `rdlp-api/src/orchestrator/thumbnail.rs`), far below `u32::MAX`.
+//! [`build_picture_block`] validates that the MIME type and image data each
+//! fit the RFC 9639 `u32` length-prefix field itself, via `u32::try_from`,
+//! rather than trusting that a caller upholds some size cap enforced
+//! elsewhere: this module has more than one caller path (a streamed download
+//! capped by `rdlp-api`'s `MAX_THUMBNAIL_BYTES`, but also
+//! `ThumbnailStage::find_thumbnail`'s uncapped on-disk glob), so the only
+//! guarantee this builder can honestly rely on is the one it checks itself.
+//! See `image_convert.rs`'s `MAX_THUMBNAIL_DIMENSION` doc-comment for the same
+//! "don't cite a distant invariant" discipline applied to decode dimensions.
 
-#![allow(clippy::cast_possible_truncation)]
-
+use anyhow::Context as _;
 use base64::Engine as _;
 
 use rdlp_types::ThumbnailFormat;
@@ -60,25 +62,48 @@ pub(super) const fn mime_type(format: ThumbnailFormat) -> &'static str {
     }
 }
 
+/// Validate that `len` fits the RFC 9639 `u32` length-prefix field, naming
+/// `field` in the error so a rejection identifies which value (MIME type or
+/// image data) was too large. This is the builder's own, locally-enforced
+/// contract — see the module docs for why it must not rely on a cap enforced
+/// by (only some of) its callers.
+fn u32_length(len: usize, field: &str) -> anyhow::Result<u32> {
+    u32::try_from(len)
+        .with_context(|| format!("{field} length {len} exceeds the RFC 9639 u32 length-prefix"))
+}
+
 /// Build the raw (pre-base64) FLAC `PICTURE` metadata block (RFC 9639 §8.8).
 ///
 /// Field order, all big-endian `u32`: picture type; MIME length + MIME
 /// bytes; description length + description bytes (`rdlp` always writes an
 /// empty description, but still emits its zero length); width; height;
 /// colour depth; indexed-colour count; picture-data length + picture bytes.
-fn build_picture_block(mime: &str, width: u32, height: u32, image_data: &[u8]) -> Vec<u8> {
+///
+/// # Errors
+///
+/// Returns an error if `mime` or `image_data` is too long to fit the `u32`
+/// length-prefix field (see [`u32_length`]).
+fn build_picture_block(
+    mime: &str,
+    width: u32,
+    height: u32,
+    image_data: &[u8],
+) -> anyhow::Result<Vec<u8>> {
     const DESCRIPTION: &[u8] = b"";
     const FIELD_OVERHEAD: usize = 32; // 8 u32 fields, 4 bytes each.
 
     let mime_bytes = mime.as_bytes();
+    let mime_len = u32_length(mime_bytes.len(), "MIME type")?;
+    let image_len = u32_length(image_data.len(), "image data")?;
+
     let mut block = Vec::with_capacity(FIELD_OVERHEAD + mime_bytes.len() + image_data.len());
 
     block.extend_from_slice(&PICTURE_TYPE_FRONT_COVER.to_be_bytes());
 
-    block.extend_from_slice(&(mime_bytes.len() as u32).to_be_bytes());
+    block.extend_from_slice(&mime_len.to_be_bytes());
     block.extend_from_slice(mime_bytes);
 
-    block.extend_from_slice(&(DESCRIPTION.len() as u32).to_be_bytes());
+    block.extend_from_slice(&0u32.to_be_bytes()); // DESCRIPTION is always empty
     block.extend_from_slice(DESCRIPTION);
 
     block.extend_from_slice(&width.to_be_bytes());
@@ -86,28 +111,33 @@ fn build_picture_block(mime: &str, width: u32, height: u32, image_data: &[u8]) -
     block.extend_from_slice(&COLOR_DEPTH_TRUE_COLOR.to_be_bytes());
     block.extend_from_slice(&INDEXED_COLORS_NONE.to_be_bytes());
 
-    block.extend_from_slice(&(image_data.len() as u32).to_be_bytes());
+    block.extend_from_slice(&image_len.to_be_bytes());
     block.extend_from_slice(image_data);
 
-    block
+    Ok(block)
 }
 
 /// Build the `METADATA_BLOCK_PICTURE` `VorbisComment` value: the FLAC
 /// `PICTURE` block above, base64-encoded per RFC 4648 §4 (standard alphabet,
 /// `=`-padded, no line breaks).
+///
+/// # Errors
+///
+/// Returns an error if `mime` or `image_data` is too long to fit the RFC 9639
+/// `u32` length-prefix field (see [`build_picture_block`]).
 pub(super) fn build_metadata_block_picture(
     mime: &str,
     width: u32,
     height: u32,
     image_data: &[u8],
-) -> String {
-    let block = build_picture_block(mime, width, height, image_data);
-    base64::engine::general_purpose::STANDARD.encode(block)
+) -> anyhow::Result<String> {
+    let block = build_picture_block(mime, width, height, image_data)?;
+    Ok(base64::engine::general_purpose::STANDARD.encode(block))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_metadata_block_picture, build_picture_block, mime_type};
+    use super::{build_metadata_block_picture, build_picture_block, mime_type, u32_length};
     use base64::Engine as _;
     use rdlp_types::ThumbnailFormat;
 
@@ -118,7 +148,8 @@ mod tests {
     #[test]
     fn picture_block_matches_known_good_byte_layout() {
         let image_data = b"DATA";
-        let block = build_picture_block("image/png", 10, 20, image_data);
+        let block =
+            build_picture_block("image/png", 10, 20, image_data).expect("valid-length input");
 
         let mut expected = Vec::new();
         expected.extend_from_slice(&3u32.to_be_bytes()); // picture type
@@ -141,7 +172,7 @@ mod tests {
     /// offset.
     #[test]
     fn empty_description_still_emits_its_zero_length_field() {
-        let block = build_picture_block("image/jpeg", 1, 1, b"X");
+        let block = build_picture_block("image/jpeg", 1, 1, b"X").expect("valid-length input");
 
         // Offset 0..4 picture type, 4..8 mime length, 8..8+10 mime bytes
         // ("image/jpeg" is 10 bytes), then the description length u32.
@@ -178,7 +209,8 @@ mod tests {
     #[test]
     fn data_length_field_matches_actual_image_bytes() {
         let image_data = b"0123456789";
-        let block = build_picture_block("image/png", 999, 999, image_data);
+        let block =
+            build_picture_block("image/png", 999, 999, image_data).expect("valid-length input");
 
         let data_len_offset = block.len() - image_data.len() - 4;
         let data_len = u32::from_be_bytes(
@@ -195,7 +227,8 @@ mod tests {
     #[test]
     fn metadata_block_picture_base64_round_trips_to_the_same_block() {
         let image_data = b"round-trip-bytes";
-        let encoded = build_metadata_block_picture("image/jpeg", 4, 8, image_data);
+        let encoded = build_metadata_block_picture("image/jpeg", 4, 8, image_data)
+            .expect("valid-length input");
 
         assert!(
             !encoded.contains('\n') && !encoded.contains('\r'),
@@ -205,7 +238,34 @@ mod tests {
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(&encoded)
             .expect("must be valid standard-alphabet base64");
-        assert_eq!(decoded, build_picture_block("image/jpeg", 4, 8, image_data));
+        assert_eq!(
+            decoded,
+            build_picture_block("image/jpeg", 4, 8, image_data).expect("valid-length input")
+        );
+    }
+
+    /// Boundary pin: a length of exactly `u32::MAX` still fits the RFC 9639
+    /// length-prefix field and must be accepted.
+    #[test]
+    fn u32_length_accepts_the_u32_max_boundary() {
+        assert_eq!(
+            u32_length(u32::MAX as usize, "image data").expect("u32::MAX must fit a u32 field"),
+            u32::MAX
+        );
+    }
+
+    /// Boundary pin: `u32::MAX + 1` does not fit the RFC 9639 length-prefix
+    /// field and must be rejected rather than silently truncated — the exact
+    /// failure mode this builder now defends against instead of trusting a
+    /// distant size cap (see module docs).
+    #[test]
+    fn u32_length_rejects_one_past_the_u32_max_boundary() {
+        let oversized = u32::MAX as usize + 1;
+        let err = u32_length(oversized, "image data").expect_err("must reject oversize length");
+        assert!(
+            err.to_string().contains("image data"),
+            "error must name the offending field"
+        );
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/vorbis_picture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/vorbis_picture.rs
@@ -1,0 +1,220 @@
+//! `METADATA_BLOCK_PICTURE` builder for Ogg/Opus cover art (RFC 9639 §8.8).
+//!
+//! `FFmpeg`'s Ogg muxer (`oggenc.c` `ogg_init()`) hard-rejects any stream
+//! whose codec isn't Vorbis/Theora/Speex/FLAC/Opus/VP8 — so a thumbnail can
+//! never ride an `ATTACHED_PIC` video stream in an Ogg/Opus container (#531),
+//! unlike FLAC's native muxer, which does accept one and converts it
+//! internally. The container-independent workaround is to carry the cover as
+//! a base64-encoded FLAC `PICTURE` metadata block inside a `VorbisComment`
+//! field named `METADATA_BLOCK_PICTURE` — the Ogg muxer writes arbitrary
+//! metadata keys verbatim into the `VorbisComment` header, and readers
+//! (including `FFmpeg` itself, on demux) recognize the field by name.
+//!
+//! Pure byte-level builder — no `FFmpeg` calls — so it is unit-tested
+//! directly against a known-good byte vector rather than through a mux/demux
+//! round trip.
+//!
+//! # Lint allowances
+//!
+//! - `clippy::cast_possible_truncation`: `mime`/`image_data` lengths are cast
+//!   to `u32` for the RFC 9639 wire format. Thumbnails are capped at 20 MiB
+//!   by the download layer (`MAX_THUMBNAIL_BYTES`,
+//!   `rdlp-api/src/orchestrator/thumbnail.rs`), far below `u32::MAX`.
+
+#![allow(clippy::cast_possible_truncation)]
+
+use base64::Engine as _;
+
+use rdlp_types::ThumbnailFormat;
+
+/// FLAC/Vorbis picture type: "Cover (front)" (RFC 9639 §8.8, picture type table).
+const PICTURE_TYPE_FRONT_COVER: u32 = 3;
+
+/// Declared colour depth in bits per pixel (true colour). `FFmpeg`'s Ogg
+/// demuxer derives the real value from the decoded image and ignores this
+/// declaration entirely (verified empirically against this build); it is
+/// written only for the benefit of readers that DO trust the declared value
+/// (e.g. `mutagen`, some players).
+const COLOR_DEPTH_TRUE_COLOR: u32 = 24;
+
+/// Declared indexed-colour palette size. `0` means "not a palette image" —
+/// correct for every format `rdlp` embeds this way (JPEG/PNG/GIF/BMP/TIFF/WebP
+/// are all read and re-served as true-colour or grayscale raster data).
+const INDEXED_COLORS_NONE: u32 = 0;
+
+/// The IANA media type for a sniffed [`ThumbnailFormat`].
+///
+/// Matched exhaustively (no catch-all arm) so that a new [`ThumbnailFormat`]
+/// variant fails to compile here, forcing a decision about its MIME type —
+/// the same pattern `ThumbnailStage::write_covr_atom` uses for `mp4ameta`
+/// (#525).
+#[must_use]
+pub(super) const fn mime_type(format: ThumbnailFormat) -> &'static str {
+    match format {
+        ThumbnailFormat::Jpeg => "image/jpeg",
+        ThumbnailFormat::Png => "image/png",
+        ThumbnailFormat::Gif => "image/gif",
+        ThumbnailFormat::Bmp => "image/bmp",
+        ThumbnailFormat::Tiff => "image/tiff",
+        ThumbnailFormat::WebP => "image/webp",
+    }
+}
+
+/// Build the raw (pre-base64) FLAC `PICTURE` metadata block (RFC 9639 §8.8).
+///
+/// Field order, all big-endian `u32`: picture type; MIME length + MIME
+/// bytes; description length + description bytes (`rdlp` always writes an
+/// empty description, but still emits its zero length); width; height;
+/// colour depth; indexed-colour count; picture-data length + picture bytes.
+fn build_picture_block(mime: &str, width: u32, height: u32, image_data: &[u8]) -> Vec<u8> {
+    const DESCRIPTION: &[u8] = b"";
+    const FIELD_OVERHEAD: usize = 32; // 8 u32 fields, 4 bytes each.
+
+    let mime_bytes = mime.as_bytes();
+    let mut block = Vec::with_capacity(FIELD_OVERHEAD + mime_bytes.len() + image_data.len());
+
+    block.extend_from_slice(&PICTURE_TYPE_FRONT_COVER.to_be_bytes());
+
+    block.extend_from_slice(&(mime_bytes.len() as u32).to_be_bytes());
+    block.extend_from_slice(mime_bytes);
+
+    block.extend_from_slice(&(DESCRIPTION.len() as u32).to_be_bytes());
+    block.extend_from_slice(DESCRIPTION);
+
+    block.extend_from_slice(&width.to_be_bytes());
+    block.extend_from_slice(&height.to_be_bytes());
+    block.extend_from_slice(&COLOR_DEPTH_TRUE_COLOR.to_be_bytes());
+    block.extend_from_slice(&INDEXED_COLORS_NONE.to_be_bytes());
+
+    block.extend_from_slice(&(image_data.len() as u32).to_be_bytes());
+    block.extend_from_slice(image_data);
+
+    block
+}
+
+/// Build the `METADATA_BLOCK_PICTURE` `VorbisComment` value: the FLAC
+/// `PICTURE` block above, base64-encoded per RFC 4648 §4 (standard alphabet,
+/// `=`-padded, no line breaks).
+pub(super) fn build_metadata_block_picture(
+    mime: &str,
+    width: u32,
+    height: u32,
+    image_data: &[u8],
+) -> String {
+    let block = build_picture_block(mime, width, height, image_data);
+    base64::engine::general_purpose::STANDARD.encode(block)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_metadata_block_picture, build_picture_block, mime_type};
+    use base64::Engine as _;
+    use rdlp_types::ThumbnailFormat;
+
+    /// Pins the exact big-endian field layout against a known-good byte
+    /// vector: picture type 3, mime "image/png" (9 bytes), empty description
+    /// (length 0, no bytes), 10x20, depth 24, indexed 0, then 4 bytes of
+    /// "fake" image data.
+    #[test]
+    fn picture_block_matches_known_good_byte_layout() {
+        let image_data = b"DATA";
+        let block = build_picture_block("image/png", 10, 20, image_data);
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&3u32.to_be_bytes()); // picture type
+        expected.extend_from_slice(&9u32.to_be_bytes()); // mime length
+        expected.extend_from_slice(b"image/png");
+        expected.extend_from_slice(&0u32.to_be_bytes()); // description length
+        expected.extend_from_slice(&10u32.to_be_bytes()); // width
+        expected.extend_from_slice(&20u32.to_be_bytes()); // height
+        expected.extend_from_slice(&24u32.to_be_bytes()); // color depth
+        expected.extend_from_slice(&0u32.to_be_bytes()); // indexed colors
+        expected.extend_from_slice(&4u32.to_be_bytes()); // data length
+        expected.extend_from_slice(image_data);
+
+        assert_eq!(block, expected);
+    }
+
+    /// Boundary pin: an empty description must still emit its `u32` length
+    /// of `0` — a description-handling bug could skip the length field
+    /// entirely when the description is empty, corrupting every subsequent
+    /// offset.
+    #[test]
+    fn empty_description_still_emits_its_zero_length_field() {
+        let block = build_picture_block("image/jpeg", 1, 1, b"X");
+
+        // Offset 0..4 picture type, 4..8 mime length, 8..8+10 mime bytes
+        // ("image/jpeg" is 10 bytes), then the description length u32.
+        let mime_len_offset = 4;
+        let mime_len = u32::from_be_bytes(
+            block[mime_len_offset..mime_len_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(
+            mime_len, 10,
+            "mime length field must match \"image/jpeg\".len()"
+        );
+
+        let description_len_offset = mime_len_offset + 4 + mime_len as usize;
+        let description_len = u32::from_be_bytes(
+            block[description_len_offset..description_len_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(
+            description_len, 0,
+            "empty description must still emit an explicit zero-length field"
+        );
+
+        // Width immediately follows the (zero-length, zero-byte) description.
+        let width_offset = description_len_offset + 4;
+        let width = u32::from_be_bytes(block[width_offset..width_offset + 4].try_into().unwrap());
+        assert_eq!(width, 1);
+    }
+
+    /// Data-length field must equal the actual embedded byte count, not the
+    /// declared image dimensions or any other unrelated value.
+    #[test]
+    fn data_length_field_matches_actual_image_bytes() {
+        let image_data = b"0123456789";
+        let block = build_picture_block("image/png", 999, 999, image_data);
+
+        let data_len_offset = block.len() - image_data.len() - 4;
+        let data_len = u32::from_be_bytes(
+            block[data_len_offset..data_len_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(data_len, image_data.len() as u32);
+        assert_eq!(&block[data_len_offset + 4..], image_data);
+    }
+
+    /// The public entry point base64-encodes the exact same block with the
+    /// standard, padded RFC 4648 alphabet — decoding it must round-trip.
+    #[test]
+    fn metadata_block_picture_base64_round_trips_to_the_same_block() {
+        let image_data = b"round-trip-bytes";
+        let encoded = build_metadata_block_picture("image/jpeg", 4, 8, image_data);
+
+        assert!(
+            !encoded.contains('\n') && !encoded.contains('\r'),
+            "base64 value must not contain line breaks"
+        );
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&encoded)
+            .expect("must be valid standard-alphabet base64");
+        assert_eq!(decoded, build_picture_block("image/jpeg", 4, 8, image_data));
+    }
+
+    #[test]
+    fn mime_type_covers_every_thumbnail_format() {
+        assert_eq!(mime_type(ThumbnailFormat::Jpeg), "image/jpeg");
+        assert_eq!(mime_type(ThumbnailFormat::Png), "image/png");
+        assert_eq!(mime_type(ThumbnailFormat::Gif), "image/gif");
+        assert_eq!(mime_type(ThumbnailFormat::Bmp), "image/bmp");
+        assert_eq!(mime_type(ThumbnailFormat::Tiff), "image/tiff");
+        assert_eq!(mime_type(ThumbnailFormat::WebP), "image/webp");
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/vorbis_picture.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/vorbis_picture.rs
@@ -103,7 +103,8 @@ fn build_picture_block(
     block.extend_from_slice(&mime_len.to_be_bytes());
     block.extend_from_slice(mime_bytes);
 
-    block.extend_from_slice(&0u32.to_be_bytes()); // DESCRIPTION is always empty
+    let description_len = u32_length(DESCRIPTION.len(), "description")?;
+    block.extend_from_slice(&description_len.to_be_bytes());
     block.extend_from_slice(DESCRIPTION);
 
     block.extend_from_slice(&width.to_be_bytes());
@@ -258,7 +259,12 @@ mod tests {
     /// field and must be rejected rather than silently truncated — the exact
     /// failure mode this builder now defends against instead of trusting a
     /// distant size cap (see module docs).
+    ///
+    /// 64-bit-only: on a 32-bit target `usize` cannot represent `u32::MAX + 1`
+    /// at all (the literal itself overflows `usize`), so the boundary this
+    /// test pins does not exist there.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn u32_length_rejects_one_past_the_u32_max_boundary() {
         let oversized = u32::MAX as usize + 1;
         let err = u32_length(oversized, "image data").expect_err("must reject oversize length");

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -56,5 +56,5 @@ pub use ffmpeg::{
     MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, SpeedControlError, StreamInfo,
     VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs,
     default_codec_for_container, encoding_tool_tag, resolve_recode_encoder, set_verbose,
-    validate_speed_controls,
+    supports_thumbnail_embed, validate_speed_controls,
 };

--- a/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
+++ b/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
@@ -159,12 +159,18 @@ async fn jpeg_and_png_are_accepted_by_every_supported_container() {
     // Containers where the jpeg/png baseline is VERIFIED to embed.
     //
     // Deliberately narrower than SUPPORTED_CONTAINERS: `ogg` and `opus` are
-    // listed there but cannot carry an image stream at all, failing with
-    // "Unsupported codec id in stream 1" even for jpeg/png (#531, pre-existing
-    // — the previous whitelist reached the same failure). Do NOT "complete"
-    // this list with them: the gate returns `true` for jpeg/png there via the
-    // baseline, so the assertions would PASS while the embed stays broken,
-    // turning a known bug into a test that certifies it as correct.
+    // listed there but genuinely cannot carry an image STREAM at all — their
+    // muxer's `ogg_init()` hard-rejects any stream whose codec isn't
+    // Vorbis/Theora/Speex/FLAC/Opus/VP8, which is exactly the question this
+    // function asks. #531 fixed the actual embed by carrying the cover as a
+    // `METADATA_BLOCK_PICTURE` VorbisComment field instead of an
+    // `ATTACHED_PIC` stream (see `rdlp-ffmpeg/src/ffmpeg/thumbnail/
+    // vorbis_picture.rs`), so the embed itself no longer fails — but that
+    // path bypasses this stream-codec query entirely, the same situation as
+    // Matroska's attachment path documented above. Do NOT "complete" this
+    // list with ogg/opus: the gate would still (correctly) answer `true` for
+    // jpeg/png here via the baseline, which says nothing about whether the
+    // embed works — asserting on it would test the wrong mechanism.
     let containers = ["mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac"];
 
     for format in ["jpg", "png"] {

--- a/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
+++ b/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
@@ -13,13 +13,27 @@
 //! read, `FFmpeg` re-exposes it as an `attached_pic` video stream.
 //!
 //! Self-skips when the `ffmpeg` CLI is absent (used only to build fixtures),
-//! mirroring `container_accepts_image_codec.rs`.
+//! mirroring `container_accepts_image_codec.rs` — unless
+//! [`REQUIRE_FFMPEG_ENV`] is set, in which case a missing CLI is a hard
+//! failure rather than a silent no-assertions-made green run.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use base64::Engine as _;
 use rdlp_ffmpeg::FFmpegRunner;
+
+/// Env var that turns a missing-`ffmpeg`-CLI skip into a hard test failure —
+/// set by CI (or a local strict run) to guarantee this module's #531
+/// regression coverage actually executed at least once, rather than
+/// silently reporting green with zero assertions made.
+const REQUIRE_FFMPEG_ENV: &str = "RDLP_REQUIRE_FFMPEG_TESTS";
+
+/// The still-cover fixture's fixed pixel dimensions (see [`make_cover`]) —
+/// the "real" dimensions the width/height pin below checks the declared
+/// `METADATA_BLOCK_PICTURE` fields against.
+const COVER_DIMENSION_PX: u32 = 32;
 
 fn ffmpeg_cli_available() -> bool {
     Command::new("ffmpeg")
@@ -29,12 +43,28 @@ fn ffmpeg_cli_available() -> bool {
         .unwrap_or(false)
 }
 
-/// Render a 1-frame solid-color still cover image.
+/// Skip the calling test unless [`REQUIRE_FFMPEG_ENV`] is set, in which case
+/// a missing `ffmpeg` CLI is a hard failure instead of a silent skip.
+fn skip_or_panic_without_ffmpeg_cli(test_name: &str) {
+    assert!(
+        std::env::var_os(REQUIRE_FFMPEG_ENV).is_none(),
+        "{REQUIRE_FFMPEG_ENV} is set but the ffmpeg CLI is unavailable — \
+         {test_name} cannot run its #531 regression coverage"
+    );
+    eprintln!("skipping {test_name}: ffmpeg CLI not available");
+}
+
+/// Render a 1-frame solid-color still cover image at [`COVER_DIMENSION_PX`].
 fn make_cover(dir: &Path, format: &str) -> PathBuf {
     let path = dir.join(format!("cover.{format}"));
     let status = Command::new("ffmpeg")
         .args(["-hide_banner", "-loglevel", "error", "-y"])
-        .args(["-f", "lavfi", "-i", "color=c=red:s=32x32:d=1"])
+        .args([
+            "-f",
+            "lavfi",
+            "-i",
+            &format!("color=c=red:s={COVER_DIMENSION_PX}x{COVER_DIMENSION_PX}:d=1"),
+        ])
         .args(["-frames:v", "1"])
         .arg(&path)
         .status()
@@ -77,22 +107,100 @@ fn extract_cover(media: &Path, dst: &Path) {
     );
 }
 
-/// Load-bearing regression: embedding a thumbnail into Opus must succeed and
-/// must NOT reproduce the old "Unsupported codec id" mux failure.
-#[tokio::test]
-async fn embed_thumbnail_into_opus_round_trips_byte_identical_cover() {
+/// Read `media`'s raw `METADATA_BLOCK_PICTURE` `VorbisComment` tag directly
+/// from the file's bytes and base64-decode it back to the FLAC `PICTURE`
+/// block — independent of both `vorbis_picture::build_picture_block` (so
+/// this doesn't just re-check the builder against itself) AND of `FFmpeg`'s
+/// own demuxer (`ffprobe`/`ffmpeg -i` cannot be used here: `FFmpeg`'s Ogg
+/// demuxer consumes this exact tag on read and re-exposes it as a decoded
+/// `attached_pic` video stream instead of leaving it in `format_tags`,
+/// verified empirically against this build — see `vorbis_picture.rs`'s
+/// module docs on `FFmpeg` deriving dimensions from the decoded frame). The
+/// `VorbisComment` comment header stores each `KEY=value` pair as plain
+/// ASCII/UTF-8 preceded by its own 4-byte little-endian length (Xiph's
+/// "Vorbis comment field and header specification"), so — unlike scanning
+/// forward for where the base64 "looks like it stops" (fragile: raw binary
+/// bytes belonging to the *next* field can coincidentally pass as base64
+/// alphabet) — the exact value length is read from those 4 length bytes
+/// immediately preceding the marker.
+fn read_metadata_block_picture(media: &Path) -> Vec<u8> {
+    const MARKER: &[u8] = b"METADATA_BLOCK_PICTURE=";
+
+    let bytes = std::fs::read(media).expect("read output media file");
+    let marker_start = bytes
+        .windows(MARKER.len())
+        .position(|w| w == MARKER)
+        .unwrap_or_else(|| panic!("{} has no METADATA_BLOCK_PICTURE tag", media.display()));
+    let length_prefix_start = marker_start - 4;
+    let field_len =
+        u32::from_le_bytes(bytes[length_prefix_start..marker_start].try_into().unwrap()) as usize;
+    let value_start = marker_start + MARKER.len();
+    let value_len = field_len
+        .checked_sub(MARKER.len())
+        .expect("comment field length must cover at least the key");
+    let encoded = std::str::from_utf8(&bytes[value_start..value_start + value_len])
+        .expect("base64 span must be ascii");
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .expect("METADATA_BLOCK_PICTURE must be valid base64")
+}
+
+/// Declared width/height from a FLAC `PICTURE` block (RFC 9639 §8.8), at
+/// their fixed offset following the picture-type, MIME, and description
+/// fields. `FFmpeg` ignores these on read (it derives real dimensions from
+/// the decoded frame instead — see `vorbis_picture.rs`'s module docs), but
+/// other readers (e.g. `mutagen`) trust the declared value, so nothing else
+/// in this test suite would catch a regression here.
+fn declared_dimensions(block: &[u8]) -> (u32, u32) {
+    let mime_len = u32::from_be_bytes(block[4..8].try_into().unwrap()) as usize;
+    let description_len_offset = 8 + mime_len;
+    let description_len = u32::from_be_bytes(
+        block[description_len_offset..description_len_offset + 4]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let width_offset = description_len_offset + 4 + description_len;
+    let width = u32::from_be_bytes(block[width_offset..width_offset + 4].try_into().unwrap());
+    let height = u32::from_be_bytes(
+        block[width_offset + 4..width_offset + 8]
+            .try_into()
+            .unwrap(),
+    );
+    (width, height)
+}
+
+/// One (container, audio encoder, cover extension) case for the table-driven
+/// round-trip test below.
+struct OggOpusCase {
+    /// Container/remux target passed to `embed_thumbnail`.
+    container: &'static str,
+    /// `FFmpeg` audio encoder used to build the fixture audio stream.
+    audio_encoder: &'static str,
+    /// Cover image file extension (drives the source format under test).
+    cover_ext: &'static str,
+    /// Whether this container carries the cover as a `METADATA_BLOCK_PICTURE`
+    /// tag (Ogg/Opus, #531) rather than an `ATTACHED_PIC` stream (FLAC) — the
+    /// declared-dimensions pin only applies to the former.
+    uses_metadata_block_picture: bool,
+}
+
+/// Embed `case`'s cover into a freshly-built audio fixture and assert the
+/// extracted cover round-trips byte-identical to the source. For containers
+/// using `METADATA_BLOCK_PICTURE`, additionally pins that the tag's declared
+/// width/height match the cover's real pixel dimensions.
+async fn run_case(case: &OggOpusCase, test_name: &str) {
     if !ffmpeg_cli_available() {
-        eprintln!("skipping: ffmpeg CLI not available");
+        skip_or_panic_without_ffmpeg_cli(test_name);
         return;
     }
     let dir = tempfile::TempDir::new().unwrap();
-    let cover = make_cover(dir.path(), "png");
-    let audio = make_audio(dir.path(), "opus", "libopus");
-    let output = dir.path().join("out.opus");
+    let cover = make_cover(dir.path(), case.cover_ext);
+    let audio = make_audio(dir.path(), case.container, case.audio_encoder);
+    let output = dir.path().join(format!("out.{}", case.container));
 
     let runner = FFmpegRunner::new().expect("FFmpeg");
     let result = runner
-        .embed_thumbnail(&audio, &cover, &output, "opus", None, None)
+        .embed_thumbnail(&audio, &cover, &output, case.container, None, None)
         .await;
 
     if let Err(e) = &result {
@@ -102,9 +210,14 @@ async fn embed_thumbnail_into_opus_round_trips_byte_identical_cover() {
             "the #531 mux failure recurred: {msg}"
         );
     }
-    result.expect("thumbnail embed into opus must succeed");
+    result.unwrap_or_else(|e| {
+        panic!(
+            "thumbnail embed into {} must succeed: {e:#}",
+            case.container
+        )
+    });
 
-    let extracted = dir.path().join("extracted.png");
+    let extracted = dir.path().join(format!("extracted.{}", case.cover_ext));
     extract_cover(&output, &extracted);
 
     let original = std::fs::read(&cover).unwrap();
@@ -113,36 +226,48 @@ async fn embed_thumbnail_into_opus_round_trips_byte_identical_cover() {
         original, round_tripped,
         "extracted cover must be byte-identical to the source thumbnail"
     );
+
+    if case.uses_metadata_block_picture {
+        let block = read_metadata_block_picture(&output);
+        let (width, height) = declared_dimensions(&block);
+        assert_eq!(
+            (width, height),
+            (COVER_DIMENSION_PX, COVER_DIMENSION_PX),
+            "declared METADATA_BLOCK_PICTURE dimensions must match the cover's real pixel size"
+        );
+    }
+}
+
+/// Load-bearing regression: embedding a thumbnail into Opus must succeed and
+/// must NOT reproduce the old "Unsupported codec id" mux failure.
+#[tokio::test]
+async fn embed_thumbnail_into_opus_round_trips_byte_identical_cover() {
+    run_case(
+        &OggOpusCase {
+            container: "opus",
+            audio_encoder: "libopus",
+            cover_ext: "png",
+            uses_metadata_block_picture: true,
+        },
+        "embed_thumbnail_into_opus_round_trips_byte_identical_cover",
+    )
+    .await;
 }
 
 /// Same regression for `.ogg` (Vorbis audio) with a JPEG cover, pinning the
 /// other codec/container combination named in #531.
 #[tokio::test]
 async fn embed_thumbnail_into_ogg_round_trips_byte_identical_cover() {
-    if !ffmpeg_cli_available() {
-        eprintln!("skipping: ffmpeg CLI not available");
-        return;
-    }
-    let dir = tempfile::TempDir::new().unwrap();
-    let cover = make_cover(dir.path(), "jpg");
-    let audio = make_audio(dir.path(), "ogg", "libvorbis");
-    let output = dir.path().join("out.ogg");
-
-    let runner = FFmpegRunner::new().expect("FFmpeg");
-    runner
-        .embed_thumbnail(&audio, &cover, &output, "ogg", None, None)
-        .await
-        .expect("thumbnail embed into ogg must succeed");
-
-    let extracted = dir.path().join("extracted.jpg");
-    extract_cover(&output, &extracted);
-
-    let original = std::fs::read(&cover).unwrap();
-    let round_tripped = std::fs::read(&extracted).unwrap();
-    assert_eq!(
-        original, round_tripped,
-        "extracted cover must be byte-identical to the source thumbnail"
-    );
+    run_case(
+        &OggOpusCase {
+            container: "ogg",
+            audio_encoder: "libvorbis",
+            cover_ext: "jpg",
+            uses_metadata_block_picture: true,
+        },
+        "embed_thumbnail_into_ogg_round_trips_byte_identical_cover",
+    )
+    .await;
 }
 
 /// Non-regression: FLAC's `ATTACHED_PIC`-stream strategy is untouched by the
@@ -151,28 +276,14 @@ async fn embed_thumbnail_into_ogg_round_trips_byte_identical_cover() {
 /// two branches.
 #[tokio::test]
 async fn embed_thumbnail_into_flac_still_round_trips_byte_identical_cover() {
-    if !ffmpeg_cli_available() {
-        eprintln!("skipping: ffmpeg CLI not available");
-        return;
-    }
-    let dir = tempfile::TempDir::new().unwrap();
-    let cover = make_cover(dir.path(), "png");
-    let audio = make_audio(dir.path(), "flac", "flac");
-    let output = dir.path().join("out.flac");
-
-    let runner = FFmpegRunner::new().expect("FFmpeg");
-    runner
-        .embed_thumbnail(&audio, &cover, &output, "flac", None, None)
-        .await
-        .expect("thumbnail embed into flac must still succeed");
-
-    let extracted = dir.path().join("extracted.png");
-    extract_cover(&output, &extracted);
-
-    let original = std::fs::read(&cover).unwrap();
-    let round_tripped = std::fs::read(&extracted).unwrap();
-    assert_eq!(
-        original, round_tripped,
-        "extracted cover must be byte-identical to the source thumbnail"
-    );
+    run_case(
+        &OggOpusCase {
+            container: "flac",
+            audio_encoder: "flac",
+            cover_ext: "png",
+            uses_metadata_block_picture: false,
+        },
+        "embed_thumbnail_into_flac_still_round_trips_byte_identical_cover",
+    )
+    .await;
 }

--- a/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
+++ b/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
@@ -1,0 +1,178 @@
+//! Regression test for #531: thumbnail embed into Ogg/Opus.
+//!
+//! `ogg`/`opus` are listed in `SUPPORTED_CONTAINERS`
+//! (`rdlp-postprocess/src/pipeline/stages/thumbnail.rs`), but embedding via
+//! `FFmpegRunner::embed_thumbnail` failed with `Unsupported codec id in
+//! stream 1` — `FFmpeg`'s Ogg muxer (`oggenc.c` `ogg_init()`) hard-rejects
+//! any stream whose codec isn't Vorbis/Theora/Speex/FLAC/Opus/VP8, so the
+//! cover art can never ride an `ATTACHED_PIC` video stream in these
+//! containers (unlike FLAC, which does accept one).
+//!
+//! The fix carries the cover as a base64 FLAC `PICTURE` block in a
+//! `METADATA_BLOCK_PICTURE` `VorbisComment` field instead of a stream; on
+//! read, `FFmpeg` re-exposes it as an `attached_pic` video stream.
+//!
+//! Self-skips when the `ffmpeg` CLI is absent (used only to build fixtures),
+//! mirroring `container_accepts_image_codec.rs`.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rdlp_ffmpeg::FFmpegRunner;
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Render a 1-frame solid-color still cover image.
+fn make_cover(dir: &Path, format: &str) -> PathBuf {
+    let path = dir.join(format!("cover.{format}"));
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "color=c=red:s=32x32:d=1"])
+        .args(["-frames:v", "1"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build {format} cover fixture");
+    path
+}
+
+/// Build a 1-second audio-only fixture in `container` using `encoder`.
+fn make_audio(dir: &Path, container: &str, encoder: &str) -> PathBuf {
+    let path = dir.join(format!("audio.{container}"));
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "sine=frequency=440:duration=1"])
+        .args(["-c:a", encoder])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(
+        status.success(),
+        "failed to build {container} audio fixture"
+    );
+    path
+}
+
+/// Demux `media`'s attached-picture video stream to `dst` via the `ffmpeg` CLI.
+fn extract_cover(media: &Path, dst: &Path) {
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-i"])
+        .arg(media)
+        .args(["-an", "-map", "0:v", "-c", "copy"])
+        .arg(dst)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(
+        status.success(),
+        "failed to extract cover from {}",
+        media.display()
+    );
+}
+
+/// Load-bearing regression: embedding a thumbnail into Opus must succeed and
+/// must NOT reproduce the old "Unsupported codec id" mux failure.
+#[tokio::test]
+async fn embed_thumbnail_into_opus_round_trips_byte_identical_cover() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let cover = make_cover(dir.path(), "png");
+    let audio = make_audio(dir.path(), "opus", "libopus");
+    let output = dir.path().join("out.opus");
+
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+    let result = runner
+        .embed_thumbnail(&audio, &cover, &output, "opus", None, None)
+        .await;
+
+    if let Err(e) = &result {
+        let msg = format!("{e:#}");
+        assert!(
+            !msg.contains("Unsupported codec id"),
+            "the #531 mux failure recurred: {msg}"
+        );
+    }
+    result.expect("thumbnail embed into opus must succeed");
+
+    let extracted = dir.path().join("extracted.png");
+    extract_cover(&output, &extracted);
+
+    let original = std::fs::read(&cover).unwrap();
+    let round_tripped = std::fs::read(&extracted).unwrap();
+    assert_eq!(
+        original, round_tripped,
+        "extracted cover must be byte-identical to the source thumbnail"
+    );
+}
+
+/// Same regression for `.ogg` (Vorbis audio) with a JPEG cover, pinning the
+/// other codec/container combination named in #531.
+#[tokio::test]
+async fn embed_thumbnail_into_ogg_round_trips_byte_identical_cover() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let cover = make_cover(dir.path(), "jpg");
+    let audio = make_audio(dir.path(), "ogg", "libvorbis");
+    let output = dir.path().join("out.ogg");
+
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+    runner
+        .embed_thumbnail(&audio, &cover, &output, "ogg", None, None)
+        .await
+        .expect("thumbnail embed into ogg must succeed");
+
+    let extracted = dir.path().join("extracted.jpg");
+    extract_cover(&output, &extracted);
+
+    let original = std::fs::read(&cover).unwrap();
+    let round_tripped = std::fs::read(&extracted).unwrap();
+    assert_eq!(
+        original, round_tripped,
+        "extracted cover must be byte-identical to the source thumbnail"
+    );
+}
+
+/// Non-regression: FLAC's `ATTACHED_PIC`-stream strategy is untouched by the
+/// Ogg/Opus fix (`is_ogg_opus` is `false` for `flac`) and must keep working —
+/// the shared thumbnail-stream/packet code path is a common seam between the
+/// two branches.
+#[tokio::test]
+async fn embed_thumbnail_into_flac_still_round_trips_byte_identical_cover() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let cover = make_cover(dir.path(), "png");
+    let audio = make_audio(dir.path(), "flac", "flac");
+    let output = dir.path().join("out.flac");
+
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+    runner
+        .embed_thumbnail(&audio, &cover, &output, "flac", None, None)
+        .await
+        .expect("thumbnail embed into flac must still succeed");
+
+    let extracted = dir.path().join("extracted.png");
+    extract_cover(&output, &extracted);
+
+    let original = std::fs::read(&cover).unwrap();
+    let round_tripped = std::fs::read(&extracted).unwrap();
+    assert_eq!(
+        original, round_tripped,
+        "extracted cover must be byte-identical to the source thumbnail"
+    );
+}

--- a/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
+++ b/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
@@ -123,6 +123,13 @@ fn extract_cover(media: &Path, dst: &Path) {
 /// bytes belonging to the *next* field can coincidentally pass as base64
 /// alphabet) — the exact value length is read from those 4 length bytes
 /// immediately preceding the marker.
+///
+/// Assumes the comment packet fits on a single Ogg page (payload under the
+/// ~65025-byte max page size): this reads the tag's bytes directly out of
+/// `media` as one contiguous span, which an `OggS` page header would split
+/// if the field spanned pages. Not an issue at `COVER_DIMENSION_PX`'s
+/// current size, but raising it enough to push the base64 payload past a
+/// page boundary would need this helper reassembled page-aware first.
 fn read_metadata_block_picture(media: &Path) -> Vec<u8> {
     const MARKER: &[u8] = b"METADATA_BLOCK_PICTURE=";
 

--- a/crates/rdlp-postprocess/Cargo.toml
+++ b/crates/rdlp-postprocess/Cargo.toml
@@ -28,6 +28,7 @@ fs4 = "0.13"
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
 filetime = "0.2"
+strum = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -464,6 +464,60 @@ mod tests {
         assert!(!ThumbnailStage::supports_thumbnail("avi"));
     }
 
+    /// Forward direction: every string `SUPPORTED_CONTAINERS` (the REAL
+    /// const, not a copy) advertises as thumbnail-capable must actually
+    /// resolve to an embed strategy in `rdlp-ffmpeg`.
+    ///
+    /// This and the reverse-direction test below replace what used to be a
+    /// same-crate agreement test in `rdlp-ffmpeg` asserting `for_container`
+    /// against `MIRRORED_SUPPORTED_CONTAINERS` — a hand-copied duplicate of
+    /// this very list. That guarded against nothing: editing the real
+    /// `SUPPORTED_CONTAINERS` below left both the copy and the test green.
+    /// Asserting against `rdlp_ffmpeg::supports_thumbnail_embed` here closes
+    /// that gap (full consolidation of the two lists tracked by #533).
+    #[test]
+    fn supported_containers_all_resolve_to_a_strategy() {
+        use std::str::FromStr as _;
+
+        use rdlp_types::ContainerFormat;
+
+        for container in SUPPORTED_CONTAINERS {
+            let format = ContainerFormat::from_str(container)
+                .unwrap_or_else(|_| panic!("'{container}' must parse as a ContainerFormat"));
+            assert!(
+                rdlp_ffmpeg::supports_thumbnail_embed(format),
+                "'{container}' is listed in SUPPORTED_CONTAINERS but \
+                 rdlp_ffmpeg::supports_thumbnail_embed returned false"
+            );
+        }
+    }
+
+    /// Reverse direction: every container `rdlp-ffmpeg` resolves an embed
+    /// strategy for must be advertised by `SUPPORTED_CONTAINERS` — otherwise
+    /// `ThumbnailStage` would never reach this code for that container at
+    /// all, and the two would have quietly diverged.
+    #[test]
+    fn every_strategy_supported_format_is_in_supported_containers() {
+        use strum::IntoEnumIterator as _;
+
+        use rdlp_types::ContainerFormat;
+
+        for format in ContainerFormat::iter() {
+            if rdlp_ffmpeg::supports_thumbnail_embed(format) {
+                // `as_ext()` (not `Display`/`to_string()`) is the canonical
+                // extension string: `ContainerFormat`'s `Display` impl does
+                // not necessarily print the same alias `SUPPORTED_CONTAINERS`
+                // uses (e.g. `Mkv`'s `Display` is "matroska", not "mkv").
+                let name = format.as_ext();
+                assert!(
+                    SUPPORTED_CONTAINERS.contains(&name),
+                    "'{name}' resolves to a thumbnail strategy but is missing from \
+                     SUPPORTED_CONTAINERS"
+                );
+            }
+        }
+    }
+
     #[test]
     fn is_mp4_family() {
         assert!(ThumbnailStage::is_mp4_family("mp4"));

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -1,12 +1,14 @@
 //! Container format types for video/audio files
 
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
+use strum_macros::{Display, EnumIter, EnumString};
 
 /// Supported container formats for video/audio files.
 ///
 /// Used for merge output, remux targets, and video recode targets.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
 pub enum ContainerFormat {
@@ -172,43 +174,11 @@ impl ContainerFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// All variants for exhaustive testing.
-    const ALL_FORMATS: [ContainerFormat; 29] = [
-        ContainerFormat::Mp4,
-        ContainerFormat::Mkv,
-        ContainerFormat::WebM,
-        ContainerFormat::Mov,
-        ContainerFormat::M4v,
-        ContainerFormat::Ts,
-        ContainerFormat::Flv,
-        ContainerFormat::Avi,
-        ContainerFormat::ThreeGp,
-        ContainerFormat::Mpg,
-        ContainerFormat::F4v,
-        ContainerFormat::Asf,
-        ContainerFormat::Mxf,
-        ContainerFormat::Vob,
-        ContainerFormat::Dv,
-        ContainerFormat::Nut,
-        ContainerFormat::Ivf,
-        ContainerFormat::Ogg,
-        ContainerFormat::M4a,
-        ContainerFormat::Mp3,
-        ContainerFormat::Wav,
-        ContainerFormat::Flac,
-        ContainerFormat::Opus,
-        ContainerFormat::Aac,
-        ContainerFormat::Aiff,
-        ContainerFormat::Mka,
-        ContainerFormat::Wv,
-        ContainerFormat::Caf,
-        ContainerFormat::Ac3,
-    ];
+    use strum::IntoEnumIterator as _;
 
     #[test]
     fn test_display_roundtrip() {
-        for fmt in ALL_FORMATS {
+        for fmt in ContainerFormat::iter() {
             let s = fmt.to_string();
             let parsed: ContainerFormat = s.parse().unwrap();
             assert_eq!(fmt, parsed, "roundtrip failed for {s}");

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -23,6 +23,9 @@ pub enum ContainerFormat {
     /// Apple `QuickTime`, good for editing
     #[strum(serialize = "mov", serialize = "quicktime")]
     Mov,
+    /// MPEG-4 Part 14, video variant (iTunes video) — audio-only sibling is [`Self::M4a`]
+    #[strum(serialize = "m4v")]
+    M4v,
     /// MPEG Transport Stream, broadcast/streaming
     #[strum(serialize = "ts", serialize = "mpegts")]
     Ts,
@@ -109,6 +112,7 @@ impl ContainerFormat {
             Self::Mkv => "mkv",
             Self::WebM => "webm",
             Self::Mov => "mov",
+            Self::M4v => "m4v",
             Self::Ts => "ts",
             Self::Flv => "flv",
             Self::Avi => "avi",
@@ -140,7 +144,7 @@ impl ContainerFormat {
     #[inline]
     #[must_use]
     pub const fn supports_faststart(&self) -> bool {
-        matches!(self, Self::Mp4 | Self::Mov | Self::F4v)
+        matches!(self, Self::Mp4 | Self::Mov | Self::M4v | Self::F4v)
     }
 
     /// Whether this is an audio-only container format.
@@ -170,11 +174,12 @@ mod tests {
     use super::*;
 
     /// All variants for exhaustive testing.
-    const ALL_FORMATS: [ContainerFormat; 28] = [
+    const ALL_FORMATS: [ContainerFormat; 29] = [
         ContainerFormat::Mp4,
         ContainerFormat::Mkv,
         ContainerFormat::WebM,
         ContainerFormat::Mov,
+        ContainerFormat::M4v,
         ContainerFormat::Ts,
         ContainerFormat::Flv,
         ContainerFormat::Avi,
@@ -291,9 +296,28 @@ mod tests {
     fn test_faststart() {
         assert!(ContainerFormat::Mp4.supports_faststart());
         assert!(ContainerFormat::Mov.supports_faststart());
+        assert!(ContainerFormat::M4v.supports_faststart());
         assert!(ContainerFormat::F4v.supports_faststart());
         assert!(!ContainerFormat::Mkv.supports_faststart());
         assert!(!ContainerFormat::Avi.supports_faststart());
+    }
+
+    /// `m4v` (MPEG-4 video) parses to its own variant rather than silently
+    /// aliasing `Mp4`/`Mov` — it is a distinct extension already used by the
+    /// MP4-family thumbnail-embed strategy (`rdlp-postprocess`,
+    /// `rdlp-ffmpeg`) before this variant existed.
+    #[test]
+    fn test_m4v_parses_to_its_own_variant() {
+        assert_eq!(
+            "m4v".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::M4v
+        );
+        assert_eq!(
+            "M4V".parse::<ContainerFormat>().unwrap(),
+            ContainerFormat::M4v
+        );
+        assert_eq!(ContainerFormat::M4v.as_ext(), "m4v");
+        assert!(!ContainerFormat::M4v.is_audio_only());
     }
 
     #[test]


### PR DESCRIPTION
## Resolves

Closes #531.

## Problem

Embedding a thumbnail into `ogg`/`opus` failed at mux time with `Unsupported codec id in stream 1` — even for JPEG and PNG, which embed fine in every other supported container. Pre-existing; the hardcoded whitelist that preceded #525 hit the same failure.

Root cause, confirmed in FFmpeg's source: `libavformat/oggenc.c`'s `ogg_init()` rejects any stream whose codec isn't Vorbis/Theora/Speex/FLAC/Opus/VP8, and emits exactly that string. No image codec is in that whitelist, so the `attached_pic` stream strategy can *never* work for Ogg — it's a category error, not a tunable.

## Fix

Ogg/Opus carry cover art as a base64-encoded FLAC PICTURE block (RFC 9639 §8.8) in a `METADATA_BLOCK_PICTURE` VorbisComment field, not as a stream. This builds that block and sets it as format-level metadata; no video stream is added for those containers.

This is what `.claude/rules/crate-postprocess.md` already documented as the intended design — the implementation had never caught up.

### Why implement rather than remove ogg/opus

Removing them from the supported set was the alternative. Implementing won on measured cost: FFmpeg's Ogg muxer writes arbitrary metadata keys verbatim into the VorbisComment header (`ogg_init` → `ogg_build_opus_headers` → `ff_vorbiscomment_write`, whose write loop has no key filtering), and its demuxer already parses `METADATA_BLOCK_PICTURE` via `ff_flac_parse_picture`. So no FFmpeg bypass and no hand-rolled Ogg header rewriting were needed — it's a pure binary encoder plus one dictionary set.

Verified empirically before any code was written: a correctly-built block muxes into both `.opus` and `.ogg`, FFmpeg re-exposes it as an `attached_pic` stream on read, and the extracted cover is **byte-identical** to the source. FLAC and MP3 were confirmed unaffected — `attached_pic` genuinely works for both — so the defect is scoped to ogg/opus alone.

## Secondary: typed container dispatch

Container handling in `embed_thumbnail_sync` was four scattered raw-string predicates (`is_mkv`, `is_mp3`, the mp4-family list, plus the new ogg/opus check), violating the CLAUDE.md rule against raw strings for container formats. They're now one exhaustively-matched `ThumbnailEmbedStrategy::for_container(ContainerFormat) -> Option<Self>`; the container is parsed once at the boundary and every downstream decision matches on the strategy. A new container fails to compile rather than silently taking a wrong arm.

## Behavior changes worth calling out

- **`ContainerFormat::M4v` is new, and load-bearing rather than incidental.** The enum previously had no `m4v` serialization on any variant, so `"m4v".parse()` failed outright; without the variant, parse-at-the-boundary would hard-error on every `.m4v` embed that previously worked. **Side effect: `--remux-container m4v` and `--recode-video m4v` are now accepted where they previously errored.** Benign and arguably correct, but it is a user-facing surface widening riding a bugfix.
- **Unrecognized containers now error** instead of falling through to the generic `attached_pic` path. Verified unreachable from production: the only non-test caller gates on `SUPPORTED_CONTAINERS` (10 strings) and `for_container` returns `Some` for exactly those 10. The stage treats failures as non-fatal warnings, so it fails closed — thumbnail skipped, postprocess continues.

## Tests

Failing-first: the e2e tests were confirmed failing against unpatched source (reproducing the reported mux failure), then passing after the fix.

- 3 table-driven e2e round-trips (opus+png, ogg+jpg, flac+png non-regression) asserting byte-identical cover extraction against real ffmpeg-CLI fixtures.
- RFC 9639 byte-layout pin, plus boundary tests at `u32::MAX` and `u32::MAX + 1` for the length-prefix guard.
- A dimensions pin reading the **raw** `METADATA_BLOCK_PICTURE` bytes — FFmpeg's demuxer derives real dimensions from the image data and ignores the declared fields, so nothing else would catch a regression in values other readers (mutagen) do trust.
- Bidirectional agreement test binding `SUPPORTED_CONTAINERS` to `supports_thumbnail_embed`, **verified to fail** when a bogus container is added to the real list.
- `RDLP_REQUIRE_FFMPEG_TESTS=1` turns CLI-absent skips into hard failures so coverage can't silently evaporate to a green run. Default (skip) unchanged.

## Reviews

Security and code review both ran over the full `develop..HEAD` diff, and again over each fix round.

- **Security: PASS.** One LOW — the module doc justified `u32` truncation casts by citing a 20 MiB cap that is a function-local const in `rdlp-api`, enforced only on the download path, while the builder is also reachable via `find_thumbnail`'s uncapped on-disk glob. Fixed by having the builder validate every length via `u32::try_from` and return `Result`, which removed the truncation risk entirely and let the module-wide `clippy::cast_possible_truncation` allow be deleted rather than narrowed. Re-review confirmed CLOSED with no panics introduced.
- **Code review: Approve.** Across three rounds: the agreement test (which initially guarded a hand-copied mirror rather than the real list), a `DESCRIPTION` length literal that a fix round itself introduced, a third hand-copy of the `ContainerFormat` variant list (now `EnumIter`), `format`/`image_format` shadowing between two different domain types, lint-allow scope, test consolidation, and two inaccurate doc-comments.

Known non-blocking: the test-only raw parser does unchecked index arithmetic and could panic on a malformed file. It only ever parses this test's own freshly-generated fixture, and assumes a single Ogg page (documented).

## Known follow-ups

- **#533** — `rdlp-postprocess`'s `SUPPORTED_CONTAINERS` / `is_native_attachment_container` / `is_mp4_family` are still raw-string predicates. They encode three *different* decisions sharing a container-string key, so unifying them is a design change with its own blast radius, deliberately out of scope. The agreement test guards the drift risk meanwhile.
- **#530** — the Matroska attachment path has a parallel image→MIME table with a `_ => ("image/jpeg", "cover.jpg")` catch-all. Same defect class, different file, separate PR.

## Gate

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check -p rdlp-desktop`, and all six `scripts/check-*.sh` — all green.
