### PR TITLE
feat(cli): group --help options into task-oriented sections

### DIFF
--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -9,15 +9,25 @@ use std::path::PathBuf;
 // Task-oriented `--help` section headings. clap buckets arguments by exact
 // heading-string match, so these live as named consts to prevent a typo
 // silently splitting a group.
+/// Core download options: output paths, format selection, verbosity.
 pub const HELP_HEADING_GENERAL: &str = "General";
+/// Simulation and info-listing flags that inspect metadata without downloading.
 pub const HELP_HEADING_INFO: &str = "Simulation & Info";
+/// Post-download processing: audio extraction, metadata/thumbnail embedding, remux.
 pub const HELP_HEADING_POSTPROCESS: &str = "Post-Processing";
+/// Subtitle discovery, selection, format, and embedding options.
 pub const HELP_HEADING_SUBTITLES: &str = "Subtitles";
+/// Video/audio recode target, encoder, and per-codec tuning flags.
 pub const HELP_HEADING_RECODE: &str = "Recode & Encoding";
+/// Peak and EBU R128 loudnorm audio-level normalization options.
 pub const HELP_HEADING_AUDIO_NORM: &str = "Audio Normalization";
+/// Proxy, timeouts, browser TLS emulation, and cookie sourcing.
 pub const HELP_HEADING_NETWORK: &str = "Network & Cookies";
+/// Rate limiting, download archive, and per-video metadata filters.
 pub const HELP_HEADING_DOWNLOAD: &str = "Download Behaviour";
+/// Keyword search and per-site search filter options.
 pub const HELP_HEADING_SEARCH: &str = "Search";
+/// Config file loading and plugin trust management.
 pub const HELP_HEADING_CONFIG: &str = "Configuration & Plugins";
 
 /// Rejects an empty or whitespace-only argument value.

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -6,6 +6,20 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+// Task-oriented `--help` section headings. clap buckets arguments by exact
+// heading-string match, so these live as named consts to prevent a typo
+// silently splitting a group.
+pub const HELP_HEADING_GENERAL: &str = "General";
+pub const HELP_HEADING_INFO: &str = "Simulation & Info";
+pub const HELP_HEADING_POSTPROCESS: &str = "Post-Processing";
+pub const HELP_HEADING_SUBTITLES: &str = "Subtitles";
+pub const HELP_HEADING_RECODE: &str = "Recode & Encoding";
+pub const HELP_HEADING_AUDIO_NORM: &str = "Audio Normalization";
+pub const HELP_HEADING_NETWORK: &str = "Network & Cookies";
+pub const HELP_HEADING_DOWNLOAD: &str = "Download Behaviour";
+pub const HELP_HEADING_SEARCH: &str = "Search";
+pub const HELP_HEADING_CONFIG: &str = "Configuration & Plugins";
+
 /// Rejects an empty or whitespace-only argument value.
 ///
 /// The shared rule behind [`non_blank`] and [`non_blank_path`]. A blank value
@@ -109,148 +123,148 @@ pub struct Args {
     /// `%(epoch)s` render a different name each run, so an interrupted download cannot
     /// be resumed and restarts from zero. Build the template from stable metadata
     /// (`title`, `id`, `uploader`, `ext`, `upload_date`) for resumable downloads.
-    #[arg(short, long, value_parser = non_blank)]
+    #[arg(short, long, value_parser = non_blank, help_heading = HELP_HEADING_GENERAL)]
     pub output: Option<String>,
 
     /// Output directory (always sets base directory, combinable with -o template)
-    #[arg(short = 'P', long = "paths", value_parser = non_blank_path)]
+    #[arg(short = 'P', long = "paths", value_parser = non_blank_path, help_heading = HELP_HEADING_GENERAL)]
     pub output_dir: Option<PathBuf>,
 
     /// Format selection (e.g., "best", "bestvideo+bestaudio")
-    #[arg(short, long, value_parser = non_blank)]
+    #[arg(short, long, value_parser = non_blank, help_heading = HELP_HEADING_GENERAL)]
     pub format: Option<String>,
 
     /// Require strict video-only + audio-only streams for merge.
     /// Changes default from b/bv*+ba to b/bv+ba.
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_GENERAL)]
     pub audio_multistreams: bool,
 
     /// Quiet mode (minimal output)
