### PR TITLE
fix(api): carry thumbnail deletion authority in the type

### DIFF
--- a/crates/rdlp-api/src/orchestrator/cleanup.rs
+++ b/crates/rdlp-api/src/orchestrator/cleanup.rs
@@ -15,9 +15,15 @@ use super::thumbnail::OwnedThumbnail;
 
 /// Idempotently delete the orchestrator-owned artifacts of a cancelled job:
 /// the session-state file, the downloaded thumbnail, and (defensively) any
-/// source download files. Every delete is `exists()`-guarded and best-effort —
-/// failures are logged, never propagated, so cleanup cannot turn a cancel into
-/// a failure.
+/// source download files.
+///
+/// The session state and the thumbnail are `NotFound`-tolerant — they delete
+/// unconditionally and absorb "already gone", which is atomic; only the source
+/// files are still `exists()`-guarded (a check-then-act with a TOCTOU window,
+/// kept for now because that block predates #556).
+///
+/// Every delete is best-effort — failures are logged, never propagated, so
+/// cleanup cannot turn a cancel into a failure.
 pub(super) async fn cleanup_cancelled_artifacts(
     output_dir: &Path,
     output_to_stdout: bool,
@@ -30,7 +36,7 @@ pub(super) async fn cleanup_cancelled_artifacts(
         let sanitized = Orchestrator::sanitize_filename(title);
         let state_path = session_state::single_video_state_path(output_dir, &sanitized);
         // SessionState::delete is itself NotFound-tolerant + best-effort, so no
-        // exists()-guard is needed here (unlike the thumbnail/source blocks below).
+        // exists()-guard is needed here (unlike the source block below).
         SessionState::delete(&state_path).await;
     }
 
@@ -205,6 +211,53 @@ mod tests {
         assert!(
             not_a_file.exists(),
             "a failed delete must leave the path alone"
+        );
+    }
+
+    /// The best-effort contract at the seam: a thumbnail that fails to delete
+    /// must not abort the rest of the cleanup. Without this, mutating the
+    /// thumbnail block to `let _ = thumb.delete().await;` — or to an early
+    /// `return` — leaves every other test green while the source files silently
+    /// stop being cleaned up.
+    #[tokio::test]
+    async fn a_failing_thumbnail_delete_does_not_abort_source_cleanup() {
+        let dir = TempDir::new().unwrap();
+        let out = dir.path();
+        let title = "Resilient";
+
+        // Undeletable thumbnail: remove_file on a directory fails.
+        let undeletable = out.join("Resilient.jpg");
+        tokio::fs::create_dir(&undeletable).await.unwrap();
+
+        let state = out.join(format!(
+            "{}.rdlp_state.json",
+            Orchestrator::sanitize_filename(title)
+        ));
+        let source = out.join("Resilient [id].mp4");
+        for p in [&state, &source] {
+            tokio::fs::write(p, b"x").await.unwrap();
+        }
+
+        cleanup_cancelled_artifacts(
+            out,
+            false,
+            title,
+            std::slice::from_ref(&source),
+            Some(OwnedThumbnail::for_test(undeletable.clone())),
+        )
+        .await;
+
+        assert!(
+            !source.exists(),
+            "source cleanup must still run after a thumbnail delete fails"
+        );
+        assert!(
+            !state.exists(),
+            "session-state cleanup must still run after a thumbnail delete fails"
+        );
+        assert!(
+            undeletable.exists(),
+            "the undeletable thumbnail itself must be left alone"
         );
     }
 }

--- a/crates/rdlp-api/src/orchestrator/cleanup.rs
+++ b/crates/rdlp-api/src/orchestrator/cleanup.rs
@@ -172,4 +172,39 @@ mod tests {
             "a missing thumbnail must not be reported as an error"
         );
     }
