### PR TITLE
fix(downloader): stop resumed and adaptive downloads leaking chunk files (#568, #559)

### DIFF
--- a/crates/rdlp-api/src/orchestrator/playlist/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/resume.rs
@@ -69,11 +69,16 @@ impl Orchestrator {
     ///
     /// # Note on .part files
     ///
-    /// - HTTP chunks: `filename.mp4.part0` - few large files, resumable
-    /// - HLS segments: `filename.part0` - many small files, will be cleaned up
+    /// The `.part{i}` grammar checked below (`ChunkSet` in the non-playlist
+    /// `orchestrator::resume` module) belongs only to HTTP parallel-chunk
+    /// downloads (`filename.mp4.part0`, few large files, resumable). HLS has no `.part`
+    /// naming at all: segments stream directly to the output file and resume
+    /// state lives in `{output}.hls_state.json`, not in loose segment files
+    /// (DASH's equivalent is a `.parts` *directory*, plural, also unrelated to
+    /// this grammar). A `.part` match here is always leftover HTTP chunks.
     ///
-    /// Since HLS segments are cleaned up before each download, we just report
-    /// the count for user information.
+    /// Since leftover chunk files are cleaned up before each download, we just
+    /// report the count for user information.
     pub(super) async fn detect_existing_playlist_files(
         &self,
         playlist_dir: &std::path::Path,

--- a/crates/rdlp-api/src/orchestrator/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/resume.rs
@@ -95,20 +95,23 @@ async fn detect_chunk_files(output_path: &Path) -> Option<ChunkInfo> {
     }
 
     // 2. Check for old-style (legacy) chunks: {filename}.part{i}
-    let Ok(legacy_set) = ChunkSet::legacy(output_path) else {
-        return all_chunks
-            .into_iter()
-            .max_by_key(|info| (info.download_id.is_some(), info.download_id.unwrap_or(0)));
-    };
-    let (old_chunk_paths, old_total_size) =
-        collect_contiguous_chunks(&legacy_set, parent_dir).await;
+    // Precondition already validated above, so `Err` can only mean `output_path`
+    // changed underneath us mid-scan: skip the legacy grammar and report whatever
+    // the new-style scan already found, rather than duplicating the reduction.
+    match ChunkSet::legacy(output_path) {
+        Ok(legacy_set) => {
+            let (old_chunk_paths, old_total_size) =
+                collect_contiguous_chunks(&legacy_set, parent_dir).await;
 
-    if !old_chunk_paths.is_empty() {
-        all_chunks.push(ChunkInfo {
-            download_id: None,
-            chunk_paths: old_chunk_paths,
-            total_size: old_total_size,
-        });
+            if !old_chunk_paths.is_empty() {
+                all_chunks.push(ChunkInfo {
+                    download_id: None,
+                    chunk_paths: old_chunk_paths,
+                    total_size: old_total_size,
+                });
+            }
+        }
+        Err(_) => debug!("Skipping legacy chunk scan: output path lost its filename mid-scan"),
     }
 
     // 3. Return the most recent chunk set (highest download ID)

--- a/crates/rdlp-api/src/orchestrator/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/resume.rs
@@ -14,18 +14,25 @@ use tracing::instrument;
 const MAX_DOWNLOAD_ID_SCAN: u64 = 100;
 
 /// Ceiling on how many sequential chunk ids a scan probes within one chunk
-/// set before concluding the set is exhausted (the scan breaks earlier, on
-/// the first missing chunk id, in the overwhelmingly common case).
+/// set before concluding the set is exhausted.
 ///
 /// This is a sanity ceiling against a pathological or corrupted directory,
-/// not a live limit on either grammar: new-style power-of-two chunking can
-/// legitimately produce thousands of small chunks, and — per #559's
-/// investigation — the legacy grammar's historical `concurrent_fragments`
-/// cap of 10 was never itself enforced as a scan/cleanup bound. A hardcoded
-/// `0..10` cleanup bound would silently strand any legacy chunk set that
-/// ever did exceed 10 (see `test_cleanup_legacy_chunks_beyond_old_ten_chunk_bound`);
-/// using the same generous ceiling for both grammars removes that trap
-/// without pretending the legacy count is normally this large.
+/// not a live limit on any grammar: new-style power-of-two chunking (and the
+/// resume grammar, which chunks the same way) can legitimately produce
+/// thousands of small chunks, and — per #559's investigation — the legacy
+/// grammar's historical `concurrent_fragments` cap of 10 was never itself
+/// enforced as a scan/cleanup bound. A hardcoded `0..10` cleanup bound would
+/// silently strand any legacy chunk set that ever did exceed 10 (see
+/// `test_cleanup_legacy_chunks_beyond_old_ten_chunk_bound`); using the same
+/// generous ceiling everywhere removes that trap.
+///
+/// Only [`collect_contiguous_chunks`] breaks on the first missing id within
+/// this range — contiguity is a real correctness requirement there, since you
+/// cannot merge across a hole. [`cleanup_old_chunks`] and
+/// [`log_orphaned_resume_chunks`] do NOT break on a hole: an interrupted
+/// adaptive/resume download completes chunks out of order, so a holed set
+/// (e.g. `resume0`, `resume2`, `resume4`) is the normal case there, and
+/// breaking on the first hole would leak the remainder (#568 C1).
 const CHUNK_SCAN_CEILING: u64 = 10_000;
 
 /// Information about detected chunk files
@@ -49,13 +56,16 @@ async fn collect_contiguous_chunks(set: &ChunkSet, parent_dir: &Path) -> (Vec<Pa
 
     for chunk_id in 0..CHUNK_SCAN_CEILING {
         let chunk_path = set.path_in(parent_dir, chunk_id);
-        if chunk_path.exists() {
-            if let Ok(metadata) = tokio::fs::metadata(&chunk_path).await {
-                chunk_paths.push(chunk_path);
+        // A single async `metadata` call replaces the previous synchronous
+        // `exists()` pre-check plus a second async `metadata` call — same
+        // information, half the syscalls, and no blocking call on the async
+        // executor thread (#568 C4).
+        match tokio::fs::metadata(&chunk_path).await {
+            Ok(metadata) => {
                 total_size += metadata.len();
+                chunk_paths.push(chunk_path);
             }
-        } else {
-            break;
+            Err(_) => break,
         }
     }
 
@@ -198,20 +208,30 @@ async fn cleanup_old_chunks(output_path: &Path) {
     let mut deleted = 0;
     for chunk_id in 0..CHUNK_SCAN_CEILING {
         let chunk_path = set.path_in(parent_dir, chunk_id);
-        if chunk_path.exists() && tokio::fs::remove_file(&chunk_path).await.is_ok() {
-            deleted += 1;
+        // Attempt the delete directly instead of probing with a synchronous
+        // `exists()` first: `NotFound` tells us exactly what the probe
+        // would have, in one syscall instead of two, without blocking the
+        // async executor thread (#568 C4). Never break on a miss: a legacy
+        // set can be holed same as any other grammar, and the scan bound is
+        // [`CHUNK_SCAN_CEILING`], not "first gap".
+        match tokio::fs::remove_file(&chunk_path).await {
+            Ok(()) => deleted += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => debug!(
+                "Failed to remove legacy chunk {}: {e}",
+                chunk_path.display()
+            ),
         }
     }
 
     if deleted > 0 {
         debug!(deleted; "Cleaned up legacy-style chunk files");
     }
-
-    cleanup_orphaned_resume_chunks(output_path).await;
 }
 
-/// Clean up orphaned resume-kind chunk sets (`{filename}.{download_id}.resume{i}`)
-/// left behind by an abandoned resume attempt (refs #568, #559).
+/// Discover orphaned resume-kind chunk sets (`{filename}.{download_id}.resume{i}`)
+/// left behind by an abandoned resume attempt, and log them for the operator
+/// to remove manually (refs #568, #559, #571 HIGH). **Never deletes.**
 ///
 /// A resume chunk set encodes only a chunk index *relative* to the resume
 /// attempt's byte offset — the offset itself is never persisted in the file
@@ -220,46 +240,83 @@ async fn cleanup_old_chunks(output_path: &Path) {
 /// can never be safely merged: there is no way to recover which byte offset
 /// its `chunk_id 0` continues from, and the base file it was meant to extend
 /// may since have been deleted (an oversized-file restart) or already
-/// resumed independently at a different offset. Discover-and-delete is the
-/// safe contract; the bytes are simply re-downloaded by whatever fresh
-/// attempt follows.
+/// resumed independently at a different offset.
 ///
-/// Deletes only exact paths computed via [`ChunkSet::path_in`] — never a
-/// directory sweep (`scripts/check-no-dir-sweep-delete.sh`, #558).
-async fn cleanup_orphaned_resume_chunks(output_path: &Path) {
+/// # Why this only logs, and never deletes
+///
+/// `download_id` is a monotonic counter **per process**, starting at 0. Two
+/// rdlp processes downloading to the same output path concurrently are
+/// therefore using the same low ids *at the same time* — an existence probe
+/// here cannot tell "abandoned by a past attempt" apart from "being written
+/// right now by a live peer" (the exact defect class #558 was about, one
+/// crate over). `TempRegistry::cleanup_stale` in `rdlp-postprocess`
+/// (`pipeline::registry`) earns the right to delete by requiring an fs4
+/// exclusive advisory lock on a sidecar that its own writer
+/// (`FileTracker::register`) takes at creation time. The downloader's chunk
+/// writer takes no equivalent lock on chunk files, so reproducing that proof
+/// here would require a cross-crate change to `rdlp-downloader`'s write
+/// path — a real option, but out of proportion to the benefit: an orphaned
+/// resume set can never be merged anyway (see above), so all automatic
+/// cleanup would reclaim is a few megabytes of disk, and #568's acceptance
+/// criterion 4 explicitly allows "documented as requiring manual cleanup" as
+/// an alternative to automatic reclamation. This function takes that
+/// alternative: discover, log with the exact paths implied by
+/// `download_id`, and leave removal to the operator.
+///
+/// # Hole tolerance
+///
+/// Never breaks a per-`download_id` scan on the first missing chunk id:
+/// resume chunks complete out of order on the adaptive path (`try_buffer_unordered`),
+/// so a holed set (e.g. `resume0`, `resume2`, `resume4`) is the NORMAL case,
+/// not evidence the set ends there (#568 C1). Chunk id 0 is checked first as
+/// a cheap sentinel — a resume attempt always schedules id 0 immediately, so
+/// its absence means this `download_id` was never used, and the rest of the
+/// ceiling is skipped for it. This bounds the cost of the overwhelmingly
+/// common "nothing orphaned" case to one probe per `download_id`. Narrow
+/// limitation: a set that has lost chunk 0 specifically (e.g. to some other
+/// partial cleanup) is not discovered by this pass.
+///
+/// Returns every discovered chunk path (across all `download_id`s), so
+/// callers/tests can assert on discovery independently of the (absent)
+/// deletion side effect.
+pub async fn log_orphaned_resume_chunks(output_path: &Path) -> Vec<PathBuf> {
     let parent_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut discovered = Vec::new();
 
-    let mut deleted = 0;
     for download_id in 0..MAX_DOWNLOAD_ID_SCAN {
         let Ok(set) = ChunkSet::for_attempt(output_path, download_id, ChunkKind::Resume) else {
-            return;
+            break;
         };
 
-        let mut deleted_for_id = 0;
-        for chunk_id in 0..CHUNK_SCAN_CEILING {
+        let sentinel = set.path_in(parent_dir, 0);
+        if tokio::fs::metadata(&sentinel).await.is_err() {
+            continue;
+        }
+
+        let mut found_for_id = vec![sentinel];
+        for chunk_id in 1..CHUNK_SCAN_CEILING {
             let chunk_path = set.path_in(parent_dir, chunk_id);
-            if chunk_path.exists() {
-                if tokio::fs::remove_file(&chunk_path).await.is_ok() {
-                    deleted_for_id += 1;
-                }
-            } else {
-                break;
+            if tokio::fs::metadata(&chunk_path).await.is_ok() {
+                found_for_id.push(chunk_path);
             }
         }
 
-        if deleted_for_id > 0 {
-            warn!(
-                download_id, deleted_for_id;
-                "Deleting orphaned resume chunk set: safely merging requires the \
-                 original byte offset, which chunk file names don't encode"
-            );
-            deleted += deleted_for_id;
-        }
+        warn!(
+            download_id,
+            chunk_count = found_for_id.len();
+            "Found an orphaned resume chunk set (download_id {download_id}) next to {}: \
+             not deleting automatically — a concurrent rdlp process may still own this \
+             download_id, and safely merging would require the original byte offset, \
+             which chunk file names don't encode. Remove \
+             '{}.{download_id}.resume*' manually once you've confirmed no other rdlp \
+             process is using this output path.",
+            output_path.display(),
+            output_path.display(),
+        );
+        discovered.extend(found_for_id);
     }
 
-    if deleted > 0 {
-        debug!(deleted; "Cleaned up orphaned resume-style chunk files");
-    }
+    discovered
 }
 
 impl Orchestrator {
@@ -281,6 +338,13 @@ impl Orchestrator {
         output_path: &Path,
         expected_size: Option<u64>,
     ) -> Result<u64> {
+        // 0. Discover (and log-only) any orphaned resume-kind chunk sets.
+        // Unconditional and first, so every branch below sees it run — not
+        // just the branches that also happen to run legacy cleanup (#568 C3:
+        // the old call was nested inside `cleanup_old_chunks`/one `else`
+        // arm, so the legacy-chunk-present branch never reached it).
+        log_orphaned_resume_chunks(output_path).await;
+
         // 1. Check for existing complete or partial download file
         if output_path.exists()
             && let Ok(metadata) = tokio::fs::metadata(output_path).await
@@ -362,10 +426,8 @@ impl Orchestrator {
             }
         } else {
             // No main file, and no legacy/new-style Fresh chunk set found
-            // either. Still clean up any orphaned resume chunks so they
-            // don't leak indefinitely (#568/#559 item 4) — nothing else on
-            // this path would ever reach them.
-            cleanup_orphaned_resume_chunks(output_path).await;
+            // either. Orphaned resume chunks (if any) were already
+            // discovered and logged by step 0 above.
             Ok(0)
         }
     }

--- a/crates/rdlp-api/src/orchestrator/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/resume.rs
@@ -3,8 +3,30 @@
 use super::{Orchestrator, errors::Result};
 use anyhow::Context;
 use log::{debug, warn};
+use rdlp_downloader::{ChunkKind, ChunkSet};
 use std::path::{Path, PathBuf};
 use tracing::instrument;
+
+/// Upper bound on how many distinct download attempts (`download_id`s) a
+/// scan probes for new-style chunks. Not a grammar constraint — `download_id`
+/// is a monotonic per-process counter starting at 0, so any in-progress or
+/// recently-abandoned download is well within this window.
+const MAX_DOWNLOAD_ID_SCAN: u64 = 100;
+
+/// Ceiling on how many sequential chunk ids a scan probes within one chunk
+/// set before concluding the set is exhausted (the scan breaks earlier, on
+/// the first missing chunk id, in the overwhelmingly common case).
+///
+/// This is a sanity ceiling against a pathological or corrupted directory,
+/// not a live limit on either grammar: new-style power-of-two chunking can
+/// legitimately produce thousands of small chunks, and — per #559's
+/// investigation — the legacy grammar's historical `concurrent_fragments`
+/// cap of 10 was never itself enforced as a scan/cleanup bound. A hardcoded
+/// `0..10` cleanup bound would silently strand any legacy chunk set that
+/// ever did exceed 10 (see `test_cleanup_legacy_chunks_beyond_old_ten_chunk_bound`);
+/// using the same generous ceiling for both grammars removes that trap
+/// without pretending the legacy count is normally this large.
+const CHUNK_SCAN_CEILING: u64 = 10_000;
 
 /// Information about detected chunk files
 #[derive(Debug, Clone)]
@@ -17,6 +39,29 @@ pub struct ChunkInfo {
     pub(crate) total_size: u64,
 }
 
+/// Probe `set` for a contiguous run of chunk ids starting at 0, stopping at
+/// the first missing id (or at [`CHUNK_SCAN_CEILING`]). Read-only: builds
+/// each candidate path via [`ChunkSet::path_in`] and checks existence, never
+/// enumerating the directory's contents.
+async fn collect_contiguous_chunks(set: &ChunkSet, parent_dir: &Path) -> (Vec<PathBuf>, u64) {
+    let mut chunk_paths = Vec::new();
+    let mut total_size = 0u64;
+
+    for chunk_id in 0..CHUNK_SCAN_CEILING {
+        let chunk_path = set.path_in(parent_dir, chunk_id);
+        if chunk_path.exists() {
+            if let Ok(metadata) = tokio::fs::metadata(&chunk_path).await {
+                chunk_paths.push(chunk_path);
+                total_size += metadata.len();
+            }
+        } else {
+            break;
+        }
+    }
+
+    (chunk_paths, total_size)
+}
+
 /// Detect chunk files for a given output path
 ///
 /// Supports both:
@@ -25,32 +70,20 @@ pub struct ChunkInfo {
 ///
 /// Returns the most recent chunk set (highest download ID)
 async fn detect_chunk_files(output_path: &Path) -> Option<ChunkInfo> {
-    let base_name = output_path.file_name()?.to_string_lossy();
+    // Validates the precondition every `ChunkSet` constructor below shares.
+    output_path.file_name()?;
     let parent_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
 
     let mut all_chunks: Vec<ChunkInfo> = Vec::new();
 
     // 1. Check for new-style chunks: {filename}.{downloadid}.part{i}
-    // Scan for download IDs from 0 to 100 (reasonable upper bound)
-    for download_id in 0..100 {
-        let mut chunk_paths = Vec::new();
-        let mut total_size = 0u64;
-
-        // Scan for chunks with this download ID
-        // Check up to 10000 chunks (power-of-two chunking can create many small chunks)
-        for chunk_id in 0..10000 {
-            let chunk_path = parent_dir.join(format!("{base_name}.{download_id}.part{chunk_id}"));
-
-            if chunk_path.exists() {
-                if let Ok(metadata) = tokio::fs::metadata(&chunk_path).await {
-                    chunk_paths.push(chunk_path);
-                    total_size += metadata.len();
-                }
-            } else {
-                // No more chunks for this download ID
-                break;
-            }
-        }
+    for download_id in 0..MAX_DOWNLOAD_ID_SCAN {
+        // Precondition already validated above; a failure here can only mean
+        // `output_path` changed underneath us mid-scan, so skip rather than panic.
+        let Ok(set) = ChunkSet::for_attempt(output_path, download_id, ChunkKind::Fresh) else {
+            break;
+        };
+        let (chunk_paths, total_size) = collect_contiguous_chunks(&set, parent_dir).await;
 
         if !chunk_paths.is_empty() {
             all_chunks.push(ChunkInfo {
@@ -61,24 +94,14 @@ async fn detect_chunk_files(output_path: &Path) -> Option<ChunkInfo> {
         }
     }
 
-    // 2. Check for old-style chunks: {filename}.part{i}
-    let mut old_chunk_paths = Vec::new();
-    let mut old_total_size = 0u64;
-
-    for i in 0..10 {
-        // Old system used max 10 chunks (concurrent_fragments capped at 10)
-        let chunk_path = parent_dir.join(format!("{base_name}.part{i}"));
-
-        if chunk_path.exists() {
-            if let Ok(metadata) = tokio::fs::metadata(&chunk_path).await {
-                old_chunk_paths.push(chunk_path);
-                old_total_size += metadata.len();
-            }
-        } else {
-            // Old chunks are sequential
-            break;
-        }
-    }
+    // 2. Check for old-style (legacy) chunks: {filename}.part{i}
+    let Ok(legacy_set) = ChunkSet::legacy(output_path) else {
+        return all_chunks
+            .into_iter()
+            .max_by_key(|info| (info.download_id.is_some(), info.download_id.unwrap_or(0)));
+    };
+    let (old_chunk_paths, old_total_size) =
+        collect_contiguous_chunks(&legacy_set, parent_dir).await;
 
     if !old_chunk_paths.is_empty() {
         all_chunks.push(ChunkInfo {
@@ -157,24 +180,82 @@ pub async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo) -> an
     Ok(total_size)
 }
 
-/// Clean up old-style chunks when new-style chunks are used
+/// Clean up legacy-grammar chunks (`{filename}.part{i}`) when they are no
+/// longer going to be used for resume (a complete/oversized/simple-partial
+/// file was found, or new-style chunks were used instead).
+///
+/// Deletes only exact paths computed via [`ChunkSet::path_in`] — never a
+/// directory sweep (`scripts/check-no-dir-sweep-delete.sh`, #558).
 async fn cleanup_old_chunks(output_path: &Path) {
-    let Some(name) = output_path.file_name() else {
+    let Ok(set) = ChunkSet::legacy(output_path) else {
         return;
     };
-    let base_name = name.to_string_lossy();
     let parent_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
 
     let mut deleted = 0;
-    for i in 0..10 {
-        let chunk_path = parent_dir.join(format!("{base_name}.part{i}"));
+    for chunk_id in 0..CHUNK_SCAN_CEILING {
+        let chunk_path = set.path_in(parent_dir, chunk_id);
         if chunk_path.exists() && tokio::fs::remove_file(&chunk_path).await.is_ok() {
             deleted += 1;
         }
     }
 
     if deleted > 0 {
-        debug!(deleted; "Cleaned up old-style chunk files");
+        debug!(deleted; "Cleaned up legacy-style chunk files");
+    }
+
+    cleanup_orphaned_resume_chunks(output_path).await;
+}
+
+/// Clean up orphaned resume-kind chunk sets (`{filename}.{download_id}.resume{i}`)
+/// left behind by an abandoned resume attempt (refs #568, #559).
+///
+/// A resume chunk set encodes only a chunk index *relative* to the resume
+/// attempt's byte offset — the offset itself is never persisted in the file
+/// name or anywhere on disk (see `Attempt::Resume` in
+/// `rdlp_downloader::http::parallel`), so a resume chunk set discovered here
+/// can never be safely merged: there is no way to recover which byte offset
+/// its `chunk_id 0` continues from, and the base file it was meant to extend
+/// may since have been deleted (an oversized-file restart) or already
+/// resumed independently at a different offset. Discover-and-delete is the
+/// safe contract; the bytes are simply re-downloaded by whatever fresh
+/// attempt follows.
+///
+/// Deletes only exact paths computed via [`ChunkSet::path_in`] — never a
+/// directory sweep (`scripts/check-no-dir-sweep-delete.sh`, #558).
+async fn cleanup_orphaned_resume_chunks(output_path: &Path) {
+    let parent_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
+
+    let mut deleted = 0;
+    for download_id in 0..MAX_DOWNLOAD_ID_SCAN {
+        let Ok(set) = ChunkSet::for_attempt(output_path, download_id, ChunkKind::Resume) else {
+            return;
+        };
+
+        let mut deleted_for_id = 0;
+        for chunk_id in 0..CHUNK_SCAN_CEILING {
+            let chunk_path = set.path_in(parent_dir, chunk_id);
+            if chunk_path.exists() {
+                if tokio::fs::remove_file(&chunk_path).await.is_ok() {
+                    deleted_for_id += 1;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if deleted_for_id > 0 {
+            warn!(
+                download_id, deleted_for_id;
+                "Deleting orphaned resume chunk set: safely merging requires the \
+                 original byte offset, which chunk file names don't encode"
+            );
+            deleted += deleted_for_id;
+        }
+    }
+
+    if deleted > 0 {
+        debug!(deleted; "Cleaned up orphaned resume-style chunk files");
     }
 }
 
@@ -277,6 +358,11 @@ impl Orchestrator {
                 }
             }
         } else {
+            // No main file, and no legacy/new-style Fresh chunk set found
+            // either. Still clean up any orphaned resume chunks so they
+            // don't leak indefinitely (#568/#559 item 4) — nothing else on
+            // this path would ever reach them.
+            cleanup_orphaned_resume_chunks(output_path).await;
             Ok(0)
         }
     }

--- a/crates/rdlp-api/src/orchestrator/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/resume.rs
@@ -50,6 +50,12 @@ pub struct ChunkInfo {
 /// the first missing id (or at [`CHUNK_SCAN_CEILING`]). Read-only: builds
 /// each candidate path via [`ChunkSet::path_in`] and checks existence, never
 /// enumerating the directory's contents.
+///
+/// No chunk-0 sentinel is needed here (unlike [`cleanup_old_chunks`] and
+/// [`log_orphaned_resume_chunks`]): breaking on the first missing id is
+/// already the cheapest possible short-circuit for the "nothing here" case
+/// — an absent chunk 0 is itself the first miss, so the loop below exits
+/// after exactly one probe.
 async fn collect_contiguous_chunks(set: &ChunkSet, parent_dir: &Path) -> (Vec<PathBuf>, u64) {
     let mut chunk_paths = Vec::new();
     let mut total_size = 0u64;
@@ -199,6 +205,29 @@ pub async fn merge_chunk_files(output_path: &Path, chunk_info: &ChunkInfo) -> an
 ///
 /// Deletes only exact paths computed via [`ChunkSet::path_in`] — never a
 /// directory sweep (`scripts/check-no-dir-sweep-delete.sh`, #558).
+///
+/// # Sentinel gate
+///
+/// This runs on essentially every `detect_resume_point` call (up to 3x per
+/// call — see the branches below), so its cost has to be bounded for the
+/// overwhelmingly common case where there is no legacy chunk set at all.
+/// Chunk id 0 is checked first: a legacy download always writes id 0 first,
+/// so its absence means there is nothing here to clean up, and the rest of
+/// [`CHUNK_SCAN_CEILING`] is skipped entirely rather than attempting up to
+/// 10,000 `remove_file` calls that all resolve to `NotFound`. This mirrors
+/// the sentinel [`log_orphaned_resume_chunks`] already uses for the same
+/// reason.
+///
+/// When chunk 0 IS present, the full ceiling is scanned without breaking on
+/// a hole: an interrupted adaptive/resume download completes chunks out of
+/// order, so a holed set (e.g. `part0`, `part2`, `part5`) is the normal case,
+/// and breaking on the first gap would leak the remainder (#568 C1).
+///
+/// Narrow limitation, shared with `log_orphaned_resume_chunks`: a set that
+/// has lost chunk 0 specifically (to some other partial cleanup) is not
+/// cleaned by this pass. That trade is acceptable — it bounds the cost of
+/// the common "nothing here" case to a single syscall, and a legacy chunk
+/// set missing its first chunk is itself an unusual, already-degraded state.
 async fn cleanup_old_chunks(output_path: &Path) {
     let Ok(set) = ChunkSet::legacy(output_path) else {
         return;
@@ -206,7 +235,14 @@ async fn cleanup_old_chunks(output_path: &Path) {
     let parent_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
 
     let mut deleted = 0;
-    for chunk_id in 0..CHUNK_SCAN_CEILING {
+    let sentinel = set.path_in(parent_dir, 0);
+    match tokio::fs::remove_file(&sentinel).await {
+        Ok(()) => deleted += 1,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => debug!("Failed to remove legacy chunk {}: {e}", sentinel.display()),
+    }
+
+    for chunk_id in 1..CHUNK_SCAN_CEILING {
         let chunk_path = set.path_in(parent_dir, chunk_id);
         // Attempt the delete directly instead of probing with a synchronous
         // `exists()` first: `NotFound` tells us exactly what the probe

--- a/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
@@ -309,6 +309,99 @@ mod resume_compatibility_tests {
         }
     }
 
+    /// #571 MEDIUM follow-up: `cleanup_old_chunks` gates its
+    /// [`resume::CHUNK_SCAN_CEILING`]-wide scan on chunk 0's presence (same
+    /// sentinel as `log_orphaned_resume_chunks`), but MUST NOT reintroduce
+    /// break-on-first-hole *within* a set that does exist — an interrupted
+    /// parallel download completes chunks out of order, so `part0`, `part2`,
+    /// `part5` present with `part1`/`part3`/`part4` missing is the normal
+    /// shape, not evidence the set ends at `part0`. A break-on-first-miss
+    /// scan would only remove `part0` here; the fix must remove all three.
+    #[tokio::test]
+    async fn test_cleanup_legacy_chunks_across_holes_when_chunk_zero_present() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        let complete_data = vec![7u8; 4096];
+        tokio::fs::write(&output_path, &complete_data)
+            .await
+            .unwrap();
+
+        tokio::fs::write(temp_dir.path().join("video.mp4.part0"), &[1u8; 64])
+            .await
+            .unwrap();
+        // part1 deliberately absent.
+        tokio::fs::write(temp_dir.path().join("video.mp4.part2"), &[2u8; 64])
+            .await
+            .unwrap();
+        // part3, part4 deliberately absent.
+        tokio::fs::write(temp_dir.path().join("video.mp4.part5"), &[3u8; 64])
+            .await
+            .unwrap();
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, Some(4096))
+            .await
+            .unwrap();
+
+        assert_eq!(resume_offset, 4096);
+        assert!(
+            !temp_dir.path().join("video.mp4.part0").exists(),
+            "part0 should have been cleaned up"
+        );
+        assert!(
+            !temp_dir.path().join("video.mp4.part2").exists(),
+            "part2 should have been cleaned up despite the hole at part1"
+        );
+        assert!(
+            !temp_dir.path().join("video.mp4.part5").exists(),
+            "part5 should have been cleaned up despite the holes at part3/part4"
+        );
+    }
+
+    /// The chunk-0 sentinel must short-circuit the full scan when chunk 0 is
+    /// absent: a legacy set that never wrote id 0 is not a real set to clean
+    /// up, and later ids belonging to some other (foreign) file must survive
+    /// untouched. This is the observable side effect of the short-circuit —
+    /// with the gate skipped, `cleanup_old_chunks` would fall through to the
+    /// unconditional `0..CHUNK_SCAN_CEILING` loop and delete these files too.
+    #[tokio::test]
+    async fn test_cleanup_short_circuits_when_chunk_zero_absent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        let complete_data = vec![7u8; 4096];
+        tokio::fs::write(&output_path, &complete_data)
+            .await
+            .unwrap();
+
+        // part0 deliberately absent -- part1/part2 exist but must NOT be
+        // reached by the scan once the chunk-0 sentinel gate is in place.
+        tokio::fs::write(temp_dir.path().join("video.mp4.part1"), &[1u8; 64])
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("video.mp4.part2"), &[2u8; 64])
+            .await
+            .unwrap();
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, Some(4096))
+            .await
+            .unwrap();
+
+        assert_eq!(resume_offset, 4096);
+        assert!(
+            temp_dir.path().join("video.mp4.part1").exists(),
+            "part1 must survive: the chunk-0 sentinel gate should skip the scan entirely"
+        );
+        assert!(
+            temp_dir.path().join("video.mp4.part2").exists(),
+            "part2 must survive: the chunk-0 sentinel gate should skip the scan entirely"
+        );
+    }
+
     /// A foreign file that merely shares the output file's prefix must never
     /// be deleted by chunk cleanup — cleanup only removes exact computed
     /// chunk paths, never a directory sweep.

--- a/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
@@ -270,6 +270,129 @@ mod resume_compatibility_tests {
         assert!(!temp_dir.path().join("video.mp4.part2").exists());
     }
 
+    /// #559 acceptance: the legacy `0..10` scan bound never leaked in
+    /// practice (legacy `concurrent_fragments` was capped at 10), but a
+    /// hardcoded ceiling on cleanup is still a defect waiting to happen if
+    /// that assumption ever drifts. 12 legacy chunks (2 beyond the old
+    /// bound) must ALL be cleaned up when the file is already complete.
+    #[tokio::test]
+    async fn test_cleanup_legacy_chunks_beyond_old_ten_chunk_bound() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        let complete_data = vec![7u8; 4096];
+        tokio::fs::write(&output_path, &complete_data)
+            .await
+            .unwrap();
+
+        for i in 0..12 {
+            tokio::fs::write(
+                temp_dir.path().join(format!("video.mp4.part{i}")),
+                &[i as u8; 64],
+            )
+            .await
+            .unwrap();
+        }
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, Some(4096))
+            .await
+            .unwrap();
+
+        assert_eq!(resume_offset, 4096);
+        for i in 0..12 {
+            assert!(
+                !temp_dir.path().join(format!("video.mp4.part{i}")).exists(),
+                "chunk {i} should have been cleaned up (beyond the old 0..10 bound)"
+            );
+        }
+    }
+
+    /// A foreign file that merely shares the output file's prefix must never
+    /// be deleted by chunk cleanup — cleanup only removes exact computed
+    /// chunk paths, never a directory sweep.
+    #[tokio::test]
+    async fn test_cleanup_does_not_delete_foreign_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        let complete_data = vec![9u8; 1024];
+        tokio::fs::write(&output_path, &complete_data)
+            .await
+            .unwrap();
+
+        tokio::fs::write(temp_dir.path().join("video.mp4.part0"), &[1u8; 64])
+            .await
+            .unwrap();
+        let foreign = temp_dir.path().join("video.mp4.notes.txt");
+        tokio::fs::write(&foreign, b"keep me").await.unwrap();
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, Some(1024))
+            .await
+            .unwrap();
+
+        assert_eq!(resume_offset, 1024);
+        assert!(!temp_dir.path().join("video.mp4.part0").exists());
+        assert!(foreign.exists(), "foreign file must survive cleanup");
+    }
+
+    /// #568/#559 item 4: a `.resume{N}` chunk set orphaned by an abandoned
+    /// resume attempt must be discoverable and cleaned up, not left to leak
+    /// forever, even though it can never be safely merged (the byte offset
+    /// it continues from is not persisted anywhere). Scenario: the main
+    /// output file still exists (ordinary partial-file resume applies), and
+    /// orphaned resume chunks sit alongside it.
+    #[tokio::test]
+    async fn test_orphaned_resume_chunks_cleaned_when_file_partial() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        tokio::fs::write(&output_path, &vec![1u8; 1000])
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("video.mp4.3.resume0"), &[2u8; 64])
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("video.mp4.3.resume1"), &[3u8; 64])
+            .await
+            .unwrap();
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, None)
+            .await
+            .unwrap();
+
+        assert_eq!(resume_offset, 1000);
+        assert!(!temp_dir.path().join("video.mp4.3.resume0").exists());
+        assert!(!temp_dir.path().join("video.mp4.3.resume1").exists());
+    }
+
+    /// Same as above, but there is no main output file and no fresh/legacy
+    /// chunk set either — only orphaned resume chunks. They must still be
+    /// discovered and cleaned up rather than leaking indefinitely.
+    #[tokio::test]
+    async fn test_orphaned_resume_chunks_cleaned_when_no_other_chunks_or_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        tokio::fs::write(temp_dir.path().join("video.mp4.5.resume0"), &[4u8; 64])
+            .await
+            .unwrap();
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, None)
+            .await
+            .unwrap();
+
+        assert_eq!(resume_offset, 0);
+        assert!(!temp_dir.path().join("video.mp4.5.resume0").exists());
+    }
+
     #[tokio::test]
     async fn test_prioritize_higher_download_id() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
+++ b/crates/rdlp-api/src/orchestrator/tests/resume_tests.rs
@@ -339,14 +339,17 @@ mod resume_compatibility_tests {
         assert!(foreign.exists(), "foreign file must survive cleanup");
     }
 
-    /// #568/#559 item 4: a `.resume{N}` chunk set orphaned by an abandoned
-    /// resume attempt must be discoverable and cleaned up, not left to leak
-    /// forever, even though it can never be safely merged (the byte offset
-    /// it continues from is not persisted anywhere). Scenario: the main
+    /// #568/#559/#571 HIGH: a `.resume{N}` chunk set orphaned by an
+    /// abandoned resume attempt must be DISCOVERED (so the operator learns
+    /// about it) but MUST NOT be deleted automatically — `download_id` is a
+    /// per-process counter starting at 0, so a second concurrent rdlp
+    /// process downloading the same output name may be actively writing to
+    /// that exact low id right now. Deleting on a bare existence probe would
+    /// reintroduce the #558 defect class one crate over. Scenario: the main
     /// output file still exists (ordinary partial-file resume applies), and
     /// orphaned resume chunks sit alongside it.
     #[tokio::test]
-    async fn test_orphaned_resume_chunks_cleaned_when_file_partial() {
+    async fn test_orphaned_resume_chunks_not_deleted_when_file_partial() {
         let temp_dir = tempfile::tempdir().unwrap();
         let output_path = temp_dir.path().join("video.mp4");
 
@@ -367,15 +370,16 @@ mod resume_compatibility_tests {
             .unwrap();
 
         assert_eq!(resume_offset, 1000);
-        assert!(!temp_dir.path().join("video.mp4.3.resume0").exists());
-        assert!(!temp_dir.path().join("video.mp4.3.resume1").exists());
+        // Never deleted: a live concurrent process could own this download_id.
+        assert!(temp_dir.path().join("video.mp4.3.resume0").exists());
+        assert!(temp_dir.path().join("video.mp4.3.resume1").exists());
     }
 
     /// Same as above, but there is no main output file and no fresh/legacy
     /// chunk set either — only orphaned resume chunks. They must still be
-    /// discovered and cleaned up rather than leaking indefinitely.
+    /// left untouched (never auto-deleted), same as every other branch.
     #[tokio::test]
-    async fn test_orphaned_resume_chunks_cleaned_when_no_other_chunks_or_file() {
+    async fn test_orphaned_resume_chunks_not_deleted_when_no_other_chunks_or_file() {
         let temp_dir = tempfile::tempdir().unwrap();
         let output_path = temp_dir.path().join("video.mp4");
 
@@ -390,7 +394,104 @@ mod resume_compatibility_tests {
             .unwrap();
 
         assert_eq!(resume_offset, 0);
-        assert!(!temp_dir.path().join("video.mp4.5.resume0").exists());
+        assert!(temp_dir.path().join("video.mp4.5.resume0").exists());
+    }
+
+    /// #568 C3: when `detect_chunk_files` resolves to the LEGACY set
+    /// (`download_id: None`), the old code's `if
+    /// chunk_info.download_id.is_some()` guard skipped the resume-chunk pass
+    /// entirely (it was nested inside `cleanup_old_chunks`, only called from
+    /// that one `if` arm). Orphaned resume chunks alongside a legacy chunk
+    /// set must survive (not be silently unreachable) exactly as they do on
+    /// every other branch, and the legacy merge must still proceed normally.
+    #[tokio::test]
+    async fn test_orphaned_resume_chunks_survive_legacy_chunk_branch() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        // Legacy (old-style) fresh chunks -- no main file, so this is the
+        // `detect_chunk_files` branch with `download_id: None`.
+        tokio::fs::write(temp_dir.path().join("video.mp4.part0"), &[1u8; 512])
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("video.mp4.part1"), &[2u8; 512])
+            .await
+            .unwrap();
+
+        // Orphaned resume chunks for an unrelated download_id.
+        tokio::fs::write(temp_dir.path().join("video.mp4.7.resume0"), &[9u8; 64])
+            .await
+            .unwrap();
+
+        let orchestrator = create_test_orchestrator();
+        let resume_offset = orchestrator
+            .detect_resume_point(&output_path, None)
+            .await
+            .unwrap();
+
+        // Legacy chunks merged normally.
+        assert_eq!(resume_offset, 1024);
+        assert!(!temp_dir.path().join("video.mp4.part0").exists());
+        assert!(!temp_dir.path().join("video.mp4.part1").exists());
+        // Orphaned resume chunk untouched.
+        assert!(temp_dir.path().join("video.mp4.7.resume0").exists());
+    }
+
+    /// #568 C1: resume chunks complete out of order on the adaptive
+    /// (`try_buffer_unordered`) path, so a holed set — e.g. `resume0`,
+    /// `resume2`, `resume4` present, `resume1`/`resume3` missing — is the
+    /// NORMAL case, not evidence the set ends at the first hole. A
+    /// break-on-first-missing scan would only discover `resume0` here; the
+    /// fix must discover all three. This calls `log_orphaned_resume_chunks`
+    /// directly (rather than asserting on file survival, which a no-op
+    /// would also satisfy) so the assertion pins the discovery logic itself.
+    #[tokio::test]
+    async fn test_log_orphaned_resume_chunks_discovers_across_holes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        tokio::fs::write(temp_dir.path().join("video.mp4.9.resume0"), &[1u8; 8])
+            .await
+            .unwrap();
+        // resume1 deliberately absent.
+        tokio::fs::write(temp_dir.path().join("video.mp4.9.resume2"), &[2u8; 8])
+            .await
+            .unwrap();
+        // resume3 deliberately absent.
+        tokio::fs::write(temp_dir.path().join("video.mp4.9.resume4"), &[3u8; 8])
+            .await
+            .unwrap();
+
+        let discovered = resume::log_orphaned_resume_chunks(&output_path).await;
+
+        assert_eq!(
+            discovered.len(),
+            3,
+            "expected resume0, resume2, resume4 despite the holes at 1 and 3; got {discovered:?}"
+        );
+        assert!(discovered.contains(&temp_dir.path().join("video.mp4.9.resume0")));
+        assert!(discovered.contains(&temp_dir.path().join("video.mp4.9.resume2")));
+        assert!(discovered.contains(&temp_dir.path().join("video.mp4.9.resume4")));
+
+        // Discovery never deletes.
+        assert!(temp_dir.path().join("video.mp4.9.resume0").exists());
+        assert!(temp_dir.path().join("video.mp4.9.resume2").exists());
+        assert!(temp_dir.path().join("video.mp4.9.resume4").exists());
+    }
+
+    /// The chunk-0 sentinel optimization must not cause a real orphaned set
+    /// to be skipped when chunk 0 IS present alongside later holes (the
+    /// common shape); this is the negative-space complement of the previous
+    /// test, pinning that an entirely-unused `download_id` (chunk 0 absent)
+    /// contributes nothing to the discovered set.
+    #[tokio::test]
+    async fn test_log_orphaned_resume_chunks_skips_unused_download_id() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("video.mp4");
+
+        // No files at all for this output path.
+        let discovered = resume::log_orphaned_resume_chunks(&output_path).await;
+        assert!(discovered.is_empty());
     }
 
     #[tokio::test]

--- a/crates/rdlp-downloader/src/http/chunk_ledger.rs
+++ b/crates/rdlp-downloader/src/http/chunk_ledger.rs
@@ -1,8 +1,8 @@
 //! Owned-path tracking for parallel-download chunk files.
 //!
-//! Replaces the pattern-sweep deletion [`super::chunk_name::ChunkSet`] used to
-//! perform (`ChunkSet::sweep`, removed): that scanned the temp directory for
-//! names matching this download's grammar and deleted every match. The
+//! Replaces an earlier pattern-sweep design, rejected before merge, that
+//! would have scanned the temp directory for names matching
+//! [`super::chunk_name::ChunkSet`]'s grammar and deleted every match. The
 //! grammar alone cannot distinguish "a chunk this run wrote" from "a chunk a
 //! concurrent process with the same `download_id` wrote" — `DOWNLOAD_ID_COUNTER`
 //! (`parallel.rs`) is a per-process atomic starting at 0, so two concurrent
@@ -134,17 +134,18 @@ mod tests {
         ChunkLedger::new().cleanup().await;
     }
 
-    /// This is the whole point of replacing `ChunkSet::sweep` with a ledger.
+    /// This is the whole point of replacing the earlier pattern-sweep design
+    /// with a ledger.
     ///
     /// `DOWNLOAD_ID_COUNTER` (`parallel.rs`) is a per-*process* atomic
     /// starting at 0, so two concurrent rdlp processes downloading the same
     /// filename into the same directory can both compute `download_id == 0`
     /// — at which point their chunk files are named identically
     /// (`ChunkSet::path_in` depends only on filename + `download_id` + kind +
-    /// `chunk_id`). The removed `ChunkSet::sweep` deleted every directory
-    /// entry matching that shared name grammar, so process A's sweep would
-    /// also delete process B's live, in-progress chunk file of the same
-    /// name. A `ChunkLedger` cannot make that mistake: it deletes only the
+    /// `chunk_id`). The rejected pattern-sweep design would have deleted
+    /// every directory entry matching that shared name grammar, so process
+    /// A's sweep would also delete process B's live, in-progress chunk file
+    /// of the same name. A `ChunkLedger` cannot make that mistake: it deletes only the
     /// paths THIS run explicitly registered, so a file this run never
     /// registered survives even when its name is indistinguishable from an
     /// owned chunk's.
@@ -184,8 +185,8 @@ mod tests {
             tokio::fs::metadata(&foreign_chunk).await.is_ok(),
             "a same-grammar, same-download-id chunk this run never \
              registered (standing in for a concurrent process's live chunk) \
-             must survive cleanup — the removed ChunkSet::sweep could not \
-             guarantee this"
+             must survive cleanup — the rejected pattern-sweep design could \
+             not guarantee this"
         );
     }
 }

--- a/crates/rdlp-downloader/src/http/chunk_ledger.rs
+++ b/crates/rdlp-downloader/src/http/chunk_ledger.rs
@@ -1,0 +1,191 @@
+//! Owned-path tracking for parallel-download chunk files.
+//!
+//! Replaces the pattern-sweep deletion [`super::chunk_name::ChunkSet`] used to
+//! perform (`ChunkSet::sweep`, removed): that scanned the temp directory for
+//! names matching this download's grammar and deleted every match. The
+//! grammar alone cannot distinguish "a chunk this run wrote" from "a chunk a
+//! concurrent process with the same `download_id` wrote" — `DOWNLOAD_ID_COUNTER`
+//! (`parallel.rs`) is a per-process atomic starting at 0, so two concurrent
+//! rdlp processes downloading the same filename into the same directory both
+//! use `download_id == 0`, and a pattern sweep in process A would delete
+//! process B's live chunk files. This is the #558 defect class
+//! (`cleanup_leftover_segments`'s directory-pattern sweep) reached from a
+//! different starting point; see `scripts/check-no-dir-sweep-delete.sh`.
+//!
+//! [`ChunkLedger`] closes that hole by construction: nothing is ever deleted
+//! that wasn't first registered by this run, at the moment this run computed
+//! the path — so cleanup can only ever remove paths this attempt is
+//! authoritatively known to have created (or be about to create).
+
+use log::{debug, warn};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// The set of chunk file paths one download attempt has created (or is about
+/// to create), carrying deletion authority over exactly those paths.
+///
+/// Analogous in spirit to `rdlp-api`'s `OwnedThumbnail` (#556): possession of
+/// a registration is what authorizes deletion, so designation and permission
+/// travel together instead of a cleanup path re-deriving "which paths are
+/// mine" by re-scanning the filesystem.
+///
+/// Uses a `std::sync::Mutex` rather than `tokio::sync::Mutex`: the adaptive
+/// downloader registers a path once per chunk from inside a `try_unfold`
+/// closure shared across concurrently-polled futures, so registration must
+/// be callable without threading `&mut self` through the pipeline — but each
+/// critical section is a single `Vec::push`, never held across an `.await`,
+/// so the synchronous primitive is both sufficient and cheaper.
+#[derive(Debug, Default)]
+pub(super) struct ChunkLedger {
+    paths: Mutex<Vec<PathBuf>>,
+}
+
+impl ChunkLedger {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a chunk path this run is about to write.
+    ///
+    /// Must be called BEFORE the chunk's download starts, not after it
+    /// succeeds — a chunk that fails mid-write still leaves a partial file
+    /// on disk, and that file must still be reachable by cleanup.
+    pub(super) fn register(&self, path: PathBuf) {
+        self.paths
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(path);
+    }
+
+    /// Delete every path registered so far, consuming the registration list.
+    ///
+    /// A `NotFound` on removal is not an error (the file is already gone,
+    /// which is the desired end state — e.g. a chunk already drained into
+    /// the merged output); any other I/O error is logged at `warn!` but does
+    /// not stop cleanup of the remaining paths, matching the severity and
+    /// resilience the prior directory sweep provided.
+    pub(super) async fn cleanup(&self) {
+        let paths = std::mem::take(
+            &mut *self
+                .paths
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        let total = paths.len();
+        let mut deleted = 0usize;
+        for path in &paths {
+            match tokio::fs::remove_file(path).await {
+                Ok(()) => deleted += 1,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => warn!(path:? = path; "Failed to delete chunk file: {e}"),
+            }
+        }
+        debug!(deleted = deleted, total = total; "Cleaned up owned chunk files after failed download");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cleanup_deletes_only_registered_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ledger = ChunkLedger::new();
+
+        let owned_a = dir.path().join("owned_a");
+        let owned_b = dir.path().join("owned_b");
+        tokio::fs::write(&owned_a, b"a").await.expect("write a");
+        tokio::fs::write(&owned_b, b"b").await.expect("write b");
+        ledger.register(owned_a.clone());
+        ledger.register(owned_b.clone());
+
+        // A foreign file this ledger never registered, even though nothing
+        // here distinguishes its *name* from an owned chunk's — the point of
+        // this type is that name alone is irrelevant to deletion.
+        let foreign = dir.path().join("foreign");
+        tokio::fs::write(&foreign, b"f")
+            .await
+            .expect("write foreign");
+
+        ledger.cleanup().await;
+
+        assert!(tokio::fs::metadata(&owned_a).await.is_err());
+        assert!(tokio::fs::metadata(&owned_b).await.is_err());
+        assert!(
+            tokio::fs::metadata(&foreign).await.is_ok(),
+            "an unregistered file must survive cleanup regardless of its name"
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_of_already_missing_registered_path_is_not_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ledger = ChunkLedger::new();
+        // Registered but never actually written (e.g. the write failed before
+        // any bytes landed) — cleanup must tolerate this silently.
+        ledger.register(dir.path().join("never-written"));
+
+        ledger.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_no_registrations_is_a_no_op() {
+        ChunkLedger::new().cleanup().await;
+    }
+
+    /// This is the whole point of replacing `ChunkSet::sweep` with a ledger.
+    ///
+    /// `DOWNLOAD_ID_COUNTER` (`parallel.rs`) is a per-*process* atomic
+    /// starting at 0, so two concurrent rdlp processes downloading the same
+    /// filename into the same directory can both compute `download_id == 0`
+    /// — at which point their chunk files are named identically
+    /// (`ChunkSet::path_in` depends only on filename + `download_id` + kind +
+    /// `chunk_id`). The removed `ChunkSet::sweep` deleted every directory
+    /// entry matching that shared name grammar, so process A's sweep would
+    /// also delete process B's live, in-progress chunk file of the same
+    /// name. A `ChunkLedger` cannot make that mistake: it deletes only the
+    /// paths THIS run explicitly registered, so a file this run never
+    /// registered survives even when its name is indistinguishable from an
+    /// owned chunk's.
+    #[tokio::test]
+    async fn cleanup_survives_a_foreign_file_matching_this_run_exact_grammar_and_download_id() {
+        use super::super::chunk_name::{ChunkKind, ChunkSet};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Same filename, same download_id, same kind for both "this run"
+        // and the "foreign" file below — standing in for a second, real,
+        // concurrent rdlp process that landed on the same per-process
+        // download id.
+        let shared_set =
+            ChunkSet::for_attempt("Title.mp4", 0, ChunkKind::Fresh).expect("valid filename");
+
+        let this_run = ChunkLedger::new();
+        let owned_chunk = shared_set.path_in(dir.path(), 0);
+        tokio::fs::write(&owned_chunk, b"mine")
+            .await
+            .expect("write this run's chunk 0");
+        this_run.register(owned_chunk.clone());
+
+        // The foreign process's chunk 1: identical grammar (filename,
+        // download_id, kind), never registered with THIS run's ledger.
+        let foreign_chunk = shared_set.path_in(dir.path(), 1);
+        tokio::fs::write(&foreign_chunk, b"theirs")
+            .await
+            .expect("write the foreign process's chunk 1");
+
+        this_run.cleanup().await;
+
+        assert!(
+            tokio::fs::metadata(&owned_chunk).await.is_err(),
+            "this run's own registered chunk must be deleted"
+        );
+        assert!(
+            tokio::fs::metadata(&foreign_chunk).await.is_ok(),
+            "a same-grammar, same-download-id chunk this run never \
+             registered (standing in for a concurrent process's live chunk) \
+             must survive cleanup — the removed ChunkSet::sweep could not \
+             guarantee this"
+        );
+    }
+}

--- a/crates/rdlp-downloader/src/http/chunk_name.rs
+++ b/crates/rdlp-downloader/src/http/chunk_name.rs
@@ -15,9 +15,20 @@
 //!    `total_chunks`, a count the adaptive controller doesn't have — it
 //!    generates chunk ids lazily via `stream::try_unfold` (`parallel.rs`) —
 //!    so an adaptive download can exceed any a-priori bound, and the
-//!    adaptive path calls no cleanup function at all. [`ChunkSet::sweep`]
-//!    replaces the bounded loop with a directory scan, so the final chunk
-//!    count need never be known up front.
+//!    adaptive path calls no cleanup function at all.
+//!
+//! Cleanup of a failed download no longer scans a directory at all: the
+//! writer registers each chunk path with a [`super::chunk_ledger::ChunkLedger`]
+//! at construction time, and cleanup deletes exactly those registered paths.
+//! An earlier version of this module scanned the temp directory for names
+//! matching this grammar and deleted every match — but `DOWNLOAD_ID_COUNTER`
+//! (`parallel.rs`) is a per-process counter starting at 0, so two concurrent
+//! rdlp processes downloading the same filename into the same directory can
+//! both compute `download_id == 0`, and a pattern-sweep in one process would
+//! then delete the other's live chunk files. This is the same defect class
+//! as #558 (`cleanup_leftover_segments`'s pattern-matched directory sweep),
+//! just reached from a different starting point; see
+//! `scripts/check-no-dir-sweep-delete.sh` for the standing gate against it.
 //!
 //! (The `rdlp-api` legacy-chunk cleaner's `0..10` scan bound, by contrast,
 //! never leaked in practice: the legacy grammar predates power-of-two
@@ -34,8 +45,6 @@
 //! `filename` is the full output file name including extension (e.g.
 //! `Title.mp4`), so a real chunk looks like `Title.mp4.7.resume3`.
 
-use anyhow::Context;
-use log::{debug, warn};
 use std::path::{Path, PathBuf};
 
 /// Origin of a chunk within its download attempt: a fresh transfer or one
@@ -43,7 +52,7 @@ use std::path::{Path, PathBuf};
 ///
 /// Modeled as an enum (not a raw `&str` marker) because the set of markers is
 /// closed and a typo in a string literal would silently create an
-/// unclaimable — and therefore unsweepable — chunk file.
+/// unclaimable chunk file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChunkKind {
     /// A chunk written by a brand-new download attempt.
@@ -61,26 +70,6 @@ impl ChunkKind {
             Self::Resume => "resume",
         }
     }
-}
-
-/// Report of a [`ChunkSet::sweep`] pass over a directory.
-///
-/// No `PartialEq`/`Eq`: `std::io::Error` implements neither (it may wrap an
-/// arbitrary boxed source), and no caller needs whole-struct equality — every
-/// test in this module asserts on `deleted`/`errors` directly, which is also
-/// the more informative failure message on assertion failure.
-#[derive(Debug, Default)]
-#[must_use]
-pub struct SweepReport {
-    /// Number of chunk files this set claimed and successfully deleted.
-    pub deleted: usize,
-    /// Per-file errors encountered while deleting a claimed chunk, paired
-    /// with the path that failed. A `NotFound` on removal is not recorded
-    /// here (the file is already gone, which is the desired end state);
-    /// every other I/O error is, kept as a typed [`std::io::Error`] so a
-    /// caller can distinguish e.g. `PermissionDenied` from a transient
-    /// failure rather than pattern-matching a formatted string.
-    pub errors: Vec<(PathBuf, std::io::Error)>,
 }
 
 /// A named, addressable set of parallel-download chunk files sharing one
@@ -108,10 +97,10 @@ impl ChunkSet {
     /// migrating call site otherwise duplicated its own
     /// `.file_name().to_string_lossy()` boilerplate, and an empty or
     /// filename-less string would silently build a set whose prefix is
-    /// `.{download_id}.part`, wide enough to claim (and sweep would then
-    /// delete) any foreign `.partN` file sharing that download id. Taking
-    /// `&Path` and delegating to [`Path::file_name`] makes that state
-    /// unrepresentable instead of validating a `String` after the fact.
+    /// `.{download_id}.part`, wide enough to claim any foreign `.partN` file
+    /// sharing that download id. Taking `&Path` and delegating to
+    /// [`Path::file_name`] makes that state unrepresentable instead of
+    /// validating a `String` after the fact.
     ///
     /// # Errors
     ///
@@ -190,111 +179,25 @@ impl ChunkSet {
     /// a leading-zero chunk id, but `claims` parses the digit run with
     /// ordinary decimal parsing, so e.g. `"part007"` also claims chunk id
     /// `7` (see the `claims_lenient_leading_zeros_alias_to_same_chunk_id`
-    /// test). This is deliberate, not an oversight: [`Self::sweep`] must
-    /// delete whatever file it claims by name, and a stricter parse could
-    /// leave orphaned a chunk file written with leading zeros by some other
-    /// rdlp version.
+    /// test). This is deliberate, not an oversight: resume detection
+    /// (rdlp-api, #559) must recognize whatever file it claims by name, and
+    /// a stricter parse could leave a chunk file written with leading zeros
+    /// by some other rdlp version unrecognized.
     #[must_use]
     pub fn claims(&self, file_name: &str) -> Option<u64> {
         Self::claims_with_prefix(&self.prefix(), file_name)
     }
 
     /// Shared matching logic behind [`Self::claims`], taking an
-    /// already-built `prefix` so [`Self::sweep`] can compute it once per
-    /// directory scan instead of once per entry.
+    /// already-built `prefix` so a caller checking many file names against
+    /// the same set (e.g. resume detection scanning a directory read-only)
+    /// can compute it once instead of once per entry.
     fn claims_with_prefix(prefix: &str, file_name: &str) -> Option<u64> {
         let rest = file_name.strip_prefix(prefix)?;
         if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
             return None;
         }
         rest.parse().ok()
-    }
-
-    /// Scan `dir` and delete every entry this set [`claims`](Self::claims).
-    ///
-    /// This is a directory scan rather than an index loop over an assumed
-    /// chunk-id range: the adaptive downloader generates chunk ids lazily,
-    /// so the final count is unknown at cleanup time, and a bounded loop is
-    /// exactly the defect (#559) this module exists to close.
-    ///
-    /// A missing directory is not an error (nothing to sweep); any other
-    /// I/O error reading the directory is surfaced. Per-file deletion
-    /// errors are collected in the returned [`SweepReport`] rather than
-    /// aborting the sweep, so one locked/foreign-owned file doesn't stop
-    /// cleanup of the rest — but each is also logged at `warn!` level here,
-    /// matching the severity the pre-existing bounded cleanup used, so a
-    /// failed delete stays operator-visible even though it no longer aborts
-    /// the sweep.
-    ///
-    /// Only regular files are ever deleted: an entry whose name matches this
-    /// set's grammar but whose [`std::fs::FileType`] is not a plain file
-    /// (most notably a directory) is never ours — nothing in this tree
-    /// creates a chunk *directory* — so it is skipped rather than handed to
-    /// `remove_file`, which would otherwise fail it into [`SweepReport`] as
-    /// a spurious `IsADirectory`/`EISDIR` error for a path this sweep must
-    /// not touch.
-    ///
-    /// `std::fs::remove_file` (and its `tokio::fs` equivalent used here)
-    /// removes a symlink itself rather than following it, so a hostile
-    /// symlink named to match this set's grammar cannot be used to delete
-    /// an arbitrary target through this pattern-based sweep.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `dir` exists but cannot be read (permissions,
-    /// I/O failure) or if iterating its entries fails partway through.
-    /// A missing `dir` is not an error.
-    pub async fn sweep(&self, dir: &Path) -> anyhow::Result<SweepReport> {
-        let mut report = SweepReport::default();
-
-        let mut entries = match tokio::fs::read_dir(dir).await {
-            Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(report),
-            Err(e) => {
-                return Err(e).with_context(|| format!("reading directory {}", dir.display()));
-            }
-        };
-
-        let prefix = self.prefix();
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .with_context(|| format!("iterating directory {}", dir.display()))?
-        {
-            let name = entry.file_name();
-            let Some(name) = name.to_str() else {
-                debug!(
-                    path:? = entry.path();
-                    "Skipping non-UTF-8 directory entry during chunk sweep: {}",
-                    name.to_string_lossy()
-                );
-                continue;
-            };
-            if Self::claims_with_prefix(&prefix, name).is_none() {
-                continue;
-            }
-
-            match entry.file_type().await {
-                Ok(file_type) if file_type.is_file() => {}
-                Ok(_) => continue, // not ours: no code in this tree creates a chunk directory/symlink
-                Err(e) => {
-                    warn!(path:? = entry.path(); "Failed to stat directory entry during chunk sweep: {e}");
-                    continue;
-                }
-            }
-
-            let path = entry.path();
-            match tokio::fs::remove_file(&path).await {
-                Ok(()) => report.deleted += 1,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    warn!(path:? = path; "Failed to delete chunk file: {e}");
-                    report.errors.push((path, e));
-                }
-            }
-        }
-
-        Ok(report)
     }
 }
 
@@ -421,121 +324,5 @@ mod tests {
         // hazard described above.
         assert!(ChunkSet::for_attempt("", 1, ChunkKind::Fresh).is_err());
         assert!(ChunkSet::legacy("").is_err());
-    }
-
-    #[tokio::test]
-    async fn sweep_deletes_only_claimed_chunks() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-
-        // 12 chunks belonging to this set — well past the legacy 0..10 bound.
-        for chunk_id in 0..12u64 {
-            let path = set.path_in(dir.path(), chunk_id);
-            tokio::fs::write(&path, b"chunk")
-                .await
-                .expect("write chunk");
-        }
-
-        // 2 foreign files that must survive the sweep untouched.
-        let foreign_a = dir.path().join("Title.mp4");
-        let foreign_b = dir.path().join("Other.mp4.7.part0");
-        tokio::fs::write(&foreign_a, b"final")
-            .await
-            .expect("write foreign a");
-        tokio::fs::write(&foreign_b, b"other")
-            .await
-            .expect("write foreign b");
-
-        let report = set.sweep(dir.path()).await.expect("sweep");
-        assert_eq!(report.deleted, 12);
-        assert!(report.errors.is_empty());
-
-        let mut remaining = Vec::new();
-        let mut entries = tokio::fs::read_dir(dir.path()).await.expect("read_dir");
-        while let Some(entry) = entries.next_entry().await.expect("next_entry") {
-            remaining.push(entry.file_name().to_string_lossy().into_owned());
-        }
-        assert_eq!(remaining.len(), 2);
-        assert!(remaining.contains(&"Title.mp4".to_owned()));
-        assert!(remaining.contains(&"Other.mp4.7.part0".to_owned()));
-    }
-
-    #[tokio::test]
-    async fn sweep_missing_directory_is_not_an_error() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        let report = set
-            .sweep(Path::new("/nonexistent/rdlp-chunk-name-test-dir"))
-            .await
-            .expect("missing dir sweeps clean");
-        assert_eq!(report.deleted, 0);
-        assert!(report.errors.is_empty());
-    }
-
-    #[tokio::test]
-    async fn sweep_skips_directory_matching_chunk_grammar() {
-        // N1: a directory named exactly like a claimed chunk (e.g. some
-        // out-of-band tool, or a user, created `Title.mp4.7.part3/`) is not
-        // ours — nothing in this tree ever creates a chunk *directory* — so
-        // it must survive sweep untouched and must not surface as an error.
-        let dir = tempfile::tempdir().expect("tempdir");
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        let claimed_dir = set.path_in(dir.path(), 3);
-        tokio::fs::create_dir(&claimed_dir)
-            .await
-            .expect("create directory standing in for a chunk");
-
-        let report = set.sweep(dir.path()).await.expect("sweep");
-
-        assert_eq!(report.deleted, 0);
-        assert!(report.errors.is_empty());
-        assert!(
-            tokio::fs::metadata(&claimed_dir)
-                .await
-                .expect("directory must survive sweep")
-                .is_dir()
-        );
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn sweep_records_typed_error_for_undeletable_entry() {
-        // A regular file inside a directory with its write bit cleared
-        // cannot be unlinked (no write permission on the containing
-        // directory), so it deterministically exercises the
-        // `SweepReport::errors` path with a real `io::ErrorKind` rather
-        // than a synthetic one. (A chunk-named *directory* no longer takes
-        // this path at all — see `sweep_skips_directory_matching_chunk_grammar`
-        // — so a permission failure on a regular file is the remaining way
-        // to exercise this branch.)
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        let undeletable = set.path_in(dir.path(), 0);
-        tokio::fs::write(&undeletable, b"chunk")
-            .await
-            .expect("write chunk standing in for the undeletable file");
-
-        let mut perms = tokio::fs::metadata(dir.path())
-            .await
-            .expect("stat dir")
-            .permissions();
-        perms.set_mode(0o555); // read + execute, no write: entries can't be unlinked
-        tokio::fs::set_permissions(dir.path(), perms.clone())
-            .await
-            .expect("make directory read-only");
-
-        let report = set.sweep(dir.path()).await.expect("sweep");
-
-        perms.set_mode(0o755);
-        tokio::fs::set_permissions(dir.path(), perms)
-            .await
-            .expect("restore directory permissions for cleanup");
-
-        assert_eq!(report.deleted, 0);
-        assert_eq!(report.errors.len(), 1);
-        let (path, err) = &report.errors[0];
-        assert_eq!(path, &undeletable);
-        assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/crates/rdlp-downloader/src/http/chunk_name.rs
+++ b/crates/rdlp-downloader/src/http/chunk_name.rs
@@ -5,17 +5,17 @@
 //! the divergence already produced two live defects this module closes
 //! (refs #568, #559):
 //!
-//! 1. **Kind-blind cleanup** (`parallel.rs::cleanup_chunk_files`) hardcodes
-//!    the `.part{chunk_id}` marker while the chunk writer interpolates a
-//!    `suffix` that is `"resume"` on the resume path — so a failed *resumed*
-//!    download's cleanup pass silently deletes nothing. This is #568's live
-//!    leak and the reason chunk kind ([`ChunkKind`]) is part of the grammar,
-//!    not an afterthought.
-//! 2. **Range-bounded cleanup**: the same function bounds deletion by
+//! 1. **Kind-blind cleanup** (`parallel.rs`'s pre-fix cleanup function)
+//!    hardcoded the `.part{chunk_id}` marker while the chunk writer
+//!    interpolates a `suffix` that is `"resume"` on the resume path — so a
+//!    failed *resumed* download's cleanup pass silently deleted nothing.
+//!    This is #568's live leak and the reason chunk kind ([`ChunkKind`]) is
+//!    part of the grammar, not an afterthought.
+//! 2. **Range-bounded cleanup**: the same function bounded deletion by
 //!    `total_chunks`, a count the adaptive controller doesn't have — it
 //!    generates chunk ids lazily via `stream::try_unfold` (`parallel.rs`) —
-//!    so an adaptive download can exceed any a-priori bound, and the
-//!    adaptive path calls no cleanup function at all.
+//!    so an adaptive download could exceed any a-priori bound, and the
+//!    adaptive path called no cleanup function at all.
 //!
 //! Cleanup of a failed download no longer scans a directory at all: the
 //! writer registers each chunk path with a [`super::chunk_ledger::ChunkLedger`]
@@ -53,7 +53,7 @@ use std::path::{Path, PathBuf};
 /// Modeled as an enum (not a raw `&str` marker) because the set of markers is
 /// closed and a typo in a string literal would silently create an
 /// unclaimable chunk file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChunkKind {
     /// A chunk written by a brand-new download attempt.
     Fresh,
@@ -82,7 +82,7 @@ impl ChunkKind {
 /// chunk set has no producer anywhere in the tree, so it is deliberately
 /// unreachable through this type's public constructors rather than merely
 /// undocumented.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChunkSet {
     filename: String,
     download_id: Option<u64>,
@@ -166,39 +166,6 @@ impl ChunkSet {
     pub fn path_in(&self, dir: &Path, chunk_id: u64) -> PathBuf {
         dir.join(format!("{}{chunk_id}", self.prefix()))
     }
-
-    /// If `file_name` belongs to this set, return its chunk id.
-    ///
-    /// A match requires the exact prefix for this set's filename,
-    /// download id, and kind, followed by one or more ASCII digits and
-    /// nothing else — so a foreign file, a different download id, a
-    /// different [`ChunkKind`], or a non-numeric/empty suffix are all
-    /// rejected.
-    ///
-    /// **Not a strict inverse of [`Self::path_in`].** `path_in` never emits
-    /// a leading-zero chunk id, but `claims` parses the digit run with
-    /// ordinary decimal parsing, so e.g. `"part007"` also claims chunk id
-    /// `7` (see the `claims_lenient_leading_zeros_alias_to_same_chunk_id`
-    /// test). This is deliberate, not an oversight: resume detection
-    /// (rdlp-api, #559) must recognize whatever file it claims by name, and
-    /// a stricter parse could leave a chunk file written with leading zeros
-    /// by some other rdlp version unrecognized.
-    #[must_use]
-    pub fn claims(&self, file_name: &str) -> Option<u64> {
-        Self::claims_with_prefix(&self.prefix(), file_name)
-    }
-
-    /// Shared matching logic behind [`Self::claims`], taking an
-    /// already-built `prefix` so a caller checking many file names against
-    /// the same set (e.g. resume detection scanning a directory read-only)
-    /// can compute it once instead of once per entry.
-    fn claims_with_prefix(prefix: &str, file_name: &str) -> Option<u64> {
-        let rest = file_name.strip_prefix(prefix)?;
-        if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
-            return None;
-        }
-        rest.parse().ok()
-    }
 }
 
 #[cfg(test)]
@@ -206,7 +173,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn round_trip_new_style_fresh() {
+    fn path_in_builds_new_style_fresh_name() {
         let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 3);
@@ -214,115 +181,36 @@ mod tests {
             path.file_name().unwrap().to_str().unwrap(),
             "Title.mp4.7.part3"
         );
-        let name = path.file_name().unwrap().to_str().unwrap();
-        assert_eq!(set.claims(name), Some(3));
     }
 
     #[test]
-    fn round_trip_new_style_resume() {
+    fn path_in_builds_new_style_resume_name() {
         let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume).expect("valid filename");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 3);
         let name = path.file_name().unwrap().to_str().unwrap();
         assert_eq!(name, "Title.mp4.7.resume3");
-        assert_eq!(set.claims(name), Some(3));
     }
 
     #[test]
-    fn round_trip_legacy() {
+    fn path_in_builds_legacy_name() {
         let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 4);
         let name = path.file_name().unwrap().to_str().unwrap();
         assert_eq!(name, "Title.mp4.part4");
-        assert_eq!(set.claims(name), Some(4));
-    }
-
-    #[test]
-    fn claims_rejects_different_download_id() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.8.part3"), None);
-    }
-
-    #[test]
-    fn claims_rejects_different_filename() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        assert_eq!(set.claims("Other.mp4.7.part3"), None);
-    }
-
-    #[test]
-    fn claims_rejects_bare_marker_with_no_digits() {
-        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.part"), None);
-    }
-
-    #[test]
-    fn claims_rejects_non_numeric_suffix() {
-        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.part1x"), None);
-    }
-
-    #[test]
-    fn claims_rejects_foreign_file() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        assert_eq!(set.claims("Title.mp4"), None);
-    }
-
-    #[test]
-    fn fresh_set_does_not_claim_resume_chunk() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.7.resume3"), None);
-    }
-
-    #[test]
-    fn resume_set_does_not_claim_fresh_chunk() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume).expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.7.part3"), None);
-    }
-
-    #[test]
-    fn claims_unbounded_index_beyond_legacy_ten_chunk_cap() {
-        // #559: the legacy scanner bounded chunk ids to 0..10. This set must
-        // claim chunk ids well beyond that bound.
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.7.part12"), Some(12));
-        assert_eq!(set.claims("Title.mp4.7.part100"), Some(100));
-    }
-
-    #[test]
-    fn claims_lenient_leading_zeros_alias_to_same_chunk_id() {
-        // N2: `claims` is deliberately not a strict inverse of `path_in` —
-        // see the doc comment on `claims`. Pinned here so the aliasing is a
-        // recorded decision, not an accident a future refactor "fixes" away.
-        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
-        assert_eq!(set.claims("Title.mp4.part007"), Some(7));
-        // `path_in` itself never produces the leading-zero form.
-        let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
-        assert_eq!(
-            set.path_in(dir, 7).file_name().unwrap().to_str().unwrap(),
-            "Title.mp4.part7"
-        );
     }
 
     #[test]
     fn for_attempt_rejects_empty_filename() {
         // N4: an empty filename would otherwise build a set whose prefix is
-        // bare `.{download_id}.part`, claiming any foreign `.partN` file
-        // sharing that download id.
+        // bare `.{download_id}.part`, wide enough to build a path colliding
+        // with any foreign `.partN` file sharing that download id.
         assert!(ChunkSet::for_attempt("", 7, ChunkKind::Fresh).is_err());
     }
 
     #[test]
     fn legacy_rejects_empty_filename() {
-        assert!(ChunkSet::legacy("").is_err());
-    }
-
-    #[test]
-    fn empty_filename_error_prevents_claiming_a_foreign_part_file() {
-        // N4b: construction fails outright, so there is no `ChunkSet` in
-        // existence that could claim a foreign `.part1` via the empty-prefix
-        // hazard described above.
-        assert!(ChunkSet::for_attempt("", 1, ChunkKind::Fresh).is_err());
         assert!(ChunkSet::legacy("").is_err());
     }
 }

--- a/crates/rdlp-downloader/src/http/chunk_name.rs
+++ b/crates/rdlp-downloader/src/http/chunk_name.rs
@@ -1,0 +1,299 @@
+//! Single authoritative grammar for parallel-download chunk file names.
+//!
+//! Before this module existed, the chunk-name grammar was duplicated as five
+//! independent `format!` strings across `rdlp-downloader` and `rdlp-api`, and
+//! the divergence already produced a live data leak (refs #568, #559): the
+//! `rdlp-api` cleaner bounded its directory scan to `0..10` chunks, silently
+//! leaking every chunk beyond that when a download used more connections.
+//!
+//! [`ChunkSet`] is the one place a chunk file name is built or parsed. Two
+//! grammars are represented:
+//!
+//! - **new-style** (`download_id: Some(_)`): `{filename}.{download_id}.{marker}{chunk_id}`
+//! - **legacy** (`download_id: None`, pre-Phase-2.5): `{filename}.{marker}{chunk_id}`
+//!
+//! `filename` is the full output file name including extension (e.g.
+//! `Title.mp4`), so a real chunk looks like `Title.mp4.7.resume3`.
+
+use anyhow::Context;
+use std::path::{Path, PathBuf};
+
+/// Origin of a chunk within its download attempt: a fresh transfer or one
+/// resumed from a previous, interrupted attempt.
+///
+/// Modeled as an enum (not a raw `&str` marker) because the set of markers is
+/// closed and a typo in a string literal would silently create an
+/// unclaimable — and therefore unsweepable — chunk file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChunkKind {
+    /// A chunk written by a brand-new download attempt.
+    Fresh,
+    /// A chunk written while resuming a previously interrupted attempt.
+    Resume,
+}
+
+impl ChunkKind {
+    /// The literal marker embedded in the chunk file name for this kind.
+    #[must_use]
+    pub const fn marker(self) -> &'static str {
+        match self {
+            Self::Fresh => "part",
+            Self::Resume => "resume",
+        }
+    }
+}
+
+/// Report of a [`ChunkSet::sweep`] pass over a directory.
+#[derive(Debug, Clone, Default)]
+pub struct SweepReport {
+    /// Number of chunk files this set claimed and successfully deleted.
+    pub deleted: usize,
+    /// Per-file errors encountered while deleting a claimed chunk. A
+    /// `NotFound` on removal is not recorded here (the file is already gone,
+    /// which is the desired end state); every other I/O error is.
+    pub errors: Vec<String>,
+}
+
+/// A named, addressable set of parallel-download chunk files sharing one
+/// output filename, one download attempt (or the legacy "no id" attempt),
+/// and one [`ChunkKind`].
+///
+/// `download_id: None` denotes the legacy pre-Phase-2.5 grammar
+/// (`{filename}.part{chunk_id}`, no download id segment).
+#[derive(Debug, Clone)]
+pub struct ChunkSet {
+    filename: String,
+    download_id: Option<u64>,
+    kind: ChunkKind,
+}
+
+impl ChunkSet {
+    /// Construct a chunk set descriptor. Does not touch the filesystem.
+    pub fn new(filename: impl Into<String>, download_id: Option<u64>, kind: ChunkKind) -> Self {
+        Self {
+            filename: filename.into(),
+            download_id,
+            kind,
+        }
+    }
+
+    /// The shared prefix every chunk file name in this set begins with,
+    /// immediately followed by the chunk id's decimal digits.
+    fn prefix(&self) -> String {
+        self.download_id.map_or_else(
+            || format!("{}.{}", self.filename, self.kind.marker()),
+            |id| format!("{}.{id}.{}", self.filename, self.kind.marker()),
+        )
+    }
+
+    /// Build the path for `chunk_id` within `dir`.
+    #[must_use]
+    pub fn path_in(&self, dir: &Path, chunk_id: u64) -> PathBuf {
+        dir.join(format!("{}{chunk_id}", self.prefix()))
+    }
+
+    /// If `file_name` belongs to this set, return its chunk id.
+    ///
+    /// A match requires the exact prefix for this set's filename,
+    /// download id, and kind, followed by one or more ASCII digits and
+    /// nothing else — so a foreign file, a different download id, a
+    /// different [`ChunkKind`], or a non-numeric/empty suffix are all
+    /// rejected.
+    #[must_use]
+    pub fn claims(&self, file_name: &str) -> Option<u64> {
+        let rest = file_name.strip_prefix(self.prefix().as_str())?;
+        if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        rest.parse().ok()
+    }
+
+    /// Scan `dir` and delete every entry this set [`claims`](Self::claims).
+    ///
+    /// This is a directory scan rather than an index loop over an assumed
+    /// chunk-id range: the adaptive downloader generates chunk ids lazily,
+    /// so the final count is unknown at cleanup time, and a bounded loop is
+    /// exactly the defect (#559) this module exists to close.
+    ///
+    /// A missing directory is not an error (nothing to sweep); any other
+    /// I/O error reading the directory is surfaced. Per-file deletion
+    /// errors are collected in the returned [`SweepReport`] rather than
+    /// aborting the sweep, so one locked/foreign-owned file doesn't stop
+    /// cleanup of the rest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `dir` exists but cannot be read (permissions,
+    /// I/O failure) or if iterating its entries fails partway through.
+    /// A missing `dir` is not an error.
+    pub async fn sweep(&self, dir: &Path) -> anyhow::Result<SweepReport> {
+        let mut report = SweepReport::default();
+
+        let mut entries = match tokio::fs::read_dir(dir).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+            Err(e) => {
+                return Err(e).with_context(|| format!("reading directory {}", dir.display()));
+            }
+        };
+
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .with_context(|| format!("iterating directory {}", dir.display()))?
+        {
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            if self.claims(&name).is_none() {
+                continue;
+            }
+
+            let path = entry.path();
+            match tokio::fs::remove_file(&path).await {
+                Ok(()) => report.deleted += 1,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => report.errors.push(format!("{}: {e}", path.display())),
+            }
+        }
+
+        Ok(report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn round_trip_new_style_fresh() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
+        let path = set.path_in(dir, 3);
+        assert_eq!(
+            path.file_name().unwrap().to_str().unwrap(),
+            "Title.mp4.7.part3"
+        );
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(set.claims(name), Some(3));
+    }
+
+    #[tokio::test]
+    async fn round_trip_new_style_resume() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Resume);
+        let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
+        let path = set.path_in(dir, 3);
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(name, "Title.mp4.7.resume3");
+        assert_eq!(set.claims(name), Some(3));
+    }
+
+    #[tokio::test]
+    async fn round_trip_legacy() {
+        let set = ChunkSet::new("Title.mp4", None, ChunkKind::Fresh);
+        let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
+        let path = set.path_in(dir, 4);
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(name, "Title.mp4.part4");
+        assert_eq!(set.claims(name), Some(4));
+    }
+
+    #[tokio::test]
+    async fn claims_rejects_different_download_id() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        assert_eq!(set.claims("Title.mp4.8.part3"), None);
+    }
+
+    #[tokio::test]
+    async fn claims_rejects_different_filename() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        assert_eq!(set.claims("Other.mp4.7.part3"), None);
+    }
+
+    #[tokio::test]
+    async fn claims_rejects_bare_marker_with_no_digits() {
+        let set = ChunkSet::new("Title.mp4", None, ChunkKind::Fresh);
+        assert_eq!(set.claims("Title.mp4.part"), None);
+    }
+
+    #[tokio::test]
+    async fn claims_rejects_non_numeric_suffix() {
+        let set = ChunkSet::new("Title.mp4", None, ChunkKind::Fresh);
+        assert_eq!(set.claims("Title.mp4.part1x"), None);
+    }
+
+    #[tokio::test]
+    async fn claims_rejects_foreign_file() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        assert_eq!(set.claims("Title.mp4"), None);
+    }
+
+    #[tokio::test]
+    async fn fresh_set_does_not_claim_resume_chunk() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        assert_eq!(set.claims("Title.mp4.7.resume3"), None);
+    }
+
+    #[tokio::test]
+    async fn resume_set_does_not_claim_fresh_chunk() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Resume);
+        assert_eq!(set.claims("Title.mp4.7.part3"), None);
+    }
+
+    #[tokio::test]
+    async fn claims_unbounded_index_beyond_legacy_ten_chunk_cap() {
+        // #559: the legacy scanner bounded chunk ids to 0..10. This set must
+        // claim chunk ids well beyond that bound.
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        assert_eq!(set.claims("Title.mp4.7.part12"), Some(12));
+        assert_eq!(set.claims("Title.mp4.7.part100"), Some(100));
+    }
+
+    #[tokio::test]
+    async fn sweep_deletes_only_claimed_chunks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+
+        // 12 chunks belonging to this set — well past the legacy 0..10 bound.
+        for chunk_id in 0..12u64 {
+            let path = set.path_in(dir.path(), chunk_id);
+            tokio::fs::write(&path, b"chunk")
+                .await
+                .expect("write chunk");
+        }
+
+        // 2 foreign files that must survive the sweep untouched.
+        let foreign_a = dir.path().join("Title.mp4");
+        let foreign_b = dir.path().join("Other.mp4.7.part0");
+        tokio::fs::write(&foreign_a, b"final")
+            .await
+            .expect("write foreign a");
+        tokio::fs::write(&foreign_b, b"other")
+            .await
+            .expect("write foreign b");
+
+        let report = set.sweep(dir.path()).await.expect("sweep");
+        assert_eq!(report.deleted, 12);
+        assert!(report.errors.is_empty());
+
+        let mut remaining = Vec::new();
+        let mut entries = tokio::fs::read_dir(dir.path()).await.expect("read_dir");
+        while let Some(entry) = entries.next_entry().await.expect("next_entry") {
+            remaining.push(entry.file_name().to_string_lossy().into_owned());
+        }
+        assert_eq!(remaining.len(), 2);
+        assert!(remaining.contains(&"Title.mp4".to_owned()));
+        assert!(remaining.contains(&"Other.mp4.7.part0".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn sweep_missing_directory_is_not_an_error() {
+        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        let report = set
+            .sweep(Path::new("/nonexistent/rdlp-chunk-name-test-dir"))
+            .await
+            .expect("missing dir sweeps clean");
+        assert_eq!(report.deleted, 0);
+        assert!(report.errors.is_empty());
+    }
+}

--- a/crates/rdlp-downloader/src/http/chunk_name.rs
+++ b/crates/rdlp-downloader/src/http/chunk_name.rs
@@ -2,9 +2,28 @@
 //!
 //! Before this module existed, the chunk-name grammar was duplicated as five
 //! independent `format!` strings across `rdlp-downloader` and `rdlp-api`, and
-//! the divergence already produced a live data leak (refs #568, #559): the
-//! `rdlp-api` cleaner bounded its directory scan to `0..10` chunks, silently
-//! leaking every chunk beyond that when a download used more connections.
+//! the divergence already produced two live defects this module closes
+//! (refs #568, #559):
+//!
+//! 1. **Kind-blind cleanup** (`parallel.rs::cleanup_chunk_files`) hardcodes
+//!    the `.part{chunk_id}` marker while the chunk writer interpolates a
+//!    `suffix` that is `"resume"` on the resume path — so a failed *resumed*
+//!    download's cleanup pass silently deletes nothing. This is #568's live
+//!    leak and the reason chunk kind ([`ChunkKind`]) is part of the grammar,
+//!    not an afterthought.
+//! 2. **Range-bounded cleanup**: the same function bounds deletion by
+//!    `total_chunks`, a count the adaptive controller doesn't have — it
+//!    generates chunk ids lazily via `stream::try_unfold` (`parallel.rs`) —
+//!    so an adaptive download can exceed any a-priori bound, and the
+//!    adaptive path calls no cleanup function at all. [`ChunkSet::sweep`]
+//!    replaces the bounded loop with a directory scan, so the final chunk
+//!    count need never be known up front.
+//!
+//! (The `rdlp-api` legacy-chunk cleaner's `0..10` scan bound, by contrast,
+//! never leaked in practice: the legacy grammar predates power-of-two
+//! chunking, when `concurrent_fragments` was capped at 10 — see
+//! `orchestrator/resume.rs`. It's included here only because [`ChunkSet`]
+//! now also owns that grammar's parsing.)
 //!
 //! [`ChunkSet`] is the one place a chunk file name is built or parsed. Two
 //! grammars are represented:
@@ -16,6 +35,7 @@
 //! `Title.mp4`), so a real chunk looks like `Title.mp4.7.resume3`.
 
 use anyhow::Context;
+use log::warn;
 use std::path::{Path, PathBuf};
 
 /// Origin of a chunk within its download attempt: a fresh transfer or one
@@ -44,23 +64,52 @@ impl ChunkKind {
 }
 
 /// Report of a [`ChunkSet::sweep`] pass over a directory.
-#[derive(Debug, Clone, Default)]
+///
+/// `std::io::Error` implements neither `Clone` nor `PartialEq` (it may wrap
+/// an arbitrary boxed source), so this type's equality is hand-written
+/// below rather than derived: two reports are equal when they deleted the
+/// same count and their errors match pairwise by path and
+/// [`std::io::ErrorKind`] (the part of an `io::Error` that is meaningfully
+/// comparable).
+#[derive(Debug, Default)]
+#[must_use]
 pub struct SweepReport {
     /// Number of chunk files this set claimed and successfully deleted.
     pub deleted: usize,
-    /// Per-file errors encountered while deleting a claimed chunk. A
-    /// `NotFound` on removal is not recorded here (the file is already gone,
-    /// which is the desired end state); every other I/O error is.
-    pub errors: Vec<String>,
+    /// Per-file errors encountered while deleting a claimed chunk, paired
+    /// with the path that failed. A `NotFound` on removal is not recorded
+    /// here (the file is already gone, which is the desired end state);
+    /// every other I/O error is, kept as a typed [`std::io::Error`] so a
+    /// caller can distinguish e.g. `PermissionDenied` from a transient
+    /// failure rather than pattern-matching a formatted string.
+    pub errors: Vec<(PathBuf, std::io::Error)>,
 }
+
+impl PartialEq for SweepReport {
+    fn eq(&self, other: &Self) -> bool {
+        self.deleted == other.deleted
+            && self.errors.len() == other.errors.len()
+            && self.errors.iter().zip(&other.errors).all(
+                |((path, err), (other_path, other_err))| {
+                    path == other_path && err.kind() == other_err.kind()
+                },
+            )
+    }
+}
+
+impl Eq for SweepReport {}
 
 /// A named, addressable set of parallel-download chunk files sharing one
 /// output filename, one download attempt (or the legacy "no id" attempt),
 /// and one [`ChunkKind`].
 ///
 /// `download_id: None` denotes the legacy pre-Phase-2.5 grammar
-/// (`{filename}.part{chunk_id}`, no download id segment).
-#[derive(Debug, Clone)]
+/// (`{filename}.part{chunk_id}`, no download id segment). The legacy
+/// grammar is Fresh-only (see [`ChunkSet::legacy`]); a legacy *resumed*
+/// chunk set has no producer anywhere in the tree, so it is deliberately
+/// unreachable through this type's public constructors rather than merely
+/// undocumented.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChunkSet {
     filename: String,
     download_id: Option<u64>,
@@ -68,12 +117,26 @@ pub struct ChunkSet {
 }
 
 impl ChunkSet {
-    /// Construct a chunk set descriptor. Does not touch the filesystem.
-    pub fn new(filename: impl Into<String>, download_id: Option<u64>, kind: ChunkKind) -> Self {
+    /// Construct the descriptor for a chunk belonging to a specific,
+    /// numbered download attempt. Does not touch the filesystem.
+    pub fn for_attempt(filename: impl Into<String>, download_id: u64, kind: ChunkKind) -> Self {
         Self {
             filename: filename.into(),
-            download_id,
+            download_id: Some(download_id),
             kind,
+        }
+    }
+
+    /// Construct the descriptor for the legacy pre-Phase-2.5 grammar
+    /// (`{filename}.part{chunk_id}`, no download-id segment). Always
+    /// [`ChunkKind::Fresh`] — the legacy grammar predates resume support,
+    /// so a legacy chunk set is read/delete-only against files nothing in
+    /// the tree still writes. Does not touch the filesystem.
+    pub fn legacy(filename: impl Into<String>) -> Self {
+        Self {
+            filename: filename.into(),
+            download_id: None,
+            kind: ChunkKind::Fresh,
         }
     }
 
@@ -101,7 +164,14 @@ impl ChunkSet {
     /// rejected.
     #[must_use]
     pub fn claims(&self, file_name: &str) -> Option<u64> {
-        let rest = file_name.strip_prefix(self.prefix().as_str())?;
+        Self::claims_with_prefix(&self.prefix(), file_name)
+    }
+
+    /// Shared matching logic behind [`Self::claims`], taking an
+    /// already-built `prefix` so [`Self::sweep`] can compute it once per
+    /// directory scan instead of once per entry.
+    fn claims_with_prefix(prefix: &str, file_name: &str) -> Option<u64> {
+        let rest = file_name.strip_prefix(prefix)?;
         if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
             return None;
         }
@@ -119,7 +189,15 @@ impl ChunkSet {
     /// I/O error reading the directory is surfaced. Per-file deletion
     /// errors are collected in the returned [`SweepReport`] rather than
     /// aborting the sweep, so one locked/foreign-owned file doesn't stop
-    /// cleanup of the rest.
+    /// cleanup of the rest — but each is also logged at `warn!` level here,
+    /// matching the severity the pre-existing bounded cleanup used, so a
+    /// failed delete stays operator-visible even though it no longer aborts
+    /// the sweep.
+    ///
+    /// `std::fs::remove_file` (and its `tokio::fs` equivalent used here)
+    /// removes a symlink itself rather than following it, so a hostile
+    /// symlink named to match this set's grammar cannot be used to delete
+    /// an arbitrary target through this pattern-based sweep.
     ///
     /// # Errors
     ///
@@ -137,15 +215,17 @@ impl ChunkSet {
             }
         };
 
+        let prefix = self.prefix();
         while let Some(entry) = entries
             .next_entry()
             .await
             .with_context(|| format!("iterating directory {}", dir.display()))?
         {
-            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
                 continue;
             };
-            if self.claims(&name).is_none() {
+            if Self::claims_with_prefix(&prefix, name).is_none() {
                 continue;
             }
 
@@ -153,7 +233,10 @@ impl ChunkSet {
             match tokio::fs::remove_file(&path).await {
                 Ok(()) => report.deleted += 1,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => report.errors.push(format!("{}: {e}", path.display())),
+                Err(e) => {
+                    warn!(path:? = path; "Failed to delete chunk file: {e}");
+                    report.errors.push((path, e));
+                }
             }
         }
 
@@ -165,9 +248,9 @@ impl ChunkSet {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn round_trip_new_style_fresh() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+    #[test]
+    fn round_trip_new_style_fresh() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 3);
         assert_eq!(
@@ -178,9 +261,9 @@ mod tests {
         assert_eq!(set.claims(name), Some(3));
     }
 
-    #[tokio::test]
-    async fn round_trip_new_style_resume() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Resume);
+    #[test]
+    fn round_trip_new_style_resume() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume);
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 3);
         let name = path.file_name().unwrap().to_str().unwrap();
@@ -188,9 +271,9 @@ mod tests {
         assert_eq!(set.claims(name), Some(3));
     }
 
-    #[tokio::test]
-    async fn round_trip_legacy() {
-        let set = ChunkSet::new("Title.mp4", None, ChunkKind::Fresh);
+    #[test]
+    fn round_trip_legacy() {
+        let set = ChunkSet::legacy("Title.mp4");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 4);
         let name = path.file_name().unwrap().to_str().unwrap();
@@ -198,53 +281,53 @@ mod tests {
         assert_eq!(set.claims(name), Some(4));
     }
 
-    #[tokio::test]
-    async fn claims_rejects_different_download_id() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+    #[test]
+    fn claims_rejects_different_download_id() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         assert_eq!(set.claims("Title.mp4.8.part3"), None);
     }
 
-    #[tokio::test]
-    async fn claims_rejects_different_filename() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+    #[test]
+    fn claims_rejects_different_filename() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         assert_eq!(set.claims("Other.mp4.7.part3"), None);
     }
 
-    #[tokio::test]
-    async fn claims_rejects_bare_marker_with_no_digits() {
-        let set = ChunkSet::new("Title.mp4", None, ChunkKind::Fresh);
+    #[test]
+    fn claims_rejects_bare_marker_with_no_digits() {
+        let set = ChunkSet::legacy("Title.mp4");
         assert_eq!(set.claims("Title.mp4.part"), None);
     }
 
-    #[tokio::test]
-    async fn claims_rejects_non_numeric_suffix() {
-        let set = ChunkSet::new("Title.mp4", None, ChunkKind::Fresh);
+    #[test]
+    fn claims_rejects_non_numeric_suffix() {
+        let set = ChunkSet::legacy("Title.mp4");
         assert_eq!(set.claims("Title.mp4.part1x"), None);
     }
 
-    #[tokio::test]
-    async fn claims_rejects_foreign_file() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+    #[test]
+    fn claims_rejects_foreign_file() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         assert_eq!(set.claims("Title.mp4"), None);
     }
 
-    #[tokio::test]
-    async fn fresh_set_does_not_claim_resume_chunk() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+    #[test]
+    fn fresh_set_does_not_claim_resume_chunk() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         assert_eq!(set.claims("Title.mp4.7.resume3"), None);
     }
 
-    #[tokio::test]
-    async fn resume_set_does_not_claim_fresh_chunk() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Resume);
+    #[test]
+    fn resume_set_does_not_claim_fresh_chunk() {
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume);
         assert_eq!(set.claims("Title.mp4.7.part3"), None);
     }
 