-    #[arg(short, long)]
+    #[arg(short, long, help_heading = HELP_HEADING_GENERAL)]
     pub quiet: bool,
 
     /// Verbose mode (detailed output)
-    #[arg(short, long)]
+    #[arg(short, long, help_heading = HELP_HEADING_GENERAL)]
     pub verbose: bool,
 
     /// List all supported extractors
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_INFO)]
     pub list_extractors: bool,
 
     /// List all supported download protocols
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_INFO)]
     pub list_downloaders: bool,
 
     /// List all supported audio and video codecs
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_INFO)]
     pub list_codecs: bool,
 
     /// Simulate (don't actually download, shows extraction summary)
-    #[arg(short = 's', long)]
+    #[arg(short = 's', long, help_heading = HELP_HEADING_INFO)]
     pub simulate: bool,
 
     /// Dump full metadata as JSON to stdout (no download)
-    #[arg(short = 'j', long)]
+    #[arg(short = 'j', long, help_heading = HELP_HEADING_INFO)]
     pub dump_json: bool,
 
     /// List available formats as a table (no download)
-    #[arg(short = 'F', long)]
+    #[arg(short = 'F', long, help_heading = HELP_HEADING_INFO)]
     pub list_formats: bool,
 
     /// Print specific field(s) from metadata (no download)
     /// e.g., --print title or --print "id,title,extractor"
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_INFO)]
     pub print: Option<String>,
 
     /// Interactive format selection
-    #[arg(short = 'i', long)]
+    #[arg(short = 'i', long, help_heading = HELP_HEADING_GENERAL)]
     pub interactive: bool,
 
     // === Post-processing options ===
     /// Extract audio only (requires `FFmpeg`)
-    #[arg(short = 'x', long)]
+    #[arg(short = 'x', long, help_heading = HELP_HEADING_POSTPROCESS)]
     pub extract_audio: bool,
 
     /// Audio format for extraction
     /// Use --audio-format for interactive, --audio-format=mp3 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
     pub audio_format: Option<String>,
 
     /// Audio quality (VBR level 0-9 or bitrate like "192K")
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
     pub audio_quality: Option<String>,
 
     /// Embed metadata (title, artist, etc.) in the file
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
     pub embed_metadata: bool,
 
     /// Disable automatic thumbnail download and embedding
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
     pub no_thumbnail: bool,
 
     /// Write thumbnail image to disk alongside media file
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
     pub write_thumbnail: bool,
 
     // === Subtitle options ===
     /// Download subtitles
-    #[arg(long, alias = "write-subs")]
+    #[arg(long, alias = "write-subs", help_heading = HELP_HEADING_SUBTITLES)]
     pub write_subtitles: bool,
 
     /// Download auto-generated subtitles
-    #[arg(long, alias = "write-auto-subs")]
+    #[arg(long, alias = "write-auto-subs", help_heading = HELP_HEADING_SUBTITLES)]
     pub write_auto_subtitles: bool,
 
     /// Subtitle languages to download (comma-separated, e.g., "en,es")
     /// Use "all" to download all available
-    #[arg(long, alias = "sub-langs", value_parser = non_blank)]
+    #[arg(long, alias = "sub-langs", value_parser = non_blank, help_heading = HELP_HEADING_SUBTITLES)]
     pub sub_langs: Option<String>,
 
     /// Preferred subtitle format (srt, vtt, ass, ssa, lrc)
-    #[arg(long, alias = "sub-format", value_parser = non_blank)]
+    #[arg(long, alias = "sub-format", value_parser = non_blank, help_heading = HELP_HEADING_SUBTITLES)]
     pub sub_format: Option<String>,
 
     /// Embed subtitles in video file (requires `FFmpeg`)