+
+    /// The error-propagating arm. Only `NotFound` is absorbed; every other
+    /// failure must surface so the cancel path can log it. Without this test,
+    /// mutating `other => other` into `_ => Ok(())` — silently swallowing every
+    /// real I/O failure — leaves the whole suite green.
+    ///
+    /// Also pins the path into the error text: the token has no accessor by
+    /// design, so `delete` is the only place that can supply it, and that one
+    /// log line is all an operator gets for a cleanup failure.
+    #[tokio::test]
+    async fn deleting_an_undeletable_thumbnail_reports_the_error() {
+        let dir = TempDir::new().unwrap();
+        // `remove_file` on a directory fails with a non-NotFound error.
+        let not_a_file = dir.path().join("a-directory.jpg");
+        tokio::fs::create_dir(&not_a_file).await.unwrap();
+
+        let err = OwnedThumbnail::for_test(not_a_file.clone())
+            .delete()
+            .await
+            .expect_err("a non-NotFound failure must not be absorbed");
+
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "the original ErrorKind must survive so callers can still match on it"
+        );
+        assert!(
+            err.to_string().contains("a-directory.jpg"),
+            "the error text must name the thumbnail: {err}"
+        );
+        assert!(
+            not_a_file.exists(),
+            "a failed delete must leave the path alone"
+        );
+    }
 }

--- a/crates/rdlp-api/src/orchestrator/cleanup.rs
+++ b/crates/rdlp-api/src/orchestrator/cleanup.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 
 use super::Orchestrator;
 use super::session_state::{self, SessionState};
+use super::thumbnail::OwnedThumbnail;
 
 /// Idempotently delete the orchestrator-owned artifacts of a cancelled job:
 /// the session-state file, the downloaded thumbnail, and (defensively) any
@@ -22,7 +23,7 @@ pub(super) async fn cleanup_cancelled_artifacts(
     output_to_stdout: bool,
     title: &str,
     source_files: &[PathBuf],
-    thumbnail: Option<&Path>,
+    thumbnail: Option<OwnedThumbnail>,
 ) {
     // Session state — skip in stdout mode (none is ever written there).
     if !output_to_stdout {
@@ -33,15 +34,13 @@ pub(super) async fn cleanup_cancelled_artifacts(
         SessionState::delete(&state_path).await;
     }
 
-    // Downloaded thumbnail (exact captured path).
+    // Downloaded thumbnail. The token is proof rdlp created this file; a
+    // borrowed run cannot produce one, so this path cannot reach a user file.
     if let Some(thumb) = thumbnail
-        && thumb.exists()
-        && let Err(e) = tokio::fs::remove_file(thumb).await
+        && let Err(e) = thumb.delete().await
     {
-        log::warn!(
-            "cleanup_cancelled_artifacts: failed to delete thumbnail {}: {e}",
-            thumb.display()
-        );
+        // Best-effort: cleanup must not turn a cancel into a failure (#404).
+        log::warn!("cleanup_cancelled_artifacts: failed to delete thumbnail: {e}");
     }
 
     // Source download files — defense-in-depth; normally already removed by the
@@ -81,7 +80,7 @@ mod tests {
             false,
             title,
             std::slice::from_ref(&source),
-            Some(thumb.as_path()),
+            Some(OwnedThumbnail::for_test(thumb.clone())),
         )
         .await;
 
@@ -99,7 +98,7 @@ mod tests {
             false,
             "Gone",
             &[dir.path().join("missing.mp4")],
-            Some(&dir.path().join("missing.webp")),
+            Some(OwnedThumbnail::for_test(dir.path().join("missing.webp"))),
         )
         .await;
     }
@@ -134,13 +133,43 @@ mod tests {
             false,
             title,
             std::slice::from_ref(&absent_source),
-            Some(thumb.as_path()),
+            Some(OwnedThumbnail::for_test(thumb.clone())),
         )
         .await;
 
         assert!(
             !thumb.exists(),
             "thumbnail must be deleted even when source/state absent"
+        );
+    }
+
+    /// The keep-by-default invariant: a token that never reaches cleanup must
+    /// leave the file alone. This is what makes the absence of a `Drop` impl
+    /// safe — dropping the token is inert.
+    #[tokio::test]
+    async fn dropped_token_does_not_delete_the_thumbnail() {
+        let dir = TempDir::new().unwrap();
+        let thumb = dir.path().join("Kept.jpg");
+        tokio::fs::write(&thumb, b"x").await.unwrap();
+
+        let token = OwnedThumbnail::for_test(thumb.clone());
+        drop(token);
+
+        assert!(
+            thumb.exists(),
+            "dropping the token must not delete the thumbnail (keep-by-default)"
+        );
+    }
+
+    /// `NotFound` is success: the postcondition ("no thumbnail here") holds.
+    #[tokio::test]
+    async fn deleting_an_absent_thumbnail_is_ok() {
+        let dir = TempDir::new().unwrap();
+        let token = OwnedThumbnail::for_test(dir.path().join("never-existed.jpg"));
+
+        assert!(
+            token.delete().await.is_ok(),
+            "a missing thumbnail must not be reported as an error"
         );
     }
 }

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -368,7 +368,7 @@ impl Orchestrator {
                     self.config.output_to_stdout,
                     &final_info.title,
                     &download_files,
-                    thumbnail_path.as_deref(),
+                    thumbnail_path,
                 )
                 .await;
                 return Err(e);

