### PR TITLE
refactor(postprocess): type the three thumbnail container predicates

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -58,7 +58,7 @@ mod remux;
 pub(crate) mod salvage;
 pub mod speed_controls;
 mod thumbnail;
-pub use thumbnail::supports_thumbnail_embed;
+pub use thumbnail::{supports_thumbnail_embed, uses_native_attachment};
 mod transcode;
 pub use speed_controls::{
     SpeedControlError, default_codec_for_container, resolve_recode_encoder, validate_speed_controls,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
@@ -84,13 +84,27 @@ impl ThumbnailEmbedStrategy {
 /// Whether `format` can carry an embedded thumbnail at all.
 ///
 /// The public gateway to [`ThumbnailEmbedStrategy::for_container`] — exposed
-/// so `rdlp-postprocess`'s `SUPPORTED_CONTAINERS` can be asserted against the
-/// real strategy table instead of a hand-copied mirror of it (full
-/// consolidation of the two lists into one source of truth is tracked by
-/// #533).
+/// so `rdlp-postprocess` gates its auto-remux/embed decision directly against
+/// the real strategy table instead of a hand-copied mirror of it (#533).
 #[must_use]
 pub const fn supports_thumbnail_embed(format: ContainerFormat) -> bool {
     ThumbnailEmbedStrategy::for_container(format).is_some()
+}
+
+/// Whether `format` attaches the thumbnail's source codec natively
+/// (Matroska attachment) and therefore never needs image normalization.
+///
+/// The public gateway to the [`ThumbnailEmbedStrategy::MatroskaAttachment`]
+/// case — exposed so `rdlp-postprocess` derives its normalization gate from
+/// the real strategy table instead of a hand-copied container list (#533).
+/// Named for the PROPERTY the caller cares about (no stream-codec
+/// normalization needed), not the variant name.
+#[must_use]
+pub const fn uses_native_attachment(format: ContainerFormat) -> bool {
+    matches!(
+        ThumbnailEmbedStrategy::for_container(format),
+        Some(ThumbnailEmbedStrategy::MatroskaAttachment)
+    )
 }
 
 #[cfg(test)]
@@ -156,9 +170,9 @@ mod tests {
     }
 
     /// Negative: a container `rdlp` never advertises as thumbnail-capable
-    /// (`SUPPORTED_CONTAINERS` in `rdlp-postprocess`) must resolve to `None`,
-    /// not silently fall through to a stream-based strategy that would fail
-    /// at mux time.
+    /// (i.e. `supports_thumbnail_embed` returns `false`) must resolve to
+    /// `None`, not silently fall through to a stream-based strategy that
+    /// would fail at mux time.
     #[test]
     fn unsupported_container_resolves_to_none() {
         assert_eq!(
@@ -173,5 +187,27 @@ mod tests {
             ThumbnailEmbedStrategy::for_container(ContainerFormat::Avi),
             None
         );
+    }
+
+    /// Positive: Matroska containers (the only `MatroskaAttachment` case)
+    /// report native attachment support.
+    #[test]
+    fn matroska_containers_use_native_attachment_property() {
+        assert!(super::uses_native_attachment(ContainerFormat::Mkv));
+        assert!(super::uses_native_attachment(ContainerFormat::Mka));
+    }
+
+    /// Negative: every other resolvable strategy (stream-based) — and the
+    /// unsupported case — must NOT report native attachment support. A
+    /// regression that also flagged MP4-family as native would silently
+    /// re-introduce the webp-mux-failure bug `normalize_thumbnail_for_embed`
+    /// exists to prevent.
+    #[test]
+    fn non_matroska_containers_reject_native_attachment() {
+        assert!(!super::uses_native_attachment(ContainerFormat::Mp4));
+        assert!(!super::uses_native_attachment(ContainerFormat::Mov));
+        assert!(!super::uses_native_attachment(ContainerFormat::Mp3));
+        assert!(!super::uses_native_attachment(ContainerFormat::Ogg));
+        assert!(!super::uses_native_attachment(ContainerFormat::WebM));
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -47,7 +47,7 @@ use rdlp_types::ContainerFormat;
 use crate::error::{PostProcessError, Result};
 
 use self::embed_strategy::ThumbnailEmbedStrategy;
-pub use self::embed_strategy::supports_thumbnail_embed;
+pub use self::embed_strategy::{supports_thumbnail_embed, uses_native_attachment};
 use super::{FFmpegRunner, ensure_init};
 
 impl FFmpegRunner {

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -56,5 +56,5 @@ pub use ffmpeg::{
     MediaInfo, NormalizeOptions, PeakAnalysis, RemuxOptions, SpeedControlError, StreamInfo,
     VideoCodecInfo, VideoConvertOptions, VideoEncoderInfo, bridge_ffmpeg_logs,
     default_codec_for_container, encoding_tool_tag, resolve_recode_encoder, set_verbose,
-    supports_thumbnail_embed, validate_speed_controls,
+    supports_thumbnail_embed, uses_native_attachment, validate_speed_controls,
 };

--- a/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
+++ b/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
@@ -89,9 +89,10 @@ async fn mp4_accepts_jpeg_and_png() {
 /// bypasses codec tags entirely. So the muxer's "no" here does not contradict
 /// MKV thumbnail support — the two mechanisms are different.
 ///
-/// This is why the embed gate must test `is_native_attachment_container` BEFORE
-/// consulting this query: asking the stream question about a container that
-/// uses attachments would force a needless transcode for every MKV thumbnail.
+/// This is why the embed gate must test `rdlp_ffmpeg::uses_native_attachment`
+/// BEFORE consulting this query: asking the stream question about a
+/// container that uses attachments would force a needless transcode for
+/// every MKV thumbnail.
 #[tokio::test]
 async fn matroska_rejects_webp_as_a_stream_despite_attachment_support() {
     if !ffmpeg_cli_available() {
@@ -158,8 +159,9 @@ async fn jpeg_and_png_are_accepted_by_every_supported_container() {
 
     // Containers where the jpeg/png baseline is VERIFIED to embed.
     //
-    // Deliberately narrower than SUPPORTED_CONTAINERS: `ogg` and `opus` are
-    // listed there but genuinely cannot carry an image STREAM at all — their
+    // Deliberately narrower than `rdlp_ffmpeg::supports_thumbnail_embed`'s
+    // accepted set: `ogg` and `opus` resolve to a strategy there but
+    // genuinely cannot carry an image STREAM at all — their
     // muxer's `ogg_init()` hard-rejects any stream whose codec isn't
     // Vorbis/Theora/Speex/FLAC/Opus/VP8, which is exactly the question this
     // function asks. #531 fixed the actual embed by carrying the cover as a

--- a/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
+++ b/crates/rdlp-ffmpeg/tests/ogg_opus_thumbnail_embed.rs
@@ -1,8 +1,7 @@
 //! Regression test for #531: thumbnail embed into Ogg/Opus.
 //!
-//! `ogg`/`opus` are listed in `SUPPORTED_CONTAINERS`
-//! (`rdlp-postprocess/src/pipeline/stages/thumbnail.rs`), but embedding via
-//! `FFmpegRunner::embed_thumbnail` failed with `Unsupported codec id in
+//! `ogg`/`opus` resolve to `Some` via `rdlp_ffmpeg::supports_thumbnail_embed`,
+//! but embedding via `FFmpegRunner::embed_thumbnail` failed with `Unsupported codec id in
 //! stream 1` — `FFmpeg`'s Ogg muxer (`oggenc.c` `ogg_init()`) hard-rejects
 //! any stream whose codec isn't Vorbis/Theora/Speex/FLAC/Opus/VP8, so the
 //! cover art can never ride an `ATTACHED_PIC` video stream in these

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -86,6 +86,19 @@ impl ThumbnailStage {
     /// uncertainty — `Tag::read_from_path` falls back to `Tag::default()` on
     /// read failure, and a write failure only logs a `warn!` (non-fatal).
     ///
+    /// `ThreeGp` is `false` here, but NOT because `mp4ameta` rejects it as a
+    /// capability matter — `mp4ameta`'s own `ftyp` parsing
+    /// (`atom/ftyp.rs:13`) only errors when the atom is entirely missing, so
+    /// a `.3gp` file would very likely be accepted if this predicate were
+    /// ever consulted for one. It never is: the call site (~line 478) asks
+    /// this question using the POST-REMUX extension, and `ThreeGp` fails
+    /// `rdlp_ffmpeg::supports_thumbnail_embed`, so any `.3gp` input is
+    /// auto-remuxed to `.mp4` before `supports_covr_atom` is ever reached —
+    /// the value can never actually be tested for `ThreeGp`. `false` is kept
+    /// here as the conservative, unreachable placeholder rather than `true`,
+    /// so a future reader doesn't mistake it for a verified capability claim
+    /// and "fix" it to `true` believing they changed real behavior.
+    ///
     /// Matched exhaustively over every [`ContainerFormat`] variant (no
     /// catch-all arm), mirroring the discipline `write_covr_atom`'s own
     /// `ThumbnailFormat` match already uses: a newly-added container format
@@ -136,6 +149,12 @@ impl ThumbnailStage {
     /// support for a container `rdlp-ffmpeg` doesn't recognize at all.
     fn is_native_attachment(extension: &str) -> bool {
         ContainerFormat::from_str(extension).is_ok_and(rdlp_ffmpeg::uses_native_attachment)
+    }
+
+    /// Whether `extension`'s container can carry an embedded thumbnail at all.
+    /// Thin wrapper over `rdlp_ffmpeg::supports_thumbnail_embed` (#533).
+    fn supports_thumbnail(extension: &str) -> bool {
+        ContainerFormat::from_str(extension).is_ok_and(rdlp_ffmpeg::supports_thumbnail_embed)
     }
 
     /// Normalize `thumbnail_file` to a tracker-owned temp `.jpg` when the
@@ -363,11 +382,9 @@ impl PipelineStage for ThumbnailStage {
         // ascii-case-insensitive WITH ALIASES (`"matroska"` → `Mkv`,
         // `"quicktime"` → `Mov`), so a `.matroska`/`.quicktime` extension now
         // takes the embed path instead of auto-remuxing to mp4. See
-        // `matroska_and_quicktime_aliases_take_embed_path_not_remux` for the
+        // `matroska_and_quicktime_aliases_now_resolve_to_embed_support` for the
         // pinned behavior.
-        let supports_thumbnail = ContainerFormat::from_str(&extension)
-            .ok()
-            .is_some_and(rdlp_ffmpeg::supports_thumbnail_embed);
+        let supports_thumbnail = Self::supports_thumbnail(&extension);
         let (media_file, extension) = if supports_thumbnail {
             (media_file, extension)
         } else {
@@ -566,23 +583,14 @@ mod tests {
         assert!(!stage.is_fatal());
     }
 
-    /// The production gate now used in `process()`: parse the extension into
-    /// `ContainerFormat`, then ask the real `rdlp-ffmpeg` strategy table
-    /// (`supports_thumbnail_embed`) — not a hand-copied string list (#533).
-    fn supports_thumbnail(extension: &str) -> bool {
-        ContainerFormat::from_str(extension)
-            .ok()
-            .is_some_and(rdlp_ffmpeg::supports_thumbnail_embed)
-    }
-
     #[test]
     fn supports_thumbnail_containers() {
-        assert!(supports_thumbnail("mp4"));
-        assert!(supports_thumbnail("mkv"));
-        assert!(supports_thumbnail("mp3"));
-        assert!(supports_thumbnail("flac"));
-        assert!(!supports_thumbnail("ts"));
-        assert!(!supports_thumbnail("avi"));
+        assert!(ThumbnailStage::supports_thumbnail("mp4"));
+        assert!(ThumbnailStage::supports_thumbnail("mkv"));
+        assert!(ThumbnailStage::supports_thumbnail("mp3"));
+        assert!(ThumbnailStage::supports_thumbnail("flac"));
+        assert!(!ThumbnailStage::supports_thumbnail("ts"));
+        assert!(!ThumbnailStage::supports_thumbnail("avi"));
     }
 
     /// Behavior-widening regression pin (#533): `ContainerFormat` is
@@ -599,11 +607,11 @@ mod tests {
     #[test]
     fn matroska_and_quicktime_aliases_now_resolve_to_embed_support() {
         assert!(
-            supports_thumbnail("matroska"),
+            ThumbnailStage::supports_thumbnail("matroska"),
             "'matroska' aliases to ContainerFormat::Mkv and must now take the embed path"
         );
         assert!(
-            supports_thumbnail("quicktime"),
+            ThumbnailStage::supports_thumbnail("quicktime"),
             "'quicktime' aliases to ContainerFormat::Mov and must now take the embed path"
         );
     }
@@ -620,7 +628,7 @@ mod tests {
         for format in ContainerFormat::iter() {
             if rdlp_ffmpeg::supports_thumbnail_embed(format) {
                 assert!(
-                    supports_thumbnail(format.as_ext()),
+                    ThumbnailStage::supports_thumbnail(format.as_ext()),
                     "'{}' resolves to a thumbnail strategy but supports_thumbnail returned false",
                     format.as_ext()
                 );
@@ -634,6 +642,13 @@ mod tests {
         assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::M4a));
         assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::M4v));
         assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::Mov));
+        // Behavior-widening regression pin (#533): "quicktime" aliases to
+        // ContainerFormat::Mov via `from_str`, so a `.quicktime` extension
+        // now also resolves to covr-atom support, same as `.mov`.
+        assert!(
+            ContainerFormat::from_str("quicktime").is_ok_and(ThumbnailStage::supports_covr_atom),
+            "'quicktime' aliases to ContainerFormat::Mov and must resolve to covr-atom support"
+        );
     }
 
     /// Negative: Matroska is rejected (different atom mechanism entirely —
@@ -798,6 +813,13 @@ mod tests {
     fn native_attachment_container_accepts_mkv_mka() {
         assert!(ThumbnailStage::is_native_attachment("mkv"));
         assert!(ThumbnailStage::is_native_attachment("mka"));
+        // Behavior-widening regression pin (#533): "matroska" aliases to
+        // ContainerFormat::Mkv, so a `.matroska` file now also skips
+        // normalization via the native-attachment path, same as `.mkv`.
+        assert!(
+            ThumbnailStage::is_native_attachment("matroska"),
+            "'matroska' aliases to ContainerFormat::Mkv and must resolve to native attachment support"
+        );
     }
 
     /// Boundary test: an uppercase `.MKA` extension must still resolve to

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -9,6 +9,7 @@
 //! 2. `mp4ameta` iTunes `covr` atom (Windows Explorer visibility)
 
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -16,18 +17,9 @@ use async_trait::async_trait;
 use log::{debug, info, warn};
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
-use rdlp_types::{THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
+use rdlp_types::{ContainerFormat, THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
 
 use crate::pipeline::{PipelineMessage, PipelineStage};
-
-/// Containers that support thumbnail embedding via `FFmpeg`.
-const SUPPORTED_CONTAINERS: &[&str] = &[
-    "mp4", "m4a", "m4v", "mov", "mkv", "mka", "mp3", "flac", "ogg", "opus",
-];
-
-/// Containers that attach the thumbnail's source codec natively (Matroska) and
-/// therefore never need image normalization.
-const NATIVE_ATTACHMENT_CONTAINERS: &[&str] = &["mkv", "mka"];
 
 /// Embeds thumbnail into the primary current file.
 ///
@@ -73,35 +65,87 @@ impl ThumbnailStage {
         None
     }
 
-    /// Check if the container supports thumbnail embedding.
-    fn supports_thumbnail(extension: &str) -> bool {
-        SUPPORTED_CONTAINERS
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(extension))
+    /// Whether `extension`'s container can hold an iTunes `covr` metadata
+    /// atom via `mp4ameta`.
+    ///
+    /// This is NOT the same question as thumbnail-embed support
+    /// (`rdlp_ffmpeg::supports_thumbnail_embed`) or native-attachment support
+    /// (`rdlp_ffmpeg::uses_native_attachment`): `write_covr_atom` never
+    /// touches `FFmpeg` at all — it is pure `mp4ameta`, whose real
+    /// precondition is a parseable ISO-BMFF `ftyp` atom (`mp4ameta` returns
+    /// `ErrorKind::NoFtyp` otherwise). The four containers accepted here
+    /// happen to coincide with `rdlp-ffmpeg`'s `Mp4FamilyAttachedPic`
+    /// strategy today, but that is incidental, not an identity — so this
+    /// predicate is NOT derived from `rdlp-ffmpeg` and must be kept in sync
+    /// with `mp4ameta`'s own container support, not `FFmpeg`'s.
+    ///
+    /// `.mov` is the weak member of this set: `QuickTime`'s native metadata
+    /// atom is `udta`, not the iTunes `ilst` atom `mp4ameta` writes, so a
+    /// `.mov` file may or may not expose the cover the same way a real `.mp4`
+    /// does. The existing call site already hedges for exactly this kind of
+    /// uncertainty — `Tag::read_from_path` falls back to `Tag::default()` on
+    /// read failure, and a write failure only logs a `warn!` (non-fatal).
+    ///
+    /// Matched exhaustively over every [`ContainerFormat`] variant (no
+    /// catch-all arm), mirroring the discipline `write_covr_atom`'s own
+    /// `ThumbnailFormat` match already uses: a newly-added container format
+    /// fails to compile here, forcing an explicit decision about whether
+    /// `mp4ameta` can represent it, rather than silently inheriting `false`
+    /// (or, worse, `true`) from a catch-all.
+    const fn supports_covr_atom(format: ContainerFormat) -> bool {
+        match format {
+            ContainerFormat::Mp4
+            | ContainerFormat::Mov
+            | ContainerFormat::M4v
+            | ContainerFormat::M4a => true,
+            ContainerFormat::Mkv
+            | ContainerFormat::WebM
+            | ContainerFormat::Ts
+            | ContainerFormat::Flv
+            | ContainerFormat::Avi
+            | ContainerFormat::ThreeGp
+            | ContainerFormat::Mpg
+            | ContainerFormat::F4v
+            | ContainerFormat::Asf
+            | ContainerFormat::Mxf
+            | ContainerFormat::Vob
+            | ContainerFormat::Dv
+            | ContainerFormat::Nut
+            | ContainerFormat::Ivf
+            | ContainerFormat::Ogg
+            | ContainerFormat::Mp3
+            | ContainerFormat::Wav
+            | ContainerFormat::Flac
+            | ContainerFormat::Opus
+            | ContainerFormat::Aac
+            | ContainerFormat::Aiff
+            | ContainerFormat::Mka
+            | ContainerFormat::Wv
+            | ContainerFormat::Caf
+            | ContainerFormat::Ac3 => false,
+        }
     }
 
-    /// Check if the container is an MP4-family format (supports `covr` atom).
-    fn is_mp4_family(extension: &str) -> bool {
-        ["mp4", "m4a", "m4v", "mov"]
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(extension))
-    }
-
-    /// Check if the container attaches the thumbnail's source codec natively
-    /// (Matroska), so it never needs image normalization.
-    fn is_native_attachment_container(extension: &str) -> bool {
-        NATIVE_ATTACHMENT_CONTAINERS
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(extension))
+    /// Whether `extension`'s container attaches the thumbnail's source codec
+    /// natively (Matroska), and therefore never needs image normalization.
+    ///
+    /// Thin wrapper over `rdlp_ffmpeg::uses_native_attachment` — the
+    /// production-code gateway to the real strategy table (#533). An
+    /// unparseable extension answers `false`, the safe direction: it routes
+    /// into the normal transcode-to-jpeg path rather than assuming native
+    /// support for a container `rdlp-ffmpeg` doesn't recognize at all.
+    fn is_native_attachment(extension: &str) -> bool {
+        ContainerFormat::from_str(extension).is_ok_and(rdlp_ffmpeg::uses_native_attachment)
     }
 
     /// Normalize `thumbnail_file` to a tracker-owned temp `.jpg` when the
     /// target container can't consume its codec directly.
     ///
-    /// Matroska is handled entirely separately (see
-    /// [`Self::mkv_attachment_renders_natively`]): it carries the image as a
-    /// file attachment rather than a stream, so the stream-codec-tag question
-    /// below does not govern it at all. `jpeg`/`png`/`gif`/`tiff` attachments
+    /// Matroska (`rdlp_ffmpeg::uses_native_attachment`) is handled entirely
+    /// separately (see [`Self::mkv_attachment_renders_natively`]): it carries
+    /// the image as a file attachment rather than a stream, so the
+    /// stream-codec-tag question below does not govern it at all.
+    /// `jpeg`/`png`/`gif`/`tiff` attachments
     /// render natively and return early untouched; `bmp`/`webp` are not
     /// recognized by `FFmpeg`'s own attachment-mimetype read-back table
     /// (`ThumbnailFormat::matroska_attachment`) and are unconditionally
@@ -128,7 +172,7 @@ impl ThumbnailStage {
         extension: &str,
         thumbnail_file: &Path,
     ) -> PathBuf {
-        if Self::is_native_attachment_container(extension) {
+        if Self::is_native_attachment(extension) {
             return if Self::mkv_attachment_renders_natively(thumbnail_file).await {
                 thumbnail_file.to_path_buf()
             } else {
@@ -311,7 +355,20 @@ impl PipelineStage for ThumbnailStage {
             .to_string();
 
         // Auto-remux containers that don't support thumbnail embedding (e.g. .ts → .mp4).
-        let (media_file, extension) = if Self::supports_thumbnail(&extension) {
+        // The gate is the REAL strategy table in `rdlp-ffmpeg`
+        // (`ContainerFormat::from_str` + `supports_thumbnail_embed`), not a
+        // hand-copied string list — full consolidation of what used to be
+        // two independently-maintained container lists (#533). This widens
+        // accepted input over the old list: `ContainerFormat` is
+        // ascii-case-insensitive WITH ALIASES (`"matroska"` → `Mkv`,
+        // `"quicktime"` → `Mov`), so a `.matroska`/`.quicktime` extension now
+        // takes the embed path instead of auto-remuxing to mp4. See
+        // `matroska_and_quicktime_aliases_take_embed_path_not_remux` for the
+        // pinned behavior.
+        let supports_thumbnail = ContainerFormat::from_str(&extension)
+            .ok()
+            .is_some_and(rdlp_ffmpeg::supports_thumbnail_embed);
+        let (media_file, extension) = if supports_thumbnail {
             (media_file, extension)
         } else {
             let remuxed_path = msg.tracker.temp_path(&media_file, "mp4");
@@ -417,7 +474,9 @@ impl PipelineStage for ThumbnailStage {
                 // transcode fails. `write_covr_atom` therefore re-checks the
                 // bytes itself and refuses what mp4ameta cannot represent,
                 // rather than trusting an invariant that can be violated.
-                if Self::is_mp4_family(&extension) {
+                let supports_covr =
+                    ContainerFormat::from_str(&extension).is_ok_and(Self::supports_covr_atom);
+                if supports_covr {
                     Self::write_covr_atom(&temp_output, &embed_source).await;
                 }
 
@@ -507,77 +566,103 @@ mod tests {
         assert!(!stage.is_fatal());
     }
 
+    /// The production gate now used in `process()`: parse the extension into
+    /// `ContainerFormat`, then ask the real `rdlp-ffmpeg` strategy table
+    /// (`supports_thumbnail_embed`) — not a hand-copied string list (#533).
+    fn supports_thumbnail(extension: &str) -> bool {
+        ContainerFormat::from_str(extension)
+            .ok()
+            .is_some_and(rdlp_ffmpeg::supports_thumbnail_embed)
+    }
+
     #[test]
     fn supports_thumbnail_containers() {
-        assert!(ThumbnailStage::supports_thumbnail("mp4"));
-        assert!(ThumbnailStage::supports_thumbnail("mkv"));
-        assert!(ThumbnailStage::supports_thumbnail("mp3"));
-        assert!(ThumbnailStage::supports_thumbnail("flac"));
-        assert!(!ThumbnailStage::supports_thumbnail("ts"));
-        assert!(!ThumbnailStage::supports_thumbnail("avi"));
+        assert!(supports_thumbnail("mp4"));
+        assert!(supports_thumbnail("mkv"));
+        assert!(supports_thumbnail("mp3"));
+        assert!(supports_thumbnail("flac"));
+        assert!(!supports_thumbnail("ts"));
+        assert!(!supports_thumbnail("avi"));
     }
 
-    /// Forward direction: every string `SUPPORTED_CONTAINERS` (the REAL
-    /// const, not a copy) advertises as thumbnail-capable must actually
-    /// resolve to an embed strategy in `rdlp-ffmpeg`.
-    ///
-    /// This and the reverse-direction test below replace what used to be a
-    /// same-crate agreement test in `rdlp-ffmpeg` asserting `for_container`
-    /// against `MIRRORED_SUPPORTED_CONTAINERS` — a hand-copied duplicate of
-    /// this very list. That guarded against nothing: editing the real
-    /// `SUPPORTED_CONTAINERS` below left both the copy and the test green.
-    /// Asserting against `rdlp_ffmpeg::supports_thumbnail_embed` here closes
-    /// that gap (full consolidation of the two lists tracked by #533).
+    /// Behavior-widening regression pin (#533): `ContainerFormat` is
+    /// `#[strum(ascii_case_insensitive)]` WITH ALIASES — `"matroska"` parses
+    /// to `Mkv` and `"quicktime"` parses to `Mov`. The old hand-copied
+    /// `SUPPORTED_CONTAINERS` string list only ever matched the short
+    /// extensions (`"mkv"`, `"mov"`), so `.matroska`/`.quicktime` files
+    /// previously fell into the ".ts → .mp4"-style auto-remux branch. Under
+    /// the typed gate they now resolve directly to the embed path instead.
+    /// A `.matroska`/`.quicktime` file extension is unrealistic in practice
+    /// (real files use `.mkv`/`.mov`), and taking the embed path is safe —
+    /// but it is a real, deliberate behavior change, pinned here rather than
+    /// left as an unstated side effect of the migration.
     #[test]
-    fn supported_containers_all_resolve_to_a_strategy() {
-        use std::str::FromStr as _;
-
-        use rdlp_types::ContainerFormat;
-
-        for container in SUPPORTED_CONTAINERS {
-            let format = ContainerFormat::from_str(container)
-                .unwrap_or_else(|_| panic!("'{container}' must parse as a ContainerFormat"));
-            assert!(
-                rdlp_ffmpeg::supports_thumbnail_embed(format),
-                "'{container}' is listed in SUPPORTED_CONTAINERS but \
-                 rdlp_ffmpeg::supports_thumbnail_embed returned false"
-            );
-        }
+    fn matroska_and_quicktime_aliases_now_resolve_to_embed_support() {
+        assert!(
+            supports_thumbnail("matroska"),
+            "'matroska' aliases to ContainerFormat::Mkv and must now take the embed path"
+        );
+        assert!(
+            supports_thumbnail("quicktime"),
+            "'quicktime' aliases to ContainerFormat::Mov and must now take the embed path"
+        );
     }
 
-    /// Reverse direction: every container `rdlp-ffmpeg` resolves an embed
-    /// strategy for must be advertised by `SUPPORTED_CONTAINERS` — otherwise
-    /// `ThumbnailStage` would never reach this code for that container at
-    /// all, and the two would have quietly diverged.
+    /// Every container the real `rdlp-ffmpeg` strategy table resolves an
+    /// embed strategy for must be reachable via `supports_thumbnail` — this
+    /// is the identity the typed gate is now defined by, so it holds by
+    /// construction; kept as an explicit assertion so a future change to
+    /// either side that breaks the identity is caught here.
     #[test]
-    fn every_strategy_supported_format_is_in_supported_containers() {
+    fn every_strategy_supported_format_is_reachable() {
         use strum::IntoEnumIterator as _;
-
-        use rdlp_types::ContainerFormat;
 
         for format in ContainerFormat::iter() {
             if rdlp_ffmpeg::supports_thumbnail_embed(format) {
-                // `as_ext()` (not `Display`/`to_string()`) is the canonical
-                // extension string: `ContainerFormat`'s `Display` impl does
-                // not necessarily print the same alias `SUPPORTED_CONTAINERS`
-                // uses (e.g. `Mkv`'s `Display` is "matroska", not "mkv").
-                let name = format.as_ext();
                 assert!(
-                    SUPPORTED_CONTAINERS.contains(&name),
-                    "'{name}' resolves to a thumbnail strategy but is missing from \
-                     SUPPORTED_CONTAINERS"
+                    supports_thumbnail(format.as_ext()),
+                    "'{}' resolves to a thumbnail strategy but supports_thumbnail returned false",
+                    format.as_ext()
                 );
             }
         }
     }
 
     #[test]
-    fn is_mp4_family() {
-        assert!(ThumbnailStage::is_mp4_family("mp4"));
-        assert!(ThumbnailStage::is_mp4_family("m4a"));
-        assert!(ThumbnailStage::is_mp4_family("mov"));
-        assert!(!ThumbnailStage::is_mp4_family("mkv"));
-        assert!(!ThumbnailStage::is_mp4_family("mp3"));
+    fn supports_covr_atom_accepts_mp4_family() {
+        assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::Mp4));
+        assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::M4a));
+        assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::M4v));
+        assert!(ThumbnailStage::supports_covr_atom(ContainerFormat::Mov));
+    }
+
+    /// Negative: Matroska is rejected (different atom mechanism entirely —
+    /// `covr` is an iTunes/ISO-BMFF concept, Matroska carries attachments).
+    #[test]
+    fn supports_covr_atom_rejects_mkv() {
+        assert!(!ThumbnailStage::supports_covr_atom(ContainerFormat::Mkv));
+    }
+
+    /// Negative: MP3 is rejected — it uses `ID3v2` APIC, not a covr atom.
+    #[test]
+    fn supports_covr_atom_rejects_mp3() {
+        assert!(!ThumbnailStage::supports_covr_atom(ContainerFormat::Mp3));
+    }
+
+    /// Negative, and the load-bearing case for this predicate's existence:
+    /// `F4v` is ISO-BMFF (an MP4 variant — `ContainerFormat::
+    /// supports_faststart` groups it with `Mp4`/`Mov`/`M4v`) yet is NOT
+    /// covr-gated today (nor, independently, does `rdlp-ffmpeg`'s
+    /// `ThumbnailEmbedStrategy` resolve a thumbnail-embed strategy for it at
+    /// all). This pins current behavior explicitly so a future change to
+    /// widen `supports_covr_atom` to "any ISO-BMFF container" is a
+    /// deliberate decision, not an accidental consequence of conflating the
+    /// covr-atom axis with `rdlp-ffmpeg`'s embed-strategy axis — the two
+    /// questions are independent, which is the entire point of keeping this
+    /// predicate un-derived from `rdlp-ffmpeg`.
+    #[test]
+    fn supports_covr_atom_rejects_f4v_despite_iso_bmff_kinship() {
+        assert!(!ThumbnailStage::supports_covr_atom(ContainerFormat::F4v));
     }
 
     #[test]
@@ -711,8 +796,23 @@ mod tests {
 
     #[test]
     fn native_attachment_container_accepts_mkv_mka() {
-        assert!(ThumbnailStage::is_native_attachment_container("mkv"));
-        assert!(ThumbnailStage::is_native_attachment_container("MKA"));
+        assert!(ThumbnailStage::is_native_attachment("mkv"));
+        assert!(ThumbnailStage::is_native_attachment("mka"));
+    }
+
+    /// Boundary test: an uppercase `.MKA` extension must still resolve to
+    /// native-attachment support end to end. Under the string-list design
+    /// this was `is_native_attachment_container`'s own case-insensitive
+    /// comparison; under the typed design that behavior has moved into
+    /// `ContainerFormat::from_str`'s `#[strum(ascii_case_insensitive)]`
+    /// parsing. Kept as an explicit test so this coverage isn't silently
+    /// lost in the migration (#533).
+    #[test]
+    fn uppercase_extension_still_resolves_native_attachment() {
+        assert!(
+            ThumbnailStage::is_native_attachment("MKA"),
+            "an uppercase .MKA extension must still parse and resolve to native attachment support"
+        );
     }
 
     /// Negative: MP4-family (and other non-Matroska) containers must NOT be
@@ -721,9 +821,9 @@ mod tests {
     /// exempted "mp4" would silently re-introduce the webp mux failure.
     #[test]
     fn native_attachment_container_rejects_mp4_family() {
-        assert!(!ThumbnailStage::is_native_attachment_container("mp4"));
-        assert!(!ThumbnailStage::is_native_attachment_container("mov"));
-        assert!(!ThumbnailStage::is_native_attachment_container("mp3"));
+        assert!(!ThumbnailStage::is_native_attachment("mp4"));
+        assert!(!ThumbnailStage::is_native_attachment("mov"));
+        assert!(!ThumbnailStage::is_native_attachment("mp3"));
     }
 
     // #530 end-to-end coverage (gif/tiff attach natively, bmp/webp get


### PR DESCRIPTION
## Resolves

Closes #533.

## Problem

`crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs` keyed three decisions off raw container strings, violating the CLAUDE.md rule "NEVER use raw strings for container formats — always the corresponding enum":

- `SUPPORTED_CONTAINERS` (10 strings) → whether the stage runs at all
- `is_mp4_family` (a *second*, inline 4-string list) → whether to write the iTunes `covr` atom
- `NATIVE_ATTACHMENT_CONTAINERS` → whether to normalize the image codec before embedding

## The three are NOT the same question — research inverted the issue's own rationale

The issue (which I filed) justified deferring this by claiming these are "three different questions that merely share a container-string key." Measurement says that is **right about one and wrong about two**:

| Predicate | Verdict |
|---|---|
| `supports_thumbnail` | **Identity.** The question is verbatim "will `rdlp-ffmpeg::embed_thumbnail` accept this?" — and ffmpeg re-asks it anyway, re-parsing and erroring on `None`. Two sources of truth for one fact. |
| `is_native_attachment_container` | **Identity.** Exists solely to predict which branch `embed_thumbnail_sync` takes, so stream-codec normalization can be skipped. |
| `is_mp4_family` | **Coincidence.** Same four containers today, different question. |

`Mp4FamilyAttachedPic` means one operational thing in rdlp-ffmpeg: set `movflags=+faststart`. But `is_mp4_family` gates `write_covr_atom`, which touches FFmpeg **not at all** — it is pure `mp4ameta` (a postprocess-only dependency), whose real precondition is a parseable `ftyp` atom. `.mov` is the weak member (QuickTime `udta` vs iTunes `ilst`; the code already hedges), and `3gp`/`f4v` are ISO-BMFF yet resolve to `None` in the strategy table. Collapsing it would encode "FFmpeg faststart strategy" as the definition of "mp4ameta can hold artwork."

So the three are treated **asymmetrically, on purpose**.

## Changes

1. **`supports_thumbnail`** — the hand-copied `SUPPORTED_CONTAINERS` const is deleted; a thin private fn wraps `ContainerFormat::from_str(ext).is_ok_and(rdlp_ffmpeg::supports_thumbnail_embed)`. This promotes `supports_thumbnail_embed` from test-only API (added in #534 purely so a test could assert against the real list) to the production gate it was designed to be. Both "agreement tests" are deleted as vacuous — they existed only to prove a copied string list agreed with the enum.
2. **`is_native_attachment`** — derived from a new `pub const fn rdlp_ffmpeg::uses_native_attachment(ContainerFormat) -> bool`, named for the property postprocess cares about rather than the variant it wraps.
3. **`supports_covr_atom`** (was `is_mp4_family`) — kept independent of rdlp-ffmpeg, rewritten as an exhaustive `match` over all 29 `ContainerFormat` variants with **no catch-all**, documented against mp4ameta's `ftyp` requirement.

`ThumbnailEmbedStrategy` deliberately stays `pub(super)`. Cargo's SemVer rules on public enums are *neutral* here (these are unpublished, lockstep-versioned path deps, so break-on-add is just "the compiler lists the call sites"); what decides it is encapsulation — the variants encode FFmpeg muxer internals, and `rdlp-types` is explicitly scoped to "pure domain types, no I/O dependencies", so hoisting was rejected too.

## Behavior change: alias widening

`ContainerFormat` is `#[strum(ascii_case_insensitive)]` **with aliases**. `"matroska"` → `Mkv` and `"quicktime"` → `Mov` now pass gates the string lists rejected, so such files take the embed path rather than auto-remux.

Every alias on every variant was enumerated: the other multi-alias variants (`Ts`, `ThreeGp`, `Mpg`, `Asf`, `Wav`, `Aac`, `Aiff`, `Wv`) all resolve to `None` in the strategy table, so **`.matroska` and `.quicktime` are the complete set** of newly-accepted extensions. Both are safe (they route to containers that genuinely support embedding) and practically unreachable — `extension` comes from a path rdlp itself produced, and rdlp emits the short forms. All three affected predicates are now test-pinned.

## Tests

14 string assertions migrated to `ContainerFormat`. Two agreement tests deleted as vacuous. New coverage: the alias widening on all three predicates; `supports_covr_atom` accept/reject including `f4v` (ISO-BMFF kinship yet correctly rejected); and an uppercase `.MKA` boundary test replacing coverage that would otherwise have been silently lost when case-insensitivity moved from the predicate to `ContainerFormat`'s parsing.

## Reviews

- **Security: PASS**, no findings. Independently enumerated every alias and confirmed the widening set is exactly two, that the covr write surface is unchanged (same four containers), that the deleted tests had no independent value, and that #535's webp/bmp Matroska reject guard is untouched.
- **Code review: Approve with minor fixes** — all four applied in `29cde279`:
  1. The gate had been inlined at the call site while `mod tests` re-implemented it, so the tests exercised a copy and byte-identical logic appeared twice in one file. Extracted to a production fn — restoring the shape its two sibling predicates already had, which is what made it the odd one out in the first place.
  2. A doc comment cited a test name that existed nowhere.
  3. Two of the three alias widenings were unpinned while the docs framed the change as fully accounted for.
  4. `ThreeGp`'s `false` arm was justified on the wrong grounds — mp4ameta does not brand-gate, so it would likely *accept* a `.3gp`. What actually makes `false` safe is reachability: `supports_covr_atom` is consulted with the **post-remux** extension, so a `.3gp` arrives as `"mp4"` and `ThreeGp` can never be the value tested. Now documented as unreachable-and-conservative rather than a capability claim.

## Follow-up

**#536** — widen `embed_thumbnail` / `container_accepts_image_codec` from `container: &str` to `ContainerFormat`, deleting the redundant re-parse inside `embed_thumbnail_sync` and its "unrecognized container" error branch. That makes the no-raw-strings rule structurally enforced at the API rather than conventionally observed. Depends on this PR.

## Gate

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (105 suites, 0 failures), `cargo check -p rdlp-desktop`, and all six `scripts/check-*.sh` — all green, including `check-dedup` after the duplication removal.
