### PR TITLE
fix(config): make the config file and the CLI accept the same format vocabulary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,20 @@ jobs:
         # decays into an unchecked claim as the matcher evolves.
         run: bash scripts/check-no-dir-sweep-delete.sh --self-test
 
+      - name: Check CLI arguments reject blank values
+        # #540: a blank value reaches the domain layer looking like a real one --
+        # `--recode-audio=` became `Encoder { name: "" }` and failed inside
+        # FFmpeg after the download completed. clap has no built-in for this and
+        # applies value_parser per field, so the risk is the next argument
+        # silently omitting the rule.
+        run: bash scripts/check-arg-blank-validation.sh
+
+      - name: Verify the blank-value gate still fires
+        # Same reasoning as the dir-sweep canary: the matcher must be proven to
+        # flag an unvalidated argument, and to STOP on a field type it cannot
+        # classify rather than skipping it and reporting OK.
+        run: bash scripts/check-arg-blank-validation.sh --self-test
+
       - name: Install semgrep
         run: pipx install semgrep || pip install semgrep
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6374,6 +6374,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with",
  "strum",
  "strum_macros",
  "toml 0.9.12+spec-1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -140,15 +140,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -315,7 +315,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -491,7 +491,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -793,7 +793,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -995,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1017,14 +1017,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1505,7 +1505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1515,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1551,7 +1551,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1585,7 +1585,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1598,7 +1598,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1609,7 +1609,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1620,7 +1620,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1720,7 +1720,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1751,7 +1751,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1761,7 +1761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1774,7 +1774,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1796,7 +1796,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1879,7 +1879,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1902,7 +1902,7 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1967,7 +1967,7 @@ checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2148,7 +2148,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2168,7 +2168,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2534,7 +2534,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2776,7 +2776,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2866,7 +2866,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2981,7 +2981,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3693,7 +3693,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3718,7 +3718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3867,7 +3867,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4156,7 +4156,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4462,7 +4462,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4850,7 +4850,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5218,7 +5218,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5231,7 +5231,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5287,7 +5287,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5475,7 +5475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5558,7 +5558,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5620,7 +5620,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -5634,7 +5634,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5669,7 +5669,7 @@ checksum = "7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5799,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -6449,7 +6449,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6860,7 +6860,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7032,7 +7032,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7043,7 +7043,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7087,7 +7087,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7148,7 +7148,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7170,7 +7170,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7329,7 +7329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7461,7 +7461,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7626,7 +7626,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7659,9 +7659,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7685,7 +7685,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7765,7 +7765,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7877,7 +7877,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.116",
+ "syn 2.0.119",
  "tauri-utils",
  "thiserror 2.0.18",
  "time",
@@ -7895,7 +7895,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -8173,7 +8173,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8184,7 +8184,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8274,7 +8274,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8312,7 +8312,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8570,7 +8570,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8620,7 +8620,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8668,7 +8668,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9041,7 +9041,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -9265,7 +9265,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser 0.224.1",
@@ -9392,7 +9392,7 @@ checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9587,7 +9587,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9741,7 +9741,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9752,7 +9752,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10143,7 +10143,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.116",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -10159,7 +10159,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -10398,7 +10398,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -10446,7 +10446,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -10480,7 +10480,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10500,7 +10500,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -10521,7 +10521,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10555,7 +10555,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10615,7 +10615,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
@@ -10628,6 +10628,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.116",
+ "syn 2.0.119",
  "winnow 0.7.14",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ backon = { version = "1.6", features = ["tokio-sleep"] }
 boa_engine = "0.21"
 
 # CLI
-clap = { version = "4.5", features = ["derive", "cargo"] }
+clap = { version = "4.6", features = ["derive", "cargo"] }
 indicatif = "0.18.3"
 inquire = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ url = "2.5"
 scraper = "0.25"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# `DeserializeFromStr` lets the format enums derive Deserialize from their strum