-    #[arg(long, alias = "embed-subs")]
+    #[arg(long, alias = "embed-subs", help_heading = HELP_HEADING_SUBTITLES)]
     pub embed_subtitles: bool,
 
     /// Interactive subtitle selection + video download (implies --write-subtitles)
-    #[arg(long, alias = "list-subs")]
+    #[arg(long, alias = "list-subs", help_heading = HELP_HEADING_SUBTITLES)]
     pub list_subs: bool,
 
     /// Show subtitle menu, download only subtitles (no video), then exit
-    #[arg(long, alias = "list-subs-only")]
+    #[arg(long, alias = "list-subs-only", help_heading = HELP_HEADING_SUBTITLES)]
     pub list_subs_only: bool,
 
     /// Strict subtitle mode: fail download if requested subs are missing
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES)]
     pub strict_subs: bool,
 
     /// Pre-validate subtitle URLs with HEAD requests before download
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES)]
     pub verify_sub_urls: bool,
 
     /// Retry subtitle downloads for already-downloaded videos missing subs
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES)]
     pub retry_subs: bool,
 
     /// Video encoder to use (e.g., libsvtav1, libx264).
     /// Overrides automatic encoder selection.
-    #[arg(long, value_name = "NAME", value_parser = non_blank)]
+    #[arg(long, value_name = "NAME", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
     pub video_encoder: Option<String>,
 
     /// List available video encoders and exit.
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_INFO)]
     pub list_encoders: bool,
 
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
     pub recode_video: Option<String>,
 
     /// Target container format for video recode (e.g., mp4, mkv, webm).
     /// Takes precedence over --recode-video when both are specified.
-    #[arg(long, value_name = "FMT", value_parser = non_blank)]
+    #[arg(long, value_name = "FMT", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
     pub recode_container: Option<String>,
 
     /// Audio mode during video recode: copy (default), auto, or an encoder name
