### PR TITLE
fix(api): remove the leftover-segment directory sweep that deleted user files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
         # stale mirror.
         run: bash scripts/check-ts-enum-drift.sh
 
+      - name: Check no directory-sweep deletion
+        # #558: deleting files found by scanning a directory cannot tell "a file
+        # rdlp created" from "a file the user already had". CERT FIO21-C; no
+        # comparable tool (yt-dlp/aria2/curl/wget/rsync) deletes by pattern match.
+        run: bash scripts/check-no-dir-sweep-delete.sh
+
       - name: Install semgrep
         run: pipx install semgrep || pip install semgrep
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
         # comparable tool (yt-dlp/aria2/curl/wget/rsync) deletes by pattern match.
         run: bash scripts/check-no-dir-sweep-delete.sh
 
+      - name: Verify the dir-sweep gate still fires
+        # Scans a synthetic sweep in a temp dir. Without this, "canary-verified"
+        # decays into an unchecked claim as the matcher evolves.
+        run: bash scripts/check-no-dir-sweep-delete.sh --self-test
+
       - name: Install semgrep
         run: pipx install semgrep || pip install semgrep
 

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -440,8 +440,23 @@ Before committing, ensure:
 - ✅ `cargo test` passes
 - ✅ `cargo clippy` has zero warnings
 - ✅ `cargo fmt` has been run
+- ✅ `bash scripts/check-all.sh` passes (the invariant gates — see below)
 - ✅ No secrets or credentials in code
 - ✅ Documentation updated if API changed
