### PR TITLE
fix(postprocess): explicit container beats thumbnail embedding, and never delete a user's files

### DIFF
--- a/crates/rdlp-api/src/orchestrator/container_resolver.rs
+++ b/crates/rdlp-api/src/orchestrator/container_resolver.rs
@@ -5,30 +5,22 @@
 //! decisions and every fallback is explicitly logged.
 
 use log::debug;
-use rdlp_types::ContainerFormat;
+use rdlp_types::{ContainerFormat, ContainerRequest, ContainerSource};
 use std::path::{Path, PathBuf};
-
-/// How the container format was determined.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ContainerSource {
-    /// User explicitly set via `--remux=<container>`.
-    RemuxConfig,
-    /// User explicitly set `postprocess.merge_output_format`.
-    ///
-    /// There is no CLI flag for this: it is settable only from the config TOML
-    /// (`[postprocess] merge_output_format = "<container>"`) or by an API caller
-    /// constructing [`rdlp_types::PostProcess`] directly.
-    MergeConfig,
-    /// Inferred from the output file's extension (reflects format selection).
-    FileExtension,
-    /// No user preference; fell back to a safe default.
-    Fallback,
-}
 
 /// A container format with provenance tracking.
 ///
-/// Every container decision flows through [`resolve()`](Self::resolve),
-/// which applies the precedence rules and logs fallbacks.
+/// The download/merge container decision flows through
+/// [`resolve()`](Self::resolve), which applies the precedence rules and logs
+/// fallbacks.
+///
+/// NOT every container decision in the codebase: post-processing stages ask
+/// [`rdlp_types::PostProcess::explicit_container`] instead, whose chain also
+/// covers the recode targets this one does not (they are irrelevant here — a
+/// recode happens after the download container is already chosen). The two
+/// share [`ContainerSource`]/[`ContainerRequest`] so the provenance vocabulary
+/// is one definition, but they answer different questions and their precedence
+/// deliberately differs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResolvedContainer {
     /// The resolved container format.
