### PR TITLE
fix(ffmpeg): declare honest Matroska cover mimetype; normalize bmp/webp

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -245,11 +245,43 @@ impl FFmpegRunner {
             (*codecpar).extradata = extradata.cast::<u8>();
             (*codecpar).extradata_size = thumb_data.len() as i32;
 
-            // Set mimetype and filename metadata (required by Matroska muxer)
-            let (mimetype, filename) = match thumb_codec_id {
-                ffi::AVCodecID::AV_CODEC_ID_PNG => ("image/png", "cover.png"),
-                ffi::AVCodecID::AV_CODEC_ID_WEBP => ("image/webp", "cover.webp"),
-                _ => ("image/jpeg", "cover.jpg"),
+            // Set mimetype and filename metadata (required by Matroska muxer).
+            //
+            // Derived from the THUMBNAIL BYTES (`thumb_data`, already read
+            // above) via `rdlp_types::sniff_thumbnail_format` — the same
+            // content sniffer used everywhere else in rdlp (download naming,
+            // discovery, the MP4 `covr` atom) — rather than a second,
+            // parallel `AVCodecID` table. `thumb_codec_id` above is a
+            // separate concern: it only tags the attachment stream's
+            // `codecpar.codec_id`, which no downstream reader consults for
+            // cover-art rendering.
+            //
+            // `ThumbnailFormat::matroska_attachment` is the single source of
+            // truth for which formats the linked `FFmpeg` build actually
+            // renders as a visible cover (jpeg/png/gif/tiff) versus which
+            // silently produce an invisible, generic attachment (bmp/webp) —
+            // see #530. A format that resolves to `None` here means the
+            // caller failed to normalize it first; that is a contract
+            // violation, not something to paper over with a fallback
+            // mimetype (the exact defect #530 reports: gif/tiff/bmp silently
+            // relabeled `image/jpeg`).
+            let sniffed = rdlp_types::sniff_thumbnail_format(&thumb_data);
+            let Some((mimetype, filename)) =
+                sniffed.and_then(rdlp_types::ThumbnailFormat::matroska_attachment)
+            else {
+                let reason = sniffed.map_or_else(
+                    || "unrecognized image bytes".to_string(),
+                    |format| format!("{} content", format.extension()),
+                );
+                ffi::avformat_close_input(&mut media_ctx);
+                ffi::avformat_close_input(&mut thumb_ctx);
+                ffi::avformat_free_context(ofmt_ctx);
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: format!(
+                        "cannot attach {reason} as a Matroska cover without normalizing to \
+                         jpeg/png/gif/tiff first"
+                    ),
+                });
             };
 
             let key_mime = CString::new("mimetype").expect("static string has no null bytes");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -211,41 +211,12 @@ impl FFmpegRunner {
                 }
             })?;
 
-            let out_stream = ffi::avformat_new_stream(ofmt_ctx, ptr::null());
-            if out_stream.is_null() {
-                ffi::avformat_close_input(&mut media_ctx);
-                ffi::avformat_close_input(&mut thumb_ctx);
-                ffi::avformat_free_context(ofmt_ctx);
-                return Err(PostProcessError::FFmpegLibraryError {
-                    message: "Failed to create attachment stream".into(),
-                });
-            }
-
-            // Configure as attachment stream
-            let codecpar = (*out_stream).codecpar;
-            (*codecpar).codec_type = ffi::AVMediaType::AVMEDIA_TYPE_ATTACHMENT;
-            (*codecpar).codec_id = thumb_codec_id;
-
-            // Copy thumbnail data into extradata (must be av_malloc'd)
-            let alloc_size = thumb_data.len() + ffi::AV_INPUT_BUFFER_PADDING_SIZE as usize;
-            let extradata = ffi::av_mallocz(alloc_size);
-            if extradata.is_null() {
-                ffi::avformat_close_input(&mut media_ctx);
-                ffi::avformat_close_input(&mut thumb_ctx);
-                ffi::avformat_free_context(ofmt_ctx);
-                return Err(PostProcessError::FFmpegLibraryError {
-                    message: "Failed to allocate memory for thumbnail attachment".into(),
-                });
-            }
-            ptr::copy_nonoverlapping(
-                thumb_data.as_ptr(),
-                extradata.cast::<u8>(),
-                thumb_data.len(),
-            );
-            (*codecpar).extradata = extradata.cast::<u8>();
-            (*codecpar).extradata_size = thumb_data.len() as i32;
-
-            // Set mimetype and filename metadata (required by Matroska muxer).
+            // Determine the mimetype/filename metadata (required by Matroska
+            // muxer) BEFORE creating the attachment stream or allocating
+            // extradata, so a format the caller failed to normalize is
+            // rejected without paying for the `av_mallocz` + full-image
+            // `copy_nonoverlapping` below (#530 code review: the allocation
+            // was previously wasted work on every rejected bmp/webp).
             //
             // Derived from the THUMBNAIL BYTES (`thumb_data`, already read
             // above) via `rdlp_types::sniff_thumbnail_format` — the same
@@ -283,6 +254,40 @@ impl FFmpegRunner {
                     ),
                 });
             };
+
+            let out_stream = ffi::avformat_new_stream(ofmt_ctx, ptr::null());
+            if out_stream.is_null() {
+                ffi::avformat_close_input(&mut media_ctx);
+                ffi::avformat_close_input(&mut thumb_ctx);
+                ffi::avformat_free_context(ofmt_ctx);
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "Failed to create attachment stream".into(),
+                });
+            }
+
+            // Configure as attachment stream
+            let codecpar = (*out_stream).codecpar;
+            (*codecpar).codec_type = ffi::AVMediaType::AVMEDIA_TYPE_ATTACHMENT;
+            (*codecpar).codec_id = thumb_codec_id;
+
+            // Copy thumbnail data into extradata (must be av_malloc'd)
+            let alloc_size = thumb_data.len() + ffi::AV_INPUT_BUFFER_PADDING_SIZE as usize;
+            let extradata = ffi::av_mallocz(alloc_size);
+            if extradata.is_null() {
+                ffi::avformat_close_input(&mut media_ctx);
+                ffi::avformat_close_input(&mut thumb_ctx);
+                ffi::avformat_free_context(ofmt_ctx);
+                return Err(PostProcessError::FFmpegLibraryError {
+                    message: "Failed to allocate memory for thumbnail attachment".into(),
+                });
+            }
+            ptr::copy_nonoverlapping(
+                thumb_data.as_ptr(),
+                extradata.cast::<u8>(),
+                thumb_data.len(),
+            );
+            (*codecpar).extradata = extradata.cast::<u8>();
+            (*codecpar).extradata_size = thumb_data.len() as i32;
 
             let key_mime = CString::new("mimetype").expect("static string has no null bytes");
             let val_mime = CString::new(mimetype).expect("mimetype has no null bytes");

