### PR TITLE
feat(cli): typed --help placeholders + leading usage examples

### DIFF
--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -127,21 +127,26 @@ pub struct Args {
     #[arg(value_parser = non_blank)]
     pub url: Option<String>,
 
+    // Deliberately two paragraphs: para 1 renders in `-h`; the resume-determinism
+    // caveat below renders only in `--help` (clap doc-comment split). Do not merge.
     /// Output template or directory (e.g., "%(title)s.%(ext)s" or "./downloads/")
     ///
     /// Note: resume across restarts requires a deterministic name. Templates using
     /// `%(epoch)s` render a different name each run, so an interrupted download cannot
     /// be resumed and restarts from zero. Build the template from stable metadata
     /// (`title`, `id`, `uploader`, `ext`, `upload_date`) for resumable downloads.
-    #[arg(short, long, value_parser = non_blank, help_heading = HELP_HEADING_GENERAL)]
+    #[arg(short, long, value_parser = non_blank, value_name = "TEMPLATE", help_heading = HELP_HEADING_GENERAL)]
     pub output: Option<String>,
 
     /// Output directory (always sets base directory, combinable with -o template)
-    #[arg(short = 'P', long = "paths", value_parser = non_blank_path, help_heading = HELP_HEADING_GENERAL)]
+    #[arg(short = 'P', long = "paths", value_parser = non_blank_path, value_name = "DIR", help_heading = HELP_HEADING_GENERAL)]
     pub output_dir: Option<PathBuf>,
 
     /// Format selection (e.g., "best", "bestvideo+bestaudio")
-    #[arg(short, long, value_parser = non_blank, help_heading = HELP_HEADING_GENERAL)]
+    // SELECTOR, not FORMAT: `format`.to_uppercase() == "FORMAT" is
+    // indistinguishable from clap's inferred echo and would defeat the
+    // placeholder canary.
+    #[arg(short, long, value_parser = non_blank, value_name = "SELECTOR", help_heading = HELP_HEADING_GENERAL)]
     pub format: Option<String>,
 
     /// Require strict video-only + audio-only streams for merge.
@@ -183,7 +188,7 @@ pub struct Args {
 
     /// Print specific field(s) from metadata (no download)
     /// e.g., --print title or --print "id,title,extractor"
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_INFO)]
+    #[arg(long, value_parser = non_blank, value_name = "FIELD", help_heading = HELP_HEADING_INFO)]
     pub print: Option<String>,
 
     /// Interactive format selection
@@ -197,11 +202,11 @@ pub struct Args {
 
     /// Audio format for extraction
     /// Use --audio-format for interactive, --audio-format=mp3 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_POSTPROCESS)]
     pub audio_format: Option<String>,
 
     /// Audio quality (VBR level 0-9 or bitrate like "192K")
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, value_parser = non_blank, value_name = "QUALITY", help_heading = HELP_HEADING_POSTPROCESS)]
     pub audio_quality: Option<String>,
 
     /// Embed metadata (title, artist, etc.) in the file
@@ -227,11 +232,11 @@ pub struct Args {
 
     /// Subtitle languages to download (comma-separated, e.g., "en,es")
     /// Use "all" to download all available
-    #[arg(long, alias = "sub-langs", value_parser = non_blank, help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, alias = "sub-langs", value_parser = non_blank, value_name = "LANGS", help_heading = HELP_HEADING_SUBTITLES)]
     pub sub_langs: Option<String>,
 
     /// Preferred subtitle format (srt, vtt, ass, ssa, lrc)
-    #[arg(long, alias = "sub-format", value_parser = non_blank, help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, alias = "sub-format", value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_SUBTITLES)]
     pub sub_format: Option<String>,
 
     /// Embed subtitles in video file (requires `FFmpeg`)
@@ -269,7 +274,7 @@ pub struct Args {
 
     /// Convert video to specified format
     /// Use --recode-video for interactive, --recode-video=mp4 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_RECODE)]
     pub recode_video: Option<String>,
 
     /// Target container format for video recode (e.g., mp4, mkv, webm).
@@ -317,7 +322,7 @@ pub struct Args {
 
     /// Remux to container for better seeking - no re-encoding
     /// Use --remux for interactive, --remux=mp4 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_POSTPROCESS)]
     pub remux: Option<String>,
 
     /// Normalize audio levels (peak mode: volume + limiter)
@@ -329,23 +334,23 @@ pub struct Args {
     pub loudnorm: bool,
 
     /// Target peak level in dBFS for peak normalization (default: -1.0)
-    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "DBFS", help_heading = HELP_HEADING_AUDIO_NORM)]
     pub audio_gain_target: Option<f64>,
 
     /// Loudnorm preset: broadcast (-23 LUFS), streaming (-14 LUFS), loud (-11 LUFS)
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, value_parser = non_blank, value_name = "PRESET", help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_preset: Option<String>,
 
     /// Target integrated loudness in LUFS for loudnorm (e.g., -14)
-    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "LUFS", help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_i: Option<f64>,
 
     /// Target true peak in dBTP for loudnorm (e.g., -1)
-    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "DBTP", help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_tp: Option<f64>,
 
     /// Target loudness range in LU for loudnorm (e.g., 11)
-    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, value_name = "LU", help_heading = HELP_HEADING_AUDIO_NORM)]
     pub loudnorm_lra: Option<f64>,
 
     /// Force dynamic (per-frame compression) mode in loudnorm pass 2