+
+### Invariant Gates
+
+`scripts/check-*.sh` enforce invariants the compiler cannot: no external CLI
+spawning, URL redaction in logs, WIT contract drift, TypeScript enum drift, and
+no deletion of files discovered by directory scan (#558). Run them all with:
+
+```bash
+bash scripts/check-all.sh
+```
+
+Each script is also wired into `.github/workflows/ci.yml`. Run the aggregate
+locally before pushing — a gate that only exists in CI is a gate that does not
+run when CI is dormant.
 
 ## Documentation Standards
 

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -147,9 +147,6 @@ impl Orchestrator {
                         let filename = format!("{sanitized_title}.{file_ext}");
                         let path = output_dir.join(&filename);
 
-                        self.cleanup_leftover_segments(output_dir, &sanitized_title)
-                            .await;
-
                         debug!(path:? = path.display(); "Downloading to");
                         output_path = Some(path);
                     }
@@ -249,9 +246,6 @@ impl Orchestrator {
                         let sanitized_title = Self::sanitize_filename(&info_ref.title);
                         let filename = format!("{sanitized_title}.{file_ext}");
                         let path = output_dir.join(&filename);
-
-                        self.cleanup_leftover_segments(output_dir, &sanitized_title)
-                            .await;
 
                         debug!(path:? = path.display(); "Downloading merge to");
                         output_path = Some(path);

--- a/crates/rdlp-api/src/orchestrator/playlist/tests.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/tests.rs
@@ -113,3 +113,92 @@ fn test_extract_cdn_host_stickiness_sort() {
     // s2 (same host) should sort first
     assert!(urls[0].contains("s2.netmagcdn.com"));
 }
+
+// ---------------------------------------------------------------------------
+// #558 regression: a download must not delete files it did not create
+// ---------------------------------------------------------------------------
+
+/// `cleanup_leftover_segments` used to enumerate the output directory before a
+/// download and unlink every entry matching `starts_with(title)` +
+/// `contains(".part")` + digits after the last `.part`. That matched partial
+/// files left by other tools (wget, aria2, a browser) and deleted them on a
+/// normal, successful download.
+///
+/// This drives the real `download_from_info_to_dir` path against a mock server
+/// rather than asserting on source text, so it stays valid however a future
+/// sweep might be spelled — including the existence-probe shape that
+/// `scripts/check-no-dir-sweep-delete.sh` cannot see.
+// The `mockito::Server` must stay alive for the whole body — it stops serving
+// when dropped — so its drop cannot be tightened. Same rationale as the
+// module-level allow in `orchestrator/tests/hls_e2e.rs`.
+#[allow(clippy::significant_drop_tightening)]
+#[tokio::test]
+async fn foreign_part_files_survive_an_episode_download() {
+    use crate::events::Event;
+    use crate::handle::DownloadId;
+    use crate::orchestrator::Orchestrator;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    let mut server = mockito::Server::new_async().await;
+    let body = b"video-bytes";
+    let _mock = server
+        .mock("GET", "/video.mp4")
+        .with_status(200)
+        .with_header("content-length", &body.len().to_string())
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let title = "My Show S01E01";
+
+    // Files another tool could plausibly have left in the user's download
+    // directory. Each matched the old sweep's pattern.
+    let foreign_part = dir.path().join(format!("{title}.mp4.part1"));
+    // The old digit check accepted an EMPTY suffix too: all() on an empty
+    // iterator is vacuously true, so a bare `.part` matched as well.
+    let foreign_bare = dir.path().join(format!("{title}.mp4.part"));
+    let unrelated = dir.path().join("holiday.jpg");
+    for p in [&foreign_part, &foreign_bare, &unrelated] {
+        tokio::fs::write(p, b"not rdlp's").await.unwrap();
+    }
+
+    let fmt = rdlp_types::Format::new(
+        "http-1",
+        format!("{}/video.mp4", server.url()),
+        "mp4",
+        rdlp_types::DownloadProtocol::Https,
+    );
+    let mut info =
+        rdlp_types::InfoDict::new("id-558", title, "test", format!("{}/watch", server.url()));
+    info.formats = vec![fmt];
+
+    let (tx, _rx) = mpsc::channel::<Event>(64);
+    let orch = Orchestrator::new(
+        Arc::new(rdlp_types::Config::default()),
+        tx,
+        DownloadId::next(),
+        CancellationToken::new(),
+        None,
+    );
+
+    let _ = orch
+        .download_from_info_to_dir(&info, false, dir.path(), &[], None, None)
+        .await;
+
+    // The assertions are about the foreign files, not the download's outcome:
+    // the sweep ran before the download, so it destroyed these even on paths
+    // where the download itself later failed.
+    assert!(
+        foreign_part.exists(),
+        "a foreign .part1 file must survive — deleting it is #558"
+    );
+    assert!(
+        foreign_bare.exists(),
+        "a foreign bare .part file must survive (empty-suffix match)"
+    );
+    assert!(unrelated.exists(), "an unrelated file must survive");
+}

--- a/crates/rdlp-api/src/orchestrator/playlist/tests.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/tests.rs
@@ -185,13 +185,33 @@ async fn foreign_part_files_survive_an_episode_download() {
         None,
     );
 
-    let _ = orch
+    let result = orch
         .download_from_info_to_dir(&info, false, dir.path(), &[], None, None)
         .await;
 
-    // The assertions are about the foreign files, not the download's outcome:
-    // the sweep ran before the download, so it destroyed these even on paths
-    // where the download itself later failed.
+    // Reachability guard. The foreign-file assertions below are deliberately
+    // independent of the download's outcome — the sweep ran BEFORE the
+    // download, so it destroyed these even when the download later failed. But
+    // that independence means all three would pass vacuously if a future change
+    // made this call bail BEFORE the former sweep site, so pin how far we got.
+    //
+    // The download cannot actually succeed here: mockito serves on loopback and
+    // `validate_url_security` rejects private hosts for format URLs. That
+    // rejection is itself the proof we need — it happens at download dispatch,
+    // which is downstream of where the sweep ran (`episode.rs`, right after the
+    // output path was computed). An earlier bail-out would surface as a
+    // different variant and fail this assertion.
+    let err = result.expect_err("loopback format URL must be rejected by the SSRF gate");
+    assert!(
+        matches!(
+            err,
+            crate::orchestrator::errors::OrchestratorError::DownloadFailed(_)
+        ),
+        "expected to reach download dispatch (downstream of the old sweep site); \
+         a different error means this test no longer exercises that path and the \
+         assertions below are vacuous. Got: {err:?}"
+    );
+
     assert!(
         foreign_part.exists(),
         "a foreign .part1 file must survive — deleting it is #558"

--- a/crates/rdlp-api/src/orchestrator/postprocess.rs
+++ b/crates/rdlp-api/src/orchestrator/postprocess.rs
@@ -222,57 +222,6 @@ impl Orchestrator {
             Err(e) => Err(classify_pipeline_err(&e)),
         }
     }
-
-    /// Clean up leftover HLS segment files from interrupted downloads
-    ///
-    /// When HLS downloads are interrupted via Ctrl+C, segment files like
-    /// `filename.part0`, `filename.part1`, etc. may be left behind.
-    /// This function removes them before starting a new download.
-    pub(super) async fn cleanup_leftover_segments(&self, dir: &std::path::Path, base_name: &str) {
-        if !dir.exists() {
-            return;
-        }
-
-        let mut entries = match tokio::fs::read_dir(dir).await {
-            Ok(entries) => entries,
-            Err(e) => {
-                log::warn!(
-                    "cleanup_leftover_segments: could not enumerate {} ({e}); \
-                     stale .partN files may persist and confuse the next download's \
-                     resume detection",
-                    dir.display()
-                );
-                return;
-            }
-        };
-
-        let mut deleted = 0;
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
-                continue;
-            };
-
-            // Match pattern: base_name.part{number}
-            if !filename.starts_with(base_name) || !filename.contains(".part") {
-                continue;
-            }
-
-            // Verify it's a segment file (has numeric suffix after .part)
-            if let Some(part_idx) = filename.rfind(".part") {
-                let suffix = &filename[part_idx + 5..];
-                if suffix.chars().all(|c| c.is_ascii_digit())
-                    && tokio::fs::remove_file(&path).await.is_ok()
-                {
-                    deleted += 1;
-                }
-            }
-        }
-
-        if deleted > 0 {
-            debug!(deleted; "Cleaned up leftover segment files");
-        }
-    }
 }
 
 #[cfg(test)]

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -23,6 +23,19 @@ for script in scripts/check-*.sh; do
     fi
 done
 