--- a/crates/rdlp-api/src/orchestrator/state/mod.rs
+++ b/crates/rdlp-api/src/orchestrator/state/mod.rs
@@ -508,7 +508,7 @@ impl DownloadPhase {
                             orchestrator.config.output_to_stdout,
                             &info.title,
                             &download_files,
-                            thumbnail_path.as_deref(),
+                            thumbnail_path,
                         )
                         .await;
                         return Err(e);

--- a/crates/rdlp-api/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-api/src/orchestrator/thumbnail.rs
@@ -342,3 +342,32 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod signature_pin {
+    use super::OwnedThumbnail;
+    use std::future::Future;
+
+    /// Coercing the fn item to a fn pointer pins arity, parameter types,
+    /// receiver mode, and return type. The generic form is required because
+    /// `delete` is `async`: its return type is an anonymous future, so a plain
+    /// `const _: fn(..) -> ..` cannot name it.
+    fn assert_delete_signature<F: Future<Output = std::io::Result<()>>>(
+        _f: fn(OwnedThumbnail) -> F,
+    ) {
+    }
+
+    /// The type system enforces that a bare `&Path` cannot reach the deletion
+    /// path — but nothing stops a future change from reverting the signature,
+    /// which would silently remove the guarantee. This pins it: `delete(&self)`
+    /// or a `&Path` parameter becomes `E0308` at `cargo check`.
+    ///
+    /// Verified by mutation, both directions (see the design rationale on
+    /// #556). A compile-fail test is not viable here — doctests and trybuild
+    /// compile as external crates and cannot name a `pub(crate)` item, so any
+    /// such test would pass for the wrong reason.
+    #[test]
+    fn delete_signature_is_pinned() {
+        assert_delete_signature(OwnedThumbnail::delete);
+    }
+}

--- a/crates/rdlp-api/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-api/src/orchestrator/thumbnail.rs
@@ -92,17 +92,19 @@ impl OwnedThumbnail {
     /// that can supply it — the token has no accessor, and by the time a caller
     /// holds the error `self` is already consumed — and a cleanup failure is
     /// otherwise silent apart from that one log line. The path lands in the
-    /// message only, never as a value the caller can recover, and the original
+    /// message only, never as a value the caller can recover.
+    ///
     /// [`std::io::ErrorKind`] is preserved so callers can still match on it.
+    /// The rewrap does box the original as a string, so `raw_os_error()` and a
+    /// `.source()` downcast to [`std::io::Error`] are lost; no caller needs
+    /// either, and the kind is what the cancel path matches on.
     pub(super) async fn delete(self) -> std::io::Result<()> {
         match tokio::fs::remove_file(&self.0).await {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            other => other.map_err(|e| {
-                std::io::Error::new(
-                    e.kind(),
-                    format!("delete thumbnail {}: {e}", self.0.display()),
-                )
-            }),
+            // The caller's log line already says "failed to delete thumbnail",
+            // so this supplies only what the caller cannot: the path.
+            other => other
+                .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", self.0.display()))),
         }
     }
 }