@@ -264,81 +278,81 @@ pub struct Args {
     // unconditional assignment downstream then discarded the config value on
     // every run (#540). Plain `//` — a `///` here would print this note in
     // `rdlp --help`.
-    #[arg(long, value_name = "MODE", value_parser = non_blank)]
+    #[arg(long, value_name = "MODE", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
     pub recode_audio: Option<String>,
 
     // Help text hardcodes the bounds: keep `1-64` in sync with
     // `rdlp_types::config::MAX_RECODE_THREADS` and `8` in sync with
     // `rdlp_ffmpeg`'s `AUTO_RECODE_THREADS_CAP`.
     /// Encoder threads for video recode (1-64). Omit for auto (min(cores, 8)).
-    #[arg(long, value_name = "N")]
+    #[arg(long, value_name = "N", help_heading = HELP_HEADING_RECODE)]
     pub recode_threads: Option<u32>,
 
     /// Encoder preset override for video recode (e.g. `faster`, `medium`, `slow`).
     /// Omit to use the per-codec default. `libvvenc`: try `faster` for speed.
-    #[arg(long, value_name = "PRESET", value_parser = non_blank)]
+    #[arg(long, value_name = "PRESET", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
     pub recode_preset: Option<String>,
 
     /// libvpx deadline for VP8/VP9 recode: best | good | realtime.
-    #[arg(long, value_name = "MODE", value_parser = non_blank)]
+    #[arg(long, value_name = "MODE", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
     pub recode_deadline: Option<String>,
 
     /// libvpx cpu-used for VP8/VP9 recode (VP9: -8..8, VP8: -16..16).
-    #[arg(long, value_name = "N", allow_hyphen_values = true)]
+    #[arg(long, value_name = "N", allow_hyphen_values = true, help_heading = HELP_HEADING_RECODE)]
     pub recode_cpu_used: Option<i32>,
 
     /// libxavs2 `speed_level` for AVS2 recode (0..9).
-    #[arg(long, value_name = "N")]
+    #[arg(long, value_name = "N", help_heading = HELP_HEADING_RECODE)]
     pub recode_speed_level: Option<u32>,
 
     /// Remux to container for better seeking - no re-encoding
     /// Use --remux for interactive, --remux=mp4 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
     pub remux: Option<String>,
 
     /// Normalize audio levels (peak mode: volume + limiter)
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub normalize_audio: bool,
 
     /// Use EBU R128 loudnorm normalization (two-pass, implies --normalize-audio)
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm: bool,
 
     /// Target peak level in dBFS for peak normalization (default: -1.0)
-    #[arg(long, allow_hyphen_values = true)]
+    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub audio_gain_target: Option<f64>,
 
     /// Loudnorm preset: broadcast (-23 LUFS), streaming (-14 LUFS), loud (-11 LUFS)
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_preset: Option<String>,
 
     /// Target integrated loudness in LUFS for loudnorm (e.g., -14)
-    #[arg(long, allow_hyphen_values = true)]
+    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_i: Option<f64>,
 
     /// Target true peak in dBTP for loudnorm (e.g., -1)
-    #[arg(long, allow_hyphen_values = true)]
+    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_tp: Option<f64>,
 
     /// Target loudness range in LU for loudnorm (e.g., 11)
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_lra: Option<f64>,
 
     /// Force dynamic (per-frame compression) mode in loudnorm pass 2
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_dynamic: bool,
 
     /// Prepend a mild acompressor before loudnorm to tame extreme peaks
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_precompress: bool,
 
     /// Enable limiter-boost fallback (+12 dB gain + hard limiter) for
     /// over-compressed content (implies --loudnorm)
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub normalize_boost: bool,
 
     /// Gain in dB for limiter-boost fallback (default: 12.0)
-    #[arg(long, allow_hyphen_values = true)]
+    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
     pub normalize_boost_db: Option<f64>,
 
     /// Fixup policy: never, warn, `detect_or_warn` [default: `detect_or_warn`]
@@ -351,48 +365,48 @@ pub struct Args {
     // is builder-only, so the derive API expresses it as `Option`, with the
     // default supplied by `Config::default()`. Plain `//` — a `///` here would
     // print this note in `rdlp --help`.
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
     pub fixup: Option<String>,
 
     /// Keep original video file after post-processing
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
     pub keep_video: bool,
 
     /// Path to `FFmpeg` executable (if not in PATH)
-    #[arg(long, value_parser = non_blank_path)]
+    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_POSTPROCESS)]
     pub ffmpeg_location: Option<PathBuf>,
 
     // === Network options ===
     /// HTTP/HTTPS/SOCKS proxy URL (e.g., <socks5://127.0.0.1:1080>)
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_NETWORK)]
     pub proxy: Option<String>,
 
     /// Connect/handshake timeout in seconds.
     /// Validated post-parse by `Config::validate()`: must be 1..=300.
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
     pub socket_timeout: Option<u64>,
 
     /// Per-read idle timeout in seconds.
     /// Validated post-parse by `Config::validate()`: must be 1..=600.
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
     pub read_timeout: Option<u64>,
 
     /// Idle keep-alive socket eviction timeout in seconds. `0` is the
     /// documented sentinel meaning "disable eviction (keep idle sockets
     /// forever)".
     /// Validated post-parse by `Config::validate()`: must be 0..=3600.
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
     pub pool_idle_timeout: Option<u64>,
 
     /// Total download timeout in seconds (the entire file must complete within
     /// this). Default 3600.
     /// Validated post-parse by `Config::validate()`: must be 1..=86400.
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
     pub download_timeout: Option<u64>,
 
     /// Merge (mux/concat) operation timeout in seconds. Default 1800.
     /// Validated post-parse by `Config::validate()`: must be 1..=86400.
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
     pub merge_timeout: Option<u64>,
 
     /// Browser emulation profile for the TLS / HTTP stack