@@ -50,7 +42,7 @@ impl ResolvedContainer {
         if let Some(c) = config.postprocess.remux_container {
             return Self {
                 format: c,
-                source: ContainerSource::RemuxConfig,
+                source: ContainerSource::Requested(ContainerRequest::Remux),
             };
         }
 
@@ -58,7 +50,7 @@ impl ResolvedContainer {
         if let Some(c) = config.postprocess.merge_output_format {
             return Self {
                 format: c,
-                source: ContainerSource::MergeConfig,
+                source: ContainerSource::Requested(ContainerRequest::MergeOutputFormat),
             };
         }
 
@@ -139,7 +131,10 @@ mod tests {
         let path = PathBuf::from("/tmp/video.webm");
         let r = ResolvedContainer::resolve(&config, Some(&path));
         assert_eq!(r.format, ContainerFormat::Mkv);
-        assert_eq!(r.source, ContainerSource::RemuxConfig);
+        assert_eq!(
+            r.source,
+            ContainerSource::Requested(ContainerRequest::Remux)
+        );
     }
 
     #[test]
@@ -149,7 +144,10 @@ mod tests {
         let path = PathBuf::from("/tmp/video.mp4");
         let r = ResolvedContainer::resolve(&config, Some(&path));
         assert_eq!(r.format, ContainerFormat::Mkv);
-        assert_eq!(r.source, ContainerSource::MergeConfig);
+        assert_eq!(
+            r.source,
+            ContainerSource::Requested(ContainerRequest::MergeOutputFormat)
+        );
     }
 
     #[test]
@@ -184,7 +182,10 @@ mod tests {
         config.postprocess.merge_output_format = Some(ContainerFormat::Mkv);
         let r = ResolvedContainer::resolve(&config, None);
         assert_eq!(r.format, ContainerFormat::Mkv);
-        assert_eq!(r.source, ContainerSource::MergeConfig);
+        assert_eq!(
+            r.source,
+            ContainerSource::Requested(ContainerRequest::MergeOutputFormat)
+        );
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -23,6 +23,7 @@
 )]
 
 pub mod registry;
+pub mod sidecar;
 pub mod stages;
 pub mod tracker;
 
@@ -38,6 +39,7 @@ use rdlp_types::InfoDict;
 use rdlp_types::PostProcess;
 
 pub use registry::TempRegistry;
+pub use sidecar::SidecarOwnership;
 pub use tracker::FileTracker;
 
 // ---------------------------------------------------------------------------

--- a/crates/rdlp-postprocess/src/pipeline/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/mod.rs
@@ -39,7 +39,7 @@ use rdlp_types::InfoDict;
 use rdlp_types::PostProcess;
 
 pub use registry::TempRegistry;
-pub use sidecar::SidecarOwnership;
+pub use sidecar::{DiscoveredSidecar, SidecarOwnership};
 pub use tracker::FileTracker;
 
 // ---------------------------------------------------------------------------

--- a/crates/rdlp-postprocess/src/pipeline/sidecar.rs
+++ b/crates/rdlp-postprocess/src/pipeline/sidecar.rs
@@ -24,10 +24,22 @@ use crate::pipeline::PipelineMessage;
 
 /// A companion file located by stem-matching next to the media file.
 ///
-/// Wraps the path so its ownership CANNOT be skipped. `FileTracker::mark_temp`
-/// takes a `PathBuf`, so a `DiscoveredSidecar` cannot reach it without first
-/// going through [`Self::into_disposable`] — a stage that forgets to ask who
-/// owns the file gets a type error instead of silently deleting a user's file.
+/// Wraps the path so ownership is not skipped by ACCIDENT. The inner field is
+/// private, so the only routine way to obtain a deletable `PathBuf` is
+/// [`Self::into_disposable`]: a stage that forgets to ask who owns the file
+/// gets `error[E0308]: expected PathBuf, found DiscoveredSidecar` from
+/// `FileTracker::mark_temp` rather than silently deleting a user's file.
+///
+/// This is a strong speed bump, NOT a capability boundary — be precise about
+/// which, because this doc is what a future maintainer will trust when
+/// deciding whether they still have to think about ownership. A deliberate
+/// `sidecar.path().to_path_buf()` handed to `mark_temp` still compiles
+/// (verified). What the type buys is that the bypass has to be *written out
+/// explicitly*, where a reviewer can see it, instead of being the default
+/// thing that happens when someone forgets. Closing that last gap would mean
+/// `mark_temp` itself taking a `Disposable` newtype, which would force
+/// wrapping at the legitimate tracker-created callers (`fixup.rs`,
+/// `metadata.rs`) for no further safety — the cost exceeds the benefit.
 ///
 /// This exists because the convention alone was not enough: the same defect
 /// shipped or nearly shipped three times in one session (#548's keep-container

--- a/crates/rdlp-postprocess/src/pipeline/sidecar.rs
+++ b/crates/rdlp-postprocess/src/pipeline/sidecar.rs
@@ -18,7 +18,51 @@
 //! `SubtitleStage` had the identical defect and no gate at all, which is what
 //! prompted hoisting it.
 
+use std::path::{Path, PathBuf};
+
 use crate::pipeline::PipelineMessage;
+
+/// A companion file located by stem-matching next to the media file.
+///
+/// Wraps the path so its ownership CANNOT be skipped. `FileTracker::mark_temp`
+/// takes a `PathBuf`, so a `DiscoveredSidecar` cannot reach it without first
+/// going through [`Self::into_disposable`] — a stage that forgets to ask who
+/// owns the file gets a type error instead of silently deleting a user's file.
+///
+/// This exists because the convention alone was not enough: the same defect
+/// shipped or nearly shipped three times in one session (#548's keep-container
+/// guard, the thumbnail embed path, and `SubtitleStage`), each time as "a stage
+/// discovers a companion file, then deletes it without asking whose it is".
+/// Two of the three were caught only because a reviewer went looking (#553).
+///
+/// Reading the path for any NON-destructive purpose (embedding, probing,
+/// logging) is unrestricted via [`Self::path`] — the type constrains deletion,
+/// not use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredSidecar(PathBuf);
+
+impl DiscoveredSidecar {
+    /// Wrap a stem-matched companion file whose ownership is not yet known.
+    #[must_use]
+    pub const fn new(path: PathBuf) -> Self {
+        Self(path)
+    }
+
+    /// Borrow the path for non-destructive use.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Yield a deletable path, but only when rdlp owns the file.
+    ///
+    /// `None` means the file is the user's and must be left alone — the caller
+    /// simply has nothing to mark temp.
+    #[must_use]
+    pub fn into_disposable(self, ownership: SidecarOwnership) -> Option<PathBuf> {
+        ownership.is_disposable().then_some(self.0)
+    }
+}
 
 /// Who owns the sidecar files sitting next to the media file.
 ///
@@ -64,7 +108,8 @@ impl SidecarOwnership {
 
 #[cfg(test)]
 mod tests {
-    use super::SidecarOwnership;
+    use super::{DiscoveredSidecar, SidecarOwnership};
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn rdlp_owned_sidecars_are_disposable() {
@@ -76,5 +121,30 @@ mod tests {
     #[test]
     fn user_owned_sidecars_are_never_disposable() {
         assert!(!SidecarOwnership::UserOwned.is_disposable());
+    }
+
+    #[test]
+    fn rdlp_owned_sidecar_yields_a_deletable_path() {
+        let sidecar = DiscoveredSidecar::new(PathBuf::from("/tmp/video.jpg"));
+        assert_eq!(
+            sidecar.into_disposable(SidecarOwnership::RdlpOwned),
+            Some(PathBuf::from("/tmp/video.jpg"))
+        );
+    }
+
+    /// The data-loss direction: a user-owned sidecar yields NO path, so there
+    /// is nothing the caller could hand to `mark_temp`.
+    #[test]
+    fn user_owned_sidecar_yields_no_deletable_path() {
+        let sidecar = DiscoveredSidecar::new(PathBuf::from("/home/me/myvideo.jpg"));
+        assert_eq!(sidecar.into_disposable(SidecarOwnership::UserOwned), None);
+    }
+
+    /// Non-destructive reads stay unrestricted — the type constrains deletion,
+    /// not use (the embed path still needs to read the image).
+    #[test]
+    fn path_is_readable_without_resolving_ownership() {
+        let sidecar = DiscoveredSidecar::new(PathBuf::from("/tmp/video.jpg"));
+        assert_eq!(sidecar.path(), Path::new("/tmp/video.jpg"));
     }
 }

--- a/crates/rdlp-postprocess/src/pipeline/sidecar.rs
+++ b/crates/rdlp-postprocess/src/pipeline/sidecar.rs
@@ -1,0 +1,80 @@
+//! Who owns the sidecar files a stage discovers next to the media file.
+//!
+//! Several stages locate companion files by stem-matching beside the media
+//! file — `ThumbnailStage` finds `{stem}.jpg`, `SubtitleStage` finds
+//! `{stem}.{lang}.srt` — and then delete them once done, unless the user asked
+//! to keep them (`--write-thumbnail` / `--write-subtitles`).
+//!
+//! Stem-matching cannot by itself tell "a file rdlp downloaded" from "a file
+//! the user already had". For a **borrowed** input (`rdlp /home/me/clip.mp4`,
+//! local-file post-processing) the neighbouring `clip.jpg` / `clip.en.srt` is
+//! the USER'S OWN FILE, and deleting it is silent data loss — the #414
+//! incident class (local-file source preservation) applied to sidecars rather
+//! than to the media file.
+//!
+//! This lives here, not on a stage, because the question is stage-agnostic:
+//! the same predicate governs every stage that discovers-then-deletes a
+//! companion file. It was originally a private helper on `ThumbnailStage`;
+//! `SubtitleStage` had the identical defect and no gate at all, which is what
+//! prompted hoisting it.
+
+use crate::pipeline::PipelineMessage;
+
+/// Who owns the sidecar files sitting next to the media file.
+///
+/// Deliberately an enum rather than a `bool`: `is_disposable(msg) -> bool`
+/// reads as a yes/no at the call site and loses *why*, and a boolean this
+/// close to a `remove_file` is exactly the kind of flag that gets inverted in
+/// a refactor without anyone noticing. Naming both states makes the
+/// data-loss-relevant one impossible to read past.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidecarOwnership {
+    /// rdlp downloaded these files itself, so cleaning them up is correct.
+    RdlpOwned,
+    /// The user brought these files. Never delete them, on any path.
+    UserOwned,
+}
+
+impl SidecarOwnership {
+    /// Resolve ownership for this pipeline run.
+    ///
+    /// The question is whether the RUN started from a user-owned file, not
+    /// whether the file currently in hand is borrowed. By the time a late
+    /// stage executes, a container-changing stage has usually replaced the
+    /// borrowed input with an rdlp-created derivative (`RemuxStage` turns the
+    /// user's `clip.mp4` into `clip.ts`), so a per-path check answers
+    /// "not borrowed" and deletes the user's sidecar anyway. That distinction
+    /// is invisible to a single-stage test and was caught only by running the
+    /// release binary.
+    #[must_use]
+    pub const fn of(msg: &PipelineMessage) -> Self {
+        if msg.tracker.has_borrowed_inputs() {
+            Self::UserOwned
+        } else {
+            Self::RdlpOwned
+        }
+    }
+
+    /// Whether a discovered sidecar may be marked temp for deletion.
+    #[must_use]
+    pub const fn is_disposable(self) -> bool {
+        matches!(self, Self::RdlpOwned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SidecarOwnership;
+
+    #[test]
+    fn rdlp_owned_sidecars_are_disposable() {
+        assert!(SidecarOwnership::RdlpOwned.is_disposable());
+    }
+
+    /// The load-bearing direction: a user-owned sidecar must never be
+    /// disposable. Inverting `is_disposable` fails here.
+    #[test]
+    fn user_owned_sidecars_are_never_disposable() {
+        assert!(!SidecarOwnership::UserOwned.is_disposable());
+    }
+}

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
@@ -11,7 +11,7 @@ use log::{debug, warn};
 
 use rdlp_ffmpeg::FFmpegRunner;
 
-use crate::pipeline::{PipelineMessage, PipelineStage, SidecarOwnership};
+use crate::pipeline::{DiscoveredSidecar, PipelineMessage, PipelineStage, SidecarOwnership};
 
 /// Subtitle file extensions to search for.
 const SUBTITLE_EXTENSIONS: &[&str] = &["srt", "vtt", "ass", "ssa", "lrc"];
@@ -66,7 +66,10 @@ impl SubtitleStage {
     ///
     /// Uses `tokio::fs::read_dir` so the async runtime thread isn't stalled
     /// by blocking directory-scan syscalls on slow / network filesystems.
-    async fn find_subtitle_files(media_file: &Path, original_stem: &str) -> Vec<(String, PathBuf)> {
+    async fn find_subtitle_files(
+        media_file: &Path,
+        original_stem: &str,
+    ) -> Vec<(String, DiscoveredSidecar)> {
         let Some(parent) = media_file.parent() else {
             return Vec::new();
         };
@@ -126,7 +129,7 @@ impl SubtitleStage {
                     };
 
                     if !lang.is_empty() {
-                        result.push((lang.to_string(), path.clone()));
+                        result.push((lang.to_string(), DiscoveredSidecar::new(path.clone())));
                         break;
                     }
                 }
@@ -203,7 +206,7 @@ impl PipelineStage for SubtitleStage {
         for (lang, sub_path) in &subtitle_files {
             debug!(
                 "SubtitleStage: pending-implementation. lang={lang} codec={codec} path={}",
-                sub_path.display()
+                sub_path.path().display()
             );
         }
 
@@ -219,9 +222,12 @@ impl PipelineStage for SubtitleStage {
         // input. `find_subtitle_files` discovers them by stem-matching, which
         // cannot tell an rdlp-fetched sidecar from one the user already had;
         // see `SidecarOwnership`. Same defect the thumbnail sidecar had.
-        if !msg.config.write_subtitles && SidecarOwnership::of(&msg).is_disposable() {
-            for (_, path) in subtitle_files {
-                msg.tracker.mark_temp(path);
+        if !msg.config.write_subtitles {
+            let ownership = SidecarOwnership::of(&msg);
+            for (_, sidecar) in subtitle_files {
+                if let Some(path) = sidecar.into_disposable(ownership) {
+                    msg.tracker.mark_temp(path);
+                }
             }
         }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
@@ -11,7 +11,7 @@ use log::{debug, warn};
 
 use rdlp_ffmpeg::FFmpegRunner;
 
-use crate::pipeline::{PipelineMessage, PipelineStage};
+use crate::pipeline::{PipelineMessage, PipelineStage, SidecarOwnership};
 
 /// Subtitle file extensions to search for.
 const SUBTITLE_EXTENSIONS: &[&str] = &["srt", "vtt", "ass", "ssa", "lrc"];
@@ -214,8 +214,12 @@ impl PipelineStage for SubtitleStage {
             langs.join(", "),
         ));
 
-        // Mark subtitle files as temps unless write_subtitles is set.
-        if !msg.config.write_subtitles {
+        // Mark subtitle files as temps unless write_subtitles is set — and
+        // never when they are the user's own files sitting next to a borrowed
+        // input. `find_subtitle_files` discovers them by stem-matching, which
+        // cannot tell an rdlp-fetched sidecar from one the user already had;
+        // see `SidecarOwnership`. Same defect the thumbnail sidecar had.
+        if !msg.config.write_subtitles && SidecarOwnership::of(&msg).is_disposable() {
             for (_, path) in subtitle_files {
                 msg.tracker.mark_temp(path);
             }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -418,7 +418,7 @@ impl PipelineStage for ThumbnailStage {
             // This early return bypasses the normal embed path below, which is
             // the ONLY other place the orchestrator-downloaded thumbnail
             // sidecar is marked temp for cleanup (the embed-success path's own
-            // `mark_temp(thumbnail_file)` below, guarded on the
+            // `thumbnail_sidecar.into_disposable(..)` below, guarded on the
             // same `!write_thumbnail` condition). Without this, every run
             // that hits this guard with the default `--write-thumbnail=false`
             // leaves a stray sidecar image next to the kept-container output.
@@ -546,7 +546,7 @@ impl PipelineStage for ThumbnailStage {
 
                 // Clean up thumbnail unless --write-thumbnail was requested —
                 // and never when it is the user's own file sitting next to a
-                // borrowed input (see `sidecar_is_disposable`).
+                // borrowed input (see `SidecarOwnership`).
                 if !msg.config.write_thumbnail
                     && let Some(path) =
                         thumbnail_sidecar.into_disposable(SidecarOwnership::of(&msg))
@@ -559,6 +559,20 @@ impl PipelineStage for ThumbnailStage {
                 msg.warnings
                     .push(format!("Thumbnail embedding failed: {e}"));
                 msg.tracker.mark_temp(temp_output);
+
+                // The sidecar needs the same disposal as on the success path.
+                // Marking only `temp_output` here left an rdlp-downloaded
+                // thumbnail on disk whenever the embed failed — a disk leak
+                // (found by the pre-push security review of #553), relying on
+                // `TempRegistry`'s stale sweep to eventually collect it.
+                // Ownership still governs: a user's own file is retained,
+                // failure or not.
+                if !msg.config.write_thumbnail
+                    && let Some(path) =
+                        thumbnail_sidecar.into_disposable(SidecarOwnership::of(&msg))
+                {
+                    msg.tracker.mark_temp(path);
+                }
             }
         }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -91,7 +91,7 @@ impl ThumbnailStage {
     /// capability matter — `mp4ameta`'s own `ftyp` parsing
     /// (`atom/ftyp.rs:13`) only errors when the atom is entirely missing, so
     /// a `.3gp` file would very likely be accepted if this predicate were
-    /// ever consulted for one. It never is: the call site (~line 478) asks
+    /// ever consulted for one. It never is: the `write_covr_atom` call site asks
     /// this question using the POST-REMUX extension, and `ThreeGp` fails
     /// `rdlp_ffmpeg::supports_thumbnail_embed`, so any `.3gp` input is
     /// auto-remuxed to `.mp4` before `supports_covr_atom` is ever reached —

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -386,19 +386,29 @@ impl PipelineStage for ThumbnailStage {
         // pinned behavior.
         let supports_thumbnail = Self::supports_thumbnail(&extension);
 
-        // #548: an explicit `--remux` container must never be silently
-        // discarded by the auto-remux-to-mp4 fallback below. `remux_container`
-        // is `Some` ONLY when the user explicitly requested a container
-        // (`RemuxStage`'s own gate); `None` means rdlp picked the container
-        // itself (e.g. post-HLS `.ts` with no explicit `--remux`), where the
-        // auto-remux-to-mp4 fallback is correct and unaffected by this guard.
-        // Compared as `ContainerFormat`, never a raw extension string.
+        // #548/#551: an explicitly requested container must never be silently
+        // discarded by the auto-remux-to-mp4 fallback below. The request is
+        // resolved by `PostProcess::explicit_container` (the single source of
+        // truth for the `recode_container` > `recode_video` > `remux_container`
+        // precedence chain) — #548 keyed this guard on `remux_container` alone,
+        // which is why `--recode-video=ts` still lost its container (#551).
+        //
+        // `None` means rdlp picked the container itself (e.g. post-HLS `.ts`
+        // with no explicit flag), where the auto-remux-to-mp4 fallback is
+        // correct and unaffected by this guard.
+        //
+        // The comparison is EQUALITY against the container actually on disk,
+        // not `.is_some()`: an explicit request for a DIFFERENT container must
+        // still take the auto-remux path. Compared as `ContainerFormat`, never
+        // a raw extension string.
         if !supports_thumbnail
             && let Ok(current) = ContainerFormat::from_str(&extension)
-            && msg.config.remux_container == Some(current)
+            && let Some(explicit) = msg.config.explicit_container()
+            && explicit.format == current
         {
+            let flag = explicit.flag;
             let reason = format!(
-                "kept explicit --remux={current} container; thumbnail embed skipped \
+                "kept explicit {flag}={current} container; thumbnail embed skipped \
                  because {current} cannot carry an embedded thumbnail"
             );
             warn!("ThumbnailStage: {reason}");

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -407,7 +407,7 @@ impl PipelineStage for ThumbnailStage {
             && let Some(explicit) = msg.config.explicit_container()
             && explicit.format == current
         {
-            let flag = explicit.source.cli_flag();
+            let flag = explicit.source.setting_name();
             let reason = format!(
                 "kept explicit {flag}={current} container; thumbnail embed skipped \
                  because {current} cannot carry an embedded thumbnail"

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -151,6 +151,37 @@ impl ThumbnailStage {
         ContainerFormat::from_str(extension).is_ok_and(rdlp_ffmpeg::uses_native_attachment)
     }
 
+    /// Whether a discovered thumbnail sidecar may be deleted once this stage
+    /// is done with it.
+    ///
+    /// [`Self::find_thumbnail`] locates the sidecar by stem-matching next to
+    /// the media file, which cannot by itself distinguish "a thumbnail rdlp
+    /// downloaded" from "a file the user already had". For a **borrowed**
+    /// input (`rdlp /home/me/clip.mp4` — local-file post-processing via
+    /// `FileTracker::new_borrowing`) the neighbouring `clip.jpg` is the user's
+    /// own file, and deleting it is silent data loss: the #414 incident class
+    /// (local-file source preservation) applied to sidecars rather than to the
+    /// media file. The orchestrator downloads no thumbnail on that path, so a
+    /// sidecar found beside a borrowed input is ALWAYS user-owned.
+    ///
+    /// `FileTracker::mark_temp`'s own `debug_assert!(!is_borrowed(..))` does
+    /// not cover this: it is compiled out in release builds (where the data
+    /// loss was reproduced), and the sidecar was never in the borrowed set to
+    /// begin with — only the media file was.
+    ///
+    /// The question is `has_borrowed_inputs` (did this RUN start from a user
+    /// file), NOT `is_borrowed(media_file)` (is the file in hand user-owned).
+    /// By the time this stage runs, a container-changing stage has usually
+    /// replaced the borrowed input with an rdlp-created derivative — after
+    /// `--remux=ts`, the current file is a `.ts` rdlp made, so the per-path
+    /// question answers `false` and the user's sidecar gets deleted anyway.
+    /// That distinction is invisible to a single-stage test that feeds the
+    /// borrowed file in directly; it was caught only by running the real
+    /// binary.
+    const fn sidecar_is_disposable(msg: &PipelineMessage) -> bool {
+        !msg.tracker.has_borrowed_inputs()
+    }
+
     /// Whether `extension`'s container can carry an embedded thumbnail at all.
     /// Thin wrapper over `rdlp_ffmpeg::supports_thumbnail_embed` (#533).
     fn supports_thumbnail(extension: &str) -> bool {
@@ -421,6 +452,7 @@ impl PipelineStage for ThumbnailStage {
             // that hits this guard with the default `--write-thumbnail=false`
             // leaves a stray sidecar image next to the kept-container output.
             if !msg.config.write_thumbnail
+                && Self::sidecar_is_disposable(&msg)
                 && let Some(sidecar) = Self::find_thumbnail(&media_file, &msg.original_stem)
             {
                 msg.tracker.mark_temp(sidecar);
@@ -541,8 +573,10 @@ impl PipelineStage for ThumbnailStage {
                     Self::write_covr_atom(&temp_output, &embed_source).await;
                 }
 
-                // Clean up thumbnail unless --write-thumbnail was requested.
-                if !msg.config.write_thumbnail {
+                // Clean up thumbnail unless --write-thumbnail was requested —
+                // and never when it is the user's own file sitting next to a
+                // borrowed input (see `sidecar_is_disposable`).
+                if !msg.config.write_thumbnail && Self::sidecar_is_disposable(&msg) {
                     msg.tracker.mark_temp(thumbnail_file);
                 }
             }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -19,7 +19,7 @@ use log::{debug, info, warn};
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 use rdlp_types::{ContainerFormat, THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
 
-use crate::pipeline::{PipelineMessage, PipelineStage, SidecarOwnership};
+use crate::pipeline::{DiscoveredSidecar, PipelineMessage, PipelineStage, SidecarOwnership};
 
 /// Embeds thumbnail into the primary current file.
 ///
@@ -41,7 +41,7 @@ impl ThumbnailStage {
     /// Searches `{parent}/{original_stem}.{ext}` for each `ext` in
     /// [`rdlp_types::THUMBNAIL_EXTENSIONS`]. Also tries the current file's stem
     /// as a fallback.
-    fn find_thumbnail(media_file: &Path, original_stem: &str) -> Option<PathBuf> {
+    fn find_thumbnail(media_file: &Path, original_stem: &str) -> Option<DiscoveredSidecar> {
         let parent = media_file.parent()?;
 
         // Try original_stem first (most accurate after UUID renames).
@@ -50,7 +50,7 @@ impl ThumbnailStage {
             .map(|ext| parent.join(format!("{original_stem}.{ext}")))
             .find(|path| path.exists())
         {
-            return Some(path);
+            return Some(DiscoveredSidecar::new(path));
         }
 
         // Fallback: try current file stem.
@@ -59,7 +59,8 @@ impl ThumbnailStage {
             return THUMBNAIL_EXTENSIONS
                 .iter()
                 .map(|ext| parent.join(format!("{current_stem}.{ext}")))
-                .find(|path| path.exists());
+                .find(|path| path.exists())
+                .map(DiscoveredSidecar::new);
         }
 
         None
@@ -422,10 +423,10 @@ impl PipelineStage for ThumbnailStage {
             // that hits this guard with the default `--write-thumbnail=false`
             // leaves a stray sidecar image next to the kept-container output.
             if !msg.config.write_thumbnail
-                && SidecarOwnership::of(&msg).is_disposable()
                 && let Some(sidecar) = Self::find_thumbnail(&media_file, &msg.original_stem)
+                && let Some(path) = sidecar.into_disposable(SidecarOwnership::of(&msg))
             {
-                msg.tracker.mark_temp(sidecar);
+                msg.tracker.mark_temp(path);
             }
 
             return Ok(msg);
@@ -465,7 +466,7 @@ impl PipelineStage for ThumbnailStage {
         };
 
         // Use original_stem for thumbnail discovery (per architecture constraint 5).
-        let Some(thumbnail_file) = Self::find_thumbnail(&media_file, &msg.original_stem) else {
+        let Some(thumbnail_sidecar) = Self::find_thumbnail(&media_file, &msg.original_stem) else {
             debug!(
                 "ThumbnailStage: no thumbnail file found for stem '{}'",
                 msg.original_stem
@@ -479,12 +480,12 @@ impl PipelineStage for ThumbnailStage {
 
         info!(
             "ThumbnailStage: embedding thumbnail {} into {}",
-            thumbnail_file.display(),
+            thumbnail_sidecar.path().display(),
             media_file.display()
         );
 
         let embed_source = self
-            .normalize_thumbnail_for_embed(&mut msg, &extension, &thumbnail_file)
+            .normalize_thumbnail_for_embed(&mut msg, &extension, thumbnail_sidecar.path())
             .await;
 
         let temp_output = msg.tracker.temp_path(&media_file, &extension);
@@ -546,8 +547,11 @@ impl PipelineStage for ThumbnailStage {
                 // Clean up thumbnail unless --write-thumbnail was requested —
                 // and never when it is the user's own file sitting next to a
                 // borrowed input (see `sidecar_is_disposable`).
-                if !msg.config.write_thumbnail && SidecarOwnership::of(&msg).is_disposable() {
-                    msg.tracker.mark_temp(thumbnail_file);
+                if !msg.config.write_thumbnail
+                    && let Some(path) =
+                        thumbnail_sidecar.into_disposable(SidecarOwnership::of(&msg))
+                {
+                    msg.tracker.mark_temp(path);
                 }
             }
             Err(e) => {
@@ -754,7 +758,7 @@ mod tests {
             let media = dir.path().join("clip.rdlp-tmp-abc123.mp4");
             let result = ThumbnailStage::find_thumbnail(&media, "clip");
             assert_eq!(
-                result,
+                result.map(|s| s.path().to_path_buf()),
                 Some(thumb),
                 "find_thumbnail must discover a .{ext} sidecar via original_stem"
             );
@@ -772,7 +776,7 @@ mod tests {
 
         let media = dir.path().join("original-title.rdlp-tmp-abc123.mp4");
         let result = ThumbnailStage::find_thumbnail(&media, "original-title");
-        assert_eq!(result, Some(thumb));
+        assert_eq!(result.map(|s| s.path().to_path_buf()), Some(thumb));
     }
 
     /// Slice 2 (#406 Task 3): `original_stem` is the CLEAN stem (marker-stripped
@@ -799,7 +803,7 @@ mod tests {
 
         let result = ThumbnailStage::find_thumbnail(&seam_media, original_stem);
         assert_eq!(
-            result,
+            result.map(|s| s.path().to_path_buf()),
             Some(thumb),
             "find_thumbnail must find My.Video.jpg via original_stem \
              even when the media file is seam-named"

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -19,7 +19,7 @@ use log::{debug, info, warn};
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
 use rdlp_types::{ContainerFormat, THUMBNAIL_EXTENSIONS, ThumbnailFormat, sniff_thumbnail_format};
 
-use crate::pipeline::{PipelineMessage, PipelineStage};
+use crate::pipeline::{PipelineMessage, PipelineStage, SidecarOwnership};
 
 /// Embeds thumbnail into the primary current file.
 ///
@@ -149,37 +149,6 @@ impl ThumbnailStage {
     /// support for a container `rdlp-ffmpeg` doesn't recognize at all.
     fn is_native_attachment(extension: &str) -> bool {
         ContainerFormat::from_str(extension).is_ok_and(rdlp_ffmpeg::uses_native_attachment)
-    }
-
-    /// Whether a discovered thumbnail sidecar may be deleted once this stage
-    /// is done with it.
-    ///
-    /// [`Self::find_thumbnail`] locates the sidecar by stem-matching next to
-    /// the media file, which cannot by itself distinguish "a thumbnail rdlp
-    /// downloaded" from "a file the user already had". For a **borrowed**
-    /// input (`rdlp /home/me/clip.mp4` — local-file post-processing via
-    /// `FileTracker::new_borrowing`) the neighbouring `clip.jpg` is the user's
-    /// own file, and deleting it is silent data loss: the #414 incident class
-    /// (local-file source preservation) applied to sidecars rather than to the
-    /// media file. The orchestrator downloads no thumbnail on that path, so a
-    /// sidecar found beside a borrowed input is ALWAYS user-owned.
-    ///
-    /// `FileTracker::mark_temp`'s own `debug_assert!(!is_borrowed(..))` does
-    /// not cover this: it is compiled out in release builds (where the data
-    /// loss was reproduced), and the sidecar was never in the borrowed set to
-    /// begin with — only the media file was.
-    ///
-    /// The question is `has_borrowed_inputs` (did this RUN start from a user
-    /// file), NOT `is_borrowed(media_file)` (is the file in hand user-owned).
-    /// By the time this stage runs, a container-changing stage has usually
-    /// replaced the borrowed input with an rdlp-created derivative — after
-    /// `--remux=ts`, the current file is a `.ts` rdlp made, so the per-path
-    /// question answers `false` and the user's sidecar gets deleted anyway.
-    /// That distinction is invisible to a single-stage test that feeds the
-    /// borrowed file in directly; it was caught only by running the real
-    /// binary.
-    const fn sidecar_is_disposable(msg: &PipelineMessage) -> bool {
-        !msg.tracker.has_borrowed_inputs()
     }
 
     /// Whether `extension`'s container can carry an embedded thumbnail at all.
@@ -437,7 +406,7 @@ impl PipelineStage for ThumbnailStage {
             && let Some(explicit) = msg.config.explicit_container()
             && explicit.format == current
         {
-            let flag = explicit.flag;
+            let flag = explicit.source.cli_flag();
             let reason = format!(
                 "kept explicit {flag}={current} container; thumbnail embed skipped \
                  because {current} cannot carry an embedded thumbnail"
@@ -447,12 +416,13 @@ impl PipelineStage for ThumbnailStage {
 
             // This early return bypasses the normal embed path below, which is
             // the ONLY other place the orchestrator-downloaded thumbnail
-            // sidecar is marked temp for cleanup (~line 522, guarded on the
+            // sidecar is marked temp for cleanup (the embed-success path's own
+            // `mark_temp(thumbnail_file)` below, guarded on the
             // same `!write_thumbnail` condition). Without this, every run
             // that hits this guard with the default `--write-thumbnail=false`
             // leaves a stray sidecar image next to the kept-container output.
             if !msg.config.write_thumbnail
-                && Self::sidecar_is_disposable(&msg)
+                && SidecarOwnership::of(&msg).is_disposable()
                 && let Some(sidecar) = Self::find_thumbnail(&media_file, &msg.original_stem)
             {
                 msg.tracker.mark_temp(sidecar);
@@ -576,7 +546,7 @@ impl PipelineStage for ThumbnailStage {
                 // Clean up thumbnail unless --write-thumbnail was requested —
                 // and never when it is the user's own file sitting next to a
                 // borrowed input (see `sidecar_is_disposable`).
-                if !msg.config.write_thumbnail && Self::sidecar_is_disposable(&msg) {
+                if !msg.config.write_thumbnail && SidecarOwnership::of(&msg).is_disposable() {
                     msg.tracker.mark_temp(thumbnail_file);
                 }
             }

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -145,8 +145,7 @@ impl FileTracker {
     /// When `std::fs::canonicalize` can't run (Drop/cleanup, file already gone),
     /// step 2 simply doesn't match and the result is determined by step 1 —
     /// never worse than the original exact-match implementation.
-    #[must_use]
-    pub fn is_borrowed(&self, path: &Path) -> bool {
+    fn is_borrowed(&self, path: &Path) -> bool {
         // Step 1: raw equality — O(n) but no syscall.
         if self.borrowed.iter().any(|(raw, _)| raw.as_path() == path) {
             return true;
@@ -179,8 +178,13 @@ impl FileTracker {
     /// on the user's own files. Deciding sidecar ownership needs THIS question,
     /// not the per-path one — asking the per-path question deletes the user's
     /// `clip.jpg` the moment any container-changing stage has run.
+    ///
+    /// Failure direction, if the equivalence this relies on ever breaks (a
+    /// future `keep_inputs: true` path that DOES download a thumbnail): the
+    /// sidecar leaks instead of being deleted. Leaking a temp file is the
+    /// right way to be wrong here; deleting a user's file is not.
     #[must_use]
-    pub const fn has_borrowed_inputs(&self) -> bool {
+    pub(crate) const fn has_borrowed_inputs(&self) -> bool {
         !self.borrowed.is_empty()
     }
 
@@ -358,6 +362,49 @@ mod tests {
 
     fn test_registry() -> Arc<TempRegistry> {
         Arc::new(TempRegistry::new())
+    }
+
+    /// The download path owns everything it created, so no sidecar next to it
+    /// is user-owned.
+    #[test]
+    fn has_borrowed_inputs_is_false_for_the_download_path() {
+        let tracker = FileTracker::new(
+            vec![PathBuf::from("/tmp/v.rdlp-tmp-1.mp4")],
+            test_registry(),
+        );
+        assert!(!tracker.has_borrowed_inputs());
+    }
+
+    /// Local-file post-processing: the run started from a user's own file, so
+    /// discovered sidecars must be treated as theirs (#414 class).
+    #[test]
+    fn has_borrowed_inputs_is_true_for_a_borrowed_input() {
+        let dir = TempDir::new().unwrap();
+        let media = dir.path().join("myvideo.mp4");
+        fs::write(&media, b"x").unwrap();
+        let tracker = FileTracker::new_borrowing(vec![media], test_registry());
+        assert!(tracker.has_borrowed_inputs());
+    }
+
+    /// The predicate must stay a property of the RUN, not of the current file:
+    /// after a container-changing stage swaps the borrowed input for an
+    /// rdlp-created derivative, it must still report `true`. This is exactly
+    /// the case a per-path `is_borrowed` check gets wrong.
+    #[test]
+    fn has_borrowed_inputs_survives_replacing_the_borrowed_input() {
+        let dir = TempDir::new().unwrap();
+        let media = dir.path().join("myvideo.mp4");
+        fs::write(&media, b"x").unwrap();
+        let mut tracker = FileTracker::new_borrowing(vec![media], test_registry());
+
+        let derived = dir.path().join("myvideo.ts");
+        tracker.replace(vec![derived.clone()]);
+
+        assert!(!tracker.is_borrowed(&derived), "the derived file is rdlp's");
+        assert!(
+            tracker.has_borrowed_inputs(),
+            "but the RUN still started from a user-owned file"
+        );
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/pipeline/tracker.rs
+++ b/crates/rdlp-postprocess/src/pipeline/tracker.rs
@@ -145,7 +145,8 @@ impl FileTracker {
     /// When `std::fs::canonicalize` can't run (Drop/cleanup, file already gone),
     /// step 2 simply doesn't match and the result is determined by step 1 —
     /// never worse than the original exact-match implementation.
-    fn is_borrowed(&self, path: &Path) -> bool {
+    #[must_use]
+    pub fn is_borrowed(&self, path: &Path) -> bool {
         // Step 1: raw equality — O(n) but no syscall.
         if self.borrowed.iter().any(|(raw, _)| raw.as_path() == path) {
             return true;
@@ -164,6 +165,23 @@ impl FileTracker {
             return true;
         }
         false
+    }
+
+    /// Whether this pipeline was handed any borrowed (user-owned) input at
+    /// all — i.e. whether it is post-processing a pre-existing local file
+    /// rather than something rdlp downloaded.
+    ///
+    /// Distinct from [`is_borrowed`], which asks about ONE path. By the time a
+    /// late stage runs, the borrowed input has usually been replaced by a
+    /// derived file (`RemuxStage` turns the user's `clip.mp4` into an
+    /// rdlp-created `clip.ts`), so `is_borrowed(current_file)` is `false` even
+    /// though the run as a whole is operating inside the user's own directory
+    /// on the user's own files. Deciding sidecar ownership needs THIS question,
+    /// not the per-path one — asking the per-path question deletes the user's
+    /// `clip.jpg` the moment any container-changing stage has run.
+    #[must_use]
+    pub const fn has_borrowed_inputs(&self) -> bool {
+        !self.borrowed.is_empty()
     }
 
     /// Promote `new_files` to `current_files`, moving the old current files

--- a/crates/rdlp-postprocess/tests/common/mod.rs
+++ b/crates/rdlp-postprocess/tests/common/mod.rs
@@ -1,10 +1,12 @@
-//! Shared fixtures for the `ThumbnailStage` integration suites.
+//! Shared fixtures for the `ThumbnailStage` / `SubtitleStage` integration
+//! suites.
 //!
-//! `thumbnail_explicit_container_548.rs` (#548), `..._551.rs` (#551) and
-//! `thumbnail_borrowed_sidecar.rs` each need the same three things: a real
-//! ffmpeg-built media fixture, a real JPEG sidecar, and a `PipelineMessage`
-//! wrapping them. Those helpers were copied per-file as the suites were added;
-//! this module is the single definition.
+//! `thumbnail_explicit_container_548.rs` (#548), `..._551.rs` (#551),
+//! `thumbnail_borrowed_sidecar.rs` and `subtitle_borrowed_sidecar.rs` each need
+//! the same three things: a real ffmpeg-built media fixture, a real image or
+//! subtitle sidecar, and a `PipelineMessage` wrapping them. Those helpers were
+//! copied per-file as the suites were added; this module is the single
+//! definition.
 //!
 //! Real, decodable fixtures are mandatory across all three suites. #548 shipped
 //! tests that passed against UNPATCHED code because their fixtures were
@@ -109,6 +111,22 @@ impl Default for MsgOptions {
             borrowing: false,
             original_stem: "video",
         }
+    }
+}
+
+/// `MsgOptions` for a run over a media file with the given stem, choosing
+/// whether the input is user-owned (`borrowing`) or rdlp-downloaded.
+///
+/// The sidecar suites all need exactly this pair, and BOTH values matter:
+/// a gate of the form `!write_x && ownership.is_disposable()` short-circuits
+/// on ownership, so a test that only ever passes `borrowing: true` cannot pin
+/// the `write_x` half of it (caught in review — all three subtitle tests
+/// stayed green with `!write_subtitles` deleted outright).
+pub fn opts(stem: &'static str, borrowing: bool) -> MsgOptions {
+    MsgOptions {
+        borrowing,
+        original_stem: stem,
+        ..MsgOptions::default()
     }
 }
 

--- a/crates/rdlp-postprocess/tests/common/mod.rs
+++ b/crates/rdlp-postprocess/tests/common/mod.rs
@@ -1,0 +1,142 @@
+//! Shared fixtures for the `ThumbnailStage` integration suites.
+//!
+//! `thumbnail_explicit_container_548.rs` (#548), `..._551.rs` (#551) and
+//! `thumbnail_borrowed_sidecar.rs` each need the same three things: a real
+//! ffmpeg-built media fixture, a real JPEG sidecar, and a `PipelineMessage`
+//! wrapping them. Those helpers were copied per-file as the suites were added;
+//! this module is the single definition.
+//!
+//! Real, decodable fixtures are mandatory across all three suites. #548 shipped
+//! tests that passed against UNPATCHED code because their fixtures were
+//! nonexistent paths: a missing input makes the pre-existing auto-remux failure
+//! warning coincidentally contain the fixture's own extension and the word
+//! "thumbnail", so the assertions matched without the fix being present.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    dead_code
+)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::PostProcess;
+use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, TempRegistry};
+use rdlp_types::InfoDict;
+
+/// `ffmpeg` is present but the fixture could not be built — a broken muxer
+/// name, a libx264-less build, or a permissions problem. This must FAIL the
+/// suite, never skip it: a silent skip would leave every test vacuously green
+/// with only an `eprintln` that `cargo test` swallows without `--nocapture`,
+/// reproducing exactly the failure mode #548 hit.
+pub const FIXTURE_FAILED: &str = "ffmpeg is available but building the fixture failed";
+
+/// Whether the system `ffmpeg` CLI is usable. Used ONLY to build fixtures —
+/// production code never spawns a subprocess (library-first rule).
+pub fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Build a 1-frame H.264 fixture, muxed explicitly as `muxer` (the output
+/// extension alone is ambiguous for some containers, e.g. `.f4v`, so the muxer
+/// name is passed via `-f`).
+pub fn build_video_fixture(path: &Path, muxer: &str) -> Result<(), ()> {
+    run_ffmpeg(&[
+        "-f",
+        "lavfi",
+        "-i",
+        "testsrc=d=1:s=320x240",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-f",
+        muxer,
+        path.to_str().unwrap(),
+    ])
+}
+
+/// Build a REAL JPEG. Placeholder bytes are not a substitute: an invalid image
+/// makes the embed fail early and skip the sidecar cleanup entirely, which
+/// hides sidecar-lifecycle bugs — the first investigation of the borrowed-input
+/// data loss was misled by exactly that.
+pub fn build_jpeg_fixture(path: &Path) -> Result<(), ()> {
+    run_ffmpeg(&[
+        "-f",
+        "lavfi",
+        "-i",
+        "testsrc=d=1:s=64x64",
+        "-frames:v",
+        "1",
+        path.to_str().unwrap(),
+    ])
+}
+
+fn run_ffmpeg(args: &[&str]) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args(["-y", "-loglevel", "error"])
+        .args(args)
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+/// The axes the thumbnail suites vary when building a `PipelineMessage`.
+/// Grouped into one parameter object so [`make_msg`] stays at three arguments.
+pub struct MsgOptions {
+    /// Drives `RemuxStage`'s HLS auto-remux path.
+    pub is_hls: bool,
+    /// `true` selects [`FileTracker::new_borrowing`] (a user-owned local file,
+    /// which must never be deleted) over [`FileTracker::new`] (a file rdlp
+    /// downloaded and therefore owns).
+    pub borrowing: bool,
+    /// Stem used for thumbnail sidecar discovery.
+    pub original_stem: &'static str,
+}
+
+impl Default for MsgOptions {
+    fn default() -> Self {
+        Self {
+            is_hls: false,
+            borrowing: false,
+            original_stem: "video",
+        }
+    }
+}
+
+/// Build a `PipelineMessage` around `files` for a single-stage test.
+pub fn make_msg(files: Vec<PathBuf>, config: PostProcess, opts: MsgOptions) -> PipelineMessage {
+    let reg = Arc::new(TempRegistry::new());
+    let (error_tx, _) = oneshot::channel();
+    let tracker = if opts.borrowing {
+        FileTracker::new_borrowing(files, reg)
+    } else {
+        FileTracker::new(files, reg)
+    };
+    PipelineMessage {
+        info: InfoDict::new(
+            "id".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com".to_string(),
+        ),
+        tracker,
+        config: Arc::new(config),
+        original_stem: opts.original_stem.to_string(),
+        is_hls: opts.is_hls,
+        verbose: false,
+        callback_factory: None,
+        error_tx: Some(error_tx),
+        warnings: Vec::new(),
+        encoding_tool: None,
+        cancel: CancellationToken::new(),
+    }
+}

--- a/crates/rdlp-postprocess/tests/subtitle_borrowed_sidecar.rs
+++ b/crates/rdlp-postprocess/tests/subtitle_borrowed_sidecar.rs
@@ -20,14 +20,10 @@ use rdlp_postprocess::pipeline::PipelineStage;
 use rdlp_postprocess::{FFmpegRunner, PostProcess, SubtitleStage};
 
 mod common;
-use common::{FIXTURE_FAILED, MsgOptions, build_video_fixture, ffmpeg_cli_available, make_msg};
+use common::{FIXTURE_FAILED, build_video_fixture, ffmpeg_cli_available, make_msg, opts};
 
-fn opts(borrowing: bool) -> MsgOptions {
-    MsgOptions {
-        borrowing,
-        original_stem: "myvideo",
-        ..MsgOptions::default()
-    }
+fn subs_opts(borrowing: bool) -> common::MsgOptions {
+    opts("myvideo", borrowing)
 }
 
 /// The user's own `myvideo.en.srt` next to their own `myvideo.mp4` must
@@ -53,7 +49,7 @@ async fn subtitle_stage_never_deletes_a_user_owned_sidecar() {
         write_subtitles: false,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, opts(true));
+    let msg = make_msg(vec![media], config, subs_opts(true));
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     result.tracker.cleanup();
@@ -87,7 +83,7 @@ async fn downloaded_subtitle_sidecar_is_still_cleaned_up() {
         write_subtitles: false,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, opts(false));
+    let msg = make_msg(vec![media], config, subs_opts(false));
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     result.tracker.cleanup();
@@ -98,9 +94,16 @@ async fn downloaded_subtitle_sidecar_is_still_cleaned_up() {
     );
 }
 
-/// `--write-subtitles` retains the user's sidecar too.
+/// Pins the OTHER half of the gate: `--write-subtitles` must retain the
+/// sidecar on the DOWNLOAD path, where ownership alone would happily delete
+/// it. Deliberately NOT the borrowed path — with `borrowing: true` the
+/// ownership term already makes `!write_subtitles && is_disposable()` false,
+/// so the assertion holds no matter what the `write_subtitles` term does, and
+/// deleting that term from the guard leaves the test green (verified by
+/// mutation). A test whose subject is short-circuited before it is reached
+/// tests nothing.
 #[tokio::test]
-async fn write_subtitles_retains_user_owned_sidecar() {
+async fn write_subtitles_retains_downloaded_sidecar() {
     if !ffmpeg_cli_available() {
         eprintln!("[SKIP] ffmpeg CLI not available");
         return;
@@ -119,7 +122,7 @@ async fn write_subtitles_retains_user_owned_sidecar() {
         write_subtitles: true,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, opts(true));
+    let msg = make_msg(vec![media], config, subs_opts(false));
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     result.tracker.cleanup();

--- a/crates/rdlp-postprocess/tests/subtitle_borrowed_sidecar.rs
+++ b/crates/rdlp-postprocess/tests/subtitle_borrowed_sidecar.rs
@@ -1,0 +1,128 @@
+//! `SubtitleStage` must never delete a user-owned subtitle sidecar.
+//!
+//! Same defect class as the thumbnail sidecar bug (see
+//! `thumbnail_borrowed_sidecar.rs`) in a second stage, surfaced by the
+//! pre-push security review of that fix: `SubtitleStage::find_subtitle_files`
+//! discovers `{stem}.{lang}.srt` beside the media file and, when
+//! `--write-subtitles` was not requested, marks every one temp — with no
+//! ownership gate at all.
+//!
+//! On the borrowed path (`rdlp /home/me/clip.mp4 --embed-subtitles`) those are
+//! the user's own subtitle files. Subtitle *embedding* is not implemented yet,
+//! so the stage's only real effect there was deleting them.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use rdlp_postprocess::pipeline::PipelineStage;
+use rdlp_postprocess::{FFmpegRunner, PostProcess, SubtitleStage};
+
+mod common;
+use common::{FIXTURE_FAILED, MsgOptions, build_video_fixture, ffmpeg_cli_available, make_msg};
+
+fn opts(borrowing: bool) -> MsgOptions {
+    MsgOptions {
+        borrowing,
+        original_stem: "myvideo",
+        ..MsgOptions::default()
+    }
+}
+
+/// The user's own `myvideo.en.srt` next to their own `myvideo.mp4` must
+/// survive. Fails against the unpatched stage, which marks it temp
+/// unconditionally.
+#[tokio::test]
+async fn subtitle_stage_never_deletes_a_user_owned_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let subs = dir.path().join("myvideo.en.srt");
+    std::fs::write(&subs, b"1\n00:00:00,000 --> 00:00:01,000\nhello\n").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = SubtitleStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_subtitles: true,
+        write_subtitles: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, opts(true));
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        subs.exists(),
+        "the user's own myvideo.en.srt must survive post-processing of their own local file"
+    );
+}
+
+/// Regression guard for the DOWNLOAD path: an rdlp-fetched subtitle sidecar
+/// must still be cleaned up without `--write-subtitles`. Dies if the fix is
+/// over-broad ("never delete any subtitle sidecar").
+#[tokio::test]
+async fn downloaded_subtitle_sidecar_is_still_cleaned_up() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let subs = dir.path().join("myvideo.en.srt");
+    std::fs::write(&subs, b"1\n00:00:00,000 --> 00:00:01,000\nhello\n").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = SubtitleStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_subtitles: true,
+        write_subtitles: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, opts(false));
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        !subs.exists(),
+        "an rdlp-downloaded subtitle sidecar must still be cleaned up"
+    );
+}
+
+/// `--write-subtitles` retains the user's sidecar too.
+#[tokio::test]
+async fn write_subtitles_retains_user_owned_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let subs = dir.path().join("myvideo.en.srt");
+    std::fs::write(&subs, b"1\n00:00:00,000 --> 00:00:01,000\nhello\n").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = SubtitleStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_subtitles: true,
+        write_subtitles: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, opts(true));
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(subs.exists(), "--write-subtitles must retain the sidecar");
+}

--- a/crates/rdlp-postprocess/tests/thumbnail_borrowed_sidecar.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_borrowed_sidecar.rs
@@ -179,6 +179,81 @@ async fn downloaded_sidecar_is_still_cleaned_up_when_not_borrowed() {
     );
 }
 
+/// Disk-leak guard on the embed-FAILURE branch (found by the pre-push
+/// security review of #553). The `Err(..)` arm marked the stage's own
+/// `temp_output` temp but never the discovered sidecar, so an rdlp-downloaded
+/// thumbnail that failed to embed was left on disk next to the output.
+///
+/// Deliberately on the DOWNLOAD path: with a user-owned sidecar the correct
+/// behaviour is to retain it, so a borrowed fixture could not distinguish the
+/// leak from the intended retention. The embed is made to fail deterministically
+/// by giving the sidecar a valid image EXTENSION but garbage bytes — nothing
+/// can decode it, so both the transcode and the embed fail.
+#[tokio::test]
+async fn embed_failure_still_cleans_up_a_downloaded_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let thumb = dir.path().join("myvideo.jpg");
+    std::fs::write(&thumb, b"not-a-decodable-image").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        write_thumbnail: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, owned_opts());
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        !thumb.exists(),
+        "an rdlp-downloaded sidecar must not be left on disk when the embed fails"
+    );
+}
+
+/// Companion: the same failure on the BORROWED path must still retain the
+/// user's file. This is what stops the leak fix from becoming a data-loss fix
+/// in disguise.
+#[tokio::test]
+async fn embed_failure_still_retains_a_user_owned_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let thumb = dir.path().join("myvideo.jpg");
+    std::fs::write(&thumb, b"not-a-decodable-image").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        write_thumbnail: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, borrowed_opts());
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        thumb.exists(),
+        "the user's own sidecar must survive even when the embed fails"
+    );
+}
+
 /// Pins the OTHER half of the embed-path gate: `--write-thumbnail` must
 /// retain the sidecar on the DOWNLOAD path, where ownership alone would
 /// happily delete it. Deliberately NOT the borrowed path — with

--- a/crates/rdlp-postprocess/tests/thumbnail_borrowed_sidecar.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_borrowed_sidecar.rs
@@ -30,28 +30,21 @@ use rdlp_types::ContainerFormat;
 
 mod common;
 use common::{
-    FIXTURE_FAILED, MsgOptions, build_jpeg_fixture, build_video_fixture, ffmpeg_cli_available,
-    make_msg,
+    FIXTURE_FAILED, build_jpeg_fixture, build_video_fixture, ffmpeg_cli_available, make_msg, opts,
 };
 
-/// Every test here post-processes a USER-OWNED local file.
-fn borrowed_opts() -> MsgOptions {
-    MsgOptions {
-        borrowing: true,
-        original_stem: "myvideo",
-        ..MsgOptions::default()
-    }
+/// A run over the user's OWN local file.
+fn borrowed_opts() -> common::MsgOptions {
+    opts("myvideo", true)
 }
 
-/// The download path, for the regression guard: rdlp owns the sidecar.
-fn owned_opts() -> MsgOptions {
-    MsgOptions {
-        original_stem: "myvideo",
-        ..MsgOptions::default()
-    }
+/// A run over a file rdlp downloaded, sidecar included.
+fn owned_opts() -> common::MsgOptions {
+    opts("myvideo", false)
 }
 
-/// The embed-success path (`thumbnail.rs` ~line 546): an mp4 CAN carry the
+/// The embed-success path (`thumbnail.rs`'s `mark_temp(path)` after a
+/// successful embed): an mp4 CAN carry the
 /// thumbnail, so the embed runs and then cleans up the sidecar. With a
 /// borrowed input that sidecar is the user's own file. Fails against the
 /// unpatched code, which deletes it.
@@ -86,7 +79,8 @@ async fn embed_path_never_deletes_a_user_owned_sidecar() {
     );
 }
 
-/// The keep-container guard path (`thumbnail.rs` ~line 455, added by #548 and
+/// The keep-container guard path (`ThumbnailStage::process`'s early return
+/// for an explicitly-requested container, added by #548 and
 /// widened by #551): `.ts` cannot carry a thumbnail, so the guard returns
 /// early and cleans up the sidecar on the way out. Same data loss, different
 /// branch — both sites need the check.
@@ -185,10 +179,16 @@ async fn downloaded_sidecar_is_still_cleaned_up_when_not_borrowed() {
     );
 }
 
-/// `--write-thumbnail` retains the sidecar on the borrowed path too (it must
-/// never have been a deletion candidate in the first place).
+/// Pins the OTHER half of the embed-path gate: `--write-thumbnail` must
+/// retain the sidecar on the DOWNLOAD path, where ownership alone would
+/// happily delete it. Deliberately NOT the borrowed path — with
+/// `borrowing: true` the ownership term already makes
+/// `!write_thumbnail && is_disposable()` false, so the assertion holds no
+/// matter what the `write_thumbnail` term does, and deleting that term from
+/// the embed-success site leaves the whole suite green (verified by
+/// mutation — the same trap that was caught in the subtitle suite).
 #[tokio::test]
-async fn write_thumbnail_retains_user_owned_sidecar() {
+async fn write_thumbnail_retains_downloaded_sidecar() {
     if !ffmpeg_cli_available() {
         eprintln!("[SKIP] ffmpeg CLI not available");
         return;
@@ -207,7 +207,7 @@ async fn write_thumbnail_retains_user_owned_sidecar() {
         write_thumbnail: true,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, borrowed_opts());
+    let msg = make_msg(vec![media], config, owned_opts());
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     result.tracker.cleanup();

--- a/crates/rdlp-postprocess/tests/thumbnail_borrowed_sidecar.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_borrowed_sidecar.rs
@@ -1,0 +1,216 @@
+//! A user-owned sidecar image next to a **borrowed** (local, user-supplied)
+//! input must never be deleted by `ThumbnailStage`.
+//!
+//! `ThumbnailStage` discovers its thumbnail by stem-matching next to the media
+//! file (`{stem}.{jpg,png,webp,...}`) and, when `--write-thumbnail` was not
+//! requested, marks that file temp so the pipeline deletes it after embedding.
+//! That is correct for a thumbnail *rdlp itself downloaded* — but for
+//! `rdlp /home/me/myvideo.mp4` (local-file post-processing, `new_borrowing`),
+//! the discovered `myvideo.jpg` is the USER'S OWN FILE and deleting it is
+//! silent data loss.
+//!
+//! Verified against the release binary before the fix:
+//!   `rdlp myvideo.mp4` and `rdlp myvideo.mp4 --remux=ts` both destroyed a real
+//!   JPEG sitting next to the user's own source file.
+//!
+//! This is the #414 incident class (local-file source preservation) applied to
+//! sidecars rather than to the media file. `FileTracker::mark_temp`'s
+//! `debug_assert!(!is_borrowed(..))` does NOT cover it: the assert is a no-op
+//! in release builds, and the sidecar was never in the borrowed set anyway —
+//! only the video was.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use rdlp_postprocess::pipeline::PipelineStage;
+use rdlp_postprocess::{FFmpegRunner, PostProcess, RemuxStage, ThumbnailStage};
+use rdlp_types::ContainerFormat;
+
+mod common;
+use common::{
+    FIXTURE_FAILED, MsgOptions, build_jpeg_fixture, build_video_fixture, ffmpeg_cli_available,
+    make_msg,
+};
+
+/// Every test here post-processes a USER-OWNED local file.
+fn borrowed_opts() -> MsgOptions {
+    MsgOptions {
+        borrowing: true,
+        original_stem: "myvideo",
+        ..MsgOptions::default()
+    }
+}
+
+/// The download path, for the regression guard: rdlp owns the sidecar.
+fn owned_opts() -> MsgOptions {
+    MsgOptions {
+        original_stem: "myvideo",
+        ..MsgOptions::default()
+    }
+}
+
+/// The embed-success path (`thumbnail.rs` ~line 546): an mp4 CAN carry the
+/// thumbnail, so the embed runs and then cleans up the sidecar. With a
+/// borrowed input that sidecar is the user's own file. Fails against the
+/// unpatched code, which deletes it.
+#[tokio::test]
+async fn embed_path_never_deletes_a_user_owned_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let thumb = dir.path().join("myvideo.jpg");
+    build_jpeg_fixture(&thumb).expect(FIXTURE_FAILED);
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        write_thumbnail: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, borrowed_opts());
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        thumb.exists(),
+        "the user's own myvideo.jpg must survive post-processing of their own local file"
+    );
+}
+
+/// The keep-container guard path (`thumbnail.rs` ~line 455, added by #548 and
+/// widened by #551): `.ts` cannot carry a thumbnail, so the guard returns
+/// early and cleans up the sidecar on the way out. Same data loss, different
+/// branch — both sites need the check.
+///
+/// **Runs the REAL two-stage sequence** (`RemuxStage` → `ThumbnailStage`)
+/// rather than feeding a `.ts` in directly. That distinction is the whole
+/// point of this test: `RemuxStage` replaces the user's borrowed `myvideo.mp4`
+/// with an rdlp-created `myvideo.ts`, so by the time `ThumbnailStage` runs,
+/// `is_borrowed(current_file)` is FALSE even though the run started from the
+/// user's own file. A single-stage test that passes a borrowed `.ts` straight
+/// in cannot observe that, and an earlier version of this fix passed such a
+/// test while the release binary still destroyed the user's JPEG.
+#[tokio::test]
+async fn keep_container_guard_never_deletes_a_user_owned_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let thumb = dir.path().join("myvideo.jpg");
+    build_jpeg_fixture(&thumb).expect(FIXTURE_FAILED);
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        write_thumbnail: false,
+        remux_container: Some(ContainerFormat::Ts),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, borrowed_opts());
+
+    // Stage 3: turns the borrowed .mp4 into an rdlp-created .ts.
+    let remuxed = RemuxStage::new(Arc::clone(&ffmpeg))
+        .process(msg)
+        .await
+        .expect("remux stage");
+    assert_eq!(
+        remuxed
+            .tracker
+            .primary()
+            .extension()
+            .and_then(|e| e.to_str()),
+        Some("ts"),
+        "precondition: RemuxStage must have produced the .ts the guard then keeps"
+    );
+
+    // Stage 7: the keep-container guard fires and cleans up on the way out.
+    let mut result = ThumbnailStage::new(ffmpeg)
+        .process(remuxed)
+        .await
+        .expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        thumb.exists(),
+        "the user's own sidecar must survive the keep-container guard path too"
+    );
+}
+
+/// Regression guard for the DOWNLOAD path, which must be unaffected: when the
+/// media file is NOT borrowed, the sidecar is a thumbnail rdlp downloaded
+/// itself and `--write-thumbnail=false` must still delete it. This is the test
+/// that dies if the fix is over-broad (e.g. "never delete any sidecar").
+#[tokio::test]
+async fn downloaded_sidecar_is_still_cleaned_up_when_not_borrowed() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let thumb = dir.path().join("myvideo.jpg");
+    build_jpeg_fixture(&thumb).expect(FIXTURE_FAILED);
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        write_thumbnail: false,
+        ..PostProcess::default()
+    };
+    // NOT borrowing: this is a file rdlp downloaded, sidecar included.
+    let msg = make_msg(vec![media], config, owned_opts());
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(
+        !thumb.exists(),
+        "an rdlp-downloaded sidecar must still be cleaned up without --write-thumbnail"
+    );
+}
+
+/// `--write-thumbnail` retains the sidecar on the borrowed path too (it must
+/// never have been a deletion candidate in the first place).
+#[tokio::test]
+async fn write_thumbnail_retains_user_owned_sidecar() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("myvideo.mp4");
+    build_video_fixture(&media, "mp4").expect(FIXTURE_FAILED);
+    let thumb = dir.path().join("myvideo.jpg");
+    build_jpeg_fixture(&thumb).expect(FIXTURE_FAILED);
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        write_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, borrowed_opts());
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    result.tracker.cleanup();
+
+    assert!(thumb.exists(), "--write-thumbnail must retain the sidecar");
+}

--- a/crates/rdlp-postprocess/tests/thumbnail_explicit_container_548.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_explicit_container_548.rs
@@ -14,73 +14,16 @@
 //! fixtures), mirroring `thumbnail_webp_mp4_embed.rs`.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 
 use tempfile::TempDir;
-use tokio::sync::oneshot;
-use tokio_util::sync::CancellationToken;
 
-use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::pipeline::PipelineStage;
 use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
-use rdlp_types::{ContainerFormat, InfoDict};
+use rdlp_types::ContainerFormat;
 
-fn ffmpeg_cli_available() -> bool {
-    Command::new("ffmpeg")
-        .arg("-version")
-        .output()
-        .is_ok_and(|o| o.status.success())
-}
-
-/// Build a 1-frame H.264 fixture via the system `ffmpeg` CLI, muxed
-/// explicitly as `muxer` (the output extension alone is ambiguous for some
-/// containers, e.g. `.f4v`, so the muxer name is passed via `-f`).
-fn build_video_fixture(path: &Path, muxer: &str) -> Result<(), ()> {
-    let ok = Command::new("ffmpeg")
-        .args([
-            "-y",
-            "-loglevel",
-            "error",
-            "-f",
-            "lavfi",
-            "-i",
-            "testsrc=d=1:s=320x240",
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-f",
-            muxer,
-            path.to_str().unwrap(),
-        ])
-        .status()
-        .is_ok_and(|s| s.success());
-    if ok { Ok(()) } else { Err(()) }
-}
-
-fn make_msg(files: Vec<PathBuf>, config: PostProcess) -> PipelineMessage {
-    let reg = Arc::new(TempRegistry::new());
-    let (error_tx, _) = oneshot::channel();
-    PipelineMessage {
-        info: InfoDict::new(
-            "id".to_string(),
-            "Test Video".to_string(),
-            "TestExtractor".to_string(),
-            "https://example.com".to_string(),
-        ),
-        tracker: FileTracker::new(files, reg),
-        config: Arc::new(config),
-        original_stem: "video".to_string(),
-        is_hls: false,
-        verbose: false,
-        callback_factory: None,
-        error_tx: Some(error_tx),
-        warnings: Vec::new(),
-        encoding_tool: None,
-        cancel: CancellationToken::new(),
-    }
-}
+mod common;
+use common::{FIXTURE_FAILED, MsgOptions, build_video_fixture, ffmpeg_cli_available, make_msg};
 
 /// Positive + regression: an explicit `--remux=f4v` container must be KEPT
 /// (never auto-remuxed to mp4), the embed must be skipped, and a warning
@@ -95,10 +38,7 @@ async fn process_keeps_explicit_f4v_container_and_skips_embed() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.f4v");
-    if build_video_fixture(&media, "flv").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "flv").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -108,7 +48,7 @@ async fn process_keeps_explicit_f4v_container_and_skips_embed() {
         remux_container: Some(ContainerFormat::F4v),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -140,10 +80,7 @@ async fn process_keeps_explicit_ts_container_and_skips_embed() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -153,7 +90,7 @@ async fn process_keeps_explicit_ts_container_and_skips_embed() {
         remux_container: Some(ContainerFormat::Ts),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -186,10 +123,7 @@ async fn process_keeps_explicit_container_and_cleans_up_sidecar_thumbnail() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.f4v");
-    if build_video_fixture(&media, "flv").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "flv").expect(FIXTURE_FAILED);
     // Real sidecar thumbnail discoverable via original_stem ("video").
     let thumb = dir.path().join("video.jpg");
     std::fs::write(&thumb, b"fake-jpg-bytes").unwrap();
@@ -203,7 +137,7 @@ async fn process_keeps_explicit_container_and_cleans_up_sidecar_thumbnail() {
         write_thumbnail: false,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     assert_eq!(
@@ -231,10 +165,7 @@ async fn process_keeps_explicit_container_and_retains_sidecar_with_write_thumbna
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.f4v");
-    if build_video_fixture(&media, "flv").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "flv").expect(FIXTURE_FAILED);
     let thumb = dir.path().join("video.jpg");
     std::fs::write(&thumb, b"fake-jpg-bytes").unwrap();
 
@@ -247,7 +178,7 @@ async fn process_keeps_explicit_container_and_retains_sidecar_with_write_thumbna
         write_thumbnail: true,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     result.tracker.cleanup();
@@ -274,10 +205,7 @@ async fn process_auto_remuxes_ts_when_explicit_container_differs_from_current() 
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -290,7 +218,7 @@ async fn process_auto_remuxes_ts_when_explicit_container_differs_from_current() 
         remux_container: Some(ContainerFormat::Mkv),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config);
+    let msg = make_msg(vec![media], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -328,10 +256,7 @@ async fn process_still_auto_remuxes_ts_to_mp4_when_no_explicit_container() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -341,7 +266,7 @@ async fn process_still_auto_remuxes_ts_to_mp4_when_no_explicit_container() {
         remux_container: None,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config);
+    let msg = make_msg(vec![media], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 

--- a/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
@@ -1,0 +1,366 @@
+//! End-to-end proof that an explicit **recode** container (`--recode-video` /
+//! `--recode-container`) is never silently overridden by `ThumbnailStage`'s
+//! auto-remux-for-embedding fallback (#551).
+//!
+//! #548 fixed this for `--remux` only; its guard keyed on `remux_container`
+//! alone, so `RecodeStage`'s own target (`recode_container` > `recode_video`)
+//! fell straight through to the auto-remux-to-mp4 fallback. Reproduced with
+//! the real binary before the fix: `rdlp src.mp4 --recode-video=ts` exited 0,
+//! printed "Success!", and produced only `src.mp4` — no `.ts` anywhere.
+//!
+//! Real, decodable fixtures are mandatory here (not fake paths). #548's task
+//! report records the trap: a nonexistent input makes the PRE-EXISTING
+//! auto-remux failure warning coincidentally contain the fixture's own
+//! extension and the word "thumbnail", so a fake-path test passes against the
+//! UNPATCHED code and proves nothing.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! fixtures), mirroring `thumbnail_explicit_container_548.rs`.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
+use rdlp_types::{ContainerFormat, InfoDict};
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Build a 1-frame H.264 fixture via the system `ffmpeg` CLI, muxed
+/// explicitly as `muxer` (the output extension alone is ambiguous for some
+/// containers, so the muxer name is passed via `-f`).
+fn build_video_fixture(path: &Path, muxer: &str) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-f",
+            muxer,
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+fn make_msg(files: Vec<PathBuf>, config: PostProcess, is_hls: bool) -> PipelineMessage {
+    let reg = Arc::new(TempRegistry::new());
+    let (error_tx, _) = oneshot::channel();
+    PipelineMessage {
+        info: InfoDict::new(
+            "id".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com".to_string(),
+        ),
+        tracker: FileTracker::new(files, reg),
+        config: Arc::new(config),
+        original_stem: "video".to_string(),
+        is_hls,
+        verbose: false,
+        callback_factory: None,
+        error_tx: Some(error_tx),
+        warnings: Vec::new(),
+        encoding_tool: None,
+        cancel: CancellationToken::new(),
+    }
+}
+
+/// Reproduction of the reported bug: an explicit `--recode-video=ts` must be
+/// KEPT, the embed skipped, and a warning must name both the flag that won
+/// and the skipped embed. Fails against the unpatched guard, which sees
+/// `remux_container == None`, abstains, and auto-remuxes the real `.ts`
+/// fixture to a real `.mp4`.
+#[tokio::test]
+async fn process_keeps_explicit_recode_video_container_and_skips_embed() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        recode_video: Some(ContainerFormat::Ts),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config, false);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "explicit --recode-video=ts container must be kept, not auto-remuxed to mp4"
+    );
+    assert!(
+        media.exists(),
+        "the original .ts fixture must still exist, unmodified"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("--recode-video=ts") && w.contains("thumbnail")),
+        "expected a warning naming the winning flag and the skipped embed, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Same guard via the independent `--recode-container` flag, which takes
+/// precedence over `--recode-video` (mirroring `RecodeStage`'s own
+/// `recode_container.or(recode_video)` resolution).
+#[tokio::test]
+async fn process_keeps_explicit_recode_container_and_skips_embed() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        recode_container: Some(ContainerFormat::Ts),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config, false);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "explicit --recode-container=ts container must be kept"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("--recode-container=ts") && w.contains("thumbnail")),
+        "expected a warning naming --recode-container, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Precedence pin: when BOTH a recode target and a `--remux` target are set,
+/// the recode target owns the final container — `RecodeStage` (index 4) runs
+/// AFTER `RemuxStage` (index 3), so the file reaching `ThumbnailStage` is the
+/// recode target. Fails against a naive fix that puts `remux_container` first
+/// in the chain: the warning would name `--remux=mkv` instead.
+#[tokio::test]
+async fn recode_target_outranks_remux_target_in_the_kept_container_warning() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        recode_video: Some(ContainerFormat::Ts),
+        remux_container: Some(ContainerFormat::Mkv),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config, false);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "the recode target (.ts) is the container that actually reached this stage"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("--recode-video=ts")),
+        "the recode target must win the precedence chain, got: {:?}",
+        result.warnings
+    );
+    assert!(
+        !result.warnings.iter().any(|w| w.contains("--remux=mkv")),
+        "the outranked --remux target must not be named, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Equality pin (mutation guard). The guard is an EQUALITY check against the
+/// container actually on disk, not a presence check. A `.ts` file with an
+/// explicit but DIFFERENT recode target (`--recode-video=mkv`) must still take
+/// the auto-remux-to-mp4 path, and the keep-container warning must NOT fire.
+///
+/// This is the test that dies under an `is_some()` mutation of the guard —
+/// #548's report records that all four of its other tests survived exactly
+/// that mutation, so this shape is mandatory, not optional.
+#[tokio::test]
+async fn process_auto_remuxes_when_explicit_recode_container_differs_from_current() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        // Explicit, but NOT the container on disk (.ts) — the guard must not
+        // treat this as "keep the current container".
+        recode_video: Some(ContainerFormat::Mkv),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, false);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result
+            .tracker
+            .primary()
+            .extension()
+            .and_then(|e| e.to_str()),
+        Some("mp4"),
+        "a .ts file whose explicit target is mkv must still auto-remux to mp4 here"
+    );
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.contains("cannot carry an embedded thumbnail")),
+        "the keep-container warning must not fire when the explicit target differs, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Regression guard for the rdlp-chosen path: a post-HLS `.ts` with NO
+/// explicit container anywhere must still auto-remux to mp4 for embedding.
+/// This is the behavior the guard must never swallow — it is the reason the
+/// guard is an equality check against an explicit request rather than a blanket
+/// "keep whatever extension is on disk".
+#[tokio::test]
+async fn hls_ts_without_any_explicit_container_still_auto_remuxes() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        // No recode_video / recode_container / remux_container at all.
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, true);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result
+            .tracker
+            .primary()
+            .extension()
+            .and_then(|e| e.to_str()),
+        Some("mp4"),
+        "an rdlp-chosen .ts (no explicit request) must still auto-remux to mp4"
+    );
+}
+
+/// Sidecar lifecycle on the recode guard path: the early return must still
+/// mark the orchestrator-downloaded thumbnail temp when `--write-thumbnail`
+/// was not requested. This is the defect code review caught on #548 (the
+/// early return bypassed the only other `mark_temp` site); the recode path
+/// takes the same early return and needs the same coverage.
+#[tokio::test]
+async fn recode_guard_path_cleans_up_sidecar_thumbnail() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    if build_video_fixture(&media, "mpegts").is_err() {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    }
+    let thumb = dir.path().join("video.jpg");
+    std::fs::write(&thumb, b"fake-jpg-bytes").unwrap();
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        recode_video: Some(ContainerFormat::Ts),
+        write_thumbnail: false,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config, false);
+
+    let mut result = stage.process(msg).await.expect("non-fatal stage");
+    assert_eq!(result.tracker.primary(), media);
+
+    result.tracker.cleanup();
+    assert!(
+        !thumb.exists(),
+        "the downloaded sidecar must be cleaned up on the recode keep-container path"
+    );
+}

--- a/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
@@ -364,10 +364,19 @@ async fn remux_outranks_merge_output_format() {
         merge_output_format: Some(ContainerFormat::Mkv),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, MsgOptions::default());
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
+    // Assert the CONTAINER was kept, not merely that a warning fired: the
+    // warning is emitted only on the keep path today, so on its own it is a
+    // proxy rather than the property under test, and would not notice a
+    // warning emitted without the container actually surviving.
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "the remux target (.ts) must be the container that survives"
+    );
     assert!(
         result.warnings.iter().any(|w| w.contains("--remux=ts")),
         "the remux target must win over merge_output_format, got: {:?}",

--- a/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
@@ -296,3 +296,81 @@ async fn recode_guard_path_cleans_up_sidecar_thumbnail() {
         "the downloaded sidecar must be cleaned up on the recode keep-container path"
     );
 }
+
+/// #554: `merge_output_format` is an explicit container request too. It is
+/// the LOWEST-precedence one — `MergeStage` runs at index 0, before every
+/// container-changing stage, so anything later overrides it — but when
+/// nothing later is set, the merged container IS the final container and
+/// must not be silently auto-remuxed away.
+///
+/// Reached via config TOML rather than a CLI flag, which is why #551's fix
+/// did not cover it.
+#[tokio::test]
+async fn merge_output_format_alone_is_an_explicit_container() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        merge_output_format: Some(ContainerFormat::Ts),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert_eq!(
+        result.tracker.primary(),
+        media,
+        "an explicit merge_output_format must not be auto-remuxed to mp4"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("merge_output_format") && w.contains("thumbnail")),
+        "expected a warning naming the config key that won, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Precedence pin: an explicit `--remux` outranks `merge_output_format`,
+/// because `RemuxStage` (index 3) runs after `MergeStage` (index 0) and so
+/// owns the container by the time this stage sees it.
+#[tokio::test]
+async fn remux_outranks_merge_output_format() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("video.ts");
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg);
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        remux_container: Some(ContainerFormat::Ts),
+        merge_output_format: Some(ContainerFormat::Mkv),
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config, MsgOptions::default());
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+
+    assert!(
+        result.warnings.iter().any(|w| w.contains("--remux=ts")),
+        "the remux target must win over merge_output_format, got: {:?}",
+        result.warnings
+    );
+}

--- a/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_explicit_container_551.rs
@@ -18,73 +18,16 @@
 //! fixtures), mirroring `thumbnail_explicit_container_548.rs`.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 
 use tempfile::TempDir;
-use tokio::sync::oneshot;
-use tokio_util::sync::CancellationToken;
 
-use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::pipeline::PipelineStage;
 use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
-use rdlp_types::{ContainerFormat, InfoDict};
+use rdlp_types::ContainerFormat;
 
-fn ffmpeg_cli_available() -> bool {
-    Command::new("ffmpeg")
-        .arg("-version")
-        .output()
-        .is_ok_and(|o| o.status.success())
-}
-
-/// Build a 1-frame H.264 fixture via the system `ffmpeg` CLI, muxed
-/// explicitly as `muxer` (the output extension alone is ambiguous for some
-/// containers, so the muxer name is passed via `-f`).
-fn build_video_fixture(path: &Path, muxer: &str) -> Result<(), ()> {
-    let ok = Command::new("ffmpeg")
-        .args([
-            "-y",
-            "-loglevel",
-            "error",
-            "-f",
-            "lavfi",
-            "-i",
-            "testsrc=d=1:s=320x240",
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-f",
-            muxer,
-            path.to_str().unwrap(),
-        ])
-        .status()
-        .is_ok_and(|s| s.success());
-    if ok { Ok(()) } else { Err(()) }
-}
-
-fn make_msg(files: Vec<PathBuf>, config: PostProcess, is_hls: bool) -> PipelineMessage {
-    let reg = Arc::new(TempRegistry::new());
-    let (error_tx, _) = oneshot::channel();
-    PipelineMessage {
-        info: InfoDict::new(
-            "id".to_string(),
-            "Test Video".to_string(),
-            "TestExtractor".to_string(),
-            "https://example.com".to_string(),
-        ),
-        tracker: FileTracker::new(files, reg),
-        config: Arc::new(config),
-        original_stem: "video".to_string(),
-        is_hls,
-        verbose: false,
-        callback_factory: None,
-        error_tx: Some(error_tx),
-        warnings: Vec::new(),
-        encoding_tool: None,
-        cancel: CancellationToken::new(),
-    }
-}
+mod common;
+use common::{FIXTURE_FAILED, MsgOptions, build_video_fixture, ffmpeg_cli_available, make_msg};
 
 /// Reproduction of the reported bug: an explicit `--recode-video=ts` must be
 /// KEPT, the embed skipped, and a warning must name both the flag that won
@@ -99,10 +42,7 @@ async fn process_keeps_explicit_recode_video_container_and_skips_embed() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -112,7 +52,7 @@ async fn process_keeps_explicit_recode_video_container_and_skips_embed() {
         recode_video: Some(ContainerFormat::Ts),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config, false);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -146,10 +86,7 @@ async fn process_keeps_explicit_recode_container_and_skips_embed() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -159,7 +96,7 @@ async fn process_keeps_explicit_recode_container_and_skips_embed() {
         recode_container: Some(ContainerFormat::Ts),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config, false);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -191,10 +128,7 @@ async fn recode_target_outranks_remux_target_in_the_kept_container_warning() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -205,7 +139,7 @@ async fn recode_target_outranks_remux_target_in_the_kept_container_warning() {
         remux_container: Some(ContainerFormat::Mkv),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config, false);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -245,10 +179,7 @@ async fn process_auto_remuxes_when_explicit_recode_container_differs_from_curren
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -260,7 +191,7 @@ async fn process_auto_remuxes_when_explicit_recode_container_differs_from_curren
         recode_video: Some(ContainerFormat::Mkv),
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, false);
+    let msg = make_msg(vec![media], config, MsgOptions::default());
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -296,10 +227,7 @@ async fn hls_ts_without_any_explicit_container_still_auto_remuxes() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
 
     let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
     let stage = ThumbnailStage::new(ffmpeg);
@@ -309,7 +237,14 @@ async fn hls_ts_without_any_explicit_container_still_auto_remuxes() {
         // No recode_video / recode_container / remux_container at all.
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media], config, true);
+    let msg = make_msg(
+        vec![media],
+        config,
+        MsgOptions {
+            is_hls: true,
+            ..MsgOptions::default()
+        },
+    );
 
     let result = stage.process(msg).await.expect("non-fatal stage");
 
@@ -337,10 +272,7 @@ async fn recode_guard_path_cleans_up_sidecar_thumbnail() {
     }
     let dir = TempDir::new().unwrap();
     let media = dir.path().join("video.ts");
-    if build_video_fixture(&media, "mpegts").is_err() {
-        eprintln!("[SKIP] fixture build failed");
-        return;
-    }
+    build_video_fixture(&media, "mpegts").expect(FIXTURE_FAILED);
     let thumb = dir.path().join("video.jpg");
     std::fs::write(&thumb, b"fake-jpg-bytes").unwrap();
 
@@ -353,7 +285,7 @@ async fn recode_guard_path_cleans_up_sidecar_thumbnail() {
         write_thumbnail: false,
         ..PostProcess::default()
     };
-    let msg = make_msg(vec![media.clone()], config, false);
+    let msg = make_msg(vec![media.clone()], config, MsgOptions::default());
 
     let mut result = stage.process(msg).await.expect("non-fatal stage");
     assert_eq!(result.tracker.primary(), media);

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -58,7 +58,7 @@ pub use format::{
 };
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use parse_error::ParseEnumError;
-pub use postprocess::{ContainerRequest, ExplicitContainer, PostProcess};
+pub use postprocess::{ContainerRequest, ContainerSource, ExplicitContainer, PostProcess};
 pub use progress::Progress;
 pub use protocol::DownloadProtocol;
 pub use recode_audio_mode::RecodeAudioMode;

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -58,7 +58,7 @@ pub use format::{
 };
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use parse_error::ParseEnumError;
-pub use postprocess::PostProcess;
+pub use postprocess::{ExplicitContainer, PostProcess};
 pub use progress::Progress;
 pub use protocol::DownloadProtocol;
 pub use recode_audio_mode::RecodeAudioMode;

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -58,7 +58,7 @@ pub use format::{
 };
 pub use info_dict::{Chapter, InfoDict, Subtitle, Thumbnail};
 pub use parse_error::ParseEnumError;
-pub use postprocess::{ExplicitContainer, PostProcess};
+pub use postprocess::{ContainerRequest, ExplicitContainer, PostProcess};
 pub use progress::Progress;
 pub use protocol::DownloadProtocol;
 pub use recode_audio_mode::RecodeAudioMode;

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -130,6 +130,17 @@ impl PostProcess {
     /// Callers needing a hard default apply `.unwrap_or(..)` themselves —
     /// *which* default is a per-consumer concern, and `ThumbnailStage`
     /// genuinely wants the `None`.
+    ///
+    /// `merge_output_format` is deliberately NOT in this chain, and the
+    /// omission is scoped rather than settled: `MergeStage` (index 0) runs
+    /// before every container-changing stage, so its output is an
+    /// *intermediate* container that a later `--remux`/`--recode` is free to
+    /// replace — unlike a recode/remux target, it is not a statement about the
+    /// FINAL container. It nonetheless reaches `ThumbnailStage` unchanged when
+    /// no other flag is set, which is the same defect shape as #551 via the
+    /// config TOML instead of a CLI flag; tracked separately rather than
+    /// widened into this fix. Note `rdlp-api`'s `ResolvedContainer::resolve`
+    /// ranks it second, so the two chains intentionally disagree here.
     #[must_use]
     pub fn explicit_container(&self) -> Option<ExplicitContainer> {
         // Deliberately NOT a destructuring pattern: `PostProcess` has ~35

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -10,6 +10,22 @@ use crate::fixup_policy::FixupPolicy;
 use crate::recode_audio_mode::RecodeAudioMode;
 use crate::vpx_deadline::VpxDeadline;
 
+/// A container the user explicitly asked for, paired with the CLI flag that
+/// asked for it.
+///
+/// The flag travels with the format so operator-facing messages can name the
+/// exact flag that won the precedence chain (`--recode-video=ts`), rather than
+/// a bare container that leaves the user guessing which of their flags took
+/// effect. Mirrors yt-dlp, whose equivalent conflict message names both sides
+/// (`"--remux-video is ignored since --recode-video was given"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExplicitContainer {
+    /// The CLI flag that requested this container, e.g. `"--recode-video"`.
+    pub flag: &'static str,
+    /// The requested container format.
+    pub format: ContainerFormat,
+}
+
 /// Post-processing configuration controlling `FFmpeg` transforms and file handling.
 ///
 /// This struct is the canonical post-processing config type. It is placed in
@@ -94,6 +110,53 @@ pub struct PostProcess {
     pub fixup: FixupPolicy,
 }
 
+impl PostProcess {
+    /// The container the user explicitly requested, resolved in precedence
+    /// order: `recode_container` > `recode_video` > `remux_container`.
+    /// `None` means no explicit container was requested anywhere, i.e. rdlp
+    /// is free to choose one itself.
+    ///
+    /// The recode target outranks the remux target because `RecodeStage`
+    /// (pipeline index 4) runs AFTER `RemuxStage` (index 3), so when both are
+    /// set it is the recode target that survives to the end of the pipeline.
+    /// yt-dlp resolves the same conflict the same way, clearing `remuxvideo`
+    /// with `"--remux-video is ignored since --recode-video was given"`.
+    ///
+    /// Single source of truth for this precedence chain — do NOT re-spell the
+    /// `.or()` chain at a call site. A hand-copied mirror of it in
+    /// `ThumbnailStage` is exactly what shipped #551: the guard keyed on
+    /// `remux_container` alone and silently discarded `--recode-video=ts`.
+    ///
+    /// Callers needing a hard default apply `.unwrap_or(..)` themselves —
+    /// *which* default is a per-consumer concern, and `ThumbnailStage`
+    /// genuinely wants the `None`.
+    #[must_use]
+    pub fn explicit_container(&self) -> Option<ExplicitContainer> {
+        // Deliberately NOT a destructuring pattern: `PostProcess` has ~35
+        // fields, so binding every one to force a compile error when a field
+        // is added would fire on every unrelated addition (`recode_threads`,
+        // `loudnorm_*`, ...) — a false-positive treadmill, not a safety net.
+        // The doc-comment above is the contract; the unit tests pin the order.
+        self.recode_container
+            .map(|format| ExplicitContainer {
+                flag: "--recode-container",
+                format,
+            })
+            .or_else(|| {
+                self.recode_video.map(|format| ExplicitContainer {
+                    flag: "--recode-video",
+                    format,
+                })
+            })
+            .or_else(|| {
+                self.remux_container.map(|format| ExplicitContainer {
+                    flag: "--remux",
+                    format,
+                })
+            })
+    }
+}
+
 impl Default for PostProcess {
     fn default() -> Self {
         Self {
@@ -143,6 +206,103 @@ mod tests {
     #[test]
     fn default_embed_thumbnail_is_true() {
         assert!(PostProcess::default().embed_thumbnail);
+    }
+
+    // --- explicit_container precedence chain (#551) ---
+    //
+    // Each field is exercised alone (so no arm is dead), then every pairwise
+    // conflict is exercised (so the ORDER is pinned, not just the membership).
+    // A chain reordered to put `remux_container` first still passes the
+    // alone-cases; only the conflict cases catch it.
+
+    #[test]
+    fn explicit_container_is_none_when_nothing_requested() {
+        assert_eq!(PostProcess::default().explicit_container(), None);
+    }
+
+    #[test]
+    fn explicit_container_resolves_recode_container_alone() {
+        let config = PostProcess {
+            recode_container: Some(ContainerFormat::Ts),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.flag, "--recode-container");
+    }
+
+    #[test]
+    fn explicit_container_resolves_recode_video_alone() {
+        let config = PostProcess {
+            recode_video: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Mkv);
+        assert_eq!(explicit.flag, "--recode-video");
+    }
+
+    #[test]
+    fn explicit_container_resolves_remux_container_alone() {
+        let config = PostProcess {
+            remux_container: Some(ContainerFormat::F4v),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::F4v);
+        assert_eq!(explicit.flag, "--remux");
+    }
+
+    #[test]
+    fn recode_container_outranks_recode_video() {
+        let config = PostProcess {
+            recode_container: Some(ContainerFormat::Ts),
+            recode_video: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.flag, "--recode-container");
+    }
+
+    /// `RecodeStage` (index 4) runs after `RemuxStage` (index 3), so the
+    /// recode target is what survives to the end of the pipeline.
+    #[test]
+    fn recode_video_outranks_remux_container() {
+        let config = PostProcess {
+            recode_video: Some(ContainerFormat::Ts),
+            remux_container: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.flag, "--recode-video");
+    }
+
+    #[test]
+    fn recode_container_outranks_remux_container() {
+        let config = PostProcess {
+            recode_container: Some(ContainerFormat::Ts),
+            remux_container: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.flag, "--recode-container");
+    }
+
+    /// All three set at once — the full chain resolves to the head.
+    #[test]
+    fn recode_container_wins_the_full_three_way_chain() {
+        let config = PostProcess {
+            recode_container: Some(ContainerFormat::Ts),
+            recode_video: Some(ContainerFormat::Mkv),
+            remux_container: Some(ContainerFormat::F4v),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.flag, "--recode-container");
     }
 
     #[test]

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -10,18 +10,60 @@ use crate::fixup_policy::FixupPolicy;
 use crate::recode_audio_mode::RecodeAudioMode;
 use crate::vpx_deadline::VpxDeadline;
 
-/// A container the user explicitly asked for, paired with the CLI flag that
+/// Which configuration field asked for an output container.
+///
+/// A closed three-variant domain value, so it is an enum rather than a
+/// `&'static str` flag name (per `value-objects-by-default`): the variants are
+/// typo-proof at the call site, exhaustively matchable, and — the reason this
+/// is not merely style — they keep CLI presentation OUT of `rdlp-types`.
+/// Baking `"--recode-video"` into a foundation-layer data type would make
+/// every consumer inherit CLI spelling; the desktop GUI sets these same fields
+/// with no CLI involved, and would end up showing a user a flag they never
+/// typed. The flag string is therefore a rendering concern, produced by
+/// [`Self::cli_flag`] at the boundary that actually speaks CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerRequest {
+    /// `--recode-container` / `postprocess.recode_container`.
+    RecodeContainer,
+    /// `--recode-video` / `postprocess.recode_video`.
+    RecodeVideo,
+    /// `--remux` / `postprocess.remux_container`.
+    Remux,
+}
+
+impl ContainerRequest {
+    /// The CLI flag a user would type to make this request.
+    ///
+    /// Rendering only — see the type doc for why this is a method rather than
+    /// a stored field.
+    #[must_use]
+    pub const fn cli_flag(self) -> &'static str {
+        match self {
+            Self::RecodeContainer => "--recode-container",
+            Self::RecodeVideo => "--recode-video",
+            Self::Remux => "--remux",
+        }
+    }
+}
+
+impl std::fmt::Display for ContainerRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.cli_flag())
+    }
+}
+
+/// A container the user explicitly asked for, paired with the request that
 /// asked for it.
 ///
-/// The flag travels with the format so operator-facing messages can name the
-/// exact flag that won the precedence chain (`--recode-video=ts`), rather than
-/// a bare container that leaves the user guessing which of their flags took
+/// The source travels with the format so operator-facing messages can name
+/// what won the precedence chain (`--recode-video=ts`) rather than a bare
+/// container that leaves the user guessing which of their settings took
 /// effect. Mirrors yt-dlp, whose equivalent conflict message names both sides
 /// (`"--remux-video is ignored since --recode-video was given"`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExplicitContainer {
-    /// The CLI flag that requested this container, e.g. `"--recode-video"`.
-    pub flag: &'static str,
+    /// Which configuration field requested this container.
+    pub source: ContainerRequest,
     /// The requested container format.
     pub format: ContainerFormat,
 }
@@ -148,23 +190,14 @@ impl PostProcess {
         // is added would fire on every unrelated addition (`recode_threads`,
         // `loudnorm_*`, ...) — a false-positive treadmill, not a safety net.
         // The doc-comment above is the contract; the unit tests pin the order.
+        let request = |source: ContainerRequest| move |format| ExplicitContainer { source, format };
         self.recode_container
-            .map(|format| ExplicitContainer {
-                flag: "--recode-container",
-                format,
-            })
+            .map(request(ContainerRequest::RecodeContainer))
             .or_else(|| {
-                self.recode_video.map(|format| ExplicitContainer {
-                    flag: "--recode-video",
-                    format,
-                })
+                self.recode_video
+                    .map(request(ContainerRequest::RecodeVideo))
             })
-            .or_else(|| {
-                self.remux_container.map(|format| ExplicitContainer {
-                    flag: "--remux",
-                    format,
-                })
-            })
+            .or_else(|| self.remux_container.map(request(ContainerRequest::Remux)))
     }
 }
 
@@ -239,7 +272,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::Ts);
-        assert_eq!(explicit.flag, "--recode-container");
+        assert_eq!(explicit.source, ContainerRequest::RecodeContainer);
     }
 
     #[test]
@@ -250,7 +283,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::Mkv);
-        assert_eq!(explicit.flag, "--recode-video");
+        assert_eq!(explicit.source, ContainerRequest::RecodeVideo);
     }
 
     #[test]
@@ -261,7 +294,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::F4v);
-        assert_eq!(explicit.flag, "--remux");
+        assert_eq!(explicit.source, ContainerRequest::Remux);
     }
 
     #[test]
@@ -273,7 +306,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::Ts);
-        assert_eq!(explicit.flag, "--recode-container");
+        assert_eq!(explicit.source, ContainerRequest::RecodeContainer);
     }
 
     /// `RecodeStage` (index 4) runs after `RemuxStage` (index 3), so the
@@ -287,7 +320,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::Ts);
-        assert_eq!(explicit.flag, "--recode-video");
+        assert_eq!(explicit.source, ContainerRequest::RecodeVideo);
     }
 
     #[test]
@@ -299,7 +332,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::Ts);
-        assert_eq!(explicit.flag, "--recode-container");
+        assert_eq!(explicit.source, ContainerRequest::RecodeContainer);
     }
 
     /// All three set at once — the full chain resolves to the head.
@@ -313,7 +346,7 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.format, ContainerFormat::Ts);
-        assert_eq!(explicit.flag, "--recode-container");
+        assert_eq!(explicit.source, ContainerRequest::RecodeContainer);
     }
 
     #[test]

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -12,7 +12,7 @@ use crate::vpx_deadline::VpxDeadline;
 
 /// Which configuration field asked for an output container.
 ///