@@ -362,7 +367,7 @@ pub struct Args {
     pub normalize_boost: bool,
 
     /// Gain in dB for limiter-boost fallback (default: 12.0)
-    #[arg(long, allow_hyphen_values = true, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "DB", help_heading = HELP_HEADING_AUDIO_NORM)]
     pub normalize_boost_db: Option<f64>,
 
     /// Fixup policy: never, warn, `detect_or_warn` [default: `detect_or_warn`]
@@ -375,7 +380,7 @@ pub struct Args {
     // is builder-only, so the derive API expresses it as `Option`, with the
     // default supplied by `Config::default()`. Plain `//` — a `///` here would
     // print this note in `rdlp --help`.
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, value_parser = non_blank, value_name = "POLICY", help_heading = HELP_HEADING_POSTPROCESS)]
     pub fixup: Option<String>,
 
     /// Keep original video file after post-processing
@@ -383,12 +388,12 @@ pub struct Args {
     pub keep_video: bool,
 
     /// Path to `FFmpeg` executable (if not in PATH)
-    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, value_parser = non_blank_path, value_name = "PATH", help_heading = HELP_HEADING_POSTPROCESS)]
     pub ffmpeg_location: Option<PathBuf>,
 
     // === Network options ===
     /// HTTP/HTTPS/SOCKS proxy URL (e.g., <socks5://127.0.0.1:1080>)
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_parser = non_blank, value_name = "URL", help_heading = HELP_HEADING_NETWORK)]
     pub proxy: Option<String>,
 
     /// Connect/handshake timeout in seconds.
@@ -428,38 +433,38 @@ pub struct Args {
     pub browser: Option<String>,
 
     /// Limit download speed (e.g., "1M", "500K", "10M", "2.5M")
-    #[arg(long, short = 'r', value_parser = non_blank, help_heading = HELP_HEADING_DOWNLOAD)]
+    #[arg(long, short = 'r', value_parser = non_blank, value_name = "RATE", help_heading = HELP_HEADING_DOWNLOAD)]
     pub limit_rate: Option<String>,
 
     // === Cookie options ===
     /// Load cookies from browser (chrome, firefox)
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_parser = non_blank, value_name = "BROWSER", help_heading = HELP_HEADING_NETWORK)]
     pub cookies_from_browser: Option<String>,
 
     /// Path to Netscape-format cookies file
-    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_parser = non_blank_path, value_name = "FILE", help_heading = HELP_HEADING_NETWORK)]
     pub cookies: Option<PathBuf>,
 
     /// Path to download archive file (skip already-downloaded videos)
-    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_DOWNLOAD)]
+    #[arg(long, value_parser = non_blank_path, value_name = "FILE", help_heading = HELP_HEADING_DOWNLOAD)]
     pub download_archive: Option<PathBuf>,
 
     /// Filter videos by metadata (yt-dlp syntax). Repeatable (OR logic between filters).
     /// Examples: "duration > 60", "!`is_live`", "title *= cats", "`like_count` >? 100"