@@ -400,58 +414,58 @@ pub struct Args {
     /// identifier like chrome-137). Controls JA4 / JA4H fingerprint.
     /// Falls back to the `RDLP_BROWSER_EMULATION` env var, then
     /// `ChromeLatest`.
-    #[arg(long, value_name = "PROFILE", value_parser = non_blank)]
+    #[arg(long, value_name = "PROFILE", value_parser = non_blank, help_heading = HELP_HEADING_NETWORK)]
     pub browser: Option<String>,
 
     /// Limit download speed (e.g., "1M", "500K", "10M", "2.5M")
-    #[arg(long, short = 'r', value_parser = non_blank)]
+    #[arg(long, short = 'r', value_parser = non_blank, help_heading = HELP_HEADING_DOWNLOAD)]
     pub limit_rate: Option<String>,
 
     // === Cookie options ===
     /// Load cookies from browser (chrome, firefox)
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_NETWORK)]
     pub cookies_from_browser: Option<String>,
 
     /// Path to Netscape-format cookies file
-    #[arg(long, value_parser = non_blank_path)]
+    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_NETWORK)]
     pub cookies: Option<PathBuf>,
 
     /// Path to download archive file (skip already-downloaded videos)
-    #[arg(long, value_parser = non_blank_path)]
+    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_DOWNLOAD)]
     pub download_archive: Option<PathBuf>,
 
     /// Filter videos by metadata (yt-dlp syntax). Repeatable (OR logic between filters).
     /// Examples: "duration > 60", "!`is_live`", "title *= cats", "`like_count` >? 100"
-    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank)]
+    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank, help_heading = HELP_HEADING_DOWNLOAD)]
     pub match_filter: Vec<String>,
 
     // === Search options ===
     /// Perform a keyword search instead of downloading a URL
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_SEARCH)]
     pub search: Option<String>,
 
     /// Site to search (required with --search, e.g., "xhamster")
-    #[arg(long, value_parser = non_blank)]
+    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_SEARCH)]
     pub search_site: Option<String>,
 
     /// Search filter in key=value format (repeatable)
-    #[arg(long = "search-filter", value_parser = non_blank)]
+    #[arg(long = "search-filter", value_parser = non_blank, help_heading = HELP_HEADING_SEARCH)]
     pub search_filter: Vec<String>,
 
     // === Config file options ===
     /// Ignore config file (don't load from default location)
-    #[arg(long)]
+    #[arg(long, help_heading = HELP_HEADING_CONFIG)]
     pub ignore_config: bool,
 
     /// Path to config file (TOML format)
-    #[arg(long, value_parser = non_blank_path)]
+    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_CONFIG)]
     pub config_location: Option<PathBuf>,
 
     // === Plugin options ===
     /// Pre-trust a publisher identity for non-interactive plugin install.
     /// Pass repeatedly for multiple identities.
     /// Format: `sigstore:github:user/repo` or `ed25519:<8-byte-hex>`.
-    #[arg(long, global = true, value_parser = non_blank)]
+    #[arg(long, global = true, value_parser = non_blank, help_heading = HELP_HEADING_CONFIG)]
     pub trust_publisher: Vec<String>,
 
     /// Plugin management subcommand.
@@ -473,3 +487,7 @@ pub struct PluginCmdArgs {
     #[command(subcommand)]
     pub cmd: PluginCmd,
 }
+
+#[cfg(test)]
+#[path = "args_tests.rs"]
+mod args_tests;

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -145,3 +145,34 @@ fn every_option_is_classified_into_a_help_group() {
         );
     }
 }
