### PR TITLE
fix(ffmpeg): resolve codec tag per target muxer instead of always zeroing (#549)

### DIFF
--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -23,6 +23,38 @@ impl fmt::Display for CorruptionKind {
     }
 }
 
+/// Stream medium, as reported by `AVMediaType` — the closed 3-value set
+/// [`PostProcessError::IncompatibleContainerCodec`] can name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Medium {
+    /// `AVMEDIA_TYPE_VIDEO`.
+    Video,
+    /// `AVMEDIA_TYPE_AUDIO`.
+    Audio,
+    /// Any other `AVMediaType` (subtitle, data, attachment, unknown).
+    Stream,
+}
+
+impl fmt::Display for Medium {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Video => write!(f, "video"),
+            Self::Audio => write!(f, "audio"),
+            Self::Stream => write!(f, "stream"),
+        }
+    }
+}
+
+impl From<ffmpeg_the_third::ffi::AVMediaType> for Medium {
+    fn from(codec_type: ffmpeg_the_third::ffi::AVMediaType) -> Self {
+        match codec_type {
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_VIDEO => Self::Video,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_AUDIO => Self::Audio,
+            _ => Self::Stream,
+        }
+    }
+}
+
 /// Errors that can occur during post-processing.
 #[derive(Debug, Error)]
 #[allow(missing_docs)] // Field names are self-explanatory, variant docs describe them
@@ -145,18 +177,20 @@ pub enum PostProcessError {
     SalvageFailed { message: String },
 
     /// A stream's codec cannot be represented in the target container: the
-    /// muxer's codec-tag table has no entry for it (a convention gap in
-    /// this `FFmpeg` build, not a documented container standard).
-    #[error(
-        "{container} cannot represent {codec} {medium}; try mkv or another container that supports this codec"
-    )]
+    /// muxer cannot store it under any tag (a convention gap in this
+    /// `FFmpeg` build, not a documented container standard).
+    ///
+    /// The remediation is deliberately generic — naming a specific
+    /// alternative container here previously named the very container that
+    /// just failed when that container was itself incompatible.
+    #[error("{container} cannot represent {codec} {medium}; choose a different target container")]
     IncompatibleContainerCodec {
         /// Target container/muxer short name (e.g. "avi").
         container: String,
         /// Codec name as reported by `FFmpeg` (e.g. "hevc").
         codec: String,
-        /// Stream medium: "video", "audio", or "stream" for anything else.
-        medium: String,
+        /// Stream medium the codec belongs to.
+        medium: Medium,
     },
 
     /// Catch-all for errors with context chains from internal operations.

--- a/crates/rdlp-ffmpeg/src/error.rs
+++ b/crates/rdlp-ffmpeg/src/error.rs
@@ -144,6 +144,21 @@ pub enum PostProcessError {
     #[error("Input corrupt and salvage failed: {message}")]
     SalvageFailed { message: String },
 
+    /// A stream's codec cannot be represented in the target container: the
+    /// muxer's codec-tag table has no entry for it (a convention gap in
+    /// this `FFmpeg` build, not a documented container standard).
+    #[error(
+        "{container} cannot represent {codec} {medium}; try mkv or another container that supports this codec"
+    )]
+    IncompatibleContainerCodec {
+        /// Target container/muxer short name (e.g. "avi").
+        container: String,
+        /// Codec name as reported by `FFmpeg` (e.g. "hevc").
+        codec: String,
+        /// Stream medium: "video", "audio", or "stream" for anything else.
+        medium: String,
+    },
+
     /// Catch-all for errors with context chains from internal operations.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -21,6 +21,8 @@
 
 mod filter_graph;
 
+use std::path::Path;
+
 use crate::error::Result;
 
 use super::FFmpegRunner;
@@ -138,8 +140,25 @@ impl FFmpegRunner {
     ///   for AAC's `mp4a` into AVI, and H.264's `avc1` into FLV); zeroing
     ///   lets `FFmpeg` auto-fill the muxer's own preferred tag instead.
     /// - The table has **no** entry for `codec_id`: fall back to
-    ///   `avformat_query_codec` (representability, not tag choice). If it
-    ///   reports the codec is supported (MKV+HEVC, MKV+SubRip) ->
+    ///   `avformat_query_codec` (representability, not tag choice). Before
+    ///   consulting it, streams whose medium is not Video/Audio/Subtitle
+    ///   (Attachment, Data, Unknown — fonts, timed ID3, generic binary
+    ///   blobs) are never eligible for rejection at all: `Err` here means
+    ///   "this `FFmpeg` build cannot decode/play the codec in this
+    ///   container", a question that only applies to playable media
+    ///   streams. An attachment's "codec" (e.g. `ttf`) is never decoded —
+    ///   it is opaque payload the muxer stores verbatim — so `mkv`'s
+    ///   `query_codec` reporting it unsupported is not a representability
+    ///   gap, it is simply not a question `query_codec`'s table was built
+    ///   to answer for that medium. Rejecting these unconditionally broke
+    ///   `salvage_remux_sync` (the container-corruption recovery path of
+    ///   last resort, which copies every stream with no medium filter by
+    ///   design) on any input carrying a font attachment — the standard
+    ///   layout for a subtitled release. These streams resolve to
+    ///   [`CodecTagAction::Clear`] (the pre-branch behavior: no tag-table
+    ///   entry to preserve or auto-fill from, so clearing is inert).
+    /// - Otherwise (Video/Audio/Subtitle), if `avformat_query_codec` reports
+    ///   the codec is supported (MKV+HEVC, MKV+SubRip) ->
     ///   [`CodecTagAction::Clear`] — there is no tag-table entry to preserve
     ///   or auto-fill from, so clearing is simply inert here too. If it
     ///   reports unsupported (AVI+HEVC): the pairing cannot be represented
@@ -149,10 +168,27 @@ impl FFmpegRunner {
     ///   else (AVI + HEVC: tag stays 0, `riff.c` maps a zero fourcc to raw
     ///   video — exit 0, corrupt file).
     ///
+    /// `avformat_query_codec` itself returns `1` (supported), `0` (not
+    /// supported), or negative (`AVERROR_PATCHWELCOME` — information
+    /// unavailable), per its header contract in `avformat.h`. Only a
+    /// strictly positive result is treated as "supported"
+    /// (`query > 0`, not `query != 0`): a negative "unknown" answer is not
+    /// evidence the pairing works, so it takes the same conservative,
+    /// reject-before-writing branch as an explicit `0`. At every call site
+    /// this predicate actually reaches (guarded above by the tag-table-miss
+    /// branch), the linked `FFmpeg` 8.0 build's `query_codec` callbacks
+    /// (`mkv_query_codec`/`webm_query_codec`) and the C library's own
+    /// tag-table fallback in `avformat_query_codec` both only ever return
+    /// `0` or `1` here — never negative — so this correction changes no
+    /// case in the regression matrix; it is a defensive alignment with the
+    /// documented contract for a `query_codec` implementation this build
+    /// does not ship.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::error::PostProcessError::IncompatibleContainerCodec`]
-    /// when the muxer cannot represent the stream's codec under any tag.
+    /// when the muxer cannot represent a Video/Audio/Subtitle stream's codec
+    /// under any tag.
     ///
     /// `pub(crate)`: called directly (not through [`Self::add_stream_copy`])
     /// by the raw-FFI mux paths, which build `AVStream`/`AVCodecParameters`
@@ -198,7 +234,20 @@ impl FFmpegRunner {
             });
         }
 
-        // No tag-table entry: ask representability, not tag choice.
+        // No tag-table entry. Attachment/Data/Unknown streams are opaque
+        // payload, never decoded, so representability (which only applies
+        // to playable Video/Audio/Subtitle media) is not a question that
+        // can reject them — see the doc comment above.
+        if !matches!(
+            codec_type,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_VIDEO
+                | ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_AUDIO
+                | ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_SUBTITLE
+        ) {
+            return Ok(CodecTagAction::Clear);
+        }
+
+        // Ask representability, not tag choice.
         // SAFETY: `oformat` is the same live, non-null descriptor read above.
         let query = unsafe {
             ffmpeg_the_third::ffi::avformat_query_codec(
@@ -207,7 +256,7 @@ impl FFmpegRunner {
                 ffmpeg_the_third::ffi::FF_COMPLIANCE_NORMAL,
             )
         };
-        if query != 0 {
+        if query > 0 {
             return Ok(CodecTagAction::Clear);
         }
 
@@ -271,6 +320,34 @@ impl FFmpegRunner {
         unsafe {
             (*params_ptr.cast_mut()).codec_tag = 0;
         }
+    }
+
+    /// Resolve and apply the codec-tag decision for one just-added raw-FFI
+    /// output stream — [`Self::resolve_codec_tag`] followed by
+    /// [`Self::clear_codec_tag`] on [`CodecTagAction::Clear`], a no-op on
+    /// [`CodecTagAction::Preserve`].
+    ///
+    /// The 4 raw-FFI mux paths (`remux_mkv_raw_ffi`, `merge_mkv_raw_ffi`'s
+    /// two streams, `embed_thumbnail_mkv_raw_ffi`) each repeated this
+    /// 3-arm `match` verbatim; collapsing the two `Ok` arms here leaves each
+    /// call site only its own cleanup (closing input/output contexts) on
+    /// `Err`, which differs per site and cannot be folded in without losing
+    /// that context-specific teardown.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::PostProcessError::IncompatibleContainerCodec`]
+    /// when [`Self::resolve_codec_tag`] rejects the pairing; the caller is
+    /// still responsible for its own cleanup before propagating.
+    pub(crate) fn resolve_and_apply_codec_tag(
+        oformat: *const ffmpeg_the_third::ffi::AVOutputFormat,
+        codecpar: *const ffmpeg_the_third::ffi::AVCodecParameters,
+    ) -> Result<()> {
+        match Self::resolve_codec_tag(oformat, codecpar)? {
+            CodecTagAction::Preserve => {}
+            CodecTagAction::Clear => Self::clear_codec_tag(codecpar),
+        }
+        Ok(())
     }
 
     /// Copy encoder parameters back to an output stream.
@@ -491,6 +568,30 @@ impl FFmpegRunner {
     }
 }
 
+/// Delete a just-created, still-empty output file after a stream-copy setup
+/// failure (best-effort; a failure here is not itself propagated).
+///
+/// `ffmpeg_the_third::format::output(path)` (and the raw-FFI equivalent,
+/// `avio_open` under `AVIO_FLAG_WRITE`) creates/truncates `path` on disk
+/// immediately — before a single stream, header, or packet is written. If
+/// [`FFmpegRunner::add_stream_copy`] (or the raw-FFI
+/// [`FFmpegRunner::resolve_and_apply_codec_tag`]) then rejects the pairing,
+/// that 0-byte file is left behind looking like a completed-but-empty
+/// operation rather than "never ran". Six call sites across `remux.rs`,
+/// `salvage.rs`, `metadata.rs`, `fixup.rs`, `thumbnail/mod.rs`, and
+/// `merge/mod.rs` share this exact cleanup; a single helper keeps the
+/// six from drifting apart.
+///
+/// Deletes exactly the caller-supplied `path` — never a directory sweep
+/// (rdlp #558's lesson: a directory-wide cleanup can delete a concurrent
+/// operation's live output).
+pub(crate) fn cleanup_partial_output(path: &Path) {
+    // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking from
+    // async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
+    #[allow(clippy::disallowed_methods)]
+    let _ = std::fs::remove_file(path);
+}
+
 /// Release packet buffer references. Idempotent — safe on empty packets.
 ///
 /// SAFETY: `Packet::as_ptr()` returns a valid, non-null `AVPacket` pointer
@@ -554,6 +655,39 @@ pub const fn codec_threading_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// IMPORTANT #2 regression guard: the shared 0-byte-output cleanup
+    /// helper must actually delete the file it's given.
+    #[test]
+    fn cleanup_partial_output_deletes_existing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("partial.mkv");
+        // Safe: test fixture — creating an empty file synchronously is not
+        // on any async-runtime hot path.
+        #[allow(clippy::disallowed_methods)]
+        std::fs::write(&path, b"").expect("create empty fixture");
+        assert!(path.exists());
+
+        cleanup_partial_output(&path);
+
+        assert!(
+            !path.exists(),
+            "cleanup_partial_output must delete the partial output file"
+        );
+    }
+
+    /// `remove_file` on an already-absent path must not panic — every call
+    /// site invokes this from an error path where a prior step (e.g. a
+    /// mid-loop cancellation) may have already removed the file.
+    #[test]
+    fn cleanup_partial_output_is_idempotent_on_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("never_created.mkv");
+        assert!(!path.exists());
+
+        cleanup_partial_output(&path); // must not panic
+        cleanup_partial_output(&path); // still must not panic
+    }
 
     #[test]
     fn packet_unref_on_empty_packet() {
@@ -711,6 +845,55 @@ mod tests {
             CodecTagAction::Clear,
             "mp4a does not round-trip to AAC in mkv's tag table -> Clear, not Preserve"
         );
+    }
+
+    /// CRITICAL regression guard (post-#549 review): `salvage_remux_sync`
+    /// copies every stream in the corrupt input with no media-type filter
+    /// (by design — it is the last-resort recovery path and must not drop
+    /// arbitrary attachments), so an MKV carrying a font attachment (the
+    /// standard layout for a subtitled release) must not have its font
+    /// stream rejected. `AV_CODEC_ID_TTF`'s `AVMediaType` is
+    /// `AVMEDIA_TYPE_ATTACHMENT` — mkv's codec-tag table has no entry for it
+    /// and `mkv_query_codec` reports it unsupported (0), so before this fix
+    /// the fallback reached the final `Err` branch. Fails against the
+    /// unpatched predicate (which does not gate on medium at all).
+    #[test]
+    fn resolve_codec_tag_clears_ttf_attachment_into_mkv() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "mkv");
+        let params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_TTF,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_ATTACHMENT,
+        );
+
+        let action = FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params)).expect(
+            "attachment streams (e.g. embedded fonts) must never be rejected on \
+             codec representability — only Video/Audio/Subtitle streams are \
+             eligible for IncompatibleContainerCodec",
+        );
+        assert_eq!(
+            action,
+            CodecTagAction::Clear,
+            "no tag-table entry for a font attachment -> Clear (not Err)"
+        );
+    }
+
+    /// Same medium-gate bug, `AVMEDIA_TYPE_DATA` variant: `BIN_DATA` (generic
+    /// binary side-channel data, e.g. subtitle-adjacent blobs) has no
+    /// mkv tag-table entry either and must not be rejected.
+    #[test]
+    fn resolve_codec_tag_clears_data_medium_into_mkv() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "mkv");
+        let params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_BIN_DATA,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_DATA,
+        );
+
+        FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params))
+            .expect("AVMEDIA_TYPE_DATA streams must never be rejected on codec representability");
     }
 
     /// Sanity check on the other side of the same predicate: AVI's tag table

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -27,16 +27,24 @@ use super::FFmpegRunner;
 
 /// What to do with a stream's copied codec tag for the target container.
 ///
-/// Decided once, by [`FFmpegRunner::resolve_codec_tag`], and applied by
-/// [`FFmpegRunner::add_stream_copy`] — the single call site for both.
+/// Decided once, by [`FFmpegRunner::resolve_codec_tag`] — the single decision
+/// point every stream-copy call site consults, whether through the safe
+/// wrapper ([`FFmpegRunner::add_stream_copy`]) or a raw-FFI mux path
+/// (`remux_mkv_raw_ffi`, `merge_mkv_raw_ffi`, `embed_thumbnail_mkv_raw_ffi`).
+/// `pub(crate)`: those raw-FFI sites live in sibling modules and need to name
+/// this type to match on the result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CodecTagAction {
+pub(crate) enum CodecTagAction {
     /// The muxer's codec-tag table has an entry for this codec: keep the
     /// tag `avcodec_parameters_copy` already copied from the source stream.
     Preserve,
-    /// The muxer isn't tag-driven (no codec-tag table at all, e.g.
-    /// MPEG-TS): zeroing has no effect either way; zero for consistency
-    /// with this crate's historical behavior.
+    /// Zero the tag and let `FFmpeg` auto-fill from the muxer's own table.
+    ///
+    /// Two cases reach here: the muxer isn't tag-driven at all (no
+    /// codec-tag table, e.g. MPEG-TS), where zeroing is inert; or the
+    /// muxer does have an entry for this codec but under a different tag
+    /// than the source's, where preserving would write a tag the muxer's
+    /// own validation rejects (AAC `mp4a` into AVI, H.264 `avc1` into FLV).
     Clear,
 }
 