--- a/crates/rdlp-ffmpeg/tests/mkv_dts_synthesis.rs
+++ b/crates/rdlp-ffmpeg/tests/mkv_dts_synthesis.rs
@@ -107,11 +107,18 @@ fn build_unset_dts_mkv(
     Ok((src, unset))
 }
 
-/// Generate a tiny real WebP cover image in `dir`.
+/// Generate a tiny real JPEG cover image in `dir`.
+///
+/// JPEG (not WebP): since #530, the raw MKV thumbnail-embed path requires a
+/// format `FFmpeg`'s own Matroska read-back renders as a visible cover
+/// (jpeg/png/gif/tiff) and rejects webp/bmp outright, expecting callers to
+/// normalize those first. This test's subject is DTS synthesis on the MAIN
+/// media stream, not thumbnail-format handling, so any accepted cover format
+/// works — jpeg keeps it a minimal, still-valid fixture.
 ///
 /// Returns `Ok(path)` or `Err(())` (self-skip).
-fn build_webp_cover(dir: &std::path::Path) -> Result<std::path::PathBuf, ()> {
-    let cover = dir.join("cover.webp");
+fn build_jpeg_cover(dir: &std::path::Path) -> Result<std::path::PathBuf, ()> {
+    let cover = dir.join("cover.jpg");
     run_ffmpeg(&[
         "-y",
         "-loglevel",
@@ -303,7 +310,7 @@ async fn thumbnail_embed_emits_no_unset_timestamp_warning() {
         Err(()) => return, // self-skip — fixture generation failed
     };
 
-    let cover = match build_webp_cover(dir.path()) {
+    let cover = match build_jpeg_cover(dir.path()) {
         Ok(p) => p,
         Err(()) => return, // self-skip
     };

--- a/crates/rdlp-ffmpeg/tests/mkv_thumbnail_attachment_mimetype.rs
+++ b/crates/rdlp-ffmpeg/tests/mkv_thumbnail_attachment_mimetype.rs
@@ -1,0 +1,222 @@
+//! #530: `embed_thumbnail_mkv_raw_ffi` must declare the Matroska attachment's
+//! REAL mimetype, and must refuse to attach a format that FFmpeg's own
+//! read-back promotion table cannot render as a visible cover.
+//!
+//! The previous catch-all (`_ => ("image/jpeg", "cover.jpg")`) mislabeled
+//! gif/tiff/bmp thumbnails as `image/jpeg`. Separately, `image/webp` was
+//! already declared honestly but is a *latent* bug: FFmpeg's Matroska
+//! demuxer (`matroskadec.c`'s `mkv_image_mime_tags`) only promotes an
+//! attachment to a real, player-visible `attached_pic` video stream for a
+//! mimetype string it recognizes (`image/jpeg`, `image/png`, `image/gif`,
+//! `image/tiff`) — `image/bmp`/`image/webp` stay a generic, non-rendered
+//! attachment forever. Verified empirically (2026-07-19) against the linked
+//! `FFmpeg` build via `ffprobe`.
+//!
+//! Self-skips when the `ffmpeg`/`ffprobe` CLI is absent (used only to build
+//! fixtures and probe results, mirroring `container_accepts_image_codec.rs`).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rdlp_ffmpeg::FFmpegRunner;
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn ffprobe_cli_available() -> bool {
+    Command::new("ffprobe")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn tooling_available() -> bool {
+    ffmpeg_cli_available() && ffprobe_cli_available()
+}
+
+/// Render a 1-frame solid-color still in `format`.
+fn make_image(dir: &Path, format: &str) -> PathBuf {
+    let path = dir.join(format!("still.{format}"));
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "color=c=red:s=32x32:d=1"])
+        .args(["-frames:v", "1"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build {format} fixture");
+    path
+}
+
+/// Build a tiny real Matroska file to embed the thumbnail into.
+fn make_media(dir: &Path) -> PathBuf {
+    let path = dir.join("media.mkv");
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "color=c=blue:s=32x32:d=1"])
+        .args(["-c:v", "libx264", "-t", "1"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build base media fixture");
+    path
+}
+
+/// The last stream's `codec_type`, `attached_pic` disposition, and declared
+/// `mimetype` tag, read back via `ffprobe`.
+struct AttachmentStreamInfo {
+    codec_type: String,
+    attached_pic: bool,
+    mimetype: Option<String>,
+}
+
+fn probe_last_stream(mkv: &Path) -> AttachmentStreamInfo {
+    let output = Command::new("ffprobe")
+        .args(["-hide_banner", "-v", "error"])
+        .args([
+            "-show_entries",
+            "stream=index,codec_type:stream_disposition=attached_pic:stream_tags=mimetype",
+        ])
+        .args(["-of", "default=noprint_wrappers=1"])
+        .arg(mkv)
+        .output()
+        .expect("spawn ffprobe");
+    assert!(output.status.success(), "ffprobe failed to read {mkv:?}");
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    // Blocks start at "index=" — keep the LAST block (the attachment we added).
+    let last_block = text
+        .split("index=")
+        .filter(|b| !b.is_empty())
+        .last()
+        .unwrap_or_default();
+
+    let codec_type = last_block
+        .lines()
+        .find_map(|l| l.strip_prefix("codec_type="))
+        .expect("codec_type present")
+        .to_string();
+    let attached_pic = last_block
+        .lines()
+        .find_map(|l| l.strip_prefix("DISPOSITION:attached_pic="))
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false);
+    let mimetype = last_block
+        .lines()
+        .find_map(|l| l.strip_prefix("TAG:mimetype="))
+        .map(str::to_string);
+
+    AttachmentStreamInfo {
+        codec_type,
+        attached_pic,
+        mimetype,
+    }
+}
+
+/// Positive + regression guard: GIF and TIFF must attach as a REAL,
+/// player-visible cover (`Video` stream, `attached_pic=1`) declaring their
+/// own honest mimetype — not the pre-fix catch-all's `image/jpeg`.
+///
+/// Fails against the unpatched catch-all, which declared `image/jpeg` for
+/// both formats.
+#[tokio::test]
+async fn gif_and_tiff_attach_as_honest_visible_cover_art() {
+    if !tooling_available() {
+        eprintln!("skipping: ffmpeg/ffprobe CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let media = make_media(dir.path());
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for (format, expected_mime) in [("gif", "image/gif"), ("tiff", "image/tiff")] {
+        let thumb = make_image(dir.path(), format);
+        let output = dir.path().join(format!("out_{format}.mkv"));
+
+        runner
+            .embed_thumbnail(&media, &thumb, &output, "mkv", None, None)
+            .await
+            .unwrap_or_else(|e| panic!("{format} embed must succeed: {e}"));
+
+        let info = probe_last_stream(&output);
+        assert_eq!(
+            info.codec_type, "video",
+            "{format} must promote to a video (attached_pic) stream on read-back"
+        );
+        assert!(
+            info.attached_pic,
+            "{format} attachment must set the attached_pic disposition"
+        );
+        assert_eq!(
+            info.mimetype.as_deref(),
+            Some(expected_mime),
+            "{format} must declare its own mimetype, not a fallback"
+        );
+    }
+}
+
+/// Regression pin: JPEG/PNG must keep working exactly as before.
+#[tokio::test]
+async fn jpeg_and_png_still_attach_as_visible_cover_art() {
+    if !tooling_available() {
+        eprintln!("skipping: ffmpeg/ffprobe CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let media = make_media(dir.path());
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for (format, expected_mime) in [("jpg", "image/jpeg"), ("png", "image/png")] {
+        let thumb = make_image(dir.path(), format);
+        let output = dir.path().join(format!("out_{format}.mkv"));
+
+        runner
+            .embed_thumbnail(&media, &thumb, &output, "mkv", None, None)
+            .await
+            .unwrap_or_else(|e| panic!("{format} embed must succeed: {e}"));
+
+        let info = probe_last_stream(&output);
+        assert_eq!(info.codec_type, "video");
+        assert!(info.attached_pic);
+        assert_eq!(info.mimetype.as_deref(), Some(expected_mime));
+    }
+}
+
+/// #530 regression guard, failing-first: a BMP/WebP thumbnail reaching the
+/// MKV embed path DIRECTLY (i.e. bypassing the postprocess-stage
+/// normalization this task also adds) must be REJECTED, not silently
+/// attached under a fallback mimetype. Unpatched behavior: BMP hit the
+/// catch-all and was silently mislabeled `image/jpeg`; WebP was silently
+/// accepted as `image/webp`, an invisible attachment. Both are wrong —
+/// callers are expected to normalize first, and this path must say so rather
+/// than produce a broken or invisible cover.
+#[tokio::test]
+async fn bmp_and_webp_reaching_mkv_embed_directly_are_rejected() {
+    if !tooling_available() {
+        eprintln!("skipping: ffmpeg/ffprobe CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let media = make_media(dir.path());
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for format in ["bmp", "webp"] {
+        let thumb = make_image(dir.path(), format);
+        let output = dir.path().join(format!("out_{format}.mkv"));
+
+        let result = runner
+            .embed_thumbnail(&media, &thumb, &output, "mkv", None, None)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "{format} reaching the raw MKV embed path unnormalized must be \
+             rejected, not silently attached under a fallback mimetype"
+        );
+    }
+}

--- a/crates/rdlp-ffmpeg/tests/mkv_thumbnail_attachment_mimetype.rs
+++ b/crates/rdlp-ffmpeg/tests/mkv_thumbnail_attachment_mimetype.rs
@@ -213,10 +213,29 @@ async fn bmp_and_webp_reaching_mkv_embed_directly_are_rejected() {
             .embed_thumbnail(&media, &thumb, &output, "mkv", None, None)
             .await;
 
-        assert!(
-            result.is_err(),
+        let err = result.expect_err(&format!(
             "{format} reaching the raw MKV embed path unnormalized must be \
              rejected, not silently attached under a fallback mimetype"
+        ));
+
+        // Pin the FAILURE MODE, not just failure: `is_err()` alone would
+        // equally pass for a fixture-build failure, an unreadable path, or
+        // any unrelated muxer error. `embed_thumbnail`'s MKV path routes the
+        // typed `PostProcessError::FFmpegLibraryError` this guard raises
+        // through an intermediate `anyhow::Result` (see
+        // `embed_thumbnail_sync`'s `Ok(result?)`), which re-wraps it as
+        // `PostProcessError::Other` — so no typed discriminant survives to
+        // this boundary. The message text IS load-bearing here (it is what
+        // the raw-FFI guard actually asserts), so match on it rather than on
+        // the (unavailable) variant: both the rejected format's own name AND
+        // the exact normalization-contract phrase must appear, so a
+        // regression that fails for the WRONG reason cannot slip through.
+        let message = err.to_string();
+        assert!(
+            message.contains(&format!("{format} content"))
+                && message.contains("without normalizing to jpeg/png/gif/tiff first"),
+            "{format} rejection must be the mimetype-normalization guard, \
+             not some other muxer error: {message}"
         );
     }
 }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use log::{debug, info, warn};
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
-use rdlp_types::{THUMBNAIL_EXTENSIONS, ThumbnailFormat};
+use rdlp_types::{THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
 
 use crate::pipeline::{PipelineMessage, PipelineStage};
 
@@ -104,8 +104,16 @@ impl ThumbnailStage {
     /// transcoded first or the mux fails. Whether a tag exists is asked of
     /// `FFmpeg` via `container_accepts_image_codec` rather than hardcoded, so
     /// the answer always tracks the linked build instead of a list that can
-    /// drift from it. Matroska is exempt — it carries the image as a file
-    /// attachment rather than a stream, so no codec tag is involved.
+    /// drift from it.
+    ///
+    /// Matroska is checked first and separately, but is only PARTIALLY exempt:
+    /// it carries the image as a file attachment rather than a stream, so the
+    /// stream-codec-tag question below does not govern most formats — but
+    /// `image/bmp`/`image/webp` are not recognized by `FFmpeg`'s own
+    /// attachment-mimetype read-back table (`ThumbnailFormat::
+    /// matroska_attachment`), producing an invisible, non-rendering cover
+    /// (#530). Those two still fall through to the normal transcode path;
+    /// jpeg/png/gif/tiff return early untouched.
     ///
     /// On transcode failure, falls back to the original thumbnail path so the
     /// caller's existing non-fatal embed-failure handling still applies —
@@ -117,11 +125,9 @@ impl ThumbnailStage {
         extension: &str,
         thumbnail_file: &Path,
     ) -> PathBuf {
-        // Matroska is checked FIRST and separately: it carries the thumbnail as
-        // an attachment, not a stream, so the muxer's stream-codec answer below
-        // is simply not the question that governs it — asking would force a
-        // needless transcode for every MKV thumbnail.
-        if Self::is_native_attachment_container(extension) {
+        if Self::is_native_attachment_container(extension)
+            && Self::mkv_attachment_renders_natively(thumbnail_file).await
+        {
             return thumbnail_file.to_path_buf();
         }
 
@@ -166,6 +172,21 @@ impl ThumbnailStage {
                 thumbnail_file.to_path_buf()
             }
         }
+    }
+
+    /// Whether `thumbnail_file`'s content is a format the linked `FFmpeg`
+    /// build's Matroska read-back recognizes as a real, player-visible cover
+    /// (see [`ThumbnailFormat::matroska_attachment`]), so the native
+    /// attachment path can carry it as-is with no normalization.
+    ///
+    /// A read failure or an unrecognized signature answers `false` — the
+    /// safe direction, since it routes into the normal transcode-to-jpeg
+    /// path below rather than risking a silently non-rendering attachment.
+    async fn mkv_attachment_renders_natively(thumbnail_file: &Path) -> bool {
+        let Ok(bytes) = tokio::fs::read(thumbnail_file).await else {
+            return false;
+        };
+        sniff_thumbnail_format(&bytes).is_some_and(|format| format.matroska_attachment().is_some())
     }
 
     /// Write the iTunes `covr` metadata atom for Windows Explorer thumbnail visibility.
@@ -672,4 +693,11 @@ mod tests {
         assert!(!ThumbnailStage::is_native_attachment_container("mov"));
         assert!(!ThumbnailStage::is_native_attachment_container("mp3"));
     }
+
+    // #530 end-to-end coverage (gif/tiff attach natively, bmp/webp get
+    // normalized) lives in `crates/rdlp-postprocess/tests/
+    // thumbnail_mkv_cover_mimetype.rs` — those cases need the `ffmpeg` CLI to
+    // build real decodable image fixtures, which `scripts/check-no-cli.sh`
+    // forbids under `src/` (production-code CLI-usage gate); only files under
+    // `tests/` are exempt.
 }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -98,6 +98,18 @@ impl ThumbnailStage {
     /// Normalize `thumbnail_file` to a tracker-owned temp `.jpg` when the
     /// target container can't consume its codec directly.
     ///
+    /// Matroska is handled entirely separately (see
+    /// [`Self::mkv_attachment_renders_natively`]): it carries the image as a
+    /// file attachment rather than a stream, so the stream-codec-tag question
+    /// below does not govern it at all. `jpeg`/`png`/`gif`/`tiff` attachments
+    /// render natively and return early untouched; `bmp`/`webp` are not
+    /// recognized by `FFmpeg`'s own attachment-mimetype read-back table
+    /// (`ThumbnailFormat::matroska_attachment`) and are unconditionally
+    /// transcoded to jpeg first — producing an invisible, non-rendering cover
+    /// otherwise (#530). This branch never consults
+    /// `container_accepts_image_codec`, which answers an unrelated
+    /// stream-codec-tag question that does not apply to attachments.
+    ///
     /// Every non-Matroska embed strategy stream-copies the thumbnail's source
     /// codec into the target container (see `rdlp_ffmpeg::thumbnail`), so a
     /// codec the target muxer has no tag for (e.g. `webp` in MP4) must be
@@ -105,15 +117,6 @@ impl ThumbnailStage {
     /// `FFmpeg` via `container_accepts_image_codec` rather than hardcoded, so
     /// the answer always tracks the linked build instead of a list that can
     /// drift from it.
-    ///
-    /// Matroska is checked first and separately, but is only PARTIALLY exempt:
-    /// it carries the image as a file attachment rather than a stream, so the
-    /// stream-codec-tag question below does not govern most formats — but
-    /// `image/bmp`/`image/webp` are not recognized by `FFmpeg`'s own
-    /// attachment-mimetype read-back table (`ThumbnailFormat::
-    /// matroska_attachment`), producing an invisible, non-rendering cover
-    /// (#530). Those two still fall through to the normal transcode path;
-    /// jpeg/png/gif/tiff return early untouched.
     ///
     /// On transcode failure, falls back to the original thumbnail path so the
     /// caller's existing non-fatal embed-failure handling still applies —
@@ -125,10 +128,13 @@ impl ThumbnailStage {
         extension: &str,
         thumbnail_file: &Path,
     ) -> PathBuf {
-        if Self::is_native_attachment_container(extension)
-            && Self::mkv_attachment_renders_natively(thumbnail_file).await
-        {
-            return thumbnail_file.to_path_buf();
+        if Self::is_native_attachment_container(extension) {
+            return if Self::mkv_attachment_renders_natively(thumbnail_file).await {
+                thumbnail_file.to_path_buf()
+            } else {
+                self.transcode_thumbnail_to_jpg(msg, extension, thumbnail_file)
+                    .await
+            };
         }
 
         // Ask the muxer whether it can carry this image's codec, rather than
@@ -147,6 +153,22 @@ impl ThumbnailStage {
             return thumbnail_file.to_path_buf();
         }
 
+        self.transcode_thumbnail_to_jpg(msg, extension, thumbnail_file)
+            .await
+    }
+
+    /// Transcode `thumbnail_file` to a tracker-owned temp `.jpg`, falling
+    /// back to the original path on failure (non-fatal — the caller's
+    /// existing embed-failure handling still applies).
+    ///
+    /// Shared by both branches of [`Self::normalize_thumbnail_for_embed`] so
+    /// the transcode-and-fallback logic exists in exactly one place.
+    async fn transcode_thumbnail_to_jpg(
+        &self,
+        msg: &mut PipelineMessage,
+        extension: &str,
+        thumbnail_file: &Path,
+    ) -> PathBuf {
         let normalized = msg.tracker.temp_path(thumbnail_file, "jpg");
         debug!(
             "ThumbnailStage: normalizing thumbnail {} → jpg for {extension} embed",
@@ -182,6 +204,16 @@ impl ThumbnailStage {
     /// A read failure or an unrecognized signature answers `false` — the
     /// safe direction, since it routes into the normal transcode-to-jpeg
     /// path below rather than risking a silently non-rendering attachment.
+    ///
+    /// This reads `thumbnail_file` a second time when the embed later
+    /// reaches `rdlp_ffmpeg`'s raw-FFI path (which re-reads + re-sniffs the
+    /// same bytes to decide the attachment mimetype, see
+    /// `mkv_raw_ffi.rs`). Not threaded through: `embed_thumbnail`'s public
+    /// signature is shared by every container strategy (MP4/MP3/FLAC/OGG/
+    /// Matroska), most of which never sniff at all, so plumbing pre-read
+    /// bytes through it would widen that boundary for one container's
+    /// benefit. Thumbnails are small (single-frame stills), so the extra
+    /// read is a few KB/µs, not a hot path — not worth the API contortion.
     async fn mkv_attachment_renders_natively(thumbnail_file: &Path) -> bool {
         let Ok(bytes) = tokio::fs::read(thumbnail_file).await else {
             return false;

--- a/crates/rdlp-postprocess/tests/thumbnail_mkv_cover_mimetype.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_mkv_cover_mimetype.rs
@@ -1,0 +1,259 @@
+//! #530 end-to-end: `ThumbnailStage::process` must route BMP/GIF/TIFF/WebP
+//! thumbnails correctly for Matroska, mirroring `thumbnail_webp_mp4_embed.rs`'s
+//! pattern for the MP4-family path.
+//!
+//! GIF and TIFF attach as a real, player-visible Matroska cover with no
+//! transcoding (`FFmpeg`'s own attachment-mimetype read-back table
+//! recognizes `image/gif`/`image/tiff`); BMP does not (like WebP, covered in
+//! `thumbnail_webp_mp4_embed.rs`) and must be normalized to mjpeg first, or
+//! the resulting attachment silently fails to render as a cover in any
+//! player.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! image/mkv fixtures).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
+use rdlp_types::InfoDict;
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn build_mp4_fixture(path: &Path) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+/// Build a single-frame still-image thumbnail via the system `ffmpeg` CLI.
+/// The output codec/container is inferred from `path`'s extension.
+fn build_still_image_fixture(path: &Path) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-frames:v",
+            "1",
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+fn build_mkv_fixture(dir: &Path) -> Result<std::path::PathBuf, ()> {
+    let mp4_src = dir.join("src.mp4");
+    let mkv = dir.join("video.mkv");
+    build_mp4_fixture(&mp4_src)?;
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-i",
+            mp4_src.to_str().unwrap(),
+            "-c",
+            "copy",
+            mkv.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(mkv) } else { Err(()) }
+}
+
+fn make_msg(files: Vec<std::path::PathBuf>, config: PostProcess) -> PipelineMessage {
+    let reg = Arc::new(TempRegistry::new());
+    let (error_tx, _) = oneshot::channel();
+    PipelineMessage {
+        info: InfoDict::new(
+            "id".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com".to_string(),
+        ),
+        tracker: FileTracker::new(files, reg),
+        config: Arc::new(config),
+        original_stem: "video".to_string(),
+        is_hls: false,
+        verbose: false,
+        callback_factory: None,
+        error_tx: Some(error_tx),
+        warnings: Vec::new(),
+        encoding_tool: None,
+        cancel: CancellationToken::new(),
+    }
+}
+
+/// Positive + regression guard: GIF and TIFF attach into Matroska as a real,
+/// player-visible cover with NO transcoding — the resulting attached-pic
+/// stream's codec must be the thumbnail's own (`gif`/`tiff`), not `mjpeg`.
+#[tokio::test]
+async fn process_embeds_gif_and_tiff_thumbnails_into_mkv_natively() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    for (format, expected_codec) in [("gif", "gif"), ("tiff", "tiff")] {
+        let media = dir.path().join(format!("media_{format}.mkv"));
+        let thumb = dir.path().join(format!("media_{format}.{format}"));
+        let Ok(built) = build_mkv_fixture(dir.path()) else {
+            eprintln!("[SKIP] fixture build failed");
+            return;
+        };
+        std::fs::rename(&built, &media).expect("rename mkv fixture");
+        if build_still_image_fixture(&thumb).is_err() {
+            eprintln!("[SKIP] fixture build failed");
+            return;
+        }
+
+        let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+        let stage = ThumbnailStage::new(ffmpeg.clone());
+
+        let config = PostProcess {
+            embed_thumbnail: true,
+            ..PostProcess::default()
+        };
+        let mut msg = make_msg(vec![media], config);
+        msg.original_stem = format!("media_{format}");
+
+        let result = stage.process(msg).await.expect("non-fatal stage");
+        assert!(
+            result.warnings.is_empty(),
+            "{format} under mkv should embed with no warnings, got: {:?}",
+            result.warnings
+        );
+
+        let out_path = result.tracker.primary();
+        let info = ffmpeg
+            .probe(&out_path)
+            .await
+            .expect("probing embedded output must succeed");
+        let thumb_stream = info
+            .streams
+            .iter()
+            .find(|s| s.index == 1)
+            .expect("second stream (thumbnail attachment) must be present");
+        assert_eq!(thumb_stream.codec_type, "video");
+        assert_eq!(
+            thumb_stream.codec_name.as_deref(),
+            Some(expected_codec),
+            "{format} must attach natively (own codec), not be transcoded"
+        );
+    }
+}
+
+/// #530 regression guard: a BMP thumbnail is NOT recognized by `FFmpeg`'s
+/// Matroska read-back mimetype table and must be normalized to mjpeg first
+/// — otherwise the previous catch-all mislabeled it `image/jpeg` (wrong
+/// codec, corrupt attachment) and a fixed-but-unnormalized path would still
+/// attach it invisibly.
+#[tokio::test]
+async fn process_normalizes_bmp_thumbnail_into_mkv_as_mjpeg() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.mkv");
+    let thumb = dir.path().join("video.bmp");
+    let Ok(built) = build_mkv_fixture(dir.path()) else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+    std::fs::rename(&built, &media).expect("rename mkv fixture");
+    if build_still_image_fixture(&thumb).is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg.clone());
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+    assert!(
+        result.warnings.is_empty(),
+        "mkv bmp normalization should succeed with no warnings, got: {:?}",
+        result.warnings
+    );
+
+    let out_path = result.tracker.primary();
+    let info = ffmpeg
+        .probe(&out_path)
+        .await
+        .expect("probing embedded output must succeed");
+    let thumb_stream = info
+        .streams
+        .iter()
+        .find(|s| s.index == 1)
+        .expect("second stream (thumbnail attachment) must be present");
+    assert_eq!(thumb_stream.codec_type, "video");
+    assert_eq!(
+        thumb_stream.codec_name.as_deref(),
+        Some("mjpeg"),
+        "bmp under mkv must be normalized to mjpeg — its mimetype is not \
+         recognized by FFmpeg's Matroska read-back and would attach \
+         invisibly (#530)"
+    );
+
+    // A `codec_name` of "mjpeg" is necessary but NOT sufficient: the
+    // pre-#530 catch-all also declared a `mjpeg`-labeled attachment for
+    // formats it never transcoded (it just lied about the mimetype), and
+    // `matroskadec.c` assigns the read-back codec from the mimetype STRING
+    // alone — so a mislabeled attachment reports the same codec_name as a
+    // genuinely transcoded one. Decoding the actual frame is what tells them
+    // apart: real transcoded mjpeg bytes decode cleanly; raw BMP bytes
+    // wearing an mjpeg label fail to decode ("No JPEG data found").
+    let decode = Command::new("ffmpeg")
+        .args(["-v", "error", "-y"])
+        .args(["-i", out_path.to_str().unwrap()])
+        .args(["-map", "0:1", "-frames:v", "1", "-f", "null", "-"])
+        .output()
+        .expect("spawn ffmpeg decode check");
+    assert!(
+        decode.status.success() && decode.stderr.is_empty(),
+        "the normalized bmp-as-mjpeg attachment must decode cleanly as a real \
+         mjpeg frame, not just carry the label: stderr={}",
+        String::from_utf8_lossy(&decode.stderr)
+    );
+}

--- a/crates/rdlp-postprocess/tests/thumbnail_webp_mp4_embed.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_webp_mp4_embed.rs
@@ -194,11 +194,20 @@ async fn process_embeds_jpg_thumbnail_without_normalizing() {
     );
 }
 
-/// Regression guard: the Matroska path is untouched by the normalization
-/// fix — an mkv container must still embed a webp thumbnail directly (native
-/// Matroska attachment, no normalization), unlike the MP4-family path above.
+/// #530 update: unlike jpg/png/gif/tiff, a webp thumbnail is NOT carried
+/// natively into Matroska — `FFmpeg`'s own attachment-mimetype read-back
+/// table doesn't recognize `image/webp`, so an unnormalized webp attachment
+/// would silently fail to render as a cover in any player. The Matroska path
+/// must therefore normalize webp to mjpeg first, exactly like the MP4-family
+/// path above, and the embed must still succeed with no warnings.
+///
+/// Before #530 this test asserted the opposite (webp attached "natively,
+/// no normalization") and passed anyway because it never checked the
+/// resulting stream's codec — a silently non-rendering attachment produced
+/// the same "no warnings" outcome as a correct embed. The codec assertion
+/// below is what actually pins the behavior.
 #[tokio::test]
-async fn process_embeds_webp_thumbnail_into_mkv_natively() {
+async fn process_normalizes_webp_thumbnail_into_mkv_as_mjpeg() {
     if !ffmpeg_cli_available() {
         eprintln!("[SKIP] ffmpeg CLI not available");
         return;
@@ -231,7 +240,7 @@ async fn process_embeds_webp_thumbnail_into_mkv_natively() {
     }
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
-    let stage = ThumbnailStage::new(ffmpeg);
+    let stage = ThumbnailStage::new(ffmpeg.clone());
 
     let config = PostProcess {
         embed_thumbnail: true,
@@ -242,8 +251,31 @@ async fn process_embeds_webp_thumbnail_into_mkv_natively() {
     let result = stage.process(msg).await.expect("non-fatal stage");
     assert!(
         result.warnings.is_empty(),
-        "mkv native webp attachment should succeed with no warnings, got: {:?}",
+        "mkv webp normalization should succeed with no warnings, got: {:?}",
         result.warnings
+    );
+
+    let out_path = result.tracker.primary();
+    let info = ffmpeg
+        .probe(&out_path)
+        .await
+        .expect("probing embedded output must succeed");
+    let thumb_stream = info
+        .streams
+        .iter()
+        .find(|s| s.index == 1)
+        .expect("second stream (thumbnail attachment) must be present");
+    assert_eq!(
+        thumb_stream.codec_type, "video",
+        "the normalized cover must promote to a real, player-visible video \
+         (attached_pic) stream, not a generic attachment"
+    );
+    assert_eq!(
+        thumb_stream.codec_name.as_deref(),
+        Some("mjpeg"),
+        "webp under mkv must be normalized to mjpeg — the raw webp mimetype \
+         is not recognized by FFmpeg's Matroska read-back and would attach \
+         invisibly (#530)"
     );
 }
 

--- a/crates/rdlp-types/src/thumbnail.rs
+++ b/crates/rdlp-types/src/thumbnail.rs
@@ -184,6 +184,48 @@ impl ThumbnailFormat {
             Self::WebP => "webp",
         }
     }
+
+    /// The `(mimetype, filename)` pair this format renders as a *visible*
+    /// Matroska cover attachment, or `None` when it must be normalized to a
+    /// renderable format first.
+    ///
+    /// A Matroska attachment's mimetype string is not just descriptive
+    /// metadata: on read-back, `FFmpeg`'s demuxer (`matroskadec.c`'s
+    /// `mkv_image_mime_tags` table) promotes an attachment to a real,
+    /// player-visible `attached_pic` video stream ONLY when the mimetype
+    /// string is one it recognizes; every other mimetype stays a generic,
+    /// non-rendered file attachment. This is a **mimetype-string** match, not
+    /// a codec/content check — verified empirically (2026-07-19) against the
+    /// linked `FFmpeg` build by attaching the same filename under every
+    /// mimetype string and reading the result back with `ffprobe`:
+    ///
+    /// | mimetype      | read back as              |
+    /// |---------------|----------------------------|
+    /// | `image/jpeg`  | `Video` (`attached_pic=1`)   |
+    /// | `image/png`   | `Video` (`attached_pic=1`)   |
+    /// | `image/gif`   | `Video` (`attached_pic=1`)   |
+    /// | `image/tiff`  | `Video` (`attached_pic=1`)   |
+    /// | `image/bmp`   | `Attachment` (invisible)     |
+    /// | `image/webp`  | `Attachment` (invisible)     |
+    ///
+    /// RFC 9559 §21.1 recommends only JPEG/PNG cover art (a SHOULD, not a
+    /// MUST), so the wider GIF/TIFF support this `FFmpeg` build gives is not a
+    /// spec violation.
+    ///
+    /// Callers embedding into Matroska MUST normalize `Bmp`/`WebP` content
+    /// (see `rdlp_ffmpeg`'s `transcode_image`) before attaching, or the cover
+    /// silently fails to display — the bug behind #530, where the previous
+    /// catch-all additionally mislabeled GIF/TIFF/BMP as `image/jpeg`.
+    #[must_use]
+    pub const fn matroska_attachment(self) -> Option<(&'static str, &'static str)> {
+        match self {
+            Self::Jpeg => Some(("image/jpeg", "cover.jpg")),
+            Self::Png => Some(("image/png", "cover.png")),
+            Self::Gif => Some(("image/gif", "cover.gif")),
+            Self::Tiff => Some(("image/tiff", "cover.tiff")),
+            Self::Bmp | Self::WebP => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -342,6 +384,62 @@ mod tests {
             !THUMBNAIL_EXTENSIONS.contains(&"avif"),
             "avif is not decodable by the current FFmpeg build; keep it out of discovery"
         );
+    }
+
+    /// #530 regression guard: every format the linked `FFmpeg` build renders
+    /// as a real, player-visible Matroska cover (verified via `ffprobe`
+    /// against `attached_pic` disposition) must declare its OWN honest
+    /// mimetype/filename — never silently fall back to `image/jpeg` the way
+    /// the pre-fix catch-all did for gif/tiff/bmp.
+    #[test]
+    fn matroska_attachment_declares_honest_mimetype_for_renderable_formats() {
+        assert_eq!(
+            ThumbnailFormat::Jpeg.matroska_attachment(),
+            Some(("image/jpeg", "cover.jpg"))
+        );
+        assert_eq!(
+            ThumbnailFormat::Png.matroska_attachment(),
+            Some(("image/png", "cover.png"))
+        );
+        assert_eq!(
+            ThumbnailFormat::Gif.matroska_attachment(),
+            Some(("image/gif", "cover.gif"))
+        );
+        assert_eq!(
+            ThumbnailFormat::Tiff.matroska_attachment(),
+            Some(("image/tiff", "cover.tiff"))
+        );
+    }
+
+    /// #530: `Bmp`/`WebP` mimetypes are NOT recognized by `FFmpeg`'s
+    /// read-back promotion table, so they must resolve to `None` — signaling
+    /// "must normalize first" — rather than being handed a mimetype that
+    /// produces an invisible attachment.
+    #[test]
+    fn matroska_attachment_refuses_formats_that_render_invisibly() {
+        assert_eq!(ThumbnailFormat::Bmp.matroska_attachment(), None);
+        assert_eq!(ThumbnailFormat::WebP.matroska_attachment(), None);
+    }
+
+    /// No format may ever resolve to the pre-fix catch-all's mimetype unless
+    /// it genuinely IS jpeg — pins the exact defect #530 reports (gif/tiff
+    /// attached as `cover.jpg` declared `image/jpeg`).
+    #[test]
+    fn only_jpeg_declares_the_jpeg_mimetype() {
+        for format in [
+            ThumbnailFormat::Png,
+            ThumbnailFormat::Gif,
+            ThumbnailFormat::Bmp,
+            ThumbnailFormat::Tiff,
+            ThumbnailFormat::WebP,
+        ] {
+            if let Some((mimetype, _)) = format.matroska_attachment() {
+                assert_ne!(
+                    mimetype, "image/jpeg",
+                    "{format:?} must not silently claim image/jpeg"
+                );
+            }
+        }
     }
 
     /// All entries are lowercase, bare (no leading dot) extensions — callers


### PR DESCRIPTION
## Resolves

Closes #530.

## Problem

`crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs` picked a Matroska attachment's mimetype and filename from the image's `AVCodecID` with a catch-all:

```rust
_ => ("image/jpeg", "cover.jpg"),
```

Since #521 widened thumbnail discovery, a GIF, BMP, or TIFF sidecar reached that arm and was attached as `cover.jpg` declaring `image/jpeg` — a lie to any player reading the MIME type. Same defect class #525 removed from the `covr` atom, surviving one file over.

## The fix contradicts this issue's own acceptance criteria — deliberately

The issue asked for honest arms for gif, bmp, and tiff. **Research and measurement split that set**, so this PR does something different for half of it. The evidence:

FFmpeg's `libavformat/matroskadec.c` contains `mkv_image_mime_tags[]` with exactly four entries — `image/gif`, `image/jpeg`, `image/png`, `image/tiff` — and matches on the **mimetype string only**; the filename is never inspected for this decision. A match calls `ff_add_attached_pic()`, producing a real `attached_pic` video stream (what players show as cover art). No match falls through to a generic, non-rendered `AVMEDIA_TYPE_ATTACHMENT`.

Measured against the linked build, attaching with an **identical filename (`cover.x`) in every case** to isolate the mimetype as the only variable:

| declared mimetype | resulting stream | renders as cover art |
|---|---|---|
| `image/jpeg` | `Video: mjpeg (attached pic)` | yes |
| `image/png` | `Video: png (attached pic)` | yes |
| `image/gif` | `Video: gif (attached pic)` | yes |
| `image/tiff` | `Video: tiff (attached pic)` | yes |
| `image/webp` | `Attachment: none` | **no** |
| `image/bmp` | `Attachment: none` | **no** |

So:

- **gif and tiff** — honest arms are correct; they genuinely render. The concern that honesty would produce player-invisible covers does not apply to them.
- **bmp** — an honest `image/bmp` arm would be spec-legal and invisible. It is normalized to JPEG instead.
- **webp — a pre-existing latent bug neither the issue nor the fix brief anticipated.** rdlp already shipped an `image/webp` arm. That attachment was honest *and invisible*: MKV covers written from webp thumbnails have never displayed in any FFmpeg-based player. The arm is removed and webp now normalizes like bmp.

RFC 9559 §21.1 says only JPEG and PNG **SHOULD** be used for cover art — a SHOULD, not a MUST, so gif/tiff arms are not spec violations.

For reference, yt-dlp's `embedthumbnail.py` deliberately *skips* its jpg/png normalization for mkv/mka and attaches whatever format it downloaded, so yt-dlp exhibits this same invisible-webp-cover behavior. It was not treated as validation here.

## Implementation

`rdlp_types::ThumbnailFormat::matroska_attachment(self) -> Option<(&'static str, &'static str)>` is now the single source of truth — exhaustive, no catch-all, so a seventh format fails to compile rather than falling through to a lie:

```rust
Jpeg => Some(("image/jpeg", "cover.jpg"))
Png  => Some(("image/png",  "cover.png"))
Gif  => Some(("image/gif",  "cover.gif"))
Tiff => Some(("image/tiff", "cover.tiff"))
Bmp | WebP => None            // must be normalized first
```

- `mkv_raw_ffi.rs` derives the mimetype by content-sniffing the thumbnail bytes via `sniff_thumbnail_format`, and returns a typed error if bmp/webp reach it directly rather than silently mislabeling. Its private `AVCodecID`-keyed table is gone — one identity source, not two.
- The Matroska normalization exemption in `ThumbnailStage` is now conditional: jpeg/png/gif/tiff still skip the transcode (no pointless work), bmp/webp route through the existing `transcode_image` path.

## Tests

Failing-first verified: with only the production fix reverted and all tests kept, the negative tests fail for the right reason (`gif must declare its own mimetype, not a fallback`) while the jpeg/png control passes — it was never broken.

- e2e via raw FFI + ffprobe: gif/tiff attach as honest **visible** cover art (asserting `attached_pic` and the declared `TAG:mimetype`, not merely "no error"); jpeg/png regression; bmp/webp rejected at the boundary.
- Pipeline-level e2e through the public `ThumbnailStage::process`: gif/tiff native, bmp normalized and decodable.
- Unit tests on `matroska_attachment()` for both the renderable and refused sets.

### Two pre-existing tests were modified

Both were scrutinized in review against their `develop` versions:

- `thumbnail_webp_mp4_embed.rs` — `process_embeds_webp_thumbnail_into_mkv_natively` contained exactly one assertion: `result.warnings.is_empty()`. No probe, no codec check. Its "attached natively" claim was never tested, since an invisible attachment and a correct embed both produce zero warnings — **the test certified the webp bug**. Rewritten to assert normalization with a real `codec_name` check.
- `mkv_dts_synthesis.rs` — a webp cover fixture changed to jpeg. Incidental to that test's actual subject (DTS synthesis on the media stream); assertion unchanged.

## Reviews

- **Security: PASS.** The new early-return inside `unsafe` FFI was audited against all eight sibling early-return cleanup blocks — identical, correctly-ordered `avformat_close_input` ×2 → `avformat_free_context`, with the extradata owned by the output context and freed exactly once. Confirmed no content-derived string reaches `CString::new` (the mimetype/filename are `'static` literals selected by the match; bytes only choose the arm), the sniffer is bounds-safe on truncated input, the failed-transcode temp is tracked on both branches, and the stage fails closed.
- **Code review: Approve with minor fixes**, all applied — decoupling the bmp/webp normalization from an unrelated stream-codec query it was accidentally relying on, strengthening the rejection test to pin the failure mode rather than any error, and hoisting the sniff above the extradata allocation so a rejected image is not copied for nothing.

## Merge note for whoever resolves the conflict with #534

Both PRs touch `crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs`. The conflict is confined to the `normalize_thumbnail_for_embed` early-return hunk.

**The load-bearing semantic is that the Matroska early-return is now conditional.** A resolution that restores the unconditional `if is_native_attachment_container(extension) { return ...; }` silently reverts this PR — and no unit test in that file's `mod tests` would catch it, because the guarding coverage lives in integration tests that require the ffmpeg CLI.

## Gate

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check -p rdlp-desktop`, and all six `scripts/check-*.sh` — all green.
