### PR TITLE
fix(postprocess): let an explicit --remux container beat thumbnail embedding

### DIFF
--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -385,6 +385,40 @@ impl PipelineStage for ThumbnailStage {
         // `matroska_and_quicktime_aliases_now_resolve_to_embed_support` for the
         // pinned behavior.
         let supports_thumbnail = Self::supports_thumbnail(&extension);
+
+        // #548: an explicit `--remux` container must never be silently
+        // discarded by the auto-remux-to-mp4 fallback below. `remux_container`
+        // is `Some` ONLY when the user explicitly requested a container
+        // (`RemuxStage`'s own gate); `None` means rdlp picked the container
+        // itself (e.g. post-HLS `.ts` with no explicit `--remux`), where the
+        // auto-remux-to-mp4 fallback is correct and unaffected by this guard.
+        // Compared as `ContainerFormat`, never a raw extension string.
+        if !supports_thumbnail
+            && let Ok(current) = ContainerFormat::from_str(&extension)
+            && msg.config.remux_container == Some(current)
+        {
+            let reason = format!(
+                "kept explicit --remux={current} container; thumbnail embed skipped \
+                 because {current} cannot carry an embedded thumbnail"
+            );
+            warn!("ThumbnailStage: {reason}");
+            msg.warnings.push(reason);
+
+            // This early return bypasses the normal embed path below, which is
+            // the ONLY other place the orchestrator-downloaded thumbnail
+            // sidecar is marked temp for cleanup (~line 522, guarded on the
+            // same `!write_thumbnail` condition). Without this, every run
+            // that hits this guard with the default `--write-thumbnail=false`
+            // leaves a stray sidecar image next to the kept-container output.
+            if !msg.config.write_thumbnail
+                && let Some(sidecar) = Self::find_thumbnail(&media_file, &msg.original_stem)
+            {
+                msg.tracker.mark_temp(sidecar);
+            }
+
+            return Ok(msg);
+        }
+
         let (media_file, extension) = if supports_thumbnail {
             (media_file, extension)
         } else {
@@ -854,4 +888,55 @@ mod tests {
     // build real decodable image fixtures, which `scripts/check-no-cli.sh`
     // forbids under `src/` (production-code CLI-usage gate); only files under
     // `tests/` are exempt.
+
+    // #548: an explicit `--remux` container must never be silently
+    // overridden by the thumbnail stage's auto-remux-to-mp4 fallback.
+    //
+    // The "kept container" positive cases and the "no explicit container
+    // still auto-remuxes" regression guard need a REAL, decodable fixture to
+    // be trustworthy: a fake/nonexistent path makes the pre-existing
+    // auto-remux-failure warning ("Auto-remux for thumbnail embedding
+    // failed: ...") happen to contain the fixture's own extension and the
+    // word "thumbnail", passing for the wrong reason even against the
+    // unpatched code. Those cases live in
+    // `crates/rdlp-postprocess/tests/thumbnail_explicit_container_548.rs`
+    // (real `ffmpeg` CLI fixtures; self-skips when the CLI is absent), same
+    // pattern as `thumbnail_webp_mp4_embed.rs`.
+
+    /// Negative companion: an explicit container that DOES support embedding
+    /// (e.g. `--remux=mp4`) must still take the normal embed path — the
+    /// keep-container guard must not intercept it. Verified by asserting the
+    /// normal "thumbnail not found" warning fires (proving the embed path
+    /// ran), not the keep-container skip message.
+    #[tokio::test]
+    async fn process_embeds_normally_when_explicit_container_supports_thumbnail() {
+        let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+        let stage = ThumbnailStage::new(ffmpeg);
+
+        let config = PostProcess {
+            embed_thumbnail: true,
+            remux_container: Some(ContainerFormat::Mp4),
+            ..PostProcess::default()
+        };
+        let mut msg = make_msg(vec![PathBuf::from("/tmp/issue548-video.mp4")], config);
+        msg.original_stem = "issue548-nonexistent-stem".to_string();
+
+        let result = stage.process(msg).await.unwrap();
+
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("Thumbnail file not found")),
+            "expected the normal embed path (missing-thumbnail warning), got: {:?}",
+            result.warnings
+        );
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("cannot carry an embedded thumbnail")),
+            "the keep-container guard must not fire for a container that supports embedding"
+        );
+    }
 }