@@ -93,25 +101,30 @@ impl FFmpegRunner {
     /// (see [`CodecTagAction`]) — the single decision point `add_stream_copy`
     /// consults; no other call site re-implements this predicate.
     ///
-    /// Uses `av_codec_get_tag`/`av_codec_get_id` — the same public `FFmpeg`
-    /// API the muxer's own header-validation path uses internally — against
-    /// `oformat.codec_tag`, since `ffmpeg-the-third` has no safe wrapper for
-    /// either. (`avformat_query_codec` was tried first and rejected: it only
-    /// asks "does this muxer support this `codec_id` at all", not "does it
-    /// accept *this specific* tag" — reporting `1` for e.g. AAC-in-AVI even
-    /// though the source's `mp4a` tag isn't one the AVI table recognizes,
-    /// which broke real audio/FLV streams in this fix's own test matrix.)
+    /// Two distinct questions, two distinct `FFmpeg` APIs — conflating them
+    /// is the bug this fix corrects:
+    ///
+    /// - **"Which tag should this stream be written under?"** —
+    ///   `av_codec_get_tag`/`av_codec_get_id` against `oformat.codec_tag`,
+    ///   the muxer's own static fourcc table. `ffmpeg-the-third` has no safe
+    ///   wrapper for either.
+    /// - **"Can this muxer represent the codec at all?"** — `avformat_query_codec`,
+    ///   which (per `avformat.c`) dispatches to the muxer's own
+    ///   `query_codec` callback when one exists, falling back to the tag
+    ///   table only when it doesn't. `matroskaenc` defines `mkv_query_codec`
+    ///   and reports HEVC/SubRip as representable even though `mkv`'s
+    ///   *tag table* (keyed off `CodecID` strings, not a fourcc) has no
+    ///   entry for either — so gating rejection on the tag table alone
+    ///   (this fix's first attempt) hard-failed HEVC-into-MKV and any
+    ///   subtitled input, an actual regression this predicate must not
+    ///   reintroduce. `avienc` defines no `query_codec`, so AVI genuinely
+    ///   falls back to its tag table and HEVC-into-AVI stays rejected.
+    ///
+    /// Decision:
     ///
     /// - The muxer has no codec-tag table at all (`oformat.codec_tag` is
     ///   null, e.g. MPEG-TS): tag-clearing is inert either way ->
     ///   [`CodecTagAction::Clear`].
-    /// - The table has no entry for this codec's `codec_id` whatsoever
-    ///   (`av_codec_get_tag` returns 0): the pairing cannot be represented in
-    ///   this container by this `FFmpeg` build (a convention gap, not a
-    ///   documented standard — no spec covers HEVC-in-AVI). Reject before
-    ///   writing rather than let a zeroed tag silently decode as something
-    ///   else (AVI + HEVC: tag stays 0, `riff.c` maps a zero fourcc to raw
-    ///   video — exit 0, corrupt file).
     /// - The table has an entry for `codec_id`, and the source's specific
     ///   tag maps back to that same `codec_id` (`av_codec_get_id` round-trips)
     ///   -> [`CodecTagAction::Preserve`]. Zeroing here would make `FFmpeg`
@@ -124,17 +137,30 @@ impl FFmpegRunner {
     ///   write a tag the muxer's own validation rejects outright (observed
     ///   for AAC's `mp4a` into AVI, and H.264's `avc1` into FLV); zeroing
     ///   lets `FFmpeg` auto-fill the muxer's own preferred tag instead.
+    /// - The table has **no** entry for `codec_id`: fall back to
+    ///   `avformat_query_codec` (representability, not tag choice). If it
+    ///   reports the codec is supported (MKV+HEVC, MKV+SubRip) ->
+    ///   [`CodecTagAction::Clear`] — there is no tag-table entry to preserve
+    ///   or auto-fill from, so clearing is simply inert here too. If it
+    ///   reports unsupported (AVI+HEVC): the pairing cannot be represented
+    ///   in this container by this `FFmpeg` build (a convention gap, not a
+    ///   documented standard — no spec covers HEVC-in-AVI). Reject before
+    ///   writing rather than let a zeroed tag silently decode as something
+    ///   else (AVI + HEVC: tag stays 0, `riff.c` maps a zero fourcc to raw
+    ///   video — exit 0, corrupt file).
     ///
     /// # Errors
     ///
     /// Returns [`crate::error::PostProcessError::IncompatibleContainerCodec`]
-    /// when the muxer's tag table has no entry for the stream's codec.
-    fn resolve_codec_tag(
+    /// when the muxer cannot represent the stream's codec under any tag.
+    ///
+    /// `pub(crate)`: called directly (not through [`Self::add_stream_copy`])
+    /// by the raw-FFI mux paths, which build `AVStream`/`AVCodecParameters`
+    /// by hand and have no `add_stream_copy` call site to route through.
+    pub(crate) fn resolve_codec_tag(
         oformat: *const ffmpeg_the_third::ffi::AVOutputFormat,
         params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters,
     ) -> Result<CodecTagAction> {
-        use crate::error::PostProcessError;
-
         // SAFETY: `oformat` is the live output context's format descriptor
         // (see the SAFETY note at the `add_stream_copy` call site);
         // `params_ptr` is the just-copied codecpar of the stream we added to
@@ -172,7 +198,35 @@ impl FFmpegRunner {
             });
         }
 
-        // No entry for this codec at all, under any tag: unrepresentable.
+        // No tag-table entry: ask representability, not tag choice.
+        // SAFETY: `oformat` is the same live, non-null descriptor read above.
+        let query = unsafe {
+            ffmpeg_the_third::ffi::avformat_query_codec(
+                oformat,
+                codec_id,
+                ffmpeg_the_third::ffi::FF_COMPLIANCE_NORMAL,
+            )
+        };
+        if query != 0 {
+            return Ok(CodecTagAction::Clear);
+        }
+
+        Err(Self::unrepresentable_codec_error(
+            oformat, codec_id, codec_type,
+        ))
+    }
+
+    /// Build the [`crate::error::PostProcessError::IncompatibleContainerCodec`]
+    /// for a codec/container pairing `resolve_codec_tag` has already decided
+    /// is unrepresentable — kept separate so `resolve_codec_tag` stays a pure
+    /// decision (the message-building is not part of the predicate).
+    fn unrepresentable_codec_error(
+        oformat: *const ffmpeg_the_third::ffi::AVOutputFormat,
+        codec_id: ffmpeg_the_third::ffi::AVCodecID,
+        codec_type: ffmpeg_the_third::ffi::AVMediaType,
+    ) -> crate::error::PostProcessError {
+        use crate::error::{Medium, PostProcessError};
+
         // SAFETY: every registered muxer descriptor has a non-null,
         // NUL-terminated `name`.
         let container = unsafe {
@@ -180,28 +234,37 @@ impl FFmpegRunner {
                 .to_string_lossy()
                 .into_owned()
         };
-        let codec = ffmpeg_the_third::codec::Id::from(codec_id)
-            .name()
-            .to_string();
-        let medium = match codec_type {
-            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_VIDEO => "video",
-            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_AUDIO => "audio",
-            _ => "stream",
-        }
-        .to_string();
+        // `avcodec_get_name` rather than `codec::Id::from(codec_id).name()`:
+        // `codec_id` comes from a remote, attacker-influenced file, and
+        // `ffmpeg-the-third`'s `From<AVCodecID>` ends in `_ => unimplemented!()`
+        // under its default `non-exhaustive-enums` feature — so any codec the
+        // crate's compiled-in table doesn't know (one newer than the binding,
+        // or a malformed stream) would panic here. The C API always yields a
+        // valid string, falling back to "unknown_codec".
+        // SAFETY: `avcodec_get_name` accepts any AVCodecID and is documented to
+        // return a static, NUL-terminated string; it never returns NULL.
+        let codec = unsafe {
+            std::ffi::CStr::from_ptr(ffmpeg_the_third::ffi::avcodec_get_name(codec_id))
+                .to_string_lossy()
+                .into_owned()
+        };
 
-        Err(PostProcessError::IncompatibleContainerCodec {
+        PostProcessError::IncompatibleContainerCodec {
             container,
             codec,
-            medium,
-        })
+            medium: Medium::from(codec_type),
+        }
     }
 
     /// Reset the codec tag to 0 for container compatibility.
     ///
-    /// Only correct to call when the target muxer isn't tag-driven at all
-    /// (see [`Self::resolve_codec_tag`]) — zeroing then has no effect, since
-    /// there is no table for `FFmpeg` to auto-fill a tag from.
+    /// Correct to call only for the cases [`CodecTagAction::Clear`] covers
+    /// (see [`Self::resolve_codec_tag`]): either the muxer has no codec-tag
+    /// table, or it has no entry matching the source's specific tag. Calling
+    /// it unconditionally is the bug #549 fixed — for a tag-driven muxer that
+    /// *does* recognize the source tag, zeroing makes `FFmpeg` substitute its
+    /// own (for AVI + H.264, the literal `'H264'` fourcc, which then demands
+    /// Annex-B start codes that AVCC-packaged streams do not carry).
     pub(crate) fn clear_codec_tag(params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters) {
         // SAFETY: `params_ptr` points to a valid AVCodecParameters allocated by FFmpeg.
         // Setting codec_tag to 0 is always valid — it tells FFmpeg to auto-select.
@@ -540,5 +603,133 @@ mod tests {
             let rate = FFmpegRunner::pick_audio_sample_rate(&codec, 44100);
             assert_eq!(rate, 44100);
         }
+    }
+
+    /// Build a zeroed `AVCodecParameters` naming only `codec_id`/`codec_type` —
+    /// the only fields `resolve_codec_tag` reads.
+    ///
+    /// SAFETY: zero-initializing `AVCodecParameters` mirrors what
+    /// `avcodec_parameters_alloc` does internally (`av_mallocz`); every field
+    /// this test leaves zeroed (extradata pointers, side-data lists, etc.) is
+    /// never read by `resolve_codec_tag`.
+    fn fake_params(
+        codec_id: ffmpeg_the_third::ffi::AVCodecID,
+        codec_type: ffmpeg_the_third::ffi::AVMediaType,
+    ) -> ffmpeg_the_third::ffi::AVCodecParameters {
+        let mut params: ffmpeg_the_third::ffi::AVCodecParameters = unsafe { std::mem::zeroed() };
+        params.codec_id = codec_id;
+        params.codec_type = codec_type;
+        params
+    }
+
+    /// Get the live `AVOutputFormat*` for a freshly-opened output context
+    /// targeting the given extension (mirrors the capture in `add_stream_copy`).
+    fn oformat_for_extension(
+        dir: &std::path::Path,
+        ext: &str,
+    ) -> *const ffmpeg_the_third::ffi::AVOutputFormat {
+        let octx = ffmpeg_the_third::format::output(dir.join(format!("probe.{ext}")))
+            .expect("open probe output context");
+        // SAFETY: `octx` is a live output context just opened above; `oformat`
+        // is a read-only static descriptor set at alloc time.
+        unsafe { (*octx.as_ptr()).oformat }
+    }
+
+    /// CRITICAL #1/#2 regression guard: MKV's codec-tag table has no entry
+    /// for HEVC at all (Matroska keys tags off `CodecID` strings, not a
+    /// fourcc table), so the old predicate — reject whenever
+    /// `av_codec_get_tag` returns 0 — hard-failed HEVC into MKV even though
+    /// `matroskaenc` defines `mkv_query_codec` and demonstrably supports it.
+    /// Fails against the unpatched predicate (which returns
+    /// `IncompatibleContainerCodec` here).
+    #[test]
+    fn resolve_codec_tag_permits_hevc_into_mkv() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "mkv");
+        let params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_HEVC,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_VIDEO,
+        );
+
+        let action = FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params)).expect(
+            "MKV must represent HEVC: matroskaenc defines mkv_query_codec even though \
+             its static codec-tag table has no HEVC entry",
+        );
+        assert_eq!(
+            action,
+            CodecTagAction::Clear,
+            "no tag-table entry for HEVC in mkv -> Clear (not Preserve, not Err)"
+        );
+    }
+
+    /// Same predicate bug, subtitle-medium variant: MKV's tag table has no
+    /// entry for `SubRip` either, but subtitled inputs (routed through
+    /// `salvage::salvage_remux_sync`, which copies every stream with no
+    /// media-type filter) must still be representable in MKV.
+    #[test]
+    fn resolve_codec_tag_permits_subrip_into_mkv() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "mkv");
+        let params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_SUBRIP,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_SUBTITLE,
+        );
+
+        FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params))
+            .expect("MKV must represent SubRip subtitles despite no tag-table entry");
+    }
+
+    /// Hypothesis check for the raw-FFI routing change: an AAC stream tagged
+    /// with its MP4 `mp4a` fourcc, going into MKV, must resolve to
+    /// [`CodecTagAction::Clear`] — not `Preserve`. MKV's tag table *does*
+    /// carry an AAC entry, but under Matroska's own tag, not `mp4a`, so
+    /// `av_codec_get_id(tags, mp4a)` must NOT round-trip to
+    /// `AV_CODEC_ID_AAC`. This is the exact case an earlier blunt experiment
+    /// (preserving every source tag unconditionally) got wrong: preserving
+    /// `mp4a` on Matroska-bound AAC is what regressed `mp4_to_mkv`/
+    /// `ts_to_mkv`/`hevc_to_mkv` (all AAC-bearing fixtures) in that
+    /// experiment. Routing through the real predicate must NOT reproduce it.
+    #[test]
+    fn resolve_codec_tag_clears_mp4a_tagged_aac_into_mkv() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "mkv");
+        let mut params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_AAC,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_AUDIO,
+        );
+        // MP4/ISOBMFF's fourcc for AAC ('mp4a'), packed the same way FFmpeg's
+        // `MKTAG` macro does (`u32::from_le_bytes` of the ASCII bytes).
+        params.codec_tag = u32::from_le_bytes(*b"mp4a");
+
+        let action = FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params))
+            .expect("MKV must represent AAC");
+        assert_eq!(
+            action,
+            CodecTagAction::Clear,
+            "mp4a does not round-trip to AAC in mkv's tag table -> Clear, not Preserve"
+        );
+    }
+
+    /// Sanity check on the other side of the same predicate: AVI's tag table
+    /// genuinely has no representation for HEVC (`avienc` defines no
+    /// `query_codec`, so it falls back to its own tag table, which is the
+    /// case the fix must still reject).
+    #[test]
+    fn resolve_codec_tag_rejects_hevc_into_avi() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "avi");
+        let params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_HEVC,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_VIDEO,
+        );
+
+        let err = FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params))
+            .expect_err("AVI cannot represent HEVC under this FFmpeg build");
+        let msg = err.to_string().to_lowercase();
+        assert!(msg.contains("avi") && msg.contains("hevc"), "got: {msg}");
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -25,8 +25,24 @@ use crate::error::Result;
 
 use super::FFmpegRunner;
 