-/// A closed three-variant domain value, so it is an enum rather than a
+/// A closed four-variant domain value, so it is an enum rather than a
 /// `&'static str` flag name (per `value-objects-by-default`): the variants are
 /// typo-proof at the call site, exhaustively matchable, and — the reason this
 /// is not merely style — they keep CLI presentation OUT of `rdlp-types`.
@@ -20,7 +20,7 @@ use crate::vpx_deadline::VpxDeadline;
 /// every consumer inherit CLI spelling; the desktop GUI sets these same fields
 /// with no CLI involved, and would end up showing a user a flag they never
 /// typed. The flag string is therefore a rendering concern, produced by
-/// [`Self::cli_flag`] at the boundary that actually speaks CLI.
+/// [`Self::setting_name`] at the boundary that actually speaks CLI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContainerRequest {
     /// `--recode-container` / `postprocess.recode_container`.
@@ -83,14 +83,6 @@ pub enum ContainerSource {
 }
 
 impl ContainerSource {
-    /// Whether the user asked for this container, as opposed to rdlp choosing
-    /// it. The distinction that governs whether a later stage may override it
-    /// (#548, #551, #554).
-    #[must_use]
-    pub const fn is_explicit(self) -> bool {
-        matches!(self, Self::Requested(_))
-    }
-
     /// The setting an operator would edit to change this decision, or `None`
     /// when rdlp inferred it and there is no setting to name.
     #[must_use]
@@ -422,21 +414,6 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.source, ContainerRequest::RecodeVideo);
-    }
-
-    #[test]
-    fn requested_sources_are_explicit() {
-        assert!(ContainerSource::Requested(ContainerRequest::Remux).is_explicit());
-        assert!(ContainerSource::Requested(ContainerRequest::MergeOutputFormat).is_explicit());
-    }
-
-    /// The load-bearing direction: an inferred container is NOT an explicit
-    /// request, so a later stage may still override it (the post-HLS `.ts`
-    /// case that must keep auto-remuxing).
-    #[test]
-    fn inferred_sources_are_not_explicit() {
-        assert!(!ContainerSource::FileExtension.is_explicit());
-        assert!(!ContainerSource::Fallback.is_explicit());
     }
 
     #[test]

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -63,6 +63,45 @@ impl std::fmt::Display for ContainerRequest {
     }
 }
 
