### PR TITLE
feat(cli): adopt -k/-O short flags, remove no-op aliases

### DIFF
--- a/crates/rdlp-cli/src/args.rs
+++ b/crates/rdlp-cli/src/args.rs
@@ -220,10 +220,13 @@ pub struct Args {
 
     /// Print specific field(s) from metadata (no download)
     /// e.g., --print title or --print "id,title,extractor"
-    #[arg(long, value_parser = non_blank, value_name = "FIELD", help_heading = HELP_HEADING_INFO, hide_short_help = true)]
+    #[arg(short = 'O', long, value_parser = non_blank, value_name = "FIELD", help_heading = HELP_HEADING_INFO)]
     pub print: Option<String>,
 
     /// Interactive format selection
+    // Note: rdlp's `-i` is --interactive (format selection). yt-dlp's `-i` is
+    // --ignore-errors, which rdlp has no equivalent for. Kept deliberately; do not
+    // reassign — `-i URL` is a shipped example (see HELP_EXAMPLES).
     #[arg(short = 'i', long, help_heading = HELP_HEADING_GENERAL)]
     pub interactive: bool,
 
@@ -264,11 +267,11 @@ pub struct Args {
 
     /// Subtitle languages to download (comma-separated, e.g., "en,es")
     /// Use "all" to download all available
-    #[arg(long, alias = "sub-langs", value_parser = non_blank, value_name = "LANGS", help_heading = HELP_HEADING_SUBTITLES)]
+    #[arg(long, value_parser = non_blank, value_name = "LANGS", help_heading = HELP_HEADING_SUBTITLES)]
     pub sub_langs: Option<String>,
 
     /// Preferred subtitle format (srt, vtt, ass, ssa, lrc)
-    #[arg(long, alias = "sub-format", value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
+    #[arg(long, value_parser = non_blank, value_name = "FORMAT", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub sub_format: Option<String>,
 
     /// Embed subtitles in video file (requires `FFmpeg`)
@@ -276,11 +279,11 @@ pub struct Args {
     pub embed_subtitles: bool,
 
     /// Interactive subtitle selection + video download (implies --write-subtitles)
-    #[arg(long, alias = "list-subs", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub list_subs: bool,
 
     /// Show subtitle menu, download only subtitles (no video), then exit
-    #[arg(long, alias = "list-subs-only", help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
+    #[arg(long, help_heading = HELP_HEADING_SUBTITLES, hide_short_help = true)]
     pub list_subs_only: bool,
 
     /// Strict subtitle mode: fail download if requested subs are missing
@@ -416,7 +419,7 @@ pub struct Args {
     pub fixup: Option<String>,
 
     /// Keep original video file after post-processing
-    #[arg(long, help_heading = HELP_HEADING_POSTPROCESS, hide_short_help = true)]
+    #[arg(short = 'k', long, help_heading = HELP_HEADING_POSTPROCESS)]
     pub keep_video: bool,
 
     /// Path to `FFmpeg` executable (if not in PATH)

--- a/crates/rdlp-cli/src/args_tests.rs
+++ b/crates/rdlp-cli/src/args_tests.rs
@@ -302,10 +302,12 @@ const HELP_SHORT_COMMON: &[&str] = &[
     "list_formats",
     "simulate",
     "dump_json",
+    "print",
     // Post-Processing
     "extract_audio",
     "remux",
     "embed_metadata",
+    "keep_video",
     // Subtitles
     "embed_subtitles",
     "sub_langs",
@@ -335,7 +337,6 @@ const HELP_SHORT_EXPERT: &[&str] = &[
     // General
     "audio_multistreams",
     // Simulation & Info
-    "print",
     "list_extractors",
     "list_downloaders",
     "list_codecs",
@@ -346,7 +347,6 @@ const HELP_SHORT_EXPERT: &[&str] = &[
     "no_thumbnail",
     "write_thumbnail",
     "fixup",
-    "keep_video",
     "ffmpeg_location",
     // Subtitles
     "write_auto_subtitles",
@@ -394,8 +394,8 @@ const HELP_SHORT_EXPERT: &[&str] = &[
 fn every_option_is_tiered_common_or_expert() {
     use std::collections::HashSet;
 
-    assert_eq!(HELP_SHORT_COMMON.len(), 27, "common set drifted");
-    assert_eq!(HELP_SHORT_EXPERT.len(), 46, "expert set drifted");
+    assert_eq!(HELP_SHORT_COMMON.len(), 29, "common set drifted");
+    assert_eq!(HELP_SHORT_EXPERT.len(), 44, "expert set drifted");
     let common: HashSet<&str> = HELP_SHORT_COMMON.iter().copied().collect();
     let expert: HashSet<&str> = HELP_SHORT_EXPERT.iter().copied().collect();
     assert!(
@@ -466,4 +466,87 @@ fn short_help_footer_only_in_short_help() {
         !long.ends_with("\n\n"),
         "--help gained a stray trailing blank line from after_long_help = \"\"",
     );
+}
+
+#[test]
+fn short_flags_k_and_o_parse() {
+    use clap::Parser;
+
+    // -k => keep_video (yt-dlp parity)
+    let a = Args::try_parse_from(["rdlp", "-k", "https://example.com/v"]).expect("-k should parse");
+    assert!(a.keep_video, "-k must set keep_video");
+
+    // -O => print (uppercase O; coexists with lowercase -o = --output, curl precedent)
+    let b = Args::try_parse_from(["rdlp", "-O", "title", "https://example.com/v"])
+        .expect("-O should parse");
+    assert_eq!(b.print.as_deref(), Some("title"), "-O must set print");
+
+    // -o (lowercase) still means --output, not print
+    let c = Args::try_parse_from(["rdlp", "-o", "out.mp4", "https://example.com/v"])
+        .expect("-o should parse");
+    assert_eq!(
+        c.output.as_deref(),
+        Some("out.mp4"),
+        "-o must still be --output"
+    );
+    assert_eq!(c.print, None);
+}
+
+#[test]
+fn renamed_and_removed_sub_aliases_still_parse() {
+    use clap::Parser;
+
+    // Removed no-op aliases: the derived long name still works (value-taking).
+    assert!(
+        Args::try_parse_from(["rdlp", "--sub-langs", "en", "u"]).is_ok(),
+        "--sub-langs must still parse"
+    );
+    assert!(
+        Args::try_parse_from(["rdlp", "--sub-format", "srt", "u"]).is_ok(),
+        "--sub-format must still parse"
+    );
+    // Removed no-op aliases: the derived long name still works (bool flags).
+    assert!(
+        Args::try_parse_from(["rdlp", "--list-subs", "u"]).is_ok(),
+        "--list-subs must still parse"
+    );
+    assert!(
+        Args::try_parse_from(["rdlp", "--list-subs-only", "u"]).is_ok(),
+        "--list-subs-only must still parse"
+    );
+
+    // Kept real aliases (yt-dlp spellings) still parse.
+    assert!(
+        Args::try_parse_from(["rdlp", "--embed-subs", "u"]).is_ok(),
+        "--embed-subs alias kept"
+    );
+    assert!(
+        Args::try_parse_from(["rdlp", "--write-subs", "u"]).is_ok(),
+        "--write-subs alias kept"
+    );
+    assert!(
+        Args::try_parse_from(["rdlp", "--write-auto-subs", "u"]).is_ok(),
+        "--write-auto-subs alias kept"
+    );
+}
+
+#[test]
+fn no_arg_aliases_its_own_long_name() {
+    // A hidden alias identical to the arg's own long name is a no-op (clap matches
+    // aliases against registered names). Guard against re-introducing the dead
+    // aliases this PR removed. Would fail on develop pre-PR (4 no-op aliases existed).
+    let cmd = Args::command();
+    for arg in cmd.get_arguments() {
+        let Some(long) = arg.get_long() else { continue };
+        if let Some(aliases) = arg.get_all_aliases() {
+            for a in aliases {
+                assert_ne!(
+                    a,
+                    long,
+                    "arg `{}` has a no-op alias equal to its long name `{long}`",
+                    arg.get_id(),
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

PR 4 of the #585 CLI/config-unification sequence. Parse + help only, **no `merge_config` change**.

- **Two yt-dlp short flags** — `-k` (`--keep-video`) and `-O` (`--print`), the only two yt-dlp shorts that name a real rdlp option and have a free letter. `-O` (uppercase) coexists with `-o` = `--output` — clap shorts are case-sensitive (curl `-o`/`-O` precedent). Both are **promoted into the `-h` common tier** (a short flag signals "common"), growing `-h` from 27 to 29 options.
- **Alias cleanup** — removed 4 dead no-op aliases (`sub-langs`, `sub-format`, `list-subs`, `list-subs-only`), each of which aliased its *own* derived long name and so added no match path. The 3 real yt-dlp-spelling aliases (`write-subs`, `write-auto-subs`, `embed-subs`) are kept (hidden).
- **`-i` collision documented** — yt-dlp's `-i` is `--ignore-errors`; rdlp's is `--interactive` (a shipped example). Kept deliberately, with an in-code comment so it isn't "fixed" later.

## Why only two shorts (not the ~10 an earlier note implied)

Reconciling yt-dlp's full 2026 short table against rdlp's actual `Args`: every other yt-dlp short either collides (`-i`) or names an option rdlp deliberately lacks (playlists, retries, auth, batch-file, concurrent-fragments, format-sort). Only `-k` and `-O` map to real rdlp options with a free letter.

## Guardrails (tests)

- **`short_flags_k_and_o_parse`** — `-k`→keep_video, `-O`→print, and `-o` still →output (would fail before the shorts existed).
- **`no_arg_aliases_its_own_long_name`** — a canary that fails the build if any arg re-gains an alias equal to its own long name (the dead-code this PR removed); would have been RED on develop, GREEN now. Uses `Arg::get_all_aliases()`/`get_long()`.
- **`renamed_and_removed_sub_aliases_still_parse`** — the 4 removed long names + 3 kept aliases all still parse.
- Tiering canary updated to 29 common / 44 expert; PR 2's heading test still green.

## Confirmation

- No `merge_config` change; `config.rs` / `main.rs` zero diff; no `args.field` access changed.
- Only `short`/`hide_short_help`/`alias` touched on the affected fields — no `value_parser`/`action`/`num_args`/`default_value_t` change.

## Deferred to PR 4b

Boolean `--no-*` negations — confirmed a real `merge_config` feature (uv pattern: paired `bool` + `overrides_with` + `hide`, converted by `flag(pos,neg)->Option<bool>` at the merge boundary; plain `bool` on the merge struct is the anti-pattern). Gets its own plan.

## Reviews

- **security-reviewer** (whole diff): **Approve**, no findings — pure spelling/help change, no parse/log/network/trust surface.
- **code-reviewer** (whole diff): **Approve**, no findings — verified 2 shorts (no collisions), 4 dead aliases removed / 3 real kept, tiering counts consistent (29+44=73), tests non-tautological. One Task-1 reviewer note ("alias-removal test not discriminating") was addressed by adding the `no_arg_aliases_its_own_long_name` canary.

Closes #598
Refs #585