+
+/// All 10 group headings, for asserting they actually render in emitted help
+/// text (the structural test above only inspects the `Command` model).
+const ALL_HEADINGS: &[&str] = &[
+    HELP_HEADING_GENERAL,
+    HELP_HEADING_INFO,
+    HELP_HEADING_POSTPROCESS,
+    HELP_HEADING_SUBTITLES,
+    HELP_HEADING_RECODE,
+    HELP_HEADING_AUDIO_NORM,
+    HELP_HEADING_NETWORK,
+    HELP_HEADING_DOWNLOAD,
+    HELP_HEADING_SEARCH,
+    HELP_HEADING_CONFIG,
+];
+
+#[test]
+fn all_headings_render_in_short_and_long_help() {
+    let short = Args::command().render_help().to_string();
+    let long = Args::command().render_long_help().to_string();
+    for heading in ALL_HEADINGS {
+        assert!(
+            short.contains(heading),
+            "`-h` output is missing heading `{heading}`"
+        );
+        assert!(
+            long.contains(heading),
+            "`--help` output is missing heading `{heading}`"
+        );
+    }
+}

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -1,0 +1,147 @@
+//! Structural test for #585 PR 2: every CLI option must be classified into
+//! exactly one `--help` group. A new flag with no `help_heading` (or a wrong
+//! one) fails here — the CLI-side analog of the merge exhaustiveness canary.
+
+use std::collections::HashMap;
+
+use clap::CommandFactory;
+
+use crate::args::{
+    Args, HELP_HEADING_AUDIO_NORM, HELP_HEADING_CONFIG, HELP_HEADING_DOWNLOAD,
+    HELP_HEADING_GENERAL, HELP_HEADING_INFO, HELP_HEADING_NETWORK, HELP_HEADING_POSTPROCESS,
+    HELP_HEADING_RECODE, HELP_HEADING_SEARCH, HELP_HEADING_SUBTITLES,
+};
+
+/// Arg id (== Rust field name for clap-derive) → expected heading. This IS the
+/// group design; keep it in sync with the field annotations. `url` (positional)
+/// and `plugin` (subcommand) are intentionally absent.
+const EXPECTED: &[(&str, &str)] = &[
+    // General
+    ("output", HELP_HEADING_GENERAL),
+    ("output_dir", HELP_HEADING_GENERAL),
+    ("format", HELP_HEADING_GENERAL),
+    ("audio_multistreams", HELP_HEADING_GENERAL),
+    ("quiet", HELP_HEADING_GENERAL),
+    ("verbose", HELP_HEADING_GENERAL),
+    ("interactive", HELP_HEADING_GENERAL),
+    // Simulation & Info
+    ("list_extractors", HELP_HEADING_INFO),
+    ("list_downloaders", HELP_HEADING_INFO),
+    ("list_codecs", HELP_HEADING_INFO),
+    ("list_encoders", HELP_HEADING_INFO),
+    ("simulate", HELP_HEADING_INFO),
+    ("dump_json", HELP_HEADING_INFO),
+    ("list_formats", HELP_HEADING_INFO),
+    ("print", HELP_HEADING_INFO),
+    // Post-Processing
+    ("extract_audio", HELP_HEADING_POSTPROCESS),
+    ("audio_format", HELP_HEADING_POSTPROCESS),
+    ("audio_quality", HELP_HEADING_POSTPROCESS),
+    ("embed_metadata", HELP_HEADING_POSTPROCESS),
+    ("no_thumbnail", HELP_HEADING_POSTPROCESS),
+    ("write_thumbnail", HELP_HEADING_POSTPROCESS),
+    ("remux", HELP_HEADING_POSTPROCESS),
+    ("fixup", HELP_HEADING_POSTPROCESS),
+    ("keep_video", HELP_HEADING_POSTPROCESS),
+    ("ffmpeg_location", HELP_HEADING_POSTPROCESS),
+    // Subtitles
+    ("write_subtitles", HELP_HEADING_SUBTITLES),
+    ("write_auto_subtitles", HELP_HEADING_SUBTITLES),
+    ("sub_langs", HELP_HEADING_SUBTITLES),
+    ("sub_format", HELP_HEADING_SUBTITLES),
+    ("embed_subtitles", HELP_HEADING_SUBTITLES),
+    ("list_subs", HELP_HEADING_SUBTITLES),
+    ("list_subs_only", HELP_HEADING_SUBTITLES),
+    ("strict_subs", HELP_HEADING_SUBTITLES),
+    ("verify_sub_urls", HELP_HEADING_SUBTITLES),
+    ("retry_subs", HELP_HEADING_SUBTITLES),
+    // Recode & Encoding
+    ("video_encoder", HELP_HEADING_RECODE),
+    ("recode_video", HELP_HEADING_RECODE),
+    ("recode_container", HELP_HEADING_RECODE),
+    ("recode_audio", HELP_HEADING_RECODE),
+    ("recode_threads", HELP_HEADING_RECODE),
+    ("recode_preset", HELP_HEADING_RECODE),
+    ("recode_deadline", HELP_HEADING_RECODE),
+    ("recode_cpu_used", HELP_HEADING_RECODE),
+    ("recode_speed_level", HELP_HEADING_RECODE),
+    // Audio Normalization
+    ("normalize_audio", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm", HELP_HEADING_AUDIO_NORM),
+    ("audio_gain_target", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm_preset", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm_i", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm_tp", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm_lra", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm_dynamic", HELP_HEADING_AUDIO_NORM),
+    ("loudnorm_precompress", HELP_HEADING_AUDIO_NORM),
+    ("normalize_boost", HELP_HEADING_AUDIO_NORM),
+    ("normalize_boost_db", HELP_HEADING_AUDIO_NORM),
+    // Network & Cookies
+    ("proxy", HELP_HEADING_NETWORK),
+    ("socket_timeout", HELP_HEADING_NETWORK),
+    ("read_timeout", HELP_HEADING_NETWORK),
+    ("pool_idle_timeout", HELP_HEADING_NETWORK),
+    ("download_timeout", HELP_HEADING_NETWORK),
+    ("merge_timeout", HELP_HEADING_NETWORK),
+    ("browser", HELP_HEADING_NETWORK),
+    ("cookies_from_browser", HELP_HEADING_NETWORK),
+    ("cookies", HELP_HEADING_NETWORK),
+    // Download Behaviour
+    ("limit_rate", HELP_HEADING_DOWNLOAD),
+    ("download_archive", HELP_HEADING_DOWNLOAD),
+    ("match_filter", HELP_HEADING_DOWNLOAD),
+    // Search
+    ("search", HELP_HEADING_SEARCH),
+    ("search_site", HELP_HEADING_SEARCH),
+    ("search_filter", HELP_HEADING_SEARCH),
+    // Configuration & Plugins
+    ("ignore_config", HELP_HEADING_CONFIG),
+    ("config_location", HELP_HEADING_CONFIG),
+    ("trust_publisher", HELP_HEADING_CONFIG),
+];
+
+/// Ids present as clap args but intentionally NOT grouped.
+const EXEMPT: &[&str] = &["help", "version", "url", "plugin"];
+
+#[test]
+fn every_option_is_classified_into_a_help_group() {
+    let expected: HashMap<&str, &str> = EXPECTED.iter().copied().collect();
+    assert_eq!(expected.len(), EXPECTED.len(), "duplicate id in EXPECTED");
+    assert_eq!(
+        EXPECTED.len(),
+        73,
+        "group map should cover all 73 option fields"
+    );
+
+    let cmd = Args::command();
+    let mut seen = std::collections::HashSet::new();
+
+    for arg in cmd.get_arguments() {
+        let id = arg.get_id().as_str();
+        if EXEMPT.contains(&id) || arg.is_positional() {
+            continue;
+        }
+        seen.insert(id.to_owned());
+        match expected.get(id) {
+            Some(&heading) => assert_eq!(
+                arg.get_help_heading(),
+                Some(heading),
+                "flag `{id}` is in the wrong help group",
+            ),
+            None => panic!(
+                "flag `{id}` is not classified into a help group. Add it to \
+                 EXPECTED in args_tests.rs and annotate the field with \
+                 `help_heading = HELP_HEADING_<GROUP>` (residue rule, #585 PR 2).",
+            ),
+        }
+    }
+
+    // Every mapped id must correspond to a real arg (catch stale map entries).
+    for (id, _) in EXPECTED {
+        assert!(
+            seen.contains(*id),
+            "EXPECTED lists `{id}`, which is not an Args option"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of the #585 CLI/config-unification sequence. Groups the 73 flat `Args`
clap options into **10 task-oriented `-h`/`--help` sections** via per-field
`#[arg(help_heading = HELP_HEADING_<GROUP>)]` on the flat struct.

**Help-text only — zero behaviour change.** Parsing, defaults, aliases,
`merge_config`, and every `args.field` access are unchanged; all pre-existing
`rdlp-cli` tests pass unmodified.

## The group map (73 options → 10 sections)

| Section (`--help` heading) | Options |
|---|---|
| **General** | output, output_dir, format, audio_multistreams, quiet, verbose, interactive |
| **Simulation & Info** | list_extractors, list_downloaders, list_codecs, list_encoders, simulate, dump_json, list_formats, print |
| **Post-Processing** | extract_audio, audio_format, audio_quality, embed_metadata, no_thumbnail, write_thumbnail, remux, fixup, keep_video, ffmpeg_location |
| **Subtitles** | write_subtitles, write_auto_subtitles, sub_langs, sub_format, embed_subtitles, list_subs, list_subs_only, strict_subs, verify_sub_urls, retry_subs |
| **Recode & Encoding** | video_encoder, recode_video, recode_container, recode_audio, recode_threads, recode_preset, recode_deadline, recode_cpu_used, recode_speed_level |
| **Audio Normalization** | normalize_audio, loudnorm, audio_gain_target, loudnorm_preset, loudnorm_i, loudnorm_tp, loudnorm_lra, loudnorm_dynamic, loudnorm_precompress, normalize_boost, normalize_boost_db |
| **Network & Cookies** | proxy, socket_timeout, read_timeout, pool_idle_timeout, download_timeout, merge_timeout, browser, cookies_from_browser, cookies |
| **Download Behaviour** | limit_rate, download_archive, match_filter |
| **Search** | search, search_site, search_filter |
| **Configuration & Plugins** | ignore_config, config_location, trust_publisher |

`url` (positional) stays under `Arguments:`; `plugin` subcommands under `Commands:`.

## Design note — supersedes the design doc's "flatten into sub-structs"

Per-field `help_heading` on the **flat** `Args` was chosen over flattening into
`#[command(flatten)]` sub-structs. Rationale (2026-07-20 research): it is the
dominant real-world clap idiom at this scale (astral-sh/uv uses per-field
`help_heading` 136:1 over `next_help_heading`); clap buckets arguments by
heading **string** regardless of field declaration order, so no reorder is
needed; and it avoids re-touching PR 1's `merge_fields!` macro (which reads
flat `args.$field`) and the ~133 `args.field` call sites. No `Args` flatten,
no sub-structs, no field reorder.

## Guardrails (tests)

- **`every_option_is_classified_into_a_help_group`** — structural exhaustiveness
  test: fails the build if a future flag is added with no `help_heading` (or a
  wrong one). The CLI-side analog of PR 1's merge-exhaustiveness canary.
- **`all_headings_render_in_short_and_long_help`** — asserts all 10 headings
  appear in both `render_help()` (`-h`) and `render_long_help()` (`--help`).

## Manual verification

`cargo run -p rdlp-cli --bin rdlp -- --help` and `-- -h` both render these 10
section headers (identical in short and long help):

```
General
Simulation & Info
Post-Processing
Subtitles
Recode & Encoding
Audio Normalization
Network & Cookies
Download Behaviour
Search
Configuration & Plugins
```

Spot-checked flag placement: `--sub-langs` under **Subtitles**, `--proxy` under
**Network & Cookies**, `--recode-video` under **Recode & Encoding**; `-h`/`--help`/`-V` all still work.

## Confirmation

- No behaviour change — only `-h`/`--help` rendered text differs.
- `config.rs` / `merge_fields!` macro untouched; `main.rs` untouched.
- No `args.field` access site changed; `Args` not flattened; fields not reordered.

## Reviews

- **security-reviewer** (whole diff `develop..HEAD`): **Approve**, no findings —
  purely help-text/test, no parsing/validation/log/network/trust-boundary surface.
- **code-reviewer** (whole diff): **Approve** after one convention fix applied
  (per-const `///` doc comments on the 10 heading consts, matching `priority.rs`
  precedent). Confirmed no build-blocker — `missing_docs` doesn't fire on the
  binary crate; the full `cargo clippy --workspace --all-targets -- -D warnings`
  gate was green throughout.

Closes #592
Refs #585
