### PR TITLE
fix(types): give wmv/wma their own ContainerFormat variants

### DIFF
--- a/crates/rdlp-cli/src/selection.rs
+++ b/crates/rdlp-cli/src/selection.rs
@@ -29,7 +29,11 @@ pub fn select_remux_container() -> Result<Option<ContainerFormat>> {
         (ContainerFormat::ThreeGp, "3GPP mobile video"),
         (ContainerFormat::Mpg, "MPEG-1/2 program stream"),
         (ContainerFormat::F4v, "Flash Video (MP4 variant)"),
-        (ContainerFormat::Asf, "Windows Media / ASF"),
+        (ContainerFormat::Wmv, "Windows Media Video"),
+        (
+            ContainerFormat::Asf,
+            "Advanced Systems Format (third-party codecs)",
+        ),
         (
             ContainerFormat::Mxf,
             "Material eXchange, broadcast/professional",
@@ -51,6 +55,7 @@ pub fn select_remux_container() -> Result<Option<ContainerFormat>> {
         (ContainerFormat::Wv, "Audio only, WavPack lossless"),
         (ContainerFormat::Caf, "Audio only, Core Audio Format"),
         (ContainerFormat::Ac3, "Audio only, Dolby AC-3"),
+        (ContainerFormat::Wma, "Audio only, Windows Media Audio"),
     ];
 
     let items: Vec<String> = containers
@@ -110,7 +115,7 @@ pub fn select_recode_video() -> Result<Option<ContainerFormat>> {
         (ContainerFormat::Ts, "h264", "MPEG-TS, H.264"),
         (ContainerFormat::ThreeGp, "h264", "3GPP mobile, H.264"),
         (ContainerFormat::Flv, "h264", "Flash Video, H.264"),
-        (ContainerFormat::Asf, "wmv2", "Windows Media, WMV2"),
+        (ContainerFormat::Wmv, "wmv2", "Windows Media Video, WMV2"),
     ];
 
     let items: Vec<String> = formats

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -274,7 +274,7 @@ export interface DownloadJob {
  */
 export type ContainerFormat =
     | "mp4" | "mkv" | "webm" | "mov" | "m4v" | "ts" | "flv" | "avi"
-    | "threegp" | "mpg" | "f4v" | "asf" | "mxf" | "vob" | "dv"
+    | "threegp" | "mpg" | "f4v" | "wmv" | "wma" | "asf" | "mxf" | "vob" | "dv"
     | "nut" | "ivf" | "ogg" | "m4a" | "mp3" | "wav" | "flac"
     | "opus" | "aac" | "aiff" | "mka" | "wv" | "caf" | "ac3";
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -301,6 +301,11 @@ pub(super) const fn audio_only_extension_for(container: ContainerFormat) -> &'st
         | ContainerFormat::Mka
         | ContainerFormat::WebM
         // Reached the old `else` default; kept on MKA deliberately.
+        // The ASF family stays on MKA for its audio-only temp files: all three
+        // parsed to one variant before #538 and mapped here, so listing them
+        // together preserves that behaviour exactly.
+        | ContainerFormat::Wmv
+        | ContainerFormat::Wma
         | ContainerFormat::Asf
         | ContainerFormat::Mxf
         | ContainerFormat::Vob

--- a/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/thumbnail/embed_strategy.rs
@@ -65,6 +65,8 @@ impl ThumbnailEmbedStrategy {
             | ContainerFormat::ThreeGp
             | ContainerFormat::Mpg
             | ContainerFormat::F4v
+            | ContainerFormat::Wmv
+            | ContainerFormat::Wma
             | ContainerFormat::Asf
             | ContainerFormat::Mxf
             | ContainerFormat::Vob

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -87,7 +87,31 @@ impl RecodeStage {
             }),
             // Audio-only and any-other-video containers fall back to the
             // input/output ext compare.
-            other => input_ext.eq_ignore_ascii_case(other.as_ext()),
+            //
+            // Enumerated rather than left as `other =>` so a newly-added
+            // `ContainerFormat` fails to compile here instead of silently
+            // inheriting an extension compare in place of a codec check. #538
+            // is why: splitting `Asf` into three variants added two containers
+            // to this match, and a catch-all would have swapped the ASF
+            // codec-compatibility list above for an ext compare with no build
+            // error and no test failure. Same discipline as
+            // `embed_strategy::for_container` (#525).
+            ContainerFormat::Mov
+            | ContainerFormat::M4v
+            | ContainerFormat::Ts
+            | ContainerFormat::Flv
+            | ContainerFormat::Dv
+            | ContainerFormat::Ogg
+            | ContainerFormat::M4a
+            | ContainerFormat::Mp3
+            | ContainerFormat::Wav
+            | ContainerFormat::Flac
+            | ContainerFormat::Opus
+            | ContainerFormat::Aac
+            | ContainerFormat::Aiff
+            | ContainerFormat::Wv
+            | ContainerFormat::Caf
+            | ContainerFormat::Ac3 => input_ext.eq_ignore_ascii_case(output.as_ext()),
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -75,7 +75,11 @@ impl RecodeStage {
             ContainerFormat::ThreeGp => {
                 video_codec.is_some_and(|c| codec_is(c, &["h264", "avc", "h263", "mpeg4"]))
             }
-            ContainerFormat::Asf => {
+            // All three ASF-family spellings share one muxer and therefore one
+            // codec-compatibility answer. Listed explicitly rather than left to
+            // the `other` arm below: falling through would silently swap this
+            // codec check for an extension compare when #538 split the variants.
+            ContainerFormat::Wmv | ContainerFormat::Wma | ContainerFormat::Asf => {
                 video_codec.is_some_and(|c| codec_is(c, &["wmv1", "wmv2", "h264", "avc", "mpeg4"]))
             }
             ContainerFormat::Mpg | ContainerFormat::Vob => video_codec.is_some_and(|c| {

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -264,22 +264,24 @@ mod tests {
     /// shipped a file with `moov` at the end.
     #[test]
     fn faststart_follows_the_container_type_for_every_remux_target() {
-        for (container, want) in [
-            (ContainerFormat::Mp4, true),
-            (ContainerFormat::Mov, true),
-            (ContainerFormat::M4v, true),
-            (ContainerFormat::F4v, true),
-            (ContainerFormat::Mkv, false),
-            (ContainerFormat::WebM, false),
-            (ContainerFormat::Avi, false),
-            // #538: the ASF family at the stage boundary. The
-            // `output_format == as_ext()` assertion below is the one that
-            // matters here — it pins the extension the stage propagates
-            // toward the output filename, one layer closer to the user than
+        // The third column is the expected extension as a LITERAL. Asserting
+        // against `container.as_ext()` instead would be tautological — both
+        // sides would derive from the same function, so a wrong `as_ext()`
+        // (e.g. #538's `Wmv => "asf"`) would keep this test green while the
+        // stage propagated the wrong extension toward the output filename.
+        for (container, want, want_ext) in [
+            (ContainerFormat::Mp4, true, "mp4"),
+            (ContainerFormat::Mov, true, "mov"),
+            (ContainerFormat::M4v, true, "m4v"),
+            (ContainerFormat::F4v, true, "f4v"),
+            (ContainerFormat::Mkv, false, "mkv"),
+            (ContainerFormat::WebM, false, "webm"),
+            (ContainerFormat::Avi, false, "avi"),
+            // #538: the ASF family, pinned one layer closer to the user than
             // the `rdlp-types` unit tests reach.
-            (ContainerFormat::Wmv, false),
-            (ContainerFormat::Wma, false),
-            (ContainerFormat::Asf, false),
+            (ContainerFormat::Wmv, false, "wmv"),
+            (ContainerFormat::Wma, false, "wma"),
+            (ContainerFormat::Asf, false, "asf"),
         ] {
             let config = PostProcess {
                 remux_container: Some(container),
@@ -298,7 +300,11 @@ mod tests {
                 opts.faststart, want,
                 "faststart for {container:?} must follow supports_faststart()"
             );
-            assert_eq!(opts.output_format.as_deref(), Some(container.as_ext()));
+            assert_eq!(
+                opts.output_format.as_deref(),
+                Some(want_ext),
+                "the stage must propagate the literal extension for {container:?}"
+            );
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/remux.rs
@@ -272,6 +272,14 @@ mod tests {
             (ContainerFormat::Mkv, false),
             (ContainerFormat::WebM, false),
             (ContainerFormat::Avi, false),
+            // #538: the ASF family at the stage boundary. The
+            // `output_format == as_ext()` assertion below is the one that
+            // matters here — it pins the extension the stage propagates
+            // toward the output filename, one layer closer to the user than
+            // the `rdlp-types` unit tests reach.
+            (ContainerFormat::Wmv, false),
+            (ContainerFormat::Wma, false),
+            (ContainerFormat::Asf, false),
         ] {
             let config = PostProcess {
                 remux_container: Some(container),
@@ -291,6 +299,63 @@ mod tests {
                 "faststart for {container:?} must follow supports_faststart()"
             );
             assert_eq!(opts.output_format.as_deref(), Some(container.as_ext()));
+        }
+    }
+
+    /// #538 flipped the already-in-target short-circuit for the ASF family,
+    /// in both directions, and neither direction was pinned.
+    ///
+    /// `target_container` skips the remux when the input extension already
+    /// equals `container.as_ext()`. While `wmv`/`wma`/`asf` shared one variant
+    /// whose `as_ext()` was `"asf"`, a `.wmv` input compared against `"asf"`:
+    /// `--remux=wmv` re-muxed a file that was already in the requested
+    /// container, and `--remux=asf` on a `.wmv` input wrongly skipped. Splitting
+    /// the variants corrects both, so both are asserted here.
+    #[test]
+    fn asf_family_short_circuits_per_spelling_not_per_muxer() {
+        // Same spelling in and out → nothing to do.
+        for (input_ext, container) in [
+            ("wmv", ContainerFormat::Wmv),
+            ("wma", ContainerFormat::Wma),
+            ("asf", ContainerFormat::Asf),
+        ] {
+            let config = PostProcess {
+                remux_container: Some(container),
+                ..PostProcess::default()
+            };
+            let msg = make_msg_with_config(
+                vec![PathBuf::from(format!("/tmp/v.{input_ext}"))],
+                config,
+                false,
+            );
+            assert!(
+                RemuxStage::target_container(&msg, input_ext).is_none(),
+                "{input_ext} input with --remux={input_ext} must skip the remux"
+            );
+        }
+
+        // Different spelling within the same muxer family → still a real remux,
+        // because the extension the user asked for is not the one on disk.
+        for (input_ext, container) in [
+            ("wmv", ContainerFormat::Asf),
+            ("asf", ContainerFormat::Wmv),
+            ("wmv", ContainerFormat::Wma),
+        ] {
+            let config = PostProcess {
+                remux_container: Some(container),
+                ..PostProcess::default()
+            };
+            let msg = make_msg_with_config(
+                vec![PathBuf::from(format!("/tmp/v.{input_ext}"))],
+                config,
+                false,
+            );
+            assert_eq!(
+                RemuxStage::target_container(&msg, input_ext),
+                Some(container),
+                "{input_ext} input with --remux={} must still remux",
+                container.as_ext()
+            );
         }
     }
 

--- a/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/thumbnail.rs
@@ -120,6 +120,8 @@ impl ThumbnailStage {
             | ContainerFormat::ThreeGp
             | ContainerFormat::Mpg
             | ContainerFormat::F4v
+            | ContainerFormat::Wmv
+            | ContainerFormat::Wma
             | ContainerFormat::Asf
             | ContainerFormat::Mxf
             | ContainerFormat::Vob

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -432,5 +432,23 @@ mod tests {
         assert!(!ContainerFormat::Mp4.is_audio_only());
         assert!(!ContainerFormat::Mkv.is_audio_only());
         assert!(!ContainerFormat::Avi.is_audio_only());
+
+        // ASF family (#538). The negative pair carries more weight than the
+        // positive: `is_audio_only` is a `matches!`, so it can never be made
+        // exhaustive — a misclassified `Wmv`/`Asf` would be silent by
+        // construction, and dropping `| Self::Wma` from the predicate must not
+        // leave the suite green.
+        assert!(
+            ContainerFormat::Wma.is_audio_only(),
+            "wma names ASF content with no supported video streams"
+        );
+        assert!(
+            !ContainerFormat::Wmv.is_audio_only(),
+            "wmv is the ASF spelling that carries video"
+        );
+        assert!(
+            !ContainerFormat::Asf.is_audio_only(),
+            "asf is the general fallback and may carry video"
+        );
     }
 }

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -46,8 +46,33 @@ pub enum ContainerFormat {
     /// Flash Video (MP4 variant)
     #[strum(serialize = "f4v")]
     F4v,
-    /// Advanced Streaming Format / Windows Media
-    #[strum(to_string = "asf", serialize = "wmv", serialize = "wma")]
+    /// Windows Media Video — ASF container carrying a video stream.
+    ///
+    /// Shares `FFmpeg`'s `asf` muxer with [`Self::Wma`] and [`Self::Asf`]
+    /// (the muxer declares `Common extensions: asf,wmv,wma`), but is a
+    /// distinct variant so the extension survives to the output filename —
+    /// the same shape as [`Self::Mkv`]/[`Self::Mka`] over the matroska muxer.
+    /// See [`Self::Asf`] for why the spelling is load-bearing (#538).
+    #[strum(serialize = "wmv")]
+    Wmv,
+    /// Windows Media Audio — ASF container carrying only audio.
+    ///
+    /// Audio-only sibling of [`Self::Wmv`], mirroring [`Self::Mka`] to
+    /// [`Self::Mkv`].
+    #[strum(serialize = "wma")]
+    Wma,
+    /// Advanced Systems Format — the *fallback* spelling of the ASF family.
+    ///
+    /// Microsoft's [File Name Extension Guidelines] make this the name for ASF
+    /// content carrying third-party or otherwise unsupported streams: a file is
+    /// `.wmv` when it holds video, `.wma` when it holds only audio, and `.asf`
+    /// only otherwise. Because `.asf` is the exception rather than the family
+    /// name, `wmv`/`wma` are separate variants instead of aliases that
+    /// canonicalize here — folding them in made `--remux=wmv` write
+    /// `Title.asf`, inverting Microsoft's rule (#538).
+    ///
+    /// [File Name Extension Guidelines]: https://learn.microsoft.com/en-us/windows/win32/wmformat/file-name-extension-guidelines
+    #[strum(serialize = "asf")]
     Asf,
     /// Material eXchange Format (broadcast/professional)
     #[strum(serialize = "mxf")]
@@ -121,6 +146,8 @@ impl ContainerFormat {
             Self::ThreeGp => "3gp",
             Self::Mpg => "mpg",
             Self::F4v => "f4v",
+            Self::Wmv => "wmv",
+            Self::Wma => "wma",
             Self::Asf => "asf",
             Self::Mxf => "mxf",
             Self::Vob => "vob",
@@ -164,6 +191,12 @@ impl ContainerFormat {
                 | Self::Aac
                 | Self::Aiff
                 | Self::Mka
+                // Microsoft's File Name Extension Guidelines are explicit that
+                // `.wma` names ASF content with "no supported video streams" —
+                // a video stream of any codec belongs in `.wmv` or `.asf`. This
+                // predicate records that classification; it does NOT yet drop
+                // video streams from a `--remux=wma` (see #538 follow-up).
+                | Self::Wma
                 | Self::Wv
                 | Self::Caf
                 | Self::Ac3
@@ -216,8 +249,8 @@ mod tests {
             ("mpegts", ContainerFormat::Ts),
             ("3gpp", ContainerFormat::ThreeGp),
             ("mpeg", ContainerFormat::Mpg),
-            ("wmv", ContainerFormat::Asf),
-            ("wma", ContainerFormat::Asf),
+            // `wmv`/`wma` were aliases of `Asf` until #538 gave them their own
+            // variants; they are covered by `test_wmv_wma_keep_their_own_extension`.
             ("wave", ContainerFormat::Wav),
             ("adts", ContainerFormat::Aac),
             ("aif", ContainerFormat::Aiff),
@@ -264,7 +297,7 @@ mod tests {
         );
         assert_eq!(
             "WMV".parse::<ContainerFormat>().unwrap(),
-            ContainerFormat::Asf
+            ContainerFormat::Wmv
         );
         assert_eq!(
             "FLAC".parse::<ContainerFormat>().unwrap(),
@@ -307,6 +340,79 @@ mod tests {
         );
         assert_eq!(ContainerFormat::M4v.as_ext(), "m4v");
         assert!(!ContainerFormat::M4v.is_audio_only());
+    }
+
+    /// `wmv` and `wma` keep their own extension instead of canonicalizing to
+    /// `asf` (#538).
+    ///
+    /// Microsoft's File Name Extension Guidelines make `.asf` the *fallback*
+    /// spelling — reserved for ASF content carrying third-party or unsupported
+    /// streams — while `.wmv` and `.wma` are the expected names for Windows
+    /// Media video and audio. Folding all three onto one variant whose
+    /// `as_ext()` is `"asf"` inverted that rule: `--remux=wmv` wrote
+    /// `Title.asf`. They are three variants over one `FFmpeg` muxer (`asf`
+    /// declares `Common extensions: asf,wmv,wma`), mirroring how `Mkv`/`Mka`
+    /// and `Mp4`/`M4a` already share a muxer while keeping distinct extensions.
+    #[test]
+    fn test_wmv_wma_keep_their_own_extension() {
+        const SPELLINGS: &[(&str, ContainerFormat, &str)] = &[
+            ("wmv", ContainerFormat::Wmv, "wmv"),
+            ("wma", ContainerFormat::Wma, "wma"),
+            ("asf", ContainerFormat::Asf, "asf"),
+        ];
+
+        for (spelling, expected, ext) in SPELLINGS {
+            let parsed: ContainerFormat = spelling
+                .parse()
+                .unwrap_or_else(|_| panic!("'{spelling}' must parse"));
+            assert_eq!(parsed, *expected, "'{spelling}' must parse to {expected:?}");
+            assert_eq!(
+                parsed.as_ext(),
+                *ext,
+                "'{spelling}' must keep its own extension, not canonicalize"
+            );
+        }
+
+        // The three are distinct containers, not aliases of one another.
+        assert_ne!(ContainerFormat::Wmv, ContainerFormat::Asf);
+        assert_ne!(ContainerFormat::Wma, ContainerFormat::Asf);
+        assert_ne!(ContainerFormat::Wmv, ContainerFormat::Wma);
+    }
+
+    /// The counter-direction guard for #538: aliases that are format *names*
+    /// rather than file extensions must keep canonicalizing.
+    ///
+    /// This is the regression this fix could most easily cause. A general
+    /// "preserve whatever the user typed" rule would fix `wmv` and
+    /// simultaneously start writing `Title.matroska` / `Title.quicktime` —
+    /// spellings no muxer lookup recognises and no player expects. Matroska's
+    /// own documentation uses only `.mkv`; Apple's uses `.mov`; `FFmpeg`'s mpegts
+    /// muxer lists `ts,m2t,m2ts,mts` and never `mpegts`.
+    #[test]
+    fn test_format_name_aliases_still_canonicalize() {
+        const CANONICALIZING: &[(&str, &str)] = &[
+            ("matroska", "mkv"),
+            ("quicktime", "mov"),
+            ("mpegts", "ts"),
+            ("3gpp", "3gp"),
+            ("mpeg", "mpg"),
+            ("wave", "wav"),
+            ("adts", "aac"),
+            ("aif", "aiff"),
+            ("wavpack", "wv"),
+        ];
+
+        for (alias, canonical_ext) in CANONICALIZING {
+            let parsed: ContainerFormat = alias
+                .parse()
+                .unwrap_or_else(|_| panic!("alias '{alias}' must parse"));
+            assert_eq!(
+                parsed.as_ext(),
+                *canonical_ext,
+                "alias '{alias}' is a format name, not an extension — it must \
+                 canonicalize to '{canonical_ext}', never be preserved verbatim"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #538.

`--remux=wmv` produced `Title.asf`, inverting Microsoft's own naming rule. `wmv`/`wma`/`asf` all parsed to a single `ContainerFormat::Asf` whose `as_ext()` was always `"asf"`, and that extension flows verbatim through `temp_path` → `finalize_to_clean` into the user's output filename.

## Approach — three variants, not a preserved token

The issue proposed threading the user's typed token through config. This PR takes the option it called "heavier" instead, because the codebase already has the pattern: `Mkv`/`Mka` and `Mp4`/`M4a` are distinct variants sharing one muxer. `Wmv`/`Wma`/`Asf` is the identical shape, and FFmpeg's asf muxer declares `Common extensions: asf,wmv,wma`, so all three resolve to it.

It is compiler-enforced rather than stringly-typed, and it is deliberately **not** a general "preserve the user's spelling" rule — `matroska`/`quicktime`/`mpegts` are format *names*, never extensions, and must keep canonicalizing. `test_format_name_aliases_still_canonicalize` pins that counter-direction, which is the regression this fix could most easily have caused.

## Verified end-to-end with the real binary

| | before | after |
|---|---|---|
| `--remux=wmv` | `Title.asf` ❌ | `Title.wmv` ✅ |
| `--remux=wma` | `Title.asf` ❌ | `Title.wma` ✅ |
| `--remux=matroska` | `.mkv` ✅ | `.mkv` ✅ |
| `--remux=quicktime` | `.mov` ✅ | `.mov` ✅ |
| `--remux=mpegts` | `.ts` ✅ | `.ts` ✅ |

## Hardening: the site the compiler did NOT catch

Four of the five affected sites are exhaustive matches and failed to compile until handled. The fifth — `recode.rs::container_matches` — ended in a catch-all, so the two new variants would have silently taken an extension compare instead of the ASF codec-compatibility check, with no build error and no test failure.

It now enumerates every variant, so the *next* container added fails to compile there. Canary-verified (removing one variant yields `E0004`); the compiler also caught a duplicate `Mka` in the first draft. Prior behavior is unchanged for every existing variant — the security review confirmed byte-for-byte against `develop` that `Asf` always had its own arm, so no pre-existing variant ever reached that wildcard.

## `Wma` and `is_audio_only()`

Microsoft's [File Name Extension Guidelines] state normatively that `.wma` names ASF content with **"no supported video streams"**. `Wma` therefore joins `is_audio_only()`.

This records the classification only — `ContainerFormat::is_audio_only()` currently has **zero production callers** (every other `is_audio_only` hit in the workspace is HLS's unrelated struct field), so there is no runtime behavior change. Enforcement, and the question of whether that inert predicate should be wired up or deleted, is #577.

## Tests

Every assertion below was mutation-verified — each was observed failing against the unpatched behavior, not merely passing:

- `test_wmv_wma_keep_their_own_extension` — verified RED behaviorally (`left: "asf", right: "wmv"`), not merely as a compile error.
- `test_format_name_aliases_still_canonicalize` — the counter-direction guard.
- `test_is_audio_only` — positive `Wma` plus negative `Wmv`/`Asf`. The negative pair carries the weight: the predicate is a `matches!` and can never be exhaustive, so a misclassification is silent by construction.
- `asf_family_short_circuits_per_spelling_not_per_muxer` — the split flips the already-in-target short-circuit both ways; both are pinned.
- `faststart_follows_the_container_type_for_every_remux_target` — extended with the ASF family, asserting the **literal** expected extension.

## Reviews

Both mandatory pre-push reviewers ran over the full diff, and both re-ran after fixes.

- **security-reviewer** — PASS, no findings. Its first pass justified approval with "no `ContainerFormat` match anywhere uses a catch-all"; that was false (`recode.rs` had one), so it was asked to re-derive rather than restate. On re-review it verified against `git show develop:` and produced the sharper finding above.
- **code-reviewer** — 5 findings, all fixed, then a 6th on re-review: the ASF rows I added to the faststart table asserted `output_format == container.as_ext()`, where **both sides derive from `as_ext()`** — tautological. It mutation-proved the test stayed green under `Wmv => "asf"` while four other tests failed. Now asserts literals for all 10 rows, and the mutation fails it.

[File Name Extension Guidelines]: https://learn.microsoft.com/en-us/windows/win32/wmformat/file-name-extension-guidelines

## Follow-ups filed

- #576 — container/codec compatibility compares raw codec strings, hand-repeating FFmpeg alias pairs (`h264`/`avc`, `hevc`/`h265`). Includes the `audio_encoder_registry` detail both reviewers noticed: the ASF family falls to an `_ => AAC` default where `wmav2` is correct.
- #577 — `--remux` to an audio-only container still carries video, and `is_audio_only()` gates nothing.