+/// How a container format was determined — an explicit user request, or an
+/// inference rdlp made on the user's behalf.
+///
+/// Composes with [`ContainerRequest`] rather than duplicating it: the explicit
+/// cases live in exactly one enum, and `Requested(..)` lifts that set into the
+/// wider "requested or inferred" question the orchestrator asks when picking a
+/// download/merge container. Keeping them separate is what lets
+/// [`ExplicitContainer`] be unable to hold `FileExtension` — a type that could
+/// would not be an "explicit container" at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerSource {
+    /// The user asked for this container, via the named setting.
+    Requested(ContainerRequest),
+    /// Inferred from the output file's extension (reflects format selection).
+    FileExtension,
+    /// No user preference anywhere; fell back to a safe default.
+    Fallback,
+}
+
+impl ContainerSource {
+    /// Whether the user asked for this container, as opposed to rdlp choosing
+    /// it. The distinction that governs whether a later stage may override it
+    /// (#548, #551, #554).
+    #[must_use]
+    pub const fn is_explicit(self) -> bool {
+        matches!(self, Self::Requested(_))
+    }
+
+    /// The setting an operator would edit to change this decision, or `None`
+    /// when rdlp inferred it and there is no setting to name.
+    #[must_use]
+    pub const fn setting_name(self) -> Option<&'static str> {
+        match self {
+            Self::Requested(request) => Some(request.setting_name()),
+            Self::FileExtension | Self::Fallback => None,
+        }
+    }
+}
+
 /// A container the user explicitly asked for, paired with the request that
 /// asked for it.
 ///
