### PR TITLE
fix(types): make ContainerFormat's Display render the extension, not an alias

### DIFF
--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -17,19 +17,19 @@ pub enum ContainerFormat {
     #[strum(serialize = "mp4")]
     Mp4,
     /// Matroska — supports all codecs, efficient cues index
-    #[strum(serialize = "mkv", serialize = "matroska")]
+    #[strum(to_string = "mkv", serialize = "matroska")]
     Mkv,
     /// Web-optimized, VP8/VP9/AV1 + Opus/Vorbis
     #[strum(serialize = "webm")]
     WebM,
     /// Apple `QuickTime`, good for editing
-    #[strum(serialize = "mov", serialize = "quicktime")]
+    #[strum(to_string = "mov", serialize = "quicktime")]
     Mov,
     /// MPEG-4 Part 14, video variant (iTunes video) — audio-only sibling is [`Self::M4a`]
     #[strum(serialize = "m4v")]
     M4v,
     /// MPEG Transport Stream, broadcast/streaming
-    #[strum(serialize = "ts", serialize = "mpegts")]
+    #[strum(to_string = "ts", serialize = "mpegts")]
     Ts,
     /// Flash Video, legacy format
     #[strum(serialize = "flv")]
@@ -38,16 +38,16 @@ pub enum ContainerFormat {
     #[strum(serialize = "avi")]
     Avi,
     /// 3GPP mobile video
-    #[strum(serialize = "3gp", serialize = "3gpp")]
+    #[strum(to_string = "3gp", serialize = "3gpp")]
     ThreeGp,
     /// MPEG-1/2 program stream
-    #[strum(serialize = "mpg", serialize = "mpeg")]
+    #[strum(to_string = "mpg", serialize = "mpeg")]
     Mpg,
     /// Flash Video (MP4 variant)
     #[strum(serialize = "f4v")]
     F4v,
     /// Advanced Streaming Format / Windows Media
-    #[strum(serialize = "asf", serialize = "wmv", serialize = "wma")]
+    #[strum(to_string = "asf", serialize = "wmv", serialize = "wma")]
     Asf,
     /// Material eXchange Format (broadcast/professional)
     #[strum(serialize = "mxf")]
@@ -76,7 +76,7 @@ pub enum ContainerFormat {
     #[strum(serialize = "mp3")]
     Mp3,
     /// Waveform Audio (PCM)
-    #[strum(serialize = "wav", serialize = "wave")]
+    #[strum(to_string = "wav", serialize = "wave")]
     Wav,
     /// Free Lossless Audio Codec
     #[strum(serialize = "flac")]
@@ -85,7 +85,7 @@ pub enum ContainerFormat {
     #[strum(serialize = "opus")]
     Opus,
     /// Raw ADTS AAC
-    #[strum(serialize = "aac", serialize = "adts")]
+    #[strum(to_string = "aac", serialize = "adts")]
     Aac,
     /// Audio Interchange File Format (Apple)
     #[strum(serialize = "aiff", serialize = "aif")]
@@ -94,7 +94,7 @@ pub enum ContainerFormat {
     #[strum(serialize = "mka")]
     Mka,
     /// `WavPack` lossless
-    #[strum(serialize = "wv", serialize = "wavpack")]
+    #[strum(to_string = "wv", serialize = "wavpack")]
     Wv,
     /// Core Audio Format (Apple)
     #[strum(serialize = "caf")]
@@ -185,52 +185,71 @@ mod tests {
         }
     }
 
+    /// `Display` must render the file extension, not an alias.
+    ///
+    /// strum picks the longest `serialize` value when no `to_string` is set, so
+    /// without an explicit `to_string` this silently returns `"matroska"` for
+    /// `Mkv`, `"quicktime"` for `Mov`, and so on (#545). Anything that formats a
+    /// `ContainerFormat` into a filename or an `FFmpeg` extension probe then gets a
+    /// string no muxer lookup recognises.
     #[test]
-    fn test_alias_parsing() {
-        assert_eq!(
-            "matroska".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Mkv
-        );
-        assert_eq!(
-            "quicktime".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Mov
-        );
-        assert_eq!(
-            "mpegts".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Ts
-        );
-        assert_eq!(
-            "3gpp".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::ThreeGp
-        );
-        assert_eq!(
-            "mpeg".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Mpg
-        );
-        assert_eq!(
-            "wmv".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Asf
-        );
-        assert_eq!(
-            "wma".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Asf
-        );
-        assert_eq!(
-            "wave".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Wav
-        );
-        assert_eq!(
-            "adts".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Aac
-        );
-        assert_eq!(
-            "aif".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Aiff
-        );
-        assert_eq!(
-            "wavpack".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Wv
-        );
+    fn test_display_is_the_file_extension() {
+        for fmt in ContainerFormat::iter() {
+            assert_eq!(
+                fmt.to_string(),
+                fmt.as_ext(),
+                "Display for {fmt:?} must equal as_ext()"
+            );
+        }
+    }
+
+    /// Every alias must still parse after `to_string` is added.
+    ///
+    /// strum unions `to_string` into the `FromStr` set rather than replacing the
+    /// `serialize` list, so this holds — but it is the exact way the #545 fix
+    /// could have silently narrowed the accepted CLI vocabulary, so it is pinned.
+    #[test]
+    fn test_every_alias_still_parses() {
+        const ALIASES: &[(&str, ContainerFormat)] = &[
+            ("matroska", ContainerFormat::Mkv),
+            ("quicktime", ContainerFormat::Mov),
+            ("mpegts", ContainerFormat::Ts),
+            ("3gpp", ContainerFormat::ThreeGp),
+            ("mpeg", ContainerFormat::Mpg),
+            ("wmv", ContainerFormat::Asf),
+            ("wma", ContainerFormat::Asf),
+            ("wave", ContainerFormat::Wav),
+            ("adts", ContainerFormat::Aac),
+            ("aif", ContainerFormat::Aiff),
+            ("wavpack", ContainerFormat::Wv),
+        ];
+
+        for (alias, expected) in ALIASES {
+            assert_eq!(
+                alias.parse::<ContainerFormat>().ok(),
+                Some(*expected),
+                "alias '{alias}' must keep parsing"
+            );
+            // Case-insensitivity must cover the alias set too.
+            assert_eq!(
+                alias.to_uppercase().parse::<ContainerFormat>().ok(),
+                Some(*expected),
+                "alias '{alias}' must keep parsing case-insensitively"
+            );
+        }
+    }
+
+    /// Each variant's own extension parses back to that variant.
+    #[test]
+    fn test_as_ext_roundtrips() {
+        for fmt in ContainerFormat::iter() {
+            let ext = fmt.as_ext();
+            assert_eq!(
+                ext.parse::<ContainerFormat>().ok(),
+                Some(fmt),
+                "as_ext() '{ext}' must parse back to {fmt:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #545. Refs #536, #546.

## The bug

`ContainerFormat` derives `strum::Display`, which resolves to a variant's `to_string` value if present and otherwise to the **longest** `serialize` alias (ties going to the last). Nine of 29 variants had no `to_string`, so `Display` returned an alias rather than the file extension — measured over `ContainerFormat::iter()`, not inferred:

| Variant | was | now |
|---|---|---|
| `Mkv` | `matroska` | `mkv` |
| `Mov` | `quicktime` | `mov` |
| `Ts` | `mpegts` | `ts` |
| `ThreeGp` | `3gpp` | `3gp` |
| `Mpg` | `mpeg` | `mpg` |
| `Asf` | `wma` | `asf` |
| `Wav` | `wave` | `wav` |
| `Aac` | `adts` | `aac` |
| `Wv` | `wavpack` | `wv` |

`Aiff` correctly needed no change — `aiff` is already the longest of `aiff`/`aif`.

## The fix

Moves the canonical extension from `serialize` to `to_string` on exactly those nine variants.

Verified against the **strum_macros v0.27.2 source** (the version pinned in `Cargo.lock`) *before* implementing:

- `get_preferred_name` returns `to_string` immediately when present — it never inspects `serialize`.
- `get_serializations` does `attrs.push(to_string)` — a **union**, not a replacement. Every previously-accepted spelling still parses.
- `ascii_case_insensitive` is applied to the whole combined set.

The accepted `FromStr` input set is byte-identical before and after. `Serialize`/`Deserialize` are untouched — serde reads the variant identifier via `rename_all = "lowercase"` and never sees the strum attributes, so no config, IPC, archive, or resume-state representation changes.

## Why now — it disarms a trap before #536 arms it

Behaviour-neutral today, which is the point. #536 converts the thumbnail entry points from `&str` to `ContainerFormat`. `thumbnail/mod.rs` builds `format!("thumbnail.{container}")` and hands it to `av_guess_format`, which matches on **extension**. Under the old `Display`, MKV would have probed as `thumbnail.matroska`, resolved to NULL, and silently disabled thumbnail embedding for MKV — with every line still looking correct and the full gate green.

## Correction to the issue body

#545 claimed no call site formats a `ContainerFormat`. **That was wrong**, caught independently by both reviewers: `postprocess/stages/remux.rs:95` feeds `Display` into `RemuxOptions.output_format`, so `--remux=mkv` was computing `Some("matroska")`. The no-live-bug conclusion survives for a different reason — that field is write-only across the workspace and never read (`remux_sync` picks the muxer from the output path extension). This PR silently corrects a wrong value nothing consumed. The dead field is filed as #546.

## Tests

- `test_display_is_the_file_extension` — iterates every variant; **fails against unpatched code** (`Mkv`: `"matroska"` != `"mkv"`). This is the regression guard. It is not vacuous: `as_ext()` is a hand-written `const fn match`, fully independent of strum.
- `test_every_alias_still_parses` / `test_as_ext_roundtrips` — pass both before and after **by design**. They pin the alias set against a *different* plausible mutation (adding `to_string` while dropping the `serialize` alias), not against this bug. Flagging that explicitly rather than counting them as regression coverage.
- Removes `test_alias_parsing` — a strict subset of the new alias test, which also adds the uppercase case.

Known gap: the alias list is hand-maintained; strum exposes no runtime accessor for the serialize set, so a future variant's new alias won't be forced into it.

## Verification

`bash ~/.claude/skills/rust-pro/scripts/rust-gate.sh` — `fmt --check` → `check` → `clippy --all-targets -D warnings` → `test`, plus every repo `check-*.sh`: **ALL CHECKS PASSED**.

## Reviews

- **security-reviewer**: PASS, no findings. Traced path construction, persisted surfaces, and the `FromStr` validation gate.
- **code-reviewer**: Approve with minor fixes. It re-derived the nine-variant set independently by reverting the attributes and re-measuring — confirming none missed and none over-converted. Both its fixes are applied (redundant test removed; the false call-site claim corrected here and on #545).
