### PR TITLE
feat(cli): tier -h to a common subset, full list in --help

### DIFF
--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -52,6 +52,12 @@ Examples:
   rdlp --cookies-from-browser chrome URL   Use browser cookies (login-gated)
   rdlp --recode-video=mkv URL              Recode video to MKV";
 
+// Shown only in `-h` (via after_help), suppressed in `--help` by an empty
+// after_long_help — `--help` already lists every option so the pointer would be
+// noise there. Keep the line <= 78 chars (clap wraps after_help at term width).
+const HELP_SHORT_FOOTER: &str =
+    "Showing common options. Run 'rdlp --help' for the full list of options.";
+
 /// Rejects an empty or whitespace-only argument value.
 ///
 /// The shared rule behind [`non_blank`] and [`non_blank_path`]. A blank value
@@ -146,6 +152,8 @@ pub enum PluginCmd {
 #[command(version)]
 #[command(help_template = HELP_TEMPLATE)]
 #[command(before_help = HELP_EXAMPLES)]
+#[command(after_help = HELP_SHORT_FOOTER)]
+#[command(after_long_help = "")]
 pub struct Args {
     /// Video URL to download
     #[arg(value_parser = non_blank)]

--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -175,7 +175,7 @@ pub struct Args {
 
     /// Require strict video-only + audio-only streams for merge.
     /// Changes default from b/bv*+ba to b/bv+ba.
-    #[arg(long, help_heading = HELP_HEADING_GENERAL)]
+    #[arg(long, help_heading = HELP_HEADING_GENERAL, hide_short_help = true)]
     pub audio_multistreams: bool,
 
     /// Quiet mode (minimal output)
@@ -187,15 +187,15 @@ pub struct Args {
     pub verbose: bool,
 
     /// List all supported extractors
-    #[arg(long, help_heading = HELP_HEADING_INFO)]
+    #[arg(long, help_heading = HELP_HEADING_INFO, hide_short_help = true)]
     pub list_extractors: bool,
 
     /// List all supported download protocols
-    #[arg(long, help_heading = HELP_HEADING_INFO)]
+    #[arg(long, help_heading = HELP_HEADING_INFO, hide_short_help = true)]
     pub list_downloaders: bool,
 
     /// List all supported audio and video codecs
-    #[arg(long, help_heading = HELP_HEADING_INFO)]
+    #[arg(long, help_heading = HELP_HEADING_INFO, hide_short_help = true)]
     pub list_codecs: bool,
 
     /// Simulate (don't actually download, shows extraction summary)
@@ -212,7 +212,7 @@ pub struct Args {
 
     /// Print specific field(s) from metadata (no download)
     /// e.g., --print title or --print "id,title,extractor"
-    #[arg(long, value_parser = non_blank, value_name = "FIELD", help_heading = HELP_HEADING_INFO)]
+    #[arg(long, value_parser = non_blank, value_name = "FIELD", help_heading = HELP_HEADING_INFO, hide_short_help = true)]
     pub print: Option<String>,
 
     /// Interactive format selection
@@ -226,11 +226,11 @@ pub struct Args {
 
     /// Audio format for extraction
     /// Use --audio-format for interactive, --audio-format=mp3 for direct
-    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "interactive", require_equals = true, value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub audio_format: Option<String>,
 
     /// Audio quality (VBR level 0-9 or bitrate like "192K")
-    #[arg(long, value_parser = non_blank, value_name = "QUALITY", help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, value_parser = non_blank, value_name = "QUALITY", help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub audio_quality: Option<String>,
 
     /// Embed metadata (title, artist, etc.) in the file
@@ -238,11 +238,11 @@ pub struct Args {
     pub embed_metadata: bool,
 
     /// Disable automatic thumbnail download and embedding
-    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub no_thumbnail: bool,
 
     /// Write thumbnail image to disk alongside media file
-    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub write_thumbnail: bool,
 
     // === Subtitle options ===
@@ -251,7 +251,7 @@ pub struct Args {
     pub write_subtitles: bool,
 
     /// Download auto-generated subtitles
-    #[arg(long, alias = "write-auto-subs", help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, alias = "write-auto-subs", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub write_auto_subtitles: bool,
 
     /// Subtitle languages to download (comma-separated, e.g., "en,es")
@@ -260,7 +260,7 @@ pub struct Args {
     pub sub_langs: Option<String>,
 
     /// Preferred subtitle format (srt, vtt, ass, ssa, lrc)
-    #[arg(long, alias = "sub-format", value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, alias = "sub-format", value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub sub_format: Option<String>,
 
     /// Embed subtitles in video file (requires `FFmpeg`)
@@ -268,32 +268,32 @@ pub struct Args {
     pub embed_subtitles: bool,
 
     /// Interactive subtitle selection + video download (implies --write-subtitles)
-    #[arg(long, alias = "list-subs", help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, alias = "list-subs", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub list_subs: bool,
 
     /// Show subtitle menu, download only subtitles (no video), then exit
-    #[arg(long, alias = "list-subs-only", help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, alias = "list-subs-only", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub list_subs_only: bool,
 
     /// Strict subtitle mode: fail download if requested subs are missing
-    #[arg(long, help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub strict_subs: bool,
 
     /// Pre-validate subtitle URLs with HEAD requests before download
-    #[arg(long, help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub verify_sub_urls: bool,
 
     /// Retry subtitle downloads for already-downloaded videos missing subs
-    #[arg(long, help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub retry_subs: bool,
 
     /// Video encoder to use (e.g., libsvtav1, libx264).
     /// Overrides automatic encoder selection.
-    #[arg(long, value_name = "NAME", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "NAME", value_parser = non_blank, help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub video_encoder: Option<String>,
 
     /// List available video encoders and exit.
-    #[arg(long, help_heading = HELP_HEADING_INFO)]
+    #[arg(long, help_heading = HELP_HEADING_INFO, hide_short_help = true)]
     pub list_encoders: bool,
 
     /// Convert video to specified format
@@ -303,7 +303,7 @@ pub struct Args {
 
     /// Target container format for video recode (e.g., mp4, mkv, webm).
     /// Takes precedence over --recode-video when both are specified.
-    #[arg(long, value_name = "FMT", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "FMT", value_parser = non_blank, help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub recode_container: Option<String>,
 
     /// Audio mode during video recode: copy (default), auto, or an encoder name
@@ -324,24 +324,24 @@ pub struct Args {
     // `rdlp_types::config::MAX_RECODE_THREADS` and `8` in sync with
     // `rdlp_ffmpeg`'s `AUTO_RECODE_THREADS_CAP`.
     /// Encoder threads for video recode (1-64). Omit for auto (min(cores, 8)).
-    #[arg(long, value_name = "N", help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "N", help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub recode_threads: Option<u32>,
 
     /// Encoder preset override for video recode (e.g. `faster`, `medium`, `slow`).
     /// Omit to use the per-codec default. `libvvenc`: try `faster` for speed.
-    #[arg(long, value_name = "PRESET", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "PRESET", value_parser = non_blank, help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub recode_preset: Option<String>,
 
     /// libvpx deadline for VP8/VP9 recode: best | good | realtime.
-    #[arg(long, value_name = "MODE", value_parser = non_blank, help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "MODE", value_parser = non_blank, help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub recode_deadline: Option<String>,
 
     /// libvpx cpu-used for VP8/VP9 recode (VP9: -8..8, VP8: -16..16).
-    #[arg(long, value_name = "N", allow_hyphen_values = true, help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "N", allow_hyphen_values = true, help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub recode_cpu_used: Option<i32>,
 
     /// libxavs2 `speed_level` for AVS2 recode (0..9).
-    #[arg(long, value_name = "N", help_heading = HELP_HEADING_RECODE)]
+    #[arg(long, value_name = "N", help_heading = HELP_HEADING_RECODE, hide_short_help = true)]
     pub recode_speed_level: Option<u32>,
 
     /// Remux to container for better seeking - no re-encoding
@@ -358,40 +358,40 @@ pub struct Args {
     pub loudnorm: bool,
 
     /// Target peak level in dBFS for peak normalization (default: -1.0)
-    #[arg(long, allow_hyphen_values = true, value_name = "DBFS", help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "DBFS", help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub audio_gain_target: Option<f64>,
 
     /// Loudnorm preset: broadcast (-23 LUFS), streaming (-14 LUFS), loud (-11 LUFS)
-    #[arg(long, value_parser = non_blank, value_name = "PRESET", help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, value_parser = non_blank, value_name = "PRESET", help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub loudnorm_preset: Option<String>,
 
     /// Target integrated loudness in LUFS for loudnorm (e.g., -14)
-    #[arg(long, allow_hyphen_values = true, value_name = "LUFS", help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "LUFS", help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub loudnorm_i: Option<f64>,
 
     /// Target true peak in dBTP for loudnorm (e.g., -1)
-    #[arg(long, allow_hyphen_values = true, value_name = "DBTP", help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "DBTP", help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub loudnorm_tp: Option<f64>,
 
     /// Target loudness range in LU for loudnorm (e.g., 11)
-    #[arg(long, value_name = "LU", help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, value_name = "LU", help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub loudnorm_lra: Option<f64>,
 
     /// Force dynamic (per-frame compression) mode in loudnorm pass 2
-    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub loudnorm_dynamic: bool,
 
     /// Prepend a mild acompressor before loudnorm to tame extreme peaks
-    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub loudnorm_precompress: bool,
 
     /// Enable limiter-boost fallback (+12 dB gain + hard limiter) for
     /// over-compressed content (implies --loudnorm)
-    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub normalize_boost: bool,
 
     /// Gain in dB for limiter-boost fallback (default: 12.0)
-    #[arg(long, allow_hyphen_values = true, value_name = "DB", help_heading = HELP_HEADING_AUDIO_NORM)]
+    #[arg(long, allow_hyphen_values = true, value_name = "DB", help_heading = HELP_HEADING_AUDIO_NORM, hide_short_help = true)]
     pub normalize_boost_db: Option<f64>,
 
     /// Fixup policy: never, warn, `detect_or_warn` [default: `detect_or_warn`]
@@ -404,15 +404,15 @@ pub struct Args {
     // is builder-only, so the derive API expresses it as `Option`, with the
     // default supplied by `Config::default()`. Plain `//` — a `///` here would
     // print this note in `rdlp --help`.
-    #[arg(long, value_parser = non_blank, value_name = "POLICY", help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, value_parser = non_blank, value_name = "POLICY", help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub fixup: Option<String>,
 
     /// Keep original video file after post-processing
-    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub keep_video: bool,
 
     /// Path to `FFmpeg` executable (if not in PATH)
-    #[arg(long, value_parser = non_blank_path, value_name = "PATH", help_heading = HELP_HEADING_POSTPROCESS)]
+    #[arg(long, value_parser = non_blank_path, value_name = "PATH", help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
     pub ffmpeg_location: Option<PathBuf>,
 
     // === Network options ===
@@ -422,30 +422,30 @@ pub struct Args {
 
     /// Connect/handshake timeout in seconds.
     /// Validated post-parse by `Config::validate()`: must be 1..=300.
-    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK, hide_short_help = true)]
     pub socket_timeout: Option<u64>,
 
     /// Per-read idle timeout in seconds.
     /// Validated post-parse by `Config::validate()`: must be 1..=600.
-    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK, hide_short_help = true)]
     pub read_timeout: Option<u64>,
 
     /// Idle keep-alive socket eviction timeout in seconds. `0` is the
     /// documented sentinel meaning "disable eviction (keep idle sockets
     /// forever)".
     /// Validated post-parse by `Config::validate()`: must be 0..=3600.
-    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK, hide_short_help = true)]
     pub pool_idle_timeout: Option<u64>,
 
     /// Total download timeout in seconds (the entire file must complete within
     /// this). Default 3600.
     /// Validated post-parse by `Config::validate()`: must be 1..=86400.
-    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK, hide_short_help = true)]
     pub download_timeout: Option<u64>,
 
     /// Merge (mux/concat) operation timeout in seconds. Default 1800.
     /// Validated post-parse by `Config::validate()`: must be 1..=86400.
-    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_name = "SECS", help_heading = HELP_HEADING_NETWORK, hide_short_help = true)]
     pub merge_timeout: Option<u64>,
 
     /// Browser emulation profile for the TLS / HTTP stack
@@ -453,7 +453,7 @@ pub struct Args {
     /// identifier like chrome-137). Controls JA4 / JA4H fingerprint.
     /// Falls back to the `RDLP_BROWSER_EMULATION` env var, then
     /// `ChromeLatest`.
-    #[arg(long, value_name = "PROFILE", value_parser = non_blank, help_heading = HELP_HEADING_NETWORK)]
+    #[arg(long, value_name = "PROFILE", value_parser = non_blank, help_heading = HELP_HEADING_NETWORK, hide_short_help = true)]
     pub browser: Option<String>,
 
     /// Limit download speed (e.g., "1M", "500K", "10M", "2.5M")
@@ -475,7 +475,7 @@ pub struct Args {
 
     /// Filter videos by metadata (yt-dlp syntax). Repeatable (OR logic between filters).
     /// Examples: "duration > 60", "!`is_live`", "title *= cats", "`like_count` >? 100"
-    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank, value_name = "FILTER", help_heading = HELP_HEADING_DOWNLOAD)]
+    #[arg(long = "match-filter", action = clap::ArgAction::Append, value_parser = non_blank, value_name = "FILTER", help_heading = HELP_HEADING_DOWNLOAD, hide_short_help = true)]
     pub match_filter: Vec<String>,
 
     // === Search options ===
@@ -488,12 +488,12 @@ pub struct Args {
     pub search_site: Option<String>,
 
     /// Search filter in key=value format (repeatable)
-    #[arg(long = "search-filter", value_parser = non_blank, value_name = "KEY=VALUE", help_heading = HELP_HEADING_SEARCH)]
+    #[arg(long = "search-filter", value_parser = non_blank, value_name = "KEY=VALUE", help_heading = HELP_HEADING_SEARCH, hide_short_help = true)]
     pub search_filter: Vec<String>,
 
     // === Config file options ===
     /// Ignore config file (don't load from default location)
-    #[arg(long, help_heading = HELP_HEADING_CONFIG)]
+    #[arg(long, help_heading = HELP_HEADING_CONFIG, hide_short_help = true)]
     pub ignore_config: bool,
 
     /// Path to config file (TOML format)
@@ -504,7 +504,7 @@ pub struct Args {
     /// Pre-trust a publisher identity for non-interactive plugin install.
     /// Pass repeatedly for multiple identities.
     /// Format: `sigstore:github:user/repo` or `ed25519:<8-byte-hex>`.
-    #[arg(long, global = true, value_parser = non_blank, value_name = "PUBLISHER", help_heading = HELP_HEADING_CONFIG)]
+    #[arg(long, global = true, value_parser = non_blank, value_name = "PUBLISHER", help_heading = HELP_HEADING_CONFIG, hide_short_help = true)]
     pub trust_publisher: Vec<String>,
 
     /// Plugin management subcommand.

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -286,3 +286,155 @@ fn help_examples_lines_fit_80_columns() {
         );
     }
 }
+
+/// Ids visible in `-h` (short help). Everything else that takes part in tiering
+/// is EXPERT and hidden from `-h` (still shown in `--help`). Keep in sync with
+/// the `hide_short_help = true` annotations in args.rs.
+const HELP_SHORT_COMMON: &[&str] = &[
+    // General
+    "output",
+    "output_dir",
+    "format",
+    "quiet",
+    "verbose",
+    "interactive",
+    // Simulation & Info
+    "list_formats",
+    "simulate",
+    "dump_json",
+    // Post-Processing
+    "extract_audio",
+    "remux",
+    "embed_metadata",
+    // Subtitles
+    "embed_subtitles",
+    "sub_langs",
+    "write_subtitles",
+    // Recode & Encoding
+    "recode_video",
+    "recode_audio",
+    // Audio Normalization
+    "normalize_audio",
+    "loudnorm",
+    // Network & Cookies
+    "cookies_from_browser",
+    "cookies",
+    "proxy",
+    // Download Behaviour
+    "limit_rate",
+    "download_archive",
+    // Search
+    "search",
+    "search_site",
+    // Configuration & Plugins
+    "config_location",
+];
+
+/// Ids hidden from `-h` (present only in `--help`).
+const HELP_SHORT_EXPERT: &[&str] = &[
+    // General
+    "audio_multistreams",
+    // Simulation & Info
+    "print",
+    "list_extractors",
+    "list_downloaders",
+    "list_codecs",
+    "list_encoders",
+    // Post-Processing
+    "audio_format",
+    "audio_quality",
+    "no_thumbnail",
+    "write_thumbnail",
+    "fixup",
+    "keep_video",
+    "ffmpeg_location",
+    // Subtitles
+    "write_auto_subtitles",
+    "sub_format",
+    "list_subs",
+    "list_subs_only",
+    "strict_subs",
+    "verify_sub_urls",
+    "retry_subs",
+    // Recode & Encoding
+    "video_encoder",
+    "recode_container",
+    "recode_threads",
+    "recode_preset",
+    "recode_deadline",
+    "recode_cpu_used",
+    "recode_speed_level",
+    // Audio Normalization
+    "audio_gain_target",
+    "loudnorm_preset",
+    "loudnorm_i",
+    "loudnorm_tp",
+    "loudnorm_lra",
+    "loudnorm_dynamic",
+    "loudnorm_precompress",
+    "normalize_boost",
+    "normalize_boost_db",
+    // Network & Cookies
+    "socket_timeout",
+    "read_timeout",
+    "pool_idle_timeout",
+    "download_timeout",
+    "merge_timeout",
+    "browser",
+    // Download Behaviour
+    "match_filter",
+    // Search
+    "search_filter",
+    // Configuration & Plugins
+    "ignore_config",
+    "trust_publisher",
+];
+
+#[test]
+fn every_option_is_tiered_common_or_expert() {
+    use std::collections::HashSet;
+
+    assert_eq!(HELP_SHORT_COMMON.len(), 27, "common set drifted");
+    assert_eq!(HELP_SHORT_EXPERT.len(), 46, "expert set drifted");
+    let common: HashSet<&str> = HELP_SHORT_COMMON.iter().copied().collect();
+    let expert: HashSet<&str> = HELP_SHORT_EXPERT.iter().copied().collect();
+    assert!(
+        common.is_disjoint(&expert),
+        "an id is in both COMMON and EXPERT"
+    );
+
+    let cmd = Args::command();
+    let mut seen = HashSet::new();
+
+    for arg in cmd.get_arguments() {
+        let id = arg.get_id().as_str();
+        if arg.is_positional() || id == "help" || id == "version" {
+            continue;
+        }
+        seen.insert(id.to_owned());
+        let hidden = arg.is_hide_short_help_set();
+        if common.contains(id) {
+            assert!(
+                !hidden,
+                "`{id}` is COMMON but is hidden from -h (drop its hide_short_help)"
+            );
+        } else if expert.contains(id) {
+            assert!(
+                hidden,
+                "`{id}` is EXPERT but visible in -h (add hide_short_help = true)"
+            );
+        } else {
+            panic!(
+                "flag `{id}` is not tiered. Add it to HELP_SHORT_COMMON (visible in -h) or \
+                 HELP_SHORT_EXPERT + `hide_short_help = true` (—help only). #585 PR 3b.",
+            );
+        }
+    }
+
+    for id in HELP_SHORT_COMMON.iter().chain(HELP_SHORT_EXPERT) {
+        assert!(
+            seen.contains(*id),
+            "tier map lists `{id}`, not a real Args option"
+        );
+    }
+}

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -438,3 +438,32 @@ fn every_option_is_tiered_common_or_expert() {
         );
     }
 }
+
+#[test]
+fn short_help_footer_fits_80_columns() {
+    // clap wraps after_help at terminal width; keep the -h footer on one line.
+    assert!(
+        super::HELP_SHORT_FOOTER.chars().count() <= 78,
+        "HELP_SHORT_FOOTER is {} chars (>78, wraps at 80)",
+        super::HELP_SHORT_FOOTER.chars().count(),
+    );
+}
+
+#[test]
+fn short_help_footer_only_in_short_help() {
+    let short = Args::command().render_help().to_string();
+    let long = Args::command().render_long_help().to_string();
+    assert!(
+        short.contains("Run 'rdlp --help' for the full list"),
+        "`-h` output is missing the footer pointing to --help",
+    );
+    assert!(
+        !long.contains("Run 'rdlp --help' for the full list"),
+        "`--help` should NOT carry the short-help footer (it already lists everything)",
+    );
+    // The empty `after_long_help` must not leak a trailing blank block into --help.
+    assert!(
+        !long.ends_with("\n\n"),
+        "--help gained a stray trailing blank line from after_long_help = \"\"",
+    );
+}


### PR DESCRIPTION
## Summary

PR 3b of the #585 CLI/config-unification sequence — the `-h`/`--help` **tiering** step. Help-text only, **zero behaviour change**.

- **Tier `-h`** — the 46 expert/tuning flags get `hide_short_help = true`, so `-h` shows only a curated **27-option common set** while `--help` keeps all 73. Hiding a flag doesn't disable it — every flag still parses.
- **`-h`-only footer** — `after_help` (with an empty `after_long_help` to suppress it in `--help`) adds a line pointing users to `--help` for the rest.

**Measured result:** `-h` drops **113 → 69 lines** and stays scannable; `--help` unchanged at 255 with all 73 options. All 10 group headings still render in `-h` (every group keeps ≥1 common option).

## The tier map

**`-h`-visible common set (27)** — every short-flagged option + the everyday long flags:

| Group | Common (stays in `-h`) |
|---|---|
| General | `-o/--output`, `-P/--paths`, `-f/--format`, `-q/--quiet`, `-v/--verbose`, `-i/--interactive` |
| Simulation & Info | `-F/--list-formats`, `-s/--simulate`, `-j/--dump-json` |
| Post-Processing | `-x/--extract-audio`, `--remux`, `--embed-metadata` |
| Subtitles | `--embed-subtitles`, `--sub-langs`, `--write-subtitles` |
| Recode & Encoding | `--recode-video`, `--recode-audio` |
| Audio Normalization | `--normalize-audio`, `--loudnorm` |
| Network & Cookies | `--cookies-from-browser`, `--cookies`, `--proxy` |
| Download Behaviour | `-r/--limit-rate`, `--download-archive` |
| Search | `--search`, `--search-site` |
| Configuration & Plugins | `--config-location` |

The other **46** flags (tuning params, timeouts, list-* info flags, subtitle/recode detail, etc.) are `--help`-only.

## `-h` footer

```
Configuration & Plugins:
      --config-location <FILE>  Path to config file (TOML format)

Showing common options. Run 'rdlp --help' for the full list of options.
```

## Guardrails (tests)

- **`every_option_is_tiered_common_or_expert`** — fails the build if a future flag is added un-tiered (in neither list) or with the wrong `hide_short_help` state; asserts the 27/46/73 counts. The tiering analog of PR 2's grouping canary.
- **`short_help_footer_only_in_short_help`** — footer present in `-h`, absent from `--help`, and no stray trailing blank line leaks into `--help`.
- **`short_help_footer_fits_80_columns`** — footer ≤ 78 chars.
- PR 2's `all_headings_render_in_short_and_long_help` still passes unmodified — it doubles as the "no group fully hidden from `-h`" guard.

## Confirmation

- No behaviour change — only `-h`/`--help` visibility differs; every hidden flag still parses.
- `config.rs` / `merge_fields!` / `main.rs` show zero diff.
- Only `hide_short_help` appended to the 46 expert `#[arg(...)]` — no parse-affecting attribute (`value_parser`/`action`/`num_args`/`value_name`/…) altered; no `default_value_t`; no flatten/reorder.

## Deliberately out of scope

Short options / `visible_alias` / negations → PR 4. Option registry + GUI-parity gate → PR 5.

## Reviews

- **security-reviewer** (whole diff `develop..HEAD`): **Approve**, no findings — display-only, no parse/log/network/trust surface.
- **code-reviewer** (whole diff): **Approve**, no findings — verified 46/27 split exact, zero attribute drift, every group keeps a common option, tests non-tautological. Its one Minor (verify no stray `--help` blank line) was closed with the `!long.ends_with("\n\n")` guard.

Closes #596
Refs #585