+# A gate passing is not the same as a gate still working. The dir-sweep gate is
+# a textual matcher that could rot into a no-op, so verify it still fires --
+# otherwise the local checklist would be weaker than CI, which is the asymmetry
+# this aggregate exists to close.
+printf '%-44s' "check-no-dir-sweep-delete --self-test"
+if output=$(bash scripts/check-no-dir-sweep-delete.sh --self-test 2>&1); then
+    echo "OK"
+else
+    echo "FAILED"
+    printf '%s\n' "$output" | sed 's/^/    /'
+    FAILED=1
+fi
+
 if [ "$FAILED" -eq 1 ]; then
     echo ""
     echo "One or more invariant gates failed."

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Run every invariant gate. Referenced by CODING_RULES.md's Pre-Commit Checklist
+# so the gates have a committed local entry point, not only a CI one.
+#
+# Usage: bash scripts/check-all.sh
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+FAILED=0
+
+for script in scripts/check-*.sh; do
+    # Don't recurse into this aggregate.
+    [ "$(basename "$script")" = "check-all.sh" ] && continue
+    printf '%-44s' "$(basename "$script")"
+    if output=$(bash "$script" 2>&1); then
+        echo "OK"
+    else
+        echo "FAILED"
+        printf '%s\n' "$output" | sed 's/^/    /'
+        FAILED=1
+    fi
+done
+
+if [ "$FAILED" -eq 1 ]; then
+    echo ""
+    echo "One or more invariant gates failed."
+    exit 1
+fi
+
+echo ""
+echo "All invariant gates passed."