@@ -383,6 +422,41 @@ mod tests {
         };
         let explicit = config.explicit_container().expect("some");
         assert_eq!(explicit.source, ContainerRequest::RecodeVideo);
+    }
+
+    #[test]
+    fn requested_sources_are_explicit() {
+        assert!(ContainerSource::Requested(ContainerRequest::Remux).is_explicit());
+        assert!(ContainerSource::Requested(ContainerRequest::MergeOutputFormat).is_explicit());
+    }
+
+    /// The load-bearing direction: an inferred container is NOT an explicit
+    /// request, so a later stage may still override it (the post-HLS `.ts`
+    /// case that must keep auto-remuxing).
+    #[test]
+    fn inferred_sources_are_not_explicit() {
+        assert!(!ContainerSource::FileExtension.is_explicit());
+        assert!(!ContainerSource::Fallback.is_explicit());
+    }
+
+    #[test]
+    fn requested_source_names_its_setting() {
+        assert_eq!(
+            ContainerSource::Requested(ContainerRequest::Remux).setting_name(),
+            Some("--remux")
+        );
+        assert_eq!(
+            ContainerSource::Requested(ContainerRequest::MergeOutputFormat).setting_name(),
+            Some("postprocess.merge_output_format")
+        );
+    }
+
+    /// An inferred source has no setting to name — `None`, never an invented
+    /// flag string.
+    #[test]
+    fn inferred_sources_name_no_setting() {
+        assert_eq!(ContainerSource::FileExtension.setting_name(), None);
+        assert_eq!(ContainerSource::Fallback.setting_name(), None);
     }
 
     /// A config-only source must name the config key, never invent a flag.

