### PR TITLE
fix(types): pin AudioFormat/SubtitleFormat Display to their real projection

### DIFF
--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -102,74 +102,32 @@ impl AudioFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use strum::IntoEnumIterator;
+    use crate::enum_test_support::{
+        assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
+    };
 
     #[test]
     fn test_display_roundtrip() {
-        for fmt in [
-            AudioFormat::Mp3,
-            AudioFormat::Aac,
-            AudioFormat::M4a,
-            AudioFormat::Opus,
-            AudioFormat::Vorbis,
-            AudioFormat::Flac,
-            AudioFormat::Alac,
-            AudioFormat::Wav,
-            AudioFormat::Ac3,
-            AudioFormat::Eac3,
-            AudioFormat::Dts,
-            AudioFormat::Mp2,
-            AudioFormat::WavPack,
-            AudioFormat::Tta,
-        ] {
-            let s = fmt.to_string();
-            let parsed: AudioFormat = s.parse().unwrap();
-            assert_eq!(fmt, parsed, "roundtrip failed for {s}");
-        }
+        assert_display_roundtrips::<AudioFormat>();
     }
 
+    /// Every alias still parses — including the spellings displaced from
+    /// `Display` when `eac3`/`dts` were promoted to `to_string` (#580). strum
+    /// unions `to_string` into the `FromStr` set rather than replacing the
+    /// `serialize` list, so nothing should be lost; this pins that.
+    ///
+    /// Case folding of each spelling is asserted by the helper.
     #[test]
     fn test_alias_parsing() {
-        assert_eq!("ogg".parse::<AudioFormat>().unwrap(), AudioFormat::Vorbis);
-        assert_eq!("e-ac-3".parse::<AudioFormat>().unwrap(), AudioFormat::Eac3);
-        assert_eq!("e-ac3".parse::<AudioFormat>().unwrap(), AudioFormat::Eac3);
-        assert_eq!("dca".parse::<AudioFormat>().unwrap(), AudioFormat::Dts);
-        assert_eq!("wv".parse::<AudioFormat>().unwrap(), AudioFormat::WavPack);
-    }
-
-    /// Promoting a spelling from `serialize` to `to_string` must not drop any
-    /// other spelling: strum builds the `FromStr` table from `serialize` **plus**
-    /// `to_string`, so every pre-#580 input stays accepted. The canonical
-    /// spellings are asserted alongside the aliases because `to_string` is what
-    /// moved.
-    #[test]
-    fn test_to_string_promotion_preserved_every_spelling() {
-        for (input, expected) in [
+        assert_all_parse_to(&[
+            ("ogg", AudioFormat::Vorbis),
+            ("wv", AudioFormat::WavPack),
             ("eac3", AudioFormat::Eac3),
             ("e-ac-3", AudioFormat::Eac3),
             ("e-ac3", AudioFormat::Eac3),
             ("dts", AudioFormat::Dts),
             ("dca", AudioFormat::Dts),
-        ] {
-            assert_eq!(
-                input.parse::<AudioFormat>().unwrap(),
-                expected,
-                "{input} must still parse after the to_string promotion"
-            );
-        }
-    }
-
-    /// `ascii_case_insensitive` is a container-level default applied to every
-    /// spelling strum accepts — including `to_string` values, not just
-    /// `serialize` ones.
-    #[test]
-    fn test_promoted_spellings_stay_case_insensitive() {
-        for input in ["EAC3", "E-AC-3", "DTS", "Dca"] {
-            assert!(
-                input.parse::<AudioFormat>().is_ok(),
-                "{input} must parse case-insensitively"
-            );
-        }
+        ]);
     }
 
     /// The codec-vs-container split is intended, not a bug to "fix".
