### PR TITLE
fix(downloader): validate ranged fragment responses before accepting the body

### DIFF
--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
 use crate::atomic::{SIDECAR_SAVE_FAILURE_THRESHOLD, SaveFailureTracker};
-use crate::http::HttpDownloader;
+use crate::http::{HttpDownloader, RequestedSpan, validate_range_response};
 use crate::progress::SpeedMeter;
 use rdlp_security;
 
@@ -532,19 +532,34 @@ async fn fetch_with_optional_range(
     if same_origin {
         req = req.headers(http.headers());
     }
-    if let Some((start, end_exclusive)) = byte_range {
-        // Saturating_sub guards against any future caller passing end_exclusive == 0.
-        // (Caller responsibility: end_exclusive > start, validated at expand time.)
-        let end_inclusive = end_exclusive.saturating_sub(1);
-        let value = format!("bytes={start}-{end_inclusive}");
-        req = req.header(
-            "Range",
-            HeaderValue::from_str(&value).map_err(|e| rdlp_core::RdlpError::Download {
-                message: format!("fetch {safe_url}: {e}"),
-                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
-            })?,
-        );
-    }
+
+    // `byte_range` is `(start, end_exclusive)`; RFC 7233's `Range` header and
+    // `RequestedSpan` are both inclusive, so `end_exclusive` is converted once
+    // here and the same `end_inclusive` is reused below to build the span that
+    // validates the response — never recomputed a second way.
+    let requested_span = match byte_range {
+        Some((start, end_exclusive)) => {
+            let end_inclusive = end_exclusive.saturating_sub(1);
+            let value = format!("bytes={start}-{end_inclusive}");
+            req = req.header(
+                "Range",
+                HeaderValue::from_str(&value).map_err(|e| rdlp_core::RdlpError::Download {
+                    message: format!("fetch {safe_url}: {e}"),
+                    url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+                })?,
+            );
+            Some(RequestedSpan::new(start, end_inclusive).ok_or_else(|| {
+                rdlp_core::RdlpError::Download {
+                    url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+                    message: format!(
+                        "internal error: fragment requested an inverted byte range \
+                         {start}-{end_inclusive}"
+                    ),
+                }
+            })?)
+        }
+        None => None,
+    };
 
     let resp = req
         .send()
@@ -554,20 +569,58 @@ async fn fetch_with_optional_range(
             url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
         })?;
 