--- a/crates/rdlp-types/src/postprocess.rs
+++ b/crates/rdlp-types/src/postprocess.rs
@@ -29,26 +29,37 @@ pub enum ContainerRequest {
     RecodeVideo,
     /// `--remux` / `postprocess.remux_container`.
     Remux,
+    /// `postprocess.merge_output_format`. The only source with NO CLI flag —
+    /// it is settable from the config file or by an API caller (including the
+    /// desktop GUI) but not from the command line.
+    MergeOutputFormat,
 }
 
 impl ContainerRequest {
-    /// The CLI flag a user would type to make this request.
+    /// How to name this request back to an operator: the CLI flag where one
+    /// exists, else the config key.
+    ///
+    /// Deliberately NOT called `cli_flag` — `MergeOutputFormat` has no flag,
+    /// and a method promising one would have to invent a string that the user
+    /// could not actually type. Naming the config key is the honest answer,
+    /// and it is what the operator would edit to change the behaviour.
     ///
     /// Rendering only — see the type doc for why this is a method rather than
     /// a stored field.
     #[must_use]
-    pub const fn cli_flag(self) -> &'static str {
+    pub const fn setting_name(self) -> &'static str {
         match self {
             Self::RecodeContainer => "--recode-container",
             Self::RecodeVideo => "--recode-video",
             Self::Remux => "--remux",
+            Self::MergeOutputFormat => "postprocess.merge_output_format",
         }
     }
 }
 
 impl std::fmt::Display for ContainerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.cli_flag())
