### PR TITLE
fix(config): stop CLI and config layers clobbering each other (#583)

### DIFF
--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -37,7 +37,6 @@ impl MergeOverrides for OutputOptions {
                 // Mirror CLI behaviour: silence output and disable incompatible
                 // defaults so Config::validate() won't reject the combination.
                 config.quiet = true;
-                config.progress = false;
                 config.postprocess.embed_thumbnail = false;
             }
         }

--- a/crates/rdlp-api/src/merge/tests_output_format_subtitle.rs
+++ b/crates/rdlp-api/src/merge/tests_output_format_subtitle.rs
@@ -52,7 +52,6 @@ fn test_output_stdout_disables_incompatible_defaults() {
     opts.merge_into(&mut config);
     assert!(config.output_to_stdout);
     assert!(config.quiet);
-    assert!(!config.progress);
     assert!(!config.postprocess.embed_thumbnail);
 }
 

--- a/crates/rdlp-api/tests/api_integration.rs
+++ b/crates/rdlp-api/tests/api_integration.rs
@@ -26,7 +26,6 @@ use rdlp_types::Config;
 
 fn test_client() -> RdlpClient {
     let config = Config {
-        progress: false,
         ..Default::default()
     };
     RdlpClient::new(config).expect("client should build")

--- a/crates/rdlp-api/tests/plugin_bootstrap_fail_soft.rs
+++ b/crates/rdlp-api/tests/plugin_bootstrap_fail_soft.rs
@@ -53,7 +53,6 @@ fn malformed_plugin_toml_does_not_break_client() {
         std::fs::write(plug_dir.join("plugin.wasm"), b"not actual wasm").unwrap();
 
         let config = Config {
-            progress: false,
             plugin_directories: vec![tmpdir.join("plugins")],
             ..Default::default()
         };
@@ -72,7 +71,6 @@ fn missing_plugin_dir_does_not_break_client() {
         let nonexistent = tmpdir.join("does-not-exist");
 
         let config = Config {
-            progress: false,
             plugin_directories: vec![nonexistent],
             ..Default::default()
         };
@@ -100,7 +98,6 @@ fn corrupted_disabled_list_blocks_bootstrap() {
         std::fs::create_dir_all(&plug_dir).unwrap();
 
         let config = Config {
-            progress: false,
             plugin_directories: vec![plug_dir],
             ..Default::default()
         };

--- a/crates/rdlp-api/tests/plugin_dispatch_regression.rs
+++ b/crates/rdlp-api/tests/plugin_dispatch_regression.rs
@@ -109,7 +109,6 @@ signature = "PLACEHOLDER"
             let identity = format!("ed25519:{pub_hash_hex}");
 
             let config = Config {
-                progress: false,
                 plugin_directories: vec![tempdir.path().to_path_buf()],
                 plugin_trusted_publishers: vec![identity],
                 ..Default::default()

--- a/crates/rdlp-api/tests/process_local_file_e2e.rs
+++ b/crates/rdlp-api/tests/process_local_file_e2e.rs
@@ -87,7 +87,6 @@ async fn test_process_local_file_keeps_source_on_success() {
     // `source.mp4`. This forces at least one pipeline stage (RemuxStage) to run
     // and exercise the replace() → cleanup() path.
     let config = Config {
-        progress: false,
         postprocess: PostProcess {
             remux_container: Some(ContainerFormat::Mkv),
             ..PostProcess::default()

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -341,9 +341,18 @@ pub struct Args {
     #[arg(long, allow_hyphen_values = true)]
     pub normalize_boost_db: Option<f64>,
 
-    /// Fixup policy: never, warn, `detect_or_warn` (default: `detect_or_warn`)
-    #[arg(long, default_value = "detect_or_warn", value_parser = non_blank)]
-    pub fixup: String,
+    /// Fixup policy: never, warn, `detect_or_warn` [default: `detect_or_warn`]
+    //
+    // Deliberately no clap `default_value`, for the mirror-image reason to
+    // `recode_audio` above: a default made an explicit `--fixup=detect_or_warn`
+    // indistinguishable from an omitted flag, so the sentinel guard downstream
+    // skipped the assignment and a config-file `fixup` wrongly won (#583).
+    // clap's `ArgMatches::value_source` answers "was this passed?" directly but
+    // is builder-only, so the derive API expresses it as `Option`, with the
+    // default supplied by `Config::default()`. Plain `//` — a `///` here would
+    // print this note in `rdlp --help`.
+    #[arg(long, value_parser = non_blank)]
+    pub fixup: Option<String>,
 
     /// Keep original video file after post-processing
     #[arg(long)]

--- a/crates/rdlp-cli/src/config.rs
+++ b/crates/rdlp-cli/src/config.rs
@@ -127,11 +127,9 @@ pub fn merge_config(
     if args.output.as_deref() == Some("-") {
         config.output_to_stdout = true;
         // Force quiet mode — progress/log output would corrupt the byte stream.
+        // `quiet` is what actually suppresses the progress bar: the CLI event
+        // handler is constructed from it directly (see `main.rs`).
         config.quiet = true;
-        // Explicitly suppress progress as well: config.progress is derived from
-        // config.quiet further below, but setting it here guards against future
-        // refactors that might add an early return between here and the derivation.
-        config.progress = false;
         // Disable embed_thumbnail before validation: the default is `true`, and
         // Config::validate() would reject stdout + embed-thumbnail.
         if config.postprocess.embed_thumbnail {
@@ -285,13 +283,13 @@ pub fn merge_config(
     merge_bool!(config, args, postprocess.loudnorm_dynamic);
     merge_bool!(config, args, postprocess.loudnorm_precompress);
 
-    // Fixup policy
-    if args.fixup != "detect_or_warn" {
-        config.postprocess.fixup = args
-            .fixup
+    // Fixup policy — assign only when the flag was actually passed, so an
+    // explicit `--fixup=detect_or_warn` still beats a config-file value (#583).
+    if let Some(ref fixup) = args.fixup {
+        config.postprocess.fixup = fixup
             .parse::<FixupPolicy>()
             .map_err(|e| anyhow::anyhow!(e))
-            .with_context(|| format!("invalid fixup policy '{}'", args.fixup))?;
+            .with_context(|| format!("invalid fixup policy '{fixup}'"))?;
     }
 
     merge_bool!(config, args, postprocess.keep_video);
@@ -368,9 +366,6 @@ pub fn merge_config(
             .map_err(|e| anyhow::anyhow!(e))
             .with_context(|| format!("invalid match filter '{filter_str}'"))?;
     }
-
-    // Derived settings
-    config.progress = !config.quiet;
 
     if config.postprocess.extract_audio && config.postprocess.audio_format.is_none() {
         config.postprocess.audio_format = Some(AudioFormat::Mp3);

--- a/crates/rdlp-cli/src/config_tests.rs
+++ b/crates/rdlp-cli/src/config_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::args::Args;
-use rdlp_api::{AudioFormat, Config, SubtitleFormat};
+use rdlp_api::{AudioFormat, Config, FixupPolicy, SubtitleFormat};
 
 /// Helper: create default Args for testing (all fields at defaults).
 fn default_args() -> Args {
@@ -75,7 +75,7 @@ fn default_args() -> Args {
         recode_deadline: None,
         recode_cpu_used: None,
         recode_speed_level: None,
-        fixup: "detect_or_warn".to_string(),
+        fixup: None,
         match_filter: vec![],
         browser: None,
         trust_publisher: vec![],
@@ -425,7 +425,6 @@ fn test_merge_config_stdout_sets_flags() {
 
     assert!(config.output_to_stdout);
     assert!(config.quiet);
-    assert!(!config.progress);
     assert!(!config.postprocess.embed_thumbnail);
 }
 
@@ -854,7 +853,8 @@ fn test_merge_config_recode_audio_encoder_name_preserved() {
 /// The arg carried `default_value = "copy"` and was assigned unconditionally,
 /// so the clap default silently overwrote the config file's value on every run
 /// — the user's setting was discarded with no error. The adjacent `fixup` arg
-/// avoids this by guarding on its default; this one did not (#540).
+/// guarded on its default, which avoided *this* direction but broke the other
+/// one (#583); both now use the same `Option` treatment.
 #[test]
 fn test_merge_config_file_recode_audio_survives_when_flag_omitted() {
     let args = default_args(); // no --recode-audio passed
@@ -871,6 +871,51 @@ fn test_merge_config_file_recode_audio_survives_when_flag_omitted() {
             name: "libopus".to_string()
         },
         "config.toml's recode_audio must not be clobbered by the CLI default"
+    );
+}
+
+/// An explicit `--fixup=detect_or_warn` must beat a config-file `fixup`.
+///
+/// `fixup` carried `default_value = "detect_or_warn"` and was merged behind
+/// `if args.fixup != "detect_or_warn"`, so the one value a user could not
+/// express on the CLI was the default itself: passing it explicitly was
+/// byte-identical to not passing the flag, and `fixup = "never"` in
+/// `config.toml` silently won (#583). This is the mirror image of the
+/// `recode_audio` clobber above — same class, opposite direction.
+#[test]
+fn test_merge_config_explicit_fixup_overrides_file() {
+    let mut args = default_args();
+    args.fixup = Some("detect_or_warn".to_string());
+    let mut file_config = Config::default();
+    file_config.postprocess.fixup = FixupPolicy::Never;
+
+    let merged = merge_config(&args, file_config, no_interactive()).expect("merge should succeed");
+
+    assert_eq!(
+        merged.postprocess.fixup,
+        FixupPolicy::DetectOrWarn,
+        "an explicitly passed --fixup must win over config.toml, even when the \
+         value happens to equal the documented default"
+    );
+}
+
+/// A `fixup` set in `config.toml` must survive when the flag is omitted.
+///
+/// The direction the old sentinel guard got right — pinned so the #583 fix
+/// cannot regress it. Dropping `default_value` without guarding on `Option`
+/// would break exactly this.
+#[test]
+fn test_merge_config_file_fixup_survives_when_flag_omitted() {
+    let args = default_args(); // no --fixup passed
+    let mut file_config = Config::default();
+    file_config.postprocess.fixup = FixupPolicy::Never;
+
+    let merged = merge_config(&args, file_config, no_interactive()).expect("merge should succeed");
+
+    assert_eq!(
+        merged.postprocess.fixup,
+        FixupPolicy::Never,
+        "config.toml's fixup must not be clobbered by the CLI default"
     );
 }
 

--- a/crates/rdlp-cli/tests/orchestrator_integration.rs
+++ b/crates/rdlp-cli/tests/orchestrator_integration.rs
@@ -22,7 +22,6 @@ use tempfile::TempDir;
 fn create_test_config(temp_dir: &TempDir) -> Config {
     Config {
         output_directory: temp_dir.path().to_path_buf(),
-        progress: false,
         ..Default::default()
     }
 }
@@ -111,7 +110,6 @@ fn test_client_with_custom_config() {
 
     let config = Config {
         output_directory: temp_dir.path().to_path_buf(),
-        progress: false,
         format: Some("best".to_string()),
         concurrent_fragments: 8,
         ..Default::default()

--- a/crates/rdlp-cli/tests/plugin_cmd.rs
+++ b/crates/rdlp-cli/tests/plugin_cmd.rs
@@ -105,7 +105,6 @@ fn run_uninstall_rejects_path_traversal_name() {
         let plugin_dir = tmpdir.join("plugins");
         std::fs::create_dir_all(&plugin_dir).unwrap();
         let config = Config {
-            progress: false,
             plugin_directories: vec![plugin_dir],
             ..Default::default()
         };

--- a/crates/rdlp-types/src/browser_type.rs
+++ b/crates/rdlp-types/src/browser_type.rs
@@ -1,12 +1,42 @@
 //! Browser type for cookie extraction
 
-use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
+use serde::Serialize;
+
+use crate::parse_error::ParseEnumError;
+use serde_with::DeserializeFromStr;
+use strum_macros::{Display, EnumIter, EnumString};
+
+/// Builds the `FromStr` error for [`BrowserType`].
+///
+/// Named by `#[strum(parse_err_fn = ...)]`, replacing strum's fixed
+/// "Matching variant not found" with a message that names the rejected
+/// value (#583).
+fn browser_type_parse_err(input: &str) -> ParseEnumError {
+    ParseEnumError::new("browser", input)
+}
 
 /// Supported browsers for cookie extraction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString)]
+///
+/// `Deserialize` delegates to strum's `FromStr` so `config.toml` accepts the
+/// same aliases the CLI does — `chromium`, `google-chrome` and `mozilla` were
+/// CLI-only until #583. `Serialize` stays derived under
+/// `#[serde(rename_all)]`: it is a wire contract and must not move.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    DeserializeFromStr,
+    Display,
+    EnumString,
+    EnumIter,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
+#[strum(parse_err_ty = ParseEnumError, parse_err_fn = browser_type_parse_err)]
 pub enum BrowserType {
     /// Google Chrome / Chromium
     #[strum(
@@ -35,6 +65,55 @@ impl BrowserType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::enum_test_support::{
+        assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
+        assert_toml_rejects_unknown_spelling,
+    };
+
+    /// Back-compat precondition for the #583 delegation, and the drift guard
+    /// going forward. Driven by `EnumIter`, so a new variant is covered without
+    /// touching this test.
+    #[test]
+    fn test_serde_spellings_are_all_parseable() {
+        assert_serde_spellings_are_parseable::<BrowserType>();
+    }
+
+    /// The config file must accept every spelling the CLI accepts (#583).
+    ///
+    /// `--cookies-from-browser chromium` worked while
+    /// `cookies_from_browser = "chromium"` was an `unknown variant` error.
+    #[test]
+    fn test_toml_accepts_every_cli_spelling() {
+        assert_toml_accepts_every_from_str_spelling::<BrowserType>(&[
+            "chrome",
+            "firefox",
+            // aliases — CLI-only before #583
+            "chromium",
+            "google-chrome",
+            "mozilla",
+            // case-insensitivity — CLI-only before #583
+            "CHROME",
+        ]);
+    }
+
+    /// An unknown spelling must still be an error, and the message must name it.
+    #[test]
+    fn test_toml_rejects_unknown_spelling() {
+        assert_toml_rejects_unknown_spelling::<BrowserType>(
+            "safari",
+            "unsupported browser: safari",
+        );
+    }
+
+    /// #583 widens `Deserialize` only; the serialized form must not move.
+    #[test]
+    fn test_serialize_still_emits_the_wire_spelling() {
+        assert_eq!(
+            serde_json::to_string(&BrowserType::Chrome).expect("serialize"),
+            "\"chrome\"",
+            "the wire value must not change; only Deserialize was widened"
+        );
+    }
 
     #[test]
     fn test_parse_variants() {

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -264,9 +264,6 @@ pub struct Config {
     /// Verbose mode (detailed output)
     pub verbose: bool,
 
-    /// Print progress bar
-    pub progress: bool,
-
     // === Simulation ===
     /// Simulate download (don't download anything)
     pub simulate: bool,
@@ -428,7 +425,6 @@ impl Default for Config {
             // Verbosity
             quiet: false,
             verbose: false,
-            progress: true,
 
             // Simulation
             simulate: false,

--- a/crates/rdlp-types/src/fixup_policy.rs
+++ b/crates/rdlp-types/src/fixup_policy.rs
@@ -1,16 +1,47 @@
 //! Policy for automatic fixup of downloaded files.
 
-use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
+use serde::Serialize;
+
+use crate::parse_error::ParseEnumError;
+use serde_with::DeserializeFromStr;
+use strum_macros::{Display, EnumIter, EnumString};
+
+/// Builds the `FromStr` error for [`FixupPolicy`].
+///
+/// Named by `#[strum(parse_err_fn = ...)]`. Replaces strum's default
+/// `ParseError::VariantNotFound`, whose `Display` is the fixed string
+/// "Matching variant not found" — that told a user editing `config.toml`
+/// neither which value was rejected nor which field it came from (#583).
+fn fixup_policy_parse_err(input: &str) -> ParseEnumError {
+    ParseEnumError::new("fixup policy", input)
+}
 
 /// Controls how rdlp handles fixable issues in downloaded files.
 ///
 /// Maps to yt-dlp's `--fixup` option.
+///
+/// `Deserialize` delegates to strum's `FromStr` so `config.toml` accepts
+/// exactly the vocabulary the CLI accepts — the alias `detect` and
+/// case-insensitivity were CLI-only until #583. `Serialize` stays derived
+/// under `#[serde(rename_all)]` on purpose: it is a wire contract, and
+/// dropping the attribute would emit `"Never"` in place of `"never"`.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, Display, EnumString,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    DeserializeFromStr,
+    Default,
+    Display,
+    EnumString,
+    EnumIter,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(ascii_case_insensitive)]
+#[strum(parse_err_ty = ParseEnumError, parse_err_fn = fixup_policy_parse_err)]
 pub enum FixupPolicy {
     /// Never attempt to fix issues.
     #[strum(serialize = "never")]
@@ -27,6 +58,64 @@ pub enum FixupPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::enum_test_support::{
+        assert_serde_spellings_are_parseable, assert_toml_accepts_every_from_str_spelling,
+        assert_toml_rejects_unknown_spelling,
+    };
+
+    /// Back-compat precondition for the #583 delegation, and the drift guard
+    /// going forward: any variant whose serialized spelling `FromStr` rejects
+    /// would have its persisted configs silently broken. Driven by `EnumIter`,
+    /// so a newly added variant is covered without touching this test.
+    #[test]
+    fn test_serde_spellings_are_all_parseable() {
+        assert_serde_spellings_are_parseable::<FixupPolicy>();
+    }
+
+    /// The config file must accept every spelling the CLI accepts (#583).
+    ///
+    /// `--fixup=detect` worked while `fixup = "detect"` in `config.toml` was an
+    /// `unknown variant` error, because the CLI parsed via strum's `FromStr`
+    /// (which knows the alias and is case-insensitive) and the config file
+    /// parsed via a derived `Deserialize` (which knew neither).
+    #[test]
+    fn test_toml_accepts_every_cli_spelling() {
+        assert_toml_accepts_every_from_str_spelling::<FixupPolicy>(&[
+            "never",
+            "warn",
+            "detect_or_warn",
+            // alias — CLI-only before #583
+            "detect",
+            // case-insensitivity — CLI-only before #583
+            "DETECT",
+            "Never",
+        ]);
+    }
+
+    /// An unknown spelling must still be an error, and the message must name it.
+    #[test]
+    fn test_toml_rejects_unknown_spelling() {
+        assert_toml_rejects_unknown_spelling::<FixupPolicy>(
+            "nevr",
+            "unsupported fixup policy: nevr",
+        );
+    }
+
+    /// #583 widens `Deserialize` only. The serialized form is a wire contract,
+    /// so it must not move — dropping `#[serde(rename_all)]` would emit
+    /// `"Never"` instead of `"never"` and silently break persisted configs.
+    #[test]
+    fn test_serialize_still_emits_the_wire_spelling() {
+        assert_eq!(
+            serde_json::to_string(&FixupPolicy::DetectOrWarn).expect("serialize"),
+            "\"detect_or_warn\"",
+            "the wire value must not change; only Deserialize was widened"
+        );
+        assert_eq!(
+            serde_json::to_string(&FixupPolicy::Never).expect("serialize"),
+            "\"never\""
+        );
+    }
 
     #[test]
     fn default_is_detect_or_warn() {


### PR DESCRIPTION
## Resolves

Closes #583

## What

Three defects in one class — a CLI default beating a config file, two enums whose config vocabulary was narrower than their CLI vocabulary, and a field that did nothing.

**1. `--fixup` lost to the config file when passed explicitly.** The arg carried clap `default_value = "detect_or_warn"` and merged behind `if args.fixup != "detect_or_warn"`, so the one value a user couldn't express on the CLI was the default itself — passing it was byte-identical to omitting the flag, and `fixup = "never"` in `config.toml` silently won. Mirror image of the `recode_audio` clobber #540 fixed. Now `Option<String>` with no clap default, merged only when `Some`.

**2. `config.toml` accepted less than the CLI.** `FixupPolicy`/`BrowserType` parsed via strum's `FromStr` on the CLI but a derived `Deserialize` in the config file. Both now delegate via `serde_with::DeserializeFromStr` — deleting the second vocabulary table rather than hand-syncing it.

| | config accepted | CLI *also* accepted |
|---|---|---|
| `FixupPolicy` | `never`, `warn`, `detect_or_warn` | `detect`, any case variant |
| `BrowserType` | `chrome`, `firefox` | `chromium`, `google-chrome`, `mozilla`, any case variant |

**3. `config.progress` was write-only.** Three assignment sites plus the `Default` initializer, zero production reads — the bar is built from `config.quiet` alone. `progress = false` did nothing; so did `= true`. Removed rather than made tri-state, which would have wired a knob to nothing.

## Evidence

Both issue claims were filed **unverified**; both were reproduced by probe before any code changed.

- explicit `--fixup=detect_or_warn` over config `never` → merged to `Never` (CLI value lost). Omitted-flag control → `Never` (correct, must not regress).
- config `progress = false`, `quiet = false` → merged to `progress = true`; TOML deserialization yields `Ok(false)`, so the value arrives and is overwritten.
- `--fixup=detect` parses; TOML `fixup = "detect"` → `unknown variant`.

Back-compat precondition checked before converting: every spelling the current derived `Serialize` emits is already in each enum's `FromStr` table, so no persisted config can break. (This is the step that required adding a `threegp` alias for `ContainerFormat::ThreeGp` in #540; neither enum here needs it.)

## Verification

Full gate green: `fmt --check`, `check`, `clippy --workspace --all-targets -D warnings`, `test --workspace` (0 failed), `check -p rdlp-desktop`, all 9 invariant gates + 2 self-tests.

Test verification differs per direction, and the distinction is load-bearing:

- **explicit-flag-wins** — RED-verified by assertion against the pre-retype `String` field. Writing it in its final `Option` form would have been a *compile* error, which proves nothing. After the retype, mutation-verified by reintroducing the sentinel guard: this test fails, the omitted-flag one passes.
- **omitted-flag-preserves** — honestly **not** red-greenable. With `fixup: None` it passes against patched and unpatched code alike. It's a regression guard against a future `unwrap_or(default)`-then-assign, not evidence the bug existed.
- **TOML parity + reject-with-named-value** — both RED.
- **`assert_serde_spellings_are_parseable`** — trivially true for both enums today. Kept for future `EnumIter`-driven drift detection; not evidence of anything here.

Separately mutation-verified that `scripts/check-arg-blank-validation.sh` genuinely covers the retyped arg rather than passing vacuously: stripping `value_parser = non_blank` makes it fail naming `fixup: Option<String>`.

## Notes

**BREAKING (nominally):** removes the `pub progress` field from `rdlp_types::Config`. Source-breaking for external struct-literal construction. `rdlp-types` is workspace-internal and unpublished, and no config file or doc references the key, so there's no user-facing break. Existing configs still load — `Config` has no `deny_unknown_fields`, so a stale `progress` key is ignored exactly as before.

**Correction to an earlier claim:** an initial draft asserted the frozen `Serialize` spelling was gated by `scripts/check-ts-enum-drift.sh`. It is not — that gate's `PAIRS` list covers only `ContainerFormat`/`AudioFormat`/`SubtitleFormat`/`JobStatus`, and `cookies_from_browser` is typed in TypeScript as a bare `string`. The freeze is correct (`Config` derives `Serialize` and crosses the Tauri IPC boundary) but it's pinned by the new `test_serialize_still_emits_the_wire_spelling` tests, not by CI. Caught in review and corrected in the commit message.

## Reviews

- **security-reviewer** — PASS, no Critical/High/Medium. Notably verified the `BrowserType` widening introduces no string resolving to a *different* variant than before (it selects which browser's cookie store is read, so an alias collision would redirect which sensitive file is touched — Chrome's and Firefox's alias sets are disjoint), and that `ParseEnumError`'s control-character stripping reaches both new call sites.
- **code-reviewer** — Approve with minor fixes. Both fixed: implementation rationale demoted from `///` to `//` (it would have printed in `rdlp --help`; the `recode_audio` sibling documents this exact rule) — verified clean against real `--help` output; and the false `check-ts-enum-drift.sh` claim corrected. Confirmed the `SubtitleKind` carve-out is correct and found no false-passing tests.

## Follow-ups

- #585 — make a forgotten field in `merge_config` a compile error via exhaustive struct construction. Notes the `#[non_exhaustive]` trap: adding it to `Config` would silently defeat that guarantee across the `rdlp-types` → `rdlp-cli` boundary, so it directly conflicts with a hardening suggestion from this review. Both defensible; can't do both.
- #586 — `SubtitleKind` has the identical divergence but is unreachable from `config.toml`, so it's latent rather than live.
- #587 — allow disabling the progress bar without `--quiet` (the affordance the removal exposes as missing).