-    if !resp.status().is_success() {
-        return Err(rdlp_core::RdlpError::Http {
-            status: resp.status().as_u16(),
-            reason: format!("fragment HTTP {}", resp.status()),
+    // Unranged fetches keep the plain success-status gate — a 200 is exactly
+    // right there and must not be held to a 206 standard.
+    //
+    // Ranged fetches (HLS #EXT-X-BYTERANGE / DASH mediaRange) reuse the same
+    // validator #526 added for the parallel-chunk path: RFC 9110 §14.2
+    // permits a server to ignore Range entirely and reply 200 with the WHOLE
+    // resource, and §15.3.7.1 requires a single-part 206 to carry
+    // Content-Range. Skipping this check is exactly what let a whole-file
+    // body land in a slot sized for one fragment.
+    let expected_len = if let Some(span) = requested_span {
+        validate_range_response(&resp, span, url)?;
+        Some(span.len())
+    } else {
+        if !resp.status().is_success() {
+            return Err(rdlp_core::RdlpError::Http {
+                status: resp.status().as_u16(),
+                reason: format!("fragment HTTP {}", resp.status()),
+            });
+        }
+        None
+    };
+
+    let body =
+        resp.bytes()
+            .await
+            .map(|b| b.to_vec())
+            .map_err(|e| rdlp_core::RdlpError::Network {
+                message: format!("read {safe_url}: {e}"),
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+            })?;
+
+    // The Content-Range check above only inspected headers; confirm the body
+    // that actually arrived is exactly the promised length. This single
+    // post-read check covers both a short body (§14.2 permits a server to
+    // send only part of a range, expecting a re-request) and an over-long
+    // body — the chunk path checks these directions separately because it
+    // streams, but this path already buffers the whole body via
+    // `resp.bytes()`, so one length comparison after the read suffices.
+    if let Some(expected_len) = expected_len
+        && body.len() as u64 != expected_len
+    {
+        return Err(rdlp_core::RdlpError::Download {
+            url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+            message: format!(
+                "ranged fragment fetch {safe_url} delivered {} bytes; expected exactly \
+                 {expected_len} bytes per its Content-Range",
+                body.len()
+            ),
         });
     }
 
-    resp.bytes()
-        .await
-        .map(|b| b.to_vec())
-        .map_err(|e| rdlp_core::RdlpError::Network {
-            message: format!("read {safe_url}: {e}"),
-            url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
-        })
+    Ok(body)
 }
 
 pub(crate) mod state;

--- a/crates/rdlp-downloader/src/fragments.rs
+++ b/crates/rdlp-downloader/src/fragments.rs
@@ -505,7 +505,7 @@ async fn fetch_with_optional_cancel(
 
 /// Fetch `url`, optionally as an HTTP byte range.
 ///
-/// The `byte_range` tuple is `(start, end_exclusive)` and is converted to RFC 7233
+/// The `byte_range` tuple is `(start, end_exclusive)` and is converted to RFC 9110
 /// `Range: bytes=start-end_inclusive` (subtract 1 for HTTP's inclusive end).
 ///
 /// `format_origin` enforces the same-origin header gate: `http.headers()` are
@@ -533,7 +533,7 @@ async fn fetch_with_optional_range(
         req = req.headers(http.headers());
     }
 
-    // `byte_range` is `(start, end_exclusive)`; RFC 7233's `Range` header and
+    // `byte_range` is `(start, end_exclusive)`; RFC 9110's `Range` header and
     // `RequestedSpan` are both inclusive, so `end_exclusive` is converted once
     // here and the same `end_inclusive` is reused below to build the span that
     // validates the response — never recomputed a second way.

--- a/crates/rdlp-downloader/src/fragments/tests.rs
+++ b/crates/rdlp-downloader/src/fragments/tests.rs
@@ -1536,7 +1536,7 @@ fn extrapolate_total_none_on_multiplication_overflow() {
 // land in the merged output's chunk slot. `fetch_with_optional_range` sends the
 // same `Range` header for HLS BYTERANGE / DASH mediaRange fragments but only
 // gated on `resp.status().is_success()` — a server that ignores Range (legal
-// per RFC 9110 §14.4 / RFC 7233) replies 200 with the WHOLE resource, and the
+// per RFC 9110 §14.2) replies 200 with the WHOLE resource, and the
 // unvalidated body is written into a slot sized for one fragment.
 //
 // These tests drive the fix through the fragment-list entry point
@@ -1576,9 +1576,15 @@ async fn ranged_fragment_200_full_body_is_rejected() {
     let res =
         download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
             .await;
+    let err = res.expect_err(
+        "a plain 200 answering a ranged request must be rejected, not accepted as the fragment body",
+    );
+    // Discriminate: without this the test would also pass if the download
+    // failed for an unrelated reason, making it a much weaker guard.
+    let msg = err.to_string();
     assert!(
-        res.is_err(),
-        "a plain 200 answering a ranged request must be rejected, not accepted as the fragment body"
+        msg.contains("got HTTP 200") && msg.contains("expected 206"),
+        "must fail on the status check specifically, got: {msg}"
     );
 }
 
@@ -1603,9 +1609,13 @@ async fn ranged_fragment_content_range_wrong_span_is_rejected() {
     let res =
         download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
             .await;
+    let err = res.expect_err(
+        "a 206 whose Content-Range encloses a different span than requested must be rejected",
+    );
+    let msg = err.to_string();
     assert!(
-        res.is_err(),
-        "a 206 whose Content-Range encloses a different span than requested must be rejected"
+        msg.contains("Content-Range bytes 0-1023") && msg.contains("different span"),
+        "must fail on the span-equality check specifically, got: {msg}"
     );
 }
 
@@ -1630,9 +1640,13 @@ async fn ranged_fragment_short_body_is_rejected() {
     let res =
         download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
             .await;
+    let err = res.expect_err(
+        "a 206 whose body is shorter than its own Content-Range promise must be rejected",
+    );
+    let msg = err.to_string();
     assert!(
-        res.is_err(),
-        "a 206 whose body is shorter than its own Content-Range promise must be rejected"
+        msg.contains("delivered 512 bytes") && msg.contains("expected exactly 1024"),
+        "must fail on the body-length check specifically, and name both counts, got: {msg}"
     );
 }
 
@@ -1657,9 +1671,13 @@ async fn ranged_fragment_over_long_body_is_rejected() {
     let res =
         download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
             .await;
+    let err = res.expect_err(
+        "a 206 whose body is longer than its own Content-Range promise must be rejected",
+    );
+    let msg = err.to_string();
     assert!(
-        res.is_err(),
-        "a 206 whose body is longer than its own Content-Range promise must be rejected"
+        msg.contains("delivered 2048 bytes") && msg.contains("expected exactly 1024"),
+        "must fail on the body-length check specifically, and name both counts, got: {msg}"
     );
 }
 

--- a/crates/rdlp-downloader/src/fragments/tests.rs
+++ b/crates/rdlp-downloader/src/fragments/tests.rs
@@ -8,6 +8,8 @@ async fn byte_range_emits_http_range_header() {
     let _seg = server
         .mock("GET", "/seg.m4s")
         .match_header("Range", Matcher::Regex(r"^bytes=1024-2047$".to_string()))
+        .with_status(206)
+        .with_header("Content-Range", "bytes 1024-2047/8192")
         .with_body(b"X".repeat(1024))
         .expect(1)
         .create_async()
@@ -1525,4 +1527,189 @@ fn extrapolate_total_none_on_multiplication_overflow() {
         est, None,
         "overflowing extrapolation must yield None, per the \"None when unknown\" principle"
     );
+}
+
+// --- fetch_with_optional_range: ranged-fragment response validation (issue #564) ---
+//
+// #526 fixed the parallel-chunk path (crates/rdlp-downloader/src/http/mod.rs) by
+// validating a ranged response's status/Content-Range/length BEFORE any bytes
+// land in the merged output's chunk slot. `fetch_with_optional_range` sends the
+// same `Range` header for HLS BYTERANGE / DASH mediaRange fragments but only
+// gated on `resp.status().is_success()` — a server that ignores Range (legal
+// per RFC 9110 §14.4 / RFC 7233) replies 200 with the WHOLE resource, and the
+// unvalidated body is written into a slot sized for one fragment.
+//
+// These tests drive the fix through the fragment-list entry point
+// (`download_pre_resolved_fragments`) rather than calling the private
+// `fetch_with_optional_range` directly, so they exercise the exact code path
+// #564 describes end to end.
+
+fn ranged_frag(url: String, start: u64, end_exclusive: u64) -> Fragment {
+    Fragment {
+        url,
+        byte_range: Some((start, end_exclusive)),
+        init_url: None,
+        init_byte_range: None,
+        duration: Some(6.0),
+        filesize: None,
+    }
+}
+
+#[tokio::test]
+async fn ranged_fragment_200_full_body_is_rejected() {
+    // Server ignores Range (RFC 9110 §14.2) and answers 200 with the WHOLE
+    // resource — far larger than the requested 1024-byte span. Accepting
+    // this silently writes the whole file into the fragment's slot.
+    let mut server = mockito::Server::new_async().await;
+    let _seg = server
+        .mock("GET", "/seg.m4s")
+        .with_status(200)
+        .with_body(vec![0xAA; 8192])
+        .create_async()
+        .await;
+
+    let url = format!("{}/seg.m4s", server.url());
+    let frags = vec![ranged_frag(url, 1024, 2048)];
+
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let res =
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
+            .await;
+    assert!(
+        res.is_err(),
+        "a plain 200 answering a ranged request must be rejected, not accepted as the fragment body"
+    );
+}
+
+#[tokio::test]
+async fn ranged_fragment_content_range_wrong_span_is_rejected() {
+    // 206 + Content-Range present, but it encloses a DIFFERENT span than the
+    // one requested (bytes=1024-2047 requested; server claims bytes=0-1023).
+    let mut server = mockito::Server::new_async().await;
+    let _seg = server
+        .mock("GET", "/seg.m4s")
+        .with_status(206)
+        .with_header("Content-Range", "bytes 0-1023/8192")
+        .with_body(vec![0xBB; 1024])
+        .create_async()
+        .await;
+
+    let url = format!("{}/seg.m4s", server.url());
+    let frags = vec![ranged_frag(url, 1024, 2048)];
+
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let res =
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
+            .await;
+    assert!(
+        res.is_err(),
+        "a 206 whose Content-Range encloses a different span than requested must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn ranged_fragment_short_body_is_rejected() {
+    // 206 + correct Content-Range (1024-2047, 1024 bytes) but the body is
+    // shorter than promised.
+    let mut server = mockito::Server::new_async().await;
+    let _seg = server
+        .mock("GET", "/seg.m4s")
+        .with_status(206)
+        .with_header("Content-Range", "bytes 1024-2047/8192")
+        .with_body(vec![0xCC; 512])
+        .create_async()
+        .await;
+
+    let url = format!("{}/seg.m4s", server.url());
+    let frags = vec![ranged_frag(url, 1024, 2048)];
+
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let res =
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
+            .await;
+    assert!(
+        res.is_err(),
+        "a 206 whose body is shorter than its own Content-Range promise must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn ranged_fragment_over_long_body_is_rejected() {
+    // 206 + correct Content-Range (1024-2047, 1024 bytes) but the body is
+    // longer than promised.
+    let mut server = mockito::Server::new_async().await;
+    let _seg = server
+        .mock("GET", "/seg.m4s")
+        .with_status(206)
+        .with_header("Content-Range", "bytes 1024-2047/8192")
+        .with_body(vec![0xDD; 2048])
+        .create_async()
+        .await;
+
+    let url = format!("{}/seg.m4s", server.url());
+    let frags = vec![ranged_frag(url, 1024, 2048)];
+
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let res =
+        download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
+            .await;
+    assert!(
+        res.is_err(),
+        "a 206 whose body is longer than its own Content-Range promise must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn ranged_fragment_correct_206_is_accepted() {
+    // Positive: 206 + matching Content-Range + exact-length body succeeds and
+    // the exact bytes land in the output.
+    let mut server = mockito::Server::new_async().await;
+    let body = vec![0xEE; 1024];
+    let _seg = server
+        .mock("GET", "/seg.m4s")
+        .with_status(206)
+        .with_header("Content-Range", "bytes 1024-2047/8192")
+        .with_body(body.clone())
+        .create_async()
+        .await;
+
+    let url = format!("{}/seg.m4s", server.url());
+    let frags = vec![ranged_frag(url, 1024, 2048)];
+
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
+        .await
+        .expect("a correct 206 + matching Content-Range + exact body must succeed");
+    let written = tokio::fs::read(tmp.path()).await.unwrap();
+    assert_eq!(written, body, "output must be exactly the validated span");
+}
+
+#[tokio::test]
+async fn unranged_fragment_plain_200_still_succeeds() {
+    // Regression guard: a fragment fetch with byte_range: None must keep
+    // today's behavior — a plain 200 is correct there and must NOT be
+    // required to be 206. This pins that the #564 fix does not require
+    // Partial Content on the no-Range path.
+    let mut server = mockito::Server::new_async().await;
+    let body = vec![0x11; 100];
+    let _f1 = server
+        .mock("GET", "/f1")
+        .with_status(200)
+        .with_body(body.clone())
+        .create_async()
+        .await;
+
+    let frags = vec![frag(format!("{}/f1", server.url()))];
+    let http = HttpDownloader::with_client(wreq::Client::new());
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    download_pre_resolved_fragments(&http, &frags, None, None, None, tmp.path(), None, None)
+        .await
+        .expect("unranged fragment fetch must still succeed on a plain 200");
+    let written = tokio::fs::read(tmp.path()).await.unwrap();
+    assert_eq!(written, body);
 }

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -78,8 +78,9 @@ pub(crate) use rdlp_http::ProbeResult;
 ///
 /// A `200` means the server ignored `Range` — permitted by §14.2 — and the
 /// content is the WHOLE representation, not the requested span. Writing such a
-/// body into a chunk's offset slot is the corruption in #526, so the parallel
-/// chunk path accepts this status and no other.
+/// body at a position computed for one span is the corruption in #526 (parallel
+/// chunk path) and #564 (HLS/DASH fragment path), so every ranged fetch accepts
+/// this status and no other.
 const HTTP_PARTIAL_CONTENT: u16 = 206;
 
 /// A parsed, validated single-part `Content-Range` response header.
@@ -178,7 +179,7 @@ pub(crate) fn parse_content_range_total(headers: &wreq::header::HeaderMap) -> Op
     ContentRange::from_headers(headers).and_then(|range| range.complete_length)
 }
 
-/// The inclusive byte span a ranged chunk fetch asked the server for.
+/// The inclusive byte span a ranged fetch asked the server for.
 ///
 /// Both bounds are inclusive, matching the `Range: bytes=start-end` request
 /// form and RFC 9110 §14.4's `incl-range`, so the span covers
@@ -213,14 +214,20 @@ impl RequestedSpan {
 }
 
 /// Confirm a ranged response actually carries the requested span before any of
-/// its bytes are written into the chunk's offset slot in the merged output.
+/// its bytes are written into the output.
 ///
-/// A parallel chunk is concatenated at a fixed position, so a response that
-/// encloses a different span silently relocates every byte after it — the
-/// ~517 MB interior displacement in #526. RFC 9110 §15.3.7 places this duty on
-/// the client: "A client MUST inspect a 206 response's Content-Type and
-/// Content-Range field(s) to determine what parts are enclosed and whether
-/// additional requests are needed."
+/// Two callers, both writing a ranged body at a position they computed in
+/// advance:
+/// - the parallel chunk downloader ([`download_chunk_with_retry`]), which
+///   concatenates each chunk at a fixed offset in the merged output;
+/// - the HLS/DASH fragment fetcher (`fragments::fetch_with_optional_range`),
+///   which appends `#EXT-X-BYTERANGE` / `mediaRange` bodies sequentially (#564).
+///
+/// In both cases a response enclosing a different span silently relocates every
+/// byte after it — the ~517 MB interior displacement in #526. RFC 9110 §15.3.7
+/// places this duty on the client: "A client MUST inspect a 206 response's
+/// Content-Type and Content-Range field(s) to determine what parts are enclosed
+/// and whether additional requests are needed."
 ///
 /// Only `Content-Range` is inspected here. The Content-Type half of that
 /// sentence exists to distinguish a single-part response from a
@@ -241,16 +248,16 @@ pub(crate) fn validate_range_response(
 
     // §14.2 permits a server to ignore Range; the reply is then a 200 carrying
     // the WHOLE representation. Accepting it here is what wrote whole-file
-    // content into a chunk slot.
+    // content into a slot sized for one span.
     let status = response.status().as_u16();
     if status != HTTP_PARTIAL_CONTENT {
         return Err(RdlpError::Download {
             url: redacted(),
             message: format!(
-                "ranged chunk request for bytes {}-{} got HTTP {status}, expected \
+                "ranged request for bytes {}-{} got HTTP {status}, expected \
                  {HTTP_PARTIAL_CONTENT} (Partial Content). The server ignored the Range \
                  header, so the body is the whole resource rather than the requested span \
-                 and cannot be placed at this chunk's offset.",
+                 and cannot be placed at this position in the output.",
                 span.start, span.end
             ),
         });
@@ -262,7 +269,7 @@ pub(crate) fn validate_range_response(
         return Err(RdlpError::Download {
             url: redacted(),
             message: format!(
-                "ranged chunk request for bytes {}-{} got a {HTTP_PARTIAL_CONTENT} response \
+                "ranged request for bytes {}-{} got a {HTTP_PARTIAL_CONTENT} response \
                  with a missing, malformed, or invalid Content-Range header; the enclosed \
                  span cannot be verified.",
                 span.start, span.end
@@ -279,9 +286,9 @@ pub(crate) fn validate_range_response(
         return Err(RdlpError::Network {
             url: redacted(),
             message: format!(
-                "ranged chunk request for bytes {}-{} got Content-Range bytes {}-{}; the \
+                "ranged request for bytes {}-{} got Content-Range bytes {}-{}; the \
                  response encloses a different span than requested and would corrupt the \
-                 output at this chunk's offset.",
+                 output at this position.",
                 span.start, span.end, range.first_pos, range.last_pos
             ),
         });

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -197,7 +197,7 @@ impl RequestedSpan {
     /// The invariant `start <= end` is what makes [`Self::len`]'s subtraction
     /// total; enforcing it here rather than at the call site means no caller
     /// can construct a span whose length underflows.
-    const fn new(start: u64, end: u64) -> Option<Self> {
+    pub(crate) const fn new(start: u64, end: u64) -> Option<Self> {
         if end < start {
             return None;
         }
@@ -207,7 +207,7 @@ impl RequestedSpan {
     /// Number of bytes the span covers.
     ///
     /// Cannot underflow: [`Self::new`] rejects `end < start`.
-    const fn len(self) -> u64 {
+    pub(crate) const fn len(self) -> u64 {
         self.end - self.start + 1
     }
 }
@@ -232,7 +232,7 @@ impl RequestedSpan {
 /// Returns `Err` (never a silent acceptance) when the status is not 206, the
 /// `Content-Range` is absent/malformed/invalid, or the enclosed span is not
 /// exactly the one requested.
-fn validate_range_response(
+pub(crate) fn validate_range_response(
     response: &wreq::Response,
     span: RequestedSpan,
     url: &str,


### PR DESCRIPTION
## Resolves

Closes #564

## Summary

`fetch_with_optional_range` (`crates/rdlp-downloader/src/fragments.rs`) gated only on `resp.status().is_success()` for HLS `#EXT-X-BYTERANGE` and DASH `mediaRange` fragment fetches. RFC 9110 §14.2 explicitly permits a server to ignore `Range` — *"A server MAY ignore the Range header field"* — in which case it replies `200` with the **entire** representation. Those bytes were then written into a slot sized for one fragment.

This is the same defect class as #526, the silent 517 MB corruption, on a code path PR #527 did not touch.

## The fix

Reuse the existing validator rather than writing a second one. `validate_range_response` (`http/mod.rs`) already encodes the RFC discipline and is well tested; it was module-private, so this widens it to `pub(crate)` along with `RequestedSpan::new`/`len`. Nothing becomes visible outside the crate.

Coverage before and after:

| Path | Status | Content-Range span | Byte count |
|---|---|---|---|
| Parallel chunk | ✅ | ✅ | ✅ |
| Single-file resume | ✅ | ⚠️ `first_pos` only | ❌ (tracked in #566) |
| **Fragment byte-range** | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ |

Three details worth calling out:

- **Validation is conditional on `byte_range.is_some()`.** An unranged fragment fetch must still accept a plain `200`; making 206 unconditional would break every ordinary HLS/DASH download. Pinned by a dedicated regression test.
- **Headers are checked before `resp.bytes()`.** The `200`-with-whole-file case is rejected without buffering the body.
- **`end_inclusive` is computed once** and feeds both the `Range` header string and the `RequestedSpan`, so the request and the thing validating it cannot drift apart.

## Tests

Six new tests, driven through `download_pre_resolved_fragments` against `mockito` rather than reaching into the private function.

Four negatives, each verified RED against unpatched code and each discriminating on the error text so it pins *which* guard fired:

| Test | Guard | Regression it catches |
|---|---|---|
| `ranged_fragment_200_full_body_is_rejected` | status ≠ 206 | the #564 defect itself |
| `ranged_fragment_content_range_wrong_span_is_rejected` | span equality | dropping the `first_pos`/`last_pos` comparison |
| `ranged_fragment_short_body_is_rejected` | body length | `>` instead of `!=` |
| `ranged_fragment_over_long_body_is_rejected` | body length | `<` instead of `!=` |

Two positives: a correct 206 is accepted, and — load-bearing — an **unranged** fetch answered with plain `200` still succeeds.

A malformed/unparseable `Content-Range`, a `416`, and a `multipart/byteranges` response are all structurally covered by the shared validator's existing tests (`http/tests.rs`), since this path now calls the same function. That coverage story only holds *because* the validator was reused rather than duplicated.

**One pre-existing test was modified.** `byte_range_emits_http_range_header` gained `with_status(206)` and a matching `Content-Range`. Its fixture was serving a bare `200` to a `Range` request — precisely the shape #564 says must be rejected — so it was passing only because of the bug. Its assertions (`match_header("Range", …)`, `expect(1)`) are unchanged; it now fails both if the `Range` header is dropped and if a well-formed 206 is wrongly rejected. Verified independently by the code reviewer as a fixture correction, not weakened coverage.

## Verification

`cargo fmt --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` exit 0 · `cargo test --workspace` **3770 passed / 0 failed** · `cargo check -p rdlp-desktop` clean · `bash scripts/check-all.sh` all 8 invariant gates pass.

## Reviews

**security-reviewer — PASS**, no Critical/High findings. Verified the corruption path is closed for both HLS and DASH (both share this single fetch function), that validation sits *inside* the cancel-guarded `tokio::select!` so no unvalidated bytes escape via a race, that visibility is `pub(crate)` and not wider, and that no raw URL reaches a log or error message. One MEDIUM, pre-existing and not introduced here: unranged fragment bodies are buffered with no cap → filed as #569.

**code-reviewer — Approve with minor fixes**, all fixed in `813a3b9c`:

- Widening the validator gave it a second caller, but its messages and rustdoc still said "chunk" — an HLS BYTERANGE failure reported a *chunk request* that doesn't exist on that path, and "cannot be placed at this chunk's offset" implied a remediation that is wrong for a fragment fetch, which appends sequentially. Neutralized to "ranged request" / "at this position in the output"; the genuinely chunk-specific messages in `parallel.rs` are untouched.
- The four negatives asserted only `res.is_err()`, so a regression failing every ranged fetch for an unrelated reason would have left them green. Each now discriminates on the error text.
- A citation inconsistency the reviewer flagged but explicitly declined to adjudicate, now settled against the primary text: RFC 9110 line 6476 places *"A server MAY ignore the Range header field"* in **§14.2**, and RFC 9110 **obsoletes** RFC 7233 (line 8). The test header cited "§14.4 / RFC 7233" — wrong section and a superseded RFC — and two `fragments.rs` comments cited 7233. All now cite 9110 §14.2. The RFC 7233 references in `dash/manifest.rs` deliberately stay: ISO/IEC 23009-1 normatively cites 7233 for `bytes-range-spec`, so that is the DASH spec's own reference.

## Follow-ups

Both raised by the reviewers as pre-existing and out of scope here:

- **#569** — fragment and segment bodies are buffered with no size cap. The unranged path has no ceiling at all.
- **#570** — HLS fragments have no retry, unlike the chunk and DASH paths. `validate_range_response` deliberately returns a *retryable* `Network` error for a wrong span so another CDN node can be tried; that distinction is currently inert on the fragment path, so a transient bad edge node fails an entire HLS download. Still strictly better than silent corruption, but the retry the error type was designed to trigger does not happen.
