### PR TITLE
fix(postprocess): decide faststart from the container type, not a string pair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6202,6 +6202,7 @@ dependencies = [
  "rdlp-core",
  "rdlp-types",
  "serde",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/rdlp-ffmpeg/Cargo.toml
+++ b/crates/rdlp-ffmpeg/Cargo.toml
@@ -31,6 +31,7 @@ openssl-sys = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
+strum = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"

--- a/crates/rdlp-ffmpeg/src/ffmpeg/fixup.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/fixup.rs
@@ -189,10 +189,16 @@ impl FFmpegRunner {
         let has_sar_fix = issues
             .iter()
             .any(|i| matches!(i, FixupIssue::StretchedVideo { .. }));
-        let is_mp4 = input
-            .as_ref()
-            .extension()
-            .is_some_and(|e| e.eq_ignore_ascii_case("mp4") || e.eq_ignore_ascii_case("mov"));
+        // Faststart is a property of the container being WRITTEN, so ask about
+        // `output`, not `input`.
+        //
+        // For any input that HAS an extension this matches the previous
+        // input-derived answer, because the sole caller builds the output path
+        // from the input's extension. For an extensionless input the two differ:
+        // the caller defaults to `mp4`, so the file really is written through
+        // the mov/mp4 muxer and faststart is correct — where the old
+        // input-derived check answered `false` and silently skipped it.
+        let faststart = super::options::faststart_for_output(output.as_ref());
 
         info!(
             "FixupStage: repairing {} issue(s) via re-mux",
@@ -200,7 +206,7 @@ impl FFmpegRunner {
         );
 
         let opts = RemuxOptions {
-            faststart: is_mp4,
+            faststart,
             output_format: None,
             encoding_tool_override,
         };

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/dispatch.rs
@@ -14,7 +14,7 @@ use crate::error::PostProcessError;
 use super::super::{FFmpegRunner, LoudnormMeasurements, NormalizeOptions, PeakAnalysis};
 use super::encode::EncodeCallCtx;
 use super::helpers::{
-    TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD, audio_only_extension_for, build_alimiter_spec,
+    TRUE_PEAK_OVERSAMPLE_GAIN_THRESHOLD, audio_only_extension_for_ext, build_alimiter_spec,
     build_loudnorm_pass2_filter, with_mux_retry,
 };
 
@@ -179,7 +179,7 @@ impl FFmpegRunner {
             });
 
         if has_video {
-            let audio_ext = audio_only_extension_for(ext);
+            let audio_ext = audio_only_extension_for_ext(ext);
             let temp_audio = output.with_extension(format!("norm_audio.{audio_ext}"));
 
             if salvage {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -24,6 +24,8 @@ use std::path::Path;
 
 use log::{debug, warn};
 
+use rdlp_types::ContainerFormat;
+
 use crate::error::{PostProcessError, Result};
 
 use super::super::log_capture::LogCaptureGuard;
@@ -261,37 +263,67 @@ pub(super) fn default_bitrate_for_encoder(encoder: &str) -> usize {
     }
 }
 
-/// Map a container extension to an audio-only container extension for temp files.
+/// Audio-only container used when nothing more specific fits, and for any
+/// container whose own muxer is unsuitable for a long audio-only temp file.
+const DEFAULT_AUDIO_ONLY: ContainerFormat = ContainerFormat::Mka;
+
+/// Map a container to the audio-only container used for its temp files.
 ///
 /// Uses MKA for all MOV-based formats to avoid the MOV muxer's ENOMEM issue.
 /// The MOV muxer accumulates per-packet metadata in memory until trailer write,
 /// causing allocation failures on long audio tracks. Matroska writes metadata
 /// incrementally without unbounded buffering.
-pub(super) const fn audio_only_extension_for(ext: &str) -> &'static str {
-    if ext.eq_ignore_ascii_case("mp4")
-        || ext.eq_ignore_ascii_case("m4a")
-        || ext.eq_ignore_ascii_case("mov")
-        || ext.eq_ignore_ascii_case("f4v")
-        || ext.eq_ignore_ascii_case("3gp")
-        || ext.eq_ignore_ascii_case("ts")
-        || ext.eq_ignore_ascii_case("mpg")
-        || ext.eq_ignore_ascii_case("flv")
-        || ext.eq_ignore_ascii_case("mkv")
-        || ext.eq_ignore_ascii_case("mka")
-        || ext.eq_ignore_ascii_case("webm")
-    {
-        "mka"
-    } else if ext.eq_ignore_ascii_case("avi") || ext.eq_ignore_ascii_case("mp3") {
-        "mp3"
-    } else if ext.eq_ignore_ascii_case("ogg") || ext.eq_ignore_ascii_case("opus") {
-        "opus"
-    } else if ext.eq_ignore_ascii_case("flac") {
-        "flac"
-    } else if ext.eq_ignore_ascii_case("wav") {
-        "wav"
-    } else {
-        "mka"
+///
+/// Takes a `ContainerFormat` and matches exhaustively rather than testing a
+/// hand-written list of extension strings. The list previously omitted `m4v` —
+/// harmless only because the fall-through default happened to return the same
+/// answer the MOV-family arm would have. That is the same silent drift as #539,
+/// one edit to the default away from becoming a real bug. With an exhaustive
+/// match, a new `ContainerFormat` variant fails to compile until someone
+/// classifies it.
+///
+/// Every mapping below preserves the previous behaviour exactly, including the
+/// containers that reached `"mka"` via the old default.
+pub(super) const fn audio_only_extension_for(container: ContainerFormat) -> &'static str {
+    match container {
+        // MOV/ISOBMFF family — routed to MKA for the ENOMEM reason above.
+        ContainerFormat::Mp4
+        | ContainerFormat::Mov
+        | ContainerFormat::M4v
+        | ContainerFormat::F4v
+        | ContainerFormat::ThreeGp
+        | ContainerFormat::M4a
+        // Other video containers whose muxers we likewise avoid for audio-only.
+        | ContainerFormat::Ts
+        | ContainerFormat::Mpg
+        | ContainerFormat::Flv
+        | ContainerFormat::Mkv
+        | ContainerFormat::Mka
+        | ContainerFormat::WebM
+        // Reached the old `else` default; kept on MKA deliberately.
+        | ContainerFormat::Asf
+        | ContainerFormat::Mxf
+        | ContainerFormat::Vob
+        | ContainerFormat::Dv
+        | ContainerFormat::Nut
+        | ContainerFormat::Ivf
+        | ContainerFormat::Aac
+        | ContainerFormat::Aiff
+        | ContainerFormat::Wv
+        | ContainerFormat::Caf
+        | ContainerFormat::Ac3 => DEFAULT_AUDIO_ONLY.as_ext(),
+        ContainerFormat::Avi | ContainerFormat::Mp3 => ContainerFormat::Mp3.as_ext(),
+        ContainerFormat::Ogg | ContainerFormat::Opus => ContainerFormat::Opus.as_ext(),
+        ContainerFormat::Flac => ContainerFormat::Flac.as_ext(),
+        ContainerFormat::Wav => ContainerFormat::Wav.as_ext(),
     }
+}
+
+/// Boundary form of [`audio_only_extension_for`] for callers holding only a path
+/// extension. An unrecognised extension keeps the previous default.
+pub(super) fn audio_only_extension_for_ext(ext: &str) -> &'static str {
+    ext.parse::<ContainerFormat>()
+        .map_or(DEFAULT_AUDIO_ONLY.as_ext(), audio_only_extension_for)
 }
 
 /// Three-tier recovery for mux failures during audio normalization.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
@@ -221,31 +221,90 @@ fn test_build_loudnorm_pass2_filter_precompress() {
 
 #[test]
 fn test_audio_only_extension_for() {
+    use rdlp_types::ContainerFormat as C;
+
     // MOV-based formats now use MKA to avoid ENOMEM
-    assert_eq!(audio_only_extension_for("mp4"), "mka");
-    assert_eq!(audio_only_extension_for("m4a"), "mka");
-    assert_eq!(audio_only_extension_for("mov"), "mka");
-    assert_eq!(audio_only_extension_for("f4v"), "mka");
-    assert_eq!(audio_only_extension_for("3gp"), "mka");
-    assert_eq!(audio_only_extension_for("ts"), "mka");
-    assert_eq!(audio_only_extension_for("mpg"), "mka");
-    assert_eq!(audio_only_extension_for("flv"), "mka");
+    assert_eq!(audio_only_extension_for(C::Mp4), "mka");
+    assert_eq!(audio_only_extension_for(C::M4a), "mka");
+    assert_eq!(audio_only_extension_for(C::Mov), "mka");
+    assert_eq!(audio_only_extension_for(C::F4v), "mka");
+    assert_eq!(audio_only_extension_for(C::ThreeGp), "mka");
+    assert_eq!(audio_only_extension_for(C::Ts), "mka");
+    assert_eq!(audio_only_extension_for(C::Mpg), "mka");
+    assert_eq!(audio_only_extension_for(C::Flv), "mka");
 
     // Matroska-based formats
-    assert_eq!(audio_only_extension_for("mkv"), "mka");
-    assert_eq!(audio_only_extension_for("mka"), "mka");
-    assert_eq!(audio_only_extension_for("webm"), "mka");
+    assert_eq!(audio_only_extension_for(C::Mkv), "mka");
+    assert_eq!(audio_only_extension_for(C::Mka), "mka");
+    assert_eq!(audio_only_extension_for(C::WebM), "mka");
 
     // Other formats
-    assert_eq!(audio_only_extension_for("avi"), "mp3");
-    assert_eq!(audio_only_extension_for("mp3"), "mp3");
-    assert_eq!(audio_only_extension_for("ogg"), "opus");
-    assert_eq!(audio_only_extension_for("opus"), "opus");
-    assert_eq!(audio_only_extension_for("flac"), "flac");
-    assert_eq!(audio_only_extension_for("wav"), "wav");
+    assert_eq!(audio_only_extension_for(C::Avi), "mp3");
+    assert_eq!(audio_only_extension_for(C::Mp3), "mp3");
+    assert_eq!(audio_only_extension_for(C::Ogg), "opus");
+    assert_eq!(audio_only_extension_for(C::Opus), "opus");
+    assert_eq!(audio_only_extension_for(C::Flac), "flac");
+    assert_eq!(audio_only_extension_for(C::Wav), "wav");
 
-    // Default
-    assert_eq!(audio_only_extension_for("xyz"), "mka");
+    // `m4v` was absent from the old hand-written MOV-family list and only
+    // reached "mka" through the fall-through default — the #539 drift shape.
+    // Now it is classified explicitly.
+    assert_eq!(audio_only_extension_for(C::M4v), "mka");
+}
+
+/// The boundary form keeps the old default for anything unparseable.
+#[test]
+fn test_audio_only_extension_for_ext_boundary() {
+    assert_eq!(audio_only_extension_for_ext("xyz"), "mka");
+    assert_eq!(audio_only_extension_for_ext(""), "mka");
+    // Parses, so it follows the container — including aliases and case.
+    assert_eq!(audio_only_extension_for_ext("WAV"), "wav");
+    assert_eq!(audio_only_extension_for_ext("wave"), "wav");
+    assert_eq!(audio_only_extension_for_ext("m4v"), "mka");
+}
+
+/// Behavioural equivalence with the pre-refactor string implementation, over
+/// every variant — the refactor must change classification for none of them.
+#[test]
+fn audio_only_extension_matches_previous_string_behaviour() {
+    use rdlp_types::ContainerFormat;
+    use strum::IntoEnumIterator as _;
+
+    /// Verbatim copy of the pre-refactor implementation.
+    fn legacy(ext: &str) -> &'static str {
+        if ext.eq_ignore_ascii_case("mp4")
+            || ext.eq_ignore_ascii_case("m4a")
+            || ext.eq_ignore_ascii_case("mov")
+            || ext.eq_ignore_ascii_case("f4v")
+            || ext.eq_ignore_ascii_case("3gp")
+            || ext.eq_ignore_ascii_case("ts")
+            || ext.eq_ignore_ascii_case("mpg")
+            || ext.eq_ignore_ascii_case("flv")
+            || ext.eq_ignore_ascii_case("mkv")
+            || ext.eq_ignore_ascii_case("mka")
+            || ext.eq_ignore_ascii_case("webm")
+        {
+            "mka"
+        } else if ext.eq_ignore_ascii_case("avi") || ext.eq_ignore_ascii_case("mp3") {
+            "mp3"
+        } else if ext.eq_ignore_ascii_case("ogg") || ext.eq_ignore_ascii_case("opus") {
+            "opus"
+        } else if ext.eq_ignore_ascii_case("flac") {
+            "flac"
+        } else if ext.eq_ignore_ascii_case("wav") {
+            "wav"
+        } else {
+            "mka"
+        }
+    }
+
+    for c in ContainerFormat::iter() {
+        assert_eq!(
+            audio_only_extension_for(c),
+            legacy(c.as_ext()),
+            "classification for {c:?} changed; the refactor must be behaviour-preserving"
+        );
+    }
 }
 
 #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -3,6 +3,28 @@
 //! Provides `RemuxOptions`, `AudioExtractOptions`, `VideoConvertOptions`,
 //! and `ChapterEntry` used across remux, merge, transcode, and metadata modules.
 
+use std::path::Path;
+
+/// Whether output written to `path` should enable faststart.
+///
+/// This is the **boundary** form of the question: these callers receive only a
+/// filesystem path and have no `ContainerFormat` in scope, so the extension is
+/// parsed into the domain type once, here, and the answer comes from
+/// [`ContainerFormat::supports_faststart`] rather than a local string list.
+///
+/// Interior callers that already hold a `ContainerFormat` (the remux and merge
+/// pipeline stages) must call `supports_faststart()` directly instead of
+/// round-tripping through a string.
+///
+/// An unrecognised extension answers `false` — matching the previous behaviour
+/// for unknown containers.
+pub fn faststart_for_output(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .and_then(|e| e.parse::<rdlp_types::ContainerFormat>().ok())
+        .is_some_and(|c| c.supports_faststart())
+}
+
 /// Options for remux and merge operations.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RemuxOptions {
@@ -74,11 +96,75 @@ pub struct VideoConvertOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn video_convert_options_threads_defaults_none() {
         let opts = VideoConvertOptions::default();
         assert_eq!(opts.threads, None);
+    }
+
+    /// Every ISOBMFF container `supports_faststart()` claims must get faststart.
+    ///
+    /// `m4v` and `f4v` are the #539 regression: they route to the same
+    /// mov/mp4 muxer as `mp4`/`mov` and `+faststart` demonstrably relocates
+    /// their `moov` atom, but a hardcoded `"mp4" | "mov"` list silently
+    /// excluded them.
+    #[test]
+    fn faststart_enabled_for_every_container_that_supports_it() {
+        for fmt in ["mp4", "mov", "m4v", "f4v"] {
+            let path = PathBuf::from(format!("out.{fmt}"));
+            assert!(
+                faststart_for_output(&path),
+                ".{fmt} supports faststart (ContainerFormat::supports_faststart) \
+                 but faststart_for_output said false"
+            );
+        }
+    }
+
+    /// Containers outside the mov/mp4 family must not get `movflags`.
+    #[test]
+    fn faststart_disabled_for_non_isobmff_containers() {
+        for fmt in ["mkv", "webm", "avi", "ts", "flv", "mp3", "flac"] {
+            let path = PathBuf::from(format!("out.{fmt}"));
+            assert!(
+                !faststart_for_output(&path),
+                ".{fmt} does not support faststart but faststart_for_output said true"
+            );
+        }
+    }
+
+    /// Extension matching stays case-insensitive.
+    #[test]
+    fn faststart_is_case_insensitive() {
+        assert!(faststart_for_output(&PathBuf::from("out.MP4")));
+        assert!(faststart_for_output(&PathBuf::from("out.M4V")));
+        assert!(!faststart_for_output(&PathBuf::from("out.MKV")));
+    }
+
+    /// A missing or unrecognised extension answers `false`, never panics.
+    #[test]
+    fn faststart_false_for_unknown_or_missing_extension() {
+        assert!(!faststart_for_output(&PathBuf::from("out.qqq")));
+        assert!(!faststart_for_output(&PathBuf::from("out")));
+        assert!(!faststart_for_output(&PathBuf::from("")));
+    }
+
+    /// Aliases resolve to their container, so faststart follows the container.
+    ///
+    /// `ContainerFormat`'s `FromStr` is alias-aware, which the old two-literal
+    /// comparison was not: a `.quicktime` file is a `QuickTime` file.
+    #[test]
+    fn faststart_honours_container_aliases() {
+        assert!(faststart_for_output(&PathBuf::from("out.quicktime"))); // → Mov
+        assert!(!faststart_for_output(&PathBuf::from("out.matroska"))); // → Mkv
+    }
+
+    /// The `fixup` caller defaults an extensionless input to `mp4`, so the
+    /// output path it builds is `.mp4` and must get faststart.
+    #[test]
+    fn faststart_true_for_the_mp4_default_fixup_builds() {
+        assert!(faststart_for_output(&PathBuf::from("v.rdlp-tmp-abc.mp4")));
     }
 }
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_convert.rs
@@ -99,10 +99,8 @@ impl FFmpegRunner {
         cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<()> {
         if opts.remux_only {
-            // Determine if output is MP4/MOV for faststart
-            let ext = output.extension().and_then(|e| e.to_str()).unwrap_or("");
             let remux_opts = RemuxOptions {
-                faststart: ext.eq_ignore_ascii_case("mp4") || ext.eq_ignore_ascii_case("mov"),
+                faststart: crate::ffmpeg::options::faststart_for_output(output),
                 ..Default::default()
             };
             Ok(Self::remux_sync(input, output, &remux_opts, progress_fn)

--- a/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/merge.rs
@@ -18,6 +18,8 @@ use log::{debug, info};
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 
+use rdlp_types::ContainerFormat;
+
 use crate::pipeline::{PipelineMessage, PipelineStage};
 
 /// Merges separate video + audio streams into a single container.
@@ -54,30 +56,30 @@ impl MergeStage {
         audio_ext: Option<&str>,
         video_codec: Option<&str>,
         audio_codec: Option<&str>,
-    ) -> &'static str {
+    ) -> ContainerFormat {
         if let Some(format) = config.merge_output_format {
-            return format.as_ext();
+            return format;
         }
         // When both codecs are known, mirror yt-dlp's get_compatible_ext:
         // try mp4 → webm → mkv (mkv as the catch-all when neither container
         // fits the codec pair). This is the path that routes VP9+AAC to
         // mkv even though both source files have .mp4 / .m4a extensions.
         if let (Some(v), Some(a)) = (video_codec, audio_codec) {
-            let ext = Self::compatible_ext_from_codecs(v, a).unwrap_or("mkv");
+            let container = Self::compatible_ext_from_codecs(v, a).unwrap_or(ContainerFormat::Mkv);
             debug!(
-                vcodec = v, acodec = a, ext;
+                vcodec = v, acodec = a, ext = container.as_ext();
                 "MergeStage: codec-aware container picked"
             );
-            return ext;
+            return container;
         }
         // Ext-only fallback (codec info missing — e.g. plugin-emitted Format
         // with no vcodec/acodec). Conservative: webm ext → mkv (broadest
         // playability), else mp4.
         match (video_ext, audio_ext) {
-            (Some("webm"), _) | (_, Some("webm")) => "mkv",
+            (Some("webm"), _) | (_, Some("webm")) => ContainerFormat::Mkv,
             _ => {
                 debug!("No codec info available; defaulting to MP4 by ext heuristic");
-                "mp4"
+                ContainerFormat::Mp4
             }
         }
     }
@@ -94,7 +96,7 @@ impl MergeStage {
     /// Returns `Some(ext)` when both codecs fit one container; `None`
     /// signals "use MKV as the catch-all" (caller's responsibility, via
     /// fall-through to the extension-only path).
-    fn compatible_ext_from_codecs(vcodec: &str, acodec: &str) -> Option<&'static str> {
+    fn compatible_ext_from_codecs(vcodec: &str, acodec: &str) -> Option<ContainerFormat> {
         // MP4-compatible: video + audio fourccs that ISO BMFF accepts.
         const MP4_COMPAT: &[&str] = &[
             "av1", "hevc", "avc1", "h264", "mp4a", "ac-4", "aacl", "ec-3",
@@ -106,12 +108,27 @@ impl MergeStage {
         let a = Self::sanitize_codec(acodec);
 
         if MP4_COMPAT.contains(&v.as_str()) && MP4_COMPAT.contains(&a.as_str()) {
-            return Some("mp4");
+            return Some(ContainerFormat::Mp4);
         }
         if WEBM_COMPAT.contains(&v.as_str()) && WEBM_COMPAT.contains(&a.as_str()) {
-            return Some("webm");
+            return Some(ContainerFormat::WebM);
         }
         None
+    }
+
+    /// Build the mux options for a resolved output container.
+    ///
+    /// Exists as a named function so the faststart decision is observable in a
+    /// test. Inlined into `process()` it was unreachable without a real `FFmpeg`
+    /// run, which let #539 ship: a test could assert `supports_faststart()` on
+    /// a container it supplied itself and never touch the production
+    /// expression at all.
+    fn merge_opts(output_format: ContainerFormat, encoding_tool: Option<String>) -> RemuxOptions {
+        RemuxOptions {
+            faststart: output_format.supports_faststart(),
+            encoding_tool_override: encoding_tool,
+            ..Default::default()
+        }
     }
 
     /// Sanitize a codec string per yt-dlp's normalisation.
@@ -212,13 +229,9 @@ impl PipelineStage for MergeStage {
         );
 
         // Use tracker.temp_path — no naming collision possible.
-        let output_path = msg.tracker.temp_path(&video_file, output_format);
+        let output_path = msg.tracker.temp_path(&video_file, output_format.as_ext());
 
-        let opts = RemuxOptions {
-            faststart: matches!(output_format, "mp4" | "mov"),
-            encoding_tool_override: msg.encoding_tool.clone(),
-            ..Default::default()
-        };
+        let opts = Self::merge_opts(output_format, msg.encoding_tool.clone());
 
         let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
         let _log_bridge = stage_callback
@@ -307,6 +320,40 @@ mod tests {
         assert!(!stage.should_run(&msg));
     }
 
+    /// #539, fourth site: merge decides faststart from the container type.
+    ///
+    /// The issue named three sites; this one was missed. It is reachable
+    /// whenever `merge_output_format` is an ISOBMFF container beyond mp4/mov,
+    /// which the old `matches!(output_format, "mp4" | "mov")` excluded.
+    #[test]
+    fn merge_faststart_follows_the_container_type() {
+        for (container, want) in [
+            (ContainerFormat::Mp4, true),
+            (ContainerFormat::Mov, true),
+            (ContainerFormat::M4v, true),
+            (ContainerFormat::F4v, true),
+            (ContainerFormat::Mkv, false),
+            (ContainerFormat::WebM, false),
+        ] {
+            let config = PostProcess {
+                merge_output_format: Some(container),
+                ..PostProcess::default()
+            };
+            let resolved =
+                MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a"), None, None);
+            assert_eq!(resolved, container);
+            // Assert on the options the stage actually builds — asserting
+            // `resolved.supports_faststart()` here would only re-test the
+            // predicate with a value this test supplied, and would stay green
+            // if the stage hardcoded `faststart: false`.
+            assert_eq!(
+                MergeStage::merge_opts(resolved, None).faststart,
+                want,
+                "merge faststart for {container:?} must follow supports_faststart()"
+            );
+        }
+    }
+
     #[test]
     fn determine_output_format_explicit_config() {
         let config = PostProcess {
@@ -315,7 +362,7 @@ mod tests {
         };
         assert_eq!(
             MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a"), None, None),
-            "mkv"
+            ContainerFormat::Mkv
         );
     }
 
@@ -325,7 +372,7 @@ mod tests {
         let config = PostProcess::default();
         assert_eq!(
             MergeStage::determine_output_format(&config, Some("webm"), Some("opus"), None, None),
-            "mkv"
+            ContainerFormat::Mkv
         );
     }
 
@@ -334,7 +381,7 @@ mod tests {
         let config = PostProcess::default();
         assert_eq!(
             MergeStage::determine_output_format(&config, Some("mp4"), Some("m4a"), None, None),
-            "mp4"
+            ContainerFormat::Mp4
         );
     }
 
@@ -351,7 +398,7 @@ mod tests {
                 Some("avc1.640028"),
                 Some("mp4a.40.2"),
             ),
-            "mp4"
+            ContainerFormat::Mp4
         );
     }
 
@@ -369,7 +416,7 @@ mod tests {
                 Some("vp09.00.30.08"),
                 Some("mp4a.40.2"),
             ),
-            "mkv"
+            ContainerFormat::Mkv
         );
     }
 
@@ -396,7 +443,7 @@ mod tests {
                 Some("av01.0.04M.08"),
                 Some("opus"),
             ),
-            "webm"
+            ContainerFormat::WebM
         );
     }
 
@@ -411,7 +458,7 @@ mod tests {
                 Some("vp09.00.30.08"),
                 Some("opus"),
             ),
-            "webm"
+            ContainerFormat::WebM
         );
     }
 