-    #[tokio::test]
-    async fn claims_unbounded_index_beyond_legacy_ten_chunk_cap() {
+    #[test]
+    fn claims_unbounded_index_beyond_legacy_ten_chunk_cap() {
         // #559: the legacy scanner bounded chunk ids to 0..10. This set must
         // claim chunk ids well beyond that bound.
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         assert_eq!(set.claims("Title.mp4.7.part12"), Some(12));
         assert_eq!(set.claims("Title.mp4.7.part100"), Some(100));
     }
@@ -252,7 +335,7 @@ mod tests {
     #[tokio::test]
     async fn sweep_deletes_only_claimed_chunks() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
 
         // 12 chunks belonging to this set — well past the legacy 0..10 bound.
         for chunk_id in 0..12u64 {
@@ -288,12 +371,34 @@ mod tests {
 
     #[tokio::test]
     async fn sweep_missing_directory_is_not_an_error() {
-        let set = ChunkSet::new("Title.mp4", Some(7), ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
         let report = set
             .sweep(Path::new("/nonexistent/rdlp-chunk-name-test-dir"))
             .await
             .expect("missing dir sweeps clean");
         assert_eq!(report.deleted, 0);
         assert!(report.errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sweep_records_typed_error_for_undeletable_entry() {
+        // A directory that matches this set's grammar can never be removed
+        // by `remove_file`, so it deterministically exercises the
+        // `SweepReport::errors` path with a real `io::ErrorKind` rather
+        // than a synthetic one.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let undeletable = set.path_in(dir.path(), 0);
+        tokio::fs::create_dir(&undeletable)
+            .await
+            .expect("create dir standing in for the chunk file");
+
+        let report = set.sweep(dir.path()).await.expect("sweep");
+
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.errors.len(), 1);
+        let (path, err) = &report.errors[0];
+        assert_eq!(path, &undeletable);
+        assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/crates/rdlp-downloader/src/http/chunk_name.rs
+++ b/crates/rdlp-downloader/src/http/chunk_name.rs
@@ -35,7 +35,7 @@
 //! `Title.mp4`), so a real chunk looks like `Title.mp4.7.resume3`.
 
 use anyhow::Context;
-use log::warn;
+use log::{debug, warn};
 use std::path::{Path, PathBuf};
 
 /// Origin of a chunk within its download attempt: a fresh transfer or one
@@ -65,12 +65,10 @@ impl ChunkKind {
 
 /// Report of a [`ChunkSet::sweep`] pass over a directory.
 ///
-/// `std::io::Error` implements neither `Clone` nor `PartialEq` (it may wrap
-/// an arbitrary boxed source), so this type's equality is hand-written
-/// below rather than derived: two reports are equal when they deleted the
-/// same count and their errors match pairwise by path and
-/// [`std::io::ErrorKind`] (the part of an `io::Error` that is meaningfully
-/// comparable).
+/// No `PartialEq`/`Eq`: `std::io::Error` implements neither (it may wrap an
+/// arbitrary boxed source), and no caller needs whole-struct equality — every
+/// test in this module asserts on `deleted`/`errors` directly, which is also
+/// the more informative failure message on assertion failure.
 #[derive(Debug, Default)]
 #[must_use]
 pub struct SweepReport {
@@ -84,20 +82,6 @@ pub struct SweepReport {
     /// failure rather than pattern-matching a formatted string.
     pub errors: Vec<(PathBuf, std::io::Error)>,
 }
-
-impl PartialEq for SweepReport {
-    fn eq(&self, other: &Self) -> bool {
-        self.deleted == other.deleted
-            && self.errors.len() == other.errors.len()
-            && self.errors.iter().zip(&other.errors).all(
-                |((path, err), (other_path, other_err))| {
-                    path == other_path && err.kind() == other_err.kind()
-                },
-            )
-    }
-}
-
-impl Eq for SweepReport {}
 
 /// A named, addressable set of parallel-download chunk files sharing one
 /// output filename, one download attempt (or the legacy "no id" attempt),
@@ -119,12 +103,30 @@ pub struct ChunkSet {
 impl ChunkSet {
     /// Construct the descriptor for a chunk belonging to a specific,
     /// numbered download attempt. Does not touch the filesystem.
-    pub fn for_attempt(filename: impl Into<String>, download_id: u64, kind: ChunkKind) -> Self {
-        Self {
-            filename: filename.into(),
+    ///
+    /// Takes the *output path*, not a pre-extracted filename string: every
+    /// migrating call site otherwise duplicated its own
+    /// `.file_name().to_string_lossy()` boilerplate, and an empty or
+    /// filename-less string would silently build a set whose prefix is
+    /// `.{download_id}.part`, wide enough to claim (and sweep would then
+    /// delete) any foreign `.partN` file sharing that download id. Taking
+    /// `&Path` and delegating to [`Path::file_name`] makes that state
+    /// unrepresentable instead of validating a `String` after the fact.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_path` has no filename component (e.g. it
+    /// is empty, `.`, `..`, or root).
+    pub fn for_attempt(
+        output_path: impl AsRef<Path>,
+        download_id: u64,
+        kind: ChunkKind,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            filename: Self::filename_of(output_path.as_ref())?,
             download_id: Some(download_id),
             kind,
-        }
+        })
     }
 
     /// Construct the descriptor for the legacy pre-Phase-2.5 grammar
@@ -132,12 +134,33 @@ impl ChunkSet {
     /// [`ChunkKind::Fresh`] — the legacy grammar predates resume support,
     /// so a legacy chunk set is read/delete-only against files nothing in
     /// the tree still writes. Does not touch the filesystem.
-    pub fn legacy(filename: impl Into<String>) -> Self {
-        Self {
-            filename: filename.into(),
+    ///
+    /// See [`Self::for_attempt`] for why this takes a path rather than a
+    /// pre-extracted filename string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_path` has no filename component (e.g. it
+    /// is empty, `.`, `..`, or root).
+    pub fn legacy(output_path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        Ok(Self {
+            filename: Self::filename_of(output_path.as_ref())?,
             download_id: None,
             kind: ChunkKind::Fresh,
-        }
+        })
+    }
+
+    /// Extract the filename component required by both constructors above.
+    fn filename_of(output_path: &Path) -> anyhow::Result<String> {
+        output_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "output path {} has no filename component",
+                    output_path.display()
+                )
+            })
     }
 
     /// The shared prefix every chunk file name in this set begins with,
@@ -162,6 +185,15 @@ impl ChunkSet {
     /// nothing else — so a foreign file, a different download id, a
     /// different [`ChunkKind`], or a non-numeric/empty suffix are all
     /// rejected.
+    ///
+    /// **Not a strict inverse of [`Self::path_in`].** `path_in` never emits
+    /// a leading-zero chunk id, but `claims` parses the digit run with
+    /// ordinary decimal parsing, so e.g. `"part007"` also claims chunk id
+    /// `7` (see the `claims_lenient_leading_zeros_alias_to_same_chunk_id`
+    /// test). This is deliberate, not an oversight: [`Self::sweep`] must
+    /// delete whatever file it claims by name, and a stricter parse could
+    /// leave orphaned a chunk file written with leading zeros by some other
+    /// rdlp version.
     #[must_use]
     pub fn claims(&self, file_name: &str) -> Option<u64> {
         Self::claims_with_prefix(&self.prefix(), file_name)
@@ -194,6 +226,14 @@ impl ChunkSet {
     /// failed delete stays operator-visible even though it no longer aborts
     /// the sweep.
     ///
+    /// Only regular files are ever deleted: an entry whose name matches this
+    /// set's grammar but whose [`std::fs::FileType`] is not a plain file
+    /// (most notably a directory) is never ours — nothing in this tree
+    /// creates a chunk *directory* — so it is skipped rather than handed to
+    /// `remove_file`, which would otherwise fail it into [`SweepReport`] as
+    /// a spurious `IsADirectory`/`EISDIR` error for a path this sweep must
+    /// not touch.
+    ///
     /// `std::fs::remove_file` (and its `tokio::fs` equivalent used here)
     /// removes a symlink itself rather than following it, so a hostile
     /// symlink named to match this set's grammar cannot be used to delete
@@ -223,10 +263,24 @@ impl ChunkSet {
         {
             let name = entry.file_name();
             let Some(name) = name.to_str() else {
+                debug!(
+                    path:? = entry.path();
+                    "Skipping non-UTF-8 directory entry during chunk sweep: {}",
+                    name.to_string_lossy()
+                );
                 continue;
             };
             if Self::claims_with_prefix(&prefix, name).is_none() {
                 continue;
+            }
+
+            match entry.file_type().await {
+                Ok(file_type) if file_type.is_file() => {}
+                Ok(_) => continue, // not ours: no code in this tree creates a chunk directory/symlink
+                Err(e) => {
+                    warn!(path:? = entry.path(); "Failed to stat directory entry during chunk sweep: {e}");
+                    continue;
+                }
             }
 
             let path = entry.path();
@@ -250,7 +304,7 @@ mod tests {
 
     #[test]
     fn round_trip_new_style_fresh() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 3);
         assert_eq!(
@@ -263,7 +317,7 @@ mod tests {
 
     #[test]
     fn round_trip_new_style_resume() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume).expect("valid filename");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 3);
         let name = path.file_name().unwrap().to_str().unwrap();
@@ -273,7 +327,7 @@ mod tests {
 
     #[test]
     fn round_trip_legacy() {
-        let set = ChunkSet::legacy("Title.mp4");
+        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
         let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
         let path = set.path_in(dir, 4);
         let name = path.file_name().unwrap().to_str().unwrap();
@@ -283,43 +337,43 @@ mod tests {
 
     #[test]
     fn claims_rejects_different_download_id() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         assert_eq!(set.claims("Title.mp4.8.part3"), None);
     }
 
     #[test]
     fn claims_rejects_different_filename() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         assert_eq!(set.claims("Other.mp4.7.part3"), None);
     }
 
     #[test]
     fn claims_rejects_bare_marker_with_no_digits() {
-        let set = ChunkSet::legacy("Title.mp4");
+        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
         assert_eq!(set.claims("Title.mp4.part"), None);
     }
 
     #[test]
     fn claims_rejects_non_numeric_suffix() {
-        let set = ChunkSet::legacy("Title.mp4");
+        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
         assert_eq!(set.claims("Title.mp4.part1x"), None);
     }
 
     #[test]
     fn claims_rejects_foreign_file() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         assert_eq!(set.claims("Title.mp4"), None);
     }
 
     #[test]
     fn fresh_set_does_not_claim_resume_chunk() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         assert_eq!(set.claims("Title.mp4.7.resume3"), None);
     }
 
     #[test]
     fn resume_set_does_not_claim_fresh_chunk() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Resume).expect("valid filename");
         assert_eq!(set.claims("Title.mp4.7.part3"), None);
     }
 
@@ -327,15 +381,52 @@ mod tests {
     fn claims_unbounded_index_beyond_legacy_ten_chunk_cap() {
         // #559: the legacy scanner bounded chunk ids to 0..10. This set must
         // claim chunk ids well beyond that bound.
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         assert_eq!(set.claims("Title.mp4.7.part12"), Some(12));
         assert_eq!(set.claims("Title.mp4.7.part100"), Some(100));
+    }
+
+    #[test]
+    fn claims_lenient_leading_zeros_alias_to_same_chunk_id() {
+        // N2: `claims` is deliberately not a strict inverse of `path_in` —
+        // see the doc comment on `claims`. Pinned here so the aliasing is a
+        // recorded decision, not an accident a future refactor "fixes" away.
+        let set = ChunkSet::legacy("Title.mp4").expect("valid filename");
+        assert_eq!(set.claims("Title.mp4.part007"), Some(7));
+        // `path_in` itself never produces the leading-zero form.
+        let dir = Path::new("/tmp/does-not-need-to-exist-for-this-test");
+        assert_eq!(
+            set.path_in(dir, 7).file_name().unwrap().to_str().unwrap(),
+            "Title.mp4.part7"
+        );
+    }
+
+    #[test]
+    fn for_attempt_rejects_empty_filename() {
+        // N4: an empty filename would otherwise build a set whose prefix is
+        // bare `.{download_id}.part`, claiming any foreign `.partN` file
+        // sharing that download id.
+        assert!(ChunkSet::for_attempt("", 7, ChunkKind::Fresh).is_err());
+    }
+
+    #[test]
+    fn legacy_rejects_empty_filename() {
+        assert!(ChunkSet::legacy("").is_err());
+    }
+
+    #[test]
+    fn empty_filename_error_prevents_claiming_a_foreign_part_file() {
+        // N4b: construction fails outright, so there is no `ChunkSet` in
+        // existence that could claim a foreign `.part1` via the empty-prefix
+        // hazard described above.
+        assert!(ChunkSet::for_attempt("", 1, ChunkKind::Fresh).is_err());
+        assert!(ChunkSet::legacy("").is_err());
     }
 
     #[tokio::test]
     async fn sweep_deletes_only_claimed_chunks() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
 
         // 12 chunks belonging to this set — well past the legacy 0..10 bound.
         for chunk_id in 0..12u64 {
@@ -371,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn sweep_missing_directory_is_not_an_error() {
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
         let report = set
             .sweep(Path::new("/nonexistent/rdlp-chunk-name-test-dir"))
             .await
@@ -381,19 +472,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sweep_records_typed_error_for_undeletable_entry() {
-        // A directory that matches this set's grammar can never be removed
-        // by `remove_file`, so it deterministically exercises the
-        // `SweepReport::errors` path with a real `io::ErrorKind` rather
-        // than a synthetic one.
+    async fn sweep_skips_directory_matching_chunk_grammar() {
+        // N1: a directory named exactly like a claimed chunk (e.g. some
+        // out-of-band tool, or a user, created `Title.mp4.7.part3/`) is not
+        // ours — nothing in this tree ever creates a chunk *directory* — so
+        // it must survive sweep untouched and must not surface as an error.
         let dir = tempfile::tempdir().expect("tempdir");
-        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh);
-        let undeletable = set.path_in(dir.path(), 0);
-        tokio::fs::create_dir(&undeletable)
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
+        let claimed_dir = set.path_in(dir.path(), 3);
+        tokio::fs::create_dir(&claimed_dir)
             .await
-            .expect("create dir standing in for the chunk file");
+            .expect("create directory standing in for a chunk");
 
         let report = set.sweep(dir.path()).await.expect("sweep");
+
+        assert_eq!(report.deleted, 0);
+        assert!(report.errors.is_empty());
+        assert!(
+            tokio::fs::metadata(&claimed_dir)
+                .await
+                .expect("directory must survive sweep")
+                .is_dir()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sweep_records_typed_error_for_undeletable_entry() {
+        // A regular file inside a directory with its write bit cleared
+        // cannot be unlinked (no write permission on the containing
+        // directory), so it deterministically exercises the
+        // `SweepReport::errors` path with a real `io::ErrorKind` rather
+        // than a synthetic one. (A chunk-named *directory* no longer takes
+        // this path at all — see `sweep_skips_directory_matching_chunk_grammar`
+        // — so a permission failure on a regular file is the remaining way
+        // to exercise this branch.)
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let set = ChunkSet::for_attempt("Title.mp4", 7, ChunkKind::Fresh).expect("valid filename");
+        let undeletable = set.path_in(dir.path(), 0);
+        tokio::fs::write(&undeletable, b"chunk")
+            .await
+            .expect("write chunk standing in for the undeletable file");
+
+        let mut perms = tokio::fs::metadata(dir.path())
+            .await
+            .expect("stat dir")
+            .permissions();
+        perms.set_mode(0o555); // read + execute, no write: entries can't be unlinked
+        tokio::fs::set_permissions(dir.path(), perms.clone())
+            .await
+            .expect("make directory read-only");
+
+        let report = set.sweep(dir.path()).await.expect("sweep");
+
+        perms.set_mode(0o755);
+        tokio::fs::set_permissions(dir.path(), perms)
+            .await
+            .expect("restore directory permissions for cleanup");
 
         assert_eq!(report.deleted, 0);
         assert_eq!(report.errors.len(), 1);

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -3,6 +3,7 @@
 //! Provides HTTP downloading with parallel chunk support, resume capability,
 //! and automatic retry logic using the backon crate.
 
+pub mod chunk_name;
 mod config;
 mod parallel;
 mod trait_impl;

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -3,6 +3,7 @@
 //! Provides HTTP downloading with parallel chunk support, resume capability,
 //! and automatic retry logic using the backon crate.
 
+mod chunk_ledger;
 pub mod chunk_name;
 mod config;
 mod parallel;

--- a/crates/rdlp-downloader/src/http/mod.rs
+++ b/crates/rdlp-downloader/src/http/mod.rs
@@ -4,7 +4,7 @@
 //! and automatic retry logic using the backon crate.
 
 mod chunk_ledger;
-pub mod chunk_name;
+pub(crate) mod chunk_name;
 mod config;
 mod parallel;
 mod trait_impl;

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -3,6 +3,7 @@
 //! Provides parallel download using multiple range requests with fine-grained chunking.
 
 use super::HttpDownloader;
+use super::chunk_ledger::ChunkLedger;
 use super::chunk_name::{ChunkKind, ChunkSet};
 use super::config::DownloaderConfig;
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ChunkRequest, ControllerMode};
@@ -175,26 +176,6 @@ impl Attempt {
 
 /// Global atomic counter for generating unique download IDs
 static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Sweep every chunk file `chunk_set` claims in `temp_dir` and log the
-/// outcome.
-///
-/// Deliberately takes no reference to the download error that triggered the
-/// sweep: logging *why* a sweep is happening is the caller's job (each call
-/// site logs its own `error!("... failed: {e}")` immediately before
-/// sweeping, so that log line exists exactly once instead of being
-/// duplicated here), so this function's only concern is "how did cleanup
-/// go".
-async fn sweep_after_failure(chunk_set: &ChunkSet, temp_dir: &Path) {
-    match chunk_set.sweep(temp_dir).await {
-        Ok(report) => {
-            debug!(deleted = report.deleted, temp_dir:? = temp_dir; "Swept chunk files after failed download");
-        }
-        Err(sweep_err) => {
-            warn!(temp_dir:? = temp_dir; "Failed to sweep chunk files after failed download: {sweep_err:#}");
-        }
-    }
-}
 
 impl HttpDownloader {
     /// Parallel download using multiple range requests with fine-grained chunking.
@@ -435,6 +416,13 @@ impl HttpDownloader {
         // itself.
         let stop_scheduling = Arc::new(AtomicBool::new(false));
 
+        // Owns the deletion authority for every chunk path this attempt
+        // creates. Registered from inside the `try_unfold` closure below,
+        // which runs concurrently across many in-flight futures — hence the
+        // `Arc` and the ledger's own interior `Mutex` rather than requiring
+        // exclusive access.
+        let ledger = Arc::new(ChunkLedger::new());
+
         let buffered = {
             let downloader = self.clone();
             let url_arc = url_shared.clone();
@@ -445,6 +433,7 @@ impl HttpDownloader {
             let cancel_outer = cancel.clone();
             let stop_flag = stop_scheduling.clone();
             let controller_for_jobs = controller.clone();
+            let ledger_for_unfold = ledger.clone();
 
             stream::try_unfold((controller.clone(), 0u64), move |(ctrl, chunk_id)| {
                 let sem = sem.clone();
@@ -452,6 +441,10 @@ impl HttpDownloader {
                 let url = url_arc.clone();
                 let progress = progress.clone();
                 let chunk_path = chunk_set_owned.path_in(&temp_dir_owned, chunk_id);
+                // Registered BEFORE this chunk's download starts (the future
+                // below hasn't been polled yet), so a chunk that fails
+                // mid-write is still tracked for cleanup.
+                ledger_for_unfold.register(chunk_path.clone());
                 let ctrl_next = ctrl.clone();
                 let cancel_for_unfold = cancel_outer.clone();
                 let stop_flag = stop_flag.clone();
@@ -500,7 +493,7 @@ impl HttpDownloader {
 
         if let Some(e) = first_err {
             error!("Adaptive download failed: {e}");
-            sweep_after_failure(chunk_set, temp_dir).await;
+            ledger.cleanup().await;
             return Err(e);
         }
 
@@ -533,10 +526,18 @@ impl HttpDownloader {
         let url_shared: Arc<str> = Arc::from(url);
         let temp_dir_owned = temp_dir.to_path_buf();
 
+        // Owns the deletion authority for every chunk path this attempt
+        // creates. The chunk ids are known up front here (unlike the
+        // adaptive path), but registration still happens per-chunk, before
+        // that chunk's download starts, so the mechanism is uniform across
+        // both paths.
+        let ledger = ChunkLedger::new();
+
         let results: Vec<(usize, PathBuf, u64)> = match stream::iter(0..plan.total_chunks)
             .map(|chunk_id| {
                 let (start, end) = plan.range_of(chunk_id);
                 let chunk_path = chunk_set.path_in(&temp_dir_owned, chunk_id as u64);
+                ledger.register(chunk_path.clone());
                 let downloader = self.clone();
                 let url = Arc::clone(&url_shared);
                 let progress = Some(progress_counter.clone());
@@ -566,7 +567,7 @@ impl HttpDownloader {
             Ok(r) => r,
             Err(e) => {
                 error!("Download failed: {e}");
-                sweep_after_failure(chunk_set, temp_dir).await;
+                ledger.cleanup().await;
                 return Err(e);
             }
         };

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -5,9 +5,10 @@
 use super::HttpDownloader;
 use super::chunk_name::{ChunkKind, ChunkSet};
 use super::config::DownloaderConfig;
-use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
-use crate::chunking::calculate_chunks;
+use crate::adaptive::{AdaptiveConfig, AdaptiveController, ChunkRequest, ControllerMode};
+use crate::chunking::{ChunkSizeStrategy, calculate_chunks};
 use crate::progress::{ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter};
+use futures::Stream;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use log::{debug, error, info, warn};
 use rdlp_core::{DownloadStats, ProgressCallback, RdlpError, Result, is_retryable_error};
@@ -17,6 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 /// Maximum number of retry attempts for a single chunk download.
@@ -121,21 +123,75 @@ impl MergeMode {
     }
 }
 
+/// The kind of download attempt in progress: a fresh transfer starting at
+/// byte 0, or a resume of a previously interrupted attempt starting at a
+/// known byte offset.
+///
+/// Chunk kind, byte offset, and merge mode must always agree — a fresh
+/// attempt merged in `Append` mode (or a resume merged in `Create` mode)
+/// silently corrupts the output file, and before this type existed nothing
+/// stopped that: `ChunkKind::Fresh` could be threaded alongside
+/// `MergeMode::Append` and the compiler would not object. That is #568's bug
+/// shape one level up — the chunk-name-grammar mismatch #568 fixed was one
+/// instance of these three settings drifting apart; this type makes the
+/// drift unrepresentable by deriving [`ChunkKind`] and [`MergeMode`] from a
+/// single value instead of threading them as three independent parameters.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Attempt {
+    /// A brand-new download, starting at byte 0.
+    Fresh,
+    /// Resuming a previously interrupted download.
+    Resume {
+        /// Byte offset already downloaded and present in the output file.
+        from: u64,
+    },
+}
+
+impl Attempt {
+    /// Byte offset every chunk's range is relative to.
+    pub(super) const fn byte_offset(self) -> u64 {
+        match self {
+            Self::Fresh => 0,
+            Self::Resume { from } => from,
+        }
+    }
+
+    /// The [`ChunkKind`] this attempt's chunk files must be named with.
+    pub(super) const fn chunk_kind(self) -> ChunkKind {
+        match self {
+            Self::Fresh => ChunkKind::Fresh,
+            Self::Resume { .. } => ChunkKind::Resume,
+        }
+    }
+
+    /// The [`MergeMode`] this attempt's chunks must be merged with.
+    const fn merge_mode(self) -> MergeMode {
+        match self {
+            Self::Fresh => MergeMode::Create,
+            Self::Resume { .. } => MergeMode::Append,
+        }
+    }
+}
+
 /// Global atomic counter for generating unique download IDs
 static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Sweep every chunk file `chunk_set` claims in `temp_dir`, logging the
-/// outcome without letting a sweep failure mask `original_err` — the download
-/// error is what the caller must surface; a cleanup failure is secondary.
-async fn sweep_after_failure(chunk_set: &ChunkSet, temp_dir: &Path, original_err: &RdlpError) {
+/// Sweep every chunk file `chunk_set` claims in `temp_dir` and log the
+/// outcome.
+///
+/// Deliberately takes no reference to the download error that triggered the
+/// sweep: logging *why* a sweep is happening is the caller's job (each call
+/// site logs its own `error!("... failed: {e}")` immediately before
+/// sweeping, so that log line exists exactly once instead of being
+/// duplicated here), so this function's only concern is "how did cleanup
+/// go".
+async fn sweep_after_failure(chunk_set: &ChunkSet, temp_dir: &Path) {
     match chunk_set.sweep(temp_dir).await {
         Ok(report) => {
-            debug!(deleted = report.deleted; "Swept chunk files after failed download: {original_err}");
+            debug!(deleted = report.deleted, temp_dir:? = temp_dir; "Swept chunk files after failed download");
         }
         Err(sweep_err) => {
-            warn!(
-                "Failed to sweep chunk files after failed download ({original_err}): {sweep_err:#}"
-            );
+            warn!(temp_dir:? = temp_dir; "Failed to sweep chunk files after failed download: {sweep_err:#}");
         }
     }
 }
@@ -155,16 +211,16 @@ impl HttpDownloader {
     ) -> Result<DownloadStats> {
         let start_time = Instant::now();
         let download_id = DOWNLOAD_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let attempt = Attempt::Fresh;
 
         let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        let filename = path
-            .file_name()
-            .ok_or_else(|| RdlpError::Download {
-                message: "Invalid output path: no filename".to_string(),
-                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
-            })?
-            .to_string_lossy()
-            .into_owned();
+        let chunk_set =
+            ChunkSet::for_attempt(path, download_id, attempt.chunk_kind()).map_err(|e| {
+                RdlpError::Download {
+                    message: format!("{e:#}"),
+                    url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+                }
+            })?;
 
         let downloaded = Arc::new(AtomicU64::new(0));
         let progress: Option<Arc<dyn rdlp_core::ProgressCallback>> = progress.map(Arc::from);
@@ -178,12 +234,10 @@ impl HttpDownloader {
             self.download_parallel_adaptive(
                 url,
                 total_size,
-                download_id,
+                &chunk_set,
                 temp_dir,
-                &filename,
                 downloaded.clone(),
-                0,
-                ChunkKind::Fresh,
+                attempt.byte_offset(),
                 progress.clone(),
                 None,
             )
@@ -192,28 +246,17 @@ impl HttpDownloader {
             self.download_parallel_static(
                 url,
                 total_size,
-                download_id,
+                &chunk_set,
                 temp_dir,
-                &filename,
                 downloaded.clone(),
-                0,
-                ChunkKind::Fresh,
+                attempt.byte_offset(),
             )
             .await?
         };
 
         let chunk_count = chunk_paths.len();
 
-        merge_chunks_ordered(
-            path,
-            temp_dir,
-            &filename,
-            download_id,
-            &chunk_paths,
-            &self.config,
-            MergeMode::Create,
-        )
-        .await?;
+        merge_chunks_ordered(path, &chunk_paths, &self.config, attempt.merge_mode()).await?;
 
         // Backstop (#526): the assembly must match the advertised length before
         // this file is handed back as a completed download.
@@ -249,16 +292,16 @@ impl HttpDownloader {
         let start_time = Instant::now();
         let remaining_size = total_size - resume_from;
         let download_id = DOWNLOAD_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let attempt = Attempt::Resume { from: resume_from };
 
         let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        let filename = path
-            .file_name()
-            .ok_or_else(|| RdlpError::Download {
-                message: "Invalid output path: no filename".to_string(),
-                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
-            })?
-            .to_string_lossy()
-            .into_owned();
+        let chunk_set =
+            ChunkSet::for_attempt(path, download_id, attempt.chunk_kind()).map_err(|e| {
+                RdlpError::Download {
+                    message: format!("{e:#}"),
+                    url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+                }
+            })?;
 
         let downloaded = Arc::new(AtomicU64::new(resume_from));
         let progress: Option<Arc<dyn rdlp_core::ProgressCallback>> = progress.map(Arc::from);
@@ -280,12 +323,10 @@ impl HttpDownloader {
             self.download_parallel_adaptive(
                 url,
                 remaining_size,
-                download_id,
+                &chunk_set,
                 temp_dir,
-                &filename,
                 downloaded.clone(),
-                resume_from,
-                ChunkKind::Resume,
+                attempt.byte_offset(),
                 progress.clone(),
                 None,
             )
@@ -294,12 +335,10 @@ impl HttpDownloader {
             self.download_parallel_static(
                 url,
                 remaining_size,
-                download_id,
+                &chunk_set,
                 temp_dir,
-                &filename,
                 downloaded.clone(),
-                resume_from,
-                ChunkKind::Resume,
+                attempt.byte_offset(),
             )
             .await
         };
@@ -313,16 +352,7 @@ impl HttpDownloader {
             }
         };
 
-        merge_chunks_ordered(
-            path,
-            temp_dir,
-            &filename,
-            download_id,
-            &chunk_paths,
-            &self.config,
-            MergeMode::Append,
-        )
-        .await?;
+        merge_chunks_ordered(path, &chunk_paths, &self.config, attempt.merge_mode()).await?;
 
         // Backstop (#526). On the resume path this also catches a `resume_from`
         // that disagreed with the file's real length: the appended bytes land
@@ -345,35 +375,13 @@ impl HttpDownloader {
         Ok(stats)
     }
 
-    /// Adaptive download: uses `AdaptiveController` for dynamic chunk sizing and concurrency.
-    ///
-    /// Returns `(chunk_paths_in_order, total_bytes_downloaded)`.
-    /// `byte_offset` is added to every chunk's start position (for resume).
-    ///
-    /// `cancel` is `Option<CancellationToken>` (owned, not a reference) so it can be
-    /// cloned into the `try_unfold` closure. `CancellationToken` is cheaply cloneable.
-    #[allow(clippy::too_many_arguments)]
-    async fn download_parallel_adaptive(
+    /// Build the AIMD controller for one adaptive download attempt.
+    fn build_controller(
         &self,
-        url: &str,
         size_to_download: u64,
-        download_id: u64,
-        temp_dir: &Path,
-        filename: &str,
-        progress_counter: Arc<AtomicU64>,
-        byte_offset: u64,
-        kind: ChunkKind,
         log_callback: Option<Arc<dyn ProgressCallback>>,
-        cancel: Option<CancellationToken>,
-    ) -> Result<(Vec<PathBuf>, u64)> {
-        let chunk_set = ChunkSet::for_attempt(filename, download_id, kind).map_err(|e| {
-            RdlpError::Download {
-                message: format!("{e:#}"),
-                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
-            }
-        })?;
-
-        let controller = Arc::new(AdaptiveController::new(
+    ) -> Arc<AdaptiveController> {
+        Arc::new(AdaptiveController::new(
             size_to_download,
             AdaptiveConfig {
                 max_connections: self.config.concurrent_fragments,
@@ -381,12 +389,34 @@ impl HttpDownloader {
             },
             ControllerMode::HttpChunked,
             log_callback,
-        ));
+        ))
+    }
 
+    /// Adaptive download: uses `AdaptiveController` for dynamic chunk sizing and concurrency.
+    ///
+    /// Returns `(chunk_paths_in_order, total_bytes_downloaded)`.
+    /// `byte_offset` is added to every chunk's start position (for resume).
+    ///
+    /// `cancel` is `Option<CancellationToken>` (owned, not a reference) so it can be
+    /// cloned into the `try_unfold` closure. `CancellationToken` is cheaply cloneable.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Each argument is a distinct piece of per-attempt state (url, size, chunk-name grammar, temp dir, progress sink, resume offset, log callback, cancel token) fed to the AIMD unfold closure; grouping them would either duplicate `Attempt` (already owns kind/offset) or bundle unrelated concerns just to hit a number."
+    )]
+    async fn download_parallel_adaptive(
+        &self,
+        url: &str,
+        size_to_download: u64,
+        chunk_set: &ChunkSet,
+        temp_dir: &Path,
+        progress_counter: Arc<AtomicU64>,
+        byte_offset: u64,
+        log_callback: Option<Arc<dyn ProgressCallback>>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<(Vec<PathBuf>, u64)> {
+        let controller = self.build_controller(size_to_download, log_callback);
         let sem = controller.semaphore().clone();
 
-        // Chunk paths collected in assignment order; we re-sort by chunk_id before merge.
-        // Each entry is (chunk_id, PathBuf, bytes_downloaded).
         let url_shared: Arc<str> = Arc::from(url);
 
         // Generate tasks lazily using stream::unfold driven by controller.next_chunk().
@@ -395,7 +425,14 @@ impl HttpDownloader {
 
         // Set once a sibling chunk fails, so the unfold generator stops
         // scheduling NEW chunks. It deliberately does NOT cancel chunks
-        // already in flight (see below) — only gates further generation.
+        // already in flight (see `drain_collecting_first_error`) — only
+        // gates further generation. This is purely a latency optimization:
+        // sweep correctness never depended on it, since a stale read of this
+        // flag only lets the generator produce one extra chunk before it
+        // observes the flip, and the drain below waits that chunk out like
+        // any other in-flight chunk. Relaxed ordering is correct for the
+        // same reason — there is no data this flag needs to publish besides
+        // itself.
         let stop_scheduling = Arc::new(AtomicBool::new(false));
 
         let buffered = {
@@ -407,17 +444,18 @@ impl HttpDownloader {
             // Clone once outside the closure; each iteration re-clones from this.
             let cancel_outer = cancel.clone();
             let stop_flag = stop_scheduling.clone();
+            let controller_for_jobs = controller.clone();
 
             stream::try_unfold((controller.clone(), 0u64), move |(ctrl, chunk_id)| {
                 let sem = sem.clone();
                 let downloader = downloader.clone();
                 let url = url_arc.clone();
                 let progress = progress.clone();
-                let ctrl_report = ctrl.clone();
                 let chunk_path = chunk_set_owned.path_in(&temp_dir_owned, chunk_id);
                 let ctrl_next = ctrl.clone();
                 let cancel_for_unfold = cancel_outer.clone();
                 let stop_flag = stop_flag.clone();
+                let controller_for_job = controller_for_jobs.clone();
 
                 async move {
                     // A sibling chunk has already failed terminally: stop
@@ -438,132 +476,56 @@ impl HttpDownloader {
                         return Err(RdlpError::Cancelled);
                     }
 
-                    let cancel_for_chunk = cancel_for_unfold.clone();
-
-                    let download_fut = async move {
-                        // F6 (#308): race semaphore acquisition against cancel so
-                        // a pending permit-wait unblocks immediately on cancellation.
-                        let _permit = if let Some(ref token) = cancel_for_chunk {
-                            tokio::select! {
-                                biased;
-                                () = token.cancelled() => return Err(RdlpError::Cancelled),
-                                p = sem.acquire_owned() => p.map_err(|_| RdlpError::Download {
-                                    message: "Semaphore closed".to_string(),
-                                    url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
-                                })?,
-                            }
-                        } else {
-                            sem.acquire_owned().await.map_err(|_| RdlpError::Download {
-                                message: "Semaphore closed".to_string(),
-                                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
-                            })?
-                        };
-                        let start_time = Instant::now();
-                        let abs_start = byte_offset + chunk.start;
-                        // end is exclusive in ChunkRequest, but HTTP Range is inclusive
-                        let abs_end = byte_offset + chunk.end - 1;
-
-                        let result = download_chunk_with_retry(
-                            &downloader,
-                            &url,
-                            abs_start,
-                            abs_end,
-                            &chunk_path,
-                            Some(progress),
-                            chunk_id,
-                            cancel_for_chunk.as_ref(),
-                        )
-                        .await;
-
-                        match &result {
-                            Ok(bytes) => {
-                                ctrl_report.report_chunk_complete(*bytes, start_time.elapsed());
-                            }
-                            Err(e) => {
-                                error!("Adaptive chunk {chunk_id} failed after retries: {e}");
-                            }
-                        }
-
-                        result.map(|bytes| (chunk_id, chunk_path, bytes))
+                    let job = AdaptiveChunkJob {
+                        downloader,
+                        url,
+                        chunk_id,
+                        chunk_path,
+                        byte_offset,
+                        chunk,
+                        progress,
+                        semaphore: sem,
+                        controller: controller_for_job,
+                        cancel: cancel_for_unfold,
                     };
 
-                    Ok(Some((download_fut, (ctrl_next, chunk_id + 1))))
+                    Ok(Some((run_adaptive_chunk(job), (ctrl_next, chunk_id + 1))))
                 }
             })
             .try_buffer_unordered(buffer_factor)
         };
         futures::pin_mut!(buffered);
 
-        // Drain every buffered future to completion rather than dropping the
-        // stream on the first error (`try_collect`'s default): dropping the
-        // `TryBufferUnordered` mid-poll abandons any chunk still in flight,
-        // and `tokio::fs` operations dispatched to the blocking pool keep
-        // running in the background after their driving future is dropped
-        // (tokio::fs docs) — sweeping immediately would race those writes and
-        // could delete a file the background write hasn't produced yet, or
-        // leave a file created just after the sweep ran. Setting
-        // `stop_scheduling` (checked above) halts new chunk generation
-        // immediately so this only waits out the already-buffered futures,
-        // not the whole remaining transfer.
-        let mut results: Vec<(u64, PathBuf, u64)> = Vec::new();
-        let mut first_err: Option<RdlpError> = None;
-        while let Some(item) = buffered.next().await {
-            match item {
-                Ok(v) => results.push(v),
-                Err(e) => {
-                    if first_err.is_none() {
-                        stop_scheduling.store(true, Ordering::Relaxed);
-                        first_err = Some(e);
-                    }
-                }
-            }
-        }
+        let (results, first_err) = drain_collecting_first_error(buffered, &stop_scheduling).await;
 
         if let Some(e) = first_err {
-            sweep_after_failure(&chunk_set, temp_dir, &e).await;
+            error!("Adaptive download failed: {e}");
+            sweep_after_failure(chunk_set, temp_dir).await;
             return Err(e);
         }
 
-        // Sort by chunk_id to ensure correct merge order.
-        let mut sorted = results;
-        sorted.sort_by_key(|(id, _, _)| *id);
-
-        let total_bytes: u64 = sorted.iter().map(|(_, _, b)| b).sum();
-        let chunk_paths: Vec<PathBuf> = sorted.into_iter().map(|(_, path, _)| path).collect();
-
-        Ok((chunk_paths, total_bytes))
+        Ok(into_ordered_paths(results))
     }
 
     /// Static download: uses a fixed chunk size and connection count.
     ///
     /// Returns `(chunk_paths_in_order, total_bytes_downloaded)`.
-    #[allow(clippy::too_many_arguments)]
     async fn download_parallel_static(
         &self,
         url: &str,
         size_to_download: u64,
-        download_id: u64,
+        chunk_set: &ChunkSet,
         temp_dir: &Path,
-        filename: &str,
         progress_counter: Arc<AtomicU64>,
         byte_offset: u64,
-        kind: ChunkKind,
     ) -> Result<(Vec<PathBuf>, u64)> {
-        let chunk_set = ChunkSet::for_attempt(filename, download_id, kind).map_err(|e| {
-            RdlpError::Download {
-                message: format!("{e:#}"),
-                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
-            }
-        })?;
-
-        let (chunk_size, total_chunks) =
-            calculate_chunks(size_to_download, self.config.chunk_strategy);
+        let plan = StaticChunkPlan::new(size_to_download, byte_offset, self.config.chunk_strategy);
 
         debug!(
-            download_id,
+            chunk_set:? = chunk_set,
             size_mb = size_to_download / 1024 / 1024,
-            chunk_kb = chunk_size / 1024,
-            chunks = total_chunks,
+            chunk_kb = plan.chunk_size / 1024,
+            chunks = plan.total_chunks,
             concurrent = self.config.concurrent_fragments;
             "Static chunk analysis"
         );
@@ -571,15 +533,9 @@ impl HttpDownloader {
         let url_shared: Arc<str> = Arc::from(url);
         let temp_dir_owned = temp_dir.to_path_buf();
 
-        let results: Vec<(usize, PathBuf, u64)> = match stream::iter(0..total_chunks)
+        let results: Vec<(usize, PathBuf, u64)> = match stream::iter(0..plan.total_chunks)
             .map(|chunk_id| {
-                let start = byte_offset + (chunk_id as u64 * chunk_size as u64);
-                let end = if chunk_id == total_chunks - 1 {
-                    byte_offset + size_to_download - 1
-                } else {
-                    start + chunk_size as u64 - 1
-                };
-
+                let (start, end) = plan.range_of(chunk_id);
                 let chunk_path = chunk_set.path_in(&temp_dir_owned, chunk_id as u64);
                 let downloader = self.clone();
                 let url = Arc::clone(&url_shared);
@@ -610,19 +566,192 @@ impl HttpDownloader {
             Ok(r) => r,
             Err(e) => {
                 error!("Download failed: {e}");
-                sweep_after_failure(&chunk_set, temp_dir, &e).await;
+                sweep_after_failure(chunk_set, temp_dir).await;
                 return Err(e);
             }
         };
 
-        let total_bytes: u64 = results.iter().map(|(_, _, b)| b).sum();
+        Ok(into_ordered_paths(results))
+    }
+}
 
-        // Results arrive in completion order; sort by chunk_id for correct merge.
-        let mut sorted = results;
-        sorted.sort_by_key(|(id, _, _)| *id);
-        let chunk_paths: Vec<PathBuf> = sorted.into_iter().map(|(_, path, _)| path).collect();
+/// Everything one adaptive-chunk worker future needs to run to completion,
+/// gathered into one named-field value so the `try_unfold` closure hands it
+/// to [`run_adaptive_chunk`] as a single argument instead of a long
+/// positional list.
+struct AdaptiveChunkJob {
+    downloader: HttpDownloader,
+    url: Arc<str>,
+    chunk_id: u64,
+    chunk_path: PathBuf,
+    byte_offset: u64,
+    chunk: ChunkRequest,
+    progress: Arc<AtomicU64>,
+    semaphore: Arc<Semaphore>,
+    controller: Arc<AdaptiveController>,
+    cancel: Option<CancellationToken>,
+}
 
-        Ok((chunk_paths, total_bytes))
+/// Run one adaptive chunk download: acquire a concurrency permit (racing
+/// cancellation), download with retry, and report the outcome to the
+/// controller.
+async fn run_adaptive_chunk(job: AdaptiveChunkJob) -> Result<(u64, PathBuf, u64)> {
+    let AdaptiveChunkJob {
+        downloader,
+        url,
+        chunk_id,
+        chunk_path,
+        byte_offset,
+        chunk,
+        progress,
+        semaphore,
+        controller,
+        cancel,
+    } = job;
+
+    // F6 (#308): race semaphore acquisition against cancel so a pending
+    // permit-wait unblocks immediately on cancellation.
+    let _permit = if let Some(ref token) = cancel {
+        tokio::select! {
+            biased;
+            () = token.cancelled() => return Err(RdlpError::Cancelled),
+            p = semaphore.acquire_owned() => p.map_err(|_| RdlpError::Download {
+                message: "Semaphore closed".to_string(),
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
+            })?,
+        }
+    } else {
+        semaphore
+            .acquire_owned()
+            .await
+            .map_err(|_| RdlpError::Download {
+                message: "Semaphore closed".to_string(),
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url.as_ref())),
+            })?
+    };
+
+    let start_time = Instant::now();
+    let abs_start = byte_offset + chunk.start;
+    // end is exclusive in ChunkRequest, but HTTP Range is inclusive
+    let abs_end = byte_offset + chunk.end - 1;
+
+    let result = download_chunk_with_retry(
+        &downloader,
+        &url,
+        abs_start,
+        abs_end,
+        &chunk_path,
+        Some(progress),
+        chunk_id,
+        cancel.as_ref(),
+    )
+    .await;
+
+    match &result {
+        Ok(bytes) => {
+            controller.report_chunk_complete(*bytes, start_time.elapsed());
+        }
+        Err(e) => {
+            error!("Adaptive chunk {chunk_id} failed after retries: {e}");
+        }
+    }
+
+    result.map(|bytes| (chunk_id, chunk_path, bytes))
+}
+
+/// Drain `stream` to completion, collecting every `Ok` item while retaining
+/// only the FIRST `Err` — later errors are logged, not silently dropped.
+///
+/// This is deliberately not `try_collect`: dropping a `TryBufferUnordered`
+/// stream mid-poll on the first error would abandon any chunk still in
+/// flight, and `tokio::fs` operations dispatched to the blocking pool keep
+/// running in the background after their driving future is dropped
+/// (`tokio::fs` docs) — sweeping immediately would race those writes and could
+/// delete a file the background write hasn't produced yet, or leave a file
+/// created just after the sweep ran.
+///
+/// `stop_scheduling` is set as soon as the first error is observed so the
+/// caller's generator (a `stream::try_unfold`) stops producing NEW work.
+/// This bounds the drain — it does not eliminate it: `BufferUnordered`
+/// (and `TryBufferUnordered`) refill their in-flight queue back up to its
+/// concurrency limit on every poll *before* checking that queue for a
+/// completed item, including the poll that surfaces this very error. So by
+/// the time the first error is observed, up to one full buffer's worth of
+/// chunks are already real, in-flight HTTP requests; the drain waits out
+/// exactly those (never zero, never the rest of the transfer — new
+/// generation is cut off from here on).
+async fn drain_collecting_first_error<S, T>(
+    mut stream: S,
+    stop_scheduling: &AtomicBool,
+) -> (Vec<T>, Option<RdlpError>)
+where
+    S: Stream<Item = Result<T>> + Unpin,
+{
+    let mut items = Vec::new();
+    let mut first_err: Option<RdlpError> = None;
+
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(v) => items.push(v),
+            Err(e) => {
+                if first_err.is_none() {
+                    stop_scheduling.store(true, Ordering::Relaxed);
+                    first_err = Some(e);
+                } else {
+                    warn!(
+                        "Additional chunk error after the first (which is what surfaces as \
+                         the download failure): {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    (items, first_err)
+}
+
+/// Sort chunk results by id and split into ordered paths + total bytes
+/// downloaded. Shared by the adaptive and static paths, which otherwise
+/// duplicated this sort-then-split.
+fn into_ordered_paths<I: Ord + Copy>(mut results: Vec<(I, PathBuf, u64)>) -> (Vec<PathBuf>, u64) {
+    results.sort_by_key(|(id, _, _)| *id);
+    let total_bytes: u64 = results.iter().map(|(_, _, b)| b).sum();
+    let chunk_paths: Vec<PathBuf> = results.into_iter().map(|(_, path, _)| path).collect();
+    (chunk_paths, total_bytes)
+}
+
+/// Byte-range plan for a static (non-adaptive) chunked download: chunk size
+/// and count are computed once from `size_to_download` and the configured
+/// [`ChunkSizeStrategy`].
+struct StaticChunkPlan {
+    chunk_size: usize,
+    total_chunks: usize,
+    size_to_download: u64,
+    byte_offset: u64,
+}
+
+impl StaticChunkPlan {
+    fn new(size_to_download: u64, byte_offset: u64, strategy: ChunkSizeStrategy) -> Self {
+        let (chunk_size, total_chunks) = calculate_chunks(size_to_download, strategy);
+        Self {
+            chunk_size,
+            total_chunks,
+            size_to_download,
+            byte_offset,
+        }
+    }
+
+    /// Inclusive byte range `(start, end)` for `chunk_id` (0-based), already
+    /// shifted by `byte_offset`. The last chunk absorbs any remainder, so
+    /// `size_to_download` need not be a multiple of `chunk_size`.
+    const fn range_of(&self, chunk_id: usize) -> (u64, u64) {
+        let start = self.byte_offset + (chunk_id as u64 * self.chunk_size as u64);
+        let end = if chunk_id == self.total_chunks - 1 {
+            self.byte_offset + self.size_to_download - 1
+        } else {
+            start + self.chunk_size as u64 - 1
+        };
+        (start, end)
     }
 }
 
@@ -669,9 +798,6 @@ pub(crate) async fn verify_merged_size(path: &Path, expected_total: u64, url: &s
 /// Merge or append chunks to file using an explicit ordered list of paths.
 async fn merge_chunks_ordered(
     path: &Path,
-    _temp_dir: &Path,
-    _filename: &str,
-    _download_id: u64,
     chunk_paths: &[PathBuf],
     config: &DownloaderConfig,
     mode: MergeMode,
@@ -680,55 +806,14 @@ async fn merge_chunks_ordered(
     let action = mode.log_action();
 
     tokio::time::timeout(merge_timeout, async {
-        let file = match mode {
-            MergeMode::Create => File::create(path).await.map_err(|e| {
-                RdlpError::Io(std::io::Error::new(
-                    e.kind(),
-                    format!("failed to create output file '{}': {e}", path.display()),
-                ))
-            })?,
-            MergeMode::Append => tokio::fs::OpenOptions::new()
-                .append(true)
-                .open(path)
-                .await
-                .map_err(|e| {
-                    RdlpError::Io(std::io::Error::new(
-                        e.kind(),
-                        format!(
-                            "failed to open output file for append '{}': {e}",
-                            path.display()
-                        ),
-                    ))
-                })?,
-        };
-        let mut writer = BufWriter::with_capacity(config.buffer_size, file);
+        let mut writer = open_merge_sink(path, mode, config.buffer_size).await?;
 
         debug!(chunks = chunk_paths.len(); "{action} chunks into file");
         let mut deleted_chunks = 0;
         let total = chunk_paths.len();
         for (idx, chunk_path) in chunk_paths.iter().enumerate() {
-            let mut chunk_file = File::open(chunk_path).await.map_err(|e| {
-                RdlpError::Io(std::io::Error::new(
-                    e.kind(),
-                    format!("failed to open chunk file '{}': {e}", chunk_path.display()),
-                ))
-            })?;
-            tokio::io::copy(&mut chunk_file, &mut writer)
-                .await
-                .map_err(|e| {
-                    RdlpError::Io(std::io::Error::new(
-                        e.kind(),
-                        format!(
-                            "failed to copy chunk '{}' into output: {e}",
-                            chunk_path.display()
-                        ),
-                    ))
-                })?;
-
-            match tokio::fs::remove_file(chunk_path).await {
-                Ok(()) => deleted_chunks += 1,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => warn!(path:? = chunk_path; "Failed to delete chunk file: {e}"),
+            if drain_chunk_into(&mut writer, chunk_path).await? {
+                deleted_chunks += 1;
             }
 
             if (idx + 1) % 100 == 0 || idx == total - 1 {
@@ -753,4 +838,224 @@ async fn merge_chunks_ordered(
         message: format!("Merge timed out after {}s", merge_timeout.as_secs()),
         url: None,
     })?
+}
+
+/// Open the merge output file per `mode`, wrapped in a buffered writer sized
+/// to `buffer_size`.
+async fn open_merge_sink(
+    path: &Path,
+    mode: MergeMode,
+    buffer_size: usize,
+) -> Result<BufWriter<File>> {
+    let file = match mode {
+        MergeMode::Create => File::create(path).await.map_err(|e| {
+            RdlpError::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to create output file '{}': {e}", path.display()),
+            ))
+        })?,
+        MergeMode::Append => tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(path)
+            .await
+            .map_err(|e| {
+                RdlpError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to open output file for append '{}': {e}",
+                        path.display()
+                    ),
+                ))
+            })?,
+    };
+    Ok(BufWriter::with_capacity(buffer_size, file))
+}
+
+/// Copy one chunk file's contents into `writer`, then delete the chunk file.
+///
+/// Returns whether the chunk file was actually deleted by this call: a
+/// `NotFound` on removal (the file is already gone, the desired end state)
+/// or any other deletion failure (logged at `warn!`, matching the severity
+/// this merge loop always used) both count as "not deleted" without failing
+/// the merge — only a failure to open or copy the chunk aborts it.
+async fn drain_chunk_into(writer: &mut BufWriter<File>, chunk_path: &Path) -> Result<bool> {
+    let mut chunk_file = File::open(chunk_path).await.map_err(|e| {
+        RdlpError::Io(std::io::Error::new(
+            e.kind(),
+            format!("failed to open chunk file '{}': {e}", chunk_path.display()),
+        ))
+    })?;
+    tokio::io::copy(&mut chunk_file, writer)
+        .await
+        .map_err(|e| {
+            RdlpError::Io(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to copy chunk '{}' into output: {e}",
+                    chunk_path.display()
+                ),
+            ))
+        })?;
+
+    match tokio::fs::remove_file(chunk_path).await {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => {
+            warn!(path:? = chunk_path; "Failed to delete chunk file: {e}");
+            Ok(false)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn download_err(msg: &str) -> RdlpError {
+        RdlpError::Download {
+            message: msg.to_string(),
+            url: None,
+        }
+    }
+
+    // ── drain_collecting_first_error ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn drain_collecting_first_error_returns_all_items_when_all_ok() {
+        let items: Vec<Result<u32>> = vec![Ok(1), Ok(2), Ok(3)];
+        let flag = AtomicBool::new(false);
+
+        let (collected, first_err) = drain_collecting_first_error(stream::iter(items), &flag).await;
+
+        assert_eq!(collected, vec![1, 2, 3]);
+        assert!(first_err.is_none());
+        assert!(!flag.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn drain_collecting_first_error_returns_first_of_two_errors() {
+        let items: Vec<Result<u32>> = vec![
+            Ok(1),
+            Err(download_err("first")),
+            Err(download_err("second")),
+        ];
+        let flag = AtomicBool::new(false);
+
+        let (_collected, first_err) =
+            drain_collecting_first_error(stream::iter(items), &flag).await;
+
+        let e = first_err.expect("an error must surface");
+        assert_eq!(format!("{e}"), format!("{}", download_err("first")));
+    }
+
+    #[tokio::test]
+    async fn drain_collecting_first_error_sets_stop_scheduling_flag() {
+        let items: Vec<Result<u32>> = vec![Err(download_err("boom"))];
+        let flag = AtomicBool::new(false);
+
+        let _ = drain_collecting_first_error(stream::iter(items), &flag).await;
+
+        assert!(flag.load(Ordering::Relaxed));
+    }
+
+    /// #568 regression guard: the drain used to be a plain `try_collect`,
+    /// which drops the stream (and abandons any in-flight work) the instant
+    /// the first error surfaces. Items the underlying stream yields AFTER
+    /// that first error represent real, already-dispatched work and MUST
+    /// still be collected — simplifying this function back to `try_collect`
+    /// silently resurrects that leak.
+    #[tokio::test]
+    async fn drain_collecting_first_error_still_collects_items_yielded_after_first_error() {
+        let items: Vec<Result<u32>> = vec![Ok(1), Err(download_err("boom")), Ok(2), Ok(3)];
+        let flag = AtomicBool::new(false);
+
+        let (collected, first_err) = drain_collecting_first_error(stream::iter(items), &flag).await;
+
+        assert_eq!(collected, vec![1, 2, 3]);
+        assert!(first_err.is_some());
+    }
+
+    // ── StaticChunkPlan ──────────────────────────────────────────────────────
+
+    #[test]
+    fn static_chunk_plan_range_of_first_chunk() {
+        let plan = StaticChunkPlan::new(10 * 1024 * 1024, 0, ChunkSizeStrategy::Fixed(1024 * 1024));
+        assert_eq!(plan.range_of(0), (0, 1024 * 1024 - 1));
+    }
+
+    #[test]
+    fn static_chunk_plan_range_of_interior_chunk() {
+        let plan = StaticChunkPlan::new(10 * 1024 * 1024, 0, ChunkSizeStrategy::Fixed(1024 * 1024));
+        assert_eq!(plan.range_of(5), (5 * 1024 * 1024, 6 * 1024 * 1024 - 1));
+    }
+
+    #[test]
+    fn static_chunk_plan_range_of_last_chunk() {
+        let plan = StaticChunkPlan::new(10 * 1024 * 1024, 0, ChunkSizeStrategy::Fixed(1024 * 1024));
+        assert_eq!(plan.total_chunks, 10);
+        assert_eq!(plan.range_of(9), (9 * 1024 * 1024, 10 * 1024 * 1024 - 1));
+    }
+
+    #[test]
+    fn static_chunk_plan_single_chunk_download() {
+        let plan = StaticChunkPlan::new(500 * 1024, 0, ChunkSizeStrategy::Fixed(1024 * 1024));
+        assert_eq!(plan.total_chunks, 1);
+        assert_eq!(plan.range_of(0), (0, 500 * 1024 - 1));
+    }
+
+    #[test]
+    fn static_chunk_plan_non_multiple_of_chunk_size_absorbs_remainder_in_last_chunk() {
+        let size = 10 * 1024 * 1024 + 500;
+        let plan = StaticChunkPlan::new(size, 0, ChunkSizeStrategy::Fixed(1024 * 1024));
+        assert_eq!(plan.total_chunks, 11);
+        let last = plan.total_chunks - 1;
+        assert_eq!(plan.range_of(last), (last as u64 * 1024 * 1024, size - 1));
+    }
+
+    #[test]
+    fn static_chunk_plan_range_of_respects_byte_offset_for_resume() {
+        let plan = StaticChunkPlan::new(
+            10 * 1024 * 1024,
+            5 * 1024 * 1024,
+            ChunkSizeStrategy::Fixed(1024 * 1024),
+        );
+        assert_eq!(plan.range_of(0), (5 * 1024 * 1024, 6 * 1024 * 1024 - 1));
+    }
+
+    // ── Attempt ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn attempt_fresh_derives_create_and_zero_offset() {
+        let attempt = Attempt::Fresh;
+        assert_eq!(attempt.byte_offset(), 0);
+        assert_eq!(attempt.chunk_kind(), ChunkKind::Fresh);
+        assert!(matches!(attempt.merge_mode(), MergeMode::Create));
+    }
+
+    #[test]
+    fn attempt_resume_derives_append_and_from_offset() {
+        let attempt = Attempt::Resume { from: 4096 };
+        assert_eq!(attempt.byte_offset(), 4096);
+        assert_eq!(attempt.chunk_kind(), ChunkKind::Resume);
+        assert!(matches!(attempt.merge_mode(), MergeMode::Append));
+    }
+
+    // ── into_ordered_paths ───────────────────────────────────────────────────
+
+    #[test]
+    fn into_ordered_paths_sorts_by_id_and_sums_bytes() {
+        let results = vec![
+            (2u64, PathBuf::from("c"), 30u64),
+            (0u64, PathBuf::from("a"), 10u64),
+            (1u64, PathBuf::from("b"), 20u64),
+        ];
+
+        let (paths, total) = into_ordered_paths(results);
+
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("a"), PathBuf::from("b"), PathBuf::from("c")]
+        );
+        assert_eq!(total, 60);
+    }
 }

--- a/crates/rdlp-downloader/src/http/parallel.rs
+++ b/crates/rdlp-downloader/src/http/parallel.rs
@@ -3,6 +3,7 @@
 //! Provides parallel download using multiple range requests with fine-grained chunking.
 
 use super::HttpDownloader;
+use super::chunk_name::{ChunkKind, ChunkSet};
 use super::config::DownloaderConfig;
 use crate::adaptive::{AdaptiveConfig, AdaptiveController, ControllerMode};
 use crate::chunking::calculate_chunks;
@@ -12,7 +13,7 @@ use log::{debug, error, info, warn};
 use rdlp_core::{DownloadStats, ProgressCallback, RdlpError, Result, is_retryable_error};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
@@ -123,24 +124,20 @@ impl MergeMode {
 /// Global atomic counter for generating unique download IDs
 static DOWNLOAD_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Cleanup chunk files by index range (used when chunk list is not available)
-async fn cleanup_chunk_files(
-    temp_dir: &Path,
-    filename: &str,
-    download_id: u64,
-    total_chunks: usize,
-) {
-    debug!(chunks = total_chunks; "Cleaning up partial chunk files");
-    let mut deleted = 0;
-    for chunk_id in 0..total_chunks {
-        let chunk_path = temp_dir.join(format!("{filename}.{download_id}.part{chunk_id}"));
-        match tokio::fs::remove_file(&chunk_path).await {
-            Ok(()) => deleted += 1,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => warn!(path:? = chunk_path; "Failed to delete chunk file: {e}"),
+/// Sweep every chunk file `chunk_set` claims in `temp_dir`, logging the
+/// outcome without letting a sweep failure mask `original_err` — the download
+/// error is what the caller must surface; a cleanup failure is secondary.
+async fn sweep_after_failure(chunk_set: &ChunkSet, temp_dir: &Path, original_err: &RdlpError) {
+    match chunk_set.sweep(temp_dir).await {
+        Ok(report) => {
+            debug!(deleted = report.deleted; "Swept chunk files after failed download: {original_err}");
+        }
+        Err(sweep_err) => {
+            warn!(
+                "Failed to sweep chunk files after failed download ({original_err}): {sweep_err:#}"
+            );
         }
     }
-    debug!(deleted; "Chunk cleanup complete");
 }
 
 impl HttpDownloader {
@@ -186,7 +183,7 @@ impl HttpDownloader {
                 &filename,
                 downloaded.clone(),
                 0,
-                "part",
+                ChunkKind::Fresh,
                 progress.clone(),
                 None,
             )
@@ -200,7 +197,7 @@ impl HttpDownloader {
                 &filename,
                 downloaded.clone(),
                 0,
-                "part",
+                ChunkKind::Fresh,
             )
             .await?
         };
@@ -288,7 +285,7 @@ impl HttpDownloader {
                 &filename,
                 downloaded.clone(),
                 resume_from,
-                "resume",
+                ChunkKind::Resume,
                 progress.clone(),
                 None,
             )
@@ -302,7 +299,7 @@ impl HttpDownloader {
                 &filename,
                 downloaded.clone(),
                 resume_from,
-                "resume",
+                ChunkKind::Resume,
             )
             .await
         };
@@ -365,10 +362,17 @@ impl HttpDownloader {
         filename: &str,
         progress_counter: Arc<AtomicU64>,
         byte_offset: u64,
-        suffix: &str,
+        kind: ChunkKind,
         log_callback: Option<Arc<dyn ProgressCallback>>,
         cancel: Option<CancellationToken>,
     ) -> Result<(Vec<PathBuf>, u64)> {
+        let chunk_set = ChunkSet::for_attempt(filename, download_id, kind).map_err(|e| {
+            RdlpError::Download {
+                message: format!("{e:#}"),
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+            }
+        })?;
+
         let controller = Arc::new(AdaptiveController::new(
             size_to_download,
             AdaptiveConfig {
@@ -389,15 +393,20 @@ impl HttpDownloader {
         // buffer_unordered with a generous buffer lets the semaphore control actual concurrency.
         let buffer_factor = self.config.concurrent_fragments * 2;
 
-        let results: Vec<(u64, PathBuf, u64)> = {
+        // Set once a sibling chunk fails, so the unfold generator stops
+        // scheduling NEW chunks. It deliberately does NOT cancel chunks
+        // already in flight (see below) — only gates further generation.
+        let stop_scheduling = Arc::new(AtomicBool::new(false));
+
+        let buffered = {
             let downloader = self.clone();
             let url_arc = url_shared.clone();
             let progress = progress_counter.clone();
             let temp_dir_owned = temp_dir.to_path_buf();
-            let filename_owned = filename.to_string();
-            let suffix_owned = suffix.to_string();
+            let chunk_set_owned = chunk_set.clone();
             // Clone once outside the closure; each iteration re-clones from this.
             let cancel_outer = cancel.clone();
+            let stop_flag = stop_scheduling.clone();
 
             stream::try_unfold((controller.clone(), 0u64), move |(ctrl, chunk_id)| {
                 let sem = sem.clone();
@@ -405,13 +414,19 @@ impl HttpDownloader {
                 let url = url_arc.clone();
                 let progress = progress.clone();
                 let ctrl_report = ctrl.clone();
-                let chunk_path = temp_dir_owned.join(format!(
-                    "{filename_owned}.{download_id}.{suffix_owned}{chunk_id}"
-                ));
+                let chunk_path = chunk_set_owned.path_in(&temp_dir_owned, chunk_id);
                 let ctrl_next = ctrl.clone();
                 let cancel_for_unfold = cancel_outer.clone();
+                let stop_flag = stop_flag.clone();
 
                 async move {
+                    // A sibling chunk has already failed terminally: stop
+                    // generating further work rather than downloading the
+                    // rest of a doomed transfer (see the drain loop below).
+                    if stop_flag.load(Ordering::Relaxed) {
+                        return Ok(None);
+                    }
+
                     let Some(chunk) = ctrl.next_chunk() else {
                         return Ok(None);
                     };
@@ -476,9 +491,38 @@ impl HttpDownloader {
                 }
             })
             .try_buffer_unordered(buffer_factor)
-            .try_collect()
-            .await?
         };
+        futures::pin_mut!(buffered);
+
+        // Drain every buffered future to completion rather than dropping the
+        // stream on the first error (`try_collect`'s default): dropping the
+        // `TryBufferUnordered` mid-poll abandons any chunk still in flight,
+        // and `tokio::fs` operations dispatched to the blocking pool keep
+        // running in the background after their driving future is dropped
+        // (tokio::fs docs) — sweeping immediately would race those writes and
+        // could delete a file the background write hasn't produced yet, or
+        // leave a file created just after the sweep ran. Setting
+        // `stop_scheduling` (checked above) halts new chunk generation
+        // immediately so this only waits out the already-buffered futures,
+        // not the whole remaining transfer.
+        let mut results: Vec<(u64, PathBuf, u64)> = Vec::new();
+        let mut first_err: Option<RdlpError> = None;
+        while let Some(item) = buffered.next().await {
+            match item {
+                Ok(v) => results.push(v),
+                Err(e) => {
+                    if first_err.is_none() {
+                        stop_scheduling.store(true, Ordering::Relaxed);
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+
+        if let Some(e) = first_err {
+            sweep_after_failure(&chunk_set, temp_dir, &e).await;
+            return Err(e);
+        }
 
         // Sort by chunk_id to ensure correct merge order.
         let mut sorted = results;
@@ -503,8 +547,15 @@ impl HttpDownloader {
         filename: &str,
         progress_counter: Arc<AtomicU64>,
         byte_offset: u64,
-        suffix: &str,
+        kind: ChunkKind,
     ) -> Result<(Vec<PathBuf>, u64)> {
+        let chunk_set = ChunkSet::for_attempt(filename, download_id, kind).map_err(|e| {
+            RdlpError::Download {
+                message: format!("{e:#}"),
+                url: Some(rdlp_redact::RedactedUrlBuf::from(url)),
+            }
+        })?;
+
         let (chunk_size, total_chunks) =
             calculate_chunks(size_to_download, self.config.chunk_strategy);
 
@@ -519,8 +570,6 @@ impl HttpDownloader {
 
         let url_shared: Arc<str> = Arc::from(url);
         let temp_dir_owned = temp_dir.to_path_buf();
-        let filename_owned = filename.to_string();
-        let suffix_owned = suffix.to_string();
 
         let results: Vec<(usize, PathBuf, u64)> = match stream::iter(0..total_chunks)
             .map(|chunk_id| {
@@ -531,9 +580,7 @@ impl HttpDownloader {
                     start + chunk_size as u64 - 1
                 };
 
-                let chunk_path = temp_dir_owned.join(format!(
-                    "{filename_owned}.{download_id}.{suffix_owned}{chunk_id}"
-                ));
+                let chunk_path = chunk_set.path_in(&temp_dir_owned, chunk_id as u64);
                 let downloader = self.clone();
                 let url = Arc::clone(&url_shared);
                 let progress = Some(progress_counter.clone());
@@ -563,7 +610,7 @@ impl HttpDownloader {
             Ok(r) => r,
             Err(e) => {
                 error!("Download failed: {e}");
-                cleanup_chunk_files(temp_dir, filename, download_id, total_chunks).await;
+                sweep_after_failure(&chunk_set, temp_dir, &e).await;
                 return Err(e);
             }
         };

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -1279,25 +1279,29 @@ fn download_format_uses_biased_select() {
 
 #[test]
 fn parallel_adaptive_cancel_uses_biased_select() {
-    // Static guard: download_parallel_adaptive's semaphore-acquire select!
-    // MUST include `biased;` so cancel-priority is deterministic.
-    // Mirrors next_with_cancel_helper_uses_biased_select (Task 12, PR #303).
+    // Static guard: run_adaptive_chunk's semaphore-acquire select! MUST
+    // include `biased;` so cancel-priority is deterministic. Mirrors
+    // next_with_cancel_helper_uses_biased_select (Task 12, PR #303). The
+    // chunk-job body (including this select!) was extracted from
+    // download_parallel_adaptive into the free function run_adaptive_chunk
+    // as part of the #568 follow-up cleanup — this guard moved with it.
     let source = include_str!("parallel.rs");
 
     let start = source
-        .find("async fn download_parallel_adaptive")
-        .expect("download_parallel_adaptive not found in parallel.rs");
+        .find("async fn run_adaptive_chunk")
+        .expect("run_adaptive_chunk not found in parallel.rs");
 
     let after_start = &source[start..];
     // End at the next top-level fn definition.
     let end = after_start[1..]
-        .find("\n    async fn ")
+        .find("\nasync fn ")
+        .or_else(|| after_start[1..].find("\nfn "))
         .map_or(after_start.len(), |i| i + 1);
     let body = &after_start[..end];
 
     let select_idx = body
         .find("tokio::select!")
-        .expect("download_parallel_adaptive must contain a tokio::select! for cancel");
+        .expect("run_adaptive_chunk must contain a tokio::select! for cancel");
     let after_select = &body[select_idx..];
     let first_arm = after_select
         .find("=>")
@@ -1306,7 +1310,7 @@ fn parallel_adaptive_cancel_uses_biased_select() {
 
     assert!(
         header.contains("biased;"),
-        "tokio::select! in download_parallel_adaptive MUST use `biased;` \
+        "tokio::select! in run_adaptive_chunk MUST use `biased;` \
          to deterministically prioritize the cancel arm. \
          Found header: {header:?}"
     );

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -1951,9 +1951,9 @@ async fn resume_rejects_response_starting_at_wrong_offset() {
 }
 
 // ---------------------------------------------------------------------------
-// #568 — chunk sweep on failed parallel downloads
+// #568 — chunk cleanup on failed parallel downloads
 //
-// Before this fix, `cleanup_chunk_files` hardcoded the `.part{N}` marker
+// Before this fix, the pre-fix cleaner hardcoded the `.part{N}` marker
 // while a resumed download's writer used `.resume{N}` — so a failed resumed
 // download's cleanup pass deleted nothing (D1). The adaptive path called no
 // cleanup at all (D2). All three tests below assert directly on the
@@ -1972,13 +1972,13 @@ async fn dir_entries(dir: &Path) -> std::collections::HashSet<String> {
 }
 
 /// Regression guard: a failed FRESH parallel download (static chunking, i.e.
-/// adaptive disabled via `Legacy` strategy) must still sweep its `.part{N}`
-/// chunk files. This path's suffix already matched pre-#568 (both writer and
-/// cleaner used `"part"`), so — unlike the two tests below — this one is
-/// expected to ALREADY PASS against the unpatched code; it pins the
+/// adaptive disabled via `Legacy` strategy) must still clean up its
+/// `.part{N}` chunk files. This path's suffix already matched pre-#568 (both
+/// writer and cleaner used `"part"`), so — unlike the two tests below — this
+/// one is expected to ALREADY PASS against the unpatched code; it pins the
 /// behavior so the migration to `ChunkSet` does not regress it.
 #[tokio::test]
-async fn static_fresh_failure_sweeps_part_chunks_regression_guard() {
+async fn static_fresh_failure_cleans_up_part_chunks_regression_guard() {
     use mockito::Server;
     use tempfile::TempDir;
 
@@ -2049,17 +2049,17 @@ async fn static_fresh_failure_sweeps_part_chunks_regression_guard() {
     assert_eq!(
         names,
         std::collections::HashSet::from(["unrelated.txt".to_string()]),
-        "chunk files must be swept after a failed fresh/static download; \
+        "chunk files must be cleaned up after a failed fresh/static download; \
          only the foreign file may remain, found: {names:?}"
     );
 }
 
 /// D1 (the live #568 leak): a failed RESUMED parallel download (static
-/// chunking) must sweep its `.resume{N}` chunk files, not the `.part{N}`
+/// chunking) must clean up its `.resume{N}` chunk files, not the `.part{N}`
 /// marker the pre-fix cleaner hardcoded. Must FAIL against the unpatched
 /// code (the stray `.resumeN` files are left behind).
 #[tokio::test]
-async fn static_resume_failure_sweeps_resume_chunks_d1() {
+async fn static_resume_failure_cleans_up_resume_chunks_d1() {
     use mockito::Server;
     use tempfile::TempDir;
 
@@ -2141,7 +2141,7 @@ async fn static_resume_failure_sweeps_resume_chunks_d1() {
     assert_eq!(
         names,
         std::collections::HashSet::from(["video.mp4".to_string(), "unrelated.txt".to_string()]),
-        "resume chunk files must be swept after a failed resumed download; \
+        "resume chunk files must be cleaned up after a failed resumed download; \
          only the output file and the foreign file may remain, found: {names:?}"
     );
 }
@@ -2149,7 +2149,7 @@ async fn static_resume_failure_sweeps_resume_chunks_d1() {
 /// D2: the adaptive path called no cleanup function at all, so a failed
 /// adaptive download leaked every chunk already written to disk regardless
 /// of how many sibling chunks had already completed successfully. Must FAIL
-/// against the unpatched code (no sweep call exists on this path at all).
+/// against the unpatched code (no cleanup call exists on this path at all).
 ///
 /// Uses the default adaptive config (no `with_chunk_strategy` override, so
 /// `config.adaptive` stays `true`). `AdaptiveConfig::initial_chunk_level` is
@@ -2159,7 +2159,7 @@ async fn static_resume_failure_sweeps_resume_chunks_d1() {
 /// `PROBE_WINDOW_BYTES` exactly (so the F3 probe and chunk 0 share one Range
 /// request/response).
 #[tokio::test]
-async fn adaptive_failure_sweeps_chunks_d2() {
+async fn adaptive_failure_cleans_up_chunks_d2() {
     use mockito::Server;
     use tempfile::TempDir;
 
@@ -2227,7 +2227,7 @@ async fn adaptive_failure_sweeps_chunks_d2() {
     assert_eq!(
         names,
         std::collections::HashSet::from(["unrelated.txt".to_string()]),
-        "chunk files must be swept after a failed adaptive download; \
+        "chunk files must be cleaned up after a failed adaptive download; \
          only the foreign file may remain, found: {names:?}"
     );
 }

--- a/crates/rdlp-downloader/src/http/tests.rs
+++ b/crates/rdlp-downloader/src/http/tests.rs
@@ -1945,3 +1945,285 @@ async fn resume_rejects_response_starting_at_wrong_offset() {
         "a rejected resume must not append foreign bytes to the partial file"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #568 — chunk sweep on failed parallel downloads
+//
+// Before this fix, `cleanup_chunk_files` hardcoded the `.part{N}` marker
+// while a resumed download's writer used `.resume{N}` — so a failed resumed
+// download's cleanup pass deleted nothing (D1). The adaptive path called no
+// cleanup at all (D2). All three tests below assert directly on the
+// filesystem: after a failure, only files a foreign process planted may
+// remain in the download's temp directory.
+// ---------------------------------------------------------------------------
+
+/// Collect the set of file names present in `dir`.
+async fn dir_entries(dir: &Path) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    let mut entries = tokio::fs::read_dir(dir).await.unwrap();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        names.insert(entry.file_name().to_string_lossy().into_owned());
+    }
+    names
+}
+
+/// Regression guard: a failed FRESH parallel download (static chunking, i.e.
+/// adaptive disabled via `Legacy` strategy) must still sweep its `.part{N}`
+/// chunk files. This path's suffix already matched pre-#568 (both writer and
+/// cleaner used `"part"`), so — unlike the two tests below — this one is
+/// expected to ALREADY PASS against the unpatched code; it pins the
+/// behavior so the migration to `ChunkSet` does not regress it.
+#[tokio::test]
+async fn static_fresh_failure_sweeps_part_chunks_regression_guard() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    let chunk_size = 4 * 1024 * 1024; // 4 MiB
+    let total_size = chunk_size * 3; // 3 chunks via Legacy{chunk_count: 3}
+    let body = vec![0xAAu8; chunk_size];
+
+    let _probe = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=0-262143")
+        .with_status(206)
+        .with_header("content-range", &format!("bytes 0-262143/{total_size}"))
+        .with_body(vec![0u8; 262144])
+        .create_async()
+        .await;
+
+    let _chunk0 = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=0-4194303")
+        .with_status(206)
+        .with_header("content-range", &format!("bytes 0-4194303/{total_size}"))
+        .with_body(body.clone())
+        .create_async()
+        .await;
+
+    let _chunk1 = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=4194304-8388607")
+        .with_status(206)
+        .with_header(
+            "content-range",
+            &format!("bytes 4194304-8388607/{total_size}"),
+        )
+        .with_body(body)
+        .create_async()
+        .await;
+
+    // Non-retryable: fails immediately, no chunk-level backoff sleep.
+    let _chunk2_fail = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=8388608-12582911")
+        .with_status(403)
+        .with_body("forbidden")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let no_retry = RetryConfig::new(0, Duration::from_millis(1), Duration::from_millis(1), 1.0);
+    let downloader = HttpDownloader::new()
+        .with_concurrent_fragments(3)
+        .with_retry_config(no_retry)
+        .with_chunk_strategy(crate::chunking::ChunkSizeStrategy::Legacy { chunk_count: 3 });
+
+    let url = format!("{}/video.mp4", server.url());
+    let output = temp_dir.path().join("output.mp4");
+
+    // Foreign file that must survive the failure's cleanup pass.
+    let foreign = temp_dir.path().join("unrelated.txt");
+    tokio::fs::write(&foreign, b"keep me").await.unwrap();
+
+    let result = downloader.download_to_file(&url, &output, None).await;
+    assert!(result.is_err(), "download must fail on chunk 2's 403");
+
+    let names = dir_entries(temp_dir.path()).await;
+    assert_eq!(
+        names,
+        std::collections::HashSet::from(["unrelated.txt".to_string()]),
+        "chunk files must be swept after a failed fresh/static download; \
+         only the foreign file may remain, found: {names:?}"
+    );
+}
+
+/// D1 (the live #568 leak): a failed RESUMED parallel download (static
+/// chunking) must sweep its `.resume{N}` chunk files, not the `.part{N}`
+/// marker the pre-fix cleaner hardcoded. Must FAIL against the unpatched
+/// code (the stray `.resumeN` files are left behind).
+#[tokio::test]
+async fn static_resume_failure_sweeps_resume_chunks_d1() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    let already_downloaded = 8 * 1024 * 1024; // 8 MiB already on disk
+    let chunk_size = 4 * 1024 * 1024; // 4 MiB per remaining chunk
+    let total_size = already_downloaded + chunk_size * 2; // 2 remaining chunks
+
+    let output = temp_dir.path().join("video.mp4");
+    let original_bytes = vec![0xAAu8; already_downloaded as usize];
+    tokio::fs::write(&output, &original_bytes).await.unwrap();
+
+    // `download_with_resume` first issues an open-ended-range analysis
+    // request (`Range: bytes={resume_from}-`) to confirm resume support and
+    // learn the total size before choosing parallel vs. sequential resume.
+    let _resume_analysis = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=8388608-")
+        .with_status(206)
+        .with_header(
+            "content-range",
+            &format!("bytes 8388608-16777215/{total_size}"),
+        )
+        .with_header("accept-ranges", "bytes")
+        .with_body(vec![0xBBu8; chunk_size as usize])
+        .create_async()
+        .await;
+
+    let _chunk0 = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=8388608-12582911")
+        .with_status(206)
+        .with_header(
+            "content-range",
+            &format!("bytes 8388608-12582911/{total_size}"),
+        )
+        .with_body(vec![0xBBu8; chunk_size as usize])
+        .create_async()
+        .await;
+
+    // Non-retryable: fails immediately, no chunk-level backoff sleep.
+    let _chunk1_fail = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=12582912-16777215")
+        .with_status(403)
+        .with_body("forbidden")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let no_retry = RetryConfig::new(0, Duration::from_millis(1), Duration::from_millis(1), 1.0);
+    let downloader = HttpDownloader::new()
+        .with_concurrent_fragments(2)
+        .with_retry_config(no_retry)
+        .with_parallel_threshold(1)
+        .with_chunk_strategy(crate::chunking::ChunkSizeStrategy::Legacy { chunk_count: 2 });
+
+    let url = format!("{}/video.mp4", server.url());
+
+    // Foreign file that must survive the failure's cleanup pass.
+    let foreign = temp_dir.path().join("unrelated.txt");
+    tokio::fs::write(&foreign, b"keep me").await.unwrap();
+
+    let result = downloader
+        .download_with_resume(&url, &output, already_downloaded, None, None)
+        .await;
+    assert!(result.is_err(), "resume must fail on chunk 1's 403");
+
+    // The original partial file must be untouched by the failed resume.
+    let contents = tokio::fs::read(&output).await.unwrap();
+    assert_eq!(
+        contents, original_bytes,
+        "a failed resume must not touch the pre-existing partial output file"
+    );
+
+    let names = dir_entries(temp_dir.path()).await;
+    assert_eq!(
+        names,
+        std::collections::HashSet::from(["video.mp4".to_string(), "unrelated.txt".to_string()]),
+        "resume chunk files must be swept after a failed resumed download; \
+         only the output file and the foreign file may remain, found: {names:?}"
+    );
+}
+
+/// D2: the adaptive path called no cleanup function at all, so a failed
+/// adaptive download leaked every chunk already written to disk regardless
+/// of how many sibling chunks had already completed successfully. Must FAIL
+/// against the unpatched code (no sweep call exists on this path at all).
+///
+/// Uses the default adaptive config (no `with_chunk_strategy` override, so
+/// `config.adaptive` stays `true`). `AdaptiveConfig::initial_chunk_level` is
+/// `MIN_CHUNK_LEVEL` (2 => 256 KiB, see `adaptive::CHUNK_LEVELS`) and
+/// `decision_interval` is 4, so with only 3 total chunks the level never
+/// changes — every chunk is deterministically 256 KiB, matching
+/// `PROBE_WINDOW_BYTES` exactly (so the F3 probe and chunk 0 share one Range
+/// request/response).
+#[tokio::test]
+async fn adaptive_failure_sweeps_chunks_d2() {
+    use mockito::Server;
+    use tempfile::TempDir;
+
+    let mut server = Server::new_async().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    let chunk_bytes = 256 * 1024; // CHUNK_LEVELS[MIN_CHUNK_LEVEL] == PROBE_WINDOW_BYTES
+    let total_size = chunk_bytes * 3;
+
+    // Chunk 0's Range coincides with the F3 probe's Range, so one mock
+    // (matched at least twice) serves both requests.
+    let _chunk0_and_probe = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=0-262143")
+        .with_status(206)
+        .with_header("content-range", &format!("bytes 0-262143/{total_size}"))
+        .with_body(vec![0xCCu8; chunk_bytes])
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let _chunk1 = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=262144-524287")
+        .with_status(206)
+        .with_header(
+            "content-range",
+            &format!("bytes 262144-524287/{total_size}"),
+        )
+        .with_body(vec![0xDDu8; chunk_bytes])
+        .create_async()
+        .await;
+
+    // Non-retryable: fails immediately, no chunk-level backoff sleep.
+    let _chunk2_fail = server
+        .mock("GET", "/video.mp4")
+        .match_header("range", "bytes=524288-786431")
+        .with_status(403)
+        .with_body("forbidden")
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let no_retry = RetryConfig::new(0, Duration::from_millis(1), Duration::from_millis(1), 1.0);
+    let downloader = HttpDownloader::new()
+        .with_concurrent_fragments(2)
+        .with_retry_config(no_retry)
+        .with_parallel_threshold(1);
+    assert!(
+        downloader.config.adaptive,
+        "this test must exercise the adaptive path"
+    );
+
+    let url = format!("{}/video.mp4", server.url());
+    let output = temp_dir.path().join("output.mp4");
+
+    // Foreign file that must survive the failure's cleanup pass.
+    let foreign = temp_dir.path().join("unrelated.txt");
+    tokio::fs::write(&foreign, b"keep me").await.unwrap();
+
+    let result = downloader.download_to_file(&url, &output, None).await;
+    assert!(result.is_err(), "download must fail on chunk 2's 403");
+
+    let names = dir_entries(temp_dir.path()).await;
+    assert_eq!(
+        names,
+        std::collections::HashSet::from(["unrelated.txt".to_string()]),
+        "chunk files must be swept after a failed adaptive download; \
+         only the foreign file may remain, found: {names:?}"
+    );
+}

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -297,6 +297,7 @@ pub use chunking::{ChunkSizeStrategy, calculate_chunks, chunk_size_for_file};
 pub use dash::DashDownloader;
 pub use hls::HlsDownloader;
 pub use http::HttpDownloader;
+pub use http::chunk_name::{ChunkKind, ChunkSet, SweepReport};
 pub use progress::{
     ProgressGuard, ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter,
 };

--- a/crates/rdlp-downloader/src/lib.rs
+++ b/crates/rdlp-downloader/src/lib.rs
@@ -297,7 +297,7 @@ pub use chunking::{ChunkSizeStrategy, calculate_chunks, chunk_size_for_file};
 pub use dash::DashDownloader;
 pub use hls::HlsDownloader;
 pub use http::HttpDownloader;
-pub use http::chunk_name::{ChunkKind, ChunkSet, SweepReport};
+pub use http::chunk_name::{ChunkKind, ChunkSet};
 pub use progress::{
     ProgressGuard, ProgressMetrics, ProgressReporterConfig, spawn_progress_reporter,
 };


### PR DESCRIPTION
## Resolves

Closes #568
Closes #559

## The defect

`cleanup_chunk_files` hardcoded a `.part` chunk suffix its caller did not always use. On the **resume** path the writer emits `.resume{N}`, so a failed resumed parallel download computed `Title.mp4.7.part0..N`, matched nothing, and deleted zero bytes. The orphaned chunks were then invisible to resume detection (which also only looked for `.part{i}`) and swept by nothing else — they stayed until the user deleted them by hand.

The **adaptive** path was worse: it had no cleanup call at all, so every failed adaptive download leaked its entire chunk set regardless of suffix. It also cannot be fixed by an index-range cleaner — the AIMD controller generates chunk ids lazily, so the count is unknown at failure time.

Both are the same root cause, which is #559: one grammar expressed as five independent `format!` strings across two crates, with nothing keeping them in sync.

## The fix

- **`chunk_name.rs`** — one authoritative definition of a chunk name. `ChunkKind{Fresh,Resume}` replaces the raw-string suffix parameter; `ChunkSet` builds every path. Constructors take the output `&Path` and extract `file_name()` themselves, so an empty filename is impossible by construction rather than by check, and the `.file_name().to_string_lossy()` boilerplate disappears from all five former call sites.
- **`chunk_ledger.rs`** — cleanup deletes only paths the run **registered**, never paths it discovered. Registration happens before each chunk's write begins, so a chunk that fails mid-write is still tracked.
- **`Attempt{Fresh,Resume{from}}`** — owns the three settings that must agree (byte offset, chunk kind, merge mode). `Fresh`+`Append` no longer compiles. This is #568's bug shape one level up: a paired parameter that could drift.
- **rdlp-api** — resume detection and cleanup now derive from the shared grammar. Orphaned `.resume{N}` sets are discovered and logged with the exact glob to remove, never auto-deleted (see below).
- Extractions: `drain_collecting_first_error`, `run_adaptive_chunk`, `StaticChunkPlan::range_of`, `open_merge_sink`, `drain_chunk_into`, `into_ordered_paths`.

## Two design decisions worth flagging

**The first cleanup design was wrong and was replaced mid-branch.** It swept the directory for files matching the chunk grammar. That violates `scripts/check-no-dir-sweep-delete.sh` — the gate added by #567 when #558 removed `cleanup_leftover_segments` for deleting users' pre-existing files. The hazard was concrete, not theoretical: `DOWNLOAD_ID_COUNTER` is a **per-process** counter starting at 0, so two concurrent rdlp processes downloading the same filename both get `download_id` 0, and process A's failure sweep would have deleted process B's live chunks. Allowlisting our own code past that gate was not an option. Hence the ledger.

**Orphaned resume chunks are logged, not deleted.** The pre-push security review found that auto-deleting them reintroduced the same cross-process hazard one crate over. There is no ownership proof available to check — `TempRegistry::cleanup_stale` can require an fs4 lock because `FileTracker` takes that lock at creation, but the chunk writer takes no lock, so reproducing the proof means a cross-crate change carrying the very risk being removed. Since an orphaned resume set can never be merged anyway (the byte offset it continues from is not persisted), automatic deletion buys only disk reclamation. #568's acceptance criterion 4 explicitly permits "documented as requiring manual cleanup"; the log names the exact glob and warns to check for a concurrent process first.

## Tests

Three e2e tests drive the public download API against a mockito server and assert on real directory contents after failure — resume-path, adaptive-path, and a fresh-path regression guard — each also asserting a planted foreign file survives. The spec reviewer independently reproduced RED for the first two by rebuilding the pre-fix tree in a worktree and applying only the new tests (`video.mp4.2.resume0` and `output.mp4.0.part{0,1}` survived).

The load-bearing unit tests: a foreign file matching this run's **exact** grammar and download_id survives cleanup (the guarantee the sweep design could not make); items yielded after the first error are still collected (pins the drain against a revert to `try_collect`); a holed legacy set is fully cleaned (out-of-order completion makes holes normal, so break-on-first-hole would leak the remainder); `StaticChunkPlan::range_of` boundaries.

## Reviews

- **Spec compliance** — PASS on each task. Verified the constructed name is byte-identical to what the old writer emitted, and independently reproduced the fail-first RED rather than accepting the implementer's claim.
- **Code quality** — findings applied across three passes: named constructors so `(None, Resume)` is unreachable, typed `io::Error` in cleanup reporting, dead `ChunkSet::claims` deleted (sweep-design residue with zero production callers), `pub(crate)` module so the re-export is the sole public surface, sweep vocabulary purged from test names.
- **Security** — initial verdict **Block** on a HIGH (cross-process deletion of a concurrent process's live resume chunks, in code this branch added). Fixed, re-reviewed, **CLOSED** — verified by absence of any delete call plus tests that fail red against the old behavior. Final: Approve with fixes; both remaining MEDIUMs addressed (syscall-volume regression fixed in 590e30a1) or tracked (#573).

The security finding is the argument for whole-diff review: every commit passed its own per-task review, and the defect only appeared at the seam — rdlp-api reintroducing the exact "delete what you found, not what you own" class that rdlp-downloader had just eliminated.

## Follow-ups filed

- #572 — `DOWNLOAD_ID_COUNTER` is per-process, so two concurrent runs can write the same chunk paths and corrupt each other. The ledger removes the cross-process *deletion* hazard; this is the remaining *write* collision.
- #573 — legacy and Fresh chunk cleanup still delete probed paths with no ownership proof. Pre-existing, wider namespace than the resume case (legacy has no download_id at all), deliberately not folded into this PR's scope.

## Correction to #559's premise

#559's body claims the `0..10` bound in `cleanup_old_chunks` leaks chunks past 10. That is **false** — the bound applies only to the legacy grammar, and legacy downloads never exceeded 10 chunks (`concurrent_fragments` was capped there). The real defects were the marker mismatch and the adaptive undercount. The bound was still worth removing as duplicated knowledge, and a regression test now covers a 12-chunk legacy set.

## Verification

`cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace` (109 suites) · `cargo check -p rdlp-desktop` · all 8 invariant gates + the dir-sweep gate's self-test — all green.