-    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank, help_heading = HELP_HEADING_DOWNLOAD)]
+    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank, value_name = "FILTER", help_heading = HELP_HEADING_DOWNLOAD)]
     pub match_filter: Vec<String>,
 
     // === Search options ===
     /// Perform a keyword search instead of downloading a URL
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_SEARCH)]
+    #[arg(long, value_parser = non_blank, value_name = "QUERY", help_heading = HELP_HEADING_SEARCH)]
     pub search: Option<String>,
 
     /// Site to search (required with --search, e.g., "xhamster")
-    #[arg(long, value_parser = non_blank, help_heading = HELP_HEADING_SEARCH)]
+    #[arg(long, value_parser = non_blank, value_name = "SITE", help_heading = HELP_HEADING_SEARCH)]
     pub search_site: Option<String>,
 
     /// Search filter in key=value format (repeatable)
-    #[arg(long = "search-filter", value_parser = non_blank, help_heading = HELP_HEADING_SEARCH)]
+    #[arg(long = "search-filter", value_parser = non_blank, value_name = "KEY=VALUE", help_heading = HELP_HEADING_SEARCH)]
     pub search_filter: Vec<String>,
 
     // === Config file options ===
@@ -468,14 +473,14 @@ pub struct Args {
     pub ignore_config: bool,
 
     /// Path to config file (TOML format)
-    #[arg(long, value_parser = non_blank_path, help_heading = HELP_HEADING_CONFIG)]
+    #[arg(long, value_parser = non_blank_path, value_name = "FILE", help_heading = HELP_HEADING_CONFIG)]
     pub config_location: Option<PathBuf>,
 
     // === Plugin options ===
     /// Pre-trust a publisher identity for non-interactive plugin install.
     /// Pass repeatedly for multiple identities.
     /// Format: `sigstore:github:user/repo` or `ed25519:<8-byte-hex>`.
-    #[arg(long, global = true, value_parser = non_blank, help_heading = HELP_HEADING_CONFIG)]
+    #[arg(long, global = true, value_parser = non_blank, value_name = "PUBLISHER", help_heading = HELP_HEADING_CONFIG)]
     pub trust_publisher: Vec<String>,
 
     /// Plugin management subcommand.

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -30,6 +30,28 @@ pub const HELP_HEADING_SEARCH: &str = "Search";
 /// Config file loading and plugin trust management.
 pub const HELP_HEADING_CONFIG: &str = "Configuration & Plugins";
 
+// Help layout: place the examples (`before_help`) AFTER the about line and
+// BEFORE usage — GNU tar / clig.dev "lead with examples" — in both `-h` and
+// `--help`. clap's default template has no slot there; this reorders the
+// standard placeholders (verified: clap_builder command.rs help_template).
+const HELP_TEMPLATE: &str = "\
+{about}
+
+{before-help}{usage-heading} {usage}
+
+{all-args}{after-help}";
+
+// Rendered in both `-h` and `--help` (before_help, not before_long_help). Every
+// line MUST stay <= 78 chars (guarded by `help_examples_lines_fit_80_columns`)
+// so it doesn't hard-wrap on an 80-col terminal — clap does not re-indent a
+// wrapped before_help continuation line, which would break the aligned table.
+const HELP_EXAMPLES: &str = "\
+Examples:
+  rdlp URL                                 Download a video (auto-resume)
+  rdlp -i URL                              Pick format/quality interactively
+  rdlp --cookies-from-browser chrome URL   Use browser cookies (login-gated)
+  rdlp --recode-video=mkv URL              Recode video to MKV";
+
 /// Rejects an empty or whitespace-only argument value.
 ///
 /// The shared rule behind [`non_blank`] and [`non_blank_path`]. A blank value
@@ -122,6 +144,8 @@ pub enum PluginCmd {
 #[command(name = "rdlp")]
 #[command(about = "Rust Download Program - A video downloader", long_about = None)]
 #[command(version)]
+#[command(help_template = HELP_TEMPLATE)]
+#[command(before_help = HELP_EXAMPLES)]
 pub struct Args {
     /// Video URL to download
     #[arg(value_parser = non_blank)]

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -176,3 +176,63 @@ fn all_headings_render_in_short_and_long_help() {
         );
     }
 }
+
+/// Maximum width for an option's value placeholder. A wider one inflates clap's
+/// shared `longest` column and flips the whole option block to next-line
+/// rendering (verified: `clap_builder` `help_template.rs` `will_args_wrap`) — the
+/// measured cause of the pre-PR-3 239-line `--help`.
+const MAX_VALUE_NAME_LEN: usize = 12;
+
+#[test]
+fn every_value_flag_has_a_tight_explicit_placeholder() {
+    let cmd = Args::command();
+    let mut checked = 0usize;
+
+    for arg in cmd.get_arguments() {
+        let id = arg.get_id().as_str();
+        // Skip positionals (e.g. `url` — its `<URL>` echo reads fine), clap's
+        // auto help/version, and flags that take no value (bools/counters
+        // render no placeholder).
+        if arg.is_positional()
+            || id == "help"
+            || id == "version"
+            || !arg.get_action().takes_values()
+        {
+            continue;
+        }
+
+        let names: Vec<&str> = arg
+            .get_value_names()
+            .map(|ns| ns.iter().map(std::convert::AsRef::as_ref).collect())
+            .unwrap_or_default();
+
+        assert!(
+            !names.is_empty(),
+            "value flag `{id}` has no value_name (clap would echo its \
+             field name). Add `value_name = \"…\"` (#585 PR 3).",
+        );
+
+        for name in names {
+            assert_ne!(
+                name,
+                id.to_uppercase(),
+                "value flag `{id}` still renders clap's inferred `<{}>` \
+                 placeholder — add an explicit tight `value_name` (#585 PR 3).",
+                id.to_uppercase(),
+            );
+            assert!(
+                name.len() <= MAX_VALUE_NAME_LEN,
+                "value_name `<{name}>` for `{id}` is {} chars (> {MAX_VALUE_NAME_LEN}); \
+                 a wide placeholder flips the whole help block to next-line rendering.",
+                name.len(),
+            );
+        }
+        checked += 1;
+    }
+
+    // Sanity: 29 annotated in this PR + 14 pre-existing tight value_names = 43.
+    assert_eq!(
+        checked, 43,
+        "expected 43 value-taking flags; got {checked} — a flag was added or removed",
+    );
+}

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -236,3 +236,53 @@ fn every_value_flag_has_a_tight_explicit_placeholder() {
         "expected 43 value-taking flags; got {checked} — a flag was added or removed",
     );
 }