--- a/crates/rdlp-postprocess/tests/thumbnail_explicit_container_548.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_explicit_container_548.rs
@@ -1,0 +1,365 @@
+//! End-to-end proof that an explicit `--remux` container is never silently
+//! overridden by `ThumbnailStage`'s auto-remux-for-embedding fallback (#548).
+//!
+//! Reproduces the reported bug: `rdlp src.mp4 --remux=f4v` (embed_thumbnail
+//! defaults to true) reported success but produced a `.mp4`, silently
+//! discarding the user's explicit `--remux=f4v` instruction. Real, decodable
+//! fixtures are required here (not fake paths) so the positive assertions are
+//! trustworthy: a fake/nonexistent input makes the PRE-EXISTING auto-remux
+//! failure warning ("Auto-remux for thumbnail embedding failed: ...")
+//! coincidentally contain the fixture's own extension and the word
+//! "thumbnail", which would pass even against the unpatched code.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! fixtures), mirroring `thumbnail_webp_mp4_embed.rs`.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
+use rdlp_types::{ContainerFormat, InfoDict};
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Build a 1-frame H.264 fixture via the system `ffmpeg` CLI, muxed
+/// explicitly as `muxer` (the output extension alone is ambiguous for some
+/// containers, e.g. `.f4v`, so the muxer name is passed via `-f`).
+fn build_video_fixture(path: &Path, muxer: &str) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-f",
+            muxer,
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+fn make_msg(files: Vec<PathBuf>, config: PostProcess) -> PipelineMessage {
+    let reg = Arc::new(TempRegistry::new());
+    let (error_tx, _) = oneshot::channel();
+    PipelineMessage {
+        info: InfoDict::new(
+            "id".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com".to_string(),
+        ),
+        tracker: FileTracker::new(files, reg),
+        config: Arc::new(config),
+        original_stem: "video".to_string(),
+        is_hls: false,
+        verbose: false,
+        callback_factory: None,
+        error_tx: Some(error_tx),
+        warnings: Vec::new(),
+        encoding_tool: None,
+        cancel: CancellationToken::new(),
+    }
+}
+
+/// Positive + regression: an explicit `--remux=f4v` container must be KEPT
+/// (never auto-remuxed to mp4), the embed must be skipped, and a warning
+/// must name both facts. Fails against the unpatched code, which
+/// auto-remuxes the real, decodable `.f4v` fixture to a real, playable
+/// `.mp4` and discards the explicit container entirely.
+#[tokio::test]
+async fn process_keeps_explicit_f4v_container_and_skips_embed() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.f4v");
+    if build_video_fixture(&media, "flv").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        remux_container: Some(ContainerFormat::F4v),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "explicit f4v container must be kept, not auto-remuxed to mp4"
+    );
+    assert!(
+        media.exists(),
+        "the original .f4v fixture must still exist, unmodified"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("--remux=f4v") && w.contains("thumbnail")),
+        "expected a warning naming both the kept container and the skipped embed, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Positive companion: same guard for an explicit `--remux=ts` container.
+#[tokio::test]
+async fn process_keeps_explicit_ts_container_and_skips_embed() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        remux_container: Some(ContainerFormat::Ts),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "explicit ts container must be kept, not auto-remuxed to mp4"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("--remux=ts") && w.contains("thumbnail")),
+        "expected a warning naming both the kept container and the skipped embed, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Code-review finding 1 (blocking): the keep-container guard's early
+/// return must still clean up the orchestrator-downloaded thumbnail sidecar
+/// when `--write-thumbnail` was NOT requested — mirroring the normal
+/// embed-success path's `mark_temp` call. Fails against the unpatched guard,
+/// which returns before `find_thumbnail` ever runs, so the sidecar is never
+/// marked temp and survives `tracker.cleanup()`.
+#[tokio::test]
+async fn process_keeps_explicit_container_and_cleans_up_sidecar_thumbnail() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.f4v");
+    if build_video_fixture(&media, "flv").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+    // Real sidecar thumbnail discoverable via original_stem ("video").
+    let thumb = dir.path().join("video.jpg");
+    std::fs::write(&thumb, b"fake-jpg-bytes").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        remux_container: Some(ContainerFormat::F4v),
+        write_thumbnail: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config);
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "explicit f4v container must still be kept"
+    );
+
+    // cleanup() deletes every path marked temp; the sidecar must be among them.
+    result.tracker.cleanup();
+    assert!(
+        !thumb.exists(),
+        "the downloaded thumbnail sidecar must be cleaned up on the \
+         keep-container guard path when --write-thumbnail was not requested"
+    );
+}
+
+/// Positive companion: `--write-thumbnail` must still RETAIN the sidecar on
+/// the same keep-container guard path.
+#[tokio::test]
+async fn process_keeps_explicit_container_and_retains_sidecar_with_write_thumbnail() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.f4v");
+    if build_video_fixture(&media, "flv").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+    let thumb = dir.path().join("video.jpg");
+    std::fs::write(&thumb, b"fake-jpg-bytes").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        remux_container: Some(ContainerFormat::F4v),
+        write_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config);
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+    assert!(
+        thumb.exists(),
+        "the thumbnail sidecar must be RETAINED when --write-thumbnail was requested"
+    );
+}
+
+/// Code-review finding 2 (blocking): the guard condition is an EQUALITY
+/// check (`remux_container == Some(current_container)`), not a presence
+/// check (`remux_container.is_some()`). A `.ts` fixture with an explicit but
+/// DIFFERENT requested container (`--remux=mkv`) must still take the
+/// auto-remux-to-mp4 path, and the "cannot carry an embedded thumbnail"
+/// warning must NOT fire. All four pre-existing #548 tests pass unchanged
+/// under an `is_some()` mutation of the guard; this test is the one that
+/// pins equality and fails under that mutation (verified manually — see
+/// PR discussion / task report).
+#[tokio::test]
+async fn process_auto_remuxes_ts_when_explicit_container_differs_from_current() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        // Explicit container requested, but it is NOT the current container
+        // (.ts) — the guard must NOT treat this as "keep the current
+        // container", since the requested container differs from it.
+        remux_container: Some(ContainerFormat::Mkv),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    let out_path = result.tracker.primary();
+    assert_eq!(
+        out_path.extension().and_then(|e| e.to_str()),
+        Some("mp4"),
+        "with remux_container=Some(Mkv) over a .ts current file, the guard's \
+         equality check must not match, so auto-remux-to-mp4 must still run"
+    );
+    assert!(
+        out_path.exists(),
+        "the auto-remuxed .mp4 must actually have been produced"
+    );
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.contains("cannot carry an embedded thumbnail")),
+        "the keep-container guard must not fire when the explicit container \
+         differs from the current container"
+    );
+}
+
+/// Negative / regression guard: with NO explicit `--remux` (rdlp-chosen
+/// container, e.g. post-HLS `.ts`), the auto-remux-to-mp4 fallback must
+/// still run and actually produce a real `.mp4` — proving the new
+/// keep-container guard is scoped strictly to an explicit user request and
+/// does not regress the HLS-style auto-remux path.
+#[tokio::test]
+async fn process_still_auto_remuxes_ts_to_mp4_when_no_explicit_container() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        remux_container: None,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    let out_path = result.tracker.primary();
+    assert_eq!(
+        out_path.extension().and_then(|e| e.to_str()),
+        Some("mp4"),
+        "with no explicit container, .ts must still auto-remux to a real .mp4 (no regression)"
+    );
+    assert!(
+        out_path.exists(),
+        "the auto-remuxed .mp4 must actually have been produced"
+    );
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.contains("cannot carry an embedded thumbnail")),
+        "the keep-container guard must not fire when no explicit container was requested"
+    );
+}