+/// What to do with a stream's copied codec tag for the target container.
+///
+/// Decided once, by [`FFmpegRunner::resolve_codec_tag`], and applied by
+/// [`FFmpegRunner::add_stream_copy`] — the single call site for both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodecTagAction {
+    /// The muxer's codec-tag table has an entry for this codec: keep the
+    /// tag `avcodec_parameters_copy` already copied from the source stream.
+    Preserve,
+    /// The muxer isn't tag-driven (no codec-tag table at all, e.g.
+    /// MPEG-TS): zeroing has no effect either way; zero for consistency
+    /// with this crate's historical behavior.
+    Clear,
+}
+
 impl FFmpegRunner {
-    /// Add a stream-copy output stream: add stream, copy parameters, clear codec tag.
+    /// Add a stream-copy output stream: add stream, copy parameters, resolve
+    /// the codec tag for the target container.
     ///
     /// This is the standard pattern for remuxing/metadata/merge where a stream
     /// is copied without re-encoding. Returns the output stream index.
@@ -35,6 +51,11 @@ impl FFmpegRunner {
     /// * `octx` - Output format context
     /// * `params` - Input stream parameters to copy
     /// * `context_msg` - Error context message (e.g., "for remux", "for merge video")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the target container's muxer cannot represent the
+    /// stream's codec at all (see [`Self::resolve_codec_tag`]).
     pub(crate) fn add_stream_copy(
         octx: &mut ffmpeg_the_third::format::context::Output,
         params: impl ffmpeg_the_third::AsPtr<ffmpeg_the_third::ffi::AVCodecParameters>,
@@ -43,6 +64,14 @@ impl FFmpegRunner {
         use crate::error::PostProcessError;
         use anyhow::Context;
 
+        // Captured before `add_stream` takes a mutable borrow of `octx`.
+        // SAFETY: `octx` owns a valid AVFormatContext; `oformat` is set once
+        // at context-alloc time (`avformat_alloc_output_context2`) and never
+        // changes afterward, so reading it through a short-lived reborrow
+        // here is sound regardless of what happens to `octx` later.
+        let oformat: *const ffmpeg_the_third::ffi::AVOutputFormat =
+            unsafe { (*octx.as_mut_ptr()).oformat };
+
         let mut ost = octx
             .add_stream(ffmpeg_the_third::encoder::find(
                 ffmpeg_the_third::codec::Id::None,
@@ -50,14 +79,129 @@ impl FFmpegRunner {
             .map_err(PostProcessError::from)
             .context(format!("failed to add output stream {context_msg}"))?;
         ost.set_parameters(params);
-        Self::clear_codec_tag(ost.parameters().as_ptr());
+
+        let params_ptr = ost.parameters().as_ptr();
+        match Self::resolve_codec_tag(oformat, params_ptr)? {
+            CodecTagAction::Preserve => {}
+            CodecTagAction::Clear => Self::clear_codec_tag(params_ptr),
+        }
+
         Ok(ost.index())
+    }
+
+    /// Decide what to do with a stream's codec tag for the target container
+    /// (see [`CodecTagAction`]) — the single decision point `add_stream_copy`
+    /// consults; no other call site re-implements this predicate.
+    ///
+    /// Uses `av_codec_get_tag`/`av_codec_get_id` — the same public `FFmpeg`
+    /// API the muxer's own header-validation path uses internally — against
+    /// `oformat.codec_tag`, since `ffmpeg-the-third` has no safe wrapper for
+    /// either. (`avformat_query_codec` was tried first and rejected: it only
+    /// asks "does this muxer support this `codec_id` at all", not "does it
+    /// accept *this specific* tag" — reporting `1` for e.g. AAC-in-AVI even
+    /// though the source's `mp4a` tag isn't one the AVI table recognizes,
+    /// which broke real audio/FLV streams in this fix's own test matrix.)
+    ///
+    /// - The muxer has no codec-tag table at all (`oformat.codec_tag` is
+    ///   null, e.g. MPEG-TS): tag-clearing is inert either way ->
+    ///   [`CodecTagAction::Clear`].
+    /// - The table has no entry for this codec's `codec_id` whatsoever
+    ///   (`av_codec_get_tag` returns 0): the pairing cannot be represented in
+    ///   this container by this `FFmpeg` build (a convention gap, not a
+    ///   documented standard — no spec covers HEVC-in-AVI). Reject before
+    ///   writing rather than let a zeroed tag silently decode as something
+    ///   else (AVI + HEVC: tag stays 0, `riff.c` maps a zero fourcc to raw
+    ///   video — exit 0, corrupt file).
+    /// - The table has an entry for `codec_id`, and the source's specific
+    ///   tag maps back to that same `codec_id` (`av_codec_get_id` round-trips)
+    ///   -> [`CodecTagAction::Preserve`]. Zeroing here would make `FFmpeg`
+    ///   auto-fill the tag from the muxer's own table, which for AVI
+    ///   substitutes a literal `'H264'` fourcc — that value arms
+    ///   `avienc.c`'s start-code guard and hard-fails AVCC-packaged H.264
+    ///   (no start codes in the bitstream).
+    /// - The table has an entry for `codec_id`, but under a *different* tag
+    ///   than the source's -> [`CodecTagAction::Clear`]. Preserving would
+    ///   write a tag the muxer's own validation rejects outright (observed
+    ///   for AAC's `mp4a` into AVI, and H.264's `avc1` into FLV); zeroing
+    ///   lets `FFmpeg` auto-fill the muxer's own preferred tag instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::PostProcessError::IncompatibleContainerCodec`]
+    /// when the muxer's tag table has no entry for the stream's codec.
+    fn resolve_codec_tag(
+        oformat: *const ffmpeg_the_third::ffi::AVOutputFormat,
+        params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters,
+    ) -> Result<CodecTagAction> {
+        use crate::error::PostProcessError;
+
+        // SAFETY: `oformat` is the live output context's format descriptor
+        // (see the SAFETY note at the `add_stream_copy` call site);
+        // `params_ptr` is the just-copied codecpar of the stream we added to
+        // that same context, so both reads are into live FFmpeg-owned memory.
+        let (codec_id, source_tag, codec_type, tags) = unsafe {
+            (
+                (*params_ptr).codec_id,
+                (*params_ptr).codec_tag,
+                (*params_ptr).codec_type,
+                (*oformat).codec_tag,
+            )
+        };
+
+        if tags.is_null() {
+            return Ok(CodecTagAction::Clear);
+        }
+
+        // SAFETY: `tags` was just proven non-null; both lookups are pure
+        // reads over the muxer's static, compiled-in tag table.
+        let (muxer_tag_for_codec, id_for_source_tag) = unsafe {
+            (
+                ffmpeg_the_third::ffi::av_codec_get_tag(tags, codec_id),
+                ffmpeg_the_third::ffi::av_codec_get_id(tags, source_tag),
+            )
+        };
+
+        if muxer_tag_for_codec != 0 {
+            return Ok(if id_for_source_tag == codec_id {
+                // The source's specific tag round-trips to this codec: keep it.
+                CodecTagAction::Preserve
+            } else {
+                // Codec supported, but not under the source's specific tag;
+                // let FFmpeg auto-fill its own preferred tag instead.
+                CodecTagAction::Clear
+            });
+        }
+
+        // No entry for this codec at all, under any tag: unrepresentable.
+        // SAFETY: every registered muxer descriptor has a non-null,
+        // NUL-terminated `name`.
+        let container = unsafe {
+            std::ffi::CStr::from_ptr((*oformat).name)
+                .to_string_lossy()
+                .into_owned()
+        };
+        let codec = ffmpeg_the_third::codec::Id::from(codec_id)
+            .name()
+            .to_string();
+        let medium = match codec_type {
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_VIDEO => "video",
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_AUDIO => "audio",
+            _ => "stream",
+        }
+        .to_string();
+
+        Err(PostProcessError::IncompatibleContainerCodec {
+            container,
+            codec,
+            medium,
+        })
     }
 
     /// Reset the codec tag to 0 for container compatibility.
     ///
-    /// When remuxing between containers, the source codec tag may not be valid
-    /// in the target container. Setting it to 0 lets `FFmpeg` auto-select.
+    /// Only correct to call when the target muxer isn't tag-driven at all
+    /// (see [`Self::resolve_codec_tag`]) — zeroing then has no effect, since
+    /// there is no table for `FFmpeg` to auto-fill a tag from.
     pub(crate) fn clear_codec_tag(params_ptr: *const ffmpeg_the_third::ffi::AVCodecParameters) {
         // SAFETY: `params_ptr` points to a valid AVCodecParameters allocated by FFmpeg.
         // Setting codec_tag to 0 is always valid — it tells FFmpeg to auto-select.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/ffi_helpers/mod.rs
@@ -571,16 +571,20 @@ impl FFmpegRunner {
 /// Delete a just-created, still-empty output file after a stream-copy setup
 /// failure (best-effort; a failure here is not itself propagated).
 ///
-/// `ffmpeg_the_third::format::output(path)` (and the raw-FFI equivalent,
-/// `avio_open` under `AVIO_FLAG_WRITE`) creates/truncates `path` on disk
+/// `ffmpeg_the_third::format::output(path)` creates/truncates `path` on disk
 /// immediately — before a single stream, header, or packet is written. If
-/// [`FFmpegRunner::add_stream_copy`] (or the raw-FFI
-/// [`FFmpegRunner::resolve_and_apply_codec_tag`]) then rejects the pairing,
-/// that 0-byte file is left behind looking like a completed-but-empty
-/// operation rather than "never ran". Six call sites across `remux.rs`,
-/// `salvage.rs`, `metadata.rs`, `fixup.rs`, `thumbnail/mod.rs`, and
-/// `merge/mod.rs` share this exact cleanup; a single helper keeps the
-/// six from drifting apart.
+/// [`FFmpegRunner::add_stream_copy`] then rejects the pairing, that 0-byte
+/// file is left behind looking like a completed-but-empty operation rather
+/// than "never ran". Ten call sites across `remux.rs`, `salvage.rs`,
+/// `metadata.rs`, `fixup.rs`, `thumbnail/mod.rs`, `merge/mod.rs`, and
+/// `transcode/{audio_extract.rs,video_transcode_phases.rs}` share this exact
+/// cleanup; a single helper keeps the ten from drifting apart.
+///
+/// The raw-FFI codec-tag callers (e.g. `merge/mkv_raw_ffi.rs`) call
+/// [`FFmpegRunner::resolve_and_apply_codec_tag`] directly, but that helper is
+/// NOT a cleanup trigger there: in every raw-FFI mux path, `avio_open` runs
+/// AFTER the per-stream loop that calls it, so no output file exists yet at
+/// the point a rejection could occur — there is nothing to clean up.
 ///
 /// Deletes exactly the caller-supplied `path` — never a directory sweep
 /// (rdlp #558's lesson: a directory-wide cleanup can delete a concurrent
@@ -914,5 +918,36 @@ mod tests {
             .expect_err("AVI cannot represent HEVC under this FFmpeg build");
         let msg = err.to_string().to_lowercase();
         assert!(msg.contains("avi") && msg.contains("hevc"), "got: {msg}");
+    }
+
+    /// IMPORTANT #5 (code-review follow-up): the medium gate at the top of
+    /// `resolve_codec_tag` exempts Attachment/Data/Unknown streams from the
+    /// representability question entirely (see
+    /// `resolve_codec_tag_clears_ttf_attachment_into_mkv` /
+    /// `resolve_codec_tag_clears_data_medium_into_mkv` above) — but Subtitle
+    /// stays in the eligible set alongside Video/Audio. Nothing pinned that a
+    /// subtitle codec a container genuinely cannot represent is still
+    /// rejected, so a future widening of the exemption to
+    /// `AVMEDIA_TYPE_SUBTITLE` would go green with no test noticing. AVI's
+    /// tag table has no entry for `SubRip` and `avienc` defines no
+    /// `query_codec` fallback (the same shape that makes
+    /// `resolve_codec_tag_rejects_hevc_into_avi` reject HEVC above), so the
+    /// pairing must still be rejected, not waved through as if it were an
+    /// attachment.
+    #[test]
+    fn resolve_codec_tag_rejects_subrip_into_avi() {
+        crate::ffmpeg::ensure_init().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oformat = oformat_for_extension(dir.path(), "avi");
+        let params = fake_params(
+            ffmpeg_the_third::ffi::AVCodecID::AV_CODEC_ID_SUBRIP,
+            ffmpeg_the_third::ffi::AVMediaType::AVMEDIA_TYPE_SUBTITLE,
+        );
+
+        let err = FFmpegRunner::resolve_codec_tag(oformat, std::ptr::from_ref(&params)).expect_err(
+            "subtitle streams must remain rejection-eligible: AVI cannot represent SubRip",
+        );
+        let msg = err.to_string().to_lowercase();
+        assert!(msg.contains("avi") && msg.contains("subrip"), "got: {msg}");
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/fixup.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/fixup.rs
@@ -231,6 +231,7 @@ impl FFmpegRunner {
 
         Self::spawn_blocking("fixup_sar", move || -> Result<()> {
             use super::ensure_init;
+            use super::ffi_helpers::cleanup_partial_output;
             use super::log_capture::LogSuppressGuard;
 
             ensure_init()?;
@@ -260,7 +261,12 @@ impl FFmpegRunner {
                 ist_time_bases[ist_index] = ist.time_base();
                 ost_index += 1;
 
-                let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for fixup")?;
+                // `format::output` above already created (truncated) `output`
+                // on disk via `avio_open` — a codec-tag rejection here must
+                // not leave that empty file behind as if a fixup remux had
+                // run and produced nothing.
+                let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for fixup")
+                    .inspect_err(|_| cleanup_partial_output(&output))?;
                 octx.stream_mut(ost_idx)
                     .expect("just-added stream")
                     .set_metadata(ist.metadata().to_owned());

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -36,6 +36,7 @@ use log::{debug, info};
 use crate::error::{PostProcessError, Result};
 
 use super::super::FFmpegRunner;
+use super::super::ffi_helpers::CodecTagAction;
 use super::av_packet_owned::AvPacketOwned;
 use super::raw_ffi_helpers::{
     dts_in_us, out_codecpar_video_delay, read_next_raw, rescale_and_write_raw,
@@ -218,7 +219,25 @@ impl FFmpegRunner {
                     message: format!("Failed to copy video codec params: error code {ret}"),
                 });
             }
-            (*(*out_video_stream).codecpar).codec_tag = 0;
+            // Resolve the codec tag through the same decision point the safe
+            // `add_stream_copy` path uses, rather than unconditionally
+            // zeroing (see the equivalent site in `remux.rs` for why this
+            // asymmetry between raw-FFI and `add_stream_copy` mattered).
+            match Self::resolve_codec_tag(
+                (*ofmt_ctx).oformat,
+                (*out_video_stream).codecpar.cast_const(),
+            ) {
+                Ok(CodecTagAction::Preserve) => {}
+                Ok(CodecTagAction::Clear) => {
+                    Self::clear_codec_tag((*out_video_stream).codecpar.cast_const());
+                }
+                Err(e) => {
+                    ffi::avformat_close_input(&mut ifmt_video);
+                    ffi::avformat_close_input(&mut ifmt_audio);
+                    ffi::avformat_free_context(ofmt_ctx);
+                    return Err(e);
+                }
+            }
 
             // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
             ffi::av_dict_copy(
@@ -281,7 +300,21 @@ impl FFmpegRunner {
                     message: format!("Failed to copy audio codec params: error code {ret}"),
                 });
             }
-            (*(*out_audio_stream).codecpar).codec_tag = 0;
+            match Self::resolve_codec_tag(
+                (*ofmt_ctx).oformat,
+                (*out_audio_stream).codecpar.cast_const(),
+            ) {
+                Ok(CodecTagAction::Preserve) => {}
+                Ok(CodecTagAction::Clear) => {
+                    Self::clear_codec_tag((*out_audio_stream).codecpar.cast_const());
+                }
+                Err(e) => {
+                    ffi::avformat_close_input(&mut ifmt_video);
+                    ffi::avformat_close_input(&mut ifmt_audio);
+                    ffi::avformat_free_context(ofmt_ctx);
+                    return Err(e);
+                }
+            }
 
             // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
             ffi::av_dict_copy(

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mkv_raw_ffi.rs
@@ -36,7 +36,6 @@ use log::{debug, info};
 use crate::error::{PostProcessError, Result};
 
 use super::super::FFmpegRunner;
-use super::super::ffi_helpers::CodecTagAction;
 use super::av_packet_owned::AvPacketOwned;
 use super::raw_ffi_helpers::{
     dts_in_us, out_codecpar_video_delay, read_next_raw, rescale_and_write_raw,
@@ -219,24 +218,19 @@ impl FFmpegRunner {
                     message: format!("Failed to copy video codec params: error code {ret}"),
                 });
             }
-            // Resolve the codec tag through the same decision point the safe
-            // `add_stream_copy` path uses, rather than unconditionally
-            // zeroing (see the equivalent site in `remux.rs` for why this
-            // asymmetry between raw-FFI and `add_stream_copy` mattered).
-            match Self::resolve_codec_tag(
+            // Resolve and apply the codec tag through the same decision
+            // point the safe `add_stream_copy` path uses, rather than
+            // unconditionally zeroing (see the equivalent site in
+            // `remux.rs` for why this asymmetry between raw-FFI and
+            // `add_stream_copy` mattered).
+            if let Err(e) = Self::resolve_and_apply_codec_tag(
                 (*ofmt_ctx).oformat,
                 (*out_video_stream).codecpar.cast_const(),
             ) {
-                Ok(CodecTagAction::Preserve) => {}
-                Ok(CodecTagAction::Clear) => {
-                    Self::clear_codec_tag((*out_video_stream).codecpar.cast_const());
-                }
-                Err(e) => {
-                    ffi::avformat_close_input(&mut ifmt_video);
-                    ffi::avformat_close_input(&mut ifmt_audio);
-                    ffi::avformat_free_context(ofmt_ctx);
-                    return Err(e);
-                }
+                ffi::avformat_close_input(&mut ifmt_video);
+                ffi::avformat_close_input(&mut ifmt_audio);
+                ffi::avformat_free_context(ofmt_ctx);
+                return Err(e);
             }
 
             // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
@@ -300,20 +294,14 @@ impl FFmpegRunner {
                     message: format!("Failed to copy audio codec params: error code {ret}"),
                 });
             }
-            match Self::resolve_codec_tag(
+            if let Err(e) = Self::resolve_and_apply_codec_tag(
                 (*ofmt_ctx).oformat,
                 (*out_audio_stream).codecpar.cast_const(),
             ) {
-                Ok(CodecTagAction::Preserve) => {}
-                Ok(CodecTagAction::Clear) => {
-                    Self::clear_codec_tag((*out_audio_stream).codecpar.cast_const());
-                }
-                Err(e) => {
-                    ffi::avformat_close_input(&mut ifmt_video);
-                    ffi::avformat_close_input(&mut ifmt_audio);
-                    ffi::avformat_free_context(ofmt_ctx);
-                    return Err(e);
-                }
+                ffi::avformat_close_input(&mut ifmt_video);
+                ffi::avformat_close_input(&mut ifmt_audio);
+                ffi::avformat_free_context(ofmt_ctx);
+                return Err(e);
             }
 
             // Copy per-stream metadata (preserves encoder tags set by RecodeStage)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::error::{PostProcessError, Result};
 
+use super::ffi_helpers::cleanup_partial_output;
 use super::log_capture::LogSuppressGuard;
 use super::{FFmpegRunner, RemuxOptions, ensure_init};
 
@@ -140,6 +141,10 @@ impl FFmpegRunner {
             .map(|s| s.index())
             .ok_or(PostProcessError::NoVideoStream)?;
 
+        // `format::output` above already created (truncated) `output` on
+        // disk via `avio_open` — a codec-tag rejection on either stream
+        // below must not leave that empty file behind as if a merge had
+        // run and produced nothing.
         let video_ost_index = Self::add_stream_copy(
             &mut octx,
             ictx_video
@@ -151,7 +156,8 @@ impl FFmpegRunner {
                 })?
                 .parameters(),
             "for merge video",
-        )?;
+        )
+        .inspect_err(|_| cleanup_partial_output(output))?;
 
         // Find best audio stream from audio input
         let audio_ist_index = ictx_audio
@@ -171,7 +177,8 @@ impl FFmpegRunner {
                 })?
                 .parameters(),
             "for merge audio",
-        )?;
+        )
+        .inspect_err(|_| cleanup_partial_output(output))?;
         // Set audio as default stream so players select it automatically
         if let Some(mut ost_audio) = octx.stream_mut(audio_ost_index) {
             unsafe {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -28,6 +28,7 @@ use rdlp_core::PostProcessCallback;
 
 use crate::error::{PostProcessError, Result};
 
+use super::ffi_helpers::cleanup_partial_output;
 use super::{ChapterEntry, FFmpegRunner, ensure_init};
 
 impl FFmpegRunner {
@@ -137,7 +138,12 @@ impl FFmpegRunner {
             ist_time_bases[ist_index] = ist.time_base();
             ost_index += 1;
 
-            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for metadata embed")?;
+            // `format::output` above already created (truncated) `output` on
+            // disk via `avio_open` — a codec-tag rejection here must not
+            // leave that empty file behind as if a metadata embed had run
+            // and produced nothing.
+            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for metadata embed")
+                .inspect_err(|_| cleanup_partial_output(output))?;
             octx.stream_mut(ost_idx)
                 .expect("just-added stream")
                 .set_metadata(ist.metadata().to_owned());

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -55,7 +55,16 @@ mod normalize_types;
 mod options;
 mod probe;
 mod remux;
-pub(crate) mod salvage;
+// `#[doc(hidden)] pub`, not `pub(crate)`: the corruption-recovery path
+// (`salvage_remux_sync`) is otherwise unreachable from `tests/`, where its
+// only meaningful coverage can live — `scripts/check-no-cli.sh` forbids
+// `std::process::Command` under `crates/*/src/`, and verifying that a font
+// attachment survives salvage requires driving the `ffmpeg`/`ffprobe` CLI to
+// build and inspect the fixture independently of rdlp's own decode path.
+// `doc(hidden)` keeps it out of the documented API surface: this is exposed
+// for testing, not for callers.
+#[doc(hidden)]
+pub mod salvage;
 pub mod speed_controls;
 mod thumbnail;
 pub use thumbnail::{supports_thumbnail_embed, uses_native_attachment};

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -30,7 +30,7 @@ use log::debug;
 
 use crate::error::{PostProcessError, Result};
 
-use super::ffi_helpers::CodecTagAction;
+use super::ffi_helpers::cleanup_partial_output;
 use super::log_capture::LogSuppressGuard;
 use super::{FFmpegRunner, RemuxOptions, ensure_init};
 
@@ -159,12 +159,7 @@ impl FFmpegRunner {
             // leave that empty file behind as if a remux had run and produced
             // nothing.
             let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for remux")
-                .inspect_err(|_| {
-                    // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking
-                    // from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
-                    #[allow(clippy::disallowed_methods)]
-                    let _ = std::fs::remove_file(output);
-                })?;
+                .inspect_err(|_| cleanup_partial_output(output))?;
             octx.stream_mut(ost_idx)
                 .expect("just-added stream")
                 .set_metadata(ist.metadata().to_owned());
@@ -379,28 +374,25 @@ impl FFmpegRunner {
                     .into());
                 }
 
-                // Resolve the codec tag through the same decision point the
-                // safe `add_stream_copy` path uses (`FFmpegRunner::resolve_codec_tag`)
-                // rather than unconditionally zeroing — the asymmetry between
-                // this raw-FFI path (always zeroed, always worked) and
+                // Resolve and apply the codec tag through the same decision
+                // point the safe `add_stream_copy` path uses
+                // (`FFmpegRunner::resolve_and_apply_codec_tag`) rather than
+                // unconditionally zeroing — the asymmetry between this
+                // raw-FFI path (always zeroed, always worked) and
                 // `add_stream_copy` (rejected on a tag-table miss) is what
                 // hid the #549 predicate bug from the regression matrix in
                 // the first place. `out_stream.codecpar` is the destination
-                // for `resolve_codec_tag`'s own `AVOutputFormat`/`AVCodecParameters`
+                // for the resolve step's own `AVOutputFormat`/`AVCodecParameters`
                 // reads: `ofmt_ctx` is the live output context this loop is
                 // building, and `(*out_stream).codecpar` was just populated
                 // by `avcodec_parameters_copy` above.
                 let oformat: *const ffi::AVOutputFormat = (*ofmt_ctx).oformat;
-                match Self::resolve_codec_tag(oformat, (*out_stream).codecpar.cast_const()) {
-                    Ok(CodecTagAction::Preserve) => {}
-                    Ok(CodecTagAction::Clear) => {
-                        Self::clear_codec_tag((*out_stream).codecpar.cast_const());
-                    }
-                    Err(e) => {
-                        ffi::avformat_close_input(&mut ifmt_ctx);
-                        ffi::avformat_free_context(ofmt_ctx);
-                        return Err(e.into());
-                    }
+                if let Err(e) =
+                    Self::resolve_and_apply_codec_tag(oformat, (*out_stream).codecpar.cast_const())
+                {
+                    ffi::avformat_close_input(&mut ifmt_ctx);
+                    ffi::avformat_free_context(ofmt_ctx);
+                    return Err(e.into());
                 }
 
                 // Copy per-stream metadata (preserves encoder tags set by RecodeStage)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -30,6 +30,7 @@ use log::debug;
 
 use crate::error::{PostProcessError, Result};
 
+use super::ffi_helpers::CodecTagAction;
 use super::log_capture::LogSuppressGuard;
 use super::{FFmpegRunner, RemuxOptions, ensure_init};
 
@@ -153,7 +154,17 @@ impl FFmpegRunner {
 
             ost_index += 1;
 
-            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for remux")?;
+            // `format::output` above already created (truncated) `output` on
+            // disk via `avio_open` — a codec-tag rejection here must not
+            // leave that empty file behind as if a remux had run and produced
+            // nothing.
+            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for remux")
+                .inspect_err(|_| {
+                    // Safe: sync FFmpeg wrapper — all callers invoke via spawn_blocking
+                    // from async boundaries (see rdlp-ffmpeg/src/ffmpeg/mod.rs spawn_blocking helper).
+                    #[allow(clippy::disallowed_methods)]
+                    let _ = std::fs::remove_file(output);
+                })?;
             octx.stream_mut(ost_idx)
                 .expect("just-added stream")
                 .set_metadata(ist.metadata().to_owned());
@@ -368,8 +379,29 @@ impl FFmpegRunner {
                     .into());
                 }
 
-                // Reset codec tag for container compatibility
-                (*(*out_stream).codecpar).codec_tag = 0;
+                // Resolve the codec tag through the same decision point the
+                // safe `add_stream_copy` path uses (`FFmpegRunner::resolve_codec_tag`)
+                // rather than unconditionally zeroing — the asymmetry between
+                // this raw-FFI path (always zeroed, always worked) and
+                // `add_stream_copy` (rejected on a tag-table miss) is what
+                // hid the #549 predicate bug from the regression matrix in
+                // the first place. `out_stream.codecpar` is the destination
+                // for `resolve_codec_tag`'s own `AVOutputFormat`/`AVCodecParameters`
+                // reads: `ofmt_ctx` is the live output context this loop is
+                // building, and `(*out_stream).codecpar` was just populated
+                // by `avcodec_parameters_copy` above.
+                let oformat: *const ffi::AVOutputFormat = (*ofmt_ctx).oformat;
+                match Self::resolve_codec_tag(oformat, (*out_stream).codecpar.cast_const()) {
+                    Ok(CodecTagAction::Preserve) => {}
+                    Ok(CodecTagAction::Clear) => {
+                        Self::clear_codec_tag((*out_stream).codecpar.cast_const());
+                    }
+                    Err(e) => {
+                        ffi::avformat_close_input(&mut ifmt_ctx);
+                        ffi::avformat_free_context(ofmt_ctx);
+                        return Err(e.into());
+                    }
+                }
 
                 // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
                 ffi::av_dict_copy(&mut (*out_stream).metadata, (*in_stream).metadata, 0);

--- a/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/salvage.rs
@@ -32,7 +32,7 @@ use log::{debug, info, warn};
 
 use crate::error::{CorruptionKind, PostProcessError, Result};
 
-use super::ffi_helpers::packet_unref;
+use super::ffi_helpers::{cleanup_partial_output, packet_unref};
 use super::log_capture::{LogCaptureGuard, LogSuppressGuard};
 use super::{FFmpegRunner, ensure_init};
 
@@ -55,6 +55,11 @@ const EBML_CORRUPTION_MARKERS: &[&str] = &[
 ///
 /// Used as Tier 3 recovery in [`super::normalize::helpers::with_mux_retry`] when
 /// both normal encode and salvage remux fail.
+///
+/// # Errors
+///
+/// Returns an error if `FFmpeg` fails to open `path` even with the resilient
+/// flags applied (e.g. the file does not exist or is not a media container).
 pub fn open_input_resilient(path: &Path) -> Result<ffmpeg_the_third::format::context::Input> {
     ensure_init()?;
 
@@ -81,6 +86,12 @@ pub fn open_input_resilient(path: &Path) -> Result<ffmpeg_the_third::format::con
 ///
 /// Returns `Ok(())` if the container is clean or not Matroska/WebM.
 /// Returns `Err(InputCorrupt { kind: MatroskaEbml, .. })` if corruption is detected.
+///
+/// # Errors
+///
+/// Returns [`PostProcessError::InputCorrupt`] when EBML structural error
+/// markers are found in the demuxer log, or any other [`PostProcessError`]
+/// if `input` cannot be opened or log capture cannot be started.
 pub fn check_matroska_integrity(input: &Path) -> Result<()> {
     ensure_init()?;
 
@@ -176,6 +187,14 @@ fn next_salvage_path(input: &Path, stem: &str, ext: &str) -> PathBuf {
 ///
 /// Returns the path to the salvaged temporary file. The caller is responsible
 /// for cleaning up this file when done.
+///
+/// # Errors
+///
+/// Returns an error if `input`/the salvage output cannot be opened, if the
+/// target container cannot represent one of the input's streams (see
+/// [`crate::error::PostProcessError::IncompatibleContainerCodec`]), if no
+/// packets at all could be recovered, or if the header/trailer cannot be
+/// written.
 pub fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
     ensure_init()?;
 
@@ -213,10 +232,29 @@ pub fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
         .map_err(PostProcessError::from)
         .with_context(|| format!("failed to create salvage output {}", salvage_path.display()))?;
 
-    // Map all input streams to output (stream copy, no re-encoding)
+    // Map all input streams to output (stream copy, no re-encoding). No
+    // medium filter: salvage is the corruption-recovery path of last
+    // resort and must not silently drop a stream (e.g. a font attachment)
+    // just because it isn't audio/video.
+    //
+    // `format::output` above already created (truncated) `salvage_path` on
+    // disk via `avio_open` — a codec-tag rejection here must not leave
+    // that empty file behind as if a salvage remux had run and produced
+    // nothing.
     let stream_count = ictx.streams().count();
     for ist in ictx.streams() {
-        FFmpegRunner::add_stream_copy(&mut octx, ist.parameters(), "for salvage")?;
+        let ost_idx = FFmpegRunner::add_stream_copy(&mut octx, ist.parameters(), "for salvage")
+            .inspect_err(|_| cleanup_partial_output(&salvage_path))?;
+        // Per-stream metadata must travel with the stream: for an
+        // attachment, Matroska's muxer hard-requires a "mimetype" tag
+        // (`matroskaenc.c`'s `mkv_write_attachments` rejects the whole
+        // mux with EINVAL when it's absent) — dropping it here would
+        // trade the codec-tag rejection this fix removes for a header
+        // -write failure instead, on the exact fixture (a font
+        // attachment) this fix exists to recover.
+        if let Some(mut ost) = octx.stream_mut(ost_idx) {
+            ost.set_metadata(ist.metadata().to_owned());
+        }
     }
 
     // Use FFmpeg's default 10s max_interleave_delta for salvage. This prevents
@@ -304,6 +342,13 @@ pub fn salvage_remux_sync(input: &Path) -> anyhow::Result<PathBuf> {
 ///
 /// If `salvage_enabled` is false and corruption is detected, returns the
 /// `InputCorrupt` error directly.
+///
+/// # Errors
+///
+/// Returns [`PostProcessError::InputCorrupt`] when corruption is detected and
+/// `salvage_enabled` is `false`, or any error [`salvage_remux_sync`] can
+/// return when `salvage_enabled` is `true` and the salvage attempt itself
+/// fails.
 pub fn prepare_input_with_salvage(
     input: &Path,
     salvage_enabled: bool,
@@ -340,7 +385,6 @@ pub fn prepare_input_with_salvage(
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn test_ebml_markers_detect_invalid_first_byte() {
         let line = "[matroska,webm @ 0x1234] invalid as first byte of an EBML number";

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -36,6 +36,7 @@ use ffmpeg_the_third::ffi;
 use crate::error::{PostProcessError, Result};
 
 use super::super::FFmpegRunner;
+use super::super::ffi_helpers::CodecTagAction;
 
 impl FFmpegRunner {
     /// Embed thumbnail in MKV using raw FFI with full stream property copying.
@@ -175,7 +176,26 @@ impl FFmpegRunner {
                         ),
                     });
                 }
-                (*(*out_stream).codecpar).codec_tag = 0;
+                // Resolve the codec tag through the same decision point the
+                // safe `add_stream_copy` path uses, rather than
+                // unconditionally zeroing (see the equivalent site in
+                // `remux.rs` for why the raw-FFI/`add_stream_copy` asymmetry
+                // mattered).
+                match Self::resolve_codec_tag(
+                    (*ofmt_ctx).oformat,
+                    (*out_stream).codecpar.cast_const(),
+                ) {
+                    Ok(CodecTagAction::Preserve) => {}
+                    Ok(CodecTagAction::Clear) => {
+                        Self::clear_codec_tag((*out_stream).codecpar.cast_const());
+                    }
+                    Err(e) => {
+                        ffi::avformat_close_input(&mut media_ctx);
+                        ffi::avformat_close_input(&mut thumb_ctx);
+                        ffi::avformat_free_context(ofmt_ctx);
+                        return Err(e);
+                    }
+                }
 
                 // Copy per-stream metadata (preserves encoder tags set by RecodeStage)
                 ffi::av_dict_copy(&mut (*out_stream).metadata, (*in_stream).metadata, 0);

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mkv_raw_ffi.rs
@@ -36,7 +36,6 @@ use ffmpeg_the_third::ffi;
 use crate::error::{PostProcessError, Result};
 
 use super::super::FFmpegRunner;
-use super::super::ffi_helpers::CodecTagAction;
 
 impl FFmpegRunner {
     /// Embed thumbnail in MKV using raw FFI with full stream property copying.
@@ -176,25 +175,19 @@ impl FFmpegRunner {
                         ),
                     });
                 }
-                // Resolve the codec tag through the same decision point the
-                // safe `add_stream_copy` path uses, rather than
+                // Resolve and apply the codec tag through the same decision
+                // point the safe `add_stream_copy` path uses, rather than
                 // unconditionally zeroing (see the equivalent site in
                 // `remux.rs` for why the raw-FFI/`add_stream_copy` asymmetry
                 // mattered).
-                match Self::resolve_codec_tag(
+                if let Err(e) = Self::resolve_and_apply_codec_tag(
                     (*ofmt_ctx).oformat,
                     (*out_stream).codecpar.cast_const(),
                 ) {
-                    Ok(CodecTagAction::Preserve) => {}
-                    Ok(CodecTagAction::Clear) => {
-                        Self::clear_codec_tag((*out_stream).codecpar.cast_const());
-                    }
-                    Err(e) => {
-                        ffi::avformat_close_input(&mut media_ctx);
-                        ffi::avformat_close_input(&mut thumb_ctx);
-                        ffi::avformat_free_context(ofmt_ctx);
-                        return Err(e);
-                    }
+                    ffi::avformat_close_input(&mut media_ctx);
+                    ffi::avformat_close_input(&mut thumb_ctx);
+                    ffi::avformat_free_context(ofmt_ctx);
+                    return Err(e);
                 }
 
                 // Copy per-stream metadata (preserves encoder tags set by RecodeStage)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -48,6 +48,7 @@ use crate::error::{PostProcessError, Result};
 
 use self::embed_strategy::ThumbnailEmbedStrategy;
 pub use self::embed_strategy::{supports_thumbnail_embed, uses_native_attachment};
+use super::ffi_helpers::cleanup_partial_output;
 use super::{FFmpegRunner, ensure_init};
 
 impl FFmpegRunner {
@@ -135,11 +136,15 @@ impl FFmpegRunner {
 
         // Baseline: JPEG and PNG embed successfully in every container rdlp
         // supports, verified end to end. `avformat_query_codec` does NOT report
-        // that — it answers `1` only for muxers carrying a `codec_tag` table,
-        // so mp3 (which answers through a `query_codec` callback returning the
-        // `APIC` tag), flac, and m4a all report "cannot store" for images they
-        // demonstrably do store. Trusting the query alone would re-encode a
-        // lossless PNG cover to lossy JPEG on those containers.
+        // that: per `avformat.c`, it dispatches to the muxer's own
+        // `query_codec` callback first when one exists, falling back to the
+        // `codec_tag` table only when it doesn't (see the matching, correct
+        // description in `ffi_helpers/mod.rs::resolve_codec_tag`) — so mp3
+        // (whose `query_codec` callback answers via the `APIC` tag rather
+        // than a plain codec match), flac, and m4a all report "cannot store"
+        // for images they demonstrably do store. Trusting the query alone
+        // would re-encode a lossless PNG cover to lossy JPEG on those
+        // containers.
         //
         // So the query below only ever WIDENS this baseline; it can never
         // narrow the answer below what is known to work.
@@ -152,8 +157,9 @@ impl FFmpegRunner {
 
         // SAFETY: `ofmt` is the non-null static descriptor returned above and
         // remains valid for the process lifetime. `avformat_query_codec` only
-        // reads that descriptor's codec-tag tables — no allocation, no
-        // ownership transfer, no mutation.
+        // reads that descriptor (its `query_codec` callback and/or its
+        // codec-tag tables, per the dispatch order noted above) — no
+        // allocation, no ownership transfer, no mutation.
         let query = unsafe {
             ffmpeg_the_third::ffi::avformat_query_codec(
                 ofmt,
@@ -318,8 +324,12 @@ impl FFmpegRunner {
             ist_time_bases[ist_index] = ist.time_base();
             ost_index += 1;
 
-            let ost_idx =
-                Self::add_stream_copy(&mut octx, ist.parameters(), "for thumbnail embed")?;
+            // `format::output` above already created (truncated) `output` on
+            // disk via `avio_open` — a codec-tag rejection here must not
+            // leave that empty file behind as if a thumbnail embed had run
+            // and produced nothing.
+            let ost_idx = Self::add_stream_copy(&mut octx, ist.parameters(), "for thumbnail embed")
+                .inspect_err(|_| cleanup_partial_output(output))?;
             octx.stream_mut(ost_idx)
                 .expect("just-added stream")
                 .set_metadata(ist.metadata().to_owned());
@@ -345,8 +355,8 @@ impl FFmpegRunner {
         let thumb_ost_index = if is_ogg_opus {
             None
         } else {
-            let ost_idx =
-                Self::add_stream_copy(&mut octx, thumb_ist.parameters(), "for thumbnail")?;
+            let ost_idx = Self::add_stream_copy(&mut octx, thumb_ist.parameters(), "for thumbnail")
+                .inspect_err(|_| cleanup_partial_output(output))?;
             {
                 let mut thumb_ost = octx
                     .stream_mut(ost_idx)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -79,13 +79,19 @@ impl FFmpegRunner {
     /// since a needless transcode costs a little work while a wrong answer
     /// costs the embed.
     ///
-    /// That query is authoritative for tag-table muxers (MP4/MOV) but
-    /// *under-reports* elsewhere: muxers that answer through a `query_codec`
-    /// callback (mp3 returns the `APIC` tag rather than `1`) or that carry
-    /// neither mechanism fall through to `AVERROR_PATCHWELCOME`, reporting
-    /// "cannot store" for images they demonstrably do store. JPEG and PNG are
-    /// therefore accepted outright as a verified baseline, and the query serves
-    /// only to widen that — never to narrow it below what is known to work.
+    /// That query is authoritative for muxers with a `query_codec` callback
+    /// (mp3's callback answers correctly once `> 0` is treated as
+    /// "supported", per the paragraph above) or a matching codec-tag-table
+    /// entry (MP4/MOV). It *under-reports* only for muxers that have
+    /// **neither** mechanism for the codec in question — no `query_codec`
+    /// callback and no codec-tag-table entry, e.g. `flac`'s bare-fourcc
+    /// muxer for MJPEG, or `m4a`'s tag table having no entry for MJPEG/PNG —
+    /// where `avformat_query_codec` falls back to a plain "unsupported"
+    /// answer (`0`, or `AVERROR_PATCHWELCOME` when even that fallback finds
+    /// nothing to match against) for images they demonstrably do store.
+    /// JPEG and PNG are therefore accepted outright as a verified baseline,
+    /// and the query serves only to widen that — never to narrow it below
+    /// what is known to work.
     ///
     /// # Errors
     ///

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/mod.rs
@@ -63,11 +63,21 @@ impl FFmpegRunner {
     /// So ask `FFmpeg` rather than maintaining a parallel whitelist that can
     /// drift from the build.
     ///
-    /// Uses `avformat_query_codec`, whose contract is: `1` the codec can be
-    /// stored, `0` it cannot, negative when the information is unavailable.
-    /// Only an explicit `1` is treated as supported — "unknown" resolves to
-    /// "transcode first", the safe direction, since a needless transcode costs
-    /// a little work while a wrong answer costs the embed.
+    /// Uses `avformat_query_codec`, whose contract is: positive the codec can
+    /// be stored, `0` it cannot, negative when the information is unavailable.
+    /// Any positive value is treated as supported — not just `1` — because a
+    /// muxer's own `query_codec` callback may answer with something other
+    /// than a bare `1`: mp3's callback (`mp3enc.c`) returns the `APIC`
+    /// `MKTAG` value (a large positive int) for every image codec `ID3v2`'s
+    /// `APIC` frame can carry (gif/mjpeg/png/tiff/bmp/webp — see
+    /// `ff_id3v2_mime_tags`), reserving the literal `1` for MP3 audio itself.
+    /// Gating on `== 1` therefore misread that positive-but-not-1 answer as
+    /// "cannot store", needlessly transcoding a lossless cover to a fresh
+    /// JPEG — matches the `> 0` convention already used for stream
+    /// representability in `ffi_helpers/mod.rs::resolve_codec_tag`. "Unknown"
+    /// (negative) still resolves to "transcode first", the safe direction,
+    /// since a needless transcode costs a little work while a wrong answer
+    /// costs the embed.
     ///
     /// That query is authoritative for tag-table muxers (MP4/MOV) but
     /// *under-reports* elsewhere: muxers that answer through a `query_codec`
@@ -136,15 +146,18 @@ impl FFmpegRunner {
 
         // Baseline: JPEG and PNG embed successfully in every container rdlp
         // supports, verified end to end. `avformat_query_codec` does NOT report
-        // that: per `avformat.c`, it dispatches to the muxer's own
-        // `query_codec` callback first when one exists, falling back to the
-        // `codec_tag` table only when it doesn't (see the matching, correct
-        // description in `ffi_helpers/mod.rs::resolve_codec_tag`) — so mp3
-        // (whose `query_codec` callback answers via the `APIC` tag rather
-        // than a plain codec match), flac, and m4a all report "cannot store"
-        // for images they demonstrably do store. Trusting the query alone
-        // would re-encode a lossless PNG cover to lossy JPEG on those
-        // containers.
+        // that for every muxer: per `avformat.c`, it dispatches to the muxer's
+        // own `query_codec` callback first when one exists, falling back to
+        // the `codec_tag` table only when it doesn't (see the matching
+        // description in `ffi_helpers/mod.rs::resolve_codec_tag`). flac and
+        // m4a carry neither a `query_codec` callback nor a `codec_tag` table
+        // entry for MJPEG/PNG, so the raw query reports "cannot store" for
+        // images they demonstrably do store; trusting it alone would
+        // re-encode a lossless PNG cover to lossy JPEG on those containers.
+        // (mp3's `query_codec` callback also answers MJPEG/PNG — via the
+        // `APIC` tag, a positive, non-`1` value — so the `> 0` query below
+        // already resolves it correctly without this baseline; the baseline
+        // still short-circuits it harmlessly first.)
         //
         // So the query below only ever WIDENS this baseline; it can never
         // narrow the answer below what is known to work.
@@ -168,7 +181,7 @@ impl FFmpegRunner {
             )
         };
 
-        Ok(query == 1)
+        Ok(query > 0)
     }
 
     /// Embed a thumbnail image into a media file via stream copy (remux).

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -145,6 +145,11 @@ impl FFmpegRunner {
             .time_base();
 
         // Add output stream (stream copy mode)
+        //
+        // `format::output` above already created (truncated) `output` on disk
+        // via `avio_open` — a codec-tag rejection here must not leave that
+        // empty file behind as if an audio extract had run and produced
+        // nothing.
         Self::add_stream_copy(
             &mut octx,
             ictx.stream(ist_index)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/audio_extract.rs
@@ -28,6 +28,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::error::{PostProcessError, Result};
 
+use super::super::ffi_helpers::cleanup_partial_output;
 use super::super::log_capture::LogSuppressGuard;
 use super::super::salvage::prepare_input_with_salvage;
 use super::super::{AudioExtractOptions, FFmpegRunner, ensure_init};
@@ -154,7 +155,8 @@ impl FFmpegRunner {
                 })?
                 .parameters(),
             "for audio copy extract",
-        )?;
+        )
+        .inspect_err(|_| cleanup_partial_output(output))?;
 
         // Set format-level encoding_tool metadata (copy, no re-encoding)
         crate::ffmpeg::encoding_tag::set_encoding_tool(&mut octx, "copy");

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -344,6 +344,10 @@ impl FFmpegRunner {
             let audio_ist = ctx.ictx.stream(audio_idx).ok_or_else(|| {
                 PostProcessError::ffmpeg_failed(format!("audio input stream {audio_idx} not found"))
             })?;
+            // `format::output` already created (truncated) `ctx.output_path` on
+            // disk via `avio_open` — a codec-tag rejection here must not leave
+            // that empty file behind as if a video transcode had run and
+            // produced nothing.
             let audio_ost_idx = Self::add_stream_copy(
                 &mut ctx.octx,
                 audio_ist.parameters(),

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -23,6 +23,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::error::PostProcessError;
 
+use super::super::ffi_helpers::cleanup_partial_output;
 use super::super::{FFmpegRunner, VideoConvertOptions};
 use super::mux_timing::flush_interleave_queue;
 use super::video_transcode_context::{AudioTranscodeState, Phase1Outputs, VideoTranscodeContext};
@@ -347,7 +348,8 @@ impl FFmpegRunner {
                 &mut ctx.octx,
                 audio_ist.parameters(),
                 "for video transcode audio copy",
-            )?;
+            )
+            .inspect_err(|_| cleanup_partial_output(ctx.output_path))?;
             ctx.octx
                 .stream_mut(audio_ost_idx)
                 .expect("just-added stream")

--- a/crates/rdlp-ffmpeg/src/lib.rs
+++ b/crates/rdlp-ffmpeg/src/lib.rs
@@ -49,7 +49,7 @@ pub mod error;
 pub mod ffmpeg;
 
 // Re-export main types at crate root
-pub use error::{CorruptionKind, PostProcessError, Result};
+pub use error::{CorruptionKind, Medium, PostProcessError, Result};
 pub use ffmpeg::{
     AudioCodecInfo, AudioEncoderInfo, AudioExtractOptions, AudioNormMode, ChapterEntry,
     FFmpegRunner, FfmpegLogBridge, LogForwarderGuard, LoudnormMeasurements, LoudnormPreset,

--- a/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
+++ b/crates/rdlp-ffmpeg/tests/container_accepts_image_codec.rs
@@ -191,6 +191,38 @@ async fn jpeg_and_png_are_accepted_by_every_supported_container() {
     }
 }
 
+/// IMPORTANT #4 (code-review follow-up): mp3's `query_codec` callback
+/// (`mp3enc.c`) answers every ID3v2-APIC-representable image codec (gif,
+/// mjpeg, png, tiff, bmp, webp — `ff_id3v2_mime_tags`) with `MKTAG('A','P',
+/// 'I','C')`, a large *positive* value, reserving the literal `1` for MP3
+/// audio itself. A predicate gated on `== 1` misreads that as "cannot
+/// store" and needlessly transcodes; `> 0` reads it correctly. mjpeg/png are
+/// already covered by the JPEG/PNG baseline above regardless of this
+/// predicate, so this test targets the codecs the baseline does NOT cover:
+/// gif, tiff, bmp, webp. Fails against the unpatched `== 1` predicate.
+#[tokio::test]
+async fn mp3_accepts_every_id3v2_apic_codec() {
+    if !ffmpeg_cli_available() {
+        eprintln!("skipping: ffmpeg CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for format in ["gif", "tiff", "bmp", "webp"] {
+        let img = make_image(dir.path(), format);
+        assert!(
+            runner
+                .container_accepts_image_codec("mp3", &img)
+                .await
+                .expect("query must succeed"),
+            "mp3 must accept {format} without transcoding — its query_codec \
+             callback answers via the APIC MKTAG value (positive, not 1) for \
+             every codec ff_id3v2_mime_tags lists"
+        );
+    }
+}
+
 /// The baseline must not swallow the actual bug: webp is still refused by the
 /// MP4 family, which is what forces normalization.
 #[tokio::test]

--- a/crates/rdlp-ffmpeg/tests/mp3_widened_thumbnail_gate.rs
+++ b/crates/rdlp-ffmpeg/tests/mp3_widened_thumbnail_gate.rs
@@ -1,0 +1,179 @@
+//! IMPORTANT #4 (code-review follow-up to #549): `container_accepts_image_codec`'s
+//! predicate widened from `avformat_query_codec(..) == 1` to `> 0`.
+//!
+//! mp3's `query_codec` callback (`mp3enc.c`) answers every ID3v2-APIC-representable
+//! image codec (gif, mjpeg, png, tiff, bmp, webp — `ff_id3v2_mime_tags`) with
+//! `MKTAG('A','P','I','C')`, a large *positive* value — not `1`, which the
+//! callback reserves for MP3 audio itself. `== 1` misread that as "cannot
+//! store" and forced a needless transcode for gif/tiff/bmp/webp covers into
+//! mp3 (JPEG/PNG are rescued by a separate baseline special-case regardless
+//! of this predicate). `> 0` reads it correctly, matching the same
+//! `avformat_query_codec` convention already used for stream representability
+//! in `ffi_helpers/mod.rs::resolve_codec_tag`.
+//!
+//! This file proves the widened gate holds at the actual `embed_thumbnail`
+//! level (not just the query `container_accepts_image_codec` answers) for
+//! every codec the widening newly lets skip normalization, and pins the
+//! unrelated paths (webp into MKV attachment, webp into MP4 ATTACHED_PIC)
+//! stay exactly as they were before this change.
+//!
+//! Self-skips when the `ffmpeg`/`ffprobe` CLI is absent (used only to build
+//! fixtures and to independently verify the embed, mirroring
+//! `container_accepts_image_codec.rs`).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rdlp_ffmpeg::FFmpegRunner;
+
+fn tooling_available() -> bool {
+    ["ffmpeg", "ffprobe"].iter().all(|bin| {
+        Command::new(bin)
+            .arg("-version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    })
+}
+
+/// Render a 1-frame solid-color still in `format`.
+fn make_image(dir: &Path, format: &str) -> PathBuf {
+    let path = dir.join(format!("still.{format}"));
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "color=c=red:s=32x32:d=1"])
+        .args(["-frames:v", "1"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build {format} fixture");
+    path
+}
+
+/// Build a short MP3 audio fixture (no video stream).
+fn make_mp3_audio(dir: &Path) -> PathBuf {
+    let path = dir.join("audio.mp3");
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "sine=d=1"])
+        .args(["-c:a", "libmp3lame"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build mp3 audio fixture");
+    path
+}
+
+/// Build a short MP4 (h264) media fixture.
+fn make_mp4_media(dir: &Path) -> PathBuf {
+    let path = dir.join("media.mp4");
+    let status = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-y"])
+        .args(["-f", "lavfi", "-i", "testsrc=d=1:s=320x240:r=25"])
+        .args(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-t", "1"])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg");
+    assert!(status.success(), "failed to build mp4 media fixture");
+    path
+}
+
+/// The embedded cover's `codec_name` and `attached_pic` disposition, read
+/// back independently via `ffprobe`.
+#[derive(Debug)]
+struct CoverInfo {
+    codec_name: String,
+    attached_pic: bool,
+}
+
+fn probe_video_stream(path: &Path) -> CoverInfo {
+    let output = Command::new("ffprobe")
+        .args(["-hide_banner", "-v", "error", "-select_streams", "v"])
+        .args([
+            "-show_entries",
+            "stream=codec_name:stream_disposition=attached_pic",
+        ])
+        .args(["-of", "default=noprint_wrappers=1"])
+        .arg(path)
+        .output()
+        .expect("spawn ffprobe");
+    assert!(output.status.success(), "ffprobe failed on {path:?}");
+    let text = String::from_utf8_lossy(&output.stdout);
+    let codec_name = text
+        .lines()
+        .find_map(|l| l.strip_prefix("codec_name="))
+        .expect("codec_name present")
+        .to_string();
+    let attached_pic = text
+        .lines()
+        .find_map(|l| l.strip_prefix("DISPOSITION:attached_pic="))
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false);
+    CoverInfo {
+        codec_name,
+        attached_pic,
+    }
+}
+
+/// The load-bearing regression: gif/tiff/bmp/webp must embed directly into
+/// mp3 via ID3v2 `APIC` — this is exactly the case `== 1` rejected (forcing
+/// a needless jpeg transcode upstream in the postprocess pipeline). JPEG/PNG
+/// are included as the pre-existing baseline regression guard.
+#[tokio::test]
+async fn mp3_embeds_every_id3v2_apic_codec_directly() {
+    if !tooling_available() {
+        eprintln!("skipping: ffmpeg/ffprobe CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let audio = make_mp3_audio(dir.path());
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    for (format, expected_codec) in [
+        ("gif", "gif"),
+        ("tiff", "tiff"),
+        ("bmp", "bmp"),
+        ("webp", "webp"),
+        ("jpg", "mjpeg"),
+        ("png", "png"),
+    ] {
+        let thumb = make_image(dir.path(), format);
+        let output = dir.path().join(format!("out_{format}.mp3"));
+
+        runner
+            .embed_thumbnail(&audio, &thumb, &output, "mp3", None, None)
+            .await
+            .unwrap_or_else(|e| panic!("{format}->mp3 embed must succeed: {e:#}"));
+
+        let info = probe_video_stream(&output);
+        assert_eq!(
+            info.codec_name, expected_codec,
+            "{format}->mp3: cover codec mismatch, got {info:?}",
+        );
+        assert!(
+            info.attached_pic,
+            "{format}->mp3: cover must carry the attached_pic disposition"
+        );
+    }
+}
+
+/// Unrelated-path regression pin: webp into MP4's `ATTACHED_PIC` strategy
+/// must still be rejected directly (MP4's tag table has no webp entry, and
+/// this path is untouched by the mp3-specific predicate widening above).
+#[tokio::test]
+async fn webp_into_mp4_still_rejected_directly() {
+    if !tooling_available() {
+        eprintln!("skipping: ffmpeg/ffprobe CLI not available");
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let media = make_mp4_media(dir.path());
+    let thumb = make_image(dir.path(), "webp");
+    let output = dir.path().join("out.mp4");
+    let runner = FFmpegRunner::new().expect("FFmpeg");
+
+    runner
+        .embed_thumbnail(&media, &thumb, &output, "mp4", None, None)
+        .await
+        .expect_err("webp reaching the MP4 ATTACHED_PIC path unnormalized must be rejected");
+}

--- a/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
+++ b/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
@@ -1,0 +1,191 @@
+//! Regression test for #549: AVI remux codec-tag policy.
+//!
+//! `add_stream_copy` unconditionally zeroed the source codec tag for every
+//! non-Matroska output. For AVI that is actively harmful:
+//! - h264 (`avc1`) -> AVI: the zeroed tag lets AVI's muxer auto-fill a
+//!   literal `'H264'` fourcc, which arms `avienc.c`'s start-code guard and
+//!   hard-fails AVCC-packaged H.264 (no start codes in the bitstream).
+//! - hevc (`hvc1`) -> AVI: AVI's tag table has NO entry for HEVC at all, so
+//!   the tag stays 0 and `riff.c` silently maps a zero fourcc to raw video
+//!   — exit 0, corrupt file.
+//!
+//! Fix: query the target muxer's codec-tag table (`avformat_query_codec`)
+//! per stream and PRESERVE the source tag when the table has an entry,
+//! REJECT before writing when it does not — rather than let a zeroed tag
+//! silently decode as something else. This is a convention this `FFmpeg`
+//! build happens to follow, not a documented container standard — no spec
+//! covers H.264/HEVC-in-AVI.
+//!
+//! Self-skips when the `ffmpeg`/`ffprobe` CLI is absent (used only to build
+//! fixtures and to independently verify decode integrity — never rdlp's own
+//! code doing the checking).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
+
+fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+        && Command::new("ffprobe")
+            .arg("-version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+
+/// Build a short (1s) fixture with the given video encoder and container.
+/// Returns `None` if the encoder isn't compiled into the linked `FFmpeg`.
+fn build_fixture(dir: &Path, stem: &str, ext: &str, vcodec: &str) -> Option<PathBuf> {
+    let path = dir.join(format!("{stem}.{ext}"));
+    let status = Command::new("ffmpeg")
+        .args(["-y", "-loglevel", "error"])
+        .args(["-f", "lavfi", "-i", "testsrc=d=1:s=320x240:r=25"])
+        .args(["-f", "lavfi", "-i", "sine=d=1"])
+        .args(["-c:v", vcodec, "-pix_fmt", "yuv420p"])
+        .args(["-c:a", "aac", "-b:a", "64k", "-shortest"])
+        .arg(&path)
+        .status()
+        .ok()?;
+    status.success().then_some(path)
+}
+
+/// True if `ffmpeg -f null` can decode every frame of `path` without error.
+/// An independent check via the system CLI, never rdlp's own decode path.
+fn decodes_cleanly(path: &Path) -> bool {
+    Command::new("ffmpeg")
+        .args(["-v", "error", "-i"])
+        .arg(path)
+        .args(["-f", "null", "-"])
+        .output()
+        .map(|o| o.status.success() && o.stderr.is_empty())
+        .unwrap_or(false)
+}
+
+/// Fixtures shared across every test in this file, built once (an `ffmpeg`
+/// subprocess per source is real work — this is the "cached, not
+/// regenerated per test" fixture idiom used across this crate's test suite).
+struct Fixtures {
+    dir: tempfile::TempDir,
+    h264_mp4: Option<PathBuf>,
+    hevc_mp4: Option<PathBuf>,
+    ts: Option<PathBuf>,
+    mkv: Option<PathBuf>,
+}
+
+static FIXTURES: OnceLock<Fixtures> = OnceLock::new();
+
+fn fixtures() -> &'static Fixtures {
+    FIXTURES.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let h264_mp4 = build_fixture(dir.path(), "h264", "mp4", "libx264");
+        let hevc_mp4 = build_fixture(dir.path(), "hevc", "mp4", "libx265");
+        let ts = build_fixture(dir.path(), "src", "ts", "libx264");
+        let mkv = build_fixture(dir.path(), "src", "mkv", "libx264");
+        Fixtures {
+            dir,
+            h264_mp4,
+            hevc_mp4,
+            ts,
+            mkv,
+        }
+    })
+}
+
+/// Remux `src` to `<label>.<target_ext>` and assert the output decodes
+/// cleanly (an independent `ffmpeg -f null -` check, not rdlp's own path).
+async fn assert_remux_decodes(runner: &FFmpegRunner, src: &Path, target_ext: &str, label: &str) {
+    let dst = fixtures().dir.path().join(format!("{label}.{target_ext}"));
+    runner
+        .remux(src, &dst, &RemuxOptions::default(), None)
+        .await
+        .unwrap_or_else(|e| panic!("{label}: remux failed: {e:#}"));
+    assert!(
+        decodes_cleanly(&dst),
+        "{label}: output does not decode cleanly"
+    );
+}
+
+/// The positive case: h264 must remux into AVI and the result must decode.
+/// Fails against unpatched code (`avienc.c`'s start-code guard rejects the
+/// muxer-auto-filled `'H264'` tag on AVCC-packaged H.264).
+#[tokio::test]
+async fn h264_mp4_to_avi_preserves_tag_and_decodes() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg/ffprobe not available");
+        return;
+    }
+    let Some(src) = fixtures().h264_mp4.clone() else {
+        eprintln!("[SKIP] libx264 fixture build failed");
+        return;
+    };
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+    assert_remux_decodes(&runner, &src, "avi", "h264_to_avi").await;
+}
+
+/// The negative case: HEVC cannot be represented in AVI (this build's tag
+/// table has no entry for it) — the remux must be REJECTED with an
+/// actionable message, not silently written as a corrupt (rawvideo-tagged)
+/// file. Fails against unpatched code, which returns `Ok(())` and leaves a
+/// corrupt file with `AV_CODEC_ID_RAWVIDEO` on read-back.
+#[tokio::test]
+async fn hevc_mp4_to_avi_is_rejected_with_actionable_message() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg/ffprobe not available");
+        return;
+    }
+    let Some(src) = fixtures().hevc_mp4.clone() else {
+        eprintln!("[SKIP] libx265 fixture build failed");
+        return;
+    };
+    let dst = fixtures().dir.path().join("hevc_to_avi.avi");
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let err = runner
+        .remux(&src, &dst, &RemuxOptions::default(), None)
+        .await
+        .expect_err("AVI cannot represent HEVC; the remux must be rejected");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("avi") && msg.contains("hevc"),
+        "error should name the container/codec pairing, got: {msg}"
+    );
+}
+
+/// Regression guard matrix: every pairing that worked before this fix must
+/// keep working — the MKV raw-FFI path (untouched) and every non-AVI,
+/// non-tag-rejecting target reachable from the generic remux path.
+#[tokio::test]
+async fn remux_regression_matrix_still_decodes() {
+    if !ffmpeg_available() {
+        eprintln!("[SKIP] ffmpeg/ffprobe not available");
+        return;
+    }
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let cases: &[(&str, Option<PathBuf>, &str)] = &[
+        ("mp4_to_mkv", fixtures().h264_mp4.clone(), "mkv"),
+        ("ts_to_mkv", fixtures().ts.clone(), "mkv"),
+        ("hevc_to_mkv", fixtures().hevc_mp4.clone(), "mkv"),
+        ("mp4_to_mp4", fixtures().h264_mp4.clone(), "mp4"),
+        ("mp4_to_mov", fixtures().h264_mp4.clone(), "mov"),
+        ("mp4_to_flv", fixtures().h264_mp4.clone(), "flv"),
+        ("mp4_to_ts", fixtures().h264_mp4.clone(), "ts"),
+        ("mkv_to_mp4", fixtures().mkv.clone(), "mp4"),
+    ];
+
+    for (label, src, target_ext) in cases {
+        let Some(src) = src else {
+            eprintln!("[SKIP] {label}: source fixture build failed");
+            continue;
+        };
+        assert_remux_decodes(&runner, src, target_ext, label).await;
+    }
+}

--- a/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
+++ b/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
@@ -345,6 +345,45 @@ async fn hevc_mp4_to_avi_is_rejected_with_actionable_message() {
     );
 }
 
+/// IMPORTANT #2 (code-review follow-up): the 0-byte-output cleanup on a
+/// codec-tag rejection previously landed only at the `remux.rs` call site;
+/// `embed_metadata` shares the exact same `format::output` (create/truncate)
+/// -then-`add_stream_copy` (can newly fail) shape and had no cleanup at all.
+/// Reuses the proven HEVC-into-AVI rejection (same as
+/// `hevc_mp4_to_avi_is_rejected_with_actionable_message` above) through a
+/// different call site to prove the cleanup helper landed there too.
+#[tokio::test]
+async fn metadata_embed_hevc_into_avi_leaves_no_partial_file() {
+    if !require_ffmpeg() {
+        return;
+    }
+    let dst = fixtures().dir.path().join("hevc_metadata_to_avi.avi");
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let err = runner
+        .embed_metadata(
+            &fixtures().hevc_mp4,
+            &dst,
+            &std::collections::HashMap::new(),
+            &[],
+            None,
+            None,
+        )
+        .await
+        .expect_err("AVI cannot represent HEVC; metadata embed must be rejected too");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("avi") && msg.contains("hevc"),
+        "error should name the container/codec pairing, got: {msg}"
+    );
+    assert!(
+        !dst.exists(),
+        "rejection must not leave a partial/empty output file at {}",
+        dst.display()
+    );
+}
+
 /// Regression guard matrix: every pairing that worked before this fix must
 /// keep working — the MKV raw-FFI path (now also routed through
 /// `resolve_codec_tag`, see `mkv_raw_ffi_audio_bearing_sources_preserve_aac_and_decode`

--- a/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
+++ b/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
@@ -9,16 +9,34 @@
 //!   the tag stays 0 and `riff.c` silently maps a zero fourcc to raw video
 //!   — exit 0, corrupt file.
 //!
-//! Fix: query the target muxer's codec-tag table (`avformat_query_codec`)
-//! per stream and PRESERVE the source tag when the table has an entry,
-//! REJECT before writing when it does not — rather than let a zeroed tag
-//! silently decode as something else. This is a convention this `FFmpeg`
-//! build happens to follow, not a documented container standard — no spec
-//! covers H.264/HEVC-in-AVI.
+//! Fix (`FFmpegRunner::resolve_codec_tag`): two distinct `FFmpeg` APIs answer
+//! two distinct questions. `av_codec_get_tag`/`av_codec_get_id` against the
+//! muxer's own tag table decide *which tag* to write (preserve the source's
+//! vs. let `FFmpeg` auto-fill) when the table has an entry for the codec.
+//! `avformat_query_codec` is consulted only when the table has **no** entry
+//! at all, to answer *representability* rather than tag choice — this is
+//! what lets HEVC/SubRip into MKV (whose sparse, `CodecID`-keyed tag table
+//! has no entry for either, but whose muxer defines `mkv_query_codec` and
+//! reports both as supported) while still rejecting HEVC into AVI (whose
+//! muxer defines no `query_codec` and genuinely cannot represent it). This is
+//! a convention this `FFmpeg` build happens to follow, not a documented
+//! container standard — no spec covers H.264/HEVC-in-AVI.
 //!
-//! Self-skips when the `ffmpeg`/`ffprobe` CLI is absent (used only to build
-//! fixtures and to independently verify decode integrity — never rdlp's own
-//! code doing the checking).
+//! `resolve_codec_tag` is also the decision point for the 4 raw-FFI MKV mux
+//! paths (`remux_mkv_raw_ffi`, `merge_mkv_raw_ffi`'s two streams,
+//! `embed_thumbnail_mkv_raw_ffi`), which previously zeroed `codec_tag`
+//! directly — that asymmetry (raw-FFI always zeroed and worked;
+//! `add_stream_copy` rejected on a tag-table miss) is what hid the HEVC/MKV
+//! regression from this file's original matrix, since `remux_sync` routes
+//! every `.mkv` target through the raw-FFI path. `mkv_raw_ffi_audio_bearing_sources_preserve_aac_and_decode`,
+//! `merge_to_mkv_preserves_h264_and_aac`, and `embed_thumbnail_mkv_preserves_stream_identity`
+//! below cover those 3 sites end to end.
+//!
+//! Requires the real `ffmpeg`/`ffprobe` CLI on `PATH` (used only to build
+//! fixtures and to independently verify decode integrity + stream identity —
+//! never rdlp's own code doing the checking). Fails closed: panics unless
+//! `RDLP_ALLOW_SKIP_FFMPEG_TESTS` is explicitly set, so a machine missing the
+//! CLI cannot silently report a green, assertion-free suite.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
 
 use std::path::{Path, PathBuf};
@@ -26,6 +44,11 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 use rdlp_ffmpeg::{FFmpegRunner, RemuxOptions};
+
+/// Number of pairings the regression matrix below is expected to exercise.
+/// Asserted after the loop so a future edit that empties (or silently
+/// shrinks) `cases` fails the test instead of passing vacuously.
+const EXPECTED_MATRIX_CASES: usize = 8;
 
 fn ffmpeg_available() -> bool {
     Command::new("ffmpeg")
@@ -40,9 +63,30 @@ fn ffmpeg_available() -> bool {
             .unwrap_or(false)
 }
 
+/// Require `ffmpeg`/`ffprobe` to be present. Returns `true` when the caller
+/// should proceed. Panics — failing the suite — unless
+/// `RDLP_ALLOW_SKIP_FFMPEG_TESTS` is explicitly set: a prior version of this
+/// file `eprintln!`-and-returned on a missing CLI, which let 3 tests report
+/// "passed" in 0.00s while asserting nothing (proven with stub binaries).
+fn require_ffmpeg() -> bool {
+    if ffmpeg_available() {
+        return true;
+    }
+    if std::env::var_os("RDLP_ALLOW_SKIP_FFMPEG_TESTS").is_some() {
+        eprintln!("[SKIP] ffmpeg/ffprobe not available (RDLP_ALLOW_SKIP_FFMPEG_TESTS set)");
+        return false;
+    }
+    panic!(
+        "ffmpeg/ffprobe not found on PATH. This suite needs the real CLI to build \
+         fixtures and independently verify output (never rdlp's own decode path). \
+         Set RDLP_ALLOW_SKIP_FFMPEG_TESTS=1 to explicitly opt into skipping it."
+    );
+}
+
 /// Build a short (1s) fixture with the given video encoder and container.
-/// Returns `None` if the encoder isn't compiled into the linked `FFmpeg`.
-fn build_fixture(dir: &Path, stem: &str, ext: &str, vcodec: &str) -> Option<PathBuf> {
+/// Panics (rather than returning `None`) if the build fails — a fixture that
+/// silently fails to build must not silently shrink the test matrix.
+fn build_fixture(dir: &Path, stem: &str, ext: &str, vcodec: &str) -> PathBuf {
     let path = dir.join(format!("{stem}.{ext}"));
     let status = Command::new("ffmpeg")
         .args(["-y", "-loglevel", "error"])
@@ -52,8 +96,13 @@ fn build_fixture(dir: &Path, stem: &str, ext: &str, vcodec: &str) -> Option<Path
         .args(["-c:a", "aac", "-b:a", "64k", "-shortest"])
         .arg(&path)
         .status()
-        .ok()?;
-    status.success().then_some(path)
+        .unwrap_or_else(|e| panic!("failed to spawn ffmpeg for {stem}.{ext} fixture: {e}"));
+    assert!(
+        status.success(),
+        "ffmpeg fixture build failed for {stem}.{ext} (vcodec={vcodec}); \
+         is {vcodec} compiled into this FFmpeg build?"
+    );
+    path
 }
 
 /// True if `ffmpeg -f null` can decode every frame of `path` without error.
@@ -68,15 +117,117 @@ fn decodes_cleanly(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// The first video stream's codec identity, per `ffprobe` — an independent
+/// check that distinguishes a correctly-tagged stream from a
+/// mistagged-but-decodable one. This is the exact corruption mode #549
+/// introduced: AVI's zeroed HEVC tag decodes cleanly as `rawvideo` (`riff.c`
+/// maps a zero fourcc to raw video), so `decodes_cleanly` alone cannot catch
+/// it — only asserting the decoded codec name is what it should be can.
+#[derive(Debug)]
+struct StreamIdentity {
+    codec_name: String,
+    codec_tag_string: String,
+}
+
+/// `selector` is an ffprobe stream selector (`"v:0"`, `"a:0"`).
+fn probe_stream(path: &Path, selector: &str) -> StreamIdentity {
+    let output = Command::new("ffprobe")
+        .args(["-v", "error", "-select_streams", selector])
+        .args(["-show_entries", "stream=codec_name,codec_tag_string"])
+        .args(["-of", "csv=p=0"])
+        .arg(path)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn ffprobe on {}: {e}", path.display()));
+    assert!(
+        output.status.success(),
+        "ffprobe failed on {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut fields = stdout.trim().split(',');
+    let codec_name = fields
+        .next()
+        .unwrap_or_else(|| panic!("no codec_name field for {} ({selector})", path.display()))
+        .to_string();
+    let codec_tag_string = fields
+        .next()
+        .unwrap_or_else(|| {
+            panic!(
+                "no codec_tag_string field for {} ({selector})",
+                path.display()
+            )
+        })
+        .to_string();
+    StreamIdentity {
+        codec_name,
+        codec_tag_string,
+    }
+}
+
+fn probe_video_stream(path: &Path) -> StreamIdentity {
+    probe_stream(path, "v:0")
+}
+
+fn probe_audio_stream(path: &Path) -> StreamIdentity {
+    probe_stream(path, "a:0")
+}
+
+/// Build a video-only h264 elementary source (no audio stream) — needed by
+/// `merge`, which takes separate video and audio inputs.
+fn build_video_only(dir: &Path) -> PathBuf {
+    let path = dir.join("video_only.mp4");
+    let status = Command::new("ffmpeg")
+        .args(["-y", "-loglevel", "error"])
+        .args(["-f", "lavfi", "-i", "testsrc=d=1:s=320x240:r=25"])
+        .args(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
+        .arg(&path)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn ffmpeg for video_only fixture: {e}"));
+    assert!(status.success(), "video_only fixture build failed");
+    path
+}
+
+/// Build an audio-only AAC elementary source (no video stream).
+fn build_audio_only(dir: &Path) -> PathBuf {
+    let path = dir.join("audio_only.m4a");
+    let status = Command::new("ffmpeg")
+        .args(["-y", "-loglevel", "error"])
+        .args(["-f", "lavfi", "-i", "sine=d=1"])
+        .args(["-c:a", "aac", "-b:a", "64k"])
+        .arg(&path)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn ffmpeg for audio_only fixture: {e}"));
+    assert!(status.success(), "audio_only fixture build failed");
+    path
+}
+
+/// Build a tiny still JPEG cover image, for thumbnail-embed tests.
+fn build_cover_jpg(dir: &Path) -> PathBuf {
+    let path = dir.join("cover.jpg");
+    let status = Command::new("ffmpeg")
+        .args(["-y", "-loglevel", "error"])
+        .args(["-f", "lavfi", "-i", "color=c=red:s=64x64"])
+        .args(["-frames:v", "1"])
+        .arg(&path)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn ffmpeg for cover.jpg fixture: {e}"));
+    assert!(status.success(), "cover.jpg fixture build failed");
+    path
+}
+
 /// Fixtures shared across every test in this file, built once (an `ffmpeg`
 /// subprocess per source is real work — this is the "cached, not
 /// regenerated per test" fixture idiom used across this crate's test suite).
 struct Fixtures {
     dir: tempfile::TempDir,
-    h264_mp4: Option<PathBuf>,
-    hevc_mp4: Option<PathBuf>,
-    ts: Option<PathBuf>,
-    mkv: Option<PathBuf>,
+    h264_mp4: PathBuf,
+    hevc_mp4: PathBuf,
+    ts: PathBuf,
+    mkv: PathBuf,
+    video_only: PathBuf,
+    audio_only: PathBuf,
+    cover_jpg: PathBuf,
 }
 
 static FIXTURES: OnceLock<Fixtures> = OnceLock::new();
@@ -88,19 +239,36 @@ fn fixtures() -> &'static Fixtures {
         let hevc_mp4 = build_fixture(dir.path(), "hevc", "mp4", "libx265");
         let ts = build_fixture(dir.path(), "src", "ts", "libx264");
         let mkv = build_fixture(dir.path(), "src", "mkv", "libx264");
+        let video_only = build_video_only(dir.path());
+        let audio_only = build_audio_only(dir.path());
+        let cover_jpg = build_cover_jpg(dir.path());
         Fixtures {
             dir,
             h264_mp4,
             hevc_mp4,
             ts,
             mkv,
+            video_only,
+            audio_only,
+            cover_jpg,
         }
     })
 }
 
-/// Remux `src` to `<label>.<target_ext>` and assert the output decodes
-/// cleanly (an independent `ffmpeg -f null -` check, not rdlp's own path).
-async fn assert_remux_decodes(runner: &FFmpegRunner, src: &Path, target_ext: &str, label: &str) {
+/// Remux `src` to `<label>.<target_ext>` and assert: the output decodes
+/// cleanly, its video codec identity matches `expected_codec`, and — when
+/// given — its `codec_tag_string` matches `expected_tag`. A mutation that
+/// flips `CodecTagAction::Preserve` <-> `Clear` cannot survive the
+/// `expected_tag` assertion: the stream would still decode (mistagged as
+/// something FFmpeg auto-fills), but under the wrong tag.
+async fn assert_remux_matches(
+    runner: &FFmpegRunner,
+    src: &Path,
+    target_ext: &str,
+    label: &str,
+    expected_codec: &str,
+    expected_tag: Option<&str>,
+) {
     let dst = fixtures().dir.path().join(format!("{label}.{target_ext}"));
     runner
         .remux(src, &dst, &RemuxOptions::default(), None)
@@ -110,45 +278,58 @@ async fn assert_remux_decodes(runner: &FFmpegRunner, src: &Path, target_ext: &st
         decodes_cleanly(&dst),
         "{label}: output does not decode cleanly"
     );
+
+    let identity = probe_video_stream(&dst);
+    assert_eq!(
+        identity.codec_name, expected_codec,
+        "{label}: decoded codec mismatch (mistagged-but-decodable is exactly \
+         the #549 corruption mode) — got {identity:?}"
+    );
+    if let Some(tag) = expected_tag {
+        assert_eq!(
+            identity.codec_tag_string, tag,
+            "{label}: codec_tag_string mismatch — got {identity:?}"
+        );
+    }
 }
 
-/// The positive case: h264 must remux into AVI and the result must decode.
-/// Fails against unpatched code (`avienc.c`'s start-code guard rejects the
-/// muxer-auto-filled `'H264'` tag on AVCC-packaged H.264).
+/// The positive case: h264 must remux into AVI, decode as h264, and keep its
+/// source `avc1` tag. Fails against unpatched code (`avienc.c`'s start-code
+/// guard rejects the muxer-auto-filled `'H264'` tag on AVCC-packaged H.264).
 #[tokio::test]
 async fn h264_mp4_to_avi_preserves_tag_and_decodes() {
-    if !ffmpeg_available() {
-        eprintln!("[SKIP] ffmpeg/ffprobe not available");
+    if !require_ffmpeg() {
         return;
     }
-    let Some(src) = fixtures().h264_mp4.clone() else {
-        eprintln!("[SKIP] libx264 fixture build failed");
-        return;
-    };
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
-    assert_remux_decodes(&runner, &src, "avi", "h264_to_avi").await;
+    assert_remux_matches(
+        &runner,
+        &fixtures().h264_mp4,
+        "avi",
+        "h264_to_avi",
+        "h264",
+        Some("avc1"),
+    )
+    .await;
 }
 
 /// The negative case: HEVC cannot be represented in AVI (this build's tag
-/// table has no entry for it) — the remux must be REJECTED with an
-/// actionable message, not silently written as a corrupt (rawvideo-tagged)
-/// file. Fails against unpatched code, which returns `Ok(())` and leaves a
-/// corrupt file with `AV_CODEC_ID_RAWVIDEO` on read-back.
+/// table has no entry for it, and `avienc` defines no `query_codec` fallback)
+/// — the remux must be REJECTED with an actionable message and must not
+/// leave a corrupt (rawvideo-tagged) or empty output file behind. Fails
+/// against unpatched code, which either returns `Ok(())` and leaves a
+/// corrupt file with `AV_CODEC_ID_RAWVIDEO` on read-back (the original bug),
+/// or rejects but leaves a 0-byte file (the pre-fix behavior of this predicate).
 #[tokio::test]
 async fn hevc_mp4_to_avi_is_rejected_with_actionable_message() {
-    if !ffmpeg_available() {
-        eprintln!("[SKIP] ffmpeg/ffprobe not available");
+    if !require_ffmpeg() {
         return;
     }
-    let Some(src) = fixtures().hevc_mp4.clone() else {
-        eprintln!("[SKIP] libx265 fixture build failed");
-        return;
-    };
     let dst = fixtures().dir.path().join("hevc_to_avi.avi");
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
 
     let err = runner
-        .remux(&src, &dst, &RemuxOptions::default(), None)
+        .remux(&fixtures().hevc_mp4, &dst, &RemuxOptions::default(), None)
         .await
         .expect_err("AVI cannot represent HEVC; the remux must be rejected");
 
@@ -157,35 +338,204 @@ async fn hevc_mp4_to_avi_is_rejected_with_actionable_message() {
         msg.contains("avi") && msg.contains("hevc"),
         "error should name the container/codec pairing, got: {msg}"
     );
+    assert!(
+        !dst.exists(),
+        "rejection must not leave a partial/empty output file at {}",
+        dst.display()
+    );
 }
 
 /// Regression guard matrix: every pairing that worked before this fix must
-/// keep working — the MKV raw-FFI path (untouched) and every non-AVI,
-/// non-tag-rejecting target reachable from the generic remux path.
+/// keep working — the MKV raw-FFI path (now also routed through
+/// `resolve_codec_tag`, see `mkv_raw_ffi_audio_bearing_sources_preserve_aac_and_decode`
+/// below for the audio-stream-specific check that change needed) and every
+/// non-AVI, non-tag-rejecting target reachable from the generic remux path.
+/// Also covers the CRITICAL regression this predicate must not reintroduce:
+/// HEVC into MKV via the generic (non-raw-FFI) path must succeed, not just
+/// the MKV-via-raw-FFI path `remux_sync` normally routes to.
 #[tokio::test]
 async fn remux_regression_matrix_still_decodes() {
-    if !ffmpeg_available() {
-        eprintln!("[SKIP] ffmpeg/ffprobe not available");
+    if !require_ffmpeg() {
         return;
     }
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
 
-    let cases: &[(&str, Option<PathBuf>, &str)] = &[
-        ("mp4_to_mkv", fixtures().h264_mp4.clone(), "mkv"),
-        ("ts_to_mkv", fixtures().ts.clone(), "mkv"),
-        ("hevc_to_mkv", fixtures().hevc_mp4.clone(), "mkv"),
-        ("mp4_to_mp4", fixtures().h264_mp4.clone(), "mp4"),
-        ("mp4_to_mov", fixtures().h264_mp4.clone(), "mov"),
-        ("mp4_to_flv", fixtures().h264_mp4.clone(), "flv"),
-        ("mp4_to_ts", fixtures().h264_mp4.clone(), "ts"),
-        ("mkv_to_mp4", fixtures().mkv.clone(), "mp4"),
+    let cases: &[(&str, &Path, &str, &str)] = &[
+        ("mp4_to_mkv", &fixtures().h264_mp4, "mkv", "h264"),
+        ("ts_to_mkv", &fixtures().ts, "mkv", "h264"),
+        ("hevc_to_mkv", &fixtures().hevc_mp4, "mkv", "hevc"),
+        ("mp4_to_mp4", &fixtures().h264_mp4, "mp4", "h264"),
+        ("mp4_to_mov", &fixtures().h264_mp4, "mov", "h264"),
+        ("mp4_to_flv", &fixtures().h264_mp4, "flv", "h264"),
+        ("mp4_to_ts", &fixtures().h264_mp4, "ts", "h264"),
+        ("mkv_to_mp4", &fixtures().mkv, "mp4", "h264"),
+    ];
+    assert_eq!(
+        cases.len(),
+        EXPECTED_MATRIX_CASES,
+        "update EXPECTED_MATRIX_CASES if this matrix is intentionally resized"
+    );
+
+    let mut executed = 0usize;
+    for (label, src, target_ext, expected_codec) in cases {
+        assert_remux_matches(&runner, src, target_ext, label, expected_codec, None).await;
+        executed += 1;
+    }
+    assert_eq!(
+        executed, EXPECTED_MATRIX_CASES,
+        "matrix silently executed fewer cases than declared"
+    );
+}
+
+/// CRITICAL regression guard (#1/#2): `remux_sync` branches HEVC/MKV away to
+/// `remux_mkv_raw_ffi` *before* it ever reaches `add_stream_copy`, so the
+/// matrix above never actually drives `resolve_codec_tag` for an MKV target.
+/// `embed_metadata` copies streams via `add_stream_copy` with no such
+/// branch, so it is the vehicle here: an HEVC source into an MKV target must
+/// succeed. Fails against a predicate that rejects whenever the muxer's tag
+/// table has no entry for the codec (MKV's sparse, `CodecID`-keyed table has
+/// none for HEVC) instead of falling back to `avformat_query_codec`.
+#[tokio::test]
+async fn hevc_mp4_to_mkv_via_add_stream_copy_succeeds() {
+    if !require_ffmpeg() {
+        return;
+    }
+    let dst = fixtures().dir.path().join("hevc_via_metadata.mkv");
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    runner
+        .embed_metadata(
+            &fixtures().hevc_mp4,
+            &dst,
+            &std::collections::HashMap::new(),
+            &[],
+            None,
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("HEVC into MKV via add_stream_copy must succeed: {e:#}"));
+
+    assert!(
+        decodes_cleanly(&dst),
+        "hevc_via_metadata: output does not decode cleanly"
+    );
+    let identity = probe_video_stream(&dst);
+    assert_eq!(identity.codec_name, "hevc", "got {identity:?}");
+}
+
+/// Empirical check for routing `remux_mkv_raw_ffi` through `resolve_codec_tag`
+/// (it previously always zeroed `codec_tag` directly): every fixture in this
+/// file carries AAC audio tagged `mp4a` (the MP4/ISOBMFF fourcc, per
+/// `build_fixture`'s `-c:a aac`), and MKV's tag table *does* have an AAC
+/// entry — just not under `mp4a` — so `resolve_codec_tag` must resolve that
+/// stream to `Clear`, not `Preserve`. A prior, cruder experiment that
+/// preserved every source tag unconditionally regressed exactly these
+/// AAC-bearing mkv targets (`mp4_to_mkv`/`ts_to_mkv`/`hevc_to_mkv` all went
+/// from OK to FAIL). This test would fail the same way if that regression
+/// reappeared: both audio and video must decode, and ffprobe must report the
+/// audio stream as `aac`, not corrupt/misidentified.
+#[tokio::test]
+async fn mkv_raw_ffi_audio_bearing_sources_preserve_aac_and_decode() {
+    if !require_ffmpeg() {
+        return;
+    }
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+
+    let cases: &[(&str, &Path, &str)] = &[
+        ("audio_mp4_to_mkv", &fixtures().h264_mp4, "h264"),
+        ("audio_ts_to_mkv", &fixtures().ts, "h264"),
+        ("audio_hevc_to_mkv", &fixtures().hevc_mp4, "hevc"),
     ];
 
-    for (label, src, target_ext) in cases {
-        let Some(src) = src else {
-            eprintln!("[SKIP] {label}: source fixture build failed");
-            continue;
-        };
-        assert_remux_decodes(&runner, src, target_ext, label).await;
+    for (label, src, expected_video_codec) in cases {
+        let dst = fixtures().dir.path().join(format!("{label}.mkv"));
+        runner
+            .remux(src, &dst, &RemuxOptions::default(), None)
+            .await
+            .unwrap_or_else(|e| panic!("{label}: remux failed: {e:#}"));
+        assert!(
+            decodes_cleanly(&dst),
+            "{label}: output does not decode cleanly"
+        );
+
+        let video = probe_video_stream(&dst);
+        assert_eq!(
+            video.codec_name, *expected_video_codec,
+            "{label}: {video:?}"
+        );
+
+        let audio = probe_audio_stream(&dst);
+        assert_eq!(
+            audio.codec_name, "aac",
+            "{label}: audio stream mistagged/misdecoded — got {audio:?}"
+        );
     }
+}
+
+/// `merge_mkv_raw_ffi`'s video and audio streams both now resolve their
+/// codec tag through `resolve_codec_tag` instead of always zeroing. Merges
+/// separate h264 video-only and aac audio-only sources into MKV and checks
+/// both stream identities.
+#[tokio::test]
+async fn merge_to_mkv_preserves_h264_and_aac() {
+    if !require_ffmpeg() {
+        return;
+    }
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+    let dst = fixtures().dir.path().join("merged.mkv");
+
+    runner
+        .merge(
+            &fixtures().video_only,
+            &fixtures().audio_only,
+            &dst,
+            &RemuxOptions::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("merge into mkv must succeed: {e:#}"));
+
+    assert!(
+        decodes_cleanly(&dst),
+        "merged output does not decode cleanly"
+    );
+    let video = probe_video_stream(&dst);
+    assert_eq!(video.codec_name, "h264", "got {video:?}");
+    let audio = probe_audio_stream(&dst);
+    assert_eq!(audio.codec_name, "aac", "got {audio:?}");
+}
+
+/// `embed_thumbnail_mkv_raw_ffi`'s media-stream loop also now resolves its
+/// codec tag through `resolve_codec_tag`. Embeds a cover image into an
+/// h264+aac source remuxed to MKV and checks both media stream identities
+/// survive alongside the attachment.
+#[tokio::test]
+async fn embed_thumbnail_mkv_preserves_stream_identity() {
+    if !require_ffmpeg() {
+        return;
+    }
+    let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
+    let dst = fixtures().dir.path().join("with_thumb.mkv");
+
+    runner
+        .embed_thumbnail(
+            &fixtures().h264_mp4,
+            &fixtures().cover_jpg,
+            &dst,
+            "mkv",
+            None,
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("thumbnail embed into mkv must succeed: {e:#}"));
+
+    assert!(
+        decodes_cleanly(&dst),
+        "thumbnail-embedded output does not decode cleanly"
+    );
+    let video = probe_video_stream(&dst);
+    assert_eq!(video.codec_name, "h264", "got {video:?}");
+    let audio = probe_audio_stream(&dst);
+    assert_eq!(audio.codec_name, "aac", "got {audio:?}");
 }

--- a/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
+++ b/crates/rdlp-ffmpeg/tests/remux_avi_codec_tag.rs
@@ -220,7 +220,7 @@ fn build_cover_jpg(dir: &Path) -> PathBuf {
 /// subprocess per source is real work — this is the "cached, not
 /// regenerated per test" fixture idiom used across this crate's test suite).
 struct Fixtures {
-    dir: tempfile::TempDir,
+    dir: PathBuf,
     h264_mp4: PathBuf,
     hevc_mp4: PathBuf,
     ts: PathBuf,
@@ -232,16 +232,35 @@ struct Fixtures {
 
 static FIXTURES: OnceLock<Fixtures> = OnceLock::new();
 
+/// Fixtures are built once per process and cached, so they live under the
+/// crate's `target/` rather than in a `TempDir`.
+///
+/// A `static` is never dropped, so a `TempDir` here could never run its
+/// cleanup — it would leak the whole fixture set (~448K of built video and
+/// image files) on every run, pass or panic. That matters because this
+/// machine's `/tmp` is a RAM-backed tmpfs, so the leak would be real memory.
+/// Building into `target/` instead makes the residue ordinary build output:
+/// it costs no RAM, `cargo clean` reclaims it, and a rebuilt fixture simply
+/// overwrites the previous one, which also makes repeat runs faster.
+fn fixture_dir() -> PathBuf {
+    // CARGO_TARGET_TMPDIR is `<target>/tmp`, provided by cargo for integration
+    // tests exactly like this one.
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("remux_avi_codec_tag");
+    std::fs::create_dir_all(&dir)
+        .unwrap_or_else(|e| panic!("create fixture dir {}: {e}", dir.display()));
+    dir
+}
+
 fn fixtures() -> &'static Fixtures {
     FIXTURES.get_or_init(|| {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let h264_mp4 = build_fixture(dir.path(), "h264", "mp4", "libx264");
-        let hevc_mp4 = build_fixture(dir.path(), "hevc", "mp4", "libx265");
-        let ts = build_fixture(dir.path(), "src", "ts", "libx264");
-        let mkv = build_fixture(dir.path(), "src", "mkv", "libx264");
-        let video_only = build_video_only(dir.path());
-        let audio_only = build_audio_only(dir.path());
-        let cover_jpg = build_cover_jpg(dir.path());
+        let dir = fixture_dir();
+        let h264_mp4 = build_fixture(&dir, "h264", "mp4", "libx264");
+        let hevc_mp4 = build_fixture(&dir, "hevc", "mp4", "libx265");
+        let ts = build_fixture(&dir, "src", "ts", "libx264");
+        let mkv = build_fixture(&dir, "src", "mkv", "libx264");
+        let video_only = build_video_only(&dir);
+        let audio_only = build_audio_only(&dir);
+        let cover_jpg = build_cover_jpg(&dir);
         Fixtures {
             dir,
             h264_mp4,
@@ -269,7 +288,7 @@ async fn assert_remux_matches(
     expected_codec: &str,
     expected_tag: Option<&str>,
 ) {
-    let dst = fixtures().dir.path().join(format!("{label}.{target_ext}"));
+    let dst = fixtures().dir.join(format!("{label}.{target_ext}"));
     runner
         .remux(src, &dst, &RemuxOptions::default(), None)
         .await
@@ -325,7 +344,7 @@ async fn hevc_mp4_to_avi_is_rejected_with_actionable_message() {
     if !require_ffmpeg() {
         return;
     }
-    let dst = fixtures().dir.path().join("hevc_to_avi.avi");
+    let dst = fixtures().dir.join("hevc_to_avi.avi");
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
 
     let err = runner
@@ -357,7 +376,7 @@ async fn metadata_embed_hevc_into_avi_leaves_no_partial_file() {
     if !require_ffmpeg() {
         return;
     }
-    let dst = fixtures().dir.path().join("hevc_metadata_to_avi.avi");
+    let dst = fixtures().dir.join("hevc_metadata_to_avi.avi");
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
 
     let err = runner
@@ -439,7 +458,7 @@ async fn hevc_mp4_to_mkv_via_add_stream_copy_succeeds() {
     if !require_ffmpeg() {
         return;
     }
-    let dst = fixtures().dir.path().join("hevc_via_metadata.mkv");
+    let dst = fixtures().dir.join("hevc_via_metadata.mkv");
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
 
     runner
@@ -487,7 +506,7 @@ async fn mkv_raw_ffi_audio_bearing_sources_preserve_aac_and_decode() {
     ];
 
     for (label, src, expected_video_codec) in cases {
-        let dst = fixtures().dir.path().join(format!("{label}.mkv"));
+        let dst = fixtures().dir.join(format!("{label}.mkv"));
         runner
             .remux(src, &dst, &RemuxOptions::default(), None)
             .await
@@ -521,7 +540,7 @@ async fn merge_to_mkv_preserves_h264_and_aac() {
         return;
     }
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
-    let dst = fixtures().dir.path().join("merged.mkv");
+    let dst = fixtures().dir.join("merged.mkv");
 
     runner
         .merge(
@@ -555,7 +574,7 @@ async fn embed_thumbnail_mkv_preserves_stream_identity() {
         return;
     }
     let runner = FFmpegRunner::new().expect("FFmpegRunner::new");
-    let dst = fixtures().dir.path().join("with_thumb.mkv");
+    let dst = fixtures().dir.join("with_thumb.mkv");
 
     runner
         .embed_thumbnail(

--- a/crates/rdlp-ffmpeg/tests/salvage_font_attachment.rs
+++ b/crates/rdlp-ffmpeg/tests/salvage_font_attachment.rs
@@ -1,0 +1,139 @@
+//! Code-review follow-up to #549: `salvage_remux_sync` copies every stream in
+//! its input with no media-type filter (unlike `remux`/`metadata`/`fixup`,
+//! which restrict to Video|Audio) — by design, since salvage is the
+//! corruption-recovery path of last resort and must not silently drop an
+//! attachment.
+//!
+//! Before the medium gate in `resolve_codec_tag`, an attachment stream was put
+//! to a *codec representability* question it was never meant to answer (FFmpeg
+//! muxes attachments outside the codec path entirely), so an MKV carrying a
+//! font attachment — the standard layout for a subtitled release — made
+//! `add_stream_copy` return `IncompatibleContainerCodec { codec: "ttf", .. }`
+//! and salvage failed outright on exactly the input it exists to recover.
+//!
+//! Verifies via `ffprobe`, independent of rdlp's own decode path, that the
+//! attachment SURVIVES the salvage remux — not merely that `salvage_remux_sync`
+//! returns `Ok`. A second latent defect surfaced while proving this: Matroska's
+//! `mkv_write_attachments` hard-requires a `mimetype` tag, so the codec-tag fix
+//! alone still failed at `write_header` until salvage copied per-stream
+//! metadata.
+//!
+//! Lives under `tests/` deliberately: `scripts/check-no-cli.sh` forbids
+//! `std::process::Command` anywhere in `crates/*/src/` (the library-first
+//! principle) and scans production sources only, so CLI-driven fixtures are
+//! sanctioned here and nowhere else.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rdlp_ffmpeg::ffmpeg::salvage::salvage_remux_sync;
+
+/// Fails closed. A missing CLI must break the run rather than silently turn
+/// this regression guard into a no-op that still reports green — the exact
+/// defect code review flagged in this branch's other test file. Set
+/// `RDLP_ALLOW_SKIP_FFMPEG_TESTS` to skip deliberately.
+fn require_cli() -> bool {
+    let have = ["ffmpeg", "ffprobe"].iter().all(|bin| {
+        Command::new(bin)
+            .arg("-version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    });
+    assert!(
+        have || std::env::var_os("RDLP_ALLOW_SKIP_FFMPEG_TESTS").is_some(),
+        "ffmpeg/ffprobe are required for the #549 salvage regression test; \
+         set RDLP_ALLOW_SKIP_FFMPEG_TESTS to skip deliberately"
+    );
+    have
+}
+
+/// A real MKV with video, audio and a native Matroska font attachment. The
+/// attached bytes need not be a genuine TTF: `-attach` embeds them verbatim
+/// with the given mimetype/filename metadata regardless of content.
+fn build_font_attached_mkv(dir: &Path) -> PathBuf {
+    let font_path = dir.join("font.ttf");
+    std::fs::write(&font_path, b"\x00\x01\x00\x00not a real font, just bytes")
+        .expect("write fake font fixture");
+
+    let media_path = dir.join("with_font.mkv");
+    let status = Command::new("ffmpeg")
+        .args(["-y", "-loglevel", "error"])
+        .args(["-f", "lavfi", "-i", "testsrc=d=1:s=320x240:r=25"])
+        .args(["-f", "lavfi", "-i", "sine=d=1"])
+        .args(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
+        .args(["-c:a", "aac", "-b:a", "64k", "-shortest"])
+        .arg("-attach")
+        .arg(&font_path)
+        .args(["-metadata:s:t", "mimetype=application/x-truetype-font"])
+        .arg(&media_path)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn ffmpeg for font-attached mkv fixture: {e}"));
+    assert!(status.success(), "font-attached mkv fixture build failed");
+    media_path
+}
+
+fn ffprobe_entries(path: &Path, args: &[&str]) -> String {
+    let output = Command::new("ffprobe")
+        .args(["-v", "error"])
+        .args(args)
+        .arg(path)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn ffprobe on {}: {e}", path.display()));
+    assert!(
+        output.status.success(),
+        "ffprobe failed on {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// The CRITICAL regression: salvage must succeed on a font-attached input and
+/// the salvaged output must still carry that attachment. Fails against the
+/// unpatched `resolve_codec_tag`, which applied its representability rejection
+/// uniformly across every `AVMediaType`.
+#[test]
+fn salvage_preserves_font_attachment() {
+    if !require_cli() {
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = build_font_attached_mkv(dir.path());
+
+    let salvaged = salvage_remux_sync(&input)
+        .unwrap_or_else(|e| panic!("salvage must succeed on a font-attached input: {e:#}"));
+
+    let tags = ffprobe_entries(
+        &salvaged,
+        &[
+            "-select_streams",
+            "t",
+            "-show_entries",
+            "stream_tags=mimetype,filename",
+            "-of",
+            "default=noprint_wrappers=1",
+        ],
+    );
+    assert!(
+        tags.contains("mimetype=application/x-truetype-font"),
+        "salvaged output lost the font attachment's mimetype tag: {tags}"
+    );
+    assert!(
+        tags.contains("filename=font.ttf"),
+        "salvaged output lost the font attachment's filename tag: {tags}"
+    );
+
+    // The video/audio streams must have survived alongside the attachment —
+    // salvage must not trade one stream for another.
+    let names = ffprobe_entries(
+        &salvaged,
+        &["-show_entries", "stream=codec_name", "-of", "csv=p=0"],
+    );
+    for expected in ["h264", "aac", "ttf"] {
+        assert!(
+            names.contains(expected),
+            "{expected} stream missing: {names}"
+        );
+    }
+}

--- a/crates/rdlp-ffmpeg/tests/salvage_font_attachment.rs
+++ b/crates/rdlp-ffmpeg/tests/salvage_font_attachment.rs
@@ -50,7 +50,11 @@ fn require_cli() -> bool {
 
 /// A real MKV with video, audio and a native Matroska font attachment. The
 /// attached bytes need not be a genuine TTF: `-attach` embeds them verbatim
-/// with the given mimetype/filename metadata regardless of content.
+/// with the given mimetype/filename metadata regardless of content. The
+/// audio stream also carries a `language` tag, unrelated to the attachment,
+/// so a test can pin that `salvage_remux_sync`'s per-stream metadata copy
+/// (`salvage.rs`) covers every stream — not just the attachment it was added
+/// to fix.
 fn build_font_attached_mkv(dir: &Path) -> PathBuf {
     let font_path = dir.join("font.ttf");
     std::fs::write(&font_path, b"\x00\x01\x00\x00not a real font, just bytes")
@@ -63,6 +67,7 @@ fn build_font_attached_mkv(dir: &Path) -> PathBuf {
         .args(["-f", "lavfi", "-i", "sine=d=1"])
         .args(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
         .args(["-c:a", "aac", "-b:a", "64k", "-shortest"])
+        .args(["-metadata:s:a:0", "language=jpn"])
         .arg("-attach")
         .arg(&font_path)
         .args(["-metadata:s:t", "mimetype=application/x-truetype-font"])
@@ -136,4 +141,37 @@ fn salvage_preserves_font_attachment() {
             "{expected} stream missing: {names}"
         );
     }
+}
+
+/// IMPORTANT #6 (code-review follow-up): `salvage_remux_sync`'s per-stream
+/// metadata copy (added to fix the attachment's `mimetype` requirement) runs
+/// unconditionally for every stream, not just attachments. This pins the
+/// non-attachment side: the audio stream's `language` tag — set on the input
+/// fixture, unrelated to the attachment fix — must also survive.
+#[test]
+fn salvage_preserves_non_attachment_stream_metadata() {
+    if !require_cli() {
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = build_font_attached_mkv(dir.path());
+
+    let salvaged = salvage_remux_sync(&input)
+        .unwrap_or_else(|e| panic!("salvage must succeed on a font-attached input: {e:#}"));
+
+    let tags = ffprobe_entries(
+        &salvaged,
+        &[
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream_tags=language",
+            "-of",
+            "default=noprint_wrappers=1",
+        ],
+    );
+    assert!(
+        tags.contains("TAG:language=jpn"),
+        "salvaged output lost the audio stream's language tag: {tags}"
+    );
 }

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -251,29 +251,39 @@ impl ThumbnailStage {
     /// decision**, not an `FFmpeg`-verified capability like
     /// [`Self::mkv_attachment_renders_natively`]'s Matroska read-back table.
     ///
-    /// `gif`/`jpeg`/`png`/`tiff` are accepted outright — they were the
-    /// baseline behavior before #549's `> 0` widening (jpeg/png always
-    /// embedded natively via the universal `MJPEG`/`PNG` baseline in
-    /// `container_accepts_image_codec`; gif/tiff were previously transcoded
-    /// under the stricter `== 1` gate, so passing them through here is a
-    /// deliberate, accepted widening, not an oversight). `bmp`/`webp` stay
-    /// normalized: #530 is the concrete precedent for "a muxer/tag mechanism
-    /// answering yes" not implying "a player renders it", and nothing in
-    /// this codebase has verified an `ID3v2` reader displaying a bmp/webp
-    /// `APIC` frame. A read failure or unrecognized signature answers
-    /// `false`, the same safe direction.
+    /// Only `jpeg`/`png` are accepted; everything else is normalized.
+    ///
+    /// ID3v2.3 §4.15 / ID3v2.4 §4.14 (id3.org): *"The 'image/png' or
+    /// 'image/jpeg' picture format should be used when interoperability is
+    /// wanted."* Advisory rather than mandatory, but every maintained reader
+    /// converges on it — `TagLib`'s `AttachedPictureFrame` docs restate it
+    /// verbatim, `mutagen` and `jaudiotagger` expose only JPEG/PNG MIME
+    /// constants, and `Mp3tag`'s "Adjust Cover" offers exactly Original,
+    /// JPEG, PNG as conversion targets. No surveyed tool treats `gif`/`tiff`
+    /// as a safer tier than `bmp`/`webp`.
+    ///
+    /// An earlier version of this predicate did, passing `gif`/`tiff`
+    /// through. That tier was imported from `FFmpeg`'s `matroskadec.c`
+    /// `mkv_image_mime_tags[]` (#530), which is a Matroska **decoder** table
+    /// resolving attachments into `attached_pic` streams. The mp3 muxer has
+    /// no analogue: it writes whatever MIME string and bytes it is handed,
+    /// so acceptance rests entirely on third-party `ID3v2` readers that have
+    /// no such table. The carve-out does not transfer between the two
+    /// mechanisms, so it is not reused here.
+    ///
+    /// `FFmpeg` muxes all six formats as valid, correctly-typed `APIC`
+    /// frames — verified, including read-back by a non-`FFmpeg` parser. That
+    /// establishes well-formedness, not that a player decodes the payload;
+    /// #530 is the precedent for those being different questions. A read
+    /// failure or unrecognized signature answers `false`, the same safe
+    /// direction.
     async fn mp3_apic_renders_natively(thumbnail_file: &Path) -> bool {
         let Ok(bytes) = tokio::fs::read(thumbnail_file).await else {
             return false;
         };
         matches!(
             rdlp_types::sniff_thumbnail_format(&bytes),
-            Some(
-                ThumbnailFormat::Jpeg
-                    | ThumbnailFormat::Png
-                    | ThumbnailFormat::Gif
-                    | ThumbnailFormat::Tiff
-            )
+            Some(ThumbnailFormat::Jpeg | ThumbnailFormat::Png)
         )
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -174,6 +174,13 @@ impl ThumbnailStage {
     /// `container_accepts_image_codec`, which answers an unrelated
     /// stream-codec-tag question that does not apply to attachments.
     ///
+    /// MP3 gets the same conservative treatment as a deliberate *policy*
+    /// carve-out, layered on top of (not a correction to) the capability
+    /// query below — see [`Self::mp3_apic_renders_natively`] for why "the
+    /// muxer can store it" and "a player renders it" are different
+    /// questions for `ID3v2` `APIC` covers, same as they were for Matroska
+    /// attachments in #530.
+    ///
     /// Every non-Matroska embed strategy stream-copies the thumbnail's source
     /// codec into the target container (see `rdlp_ffmpeg::thumbnail`), so a
     /// codec the target muxer has no tag for (e.g. `webp` in MP4) must be
@@ -201,6 +208,24 @@ impl ThumbnailStage {
             };
         }
 
+        // MP3 policy carve-out (#549 follow-up): `container_accepts_image_codec`'s
+        // `> 0` fix (#549) makes mp3's own `query_codec` callback (`mp3enc.c`)
+        // correctly report every image mime it lists — gif/jpeg/png/tiff/bmp/webp
+        // — as representable, since it answers with the shared `APIC` tag
+        // rather than a bare `1`. That answers "can the muxer store these
+        // bytes", not "will an `ID3v2` reader display them as a cover". #530
+        // found exactly that gap for Matroska (bmp/webp attach fine, render
+        // invisible); no equivalent verification exists for `ID3v2` `APIC`
+        // readers, so mp3 mirrors the same conservative policy rather than
+        // trusting the widened capability query at face value.
+        if ContainerFormat::from_str(extension) == Ok(ContainerFormat::Mp3)
+            && !Self::mp3_apic_renders_natively(thumbnail_file).await
+        {
+            return self
+                .transcode_thumbnail_to_jpg(msg, extension, thumbnail_file)
+                .await;
+        }
+
         // Ask the muxer whether it can carry this image's codec, rather than
         // consulting a hardcoded list (#525). This is the same codec-tag lookup
         // that produced the original failure, and it reads the image's real
@@ -219,6 +244,37 @@ impl ThumbnailStage {
 
         self.transcode_thumbnail_to_jpg(msg, extension, thumbnail_file)
             .await
+    }
+
+    /// Whether `thumbnail_file`'s content is a format this policy treats as a
+    /// verified-safe mp3 `ID3v2` `APIC` cover — a **conservative product
+    /// decision**, not an `FFmpeg`-verified capability like
+    /// [`Self::mkv_attachment_renders_natively`]'s Matroska read-back table.
+    ///
+    /// `gif`/`jpeg`/`png`/`tiff` are accepted outright — they were the
+    /// baseline behavior before #549's `> 0` widening (jpeg/png always
+    /// embedded natively via the universal `MJPEG`/`PNG` baseline in
+    /// `container_accepts_image_codec`; gif/tiff were previously transcoded
+    /// under the stricter `== 1` gate, so passing them through here is a
+    /// deliberate, accepted widening, not an oversight). `bmp`/`webp` stay
+    /// normalized: #530 is the concrete precedent for "a muxer/tag mechanism
+    /// answering yes" not implying "a player renders it", and nothing in
+    /// this codebase has verified an `ID3v2` reader displaying a bmp/webp
+    /// `APIC` frame. A read failure or unrecognized signature answers
+    /// `false`, the same safe direction.
+    async fn mp3_apic_renders_natively(thumbnail_file: &Path) -> bool {
+        let Ok(bytes) = tokio::fs::read(thumbnail_file).await else {
+            return false;
+        };
+        matches!(
+            rdlp_types::sniff_thumbnail_format(&bytes),
+            Some(
+                ThumbnailFormat::Jpeg
+                    | ThumbnailFormat::Png
+                    | ThumbnailFormat::Gif
+                    | ThumbnailFormat::Tiff
+            )
+        )
     }
 
     /// Transcode `thumbnail_file` to a tracker-owned temp `.jpg`, falling

--- a/crates/rdlp-postprocess/tests/thumbnail_mp3_apic_policy.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_mp3_apic_policy.rs
@@ -1,13 +1,23 @@
-//! #549 follow-up: mp3's `ID3v2` `APIC` cover embed must mirror the #530
-//! Matroska policy — `container_accepts_image_codec`'s `> 0` fix means mp3's
-//! own `query_codec` callback now reports gif/jpeg/png/tiff/bmp/webp as
-//! representable (it answers via the shared `APIC` tag rather than a bare
-//! `1`), but that only answers "can the muxer store these bytes", not "will
-//! an `ID3v2` reader display them as a cover". Nothing in this codebase
-//! verifies a player renders a bmp/webp `APIC` frame, so mp3 stays
-//! conservative in the same direction #530 established for Matroska:
-//! gif/jpeg/png/tiff pass through untouched, bmp/webp are normalized to
-//! mjpeg first.
+//! #549 follow-up: only `jpeg`/`png` embed natively as mp3 `ID3v2` `APIC`
+//! covers; `gif`, `tiff`, `bmp` and `webp` are all normalized to mjpeg first.
+//!
+//! `container_accepts_image_codec`'s `> 0` fix means mp3's `query_codec`
+//! callback reports all six as representable (it answers via the shared
+//! `APIC` tag rather than a bare `1`). But that answers only "can the muxer
+//! store these bytes", not "will an `ID3v2` reader display them as a cover" —
+//! the distinction #530 established for Matroska.
+//!
+//! ID3v2.3 §4.15 / ID3v2.4 §4.14 (id3.org): *"The 'image/png' or
+//! 'image/jpeg' picture format should be used when interoperability is
+//! wanted."* Advisory, but every maintained reader converges on it: `TagLib`
+//! restates it verbatim, `mutagen`/`jaudiotagger` expose only JPEG/PNG MIME
+//! constants, and `Mp3tag`'s "Adjust Cover" offers only Original/JPEG/PNG.
+//!
+//! An earlier revision passed `gif`/`tiff` through, inheriting the tier from
+//! `FFmpeg`'s `matroskadec.c` `mkv_image_mime_tags[]`. That is a Matroska
+//! *decoder* table for turning attachments into `attached_pic` streams; the
+//! mp3 muxer has none, so the carve-out does not transfer and no surveyed
+//! reader treats gif/tiff as safer than bmp/webp.
 //!
 //! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
 //! image/mp3 fixtures).
@@ -172,29 +182,51 @@ async fn process_normalizes_webp_thumbnail_into_mp3_as_mjpeg() {
     );
 }
 
-/// Positive: gif/tiff/jpeg/png must pass through into mp3 WITHOUT
-/// transcoding — the mp3 carve-out must not over-normalize formats the
-/// baseline/query already accept.
+/// gif and tiff are normalized too. They were briefly passed through on the
+/// strength of `FFmpeg`'s `matroskadec.c` `mkv_image_mime_tags[]` table
+/// (#530), but that is a Matroska *decoder* table for resolving attachments
+/// into `attached_pic` streams; the mp3 muxer has no equivalent, so the
+/// carve-out does not transfer to `ID3v2` `APIC`. No surveyed reader
+/// (`TagLib`, `mutagen`, `jaudiotagger`, `Mp3tag`) treats gif/tiff as safer
+/// than bmp/webp — all four sit outside the spec's recommended set.
 #[tokio::test]
-async fn process_embeds_gif_tiff_jpeg_png_thumbnails_into_mp3_without_normalizing() {
+async fn process_normalizes_gif_and_tiff_thumbnails_into_mp3_as_mjpeg() {
     if !ffmpeg_cli_available() {
         eprintln!("[SKIP] ffmpeg CLI not available");
         return;
     }
-    for (format, expected_codec) in [
-        ("gif", "gif"),
-        ("tiff", "tiff"),
-        ("jpg", "mjpeg"),
-        ("png", "png"),
-    ] {
+    for format in ["gif", "tiff"] {
+        let Some(codec) = thumbnail_codec_in_mp3(format).await else {
+            eprintln!("[SKIP] fixture build failed for {format}");
+            continue;
+        };
+        assert_eq!(
+            codec, "mjpeg",
+            "{format} under mp3 must be normalized to mjpeg — ID3v2.3 §4.15 / \
+             ID3v2.4 §4.14 recommend image/png or image/jpeg for \
+             interoperability, and no surveyed ID3v2 reader treats {format} as \
+             a safer tier than bmp/webp"
+        );
+    }
+}
+
+/// Positive: the two formats the `ID3v2` spec actually recommends must pass
+/// through untouched — the policy must not over-normalize those.
+#[tokio::test]
+async fn process_embeds_jpeg_and_png_thumbnails_into_mp3_without_normalizing() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    for (format, expected_codec) in [("jpg", "mjpeg"), ("png", "png")] {
         let Some(codec) = thumbnail_codec_in_mp3(format).await else {
             eprintln!("[SKIP] fixture build failed for {format}");
             continue;
         };
         assert_eq!(
             codec, expected_codec,
-            "{format} must embed into mp3 as its own codec, not be \
-             transcoded by the conservative bmp/webp-only carve-out"
+            "{format} is spec-recommended for APIC and must embed natively, \
+             not be transcoded"
         );
     }
 }

--- a/crates/rdlp-postprocess/tests/thumbnail_mp3_apic_policy.rs
+++ b/crates/rdlp-postprocess/tests/thumbnail_mp3_apic_policy.rs
@@ -1,0 +1,200 @@
+//! #549 follow-up: mp3's `ID3v2` `APIC` cover embed must mirror the #530
+//! Matroska policy — `container_accepts_image_codec`'s `> 0` fix means mp3's
+//! own `query_codec` callback now reports gif/jpeg/png/tiff/bmp/webp as
+//! representable (it answers via the shared `APIC` tag rather than a bare
+//! `1`), but that only answers "can the muxer store these bytes", not "will
+//! an `ID3v2` reader display them as a cover". Nothing in this codebase
+//! verifies a player renders a bmp/webp `APIC` frame, so mp3 stays
+//! conservative in the same direction #530 established for Matroska:
+//! gif/jpeg/png/tiff pass through untouched, bmp/webp are normalized to
+//! mjpeg first.
+//!
+//! Self-skips when the system `ffmpeg` CLI is absent (used only to build the
+//! image/mp3 fixtures).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::disallowed_methods)]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use rdlp_postprocess::pipeline::{FileTracker, PipelineMessage, PipelineStage, TempRegistry};
+use rdlp_postprocess::{FFmpegRunner, PostProcess, ThumbnailStage};
+use rdlp_types::InfoDict;
+
+fn ffmpeg_cli_available() -> bool {
+    Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn build_mp3_fixture(path: &Path) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=d=1",
+            "-c:a",
+            "libmp3lame",
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+/// Build a single-frame still-image thumbnail via the system `ffmpeg` CLI.
+/// The output codec/container is inferred from `path`'s extension.
+fn build_still_image_fixture(path: &Path) -> Result<(), ()> {
+    let ok = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=d=1:s=320x240",
+            "-frames:v",
+            "1",
+            path.to_str().unwrap(),
+        ])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Ok(()) } else { Err(()) }
+}
+
+fn make_msg(files: Vec<std::path::PathBuf>, config: PostProcess) -> PipelineMessage {
+    let reg = Arc::new(TempRegistry::new());
+    let (error_tx, _) = oneshot::channel();
+    PipelineMessage {
+        info: InfoDict::new(
+            "id".to_string(),
+            "Test Video".to_string(),
+            "TestExtractor".to_string(),
+            "https://example.com".to_string(),
+        ),
+        tracker: FileTracker::new(files, reg),
+        config: Arc::new(config),
+        original_stem: "audio".to_string(),
+        is_hls: false,
+        verbose: false,
+        callback_factory: None,
+        error_tx: Some(error_tx),
+        warnings: Vec::new(),
+        encoding_tool: None,
+        cancel: CancellationToken::new(),
+    }
+}
+
+async fn thumbnail_codec_in_mp3(format: &str) -> Option<String> {
+    let dir = TempDir::new().unwrap();
+    let media = dir.path().join("audio.mp3");
+    let thumb = dir.path().join(format!("audio.{format}"));
+    if build_mp3_fixture(&media).is_err() || build_still_image_fixture(&thumb).is_err() {
+        return None;
+    }
+
+    let ffmpeg = Arc::new(FFmpegRunner::new().expect("FFmpeg required"));
+    let stage = ThumbnailStage::new(ffmpeg.clone());
+
+    let config = PostProcess {
+        embed_thumbnail: true,
+        ..PostProcess::default()
+    };
+    let msg = make_msg(vec![media], config);
+
+    let result = stage.process(msg).await.expect("non-fatal stage");
+    assert!(
+        result.warnings.is_empty(),
+        "{format} thumbnail embed into mp3 should succeed with no warnings, got: {:?}",
+        result.warnings
+    );
+
+    let out_path = result.tracker.primary();
+    let info = ffmpeg
+        .probe(&out_path)
+        .await
+        .expect("probing embedded output must succeed");
+    let thumb_stream = info
+        .streams
+        .iter()
+        .find(|s| s.codec_type == "video")
+        .expect("attached-pic video stream must be present");
+    thumb_stream.codec_name.clone()
+}
+
+/// #530-mirrored regression guard: bmp must NOT pass through natively into
+/// mp3 even though `container_accepts_image_codec`'s `> 0` fix now reports
+/// mp3's `query_codec` as accepting it — it must be normalized to mjpeg.
+/// Fails against a version of `normalize_thumbnail_for_embed` with no mp3
+/// carve-out (bmp would stream-copy unchanged, `codec_name == "bmp"`).
+#[tokio::test]
+async fn process_normalizes_bmp_thumbnail_into_mp3_as_mjpeg() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let Some(codec) = thumbnail_codec_in_mp3("bmp").await else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+    assert_eq!(
+        codec, "mjpeg",
+        "bmp under mp3 must be normalized to mjpeg — no evidence an ID3v2 \
+         reader renders a raw bmp APIC frame (mirrors #530's Matroska policy)"
+    );
+}
+
+/// Same guard for webp.
+#[tokio::test]
+async fn process_normalizes_webp_thumbnail_into_mp3_as_mjpeg() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    let Some(codec) = thumbnail_codec_in_mp3("webp").await else {
+        eprintln!("[SKIP] fixture build failed");
+        return;
+    };
+    assert_eq!(
+        codec, "mjpeg",
+        "webp under mp3 must be normalized to mjpeg — no evidence an ID3v2 \
+         reader renders a raw webp APIC frame (mirrors #530's Matroska policy)"
+    );
+}
+
+/// Positive: gif/tiff/jpeg/png must pass through into mp3 WITHOUT
+/// transcoding — the mp3 carve-out must not over-normalize formats the
+/// baseline/query already accept.
+#[tokio::test]
+async fn process_embeds_gif_tiff_jpeg_png_thumbnails_into_mp3_without_normalizing() {
+    if !ffmpeg_cli_available() {
+        eprintln!("[SKIP] ffmpeg CLI not available");
+        return;
+    }
+    for (format, expected_codec) in [
+        ("gif", "gif"),
+        ("tiff", "tiff"),
+        ("jpg", "mjpeg"),
+        ("png", "png"),
+    ] {
+        let Some(codec) = thumbnail_codec_in_mp3(format).await else {
+            eprintln!("[SKIP] fixture build failed for {format}");
+            continue;
+        };
+        assert_eq!(
+            codec, expected_codec,
+            "{format} must embed into mp3 as its own codec, not be \
+             transcoded by the conservative bmp/webp-only carve-out"
+        );
+    }
+}


### PR DESCRIPTION
## Resolves

Closes #549

## The defect

`add_stream_copy` zeroed `codecpar.codec_tag` unconditionally for every non-Matroska output — the `doc/examples/remux.c` idiom. For AVI that failed two different ways, one loud and one silent:

- **h264**: the source's `avc1` tag was zeroed, so AVI's tag table auto-filled the literal `'H264'` fourcc — the exact condition arming `avienc.c`'s start-code guard (`codec_id == H264 && codec_tag == MKTAG('H','2','6','4')`). Our packets are AVCC, so the mux hard-failed.
- **hevc**: AVI's tag table has no HEVC entry at all (the HEVC fourccs live only in `ff_codec_bmp_tags_unofficial`, which the AVI muxer never references), so the tag stayed 0 — and `riff.c:219` maps `MKTAG(0,0,0,0)` to `AV_CODEC_ID_RAWVIDEO`. Exit 0, "Success!", unplayable file.

## The fix

One decision point, `resolve_codec_tag`, consulted by all ten `add_stream_copy` sites and all four raw-FFI mux paths. Two questions, two APIs:

- `av_codec_get_tag` / `av_codec_get_id` — **which tag** to write. Preserve when the source tag round-trips to the same codec; clear when the muxer knows the codec under a different tag (AAC `mp4a`→AVI, h264 `avc1`→FLV).
- `avformat_query_codec` — **representability**. It dispatches to the muxer's own `query_codec` callback when one exists and falls back to the tag table otherwise. `matroskaenc` defines `mkv_query_codec` (HEVC/SubRip into MKV permitted); `avienc` defines none (HEVC into AVI rejected with an actionable error).

Streams FFmpeg muxes outside the codec path — attachments, data — are exempt from rejection entirely. Without that, a font-bearing MKV breaks `salvage`, the corruption-recovery path of last resort.

The four raw-FFI MKV paths that previously zeroed `codec_tag` directly now route through the same decision. That asymmetry (raw-FFI zeroed and worked; `add_stream_copy` rejected) is what hid a Critical regression from the test matrix, since `remux_sync` sends every `.mkv` target down the raw-FFI path.

## Three premises in the issue were false — all mine

- **"The `ffmpeg` CLI inserts the required bitstream filter automatically."** `grep -rl h264_mp4toannexb fftools/` returns **zero hits**. The CLI never inserts it; it succeeds because `streamcopy_init` passes `avc1` through unchanged, so the guard's exact-match test is false and the check never runs. **No bitstream filter is needed for this fix at all.**
- **"rdlp does no automatic BSF insertion."** `AVFMT_FLAG_AUTO_BSF` is already set and works for muxers registering a `check_bitstream` callback. `avienc.c` implements none, so it is a documented no-op for AVI specifically.
- **"`--remux avi` fails where the CLI succeeds"** — true only for MP4 sources. `ts→avi` and `mkv→avi` fail in the CLI too and are out of scope.

Also: **no standard covers H.264 or HEVC in AVI.** OpenDML v1.02 (Feb 1996) predates H.264 by seven years and HEVC by seventeen and mentions neither; FourCC registration was never standards-governed. ITU-T H.264 §7.4.1 explicitly permits demarcation methods defined outside the spec, so neither Annex-B nor AVCC is "the conformant form" — the container's spec decides, and AVI's is silent. Nothing in the code or docs calls this spec compliance.

## Verification

Empirical matrix, release binary vs `ffmpeg -c copy`, asserting decode integrity and stream identity rather than exit status:

| source | target | before | after |
|---|---|---|---|
| h264+aac mp4 | avi | FAIL | **OK**, `h264/aac` |
| hevc+aac mp4 | avi | exit 0, `rawvideo` | **rejected before writing** |
| all sources | ts / mp4 / mkv / mov / flv | OK | OK, identity preserved |
| ts, mkv | avi | FAIL (CLI fails too) | unchanged, out of scope |

Stream identity matters here: the HEVC corruption decodes "cleanly" as rawvideo, so a decode-only check cannot catch it.

## Reviews

Three rounds of `security-reviewer` + `code-reviewer` over the full diff.

**Two Criticals were caught that a fully green gate had passed:**

1. The first predicate rejected on tag-table absence, breaking **HEVC-into-MKV across eight callers** including metadata, thumbnail, merge and salvage. Invisible to the matrix because `remux_sync` branches to the MKV raw-FFI path before reaching the changed code — the most-tested container was the one that couldn't detect the bug.
2. Salvage hard-failed on **font-attached MKVs** (the standard subtitled-release layout), turning a recoverable file into an unrecoverable one.

Also fixed: a panic-DoS (`codec::Id::from` hits `unimplemented!()` on any codec newer than the binding, reachable from any downloaded file — now `avcodec_get_name`); a test suite that **reported green while asserting nothing** when ffmpeg was absent (now fails closed, verified with stub binaries); two missed partial-output cleanup sites; and four comment inaccuracies.

Every fix was mutation-verified: adding `AVMEDIA_TYPE_SUBTITLE` to the exempt set fails the subtitle test; removing salvage's `set_metadata` fails both salvage tests; reverting `Preserve`→`Clear` fails the AVI test.

## Behaviour change beyond the AVI fix

`thumbnail/mod.rs` used `query == 1` where `resolve_codec_tag` uses `> 0` for the same C contract. Converged — mp3's `query_codec` returns `MKTAG('A','P','I','C')`, a large positive value, not `1`.

That widening would have embedded gif/tiff/bmp/webp covers natively in mp3, so the **normalize policy was tightened separately**: only `jpeg`/`png` embed natively; everything else transcodes. ID3v2.3 §4.15 / ID3v2.4 §4.14 recommend `image/png` or `image/jpeg` "when interoperability is wanted", and every maintained reader converges there (TagLib restates it verbatim; mutagen and jaudiotagger expose only JPEG/PNG constants; Mp3tag's "Adjust Cover" offers only Original/JPEG/PNG).

An earlier revision passed gif/tiff through, inheriting that tier from FFmpeg's `matroskadec.c` `mkv_image_mime_tags[]` — a Matroska **decoder** table. The mp3 muxer has no analogue, so the carve-out does not transfer. FFmpeg does mux all six as valid, correctly-typed APIC frames (confirmed by reading them back with exiftool, a non-FFmpeg parser) — but muxable is not renderable, which is #530's lesson.

## Notes

- The gate ran against system FFmpeg; the mediaforge build is mid-rebuild. The muxer tag tables `resolve_codec_tag` queries are compiled in with the muxers themselves, so results should not move between builds — worth one confirming `cargo test -p rdlp-ffmpeg` once that rebuild lands.
- `salvage` is now `#[doc(hidden)] pub` so its coverage can live under `tests/`: `check-no-cli.sh` forbids `std::process::Command` in `crates/*/src/`, and building a font-attached fixture requires the CLI.