+
+#[test]
+fn examples_lead_the_help_before_options() {
+    let short = Args::command().render_help().to_string();
+    let long = Args::command().render_long_help().to_string();
+
+    for (label, help) in [("-h", &short), ("--help", &long)] {
+        // The examples block renders…
+        let ex = help
+            .find("Examples:")
+            .unwrap_or_else(|| panic!("`{label}` help is missing the Examples block"));
+        // …after the about line…
+        let about = help
+            .find("Rust Download Program")
+            .unwrap_or_else(|| panic!("`{label}` help is missing the about line"));
+        // …before the first option heading (General) and before the Usage line.
+        let general = help
+            .find("General")
+            .unwrap_or_else(|| panic!("`{label}` help is missing the General heading"));
+        let usage = help
+            .find("Usage:")
+            .unwrap_or_else(|| panic!("`{label}` help is missing the Usage line"));
+
+        assert!(about < ex, "`{label}`: about should precede Examples");
+        assert!(ex < usage, "`{label}`: Examples should precede Usage");
+        assert!(
+            ex < general,
+            "`{label}`: Examples should precede the option list"
+        );
+        // A representative example command is present.
+        assert!(
+            help.contains("--cookies-from-browser chrome"),
+            "`{label}` help is missing a representative example line",
+        );
+    }
+}
+
+#[test]
+fn help_examples_lines_fit_80_columns() {
+    // 80 cols is the conventional terminal default; a longer example line
+    // hard-wraps and breaks the aligned Examples table. clap does not
+    // re-indent wrapped before_help continuation lines.
+    for line in super::HELP_EXAMPLES.lines() {
+        assert!(
+            line.chars().count() <= 78,
+            "example line is {} chars (>78, wraps at 80): {line:?}",
+            line.chars().count(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of the #585 CLI/config-unification sequence — the `--help` redesign. Two
pure-output changes, **zero behaviour change**:

1. **Typed placeholders** — 29 value-taking flags that rendered clap's noisy
   inferred field-name echo (`--cookies-from-browser <COOKIES_FROM_BROWSER>`)
   now use tight semantic tokens (`<BROWSER>`, `<URL>`, `<RATE>`, `<LUFS>`,
   `<FILE>`, …). This lets `-h` render options **inline** instead of next-line.
2. **Leading examples** — `-h`/`--help` now open with a curated `Examples:`
   block (clig.dev "lead with examples"), via `help_template` + `before_help`,
   in both short and long help.

**Measured result:** `-h` drops **162 → 113 lines** (options now inline).
`--help` is the full reference and stays in clap's long-help next-line mode
(like `cargo --help`); it grows only by the examples block.

## The placeholder mapping (29 flags)

| token | flags |
|---|---|
| `TEMPLATE` | output |
| `DIR` | output_dir |
| `SELECTOR` | format *(not `FORMAT` — that collides with the canary; it's a format-selector expression)* |
| `FIELD` | print |
| `FORMAT` | audio_format, sub_format, recode_video, remux |
| `QUALITY` | audio_quality |
| `POLICY` | fixup |
| `PATH` | ffmpeg_location |
| `LANGS` | sub_langs |
| `DBFS` `PRESET` `LUFS` `DBTP` `LU` `DB` | audio_gain_target, loudnorm_preset, loudnorm_i, loudnorm_tp, loudnorm_lra, normalize_boost_db |
| `URL` | proxy |
| `BROWSER` | cookies_from_browser |
| `FILE` | cookies, download_archive, config_location |
| `RATE` | limit_rate |
| `FILTER` | match_filter |
| `QUERY` `SITE` `KEY=VALUE` | search, search_site, search_filter |
| `PUBLISHER` | trust_publisher |

The 14 flags that already had tight `value_name`s (`NAME`, `FMT`, `SECS`, …) and the `url` positional are untouched.

## Help header (both `-h` and `--help`)

```
Rust Download Program - A video downloader

Examples:
  rdlp URL                                 Download a video (auto-resume)
  rdlp -i URL                              Pick format/quality interactively
  rdlp --cookies-from-browser chrome URL   Use browser cookies (login-gated)
  rdlp --recode-video=mkv URL              Recode video to MKV

Usage: rdlp [OPTIONS] [URL] [COMMAND]
```

## Guardrails (tests)

- **`every_value_flag_has_a_tight_explicit_placeholder`** — fails the build if a
  future value flag renders clap's inferred echo or uses a token > 12 chars
  (the next-line-wrap footgun). The placeholder analog of PR 2's grouping canary.
- **`examples_lead_the_help_before_options`** — asserts about < Examples < Usage
  < options in both `-h` and `--help`.
- **`help_examples_lines_fit_80_columns`** — every example line ≤ 78 chars, so a
  future edit can't reintroduce a wrapping line.

## Deliberately out of scope

- **`default_value_t`** — excluded. Research (clap 4.6 source + idiomatic
  layered-config Rust + Unix convention) confirmed it is a *compile error* on
  `Option<T>`, and on plain `T` it makes an absent flag indistinguishable from
  the default — which would regress `merge_config`'s `is_some()`-keyed layering
  (the #540/#583 silent-default class). Defaults stay hand-written prose, which
  is the idiomatic layered-config pattern and matches yt-dlp.
- **`-h`/`--help` tiering** (`hide_short_help`) → PR 3b (needs an editorial
  common-set decision).
- **Short options / aliases / negations** → PR 4.
- **No `Args` flatten** — kept flat per PR 2's decision (flatten would rework
  `merge_fields!` and ~133 call sites).

## Confirmation

- No behaviour change — only `-h`/`--help` rendered text differs.
- `config.rs` / `merge_fields!` / `main.rs` show zero diff.
- No `args.field` access changed; no field's parse-affecting attribute
  (`value_parser`/`action`/`num_args`/`default_missing_value`/…) altered.

## Reviews

- **security-reviewer** (whole diff `develop..HEAD`): **Approve**, no findings —
  pure display-only, no parsing/log/network/trust-boundary surface.
- **code-reviewer** (whole diff): **Approve**, no findings — verified all 43
  value_names, zero attribute drift, non-tautological tests. (Two per-task
  findings — a wrapping 99-char example line and a `SELECTOR`-rationale comment
  — were fixed during task review before this whole-branch pass.)

Closes #594
Refs #585