### PR DESCRIPTION
## Resolves

Closes #548. Refs #551 (follow-up filed from this review — see Known follow-up).

## Problem

`rdlp src.mp4 --remux=f4v` reported **Success, exit 0** and produced a **`.mp4`**. The user's explicit container was silently discarded. Same for `--remux=ts`.

`ThumbnailStage` auto-remuxes any container that can't carry an embedded thumbnail to mp4. That's correct for the case it was written for — a post-HLS `.ts` where no container was ever requested — but it did not distinguish "container rdlp picked" from "container the user demanded".

## Fix

A guard on `msg.config.remux_container == Some(current)`, compared as `ContainerFormat` (never a raw string, per CLAUDE.md). When the explicitly-requested container can't carry a thumbnail: keep the container, skip the embed, warn naming both facts. When `remux_container` is `None` (rdlp-chosen), the existing fallback is untouched.

The early return also marks the downloaded thumbnail sidecar temp when `--write-thumbnail` was not requested — the embed-success path was the only other place that happens, so without it every f4v/ts run leaked a stray image next to the output.

## Verification

End-to-end with the real binary (the issue's acceptance criteria are stated as real-binary repro):

| `--remux` | output | exit |
|---|---|---|
| `f4v` | `.f4v` ✅ | 0 |
| `ts` | `.ts` ✅ | 0 |
| `mkv` / `mov` / `m4v` | unchanged ✅ | 0 |

Warning observed: `ThumbnailStage: kept explicit --remux=f4v container; thumbnail embed skipped because f4v cannot carry an embedded thumbnail`. Outputs probe as genuine containers (`mpegts`; f4v as ISO BMFF, expected per #539).

Full gate green: `cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, plus all 7 `scripts/check-*.sh`.

## Tests

6 integration tests (real ffmpeg-built fixtures) + 1 unit test: explicit f4v/ts kept, sidecar cleaned when `!write_thumbnail` and retained when set, mismatched container still auto-remuxes, no-explicit-container `.ts` → `.mp4` regression guard, embed-capable explicit container still embeds.

Two test-strength traps were caught and fixed during review:

- An earlier draft used fake paths and **passed against unpatched code** — the pre-existing `"Auto-remux ... failed"` warning coincidentally contained the extension and the word "thumbnail". Moved to real decodable fixtures; both unpatched outcomes are now red.
- All tests initially survived mutating the guard to `.is_some()`, leaving the load-bearing *equality* semantics unpinned. Added a mismatch test and **verified by mutation**: under `.is_some()` only that test fails (`left: Some("ts") right: Some("mp4")`); reverted, all green.

## Known follow-up

**#551** — the recode path has the identical defect through a different flag: `--recode-video=ts` produces a `.mp4`, exit 0, because `RecodeStage` resolves `recode_container.or(recode_video)` while this guard keys only on `remux_container`. Verified E2E and filed rather than folded in, to keep this PR scoped to the `--remux` half. It should be fixed by resolving one "what the user asked for" value — possibly as a `PostProcess` accessor, since `recode.rs` already encodes that precedence.

## Reviews

- **security-reviewer**: Approve, no findings. Guard is gated on operator-set config (never attacker-influenceable), breaks no `FileTracker`/`TempRegistry` lifecycle invariant, new warning interpolates only `ContainerFormat`'s Display (no path/URL/credential), test fixtures use an arg array with no shell.
- **code-reviewer**: Approve with minor fixes — 2 blocking findings (sidecar leak; mutation-survivable tests), both fixed in this branch and re-verified; 1 non-blocking finding filed as #551.