+        f.write_str(self.setting_name())
     }
 }
 
@@ -173,16 +184,14 @@ impl PostProcess {
     /// *which* default is a per-consumer concern, and `ThumbnailStage`
     /// genuinely wants the `None`.
     ///
-    /// `merge_output_format` is deliberately NOT in this chain, and the
-    /// omission is scoped rather than settled: `MergeStage` (index 0) runs
-    /// before every container-changing stage, so its output is an
-    /// *intermediate* container that a later `--remux`/`--recode` is free to
-    /// replace — unlike a recode/remux target, it is not a statement about the
-    /// FINAL container. It nonetheless reaches `ThumbnailStage` unchanged when
-    /// no other flag is set, which is the same defect shape as #551 via the
-    /// config TOML instead of a CLI flag; tracked separately rather than
-    /// widened into this fix. Note `rdlp-api`'s `ResolvedContainer::resolve`
-    /// ranks it second, so the two chains intentionally disagree here.
+    /// `merge_output_format` is the LOWEST-precedence arm (#554). `MergeStage`
+    /// runs at index 0, before every container-changing stage, so anything
+    /// later overrides it — which is exactly why it ranks last, by the same
+    /// later-stage-wins rule that puts recode above remux. But when nothing
+    /// later is set, the merged container IS the final container, and
+    /// discarding it is the same silent override as #551, reached through the
+    /// config file instead of a CLI flag.
+    ///
     #[must_use]
     pub fn explicit_container(&self) -> Option<ExplicitContainer> {
         // Deliberately NOT a destructuring pattern: `PostProcess` has ~35
@@ -198,6 +207,10 @@ impl PostProcess {
                     .map(request(ContainerRequest::RecodeVideo))
             })
             .or_else(|| self.remux_container.map(request(ContainerRequest::Remux)))
+            .or_else(|| {
+                self.merge_output_format
+                    .map(request(ContainerRequest::MergeOutputFormat))
+            })
     }
 }
 