--- a/scripts/check-no-dir-sweep-delete.sh
+++ b/scripts/check-no-dir-sweep-delete.sh
@@ -77,7 +77,7 @@ DELETE='remove_file|remove_dir'
 # Scan one directory tree; echo any offending files. Shared by the real run and
 # the self-test so the self-test exercises the SAME matcher, not a copy of it.
 scan() {
-    local root="$1" file prod
+    local file prod
     while IFS= read -r file; do
         # Exact match, not substring: a substring test would let a new file whose
         # path contains an allowlisted path slip through unexamined.
@@ -94,8 +94,14 @@ scan() {
             && printf '%s' "$prod" | grep -qE "$DELETE"; then
             printf '%s\n' "$file"
         fi
-    done < <(find "$root" -name '*.rs' -type f)
+    done < <(find "$@" -name '*.rs' -type f)
 }
+
+# The one place the scan scope is defined. `crates/*/src` deliberately excludes
+# `crates/*/tests/` — an integration test has no `#[cfg(test)]` attribute (the
+# whole file is test code), so the stripping above would not apply and a
+# legitimate TempDir-cleanup test would be flagged as a #558 violation.
+SCAN_ROOTS=(crates/*/src)
 
 if [ "$SELF_TEST" -eq 1 ]; then
     tmp=$(mktemp -d)
@@ -116,14 +122,15 @@ FIXTURE
     exit 1
 fi
 
-# Guard against scanning nothing and calling it a pass.
-file_count=$(find crates/*/src -name '*.rs' -type f | wc -l)
+# Guard against scanning nothing and calling it a pass. Counted over the SAME
+# roots the scan walks, so the reported number is the number actually examined.
+file_count=$(find "${SCAN_ROOTS[@]}" -name '*.rs' -type f | wc -l)
 if [ "$file_count" -eq 0 ]; then
     echo "ERROR: found no .rs files under crates/*/src — refusing to report OK."
     exit 1
 fi
 
-violations=$(scan "crates")
+violations=$(scan "${SCAN_ROOTS[@]}")
 
 if [ -n "$violations" ]; then
     echo "ERROR: directory enumeration co-located with file deletion:"

--- a/scripts/check-no-dir-sweep-delete.sh
+++ b/scripts/check-no-dir-sweep-delete.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# CI guard: fail if orchestrator code enumerates a directory and deletes
+# entries by filename pattern.
+#
+# Deleting a file you merely FOUND, rather than one you can prove you
+# created, is the defect class behind #558: cleanup_leftover_segments swept
+# the user's output directory for `{title}*.part{digits}` and unlinked every
+# match. A stray `MyShow S01E01.mp4.part1` from wget or aria2 was deleted, and
+# the sweep also destroyed rdlp's own resumable chunks immediately before
+# resume detection looked for them.
+#
+# CERT FIO21-C: "the only secure solution is to not create temporary files in
+# shared directories" -- and where unavoidable, use unique names plus
+# exclusive-open, never a post-hoc scan-and-delete. See also CWE-377 and
+# CWE-59. No comparable tool (yt-dlp, aria2, curl, wget, rsync) deletes by
+# directory-pattern match; every one of them deletes only exact computed
+# paths it tracked itself.
+#
+# The sanctioned alternatives, both already in-tree:
+#   - Delete an exact path this run computed and owns (see naming.rs).
+#   - TempRegistry::cleanup_stale (rdlp-postprocess/src/pipeline/registry.rs),
+#     which marker-scans `.rdlp-tmp-` AND requires an fs4 exclusive lock
+#     before removing, so a live peer's file is never touched.
+#
+# Usage: scripts/check-no-dir-sweep-delete.sh [--canary]
+#   --canary: verify the gate actually fires (expects to FIND a violation)
+
+set -euo pipefail
+
+SCOPE="crates/rdlp-api/src/orchestrator"
+CANARY=0
+[ "${1:-}" = "--canary" ] && CANARY=1
+
+# Find files that BOTH enumerate a directory and remove files. Either alone is
+# fine -- listing a directory is harmless, and deleting a computed path is the
+# sanctioned pattern. The co-occurrence is what indicates a sweep.
+#
+# Production code only: everything from the first `#[cfg(test)]` onward is
+# dropped before scanning. Tests legitimately read_dir a TempDir to assert on
+# its contents (e.g. naming.rs's finalize tests), which is not this defect.
+violations=""
+while IFS= read -r file; do
+    prod=$(sed '/#\[cfg(test)\]/,$d' "$file")
+    if printf '%s' "$prod" | grep -q 'read_dir' \
+        && printf '%s' "$prod" | grep -q 'remove_file\|remove_dir'; then
+        violations="${violations}${file}\n"
+    fi
+done < <(find "$SCOPE" -name '*.rs' -type f 2>/dev/null)
+
+if [ -n "$violations" ]; then
+    if [ "$CANARY" -eq 1 ]; then
+        echo "CANARY OK: gate fires on:"
+        printf "%b" "$violations"
+        exit 0
+    fi
+    echo "ERROR: directory enumeration co-located with file deletion:"
+    printf "%b" "$violations"
+    echo ""
+    echo "Deleting files discovered by a directory scan cannot distinguish"
+    echo "'a file rdlp created' from 'a file the user already had' (#558)."
+    echo "Delete an exact path this run computed, or use TempRegistry's"
+    echo "lock-gated cleanup_stale. See the header of this script."
+    exit 1
+fi
+
+if [ "$CANARY" -eq 1 ]; then
+    echo "CANARY FAILED: gate found nothing -- it would not catch a regression."
+    exit 1
+fi
+
+echo "OK: No directory-sweep deletion in $SCOPE."

--- a/scripts/check-no-dir-sweep-delete.sh
+++ b/scripts/check-no-dir-sweep-delete.sh
@@ -1,51 +1,84 @@
 #!/bin/bash
-# CI guard: fail if orchestrator code enumerates a directory and deletes
-# entries by filename pattern.
+# CI guard: fail if production code enumerates a directory and deletes what it
+# finds there.
 #
-# Deleting a file you merely FOUND, rather than one you can prove you
-# created, is the defect class behind #558: cleanup_leftover_segments swept
-# the user's output directory for `{title}*.part{digits}` and unlinked every
-# match. A stray `MyShow S01E01.mp4.part1` from wget or aria2 was deleted, and
-# the sweep also destroyed rdlp's own resumable chunks immediately before
-# resume detection looked for them.
+# Deleting a file you merely FOUND, rather than one you can prove you created,
+# is the defect class behind #558: cleanup_leftover_segments swept the user's
+# output directory for `{title}*.part{digits}` and unlinked every match. A stray
+# `MyShow S01E01.mp4.part1` from wget or aria2 was deleted, and the sweep also
+# destroyed rdlp's own resumable chunks immediately before resume detection
+# looked for them.
 #
 # CERT FIO21-C: "the only secure solution is to not create temporary files in
 # shared directories" -- and where unavoidable, use unique names plus
-# exclusive-open, never a post-hoc scan-and-delete. See also CWE-377 and
-# CWE-59. No comparable tool (yt-dlp, aria2, curl, wget, rsync) deletes by
-# directory-pattern match; every one of them deletes only exact computed
-# paths it tracked itself.
+# exclusive-open, never a post-hoc scan-and-delete. See also CWE-377, CWE-59.
+# No comparable tool (yt-dlp, aria2, curl, wget, rsync) deletes by
+# directory-pattern match; each deletes only exact paths it computed itself.
 #
-# The sanctioned alternatives, both already in-tree:
-#   - Delete an exact path this run computed and owns (see naming.rs).
-#   - TempRegistry::cleanup_stale (rdlp-postprocess/src/pipeline/registry.rs),
-#     which marker-scans `.rdlp-tmp-` AND requires an fs4 exclusive lock
-#     before removing, so a live peer's file is never touched.
+# Sanctioned alternatives, both already in-tree:
+#   - Delete an exact path this run computed and owns (see orchestrator/naming.rs).
+#   - TempRegistry::cleanup_stale (rdlp-postprocess/src/pipeline/registry.rs):
+#     marker-scans `.rdlp-tmp-`, requires an fs4 exclusive lock before removing,
+#     and applies an age floor -- so a live peer's file is never touched.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS GATE DOES NOT CATCH -- read before trusting it.
+#
+# This is a textual co-occurrence check, not dataflow analysis. Known evasions,
+# all identified in the #558 security review:
+#
+#   1. EXISTENCE-PROBE LOOPS. `for i in 0..N { if p.exists() { remove_file(p) } }`
+#      never calls read_dir, so it is invisible here -- and that shape is already
+#      precedented in this codebase (resume.rs cleanup_old_chunks,
+#      parallel.rs cleanup_chunk_files). A #558-style bug rewritten that way
+#      would NOT be flagged. This is the most likely real-world evasion.
+#   2. CROSS-FILE SPLIT. A helper in module A enumerates; module B deletes what
+#      it returns. Neither file trips the co-occurrence test.
+#   3. Enumeration via an aliased or re-exported read_dir.
+#
+# Treat this as a narrow regression guard for the specific shape #558 had, not
+# as proof the defect class is eliminated. Broadening it (semgrep dataflow --
+# semgrep is already installed later in the same CI job) is tracked separately.
+# ---------------------------------------------------------------------------
 #
 # Usage: scripts/check-no-dir-sweep-delete.sh [--canary]
-#   --canary: verify the gate actually fires (expects to FIND a violation)
+#   --canary: invert the check -- expects to FIND a violation. Used to prove the
+#             gate actually fires; run it against a tree that still has one.
 
 set -euo pipefail
 
-SCOPE="crates/rdlp-api/src/orchestrator"
 CANARY=0
 [ "${1:-}" = "--canary" ] && CANARY=1
 
-# Find files that BOTH enumerate a directory and remove files. Either alone is
-# fine -- listing a directory is harmless, and deleting a computed path is the
-# sanctioned pattern. The co-occurrence is what indicates a sweep.
+# Allowlist: each entry must state why scanning-then-deleting is sound there.
 #
-# Production code only: everything from the first `#[cfg(test)]` onward is
-# dropped before scanning. Tests legitimately read_dir a TempDir to assert on
-# its contents (e.g. naming.rs's finalize tests), which is not this defect.
+# - rdlp-postprocess/src/pipeline/registry.rs: TempRegistry::cleanup_stale. Not
+#   a pattern sweep -- requires the `.rdlp-tmp-` marker AND an fs4 exclusive
+#   advisory lock AND an age floor before unlinking, so it provably never
+#   removes a live peer's file. This is the sanctioned discovery mechanism.
+# - rdlp-cli/src/plugin_cmd.rs and plugin_cmd/build_from_ytdlp.rs: `rdlp plugin
+#   remove <name>` deletes one plugin directory the user explicitly named, after
+#   validate_plugin_name rejects traversal. User-directed removal of an exact
+#   computed path, not artifact reclamation.
+ALLOWLIST='crates/rdlp-postprocess/src/pipeline/registry.rs
+crates/rdlp-cli/src/plugin_cmd.rs
+crates/rdlp-cli/src/plugin_cmd/build_from_ytdlp.rs'
+
+ENUMERATE='read_dir|WalkDir|walkdir|glob::'
+DELETE='remove_file|remove_dir'
+
 violations=""
 while IFS= read -r file; do
+    case "$ALLOWLIST" in *"$file"*) continue ;; esac
+    # Production code only: drop everything from the first `#[cfg(test)]` on.
+    # Tests legitimately read_dir a TempDir to assert on its contents (e.g.
+    # naming.rs's finalize tests), which is not this defect.
     prod=$(sed '/#\[cfg(test)\]/,$d' "$file")