+# `FromStr`, so the config file and the CLI cannot accept different vocabularies
+# (#540). Already in the tree transitively via dash-mpd/sigstore/tauri-utils.
+serde_with = { version = "3.18", default-features = false, features = ["macros"] }
 m3u8-rs = "6.0"  # HLS playlist parser
 dash-mpd = { version = "0.20", default-features = false }  # DASH MPD parser
 

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -213,12 +213,13 @@ pub struct Args {
     /// (e.g., libopus, aac, libmp3lame).
     /// `copy` copies audio unchanged; `auto` selects the best encoder for the
     /// target container; any other value is treated as an explicit encoder name.
-    ///
-    /// Omitted means "not specified on the command line", so a `recode_audio`
-    /// set in the config file survives. Carrying a clap `default_value` here
-    /// instead made the default indistinguishable from an explicit `copy`, and
-    /// the unconditional assignment downstream silently discarded the config
-    /// file's value on every run (#540).
+    //
+    // Deliberately no clap `default_value`: absent must mean "not specified on
+    // the command line" so a `recode_audio` set in the config file survives. A
+    // default made that indistinguishable from an explicit `copy`, and the
+    // unconditional assignment downstream then discarded the config value on
+    // every run (#540). Plain `//` — a `///` here would print this note in
+    // `rdlp --help`.
     #[arg(long, value_name = "MODE")]
     pub recode_audio: Option<String>,
 

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -213,8 +213,14 @@ pub struct Args {
     /// (e.g., libopus, aac, libmp3lame).
     /// `copy` copies audio unchanged; `auto` selects the best encoder for the
     /// target container; any other value is treated as an explicit encoder name.
-    #[arg(long, value_name = "MODE", default_value = "copy")]
-    pub recode_audio: String,
+    ///
+    /// Omitted means "not specified on the command line", so a `recode_audio`
+    /// set in the config file survives. Carrying a clap `default_value` here
+    /// instead made the default indistinguishable from an explicit `copy`, and
+    /// the unconditional assignment downstream silently discarded the config
+    /// file's value on every run (#540).
+    #[arg(long, value_name = "MODE")]
+    pub recode_audio: Option<String>,
 
     // Help text hardcodes the bounds: keep `1-64` in sync with
     // `rdlp_types::config::MAX_RECODE_THREADS` and `8` in sync with

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -6,6 +6,43 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+/// Rejects an empty or whitespace-only argument value.
+///
+/// The shared rule behind [`non_blank`] and [`non_blank_path`]. A blank value
+/// otherwise reaches the domain layer looking like a real one: `--recode-audio=`
+/// became `RecodeAudioMode::Encoder { name: "" }` and failed inside `FFmpeg`
+/// after the download had already completed (#540).
+///
+/// clap's own [`NonEmptyStringValueParser`] is not enough — it tests
+/// `OsStr::is_empty()` only, so `--flag="   "` passes straight through it.
+///
+/// [`NonEmptyStringValueParser`]: clap::builder::NonEmptyStringValueParser
+fn reject_blank(value: &str) -> Result<&str, String> {
+    if value.trim().is_empty() {
+        Err("value must not be empty or whitespace-only".to_owned())
+    } else {
+        Ok(value)
+    }
+}
+
+/// `value_parser` for string-valued arguments.
+///
+/// A bare `Fn(&str) -> Result<T, E>` is itself a `TypedValueParser` (clap's
+/// blanket impl), so this needs no wrapper type. Rejections travel through
+/// `Error::value_validation`, which renders the flag name, the offending value
+/// and the usage line — context a post-parse check cannot recover.
+fn non_blank(value: &str) -> Result<String, String> {
+    reject_blank(value).map(ToOwned::to_owned)
+}
+
+/// `value_parser` for path-valued arguments.
+///
+/// Same rule as [`non_blank`], typed for the `PathBuf` args — a blank path is
+/// no more meaningful than a blank string.
+fn non_blank_path(value: &str) -> Result<PathBuf, String> {
+    reject_blank(value).map(PathBuf::from)
+}
+
 /// Plugin management subcommands.
 #[derive(Subcommand, Debug)]
 pub enum PluginCmd {
@@ -14,35 +51,41 @@ pub enum PluginCmd {
     /// Show details for a specific plugin.
     Info {
         /// Plugin name.
+        #[arg(value_parser = non_blank)]
         name: String,
     },
     /// Accept a new identity for an already-installed plugin (use after the
     /// publisher legitimately rotated their signing key).
     Retrust {
         /// Plugin name.
+        #[arg(value_parser = non_blank)]
         name: String,
     },
     /// Disable a plugin for future runs (writes to disabled list).
     Disable {
         /// Plugin name.
+        #[arg(value_parser = non_blank)]
         name: String,
     },
     /// Re-enable a previously disabled plugin.
     Enable {
         /// Plugin name.
+        #[arg(value_parser = non_blank)]
         name: String,
     },
     /// Remove a plugin entirely (deletes the plugin directory + trust entry).
     Uninstall {
         /// Plugin name.
+        #[arg(value_parser = non_blank)]
         name: String,
     },
     /// Build a `.wasm` plugin from a yt-dlp-style Python extractor.
     BuildFromYtdlp {
         /// Path to the yt-dlp extractor .py file.
+        #[arg(value_parser = non_blank_path)]
         plugin_py: std::path::PathBuf,
         /// Output directory (defaults to the parent of `plugin_py`).
-        #[arg(short = 'o', long)]
+        #[arg(short = 'o', long, value_parser = non_blank_path)]
         output_dir: Option<std::path::PathBuf>,
     },
 }
@@ -57,6 +100,7 @@ pub enum PluginCmd {
 #[command(version)]
 pub struct Args {
     /// Video URL to download
+    #[arg(value_parser = non_blank)]
     pub url: Option<String>,
 
     /// Output template or directory (e.g., "%(title)s.%(ext)s" or "./downloads/")
@@ -65,15 +109,15 @@ pub struct Args {
     /// `%(epoch)s` render a different name each run, so an interrupted download cannot
     /// be resumed and restarts from zero. Build the template from stable metadata
     /// (`title`, `id`, `uploader`, `ext`, `upload_date`) for resumable downloads.
-    #[arg(short, long)]
+    #[arg(short, long, value_parser = non_blank)]
     pub output: Option<String>,
 
     /// Output directory (always sets base directory, combinable with -o template)
-    #[arg(short = 'P', long = "paths")]
+    #[arg(short = 'P', long = "paths", value_parser = non_blank_path)]
     pub output_dir: Option<PathBuf>,
 
     /// Format selection (e.g., "best", "bestvideo+bestaudio")
-    #[arg(short, long)]
+    #[arg(short, long, value_parser = non_blank)]
     pub format: Option<String>,
 
     /// Require strict video-only + audio-only streams for merge.
@@ -115,7 +159,7 @@ pub struct Args {
 
     /// Print specific field(s) from metadata (no download)
     /// e.g., --print title or --print "id,title,extractor"
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub print: Option<String>,
 
     /// Interactive format selection
@@ -129,11 +173,11 @@ pub struct Args {
 
     /// Audio format for extraction
     /// Use --audio-format for interactive, --audio-format=mp3 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank)]
     pub audio_format: Option<String>,
 
     /// Audio quality (VBR level 0-9 or bitrate like "192K")
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub audio_quality: Option<String>,
 
     /// Embed metadata (title, artist, etc.) in the file
@@ -159,11 +203,11 @@ pub struct Args {
 
     /// Subtitle languages to download (comma-separated, e.g., "en,es")
     /// Use "all" to download all available
-    #[arg(long, alias = "sub-langs")]
+    #[arg(long, alias = "sub-langs", value_parser = non_blank)]
     pub sub_langs: Option<String>,
 
     /// Preferred subtitle format (srt, vtt, ass, ssa, lrc)
-    #[arg(long, alias = "sub-format")]
+    #[arg(long, alias = "sub-format", value_parser = non_blank)]
     pub sub_format: Option<String>,
 
     /// Embed subtitles in video file (requires `FFmpeg`)
@@ -192,7 +236,7 @@ pub struct Args {
 
     /// Video encoder to use (e.g., libsvtav1, libx264).
     /// Overrides automatic encoder selection.
-    #[arg(long, value_name = "NAME")]
+    #[arg(long, value_name = "NAME", value_parser = non_blank)]
     pub video_encoder: Option<String>,
 
     /// List available video encoders and exit.
@@ -201,12 +245,12 @@ pub struct Args {
 
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank)]
     pub recode_video: Option<String>,
 
     /// Target container format for video recode (e.g., mp4, mkv, webm).
     /// Takes precedence over --recode-video when both are specified.
-    #[arg(long, value_name = "FMT")]
+    #[arg(long, value_name = "FMT", value_parser = non_blank)]
     pub recode_container: Option<String>,
 
     /// Audio mode during video recode: copy (default), auto, or an encoder name
@@ -220,7 +264,7 @@ pub struct Args {
     // unconditional assignment downstream then discarded the config value on
     // every run (#540). Plain `//` — a `///` here would print this note in
     // `rdlp --help`.
-    #[arg(long, value_name = "MODE")]
+    #[arg(long, value_name = "MODE", value_parser = non_blank)]
     pub recode_audio: Option<String>,
 
     // Help text hardcodes the bounds: keep `1-64` in sync with
@@ -232,11 +276,11 @@ pub struct Args {
 
     /// Encoder preset override for video recode (e.g. `faster`, `medium`, `slow`).
     /// Omit to use the per-codec default. `libvvenc`: try `faster` for speed.
-    #[arg(long, value_name = "PRESET")]
+    #[arg(long, value_name = "PRESET", value_parser = non_blank)]
     pub recode_preset: Option<String>,
 
     /// libvpx deadline for VP8/VP9 recode: best | good | realtime.
-    #[arg(long, value_name = "MODE")]
+    #[arg(long, value_name = "MODE", value_parser = non_blank)]
     pub recode_deadline: Option<String>,
 
     /// libvpx cpu-used for VP8/VP9 recode (VP9: -8..8, VP8: -16..16).
@@ -249,7 +293,7 @@ pub struct Args {
 
     /// Remux to container for better seeking - no re-encoding
     /// Use --remux for interactive, --remux=mp4 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank)]
     pub remux: Option<String>,
 
     /// Normalize audio levels (peak mode: volume + limiter)
@@ -265,7 +309,7 @@ pub struct Args {
     pub audio_gain_target: Option<f64>,
 
     /// Loudnorm preset: broadcast (-23 LUFS), streaming (-14 LUFS), loud (-11 LUFS)
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub loudnorm_preset: Option<String>,
 
     /// Target integrated loudness in LUFS for loudnorm (e.g., -14)
@@ -298,7 +342,7 @@ pub struct Args {
     pub normalize_boost_db: Option<f64>,
 
     /// Fixup policy: never, warn, `detect_or_warn` (default: `detect_or_warn`)
-    #[arg(long, default_value = "detect_or_warn")]
+    #[arg(long, default_value = "detect_or_warn", value_parser = non_blank)]
     pub fixup: String,
 
     /// Keep original video file after post-processing
@@ -306,12 +350,12 @@ pub struct Args {
     pub keep_video: bool,
 
     /// Path to `FFmpeg` executable (if not in PATH)
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank_path)]
     pub ffmpeg_location: Option<PathBuf>,
 
     // === Network options ===
     /// HTTP/HTTPS/SOCKS proxy URL (e.g., <socks5://127.0.0.1:1080>)
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub proxy: Option<String>,
 
     /// Connect/handshake timeout in seconds.
@@ -347,42 +391,42 @@ pub struct Args {
     /// identifier like chrome-137). Controls JA4 / JA4H fingerprint.
     /// Falls back to the `RDLP_BROWSER_EMULATION` env var, then
     /// `ChromeLatest`.
-    #[arg(long, value_name = "PROFILE")]
+    #[arg(long, value_name = "PROFILE", value_parser = non_blank)]
     pub browser: Option<String>,
 
     /// Limit download speed (e.g., "1M", "500K", "10M", "2.5M")
-    #[arg(long, short = 'r')]
+    #[arg(long, short = 'r', value_parser = non_blank)]
     pub limit_rate: Option<String>,
 
     // === Cookie options ===
     /// Load cookies from browser (chrome, firefox)
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub cookies_from_browser: Option<String>,
 
     /// Path to Netscape-format cookies file
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank_path)]
     pub cookies: Option<PathBuf>,
 
     /// Path to download archive file (skip already-downloaded videos)
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank_path)]
     pub download_archive: Option<PathBuf>,
 
     /// Filter videos by metadata (yt-dlp syntax). Repeatable (OR logic between filters).
     /// Examples: "duration > 60", "!`is_live`", "title *= cats", "`like_count` >? 100"
-    #[arg(long = "match-filter", action = clap::ArgAction::Append)]
+    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank)]
     pub match_filter: Vec<String>,
 
     // === Search options ===
     /// Perform a keyword search instead of downloading a URL
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub search: Option<String>,
 
     /// Site to search (required with --search, e.g., "xhamster")
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank)]
     pub search_site: Option<String>,
 
     /// Search filter in key=value format (repeatable)
-    #[arg(long = "search-filter")]
+    #[arg(long = "search-filter", value_parser = non_blank)]
     pub search_filter: Vec<String>,
 
     // === Config file options ===
@@ -391,14 +435,14 @@ pub struct Args {
     pub ignore_config: bool,
 
     /// Path to config file (TOML format)
-    #[arg(long)]
+    #[arg(long, value_parser = non_blank_path)]
     pub config_location: Option<PathBuf>,
 
     // === Plugin options ===
     /// Pre-trust a publisher identity for non-interactive plugin install.
     /// Pass repeatedly for multiple identities.
     /// Format: `sigstore:github:user/repo` or `ed25519:<8-byte-hex>`.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, value_parser = non_blank)]
     pub trust_publisher: Vec<String>,
 
     /// Plugin management subcommand.

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -70,6 +70,27 @@ fn resolve_interactive_values(args: &Args) -> Result<ResolvedInteractiveValues> 
     })
 }
 
+/// Merge an optional CLI arg into config, leaving the config-file value intact
+/// when the flag was not passed.
+///
+/// An omitted flag is `None`, so assigning it unconditionally writes `None` over
+/// whatever the config file set — silently discarding the user's value. That is
+/// exactly what `recode_cpu_used` and `recode_speed_level` did before #540,
+/// while their neighbours hand-wrote the correct `if let Some(..)` guard. This
+/// macro exists so the correct behaviour is the shorter thing to write.
+macro_rules! merge_opt {
+    ($config:expr, $args:expr, $field:ident) => {
+        if let Some(value) = $args.$field.clone() {
+            $config.$field = Some(value);
+        }
+    };
+    ($config:expr, $args:expr, postprocess.$field:ident) => {
+        if let Some(value) = $args.$field.clone() {
+            $config.postprocess.$field = Some(value);
+        }
+    };
+}
+
 /// Merge a boolean CLI flag into config (sets to true if flag is set).
 macro_rules! merge_bool {
     ($config:expr, $args:expr, $field:ident) => {
@@ -212,12 +233,8 @@ pub fn merge_config(
         );
     }
 
-    if let Some(threads) = args.recode_threads {
-        config.postprocess.recode_threads = Some(threads);
-    }
-    if let Some(ref preset) = args.recode_preset {
-        config.postprocess.recode_preset = Some(preset.clone());
-    }
+    merge_opt!(config, args, postprocess.recode_threads);
+    merge_opt!(config, args, postprocess.recode_preset);
     if let Some(ref deadline) = args.recode_deadline {
         config.postprocess.recode_deadline = Some(
             deadline
@@ -225,29 +242,15 @@ pub fn merge_config(
                 .map_err(|e| anyhow::anyhow!("invalid --recode-deadline: {e}"))?,
         );
     }
-    config.postprocess.recode_cpu_used = args.recode_cpu_used;
-    config.postprocess.recode_speed_level = args.recode_speed_level;
+    merge_opt!(config, args, postprocess.recode_cpu_used);
+    merge_opt!(config, args, postprocess.recode_speed_level);
 
-    // recode_audio: "copy", "auto", or an encoder name.
-    //
-    // The two mode keywords are matched case-insensitively, like every
-    // neighbouring format flag (which get it from `#[strum(ascii_case_insensitive)]`).
-    // Before #540 this was case-sensitive, so `--recode-audio=COPY` fell through
-    // to the encoder arm and failed much later inside FFmpeg with a confusing
-    // "unknown encoder" error.
-    //
-    // The encoder name itself is NOT case-folded: FFmpeg matches encoder names
-    // exactly, so `libOpus` must reach it unchanged.
-    let recode_audio = &args.recode_audio;
-    config.postprocess.recode_audio = if recode_audio.eq_ignore_ascii_case("copy") {
-        RecodeAudioMode::Copy
-    } else if recode_audio.eq_ignore_ascii_case("auto") {
-        RecodeAudioMode::Auto
-    } else {
-        RecodeAudioMode::Encoder {
-            name: recode_audio.clone(),
-        }
-    };
+    // Assigned only when the flag is present, so a `recode_audio` set in the
+    // config file survives an invocation that does not mention it (#540). The
+    // vocabulary itself is `RecodeAudioMode`'s to define, not the CLI's.
+    if let Some(recode_audio) = &args.recode_audio {
+        config.postprocess.recode_audio = RecodeAudioMode::from(recode_audio.as_str());
+    }
 
     // Audio normalization: --normalize-boost / --normalize-boost-db implies --loudnorm
     // implies --normalize-audio

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -228,16 +228,26 @@ pub fn merge_config(
     config.postprocess.recode_cpu_used = args.recode_cpu_used;
     config.postprocess.recode_speed_level = args.recode_speed_level;
 
-    // recode_audio: "copy", "auto", or an encoder name
-    match args.recode_audio.as_str() {
-        "copy" => config.postprocess.recode_audio = RecodeAudioMode::Copy,
-        "auto" => config.postprocess.recode_audio = RecodeAudioMode::Auto,
-        name => {
-            config.postprocess.recode_audio = RecodeAudioMode::Encoder {
-                name: name.to_string(),
-            };
+    // recode_audio: "copy", "auto", or an encoder name.
+    //
+    // The two mode keywords are matched case-insensitively, like every
+    // neighbouring format flag (which get it from `#[strum(ascii_case_insensitive)]`).
+    // Before #540 this was case-sensitive, so `--recode-audio=COPY` fell through
+    // to the encoder arm and failed much later inside FFmpeg with a confusing
+    // "unknown encoder" error.
+    //
+    // The encoder name itself is NOT case-folded: FFmpeg matches encoder names
+    // exactly, so `libOpus` must reach it unchanged.
+    let recode_audio = &args.recode_audio;
+    config.postprocess.recode_audio = if recode_audio.eq_ignore_ascii_case("copy") {
+        RecodeAudioMode::Copy
+    } else if recode_audio.eq_ignore_ascii_case("auto") {
+        RecodeAudioMode::Auto
+    } else {
+        RecodeAudioMode::Encoder {
+            name: recode_audio.clone(),
         }
-    }
+    };
 
     // Audio normalization: --normalize-boost / --normalize-boost-db implies --loudnorm
     // implies --normalize-audio

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -249,6 +249,13 @@ pub fn merge_config(
     // config file survives an invocation that does not mention it (#540). The
     // vocabulary itself is `RecodeAudioMode`'s to define, not the CLI's.
     if let Some(recode_audio) = &args.recode_audio {
+        // An empty value would become `Encoder { name: "" }` and fail inside
+        // FFmpeg long after the download finished. Reject it here, where the
+        // message can name the flag.
+        anyhow::ensure!(
+            !recode_audio.trim().is_empty(),
+            "--recode-audio requires a value: copy, auto, or an FFmpeg encoder name"
+        );
         config.postprocess.recode_audio = RecodeAudioMode::from(recode_audio.as_str());
     }
 
@@ -308,21 +315,11 @@ pub fn merge_config(
             .map_err(|e| anyhow::anyhow!("--proxy validation failed: {e}"))?;
         config.proxy = Some(proxy.clone());
     }
-    if let Some(secs) = args.socket_timeout {
-        config.socket_timeout = Some(secs);
-    }
-    if let Some(secs) = args.read_timeout {
-        config.read_timeout = Some(secs);
-    }
-    if let Some(secs) = args.pool_idle_timeout {
-        config.pool_idle_timeout = Some(secs);
-    }
-    if let Some(secs) = args.download_timeout {
-        config.download_timeout = Some(secs);
-    }
-    if let Some(secs) = args.merge_timeout {
-        config.merge_timeout = Some(secs);
-    }
+    merge_opt!(config, args, socket_timeout);
+    merge_opt!(config, args, read_timeout);
+    merge_opt!(config, args, pool_idle_timeout);
+    merge_opt!(config, args, download_timeout);
+    merge_opt!(config, args, merge_timeout);
     // Browser emulation: CLI flag > env var > default (ChromeLatest).
     if let Some(ref cli_browser) = args.browser {
         config.browser_emulation = parse_browser_emulation(cli_browser);

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -249,13 +249,6 @@ pub fn merge_config(
     // config file survives an invocation that does not mention it (#540). The
     // vocabulary itself is `RecodeAudioMode`'s to define, not the CLI's.
     if let Some(recode_audio) = &args.recode_audio {
-        // An empty value would become `Encoder { name: "" }` and fail inside
-        // FFmpeg long after the download finished. Reject it here, where the
-        // message can name the flag.
-        anyhow::ensure!(
-            !recode_audio.trim().is_empty(),
-            "--recode-audio requires a value: copy, auto, or an FFmpeg encoder name"
-        );
         config.postprocess.recode_audio = RecodeAudioMode::from(recode_audio.as_str());
     }
 

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -958,3 +958,23 @@ fn test_merge_config_optional_args_still_override_when_passed() {
     assert_eq!(merged.postprocess.recode_cpu_used, Some(-8));
     assert_eq!(merged.postprocess.recode_speed_level, Some(7));
 }
+
+/// An empty `--recode-audio=` must fail at parse time, not inside `FFmpeg`.
+///
+/// It would otherwise become `Encoder { name: "" }` and surface much later as
+/// an "unknown encoder" failure after the download completed — the same
+/// late-failure mode that made `--recode-audio=COPY` confusing (#540).
+#[test]
+fn test_merge_config_rejects_empty_recode_audio() {
+    for empty in ["", "   ", "\t"] {
+        let mut args = default_args();
+        args.recode_audio = Some(empty.to_string());
+        let err = merge_config(&args, Config::default(), no_interactive())
+            .expect_err("an empty --recode-audio must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--recode-audio"),
+            "the error must name the flag so the user knows what to fix; got: {msg}"
+        );
+    }
+}

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -69,7 +69,7 @@ fn default_args() -> Args {
         video_encoder: None,
         list_encoders: false,
         recode_container: None,
-        recode_audio: "copy".to_string(),
+        recode_audio: None,
         recode_threads: None,
         recode_preset: None,
         recode_deadline: None,
@@ -809,7 +809,7 @@ fn negative_cpu_used_parses_both_forms() {
 fn test_merge_config_recode_audio_mode_is_case_insensitive() {
     for spelling in ["copy", "COPY", "Copy", "cOpY"] {
         let mut args = default_args();
-        args.recode_audio = spelling.to_string();
+        args.recode_audio = Some(spelling.to_string());
         let config =
             merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
         assert_eq!(
@@ -821,7 +821,7 @@ fn test_merge_config_recode_audio_mode_is_case_insensitive() {
 
     for spelling in ["auto", "AUTO", "Auto"] {
         let mut args = default_args();
-        args.recode_audio = spelling.to_string();
+        args.recode_audio = Some(spelling.to_string());
         let config =
             merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
         assert_eq!(
@@ -837,7 +837,7 @@ fn test_merge_config_recode_audio_mode_is_case_insensitive() {
 #[test]
 fn test_merge_config_recode_audio_encoder_name_preserved() {
     let mut args = default_args();
-    args.recode_audio = "libOpus".to_string();
+    args.recode_audio = Some("libOpus".to_string());
     let config =
         merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
     assert_eq!(
@@ -847,4 +847,114 @@ fn test_merge_config_recode_audio_encoder_name_preserved() {
         },
         "encoder names are passed to FFmpeg verbatim and must not be lowercased"
     );
+}
+
+/// A `recode_audio` set in `config.toml` must survive when the flag is omitted.
+///
+/// The arg carried `default_value = "copy"` and was assigned unconditionally,
+/// so the clap default silently overwrote the config file's value on every run
+/// — the user's setting was discarded with no error. The adjacent `fixup` arg
+/// avoids this by guarding on its default; this one did not (#540).
+#[test]
+fn test_merge_config_file_recode_audio_survives_when_flag_omitted() {
+    let args = default_args(); // no --recode-audio passed
+    let mut file_config = Config::default();
+    file_config.postprocess.recode_audio = RecodeAudioMode::Encoder {
+        name: "libopus".to_string(),
+    };
+
+    let merged = merge_config(&args, file_config, no_interactive()).expect("merge should succeed");
+
+    assert_eq!(
+        merged.postprocess.recode_audio,
+        RecodeAudioMode::Encoder {
+            name: "libopus".to_string()
+        },
+        "config.toml's recode_audio must not be clobbered by the CLI default"
+    );
+}
+
+/// The flag must still win when it IS passed — including when the user
+/// explicitly asks for the same value as the old default.
+///
+/// A naive `if args.recode_audio != "copy"` guard would fix the clobber but
+/// break this: an explicit `--recode-audio=copy` would be indistinguishable
+/// from the default and the config file would wrongly win.
+#[test]
+fn test_merge_config_explicit_recode_audio_overrides_file() {
+    let mut file_config = Config::default();
+    file_config.postprocess.recode_audio = RecodeAudioMode::Encoder {
+        name: "libopus".to_string(),
+    };
+
+    let mut args = default_args();
+    args.recode_audio = Some("copy".to_string());
+    let merged =
+        merge_config(&args, file_config.clone(), no_interactive()).expect("merge should succeed");
+    assert_eq!(
+        merged.postprocess.recode_audio,
+        RecodeAudioMode::Copy,
+        "an explicit --recode-audio=copy must override the config file"
+    );
+
+    let mut args = default_args();
+    args.recode_audio = Some("libfdk_aac".to_string());
+    let merged = merge_config(&args, file_config, no_interactive()).expect("merge should succeed");
+    assert_eq!(
+        merged.postprocess.recode_audio,
+        RecodeAudioMode::Encoder {
+            name: "libfdk_aac".to_string()
+        },
+        "an explicit encoder must override the config file"
+    );
+}
+
+/// Optional CLI args must not overwrite config-file values when omitted.
+///
+/// `recode_cpu_used` and `recode_speed_level` were assigned unconditionally, so
+/// running with no flags wrote `None` over whatever the config file had set —
+/// silently discarding the user's tuning. Their immediate neighbours
+/// (`recode_threads`, `recode_preset`) guard correctly, which is what made the
+/// omission easy to miss (#540).
+#[test]
+fn test_merge_config_optional_args_do_not_clobber_config_file() {
+    let args = default_args(); // no flags passed
+    let mut file_config = Config::default();
+    file_config.postprocess.recode_cpu_used = Some(4);
+    file_config.postprocess.recode_speed_level = Some(3);
+    file_config.postprocess.recode_threads = Some(8);
+    file_config.postprocess.recode_preset = Some("slow".to_string());
+
+    let merged = merge_config(&args, file_config, no_interactive()).expect("merge should succeed");
+
+    assert_eq!(
+        merged.postprocess.recode_cpu_used,
+        Some(4),
+        "config.toml's recode_cpu_used must survive an invocation without the flag"
+    );
+    assert_eq!(
+        merged.postprocess.recode_speed_level,
+        Some(3),
+        "config.toml's recode_speed_level must survive an invocation without the flag"
+    );
+    assert_eq!(merged.postprocess.recode_threads, Some(8));
+    assert_eq!(merged.postprocess.recode_preset, Some("slow".to_string()));
+}
+
+/// The flag must still win when passed — the guard must not make config-file
+/// values sticky.
+#[test]
+fn test_merge_config_optional_args_still_override_when_passed() {
+    let mut file_config = Config::default();
+    file_config.postprocess.recode_cpu_used = Some(4);
+    file_config.postprocess.recode_speed_level = Some(3);
+
+    let mut args = default_args();
+    args.recode_cpu_used = Some(-8);
+    args.recode_speed_level = Some(7);
+
+    let merged = merge_config(&args, file_config, no_interactive()).expect("merge should succeed");
+
+    assert_eq!(merged.postprocess.recode_cpu_used, Some(-8));
+    assert_eq!(merged.postprocess.recode_speed_level, Some(7));
 }

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -959,22 +959,138 @@ fn test_merge_config_optional_args_still_override_when_passed() {
     assert_eq!(merged.postprocess.recode_speed_level, Some(7));
 }
 
-/// An empty `--recode-audio=` must fail at parse time, not inside `FFmpeg`.
+/// Empty and whitespace-only values are rejected by clap, for every string- and
+/// path-valued arg — not just the one where the problem was first noticed.
 ///
-/// It would otherwise become `Encoder { name: "" }` and surface much later as
-/// an "unknown encoder" failure after the download completed — the same
-/// late-failure mode that made `--recode-audio=COPY` confusing (#540).
+/// A blank value otherwise reaches the domain layer as a real-looking value:
+/// `--recode-audio=` became `Encoder { name: "" }` and failed inside `FFmpeg`
+/// after the download completed. Validating at the parse boundary means clap
+/// reports it with the flag name, the offending value and usage text (#540).
 #[test]
-fn test_merge_config_rejects_empty_recode_audio() {
-    for empty in ["", "   ", "\t"] {
-        let mut args = default_args();
-        args.recode_audio = Some(empty.to_string());
-        let err = merge_config(&args, Config::default(), no_interactive())
-            .expect_err("an empty --recode-audio must be rejected");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("--recode-audio"),
-            "the error must name the flag so the user knows what to fix; got: {msg}"
+fn test_blank_values_are_rejected_at_the_parse_boundary() {
+    use clap::Parser;
+
+    let blank_forms = ["", "   ", "\t"];
+    let string_flags = [
+        "--recode-audio",
+        "--format",
+        "--output",
+        "--audio-quality",
+        "--sub-langs",
+        "--video-encoder",
+        "--recode-preset",
+        "--proxy",
+        "--limit-rate",
+        "--search",
+    ];
+    for flag in string_flags {
+        for blank in blank_forms {
+            let result = Args::try_parse_from(["rdlp", &format!("{flag}={blank}"), "URL"]);
+            assert!(
+                result.is_err(),
+                "{flag}={blank:?} must be rejected at parse time"
+            );
+        }
+    }
+
+    // Path-valued args need the same rule — a blank path is equally meaningless.
+    for flag in ["--cookies", "--download-archive", "--ffmpeg-location", "-P"] {
+        for blank in blank_forms {
+            let result = Args::try_parse_from(["rdlp", &format!("{flag}={blank}"), "URL"]);
+            assert!(
+                result.is_err(),
+                "{flag}={blank:?} must be rejected at parse time"
+            );
+        }
+    }
+}
+
+/// The rejection must name the flag and the offending value, which is what
+/// clap's `ValueValidation` error shape provides.
+#[test]
+fn test_blank_rejection_message_names_flag_and_value() {
+    use clap::Parser;
+
+    let Err(err) = Args::try_parse_from(["rdlp", "--recode-audio=   ", "URL"]) else {
+        panic!("blank must be rejected");
+    };
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("--recode-audio"),
+        "must name the flag; got: {rendered}"
+    );
+    assert!(
+        rendered.contains("empty or whitespace-only"),
+        "must explain what was wrong; got: {rendered}"
+    );
+}
+
+/// Ordinary values must still parse — the guard must not reject real input.
+#[test]
+fn test_non_blank_values_still_parse() {
+    use clap::Parser;
+
+    let Ok(args) = Args::try_parse_from([
+        "rdlp",
+        "--recode-audio=libOpus",
+        "--format=bv+ba",
+        "--cookies=/tmp/c.txt",
+        "URL",
+    ]) else {
+        panic!("ordinary values must parse");
+    };
+    assert_eq!(args.recode_audio.as_deref(), Some("libOpus"));
+    assert_eq!(args.format.as_deref(), Some("bv+ba"));
+}
+
+/// The bare-flag forms must survive the blank-value parser.
+///
+/// `--audio-format`, `--recode-video` and `--remux` use
+/// `default_missing_value = "interactive"`, so the value clap substitutes also
+/// flows through `value_parser`. That value is non-blank, but the interaction
+/// is worth pinning: breaking it would silently disable interactive selection.
+#[test]
+fn test_bare_interactive_flags_still_parse() {
+    use clap::Parser;
+
+    for (flag, get) in [
+        ("--audio-format", 0usize),
+        ("--recode-video", 1),
+        ("--remux", 2),
+    ] {
+        let Ok(args) = Args::try_parse_from(["rdlp", flag, "URL"]) else {
+            panic!("{flag} with no value must still parse");
+        };
+        let actual = match get {
+            0 => args.audio_format.clone(),
+            1 => args.recode_video.clone(),
+            _ => args.remux.clone(),
+        };
+        assert_eq!(
+            actual.as_deref(),
+            Some("interactive"),
+            "{flag} with no value must yield the interactive sentinel"
         );
+    }
+}
+
+/// The same three flags must still REJECT an explicitly blank value.
+///
+/// `require_equals` + `default_missing_value` means bare `--remux` and
+/// `--remux=` take different paths through clap: the first substitutes the
+/// sentinel, the second supplies an empty value that must reach the parser.
+/// Pinning only the bare form would leave the rejection untested.
+#[test]
+fn test_interactive_flags_still_reject_an_explicit_blank() {
+    use clap::Parser;
+
+    for flag in ["--audio-format", "--recode-video", "--remux"] {
+        for blank in ["", "   "] {
+            let result = Args::try_parse_from(["rdlp", &format!("{flag}={blank}"), "URL"]);
+            assert!(
+                result.is_err(),
+                "{flag}={blank:?} must be rejected even though the bare flag is valid"
+            );
+        }
     }
 }

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -797,3 +797,54 @@ fn negative_cpu_used_parses_both_forms() {
         Some(-8)
     );
 }
+
+/// `--recode-audio` must accept `copy`/`auto` in any case, like every
+/// neighbouring format flag (#540).
+///
+/// Before the fix the match was case-sensitive, so `--recode-audio=COPY`
+/// silently became `RecodeAudioMode::Encoder { name: "COPY" }` and failed much
+/// later inside `FFmpeg` with a confusing "unknown encoder" error, rather than
+/// being recognised as the stream-copy mode the user asked for.
+#[test]
+fn test_merge_config_recode_audio_mode_is_case_insensitive() {
+    for spelling in ["copy", "COPY", "Copy", "cOpY"] {
+        let mut args = default_args();
+        args.recode_audio = spelling.to_string();
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+        assert_eq!(
+            config.postprocess.recode_audio,
+            RecodeAudioMode::Copy,
+            "--recode-audio={spelling} must mean Copy"
+        );
+    }
+
+    for spelling in ["auto", "AUTO", "Auto"] {
+        let mut args = default_args();
+        args.recode_audio = spelling.to_string();
+        let config =
+            merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+        assert_eq!(
+            config.postprocess.recode_audio,
+            RecodeAudioMode::Auto,
+            "--recode-audio={spelling} must mean Auto"
+        );
+    }
+}
+
+/// An explicit encoder name must survive verbatim — case-folding the mode
+/// keywords must not case-fold the encoder name, which `FFmpeg` matches exactly.
+#[test]
+fn test_merge_config_recode_audio_encoder_name_preserved() {
+    let mut args = default_args();
+    args.recode_audio = "libOpus".to_string();
+    let config =
+        merge_config(&args, Config::default(), no_interactive()).expect("merge should succeed");
+    assert_eq!(
+        config.postprocess.recode_audio,
+        RecodeAudioMode::Encoder {
+            name: "libOpus".to_string()
+        },
+        "encoder names are passed to FFmpeg verbatim and must not be lowercased"
+    );
+}

--- a/crates/rdlp-cli/src/main.rs
+++ b/crates/rdlp-cli/src/main.rs
@@ -8,6 +8,11 @@
 
 mod args;
 mod commands;
+// Must stay private and absent from `lib.rs`. `merge_config` trusts that its
+// `Args` came from clap, which is where blank-value rejection now lives (#540);
+// the post-parse guard was removed as redundant. Re-declaring this as
+// `pub mod config` in lib.rs is a one-line change that would hand any dependent
+// crate an unvalidated `merge_config`.
 mod config;
 mod plugin_cmd;
 mod selection;

--- a/crates/rdlp-types/Cargo.toml
+++ b/crates/rdlp-types/Cargo.toml
@@ -9,6 +9,7 @@ description = "Pure domain types for rdlp (no I/O dependencies)"
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 url = { workspace = true }
 regex = { workspace = true }
 winnow = { workspace = true }

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
+
 /// Builds the `FromStr` error for [`AudioFormat`].
 ///
 /// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
@@ -12,10 +13,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 /// "Matching variant not found" — that told a user editing `config.toml`
 /// neither which value was rejected nor which field it came from (#540).
 fn audio_format_parse_err(input: &str) -> ParseEnumError {
-    ParseEnumError {
-        type_name: "audio format",
-        input: input.to_owned(),
-    }
+    ParseEnumError::new("audio format", input)
 }
 
 /// Supported audio formats for extraction and conversion.

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -104,6 +104,7 @@ mod tests {
     use super::*;
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
+        assert_serde_spellings_are_parseable,
     };
 
     #[test]
@@ -158,6 +159,13 @@ mod tests {
     #[test]
     fn test_display_equals_codec_name() {
         assert_display_matches::<AudioFormat>(|fmt| fmt.codec_name(), "codec_name()");
+    }
+
+    /// Precondition for #540's `Deserialize` -> `FromStr` delegation: no
+    /// variant may have a serde spelling that `FromStr` rejects.
+    #[test]
+    fn test_serde_spellings_are_all_parseable() {
+        assert_serde_spellings_are_parseable::<AudioFormat>();
     }
 
     #[test]

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -1,11 +1,22 @@
 //! Audio format types for extraction and conversion
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
 
 /// Supported audio formats for extraction and conversion.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    DeserializeFromStr,
+    Display,
+    EnumString,
+    EnumIter,
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
@@ -104,7 +115,7 @@ mod tests {
     use super::*;
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
-        assert_serde_spellings_are_parseable,
+        assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
     };
 
     #[test]
@@ -166,6 +177,18 @@ mod tests {
     #[test]
     fn test_serde_spellings_are_all_parseable() {
         assert_serde_spellings_are_parseable::<AudioFormat>();
+    }
+
+    /// The config file must accept every spelling the CLI accepts (#540).
+    #[test]
+    fn test_toml_accepts_every_cli_spelling() {
+        assert_toml_accepts_every_from_str_spelling::<AudioFormat>(&[
+            "mp3", "aac", "m4a", "opus", "flac", "alac", "wav", "ac3", "mp2", "tta",
+            // aliases the config file used to reject outright
+            "vorbis", "ogg", "wavpack", "wv", "eac3", "e-ac-3", "e-ac3", "dts", "dca",
+            // case-insensitivity, which serde's rename_all never honoured
+            "MP3", "Ogg", "E-AC-3",
+        ]);
     }
 
     #[test]

--- a/crates/rdlp-types/src/audio_format.rs
+++ b/crates/rdlp-types/src/audio_format.rs
@@ -1,8 +1,22 @@
 //! Audio format types for extraction and conversion
 
 use serde::Serialize;
+
+use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
+/// Builds the `FromStr` error for [`AudioFormat`].
+///
+/// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
+/// `ParseError::VariantNotFound`, whose `Display` is the fixed string
+/// "Matching variant not found" — that told a user editing `config.toml`
+/// neither which value was rejected nor which field it came from (#540).
+fn audio_format_parse_err(input: &str) -> ParseEnumError {
+    ParseEnumError {
+        type_name: "audio format",
+        input: input.to_owned(),
+    }
+}
 
 /// Supported audio formats for extraction and conversion.
 #[derive(
@@ -20,6 +34,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
+#[strum(parse_err_ty = ParseEnumError, parse_err_fn = audio_format_parse_err)]
 pub enum AudioFormat {
     /// MPEG Audio Layer 3
     #[strum(serialize = "mp3")]
@@ -116,6 +131,7 @@ mod tests {
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
         assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
+        assert_toml_rejects_unknown_spelling,
     };
 
     #[test]
@@ -177,6 +193,15 @@ mod tests {
     #[test]
     fn test_serde_spellings_are_all_parseable() {
         assert_serde_spellings_are_parseable::<AudioFormat>();
+    }
+
+    /// An unknown spelling must still be an error, and the message must name it.
+    #[test]
+    fn test_toml_rejects_unknown_spelling() {
+        assert_toml_rejects_unknown_spelling::<AudioFormat>(
+            "mp3x",
+            "unsupported audio format: mp3x",
+        );
     }
 
     /// The config file must accept every spelling the CLI accepts (#540).

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
+
 /// Builds the `FromStr` error for [`ContainerFormat`].
 ///
 /// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
@@ -12,10 +13,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 /// "Matching variant not found" — that told a user editing `config.toml`
 /// neither which value was rejected nor which field it came from (#540).
 fn container_format_parse_err(input: &str) -> ParseEnumError {
-    ParseEnumError {
-        type_name: "container format",
-        input: input.to_owned(),
-    }
+    ParseEnumError::new("container format", input)
 }
 
 /// Supported container formats for video/audio files.

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -38,7 +38,12 @@ pub enum ContainerFormat {
     #[strum(serialize = "avi")]
     Avi,
     /// 3GPP mobile video
-    #[strum(to_string = "3gp", serialize = "3gpp")]
+    ///
+    /// `threegp` is not a real-world spelling — it is the lowercased *variant
+    /// identifier* that `#[serde(rename_all = "lowercase")]` accepted before
+    /// #540 delegated `Deserialize` to `FromStr`. It is kept as a parse-only
+    /// alias so configs persisted under the old vocabulary keep loading.
+    #[strum(to_string = "3gp", serialize = "3gpp", serialize = "threegp")]
     ThreeGp,
     /// MPEG-1/2 program stream
     #[strum(to_string = "mpg", serialize = "mpeg")]
@@ -209,6 +214,7 @@ mod tests {
     use super::*;
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
+        assert_serde_spellings_are_parseable,
     };
     use strum::IntoEnumIterator as _;
 
@@ -252,6 +258,24 @@ mod tests {
 
         // Case-insensitivity across the alias set is asserted by the helper.
         assert_all_parse_to(ALIASES);
+    }
+
+    /// Every spelling the *current* serde representation accepts must also be
+    /// in the `FromStr` table.
+    ///
+    /// This is the back-compat precondition for #540, which delegates
+    /// `Deserialize` to `FromStr` so the config file and the CLI stop accepting
+    /// different vocabularies. Until that lands, `#[serde(rename_all =
+    /// "lowercase")]` accepts the lowercased *variant identifier*, which for
+    /// `ThreeGp` is `"threegp"` — a spelling `FromStr` rejects, because strum's
+    /// table holds only `3gp`/`3gpp`. Delegating without first adding `threegp`
+    /// as an alias would silently break every persisted config that wrote it.
+    ///
+    /// Derived from the serialized form rather than a hand-listed set, so it
+    /// cannot drift as variants are added.
+    #[test]
+    fn test_serde_spellings_are_all_parseable() {
+        assert_serde_spellings_are_parseable::<ContainerFormat>();
     }
 
     /// Each variant's own extension parses back to that variant.

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -1,13 +1,24 @@
 //! Container format types for video/audio files
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
 
 /// Supported container formats for video/audio files.
 ///
 /// Used for merge output, remux targets, and video recode targets.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    DeserializeFromStr,
+    Display,
+    EnumString,
+    EnumIter,
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
@@ -214,7 +225,7 @@ mod tests {
     use super::*;
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
-        assert_serde_spellings_are_parseable,
+        assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
     };
     use strum::IntoEnumIterator as _;
 
@@ -276,6 +287,58 @@ mod tests {
     #[test]
     fn test_serde_spellings_are_all_parseable() {
         assert_serde_spellings_are_parseable::<ContainerFormat>();
+    }
+
+    /// #540 changed only `Deserialize`. The serialized form is a Tauri IPC
+    /// contract, mirrored by a TypeScript union and gated by
+    /// `scripts/check-ts-enum-drift.sh`, so it must not move.
+    ///
+    /// `ThreeGp` is where a regression would surface: `Serialize` still emits
+    /// the `rename_all` spelling `"threegp"`, while `Display`/`as_ext` render
+    /// `"3gp"`. That asymmetry is deliberate — the wire keeps the old value,
+    /// the filesystem gets the real extension, and `FromStr` now accepts both.
+    #[test]
+    fn test_serialize_still_emits_the_wire_spelling() {
+        assert_eq!(
+            serde_json::to_string(&ContainerFormat::ThreeGp).expect("serialize"),
+            "\"threegp\"",
+            "the IPC wire value must not change; only Deserialize was widened"
+        );
+        assert_eq!(ContainerFormat::ThreeGp.to_string(), "3gp");
+        assert_eq!(ContainerFormat::ThreeGp.as_ext(), "3gp");
+    }
+
+    /// The config file must accept every spelling the CLI accepts (#540).
+    #[test]
+    fn test_toml_accepts_every_cli_spelling() {
+        assert_toml_accepts_every_from_str_spelling::<ContainerFormat>(&[
+            // canonical extensions
+            "mp4",
+            "mkv",
+            "3gp",
+            "wav",
+            "aac",
+            "wv",
+            "mov",
+            "ts",
+            "mpg",
+            // strum aliases the config file used to reject outright
+            "matroska",
+            "quicktime",
+            "mpegts",
+            "3gpp",
+            "mpeg",
+            "wave",
+            "adts",
+            "aif",
+            "wavpack",
+            // the pre-#540 serde-only spelling, kept for persisted configs
+            "threegp",
+            // case-insensitivity, which serde's rename_all never honoured
+            "MP4",
+            "Mkv",
+            "MATROSKA",
+        ]);
     }
 
     /// Each variant's own extension parses back to that variant.

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -1,8 +1,22 @@
 //! Container format types for video/audio files
 
 use serde::Serialize;
+
+use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
+/// Builds the `FromStr` error for [`ContainerFormat`].
+///
+/// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
+/// `ParseError::VariantNotFound`, whose `Display` is the fixed string
+/// "Matching variant not found" — that told a user editing `config.toml`
+/// neither which value was rejected nor which field it came from (#540).
+fn container_format_parse_err(input: &str) -> ParseEnumError {
+    ParseEnumError {
+        type_name: "container format",
+        input: input.to_owned(),
+    }
+}
 
 /// Supported container formats for video/audio files.
 ///
@@ -22,6 +36,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
+#[strum(parse_err_ty = ParseEnumError, parse_err_fn = container_format_parse_err)]
 pub enum ContainerFormat {
     // === Video containers ===
     /// MPEG-4 Part 14 — best compatibility, supports faststart
@@ -226,6 +241,7 @@ mod tests {
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
         assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
+        assert_toml_rejects_unknown_spelling,
     };
     use strum::IntoEnumIterator as _;
 
@@ -306,6 +322,15 @@ mod tests {
         );
         assert_eq!(ContainerFormat::ThreeGp.to_string(), "3gp");
         assert_eq!(ContainerFormat::ThreeGp.as_ext(), "3gp");
+    }
+
+    /// An unknown spelling must still be an error, and the message must name it.
+    #[test]
+    fn test_toml_rejects_unknown_spelling() {
+        assert_toml_rejects_unknown_spelling::<ContainerFormat>(
+            "mkvv",
+            "unsupported container format: mkvv",
+        );
     }
 
     /// The config file must accept every spelling the CLI accepts (#540).

--- a/crates/rdlp-types/src/enum_test_support.rs
+++ b/crates/rdlp-types/src/enum_test_support.rs
@@ -24,6 +24,16 @@ use std::str::FromStr;
 use serde::Serialize;
 use strum::IntoEnumIterator;
 
+/// Minimal TOML document shape for the config-surface guards: `value = "..."`.
+///
+/// Shared by the accept and reject helpers so the field is genuinely read —
+/// two local copies meant the reject helper's was write-only and tripped
+/// `dead_code` under `-D warnings`.
+#[derive(serde::Deserialize, Debug)]
+struct Wrapper<U> {
+    value: U,
+}
+
 /// Asserts the config-file (serde) and CLI (`FromStr`) surfaces accept exactly
 /// the same vocabulary.
 ///
@@ -43,11 +53,6 @@ where
     T: FromStr + PartialEq + Debug + serde::de::DeserializeOwned,
     <T as FromStr>::Err: Debug,
 {
-    #[derive(serde::Deserialize)]
-    struct Wrapper<U> {
-        value: U,
-    }
-
     for spelling in spellings {
         let expected = spelling
             .parse::<T>()
@@ -64,6 +69,38 @@ where
             parsed.value
         );
     }
+}
+
+/// Asserts TOML still *rejects* a spelling that is not in the vocabulary, and
+/// that the reported error names the offending value.
+///
+/// The positive parity guards would all still pass if the delegation silently
+/// fell back to a default instead of failing, so the widened surface needs a
+/// negative case. The message assertion additionally pins the diagnostic:
+/// routing deserialization through `FromStr` means the error text now comes
+/// from `FromStr::Err`, and a bare "matching variant not found" would be a
+/// regression against the derived `Deserialize` it replaced, which named both
+/// the bad value and the accepted set.
+pub fn assert_toml_rejects_unknown_spelling<T>(unknown: &str, expected_message: &str)
+where
+    T: FromStr + Debug + serde::de::DeserializeOwned,
+    <T as FromStr>::Err: Debug,
+{
+    let doc = format!("value = \"{unknown}\"");
+    let err = toml::from_str::<Wrapper<T>>(&doc)
+        .err()
+        .unwrap_or_else(|| panic!("TOML must reject {unknown:?}, but it parsed"));
+
+    // Asserted against the *message*, not merely the rendered error: `toml`
+    // echoes the offending source line, so a `contains(unknown)` check would
+    // pass even when the message itself says nothing useful — which is exactly
+    // what `strum::ParseError`'s "Matching variant not found" did.
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains(expected_message),
+        "the error message must be {expected_message:?} so the user learns what \
+         was wrong, not just where; got:\n{rendered}"
+    );
 }
 
 /// Asserts every spelling the serde representation accepts is also in the

--- a/crates/rdlp-types/src/enum_test_support.rs
+++ b/crates/rdlp-types/src/enum_test_support.rs
@@ -21,7 +21,36 @@
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
+use serde::Serialize;
 use strum::IntoEnumIterator;
+
+/// Asserts every spelling the serde representation accepts is also in the
+/// `FromStr` table.
+///
+/// This is the back-compat precondition for #540, which delegates `Deserialize`
+/// to `FromStr` so the config file and the CLI stop accepting different
+/// vocabularies. Any variant whose serialized spelling `FromStr` rejects would
+/// have its persisted configs silently broken by that delegation — which is
+/// exactly what `ContainerFormat::ThreeGp` (`"threegp"`) would have done.
+///
+/// Derived from the serialized form rather than a hand-listed set, so it cannot
+/// drift as variants are added.
+pub fn assert_serde_spellings_are_parseable<T>()
+where
+    T: IntoEnumIterator + Serialize + FromStr + PartialEq + Debug,
+    <T as FromStr>::Err: Debug,
+{
+    for variant in T::iter() {
+        let serialized = serde_json::to_string(&variant).expect("variant must serialize");
+        let spelling = serialized.trim_matches('"');
+        let parsed = spelling.parse::<T>().ok();
+        assert!(
+            parsed.as_ref() == Some(&variant),
+            "serde accepts {spelling:?} for {variant:?}, but FromStr rejects it — \
+             delegating Deserialize to FromStr would break persisted configs"
+        );
+    }
+}
 
 /// Asserts every variant's `Display` output parses back to that variant.
 ///

--- a/crates/rdlp-types/src/enum_test_support.rs
+++ b/crates/rdlp-types/src/enum_test_support.rs
@@ -24,6 +24,48 @@ use std::str::FromStr;
 use serde::Serialize;
 use strum::IntoEnumIterator;
 
+/// Asserts the config-file (serde) and CLI (`FromStr`) surfaces accept exactly
+/// the same vocabulary.
+///
+/// This is #540's central invariant. Before it, `#[serde(rename_all =
+/// "lowercase")]` honoured neither strum's aliases nor its
+/// `ascii_case_insensitive`, so `remux_container = "3gp"` was a parse error in
+/// `config.toml` while `--remux=3gp` worked.
+///
+/// Deliberately driven through `toml`, not `serde_json`: the config file is the
+/// surface that diverged, and the two crates make different borrowed-vs-owned
+/// choices when handing a string to a `Visitor`. A delegation that works under
+/// `serde_json` can still fail under `toml` (measured — `toml` 0.9 never yields
+/// a borrowed `&str` through `from_str`), so the guard must exercise the real
+/// format.
+pub fn assert_toml_accepts_every_from_str_spelling<T>(spellings: &[&str])
+where
+    T: FromStr + PartialEq + Debug + serde::de::DeserializeOwned,
+    <T as FromStr>::Err: Debug,
+{
+    #[derive(serde::Deserialize)]
+    struct Wrapper<U> {
+        value: U,
+    }
+
+    for spelling in spellings {
+        let expected = spelling
+            .parse::<T>()
+            .unwrap_or_else(|e| panic!("test bug: {spelling:?} must parse via FromStr: {e:?}"));
+
+        let doc = format!("value = \"{spelling}\"");
+        let parsed = toml::from_str::<Wrapper<T>>(&doc).unwrap_or_else(|e| {
+            panic!("TOML rejects {spelling:?}, which the CLI accepts: {e}");
+        });
+
+        assert!(
+            parsed.value == expected,
+            "TOML parsed {spelling:?} to {:?}, but FromStr yields {expected:?}",
+            parsed.value
+        );
+    }
+}
+
 /// Asserts every spelling the serde representation accepts is also in the
 /// `FromStr` table.
 ///

--- a/crates/rdlp-types/src/parse_error.rs
+++ b/crates/rdlp-types/src/parse_error.rs
@@ -5,10 +5,41 @@ use std::fmt;
 /// Error returned when parsing a string into a typed enum fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseEnumError {
-    /// The type name being parsed (e.g., "`ContainerFormat`").
-    pub type_name: &'static str,
-    /// The invalid input value.
-    pub input: String,
+    /// Human-readable name of the vocabulary being parsed — prose, NOT a Rust
+    /// type name. Rendered as `unsupported {type_name}: {input}`, so callers
+    /// pass e.g. "container format", giving
+    /// `unsupported container format: mkvv`.
+    type_name: &'static str,
+    /// The invalid input value, with control characters already stripped.
+    ///
+    /// Private so [`ParseEnumError::new`] is the only way to build one — the
+    /// sanitisation is then an invariant of the type rather than a convention
+    /// every future call site has to remember.
+    input: String,
+}
+
+impl ParseEnumError {
+    /// Builds the error, stripping control characters from `input`.
+    ///
+    /// The input is attacker-influencable in the sense that matters here: it is
+    /// echoed back to a terminal, and a config file can be copied from a dotfile
+    /// repo or a gist. A rejected value like `mkv\u{1b}[2J` would otherwise
+    /// carry a raw ANSI escape straight to stderr and clear the user's screen
+    /// (CWE-150). `toml`'s own source-line echo is safe because it reproduces
+    /// the file's *escaped* text; this message carries the decoded value, so it
+    /// is this type's job to neutralise it.
+    ///
+    /// Sanitised at construction rather than at each display site, because this
+    /// type exists only to be shown to a user — there is no consumer that wants
+    /// the raw control bytes, and a boundary-by-boundary fix would need every
+    /// future call site to remember.
+    #[must_use]
+    pub fn new(type_name: &'static str, input: &str) -> Self {
+        Self {
+            type_name,
+            input: input.chars().filter(|c| !c.is_control()).collect(),
+        }
+    }
 }
 
 impl fmt::Display for ParseEnumError {
@@ -18,3 +49,41 @@ impl fmt::Display for ParseEnumError {
 }
 
 impl std::error::Error for ParseEnumError {}
+
+#[cfg(test)]
+mod tests {
+    use super::ParseEnumError;
+
+    #[test]
+    fn display_names_the_type_and_the_input() {
+        let e = ParseEnumError::new("container format", "mkvv");
+        assert_eq!(e.to_string(), "unsupported container format: mkvv");
+    }
+
+    /// A rejected config value must not carry terminal control sequences into
+    /// stderr (CWE-150).
+    #[test]
+    fn control_characters_are_stripped_from_the_input() {
+        let e = ParseEnumError::new("container format", "mkv\u{1b}[2J\u{7}\n");
+        assert_eq!(
+            e.to_string(),
+            "unsupported container format: mkv[2J",
+            "escape, bell and newline must not survive into the message"
+        );
+        assert!(
+            !e.to_string().chars().any(char::is_control),
+            "no control character may reach the terminal"
+        );
+    }
+
+    #[test]
+    fn ordinary_input_is_preserved_verbatim() {
+        for input in ["libOpus", "e-ac-3", "3gp", "wavpack"] {
+            let e = ParseEnumError::new("audio format", input);
+            assert!(
+                e.to_string().ends_with(input),
+                "{input} must survive sanitisation unchanged"
+            );
+        }
+    }
+}

--- a/crates/rdlp-types/src/recode_audio_mode.rs
+++ b/crates/rdlp-types/src/recode_audio_mode.rs
@@ -40,9 +40,71 @@ pub enum RecodeAudioMode {
     },
 }
 
+impl From<&str> for RecodeAudioMode {
+    /// Parses the `--recode-audio` vocabulary: `copy`, `auto`, or an `FFmpeg`
+    /// encoder name.
+    ///
+    /// `From` rather than `FromStr` because the conversion cannot fail — any
+    /// string that is not a mode keyword *is* an encoder name, and whether that
+    /// encoder exists is `FFmpeg`'s question to answer, not this type's.
+    ///
+    /// The two mode keywords are matched case-insensitively, matching every
+    /// other format vocabulary in this crate (which gets it from
+    /// `#[strum(ascii_case_insensitive)]`). The encoder name is preserved
+    /// verbatim — `FFmpeg` matches encoder names exactly, so `libOpus` must
+    /// survive unchanged.
+    fn from(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("copy") {
+            Self::Copy
+        } else if value.eq_ignore_ascii_case("auto") {
+            Self::Auto
+        } else {
+            Self::Encoder {
+                name: value.to_owned(),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn from_str_maps_the_mode_keywords_case_insensitively() {
+        for spelling in ["copy", "COPY", "Copy", "cOpY"] {
+            assert_eq!(RecodeAudioMode::from(spelling), RecodeAudioMode::Copy);
+        }
+        for spelling in ["auto", "AUTO", "Auto"] {
+            assert_eq!(RecodeAudioMode::from(spelling), RecodeAudioMode::Auto);
+        }
+    }
+
+    #[test]
+    fn from_str_preserves_encoder_name_case() {
+        assert_eq!(
+            RecodeAudioMode::from("libOpus"),
+            RecodeAudioMode::Encoder {
+                name: "libOpus".to_string()
+            },
+            "FFmpeg matches encoder names exactly; case must not be folded"
+        );
+    }
+
+    /// A keyword with surrounding content is an encoder name, not a mode —
+    /// the match is on the whole value, never a substring.
+    #[test]
+    fn from_str_does_not_match_keywords_as_substrings() {
+        for name in ["copycat", "autotune", "libcopy", "copy2"] {
+            assert_eq!(
+                RecodeAudioMode::from(name),
+                RecodeAudioMode::Encoder {
+                    name: name.to_string()
+                },
+                "{name} must be treated as an encoder name"
+            );
+        }
+    }
 
     #[test]
     fn default_is_copy() {

--- a/crates/rdlp-types/src/recode_audio_mode.rs
+++ b/crates/rdlp-types/src/recode_audio_mode.rs
@@ -71,7 +71,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_str_maps_the_mode_keywords_case_insensitively() {
+    fn from_maps_the_mode_keywords_case_insensitively() {
         for spelling in ["copy", "COPY", "Copy", "cOpY"] {
             assert_eq!(RecodeAudioMode::from(spelling), RecodeAudioMode::Copy);
         }
@@ -81,7 +81,7 @@ mod tests {
     }
 
     #[test]
-    fn from_str_preserves_encoder_name_case() {
+    fn from_preserves_encoder_name_case() {
         assert_eq!(
             RecodeAudioMode::from("libOpus"),
             RecodeAudioMode::Encoder {
@@ -94,7 +94,7 @@ mod tests {
     /// A keyword with surrounding content is an encoder name, not a mode —
     /// the match is on the whole value, never a substring.
     #[test]
-    fn from_str_does_not_match_keywords_as_substrings() {
+    fn from_does_not_match_keywords_as_substrings() {
         for name in ["copycat", "autotune", "libcopy", "copy2"] {
             assert_eq!(
                 RecodeAudioMode::from(name),

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
+
 /// Builds the `FromStr` error for [`SubtitleFormat`].
 ///
 /// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
@@ -12,10 +13,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 /// "Matching variant not found" — that told a user editing `config.toml`
 /// neither which value was rejected nor which field it came from (#540).
 fn subtitle_format_parse_err(input: &str) -> ParseEnumError {
-    ParseEnumError {
-        type_name: "subtitle format",
-        input: input.to_owned(),
-    }
+    ParseEnumError::new("subtitle format", input)
 }
 
 /// Supported subtitle formats.

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -1,11 +1,22 @@
 //! Subtitle format types
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
 
 /// Supported subtitle formats.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    DeserializeFromStr,
+    Display,
+    EnumString,
+    EnumIter,
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
@@ -47,7 +58,7 @@ mod tests {
     use super::*;
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
-        assert_serde_spellings_are_parseable,
+        assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
     };
 
     /// `Display` must render the file extension, not whichever strum alias
@@ -79,6 +90,17 @@ mod tests {
     #[test]
     fn test_serde_spellings_are_all_parseable() {
         assert_serde_spellings_are_parseable::<SubtitleFormat>();
+    }
+
+    /// The config file must accept every spelling the CLI accepts (#540).
+    #[test]
+    fn test_toml_accepts_every_cli_spelling() {
+        assert_toml_accepts_every_from_str_spelling::<SubtitleFormat>(&[
+            "srt", "vtt", "ass", "ssa", "lrc",
+            // alias the config file used to reject outright
+            "webvtt", // case-insensitivity, which serde's rename_all never honoured
+            "SRT", "WebVTT",
+        ]);
     }
 
     #[test]

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -1,8 +1,22 @@
 //! Subtitle format types
 
 use serde::Serialize;
+
+use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
 use strum_macros::{Display, EnumIter, EnumString};
+/// Builds the `FromStr` error for [`SubtitleFormat`].
+///
+/// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
+/// `ParseError::VariantNotFound`, whose `Display` is the fixed string
+/// "Matching variant not found" — that told a user editing `config.toml`
+/// neither which value was rejected nor which field it came from (#540).
+fn subtitle_format_parse_err(input: &str) -> ParseEnumError {
+    ParseEnumError {
+        type_name: "subtitle format",
+        input: input.to_owned(),
+    }
+}
 
 /// Supported subtitle formats.
 #[derive(
@@ -20,6 +34,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
+#[strum(parse_err_ty = ParseEnumError, parse_err_fn = subtitle_format_parse_err)]
 pub enum SubtitleFormat {
     /// `SubRip` Text
     #[strum(serialize = "srt")]
@@ -59,6 +74,7 @@ mod tests {
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
         assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
+        assert_toml_rejects_unknown_spelling,
     };
 
     /// `Display` must render the file extension, not whichever strum alias
@@ -90,6 +106,15 @@ mod tests {
     #[test]
     fn test_serde_spellings_are_all_parseable() {
         assert_serde_spellings_are_parseable::<SubtitleFormat>();
+    }
+
+    /// An unknown spelling must still be an error, and the message must name it.
+    #[test]
+    fn test_toml_rejects_unknown_spelling() {
+        assert_toml_rejects_unknown_spelling::<SubtitleFormat>(
+            "srtt",
+            "unsupported subtitle format: srtt",
+        );
     }
 
     /// The config file must accept every spelling the CLI accepts (#540).

--- a/crates/rdlp-types/src/subtitle_format.rs
+++ b/crates/rdlp-types/src/subtitle_format.rs
@@ -47,6 +47,7 @@ mod tests {
     use super::*;
     use crate::enum_test_support::{
         assert_all_parse_to, assert_display_matches, assert_display_roundtrips,
+        assert_serde_spellings_are_parseable,
     };
 
     /// `Display` must render the file extension, not whichever strum alias
@@ -71,6 +72,13 @@ mod tests {
     #[test]
     fn test_display_roundtrip() {
         assert_display_roundtrips::<SubtitleFormat>();
+    }
+
+    /// Precondition for #540's `Deserialize` -> `FromStr` delegation: no
+    /// variant may have a serde spelling that `FromStr` rejects.
+    #[test]
+    fn test_serde_spellings_are_all_parseable() {
+        assert_serde_spellings_are_parseable::<SubtitleFormat>();
     }
 
     #[test]

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -23,18 +23,39 @@ for script in scripts/check-*.sh; do
     fi
 done
 
-# A gate passing is not the same as a gate still working. The dir-sweep gate is
-# a textual matcher that could rot into a no-op, so verify it still fires --
-# otherwise the local checklist would be weaker than CI, which is the asymmetry
-# this aggregate exists to close.
-printf '%-44s' "check-no-dir-sweep-delete --self-test"
-if output=$(bash scripts/check-no-dir-sweep-delete.sh --self-test 2>&1); then
-    echo "OK"
-else
-    echo "FAILED"
-    printf '%s\n' "$output" | sed 's/^/    /'
-    FAILED=1
-fi
+# A gate passing is not the same as a gate still working. A textual matcher can
+# rot into a no-op and then report OK forever, so every gate that ships a
+# --self-test canary runs it here -- otherwise the local checklist would be
+# weaker than CI, which is the asymmetry this aggregate exists to close.
+#
+# Discovered by scanning for the flag rather than listing scripts by name, so a
+# new gate's canary is picked up the same way the gate itself is.
+for script in scripts/check-*.sh; do
+    [ "$(basename "$script")" = "check-all.sh" ] && continue
+    grep -q -- '--self-test' "$script" || continue
+    printf '%-44s' "$(basename "$script" .sh) --self-test"
+    # Convention: a self-test's sentinel MUST be a hardcoded literal. A gate
+    # whose canary echoed scanned file content could otherwise be spoofed by a
+    # repo file containing a line starting with the sentinel.
+    #
+    # Exit status alone is not evidence a canary ran: a gate that merely
+    # MENTIONS the flag (in a comment, or referring to a sibling's canary)
+    # ignores the argument, performs its ordinary scan and exits 0 -- reporting
+    # a green canary that does not exist. Require the sentinel on stdout so
+    # "a real canary ran" is observed rather than inferred, and so the failure
+    # mode is loud rather than silent.
+    if output=$(bash "$script" --self-test 2>&1) \
+        && printf '%s\n' "$output" | grep -q '^SELF-TEST OK'; then
+        echo "OK"
+    else
+        echo "FAILED"
+        if ! printf '%s\n' "$output" | grep -q '^SELF-TEST OK'; then
+            echo "    no 'SELF-TEST OK' sentinel — does this script actually implement --self-test?"
+        fi
+        printf '%s\n' "$output" | sed 's/^/    /'
+        FAILED=1
+    fi
+done
 
 if [ "$FAILED" -eq 1 ]; then
     echo ""

--- a/scripts/check-arg-blank-validation.sh
+++ b/scripts/check-arg-blank-validation.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Verify every string- and path-valued CLI argument rejects blank input.
+#
+# Why: a blank value reaches the domain layer looking like a real one.
+# `--recode-audio=` became `RecodeAudioMode::Encoder { name: "" }` and failed
+# inside FFmpeg *after* the download completed; `--cookies="   "` would be a
+# path that cannot exist. Validating at the parse boundary means clap reports it
+# with the flag name, the offending value and usage text (#540).
+#
+# clap has no built-in for this and no struct-level hook: `NonEmptyStringValueParser`
+# tests `OsStr::is_empty()` only, so `"   "` passes it, and the derive applies a
+# `value_parser` per field. The rule therefore has to be attached 38 times, which
+# means the real risk is the 39th argument silently omitting it. This gate is
+# what makes the invariant enforced rather than remembered.
+#
+# Usage: scripts/check-arg-blank-validation.sh [--self-test]
+#   --self-test: prove the gate still fires, by scanning a synthetic violating
+#                file in a temp dir. Runs in CI every time, so "canary-verified"
+#                stays true as the tree evolves instead of being a one-off claim.
+#
+# The parser is deliberately STRICT: the dangerous failure mode is silent. If a
+# field declaration cannot be classified, or an `#[arg(...)]` spans multiple
+# lines (which would break the contiguous-attribute assumption the same way it
+# broke check-ts-enum-drift.sh), the script exits 2 and demands extension rather
+# than skipping the field and reporting OK.
+
+set -euo pipefail
+
+# Anchor to the repo root: the target path below is relative, so running from
+# anywhere else would scan nothing and cheerfully report OK. A gate that passes
+# having scanned nothing is worse than no gate.
+cd "$(git rev-parse --show-toplevel)"
+
+TARGET="crates/rdlp-cli/src/args.rs"
+
+SELF_TEST=0
+[ "${1:-}" = "--self-test" ] && SELF_TEST=1
+
+# Scan one file; echo one line per offending field. Shared by the real run and
+# the self-test so the self-test exercises the SAME matcher, not a copy of it.
+scan() {
+    awk '
+        # Remember the most recent attribute line, and reset on any other
+        # non-blank, non-comment line so an attribute never binds to a field
+        # further down the file.
+        /^[[:space:]]*#\[arg\(/ {
+            attr = $0
+            # A multi-line attribute would leave the value_parser on a later
+            # line where this matcher cannot see it. Refuse rather than guess.
+            if ($0 !~ /\)\][[:space:]]*$/) {
+                printf "MULTILINE_ATTR:%d:%s\n", NR, $0
+            }
+            next
+        }
+        /^[[:space:]]*(#\[|\/\/|$)/ { next }
+
+        # Field declaration, matched LOOSELY on BOTH the name and the type so an
+        # unusual spelling cannot slip past by failing the pattern. The name
+        # pattern admits raw identifiers (`r#type`) and non-snake-case: a
+        # stricter one skipped them silently, which is the failure direction
+        # this gate exists to prevent. Anything that looks like a
+        # field is then classified, and an unrecognised type is a hard error --
+        # a matcher that silently skips what it does not understand reports OK
+        # on exactly the drift it exists to catch.
+        /^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?(r#)?[A-Za-z_][A-Za-z0-9_]*:[[:space:]]/ {
+            # The type must terminate on this line, or the type text this
+            # matcher classifies is only a fragment of the real one.
+            if ($0 !~ /,[[:space:]]*$/) {
+                printf "MULTILINE_FIELD:%d:%s\n", NR, $0
+                attr = ""
+                next
+            }
+
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            sub(/^pub([[:space:]]*\([^)]*\))?[[:space:]]+/, "", line)
+            idx = index(line, ":")
+            name = substr(line, 1, idx - 1)
+            type = substr(line, idx + 1)
+            gsub(/^[[:space:]]+|[[:space:]]*,[[:space:]]*$/, "", type)
+
+            needs = ""
+            if (type ~ /PathBuf/) {
+                needs = "non_blank_path"
+            } else if (type ~ /String/) {
+                # Substring, not equality: this must also catch Vec<String>,
+                # Option<Vec<String>> and fully-qualified std::string::String.
+                needs = "non_blank"
+            } else if (type ~ /^(Option<)?(bool|u8|u16|u32|u64|usize|i8|i16|i32|i64|isize|f32|f64)>?$/) {
+                needs = ""      # numeric/flag: blank is impossible by construction
+            } else if (type ~ /^(Option<)?(PluginCmd|PluginSubcommand)>?$/) {
+                needs = ""      # subcommand: its own fields are checked individually
+            } else {
+                printf "UNCLASSIFIED:%d:%s:%s\n", NR, name, type
+                attr = ""
+                next
+            }
+
+            if (needs != "" && attr !~ ("value_parser[[:space:]]*=[[:space:]]*" needs "[[:space:]]*[,)]")) {
+                printf "MISSING:%d:%s:%s:%s\n", NR, name, type, needs
+            }
+            attr = ""
+            next
+        }
+        # Residue rule. Widening the prefix pattern above fixes the spellings
+        # anticipated today; this catches the ones that are not. Any line that
+        # LOOKS like a field declaration (has a colon, ends in a comma) but fell
+        # through every rule above is reported rather than dropped, so the next
+        # unanticipated spelling fails loudly instead of silently disabling the
+        # check for that field. Verified to flag zero lines in the real args.rs.
+        /:/ && /,[[:space:]]*$/ { printf "UNPARSED:%d:%s\n", NR, $0; attr = ""; next }
+        { attr = "" }
+    ' "$1"
+}
+
+if [ "$SELF_TEST" -eq 1 ]; then
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cat > "$tmp/synthetic.rs" <<'SYNTH'
+pub struct Args {
+    /// Covered.
+    #[arg(long, value_parser = non_blank)]
+    pub good: Option<String>,
+
+    /// Not covered — the gate must catch this.
+    #[arg(long)]
+    pub bad: Option<String>,
+
+    /// Wrong parser for the type — must also be caught.
+    #[arg(long, value_parser = non_blank)]
+    pub bad_path: Option<PathBuf>,
+
+    /// A repeatable optional arg. Caught only if the String test is a
+    /// substring match; exact-equality against a literal list misses it, which
+    /// is the false pass this fixture exists to prevent.
+    #[arg(long)]
+    pub repeatable: Option<Vec<String>>,
+
+    /// Fully-qualified. Same trap, other spelling.
+    #[arg(long)]
+    pub qualified: Option<std::string::String>,
+
+    /// A raw identifier. Skipped silently by a name pattern that assumes
+    /// snake_case, which is how this shape got through the first matcher.
+    #[arg(long)]
+    pub r#type: Option<String>,
+
+    /// Restricted visibility. `(pub )?` matches neither `pub(crate) ` nor
+    /// nothing here, so a narrower prefix pattern dropped this silently —
+    /// and tightening a field's visibility is an ordinary refactor.
+    #[arg(long)]
+    pub(crate) restricted: Option<String>,
+
+    /// Irrelevant types — must be ignored, not flagged.
+    #[arg(long)]
+    pub flag: bool,
+    #[arg(long)]
+    pub count: Option<u64>,
+    #[command(subcommand)]
+    pub sub: Option<PluginSubcommand>,
+}
+SYNTH
+    cat > "$tmp/unclassified.rs" <<'SYNTH'
+pub struct Args {
+    /// A type this matcher has never seen. It must STOP, not skip.
+    #[arg(long)]
+    pub exotic: Option<Box<str>>,
+}
+SYNTH
+    cat > "$tmp/unparsed.rs" <<'SYNTH'
+pub struct Args {
+    /// A declaration spelling no rule anticipates. The residue rule must make
+    /// this loud; dropping it is how a field silently escapes the gate.
+    #[arg(long)]
+    pub odd:String,
+}
+SYNTH
+
+    found=$(scan "$tmp/synthetic.rs" || true)
+    missing=$(printf '%s\n' "$found" | grep '^MISSING:' || true)
+    missing_count=$(printf '%s\n' "$missing" | grep -c . || true)
+    if [ "$missing_count" -ne 6 ]; then
+        echo "self-test FAILED: expected 6 flagged fields (bad, bad_path, repeatable, qualified, r#type, restricted), got $missing_count" >&2
+        printf '%s\n' "$found" >&2
+        exit 1
+    fi
+    for expected in bad bad_path repeatable qualified "r#type" restricted; do
+        if ! printf '%s\n' "$missing" | grep -q ":${expected}:"; then
+            echo "self-test FAILED: matcher missed '$expected'" >&2
+            printf '%s\n' "$found" >&2
+            exit 1
+        fi
+    done
+    if printf '%s\n' "$found" | grep -qE ':(good|flag|count|sub):'; then
+        echo "self-test FAILED: the matcher flagged a compliant or irrelevant field" >&2
+        printf '%s\n' "$found" >&2
+        exit 1
+    fi
+
+    # The strictness claims must be exercised, not asserted.
+    if ! scan "$tmp/unclassified.rs" | grep -q '^UNCLASSIFIED:'; then
+        echo "self-test FAILED: an unknown field type was silently skipped instead of stopping the gate" >&2
+        exit 1
+    fi
+    if ! scan "$tmp/unparsed.rs" | grep -q '^UNPARSED:'; then
+        echo "self-test FAILED: an unrecognised declaration spelling was dropped instead of stopping the gate" >&2
+        exit 1
+    fi
+
+    echo "SELF-TEST OK: flags unvalidated/mismatched/repeatable/qualified/raw-ident/restricted-visibility args, ignores irrelevant ones, stops on an unclassifiable type or an unparseable declaration"
+    exit 0
+fi
+
+if [ ! -f "$TARGET" ]; then
+    echo "error: $TARGET not found — has the CLI arg module moved?" >&2
+    exit 2
+fi
+
+findings=$(scan "$TARGET" || true)
+
+if printf '%s\n' "$findings" | grep -q '^MULTILINE_ATTR:'; then
+    echo "error: multi-line #[arg(...)] in $TARGET — this matcher reads one attribute line" >&2
+    printf '%s\n' "$findings" | grep '^MULTILINE_ATTR:' | while IFS=: read -r _ line rest; do
+        echo "       line $line: $rest" >&2
+    done
+    echo "       Keep the attribute on one line, or extend this script." >&2
+    exit 2
+fi
+
+if printf '%s\n' "$findings" | grep -q '^MULTILINE_FIELD:'; then
+    echo "error: field declaration spans lines in $TARGET — the type this matcher" >&2
+    echo "       would classify is only a fragment of the real one" >&2
+    printf '%s\n' "$findings" | grep '^MULTILINE_FIELD:' | while IFS=: read -r _ line rest; do
+        echo "       line $line: $rest" >&2
+    done
+    exit 2
+fi
+
+if printf '%s\n' "$findings" | grep -q '^UNPARSED:'; then
+    echo "error: line looks like a field declaration but matched no rule in $TARGET." >&2
+    echo "       Refusing to skip it — an unrecognised declaration spelling is how" >&2
+    echo "       a field silently escapes this gate. Extend the matcher." >&2
+    printf '%s\n' "$findings" | grep '^UNPARSED:' | while IFS=: read -r _ line rest; do
+        printf '       %s:%s %s\n' "$TARGET" "$line" "$rest" >&2
+    done
+    exit 2
+fi
+
+if printf '%s\n' "$findings" | grep -q '^UNCLASSIFIED:'; then
+    echo "error: unrecognised field type in $TARGET — refusing to guess whether it" >&2
+    echo "       can hold a blank value. Classify it in this script's matcher." >&2
+    printf '%s\n' "$findings" | grep '^UNCLASSIFIED:' | while IFS=: read -r _ line name type; do
+        printf '       %s:%s  %s: %s\n' "$TARGET" "$line" "$name" "$type" >&2
+    done
+    exit 2
+fi
+
+missing=$(printf '%s\n' "$findings" | grep '^MISSING:' || true)
+if [ -n "$missing" ]; then
+    echo "error: CLI argument(s) accept blank values — add the value_parser:" >&2
+    printf '%s\n' "$missing" | while IFS=: read -r _ line name type needs; do
+        printf '       %s:%s  %s: %s  -> #[arg(..., value_parser = %s)]\n' \
+            "$TARGET" "$line" "$name" "$type" "$needs" >&2
+    done
+    echo "       See non_blank / non_blank_path in $TARGET (#540)." >&2
+    exit 1
+fi
+
+count=$(grep -cE 'value_parser = non_blank(_path)?\)?' "$TARGET" || true)
+echo "OK ($count string/path arguments reject blank input)"


### PR DESCRIPTION
## Resolves

Closes #540
Closes #582

## What

The config file and the CLI accepted **different vocabularies for the same field**. `--remux=3gp` worked; `remux_container = "3gp"` in `config.toml` was a parse error. `#[serde(rename_all = "lowercase")]` honoured neither strum's aliases nor its `ascii_case_insensitive`, so `matroska`, `quicktime`, `mpegts`, `wave`, `adts`, `aif`, `wavpack`, `ogg`, `wv`, `dca`, `webvtt` and every uppercase spelling were rejected from config files while working on the command line.

`Deserialize` now delegates to the same strum `FromStr` the CLI uses, so the two surfaces are identical **by construction** rather than by maintenance — which is the actual defect, since `#[serde(alias)]` would need hand-syncing against the strum attributes forever.

Auditing for other instances of the same defect turned up three more bugs and one regression this PR itself introduced. Seven commits, each verified RED before its fix:

| commit | what |
|---|---|
| `695322f1` | `threegp` back-compat alias — sequencing precondition |
| `1909a8d0` | config file accepts the CLI's vocabulary (`DeserializeFromStr`) |
| `1dcdeea4` | `--recode-audio` mode keywords case-insensitive |
| `7c301b3a` | three config-clobber bugs found by auditing for more instances |
| `d4deb8d9` | typed `FromStr` error naming the rejected value |
| `5c891415` | strip control characters from rejected values (CWE-150) |
| `d63020f0` | blank rejection across all 38 args + CI gate; clap 4.5 → 4.6.3 |

## Decisions worth reviewing

**`serde_with::DeserializeFromStr` over the issue's own `try_from = "String"` recommendation.** Its visitor implements only `visit_str` and relies on serde's default forwarding, so it is format-agnostic; `try_from` needs a hand-written `TryFrom<String>` per enum because strum emits only `FromStr` and `TryFrom<&str>`. **A third option — a macro using `<&str>::deserialize` — was measured and rejected**: it fails under `toml` (0.9 never yields a borrowed `&str` through `from_str`, even for an unescaped value) *and* under `serde_json::from_value`, the Tauri IPC command-argument path. It works only for `serde_json::from_str`. All three surfaces are exercised by this crate, so that option would have shipped a latent bug.

**`value_parser` on 38 fields rather than a newtype.** clap infers a parser from the field type via `ValueParserFactory`, so a `NonBlank(String)` newtype would need zero attributes — but it changes 38 field types plus their downstream reads, and `Args` is deliberately a stringly-typed clap DTO that `merge_config` parses into domain types afterwards. One wrapper standing for 38 unrelated concepts is also the shape `value-objects-by-default` names as the anti-pattern; the real value objects already exist downstream.

**clap 4.5 → 4.6.3 is routine maintenance, not a fix.** Targeted `cargo update -p clap`, not a broad one — a broad update has broken `wreq` here before. 4.6.0 raised MSRV to 1.85, which this workspace already pins. Stated plainly: the upgrade delivers nothing needed here; 4.5.59 had every mechanism used. Lock impact is 8 packages, all inside clap's own tree, zero added or removed.

**`ThreeGp` is deliberately asymmetric and pinned.** The IPC wire keeps `"threegp"`, `Display`/`as_ext` render `"3gp"`, `FromStr` accepts both. `Serialize` + `rename_all` are untouched because the serialized form is a Tauri IPC contract mirrored by a TypeScript union and gated by `check-ts-enum-drift.sh`.

## Audit — the same defect elsewhere

Three config-clobber bugs, each measured rather than suspected:

| field | config.toml | after merge |
|---|---|---|
| `recode_audio` | `Encoder{libopus}` | **`Copy`** |
| `recode_cpu_used` | `Some(4)` | **`None`** |
| `recode_speed_level` | `Some(3)` | **`None`** |

Fixed via a `merge_opt!` macro beside `merge_bool!`, with `recode_threads`/`recode_preset` and the five timeout merges migrated onto it so the correct behaviour is the shorter thing to write.

**The class is not fully closed.** `--fixup` uses a sentinel-string guard and has the *inverse* defect, and `config.progress = !config.quiet` overwrites a deserializable field. Both pre-existing, filed as **#583** rather than left implied by a commit message claiming more than the code delivers.

## Things this PR got wrong, and fixed

**It introduced a diagnostic regression.** Delegating to `FromStr` replaced serde's `unknown variant, expected one of ...` with strum's fixed `Matching variant not found`. I first filed that as an enhancement (#582) before review established it was caused here. Fixed via strum's `parse_err_ty`/`parse_err_fn`, pointed at the existing `ParseEnumError` — which until now was exported with zero consumers.

**The first negative test passed for the wrong reason.** It asserted the rendered error contained the bad value, which passed against the *regressed* code because `toml` echoes the source line. It now asserts on the message.

**The diagnostic fix then introduced a security bug.** Security review called it pre-existing and amplified; measuring showed the opposite — `toml`'s echo is escaped and inert, the new message carried decoded control bytes to stderr. `ParseEnumError::new` strips them, with private fields so sanitisation is an invariant rather than a convention.

## The gate, and why it took four rounds

`--recode-audio=` became `Encoder { name: "" }` and failed inside FFmpeg *after* the download completed. That check is now at the parse boundary for all 38 string/path args, using clap's own extension point (a bare `Fn(&str) -> Result<T, E>` is a `TypedValueParser`).

But no per-field rule is self-enforcing — the 39th argument can omit it — so the durable output is `scripts/check-arg-blank-validation.sh`, wired into CI beside the dir-sweep gate it is modelled on. Its matcher silently passed a valid arg shape in **three** successive rounds:

| round | shape that slipped | found by |
|---|---|---|
| 1 | `Option<Vec<String>>` | code review |
| 2 | `pub r#type:` | me, attacking my own matcher |
| 3 | `pub(crate)` | code review |

Each round widened the pattern and left the next spelling silent. The matcher now ends in a **residue rule**: any line that looks like a declaration but matched no rule is reported and exits 2 — closing the class rather than the instances. Zero false positives on the real `args.rs`; every attack shape caught.

`check-all.sh` also now requires a `SELF-TEST OK` sentinel before reporting a canary green. Discovery by exit status alone was unsound: a gate that merely *mentions* `--self-test` ignores the argument, exits 0, and gets reported as a canary it does not have — verified against `check-no-cli.sh`.

## Verification

- Every fix RED-verified first; every guard re-verified by mutation after refactoring, including through the shared test helpers.
- Deleting the residue rule fails the canary, so the canary tests the matcher rather than its own fixture.
- Parity guards driven through `toml`, not `serde_json`, because the config file is the surface that diverged.
- Full gate green: `cargo fmt --check`, `cargo check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`, `cargo check -p rdlp-desktop`, `scripts/check-all.sh` (10 gates + 2 canaries).

## Reviews

Four review rounds; every finding fixed rather than deferred.

- **security-reviewer — PASS** (×4). Verified the widened vocabulary always resolves into a closed enum whose outputs are hardcoded literals; lock diff adds no packages; `wreq` untouched; blank rejection is a pure narrowing that cannot reject a previously-valid proxy URL or path. Its two notes are applied: `mod config;` now documents that it must stay private (re-declaring it `pub` in `lib.rs` would expose an unvalidated `merge_config`), and `check-all.sh` records that a sentinel must be a hardcoded literal.
- **code-reviewer — Approve** (after one **Request changes**). Confirmed the negative test is a real guard rather than a tautology, independently verified the audit's central claim, and recommended shipping without an "expected one of" list — building one would reintroduce the hand-synced duplication this PR removes. All findings fixed, including the two silent-pass holes in the gate.

Two corrections to reviewer premises are recorded because a future contributor could rely on them: `rdlp-cli` **does** have a lib target (`src/lib.rs`; Cargo infers it), so `merge_config`'s inaccessibility rests on `mod config;` being private in `main.rs`, not on the absence of a library — a one-line change would expose it. And the terminal-escape vector was introduced by this branch, not pre-existing.