@@ -199,13 +157,7 @@ mod tests {
     /// (#545) because that enum names containers.
     #[test]
     fn test_display_equals_codec_name() {
-        for fmt in AudioFormat::iter() {
-            assert_eq!(
-                fmt.to_string(),
-                fmt.codec_name(),
-                "Display for {fmt:?} must equal codec_name()"
-            );
-        }
+        assert_display_matches::<AudioFormat>(|fmt| fmt.codec_name(), "codec_name()");
     }
 
     #[test]

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -1,10 +1,12 @@
 //! Audio format types for extraction and conversion
 
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
+use strum_macros::{Display, EnumIter, EnumString};
 
 /// Supported audio formats for extraction and conversion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
 pub enum AudioFormat {
@@ -36,10 +38,10 @@ pub enum AudioFormat {
     #[strum(serialize = "ac3")]
     Ac3,
     /// Dolby Digital Plus (Enhanced AC-3)
-    #[strum(serialize = "eac3", serialize = "e-ac-3", serialize = "e-ac3")]
+    #[strum(to_string = "eac3", serialize = "e-ac-3", serialize = "e-ac3")]
     Eac3,
     /// DTS Coherent Acoustics
-    #[strum(serialize = "dts", serialize = "dca")]
+    #[strum(to_string = "dts", serialize = "dca")]
     Dts,
     /// MPEG Audio Layer 2
     #[strum(serialize = "mp2")]
@@ -100,6 +102,7 @@ impl AudioFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strum::IntoEnumIterator;
 
     #[test]
     fn test_display_roundtrip() {
@@ -132,6 +135,77 @@ mod tests {
         assert_eq!("e-ac3".parse::<AudioFormat>().unwrap(), AudioFormat::Eac3);
         assert_eq!("dca".parse::<AudioFormat>().unwrap(), AudioFormat::Dts);
         assert_eq!("wv".parse::<AudioFormat>().unwrap(), AudioFormat::WavPack);
+    }
+
+    /// Promoting a spelling from `serialize` to `to_string` must not drop any
+    /// other spelling: strum builds the `FromStr` table from `serialize` **plus**
+    /// `to_string`, so every pre-#580 input stays accepted. The canonical
+    /// spellings are asserted alongside the aliases because `to_string` is what
+    /// moved.
+    #[test]
+    fn test_to_string_promotion_preserved_every_spelling() {
+        for (input, expected) in [
+            ("eac3", AudioFormat::Eac3),
+            ("e-ac-3", AudioFormat::Eac3),
+            ("e-ac3", AudioFormat::Eac3),
+            ("dts", AudioFormat::Dts),
+            ("dca", AudioFormat::Dts),
+        ] {
+            assert_eq!(
+                input.parse::<AudioFormat>().unwrap(),
+                expected,
+                "{input} must still parse after the to_string promotion"
+            );
+        }
+    }
+
+    /// `ascii_case_insensitive` is a container-level default applied to every
+    /// spelling strum accepts — including `to_string` values, not just
+    /// `serialize` ones.
+    #[test]
+    fn test_promoted_spellings_stay_case_insensitive() {
+        for input in ["EAC3", "E-AC-3", "DTS", "Dca"] {
+            assert!(
+                input.parse::<AudioFormat>().is_ok(),
+                "{input} must parse case-insensitively"
+            );
+        }
+    }
+
+    /// The codec-vs-container split is intended, not a bug to "fix".
+    ///
+    /// These three variants are the reason this enum's `Display` guard is
+    /// pinned to `codec_name()` rather than `as_ext()` — a future reviewer
+    /// mirroring #545's `ContainerFormat` rule onto this enum would otherwise
+    /// make `Vorbis` render `ogg`. See #580.
+    #[test]
+    fn test_codec_name_and_ext_intentionally_differ() {
+        assert_eq!(AudioFormat::Vorbis.codec_name(), "vorbis");
+        assert_eq!(AudioFormat::Vorbis.as_ext(), "ogg");
+        assert_eq!(AudioFormat::Alac.codec_name(), "alac");
+        assert_eq!(AudioFormat::Alac.as_ext(), "m4a");
+        assert_eq!(AudioFormat::WavPack.codec_name(), "wavpack");
+        assert_eq!(AudioFormat::WavPack.as_ext(), "wv");
+    }
+
+    /// `Display` must render the codec name, not whichever strum alias happens
+    /// to be longest.
+    ///
+    /// `AudioFormat` is a *codec* enum: [`AudioFormat::as_ext`] deliberately
+    /// returns the **container** extension the codec is carried in (`Vorbis` →
+    /// `ogg`, `Alac` → `m4a`), so the projection `Display` must agree with is
+    /// [`AudioFormat::codec_name`], not `as_ext`. See #580; the
+    /// `ContainerFormat` sibling of this guard is pinned to `as_ext` instead
+    /// (#545) because that enum names containers.
+    #[test]
+    fn test_display_equals_codec_name() {
+        for fmt in AudioFormat::iter() {
+            assert_eq!(
+                fmt.to_string(),
+                fmt.codec_name(),
+                "Display for {fmt:?} must equal codec_name()"
+            );
+        }
     }
 
     #[test]

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -207,15 +207,14 @@ impl ContainerFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::enum_test_support::{
+        assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
+    };
     use strum::IntoEnumIterator as _;
 
     #[test]
     fn test_display_roundtrip() {
-        for fmt in ContainerFormat::iter() {
-            let s = fmt.to_string();
-            let parsed: ContainerFormat = s.parse().unwrap();
-            assert_eq!(fmt, parsed, "roundtrip failed for {s}");
-        }
+        assert_display_roundtrips::<ContainerFormat>();
     }
 
     /// `Display` must render the file extension, not an alias.
@@ -227,13 +226,7 @@ mod tests {
     /// string no muxer lookup recognises.
     #[test]
     fn test_display_is_the_file_extension() {
-        for fmt in ContainerFormat::iter() {
-            assert_eq!(
-                fmt.to_string(),
-                fmt.as_ext(),
-                "Display for {fmt:?} must equal as_ext()"
-            );
-        }
+        assert_display_matches::<ContainerFormat>(|fmt| fmt.as_ext(), "as_ext()");
     }
 
     /// Every alias must still parse after `to_string` is added.
@@ -257,19 +250,8 @@ mod tests {
             ("wavpack", ContainerFormat::Wv),
         ];
 
-        for (alias, expected) in ALIASES {
-            assert_eq!(
-                alias.parse::<ContainerFormat>().ok(),
-                Some(*expected),
-                "alias '{alias}' must keep parsing"
-            );
-            // Case-insensitivity must cover the alias set too.
-            assert_eq!(
-                alias.to_uppercase().parse::<ContainerFormat>().ok(),
-                Some(*expected),
-                "alias '{alias}' must keep parsing case-insensitively"
-            );
-        }
+        // Case-insensitivity across the alias set is asserted by the helper.
+        assert_all_parse_to(ALIASES);
     }
 
     /// Each variant's own extension parses back to that variant.

--- a/crates/rdlp-types/src/enum_test_support.rs
+++ b/crates/rdlp-types/src/enum_test_support.rs
@@ -1,0 +1,88 @@
+//! Shared assertions for the string-projection guards on the format enums.
+//!
+//! `ContainerFormat`, `AudioFormat` and `SubtitleFormat` each derive
+//! `strum::Display` over a variant table that also lists parse aliases, and each
+//! needs the same three guarantees pinned:
+//!
+//! 1. every variant's `Display` output parses back to that variant,
+//! 2. `Display` renders the projection the enum actually names — **not**
+//!    whichever `#[strum(serialize = ...)]` spelling happens to be longest,
+//!    which is what strum picks absent an explicit `to_string` (#545, #580), and
+//! 3. promoting a spelling to `to_string` did not drop any other spelling from
+//!    the `FromStr` table.
+//!
+//! Which projection guarantee 2 asserts differs per enum — `ContainerFormat`
+//! and `SubtitleFormat` name file extensions, while `AudioFormat` names codecs
+//! and its `as_ext()` deliberately returns the *container* the codec is carried
+//! in — so the projection is passed in as a function rather than hardcoded here.
+//! Callers supply it; this module supplies the loop, the iteration source and
+//! the failure message.
+
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
+
+use strum::IntoEnumIterator;
+
+/// Asserts every variant's `Display` output parses back to that variant.
+///
+/// Iterates `EnumIter` rather than a hand-listed set, so a newly added variant
+/// is covered without touching the test.
+pub fn assert_display_roundtrips<T>()
+where
+    T: IntoEnumIterator + Display + FromStr + PartialEq + Debug,
+    <T as FromStr>::Err: Debug,
+{
+    for variant in T::iter() {
+        let rendered = variant.to_string();
+        let parsed = rendered
+            .parse::<T>()
+            .unwrap_or_else(|e| panic!("Display output {rendered:?} must parse back: {e:?}"));
+        assert_eq!(variant, parsed, "roundtrip failed for {rendered}");
+    }
+}
+
+/// Asserts `Display` equals `projection` for every variant.
+///
+/// `projection_name` names the accessor in the failure message so a failure
+/// reads `Display for Dts must equal codec_name()` rather than pointing at this
+/// helper.
+pub fn assert_display_matches<T>(projection: impl Fn(T) -> &'static str, projection_name: &str)
+where
+    T: IntoEnumIterator + Display + Debug + Copy,
+{
+    for variant in T::iter() {
+        assert_eq!(
+            variant.to_string(),
+            projection(variant),
+            "Display for {variant:?} must equal {projection_name}"
+        );
+    }
+}
+
+/// Asserts every `(input, expected)` pair parses to `expected`, in each of its
+/// as-written, upper- and lower-case forms.
+///
+/// Guards the `serialize` -> `to_string` promotions: strum unions `to_string`
+/// into the `FromStr` set rather than replacing the `serialize` list, so no
+/// spelling should be lost — but that is exactly how such a promotion could
+/// silently narrow the accepted CLI/config vocabulary, so it is pinned per enum.
+///
+/// Case folding is asserted here rather than per enum because all three format
+/// enums carry `#[strum(ascii_case_insensitive)]`, which strum applies to every
+/// spelling a variant accepts — `to_string` values included, not just
+/// `serialize` ones. A promotion that somehow escaped the case-insensitive path
+/// would therefore fail here without needing its own test per enum.
+pub fn assert_all_parse_to<T>(cases: &[(&str, T)])
+where
+    T: FromStr + PartialEq + Debug + Copy,
+    <T as FromStr>::Err: Debug,
+{
+    for &(input, expected) in cases {
+        for spelling in [input.to_owned(), input.to_uppercase(), input.to_lowercase()] {
+            let parsed = spelling
+                .parse::<T>()
+                .unwrap_or_else(|e| panic!("{spelling:?} must parse: {e:?}"));
+            assert_eq!(parsed, expected, "{spelling} must parse to {expected:?}");
+        }
+    }
+}

--- a/crates/rdlp-types/src/lib.rs
+++ b/crates/rdlp-types/src/lib.rs
@@ -29,6 +29,8 @@ pub mod browser_emulation;
 pub mod browser_type;
 pub mod config;
 pub mod container;
+#[cfg(test)]
+mod enum_test_support;
 pub mod fixup_policy;
 pub mod format;
 pub mod info_dict;

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -1,10 +1,12 @@
 //! Subtitle format types
 
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
+use strum_macros::{Display, EnumIter, EnumString};
 
 /// Supported subtitle formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
 pub enum SubtitleFormat {
@@ -12,7 +14,7 @@ pub enum SubtitleFormat {
     #[strum(serialize = "srt")]
     Srt,
     /// Web Video Text Tracks
-    #[strum(serialize = "vtt", serialize = "webvtt")]
+    #[strum(to_string = "vtt", serialize = "webvtt")]
     Vtt,
     /// Advanced `SubStation` Alpha
     #[strum(serialize = "ass")]
@@ -43,6 +45,35 @@ impl SubtitleFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strum::IntoEnumIterator;
+
+    /// `Display` must render the file extension, not whichever strum alias
+    /// happens to be longest (#580, mirroring the `ContainerFormat` guard from
+    /// #545). Unlike `AudioFormat`, this enum has a single string projection,
+    /// so `as_ext` is the one `Display` must agree with.
+    #[test]
+    fn test_display_equals_as_ext() {
+        for fmt in SubtitleFormat::iter() {
+            assert_eq!(
+                fmt.to_string(),
+                fmt.as_ext(),
+                "Display for {fmt:?} must equal as_ext()"
+            );
+        }
+    }
+
+    /// Promoting `vtt` from `serialize` to `to_string` must not drop `webvtt`:
+    /// strum's `FromStr` table is `serialize` **plus** `to_string` (#580).
+    #[test]
+    fn test_to_string_promotion_preserved_every_spelling() {
+        for input in ["vtt", "webvtt", "VTT", "WebVTT"] {
+            assert_eq!(
+                input.parse::<SubtitleFormat>().unwrap(),
+                SubtitleFormat::Vtt,
+                "{input} must still parse after the to_string promotion"
+            );
+        }
+    }
 
     #[test]
     fn test_display_roundtrip() {

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -45,7 +45,9 @@ impl SubtitleFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use strum::IntoEnumIterator;
+    use crate::enum_test_support::{
+        assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
+    };
 
     /// `Display` must render the file extension, not whichever strum alias
     /// happens to be longest (#580, mirroring the `ContainerFormat` guard from
@@ -53,41 +55,22 @@ mod tests {
     /// so `as_ext` is the one `Display` must agree with.
     #[test]
     fn test_display_equals_as_ext() {
-        for fmt in SubtitleFormat::iter() {
-            assert_eq!(
-                fmt.to_string(),
-                fmt.as_ext(),
-                "Display for {fmt:?} must equal as_ext()"
-            );
-        }
+        assert_display_matches::<SubtitleFormat>(|fmt| fmt.as_ext(), "as_ext()");
     }
 
     /// Promoting `vtt` from `serialize` to `to_string` must not drop `webvtt`:
     /// strum's `FromStr` table is `serialize` **plus** `to_string` (#580).
     #[test]
-    fn test_to_string_promotion_preserved_every_spelling() {
-        for input in ["vtt", "webvtt", "VTT", "WebVTT"] {
-            assert_eq!(
-                input.parse::<SubtitleFormat>().unwrap(),
-                SubtitleFormat::Vtt,
-                "{input} must still parse after the to_string promotion"
-            );
-        }
+    fn test_alias_parsing() {
+        assert_all_parse_to(&[
+            ("vtt", SubtitleFormat::Vtt),
+            ("webvtt", SubtitleFormat::Vtt),
+        ]);
     }
 
     #[test]
     fn test_display_roundtrip() {
-        for fmt in [
-            SubtitleFormat::Srt,
-            SubtitleFormat::Vtt,
-            SubtitleFormat::Ass,
-            SubtitleFormat::Ssa,
-            SubtitleFormat::Lrc,
-        ] {
-            let s = fmt.to_string();
-            let parsed: SubtitleFormat = s.parse().unwrap();
-            assert_eq!(fmt, parsed);
-        }
+        assert_display_roundtrips::<SubtitleFormat>();
     }
 
     #[test]


### PR DESCRIPTION
## Resolves

Closes #580

## What

strum resolves `Display` to the **longest** `#[strum(serialize = ...)]` spelling (ties to the last), not to any semantic projection. #545 fixed that for `ContainerFormat` and pinned it with a guard test; the two sibling enums were left unguarded:

| | `Display` (before) | correct projection |
|---|---|---|
| `AudioFormat::Eac3` | `e-ac-3` | `eac3` (`codec_name`) |
| `AudioFormat::Dts` | `dca` | `dts` (`codec_name`) |
| `SubtitleFormat::Vtt` | `webvtt` | `vtt` (`as_ext`) |

Promotes the correct spelling to `to_string` on those three variants — which takes unconditional precedence over `serialize` while leaving every existing spelling in the `FromStr` table — then pins each enum with a guard iterating `EnumIter`.

**Each enum is pinned to the projection it actually names, not a copy-pasted rule.** `AudioFormat` is a *codec* enum whose `as_ext()` deliberately returns the *container* extension the codec is carried in (`Vorbis` → `ogg`, `Alac` → `m4a`, `WavPack` → `wv`), so its guard asserts `Display == codec_name()`. Mirroring #545's `as_ext` rule onto it would demand `Vorbis` render `ogg` and contradict `codec_name()` — a test now pins that split so the next reviewer cannot "fix" it.

The second commit removes the duplication this created: the same three assertion shapes existed once per enum (`container.rs` already had all three). They collapse into a `#[cfg(test)] enum_test_support` module — the projection passed as a function, since it differs per enum. Net −83 lines across the three enum modules.

## Why it went unnoticed

Both enums' pre-existing `test_display_roundtrip` asserts `to_string().parse() == self`, which passes happily on `dca` and `webvtt` because both are valid `FromStr` inputs. The round-trip shape is structurally blind to this defect class — confirmed by mutation: with all three bugs reintroduced, the round-trip tests stay green while the new guards fail.

Both enums also hand-listed their variants instead of deriving `EnumIter`, so a new variant was silently untested. All three enums now iterate.

## Impact

**No behavior change.** A `Display`-usage sweep across all crates found no production caller for any of the three enums — every extension site uses `as_ext()`, every codec site `codec_name()`, and the `thumbnail/mod.rs` `container` params are plain `&str`. Serde/IPC is untouched: `rename_all = "lowercase"` drives `Serialize` on a codegen path independent of strum's `Display`, so the TypeScript union and `check-ts-enum-drift` gate are unaffected.

This closes the trap before a future `&str` → typed-enum refactor arms it — the same posture #545 was in before #536 would have armed it.

## Verification

- Guards verified **RED before** the fix; `Dts` by separate mutation, since the `Eac3` assertion short-circuits ahead of it.
- Guards re-verified by mutation **after** the extraction, proving the shared helper still bites: reverting `Dts`, `Vtt` and `Mkv` fails `test_display_equals_codec_name`, `test_display_equals_as_ext` and `test_display_is_the_file_extension` respectively.
- No vocabulary regression: `e-ac-3`, `e-ac3`, `dca`, `webvtt` all still parse, case-insensitively. Verified against strum 0.27.2's `get_serializations`, which unions `to_string` into the `FromStr` table rather than replacing `serialize`.
- Full gate green: `cargo fmt --check`, `cargo check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`, `cargo check -p rdlp-desktop`, `scripts/check-all.sh` (9/9).

## Reviews

- **security-reviewer — PASS, no findings** (re-run after the refactor). Independently mutation-tested all three guards against strum_macros 0.27.2 source rather than trusting the description; confirmed the helper is not vacuous, no coverage regression, no vocabulary regression, `#[cfg(test)]` module leaks nothing into production builds, serde wire format untouched.
- **code-reviewer — Approve** (re-run after the refactor). Confirmed the `Display == codec_name()` invariant choice is correct and pushed back on nothing; audited the coverage diff per enum and found nothing previously asserted now unasserted; judged the extraction genuine duplication removal rather than Lazy Element. Two findings from its first pass (an unwired helper module failing clippy, and `lib.rs` module ordering) are fixed; its `Copy`-bound nit and a line-count slip in the commit message are also fixed.

`Display` for these enums is now correct-by-test rather than correct-by-accident.