@@ -360,12 +362,21 @@ mod signature_pin {
     /// The type system enforces that a bare `&Path` cannot reach the deletion
     /// path — but nothing stops a future change from reverting the signature,
     /// which would silently remove the guarantee. This pins it: `delete(&self)`
-    /// or a `&Path` parameter becomes `E0308` at `cargo check`.
+    /// or a `&Path` parameter becomes `E0308` here.
     ///
-    /// Verified by mutation, both directions (see the design rationale on
-    /// #556). A compile-fail test is not viable here — doctests and trybuild
-    /// compile as external crates and cannot name a `pub(crate)` item, so any
-    /// such test would pass for the wrong reason.
+    /// Enforced by `cargo test` and `cargo clippy --all-targets`, NOT by plain
+    /// `cargo check` — the latter does not compile `#[cfg(test)]` modules.
+    ///
+    /// Verified by mutation in both directions (see the design rationale on
+    /// #556). Note that a `&Path` reversion surfaces as `E0599` at the call
+    /// sites first, because the lib target fails before this one is checked;
+    /// the pin still catches it, you just see the louder error. The `&self`
+    /// reversion is the case where this pin is the *only* guard — call sites
+    /// accept it via autoref.
+    ///
+    /// A compile-fail test is not viable here — doctests and trybuild compile
+    /// as external crates and cannot name a `pub(crate)` item, so any such test
+    /// would pass for the wrong reason.
     #[test]
     fn delete_signature_is_pinned() {
         assert_delete_signature(OwnedThumbnail::delete);

--- a/crates/rdlp-api/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-api/src/orchestrator/thumbnail.rs
@@ -52,10 +52,10 @@ fn thumbnail_extension_from_url(thumbnail_url: &str) -> String {
 /// caller asserting the second alongside a bare path.
 ///
 /// Deliberately has **no** path accessor, no `Deref`, no `AsRef<Path>`, no
-/// `Clone`, and no `Drop`. Each omission is load-bearing and documented in
-/// `docs/planning/2026-07-19-owned-thumbnail-design.md`; in particular, a
-/// `Drop` impl would invert the default from keep to delete, so any `?` between
-/// mint and cleanup would silently destroy a file the run meant to keep.
+/// `Clone`, and no `Drop`. Each omission is load-bearing (see the design
+/// rationale on #556); in particular, a `Drop` impl would invert the default
+/// from keep to delete, so any `?` between mint and cleanup would silently
+/// destroy a file the run meant to keep.
 ///
 /// The inner `PathBuf` never escapes this module: [`Self::delete`] is the only
 /// operation, so there is no unwrap for a future caller to misuse.
@@ -87,10 +87,22 @@ impl OwnedThumbnail {
     /// Cancel-path callers log and continue: cleanup must not turn a cancel
     /// into a failure (#404). That decision belongs to the caller, not here —
     /// see Rust API Guidelines C-DTOR-FAIL.
+    ///
+    /// A propagated error names the path in its *text*. This is the only place
+    /// that can supply it — the token has no accessor, and by the time a caller
+    /// holds the error `self` is already consumed — and a cleanup failure is
+    /// otherwise silent apart from that one log line. The path lands in the
+    /// message only, never as a value the caller can recover, and the original
+    /// [`std::io::ErrorKind`] is preserved so callers can still match on it.
     pub(super) async fn delete(self) -> std::io::Result<()> {
         match tokio::fs::remove_file(&self.0).await {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            other => other,
+            other => other.map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!("delete thumbnail {}: {e}", self.0.display()),
+                )
+            }),
         }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/thumbnail.rs
+++ b/crates/rdlp-api/src/orchestrator/thumbnail.rs
@@ -40,6 +40,61 @@ fn thumbnail_extension_from_url(thumbnail_url: &str) -> String {
         .map_or_else(|| "jpg".to_owned(), str::to_lowercase)
 }
 
+/// A thumbnail sidecar that rdlp downloaded and therefore may delete.
+///
+/// Minted only by [`Orchestrator::download_thumbnail`]. A borrowed run
+/// (`process_local_file`) never calls that function, so in the borrowed case
+/// this value is unconstructible — the cancel-path deletion cannot reach a
+/// user-owned file by construction rather than by call-graph accident (#556).
+///
+/// Analogous to [`std::os::fd::OwnedFd`] (RFC 3128): possession IS the
+/// authorization, so designation and permission travel together instead of the
+/// caller asserting the second alongside a bare path.
+///
+/// Deliberately has **no** path accessor, no `Deref`, no `AsRef<Path>`, no
+/// `Clone`, and no `Drop`. Each omission is load-bearing and documented in
+/// `docs/planning/2026-07-19-owned-thumbnail-design.md`; in particular, a
+/// `Drop` impl would invert the default from keep to delete, so any `?` between
+/// mint and cleanup would silently destroy a file the run meant to keep.
+///
+/// The inner `PathBuf` never escapes this module: [`Self::delete`] is the only
+/// operation, so there is no unwrap for a future caller to misuse.
+#[derive(Debug)]
+pub(super) struct OwnedThumbnail(PathBuf);
+
+impl OwnedThumbnail {
+    /// Module-private on purpose: only `download_thumbnail` mints one.
+    /// Widening this to `pub(super)` would let any orchestrator module forge a
+    /// token from an arbitrary path and defeat the provenance guarantee.
+    const fn new(path: PathBuf) -> Self {
+        Self(path)
+    }
+
+    /// Test-only mint, reachable from the sibling `cleanup` module's tests.
+    /// `#[cfg(test)]` keeps it out of release builds, so the production mint
+    /// gate is unaffected.
+    #[cfg(test)]
+    pub(super) const fn for_test(path: PathBuf) -> Self {
+        Self(path)
+    }
+
+    /// Delete the downloaded thumbnail, consuming the ownership token.
+    ///
+    /// `NotFound` is treated as success — the postcondition ("no thumbnail at
+    /// this path") already holds, and a missing file is not evidence of a
+    /// fault. This also avoids the TOCTOU race an `exists()` guard would have.
+    ///
+    /// Cancel-path callers log and continue: cleanup must not turn a cancel
+    /// into a failure (#404). That decision belongs to the caller, not here —
+    /// see Rust API Guidelines C-DTOR-FAIL.
+    pub(super) async fn delete(self) -> std::io::Result<()> {
+        match tokio::fs::remove_file(&self.0).await {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            other => other,
+        }
+    }
+}
+
 impl Orchestrator {
     /// Download thumbnail image from URL and save alongside media file.
     ///
@@ -53,13 +108,14 @@ impl Orchestrator {
     ///
     /// # Returns
     ///
-    /// - `Some(path)` — thumbnail downloaded successfully
+    /// - `Some(token)` — thumbnail downloaded successfully; the token carries
+    ///   proof that rdlp created the file and is the only way to delete it
     /// - `None` — no thumbnail URL available or download failed
     pub(super) async fn download_thumbnail(
         &self,
         info: &rdlp_types::InfoDict,
         media_file: &Path,
-    ) -> Option<PathBuf> {
+    ) -> Option<OwnedThumbnail> {
         // Streaming size cap (20 MB) — adversarial CDN can't OOM the host
         // by sending a 1 GB image before the cap fires.
         const MAX_THUMBNAIL_BYTES: usize = 20 * 1024 * 1024;
@@ -184,7 +240,7 @@ impl Orchestrator {
             "Thumbnail downloaded"
         );
 
-        Some(thumbnail_path)
+        Some(OwnedThumbnail::new(thumbnail_path))
     }
 }
 


### PR DESCRIPTION
## Resolves

Closes #556

## Summary

`cleanup_cancelled_artifacts` took `Option<&Path>`, so its guarantee that it never deletes a user-owned file rested on which functions happened to call it — a call-graph accident, not a structural property. This introduces `OwnedThumbnail`, a capability newtype minted only by `download_thumbnail`, so a borrowed run (`process_local_file`, which never downloads a thumbnail) **cannot construct one**. The deletion authority now travels in the type.

Analogous to `std::os::fd::OwnedFd` (RFC 3128): possession is the authorization, so designation and permission travel together instead of the caller asserting the second alongside a bare path.

## Design constraints and why each holds

| Constraint | Why |
|---|---|
| `#[derive(Debug)]` only | Any other derive widens what a holder can do with the token |
| No `Clone` | Two tokens for one file means a double-delete or a stale authority |
| No `Deref` / `AsRef<Path>` | Either one hands out the inner path, defeating the point |
| No `Drop` | A `Drop` impl would invert the default from **keep** to **delete** — any `?` between mint and cleanup would silently destroy a file the run meant to keep |
| No path accessor | `delete(self)` is the only operation, so the `PathBuf` never escapes the module and there is nothing to bypass |
| `fn new` module-private (no visibility modifier) | `pub(super)` would let any orchestrator module forge a token from an arbitrary path |
| `delete` returns `io::Result<()>`, does not log | Rust API Guidelines C-DTOR-FAIL — the log-and-continue decision belongs to the cancel-path caller (#404), explicitly at the call site rather than baked into the type |

The `exists()` guard before deletion was removed: it *was* the TOCTOU (check-then-act). `delete()` now calls `remove_file` unconditionally and treats `NotFound` as `Ok(())`, which is atomic.

## Note on TDD shape

#556 is **not a live defect** — current behavior is already correct, just held by accident. There is no runtime test that fails against unpatched code, so the red-green cycle is at the type level: tests were written against the new API, failed to compile (`E0432`), then passed once the type existed. This is the documented exception to the failing-test-first rule. Every *behavioral* addition after that point was mutation-verified.

## Mutation verification

| Mutation | Result | Caught by |
|---|---|---|
| `delete(self)` → `delete(&self)` | `E0308` at `thumbnail.rs:371` | The signature pin — **only** guard; call sites tolerate it via autoref |
| `OwnedThumbnail` → `&Path` param | `E0308` at the pin; `E0599` surfaces first at the call sites | Pin + call sites |
| `other => other` → `_ => Ok(())` (swallow all I/O errors) | Test failure | `deleting_an_undeletable_thumbnail_reports_the_error` |
| Early `return` in the thumbnail cleanup block | Test failure | `a_failing_thumbnail_delete_does_not_abort_source_cleanup` |
| Sibling-module forgery of a token | `E0423` | Module-private `new` |

## Verification

`cargo fmt --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` exit 0 · `cargo test --workspace` 3763 passed / 0 failed · `cargo check -p rdlp-desktop` clean · all 7 repo `check-*.sh` gates exit 0.

## Reviews

Both mandatory pre-push reviewers ran over the full `develop..HEAD` range and approved before push.

**security-reviewer — PASS, no findings at Medium or above.** Independently verified: `OwnedThumbnail::new` has exactly one call site (`thumbnail.rs:250`); `process_local_file` (`client/mod.rs:621`) calls neither `download_thumbnail` nor `cleanup_cancelled_artifacts`, so the borrowed path is structurally excluded; `#[cfg(test)] for_test` is unreachable from production. On the removed guard: `remove_file` unlinks the directory entry and never follows a symlink to its target, so a planted symlink cannot redirect the deletion. Path traversal is blocked by the fixed `THUMBNAIL_EXTENSIONS` whitelist. One INFO note (local path in error text) cleared as consistent with pre-existing logging in the same function and out of scope for the URL-redaction gates.

**code-reviewer — Approve with minor fixes; all fixed in `a3391385` before push.** Three doc statements had been invalidated by the change: the function doc still claimed "every delete is `exists()`-guarded"; an inline comment named the thumbnail block as guarded; and `signature_pin` claimed enforcement "at `cargo check`" when plain `cargo check` does not compile `#[cfg(test)]` modules. The review also identified a real coverage gap at the seam — nothing drove `cleanup_cancelled_artifacts` with a *failing* thumbnail delete, so an early return there skipped all source-file cleanup with every test still green. That test was added and mutation-verified.

## Known follow-up

`source_files` remains `&[PathBuf]` with the same "guarantee rests on who happens to call it" property this PR removes for thumbnails. Not a defect today — no borrowed caller reaches it — but the argument applies equally. Tracked in #563.