@@ -335,13 +348,60 @@ mod tests {
         assert_eq!(explicit.source, ContainerRequest::RecodeContainer);
     }
 
-    /// All three set at once — the full chain resolves to the head.
     #[test]
-    fn recode_container_wins_the_full_three_way_chain() {
+    fn explicit_container_resolves_merge_output_format_alone() {
+        let config = PostProcess {
+            merge_output_format: Some(ContainerFormat::Ts),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.source, ContainerRequest::MergeOutputFormat);
+    }
+
+    /// `MergeStage` runs at index 0, before every container-changing stage, so
+    /// merge output ranks LAST — the same later-stage-wins rule that puts
+    /// recode above remux.
+    #[test]
+    fn remux_outranks_merge_output_format() {
+        let config = PostProcess {
+            remux_container: Some(ContainerFormat::Ts),
+            merge_output_format: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.format, ContainerFormat::Ts);
+        assert_eq!(explicit.source, ContainerRequest::Remux);
+    }
+
+    #[test]
+    fn recode_video_outranks_merge_output_format() {
+        let config = PostProcess {
+            recode_video: Some(ContainerFormat::Ts),
+            merge_output_format: Some(ContainerFormat::Mkv),
+            ..PostProcess::default()
+        };
+        let explicit = config.explicit_container().expect("some");
+        assert_eq!(explicit.source, ContainerRequest::RecodeVideo);
+    }
+
+    /// A config-only source must name the config key, never invent a flag.
+    #[test]
+    fn merge_output_format_setting_name_is_the_config_key() {
+        assert_eq!(
+            ContainerRequest::MergeOutputFormat.setting_name(),
+            "postprocess.merge_output_format"
+        );
+    }
+
+    /// All four set at once — the full chain resolves to the head.
+    #[test]
+    fn recode_container_wins_the_full_chain() {
         let config = PostProcess {
             recode_container: Some(ContainerFormat::Ts),
             recode_video: Some(ContainerFormat::Mkv),
             remux_container: Some(ContainerFormat::F4v),
+            merge_output_format: Some(ContainerFormat::Avi),
             ..PostProcess::default()
         };
         let explicit = config.explicit_container().expect("some");


### PR DESCRIPTION
## Resolves

Closes #551
Closes #553
Closes #554
Closes #555

Follow-up filed: #556 (extend sidecar ownership gating to `rdlp-api`'s deletion paths).

## What this fixes

Started as #551 — a one-line-looking precedence bug — and grew because the same defect class kept turning up next to it.

**#551 — an explicit recode container was silently discarded.** #548 stopped `ThumbnailStage` overriding an explicit `--remux` container, but keyed its guard on `remux_container` alone. `RecodeStage` resolves its target from `recode_container` > `recode_video`, so `rdlp src.mp4 --recode-video=ts` produced a `.ts` with `remux_container == None`, the guard abstained, and the auto-remux-to-mp4 fallback discarded it — exit 0, "Success!", no `.ts` anywhere.

Resolved once, on the type that owns the fields: `PostProcess::explicit_container()` returns the requested container paired with the setting that requested it. The recode target outranks remux because `RecodeStage` (index 4) runs after `RemuxStage` (index 3), so it is what survives to the end of the pipeline. yt-dlp resolves the same conflict the same way (`--remux-video is ignored since --recode-video was given`).

**Three instances of a data-loss bug, then a structural close.** `ThumbnailStage` discovers its sidecar by stem-matching next to the media file and deletes it when `--write-thumbnail` is false. Correct for a thumbnail rdlp downloaded — silent data loss for `rdlp /home/me/myvideo.mp4`, where the neighbouring `myvideo.jpg` is the user's own file. The same defect existed in `SubtitleStage` (`myvideo.en.srt`) and on the embed-failure branch.

`mark_temp`'s `debug_assert!(!is_borrowed(..))` did not cover any of it: the assert compiles out in release builds, and the sidecar was never in the borrowed set — only the media file was.

Gated on `SidecarOwnership`, then made structural (#553): discovery returns a `DiscoveredSidecar`, and the only routine way to a deletable `PathBuf` is `into_disposable(ownership)`. Passing the wrapper to `mark_temp` is `error[E0308]`.

**#554 / #555 — the follow-ups.** `merge_output_format` is an explicit request too (reached via config TOML rather than a flag), folded in as lowest-precedence by the same later-stage-wins rule. And `rdlp-api`'s `ContainerSource` is unified with `ContainerRequest` by composition — `Requested(ContainerRequest) | FileExtension | Fallback` — so a flat enum can't make `ExplicitContainer { source: FileExtension }` representable.

## Verification

End-to-end, release binary, user-owned local file with their own sidecars:

| flags | exit | `.jpg` | `.srt` | output |
|---|---|---|---|---|
| *(none)* | 0 | KEPT | KEPT | `myvideo.mp4` |
| `--remux=ts` | 0 | KEPT | KEPT | `myvideo.mp4 myvideo.ts` |
| `--recode-video=ts` | 0 | KEPT | KEPT | `myvideo.mp4 myvideo.ts` |
| `--recode-container=ts` | 0 | KEPT | KEPT | `myvideo.mp4 myvideo.ts` |
| `--embed-subtitles` | 0 | KEPT | KEPT | `myvideo.mp4` |

Output containers verified real (`ffprobe`: `mpegts, 2.000000`), not just correctly named.

Gate: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo check -p rdlp-desktop`, all 7 `scripts/check-*.sh`.

Mutation-verified rather than assumed — every guard has a test that dies when the guard is broken: equality vs `.is_some()`; each precedence order; the `write_thumbnail` / `write_subtitles` terms; the per-run vs per-path ownership predicate; the embed-failure leak.

## Reviews

- **Security — PASS** (3 rounds, full diff). Round 2 found the `SubtitleStage` instance (MEDIUM, fixed). Round 3 found the embed-failure leak (LOW, fixed) and verified the fix did not become a data-loss path. Confirmed the class is closed by exhaustive sweep of every `mark_temp` / `remove_file` reachable from post-processing.
- **Code review — Approve** (4 rounds). Findings across rounds: a stringly-typed flag field, an over-exposed `is_borrowed`, stale cross-references, two tautological tests, a doc that overstated its own guarantee, a broken intra-doc link, and a speculative method. All fixed.

## Process notes, recorded because they are the useful part

Four defects reached a green gate and were caught only by review or by re-checking a measurement:

1. **A tautological test, written while fixing tautologies.** `write_*_retains_user_owned_sidecar` passed `borrowing: true`, so `!write_x && is_disposable()` was already false on the ownership term — deleting the `write_x` term from the guard left the whole suite green. Present in both the subtitle and thumbnail suites; the second was found only after the first was fixed.
2. **Three measurements that produced confident results without measuring anything.** A mutation patch silently matched nothing twice (`cargo fmt` had rewrapped the target line), and a test filter excluded the very test being checked. A mutation that fails to apply is indistinguishable from a test that survives it — worse than no mutation testing, because it manufactures confidence. Patches now assert they changed the file.
3. **A doc that overclaimed its own guarantee.** `DiscoveredSidecar` said ownership "CANNOT be skipped"; review tested it — `sidecar.path().to_path_buf()` compiles clean. It is a strong speed bump, not a capability boundary, and the doc now says exactly that. A doc claiming a stronger boundary than exists is a hazard, because the next maintainer trusts it.
4. **The pre-PR gate does not run `cargo doc`**, which is why a machine-detectable broken intra-doc link survived to the final review. Five pre-existing warnings in `rdlp-types` make a `cargo doc -D warnings` step its own cleanup rather than something to fold in here.

One judgement call left standing: `ContainerSource::setting_name()` has no production caller yet, the same position that got `is_explicit()` and an `Option`-returning `cli_flag()` deleted. Kept because the `None` arm encodes a real domain distinction (an inferred container has no setting to name) and it is the natural lift of the `ContainerRequest` method — but the argument is symmetrical, and it is named here rather than quietly kept.
