### PR TITLE
chore(types): close #534 fallout — TS union drift, stale doc counts, phantom flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,15 @@ jobs:
         # Diff guard: if the host WIT and vendored copy diverge, fail loud.
         run: bash scripts/check-wit-drift.sh
 
+      - name: Check Rust enum / TypeScript union drift
+        # crates/rdlp-desktop/src/types/index.ts hand-mirrors several lowercase
+        # serde enums from rdlp-types. Adding a Rust variant does not break the
+        # TS build — it just lets Rust serialize a value the TS type declares
+        # impossible (#534 added ContainerFormat::M4v; the union kept 28, #542).
+        # Derives the Rust side from the enum body, so it can't agree with a
+        # stale mirror.
+        run: bash scripts/check-ts-enum-drift.sh
+
       - name: Install semgrep
         run: pipx install semgrep || pip install semgrep
 

--- a/crates/rdlp-api/src/orchestrator/container_resolver.rs
+++ b/crates/rdlp-api/src/orchestrator/container_resolver.rs
@@ -13,7 +13,11 @@ use std::path::{Path, PathBuf};
 pub enum ContainerSource {
     /// User explicitly set via `--remux=<container>`.
     RemuxConfig,
-    /// User explicitly set via `--merge-output-format=<container>`.
+    /// User explicitly set `postprocess.merge_output_format`.
+    ///
+    /// There is no CLI flag for this: it is settable only from the config TOML
+    /// (`[postprocess] merge_output_format = "<container>"`) or by an API caller
+    /// constructing [`rdlp_types::PostProcess`] directly.
     MergeConfig,
     /// Inferred from the output file's extension (reflects format selection).
     FileExtension,
@@ -37,8 +41,8 @@ impl ResolvedContainer {
     /// Resolve the target container using the precedence chain.
     ///
     /// # Precedence (highest to lowest)
-    /// 1. `config.remux_container` (`--remux=<fmt>`)
-    /// 2. `config.merge_output_format` (`--merge-output-format=<fmt>`)
+    /// 1. `config.postprocess.remux_container` (`--remux=<fmt>`)
+    /// 2. `config.postprocess.merge_output_format` (config TOML / API only)
     /// 3. Output file extension (from format selection)
     /// 4. Fallback to MP4 with warning
     pub fn resolve(config: &rdlp_types::Config, output_path: Option<&Path>) -> Self {

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -273,7 +273,7 @@ export interface DownloadJob {
  * Container formats matching Rust `ContainerFormat` (#[serde(rename_all = "lowercase")]).
  */
 export type ContainerFormat =
-    | "mp4" | "mkv" | "webm" | "mov" | "ts" | "flv" | "avi"
+    | "mp4" | "mkv" | "webm" | "mov" | "m4v" | "ts" | "flv" | "avi"
     | "threegp" | "mpg" | "f4v" | "asf" | "mxf" | "vob" | "dv"
     | "nut" | "ivf" | "ogg" | "m4a" | "mp3" | "wav" | "flac"
     | "opus" | "aac" | "aiff" | "mka" | "wv" | "caf" | "ac3";

--- a/scripts/check-ts-enum-drift.sh
+++ b/scripts/check-ts-enum-drift.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Verify the desktop TypeScript string-literal unions still match the Rust enums
+# they mirror across the Tauri IPC boundary.
+#
+# Why: `crates/rdlp-desktop/src/types/index.ts` hand-mirrors several
+# `#[serde(rename_all = "lowercase")]` enums. Adding a Rust variant does not
+# break the TS build — it just lets Rust serialize a value the TS type declares
+# impossible. That is a silent contract mismatch, and it is exactly what
+# happened when `ContainerFormat::M4v` landed in #534 (see #542).
+#
+# The Rust side is derived from the enum body itself (variant identifiers,
+# lowercased — what `rename_all = "lowercase"` produces), never from a
+# hand-copied list, so the check cannot silently agree with a stale mirror.
+#
+# The parser is deliberately STRICT, because the dangerous failure mode is a
+# silent one: if a variant it cannot classify were skipped, and the TS union
+# were equally incomplete, the sets would match and the gate would print OK on
+# the very drift it exists to catch. So every line inside an enum body must be
+# blank, a comment, an attribute, or a plain unit variant — anything else
+# (tuple/struct payload, explicit discriminant, per-variant `serde(rename)`)
+# exits 2 and demands this script be extended.
+#
+# Fix when this fails: edit the union in index.ts to match the reported Rust set.
+#
+# Run from the repository root.
+
+set -euo pipefail
+
+TS_FILE="crates/rdlp-desktop/src/types/index.ts"
+
+# rust_file:rust_enum:ts_union — each enum's `rename_all = "lowercase"` is
+# asserted below, not assumed.
+PAIRS=(
+    "crates/rdlp-types/src/container.rs:ContainerFormat:ContainerFormat"
+    "crates/rdlp-types/src/audio_format.rs:AudioFormat:AudioFormat"
+    "crates/rdlp-types/src/subtitle_format.rs:SubtitleFormat:SubtitleFormat"
+    "crates/rdlp-desktop/src-tauri/src/state/download_queue.rs:JobStatus:JobStatus"
+)
+
+if [ ! -f "$TS_FILE" ]; then
+    echo "error: TypeScript type file not found at $TS_FILE" >&2
+    exit 2
+fi
+
+# Variant identifiers of `enum <name>`, lowercased, one per line, sorted.
+#
+# Also asserts the two properties that make "lowercased identifier" equal to the
+# serde wire value: the enum carries `rename_all = "lowercase"`, and no variant
+# overrides it with its own `serde(rename = ...)`.
+rust_variants() {
+    local file=$1 name=$2
+    awk -v enum_decl="pub enum $name {" -v enum_name="$name" -v file="$file" '
+        index($0, enum_decl) == 1 {
+            if (attrs !~ /rename_all[[:space:]]*=[[:space:]]*"lowercase"/) {
+                printf "error: %s in %s is not #[serde(rename_all = \"lowercase\")];\n", enum_name, file > "/dev/stderr"
+                print  "       this script maps variants to wire values by lowercasing the identifier," > "/dev/stderr"
+                print  "       which is only correct under that attribute. Extend the script." > "/dev/stderr"
+                exit 2
+            }
+            inside = 1
+            next
+        }
+
+        # Attributes/doc comments IMMEDIATELY preceding the decl. Anything else
+        # non-blank (a previous item body, a closing brace) clears the block —
+        # "since the last blank line" would let a prior enum s rename_all bleed
+        # into this one s assertion, which is the silent-wrong the check exists
+        # to prevent.
+        !inside && /^[[:space:]]*(\/\/|#\[)/ { attrs = attrs "\n" $0; next }
+        !inside && /^[[:space:]]*$/          { next }
+        !inside                              { attrs = ""; next }
+
+        inside && /^}/ { exit }
+        inside && /^[[:space:]]*$/ { next }          # blank line
+        inside && /^[[:space:]]*\/\// { next }       # `//` or `///` comment
+
+        inside && /^[[:space:]]*#\[/ {
+            if ($0 ~ /serde[[:space:]]*\([^)]*(rename[[:space:]]*=|skip)/) {
+                printf "error: %s in %s has a per-variant #[serde(rename = ...)] or #[serde(skip)]:\n  %s\n", enum_name, file, $0 > "/dev/stderr"
+                print  "       rename: the wire value no longer follows from the identifier." > "/dev/stderr"
+                print  "       skip:   the variant has no wire value at all, so counting it would" > "/dev/stderr"
+                print  "               demand a TS member that can never be produced." > "/dev/stderr"
+                print  "       Extend the script." > "/dev/stderr"
+                exit 2
+            }
+            next                                     # any other attribute
+        }
+
+        inside && /^    [A-Z][A-Za-z0-9]*,$/ {       # plain unit variant
+            gsub(/^ +|,$/, "")
+            print tolower($0)
+            next
+        }
+
+        inside {
+            printf "error: unparseable line in %s (%s):\n  %s\n", enum_name, file, $0 > "/dev/stderr"
+            print  "       Expected a plain unit variant. A tuple/struct variant, an explicit" > "/dev/stderr"
+            print  "       discriminant, or an unusual layout is NOT safely comparable against a" > "/dev/stderr"
+            print  "       TS string union — skipping it silently could let real drift pass." > "/dev/stderr"
+            print  "       Extend this script to handle it." > "/dev/stderr"
+            exit 2
+        }
+    ' "$file" | sort
+}
+
+# Quoted members of `export type <name> =` up to the terminating semicolon.
+ts_union_members() {
+    local name=$1
+    awk -v decl="export type $name =" '
+        index($0, decl) == 1 { inside = 1 }
+        inside {
+            while (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                $0 = substr($0, RSTART + RLENGTH)
+            }
+            if (/;/) exit
+        }
+    ' "$TS_FILE" | sort
+}
+
+status=0
+
+for pair in "${PAIRS[@]}"; do
+    IFS=: read -r rust_file rust_enum ts_union <<<"$pair"
+
+    if [ ! -f "$rust_file" ]; then
+        echo "error: Rust source not found at $rust_file" >&2
+        exit 2
+    fi
+
+    # awk's exit 2 must abort the run, not be swallowed by the assignment.
+    # This depends on `pipefail` (line 27): awk is piped into `sort`, so without
+    # it the pipeline would report sort's 0 and the guard would be a no-op.
+    if ! rust_set=$(rust_variants "$rust_file" "$rust_enum"); then
+        exit 2
+    fi
+    ts_set=$(ts_union_members "$ts_union")
+
+    if [ -z "$rust_set" ]; then
+        echo "error: parsed zero variants from $rust_enum in $rust_file" >&2
+        exit 2
+    fi
+    if [ -z "$ts_set" ]; then
+        echo "error: parsed zero members from TS union $ts_union in $TS_FILE" >&2
+        exit 2
+    fi
+
+    if ! diff_out=$(diff <(echo "$rust_set") <(echo "$ts_set")); then
+        status=1
+        cat <<EOF >&2
+
+ERROR: $rust_enum ($rust_file) and the TypeScript union $ts_union ($TS_FILE)
+disagree. '<' lines are Rust-only (missing from TS); '>' lines are TS-only
+(no such Rust variant).
+
+$diff_out
+EOF
+    else
+        echo "$rust_enum ↔ TS $ts_union OK ($(echo "$rust_set" | wc -l) variants)"
+    fi
+done
+
+exit "$status"


### PR DESCRIPTION
Closes #542. Refs #534, #540.

## What

`ContainerFormat::M4v` landed in #534; the hand-maintained TypeScript mirror in `crates/rdlp-desktop/src/types/index.ts` was never updated. Rust could serialize `"m4v"` into an IPC payload that the TS type declared impossible — a silent contract mismatch rather than a compile error.

- Adds `"m4v"` to the `ContainerFormat` union.
- Adds `scripts/check-ts-enum-drift.sh` (+ CI step, + pre-PR gate) so this cannot recur.
- Corrects two doc comments in `container_resolver.rs` that cited a `--merge-output-format` CLI flag which does not exist — zero references in `rdlp-cli`; the field is settable only via config TOML `[postprocess] merge_output_format` or by an API caller. Also fixes the neighbouring precedence line to name `config.postprocess.remux_container`.

Stale "28 container formats" doc counts were corrected locally; `docs/` is gitignored, so they are not in this diff.

## The gate

It derives each enum's serde spellings from the Rust enum body (variant identifiers, lowercased — what `rename_all = "lowercase"` produces) rather than a hand-copied list, so it cannot silently agree with a stale mirror. Covers all four known mirrors: `ContainerFormat` (29), `AudioFormat` (14), `SubtitleFormat` (5), `JobStatus` (6).

The parser is deliberately strict. Its dangerous failure mode is silent: if a variant it could not classify were skipped, and the TS union were equally incomplete, the sets would match and the gate would print OK on the very drift it exists to catch. So anything that is not a blank line, comment, attribute, or plain unit variant exits 2 with the offending line. The `rename_all = "lowercase"` assumption the whole mapping rests on is asserted against the attribute block immediately preceding the decl, and per-variant `serde(rename)` / `serde(skip)` are hard errors.

Every guard was canary-verified against a real mutated source, then restored:

| Mutation | Expected | Got |
|---|---|---|
| Tuple variant in Rust, absent from TS | 2 | 2 |
| Explicit discriminant (`Ivf = 7`) | 2 | 2 |
| Per-variant `#[serde(rename)]` | 2 | 2 |
| `#[serde(skip)]` variant | 2 | 2 |
| `rename_all` switched to `snake_case` | 2 | 2 |
| Adjacent enum's `rename_all` bleeding into the assertion | 2 | 2 |
| `"m4v"` removed from TS union | 1 | 1 |
| `"processing"` removed from TS `JobStatus` | 1 | 1 |
| Unmodified tree | 0 | 0 |

## Deferred

Issue item 4 (a clap `value_parser` so `--remux=nonsense` gives usage output instead of a raw strum error) is not here. Researched separately: the fix is entangled with #540, and a `ValueEnum` for this type must reuse `as_ext()` rather than strum's `Display`, which resolves to the *longest* alias (`Mkv` → `"matroska"`). It belongs in the #540 fix.

## Verification

`cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (0 failures), `npx tsc --noEmit`, and all seven gate scripts — green.

## Reviews

- **security-reviewer**: Approve, no findings. Independently verified the gate is not vacuous and fails closed.
- **code-reviewer**: *Changes required* on the first pass. It and the security reviewer independently found that the original awk matcher silently skipped non-unit variants — the false-pass described above. Also flagged that `JobStatus` was an uncovered fourth mirror, and that the `rename_all` assumption was commented but unenforced. All fixed; re-review returned *Approve with minor fixes*, and those (attribute-block bleed, `serde(skip)`, `pipefail` dependency note) are applied too.