@@ -426,7 +473,7 @@ mod tests {
                 Some("hevc"),
                 Some("mp4a"),
             ),
-            "mp4"
+            ContainerFormat::Mp4
         );
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -14,6 +14,8 @@ use log::{debug, info};
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 
+use rdlp_types::ContainerFormat;
+
 use crate::pipeline::{PipelineMessage, PipelineStage};
 
 /// Remuxes the current file to a different container.
@@ -32,22 +34,43 @@ impl RemuxStage {
         Self { ffmpeg }
     }
 
-    /// Determine the target extension for remuxing.
+    /// Determine the target container for remuxing.
     ///
     /// Returns `None` if the file is already in the target container.
-    fn target_ext(msg: &PipelineMessage, input_ext: &str) -> Option<&'static str> {
+    ///
+    /// Returns the `ContainerFormat` itself rather than its extension: the
+    /// decision originates from `config.remux_container`, which is already
+    /// typed, and callers need to ask container-level questions of it (does it
+    /// support faststart?). Handing back a `&str` forced every caller to
+    /// re-derive those answers from string literals, which is how the faststart
+    /// list silently drifted out of sync with `supports_faststart()` (#539).
+    fn target_container(msg: &PipelineMessage, input_ext: &str) -> Option<ContainerFormat> {
         if let Some(container) = msg.config.remux_container {
-            let ext = container.as_ext();
-            if input_ext.eq_ignore_ascii_case(ext) {
+            if input_ext.eq_ignore_ascii_case(container.as_ext()) {
                 return None; // already in target container
             }
-            return Some(ext);
+            return Some(container);
         }
         // HLS auto-remux: .ts → .mp4
-        if msg.is_hls && !input_ext.eq_ignore_ascii_case("mp4") {
-            return Some("mp4");
+        if msg.is_hls && !input_ext.eq_ignore_ascii_case(ContainerFormat::Mp4.as_ext()) {
+            return Some(ContainerFormat::Mp4);
         }
         None
+    }
+
+    /// Build the mux options for a resolved target container.
+    ///
+    /// Exists as a named function so the faststart decision is observable in a
+    /// test. Inlined into `process()` it was unreachable without a real `FFmpeg`
+    /// run, which let #539 ship: a test could assert `supports_faststart()` on
+    /// a container it supplied itself and never touch the production
+    /// expression at all.
+    fn remux_opts(target: ContainerFormat, encoding_tool: Option<String>) -> RemuxOptions {
+        RemuxOptions {
+            faststart: target.supports_faststart(),
+            output_format: Some(target.as_ext().to_string()),
+            encoding_tool_override: encoding_tool,
+        }
     }
 }
 
@@ -77,7 +100,7 @@ impl PipelineStage for RemuxStage {
             .and_then(|e| e.to_str())
             .unwrap_or("");
 
-        let Some(target_ext) = Self::target_ext(&msg, input_ext) else {
+        let Some(target) = Self::target_container(&msg, input_ext) else {
             debug!("RemuxStage: file already in target container ({input_ext}), skipping");
             return Ok(msg);
         };
@@ -85,20 +108,12 @@ impl PipelineStage for RemuxStage {
         info!(
             "RemuxStage: remuxing {} → {}",
             input_file.display(),
-            target_ext
+            target.as_ext()
         );
 
-        let output_path = msg.tracker.temp_path(&input_file, target_ext);
+        let output_path = msg.tracker.temp_path(&input_file, target.as_ext());
 
-        let opts = RemuxOptions {
-            faststart: matches!(target_ext, "mp4" | "mov"),
-            output_format: Some(
-                msg.config
-                    .remux_container
-                    .map_or_else(|| "mp4".to_string(), |c| c.to_string()),
-            ),
-            encoding_tool_override: msg.encoding_tool.clone(),
-        };
+        let opts = Self::remux_opts(target, msg.encoding_tool.clone());
 
         let stage_callback = msg.callback_factory.as_ref().map(|f| f(self.name()));
         let _log_bridge = stage_callback
@@ -214,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn target_ext_already_in_target_returns_none() {
+    fn target_container_already_in_target_returns_none() {
         let reg = Arc::new(TempRegistry::new());
         let (error_tx, _) = oneshot::channel::<PipelineError>();
         let msg = PipelineMessage {
@@ -238,11 +253,74 @@ mod tests {
             encoding_tool: None,
             cancel: tokio_util::sync::CancellationToken::new(),
         };
-        assert!(RemuxStage::target_ext(&msg, "mp4").is_none());
+        assert!(RemuxStage::target_container(&msg, "mp4").is_none());
+    }
+
+    /// #539: the faststart decision must come from the container type.
+    ///
+    /// `m4v`/`f4v` route to the same mov/mp4 muxer as `mp4`/`mov` and
+    /// `+faststart` demonstrably relocates their `moov` atom, but the old
+    /// `matches!(target_ext, "mp4" | "mov")` excluded them, so `--remux m4v`
+    /// shipped a file with `moov` at the end.
+    #[test]
+    fn faststart_follows_the_container_type_for_every_remux_target() {
+        for (container, want) in [
+            (ContainerFormat::Mp4, true),
+            (ContainerFormat::Mov, true),
+            (ContainerFormat::M4v, true),
+            (ContainerFormat::F4v, true),
+            (ContainerFormat::Mkv, false),
+            (ContainerFormat::WebM, false),
+            (ContainerFormat::Avi, false),
+        ] {
+            let config = PostProcess {
+                remux_container: Some(container),
+                ..PostProcess::default()
+            };
+            let msg = make_msg_with_config(vec![PathBuf::from("/tmp/v.ts")], config, false);
+            let target = RemuxStage::target_container(&msg, "ts")
+                .expect("a different container must produce a remux target");
+            assert_eq!(target, container);
+            // Assert on the options the stage actually builds — asserting
+            // `target.supports_faststart()` here would only re-test the
+            // predicate with a value this test supplied, and would stay green
+            // if the stage hardcoded `faststart: false`.
+            let opts = RemuxStage::remux_opts(target, None);
+            assert_eq!(
+                opts.faststart, want,
+                "faststart for {container:?} must follow supports_faststart()"
+            );
+            assert_eq!(opts.output_format.as_deref(), Some(container.as_ext()));
+        }
+    }
+
+    /// An explicit target is honoured verbatim, aliases included.
+    #[test]
+    fn target_container_returns_the_configured_container() {
+        let config = PostProcess {
+            remux_container: Some(ContainerFormat::M4v),
+            ..PostProcess::default()
+        };
+        let msg = make_msg_with_config(vec![PathBuf::from("/tmp/v.mp4")], config, false);
+        assert_eq!(
+            RemuxStage::target_container(&msg, "mp4"),
+            Some(ContainerFormat::M4v)
+        );
+    }
+
+    /// Already-in-target detection stays case-insensitive.
+    #[test]
+    fn target_container_none_when_already_in_target_any_case() {
+        let config = PostProcess {
+            remux_container: Some(ContainerFormat::M4v),
+            ..PostProcess::default()
+        };
+        let msg = make_msg_with_config(vec![PathBuf::from("/tmp/v.M4V")], config, false);
+        assert!(RemuxStage::target_container(&msg, "M4V").is_none());
     }
 
     #[test]
-    fn target_ext_hls_ts_returns_mp4() {
+    fn target_container_hls_ts_returns_mp4() {
         let reg = Arc::new(TempRegistry::new());
         let (error_tx, _) = oneshot::channel::<PipelineError>();
         let msg = PipelineMessage {
@@ -263,7 +341,10 @@ mod tests {
             encoding_tool: None,
             cancel: tokio_util::sync::CancellationToken::new(),
         };
-        assert_eq!(RemuxStage::target_ext(&msg, "ts"), Some("mp4"));
+        assert_eq!(
+            RemuxStage::target_container(&msg, "ts"),
+            Some(ContainerFormat::Mp4)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #539. Refs #546.

## The bug, validated end-to-end

Not from reading code — built the CLI and measured where the `moov` atom landed, against a source with `moov` at offset 11886:

| `--remux` | before | after |
|---|---|---|
| `mov` | moov @ 24 ✅ | moov @ 24 ✅ |
| `m4v` | **moov @ 11886 ❌** | moov @ 36 ✅ |
| `f4v` | **moov @ 11886 ❌** | moov @ 36 ✅ |
| `mkv` | n/a | n/a (not ISOBMFF) ✅ |

I also confirmed the premise with raw FFmpeg rather than assuming it: `.m4v`/`.f4v` both route to the mov/mp4 muxer and `+faststart` genuinely relocates their `moov` (3939 → 36). The flag isn't merely accepted — it does the work.

## Root cause

Four sites decided faststart from a hardcoded `matches!(ext, "mp4" | "mov")`, while `ContainerFormat::supports_faststart()` covers `Mp4|Mov|M4v|F4v`. **That predicate had zero non-test callers** — which is precisely how the two sets drifted apart with nothing failing. Note `cargo clippy -D warnings` (already in the gate) cannot detect this class of defect, which is the argument for removing the duplicated literal set structurally rather than trusting future vigilance.

**The issue named three sites; there were four.** `merge.rs` had the same pair, reachable whenever `merge_output_format` is `M4v`/`F4v`.

## The fix — a deliberate hybrid, not uniform treatment

Chosen from research against the Rust API Guidelines (C-CUSTOM-TYPE, C-CONV-SPECIFIC), "parse, don't validate", and LangSec's shotgun-parsing:

- **Interior** — `remux.rs::target_ext` (→ `target_container`) and `merge.rs::determine_output_format`/`compatible_ext_from_codecs` already held the enum upstream and downgraded it to `&'static str`, forcing consumers to re-derive container facts from literals. They now return `ContainerFormat`; `.as_ext()` is called only where a string is structurally required (path construction).
- **Boundary** — `video_convert.rs` and `fixup.rs` receive only a `&Path` with no enum in scope, so they parse once via the new `options::faststart_for_output`. That's the parse step, not a re-parse. Case-insensitivity and alias handling come free from strum.

Forcing uniformity either way is wrong: one direction keeps the defect class alive in the pipeline stages, the other means widening two shared low-level signatures for a faststart flag.

## Also fixes the same drift in the normalize path

`normalize::helpers::audio_only_extension_for` hand-listed the MOV family and **omitted `m4v`** — harmless only because the fall-through default happened to return the same answer, one edit to that default away from a real bug. It now takes `ContainerFormat` and matches exhaustively, so a new variant fails to compile until someone classifies it.

The compiler immediately caught `Asf`, which the hand-written list had *also* missed. A test asserts equivalence with the old string implementation across all 29 variants: **no classification changed.**

## On the tests — one of them was hollow

`faststart_for_output`'s tests are genuinely red-green: I extracted the helper with the **old** logic first, watched two tests fail, then fixed the body.

The remux and merge tests initially were **not**. They asserted `supports_faststart()` on a container the test itself supplied — a tautology. Hardcoding `faststart: false` in both stages left the entire suite green. The code reviewer caught this and proved it by mutation.

Fixed by lifting the option construction into `remux_opts`/`merge_opts` so the production expression is observable. I reproduced the mutation myself rather than taking the report on trust:

```
MUTATION: faststart: false in both stages
  merge_faststart_follows_the_container_type ... FAILED
  faststart_follows_the_container_type_for_every_remux_target ... FAILED
RESTORED: 107 passed; 0 failed
```

## Verification

`bash ~/.claude/skills/rust-pro/scripts/rust-gate.sh` — fmt → check → clippy `-D warnings` → test, plus every repo `check-*.sh`: **ALL CHECKS PASSED.** Plus the end-to-end re-measurement in the table above.

## Reviews

- **security-reviewer**: PASS. Traced path construction, persisted surfaces, and the widened `FromStr` alias set — extensions always normalize back through the `const as_ext()`, so an alias can never reach a filename or muxer arg.
- **code-reviewer**: Approve with one required fix (the vacuous tests, above), plus two accurate corrections applied — the `fixup.rs` input→output switch is **not** strictly equivalent for an extensionless input (it is now *correct* where the old code silently skipped faststart), and the comment claiming equivalence has been softened to say so.

## Discovered while validating, filed separately

- **#548** — `--remux f4v`/`ts` silently produce `.mp4`, exit 0. Higher severity than this issue.
- **#549** — `--remux avi` fails where `ffmpeg -c copy` succeeds (no automatic bitstream-filter insertion).