-    if printf '%s' "$prod" | grep -q 'read_dir' \
-        && printf '%s' "$prod" | grep -q 'remove_file\|remove_dir'; then
+    if printf '%s' "$prod" | grep -qE "$ENUMERATE" \
+        && printf '%s' "$prod" | grep -qE "$DELETE"; then
         violations="${violations}${file}\n"
     fi
-done < <(find "$SCOPE" -name '*.rs' -type f 2>/dev/null)
+done < <(find crates/*/src -name '*.rs' -type f 2>/dev/null)
 
 if [ -n "$violations" ]; then
     if [ "$CANARY" -eq 1 ]; then
@@ -68,4 +101,4 @@ if [ "$CANARY" -eq 1 ]; then
     exit 1
 fi
 
-echo "OK: No directory-sweep deletion in $SCOPE."
+echo "OK: No directory-sweep deletion in production code."

--- a/scripts/check-no-dir-sweep-delete.sh
+++ b/scripts/check-no-dir-sweep-delete.sh
@@ -41,14 +41,21 @@
 # semgrep is already installed later in the same CI job) is tracked separately.
 # ---------------------------------------------------------------------------
 #
-# Usage: scripts/check-no-dir-sweep-delete.sh [--canary]
-#   --canary: invert the check -- expects to FIND a violation. Used to prove the
-#             gate actually fires; run it against a tree that still has one.
+# Usage: scripts/check-no-dir-sweep-delete.sh [--self-test]
+#   --self-test: prove the gate still fires, by scanning a synthetic violating
+#                file in a temp dir. Runs in CI every time, so "canary-verified"
+#                stays true as the tree evolves instead of being a one-off claim.
 
 set -euo pipefail
 
-CANARY=0
-[ "${1:-}" = "--canary" ] && CANARY=1
+# Anchor to the repo root. `crates/*/src` is a relative glob: run from anywhere
+# else it expands to nothing, find scans zero files, and the script would
+# cheerfully report OK. A gate that passes having scanned nothing is worse than
+# no gate, so this is load-bearing, not tidiness.
+cd "$(git rev-parse --show-toplevel)"
+
+SELF_TEST=0
+[ "${1:-}" = "--self-test" ] && SELF_TEST=1
 
 # Allowlist: each entry must state why scanning-then-deleting is sound there.
 #
@@ -67,27 +74,60 @@ crates/rdlp-cli/src/plugin_cmd/build_from_ytdlp.rs'
 ENUMERATE='read_dir|WalkDir|walkdir|glob::'
 DELETE='remove_file|remove_dir'
 
-violations=""
-while IFS= read -r file; do
-    case "$ALLOWLIST" in *"$file"*) continue ;; esac
-    # Production code only: drop everything from the first `#[cfg(test)]` on.
-    # Tests legitimately read_dir a TempDir to assert on its contents (e.g.
-    # naming.rs's finalize tests), which is not this defect.
-    prod=$(sed '/#\[cfg(test)\]/,$d' "$file")
-    if printf '%s' "$prod" | grep -qE "$ENUMERATE" \
-        && printf '%s' "$prod" | grep -qE "$DELETE"; then
-        violations="${violations}${file}\n"
-    fi
-done < <(find crates/*/src -name '*.rs' -type f 2>/dev/null)
+# Scan one directory tree; echo any offending files. Shared by the real run and
+# the self-test so the self-test exercises the SAME matcher, not a copy of it.
+scan() {
+    local root="$1" file prod
+    while IFS= read -r file; do
+        # Exact match, not substring: a substring test would let a new file whose
+        # path contains an allowlisted path slip through unexamined.
+        if printf '%s\n' "$ALLOWLIST" | grep -Fxq "$file"; then
+            continue
+        fi
+        # Production code only: drop everything from the first `#[cfg(test)]` on.
+        # Tests legitimately read_dir a TempDir to assert on its contents (e.g.
+        # naming.rs's finalize tests), which is not this defect. This assumes the
+        # first `#[cfg(test)]` in a file begins its tail test module -- true
+        # across crates/*/src today.
+        prod=$(sed '/#\[cfg(test)\]/,$d' "$file")
+        if printf '%s' "$prod" | grep -qE "$ENUMERATE" \
+            && printf '%s' "$prod" | grep -qE "$DELETE"; then
+            printf '%s\n' "$file"
+        fi
+    done < <(find "$root" -name '*.rs' -type f)
+}
 
-if [ -n "$violations" ]; then
-    if [ "$CANARY" -eq 1 ]; then
-        echo "CANARY OK: gate fires on:"
-        printf "%b" "$violations"
+if [ "$SELF_TEST" -eq 1 ]; then
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cat > "$tmp/sweep.rs" <<'FIXTURE'
+async fn sweep(dir: &Path) {
+    let mut entries = tokio::fs::read_dir(dir).await.unwrap();
+    while let Ok(Some(e)) = entries.next_entry().await {
+        let _ = tokio::fs::remove_file(e.path()).await;
+    }
+}
+FIXTURE
+    if [ -n "$(scan "$tmp")" ]; then
+        echo "SELF-TEST OK: the gate still detects a directory sweep."
         exit 0
     fi
+    echo "SELF-TEST FAILED: the gate did NOT flag a known sweep — it is broken."
+    exit 1
+fi
+
+# Guard against scanning nothing and calling it a pass.
+file_count=$(find crates/*/src -name '*.rs' -type f | wc -l)
+if [ "$file_count" -eq 0 ]; then
+    echo "ERROR: found no .rs files under crates/*/src — refusing to report OK."
+    exit 1
+fi
+
+violations=$(scan "crates")
+
+if [ -n "$violations" ]; then
     echo "ERROR: directory enumeration co-located with file deletion:"
-    printf "%b" "$violations"
+    printf '%s\n' "$violations"
     echo ""
     echo "Deleting files discovered by a directory scan cannot distinguish"
     echo "'a file rdlp created' from 'a file the user already had' (#558)."
@@ -96,9 +136,4 @@ if [ -n "$violations" ]; then
     exit 1
 fi
 
-if [ "$CANARY" -eq 1 ]; then
-    echo "CANARY FAILED: gate found nothing -- it would not catch a regression."
-    exit 1
-fi
-
-echo "OK: No directory-sweep deletion in production code."
+echo "OK: No directory-sweep deletion in production code ($file_count files scanned)."


### PR DESCRIPTION
## Resolves

Closes #558

## Summary

`cleanup_leftover_segments` enumerated the user's output directory and unlinked every entry matching `starts_with(title)` + `contains(".part")` + digits after the last `.part`. This removes it and both call sites.

**It deleted the user's files.** A stray `MyShow S01E01.mp4.part1` left by wget, aria2, or a browser matched and was deleted on a normal, successful download. Multipart RAR (`.part1.rar`) survived only by luck — its suffix contains non-digits. The digit check also admitted an **empty** suffix, because `all()` on an empty iterator is vacuously true, so a bare `Title.mp4.part` matched too.

**It also broke the thing it was documented to protect.** rdlp's own chunks are named `{title}.rdlp-part.mp4.{id}.part{i}`, which matches the sweep. `episode.rs` ran the sweep at line 150 and called `detect_resume_point` at line 170 — so it deleted the resumable chunks immediately before looking for them. Resume could never succeed on the playlist path. (The `.rdlp-part` file itself survived by luck: `.rdlp-part` does not contain the literal substring `.part`, since the character before `part` is `-`.)

## Why removal rather than a tighter pattern

Tightening the matcher was explicitly rejected. The mechanism class is wrong, not just its parameters — that only closes the filed bug and leaves the next one.

- **CERT FIO21-C**: *"the only secure solution is to not create temporary files in shared directories"* — and where unavoidable, unique names plus exclusive-open, never post-hoc scan-and-delete. See also CWE-377, CWE-59.
- **No comparable tool deletes by directory-pattern match.** yt-dlp's `downloader/common.py` computes exactly one `.part` path and every `try_rename`/`try_remove` operates on that literal string — no `glob`/`listdir` in the cleanup path at all. aria2's `.aria2` control file is exact-path by construction, and when a transfer isn't resumable it creates no control file and *leaves the partial alone* rather than inventing a fallback. rsync `--partial-dir`, wget `-c`, curl `--continue-at`: all exact computed paths.
- **`tempfile` deliberately declines** to offer orphan reclamation, delegating it to `systemd-tmpfiles`, which reclaims on an *age* signal at the OS layer. That's the precedent for "reclaiming artifacts you cannot prove you created is not the application's job."
- **rdlp already has the sound mechanism in-tree.** `TempRegistry::cleanup_stale` marker-scans `.rdlp-tmp-`, requires an `fs4` exclusive lock, and applies an age floor — so it never touches a live peer's file.

Nothing replaces the sweep: the downloader already cleans its own chunks via `cleanup_chunk_files`, and `detect_resume_point` handles leftovers by design. Both verified independently by the security reviewer rather than taken from the commit message.

## Regression protection

**A behavioral test** (`playlist/tests.rs`) drives the real `download_from_info_to_dir` against a mockito server with three foreign files planted in the output directory, and asserts all three survive. Verified RED by restoring the sweep verbatim from `develop`. It pins the user-visible harm rather than a source-text shape, so it stays valid however a future sweep is spelled.

It carries a reachability guard. The foreign-file assertions are deliberately independent of the download's outcome — the sweep ran *before* the download, so it destroyed those files even when the download later failed — but that independence would let all three pass vacuously if a future change bailed earlier. Note the download cannot succeed in this test at all: mockito serves on loopback and `validate_url_security` rejects private hosts for format URLs. That rejection *is* the proof, since it happens at download dispatch, downstream of the old sweep site — so the guard asserts `DownloadFailed` rather than success.

**A CI gate** (`scripts/check-no-dir-sweep-delete.sh`) flags production code that both enumerates a directory and removes files, with three documented allowlist entries (`TempRegistry::cleanup_stale`; the two `plugin_cmd` sites, which delete one user-named validated path).

The gate's header states plainly **what it does not catch** rather than implying the CWE-377 class is closed: existence-probe loops (`for i in 0..N { if exists { remove } }`) never call `read_dir` and are invisible to it — and that shape is already precedented here in `cleanup_old_chunks` and `cleanup_chunk_files`. It is a narrow regression guard for the shape #558 had; the behavioral test is what covers the rest.

`scripts/check-all.sh` gives the gates a committed local entry point from `CODING_RULES.md`'s Pre-Commit Checklist — previously they were reachable only from CI and from the gitignored `CLAUDE.md`.

## Verification

`cargo fmt --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` exit 0 · `cargo test --workspace` 3764 passed / 0 failed · `cargo check -p rdlp-desktop` clean · `bash scripts/check-all.sh` all 8 gates plus the self-test pass.

## Reviews

**security-reviewer — PASS**, no findings at Medium or above on the fix itself. Independently verified the no-behavioral-gap claim, confirmed `TempRegistry::cleanup_stale` is sound, and grepped the workspace for any remaining `read_dir`+`remove_file` co-location. Raised two MEDIUM follow-ups, neither merge-blocking: the pre-existing filename-trust gap in `resume.rs` chunk merging (whose exposure window this removal widens, since the sweep incidentally cleared some stray matches), and the gate's partial coverage.

**code-reviewer — Request changes → Approve with minor fixes.** Round 1 found four issues, all fixed in `77d6b0f9`: the gate reported OK while scanning **zero files** from any CWD but the repo root; it was wired only to a CI workflow last run 2026-05-05 with no committed local path; there was no behavioral test; and `--canary` could not self-verify. Round 2 confirmed all four and found the scan scope disagreed with the count guard, with integration tests scanned as production code — fixed in `393d7b0a`.

## Follow-ups

Filed from a four-angle research pass on resume correctness (RFC 9110/9112 full-text, comparative study of aria2/yt-dlp/curl/wget/rsync, a documented-failure-mode catalogue, and an in-tree audit):

- **#564** — HLS/DASH fragment byte-range fetches accept any 2xx with no range validation. Same defect class as #526, on a path PR #527 did not touch.
- **#565** — rdlp sends no conditional validators anywhere (zero workspace hits for `If-Range`/`ETag`/`Last-Modified`), so a resource changing mid-resume corrupts silently.
- **#566** — remaining resume validation gaps: single-file path, orphan-chunk merge, `download_id` reuse, DASH segment completeness.

Also worth tracking from the security review: hardening `resume.rs` chunk-merge provenance, and broadening this gate (a semgrep dataflow rule would catch the existence-probe shape; semgrep is already installed in the same CI job).
