### PR TITLE
feat(desktop): Subtitles settings controls (5) — #585 PR 6 batch 1

### DIFF
--- a/crates/rdlp-api/src/merge/mod.rs
+++ b/crates/rdlp-api/src/merge/mod.rs
@@ -74,6 +74,12 @@ impl MergeOverrides for SubtitleOptions {
         if let Some(v) = self.strict_subs {
             config.strict_subs = v;
         }
+        if let Some(v) = self.verify_sub_urls {
+            config.verify_sub_urls = v;
+        }
+        if let Some(v) = self.retry_subs {
+            config.retry_subs = v;
+        }
     }
 }
 

--- a/crates/rdlp-api/src/merge/tests_output_format_subtitle.rs
+++ b/crates/rdlp-api/src/merge/tests_output_format_subtitle.rs
@@ -270,3 +270,59 @@ fn test_subtitle_some_overrides_strict_subs() {
     opts.merge_into(&mut config);
     assert!(config.strict_subs);
 }
+
+#[test]
+fn test_subtitle_none_preserves_verify_sub_urls() {
+    let mut config = Config {
+        verify_sub_urls: true,
+        ..Config::default()
+    };
+    let opts = SubtitleOptions::default();
+    opts.merge_into(&mut config);
+    assert!(
+        config.verify_sub_urls,
+        "None must preserve the base config value"
+    );
+}
+
+#[test]
+fn test_subtitle_some_overrides_verify_sub_urls() {
+    let mut config = Config {
+        verify_sub_urls: false,
+        ..Config::default()
+    };
+    let opts = SubtitleOptions {
+        verify_sub_urls: Some(true),
+        ..SubtitleOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert!(config.verify_sub_urls);
+}
+
+#[test]
+fn test_subtitle_none_preserves_retry_subs() {
+    let mut config = Config {
+        retry_subs: true,
+        ..Config::default()
+    };
+    let opts = SubtitleOptions::default();
+    opts.merge_into(&mut config);
+    assert!(
+        config.retry_subs,
+        "None must preserve the base config value"
+    );
+}
+
+#[test]
+fn test_subtitle_some_overrides_retry_subs() {
+    let mut config = Config {
+        retry_subs: false,
+        ..Config::default()
+    };
+    let opts = SubtitleOptions {
+        retry_subs: Some(true),
+        ..SubtitleOptions::default()
+    };
+    opts.merge_into(&mut config);
+    assert!(config.retry_subs);
+}

--- a/crates/rdlp-api/src/options.rs
+++ b/crates/rdlp-api/src/options.rs
@@ -146,7 +146,7 @@ pub const OPTION_REGISTRY: &[OptionEntry] = &[
     },
     OptionEntry {
         field: "write_auto_subtitles",
-        gui: Gui::Missing("#602"),
+        gui: Gui::Control("write_auto_subtitles"),
     },
     OptionEntry {
         field: "subtitle_langs",
@@ -162,15 +162,15 @@ pub const OPTION_REGISTRY: &[OptionEntry] = &[
     },
     OptionEntry {
         field: "strict_subs",
-        gui: Gui::Missing("#602"),
+        gui: Gui::Control("strict_subs"),
     },
     OptionEntry {
         field: "verify_sub_urls",
-        gui: Gui::Missing("#602"),
+        gui: Gui::Control("verify_sub_urls"),
     },
     OptionEntry {
         field: "retry_subs",
-        gui: Gui::Missing("#602"),
+        gui: Gui::Control("retry_subs"),
     },
     OptionEntry {
         field: "quiet",
@@ -318,7 +318,7 @@ pub const OPTION_REGISTRY: &[OptionEntry] = &[
     },
     OptionEntry {
         field: "postprocess.write_subtitles",
-        gui: Gui::Missing("#602"),
+        gui: Gui::Control("write_subtitles"),
     },
     OptionEntry {
         field: "postprocess.keep_video",
@@ -663,9 +663,9 @@ mod tests {
                 Gui::Missing(_) => missing += 1,
             }
         }
-        assert_eq!(control, 31, "Control count drifted");
+        assert_eq!(control, 36, "Control count drifted");
         assert_eq!(na, 5, "NotApplicable count drifted");
-        assert_eq!(missing, 60, "Missing count drifted");
+        assert_eq!(missing, 55, "Missing count drifted");
     }
 
     #[test]

--- a/crates/rdlp-api/src/request.rs
+++ b/crates/rdlp-api/src/request.rs
@@ -153,6 +153,10 @@ pub struct SubtitleOptions {
     pub embed_subs: Option<bool>,
     /// Fail if requested subtitles are not available. `None` preserves base config.
     pub strict_subs: Option<bool>,
+    /// Validate subtitle URLs before download. `None` preserves base config.
+    pub verify_sub_urls: Option<bool>,
+    /// Retry failed subtitle downloads. `None` preserves base config.
+    pub retry_subs: Option<bool>,
 }
 
 /// Post-processing options (remux, audio extraction, metadata, thumbnails).

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -322,11 +322,14 @@ pub async fn start_download(
             ..FormatOptions::default()
         },
         subtitles: SubtitleOptions {
-            write_subs: options.subtitles.then_some(true),
+            write_subs: Some(options.subtitles || settings.write_subtitles),
+            write_auto_subs: Some(settings.write_auto_subtitles),
             sub_langs: options.subtitle_langs,
             sub_format: settings.default_subtitle_format,
             embed_subs: embed_subtitles.then_some(true),
-            ..SubtitleOptions::default()
+            strict_subs: Some(settings.strict_subs),
+            verify_sub_urls: Some(settings.verify_sub_urls),
+            retry_subs: Some(settings.retry_subs),
         },
         postprocess: PostProcessOptions {
             remux,

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -1002,6 +1002,22 @@ mod tests {
         };
         let result_off = build_subtitle_options(&options, &settings_off, false);
         assert_eq!(result_off.write_subs, Some(false));
+
+        // Regression guard for the removed `options.subtitles || settings.write_subtitles`
+        // OR: an explicit per-download `subtitles: true` combined with the setting OFF
+        // yields `Some(true)` under the old code (`true || false`) but MUST be
+        // `Some(false)` now — `options.subtitles` no longer influences the result
+        // (per-download control deferred to #606). This case discriminates the fix.
+        let options_subs_true = DownloadOptions {
+            subtitles: true,
+            ..default_download_options()
+        };
+        let result_override = build_subtitle_options(&options_subs_true, &settings_off, false);
+        assert_eq!(
+            result_override.write_subs,
+            Some(false),
+            "options.subtitles must not influence write_subs; only the setting drives it",
+        );
     }
 
     /// Each of the 4 remaining settings-only subtitle bools MUST reach the

--- a/crates/rdlp-desktop/src-tauri/src/commands/download.rs
+++ b/crates/rdlp-desktop/src-tauri/src/commands/download.rs
@@ -166,6 +166,39 @@ fn validate_recode_preset(preset: Option<&str>) -> Result<(), AppError> {
     }
 }
 
+/// Merge per-download subtitle options with the app settings defaults.
+///
+/// `write_subs` reads the global `settings.write_subtitles` only —
+/// `options.subtitles` has no per-download UI control yet (tracked in
+/// follow-up #606), so it is intentionally not consulted here.
+///
+/// # Arguments
+///
+/// * `options` - Frontend-supplied download options.
+/// * `settings` - Persisted application settings used as defaults.
+/// * `embed_subtitles` - Already-resolved embed-subtitles flag (per-download
+///   override or settings default).
+///
+/// # Returns
+///
+/// A [`SubtitleOptions`] with every field resolved.
+fn build_subtitle_options(
+    options: &DownloadOptions,
+    settings: &crate::state::AppSettings,
+    embed_subtitles: bool,
+) -> SubtitleOptions {
+    SubtitleOptions {
+        write_subs: Some(settings.write_subtitles),
+        write_auto_subs: Some(settings.write_auto_subtitles),
+        sub_langs: options.subtitle_langs.clone(),
+        sub_format: settings.default_subtitle_format,
+        embed_subs: embed_subtitles.then_some(true),
+        strict_subs: Some(settings.strict_subs),
+        verify_sub_urls: Some(settings.verify_sub_urls),
+        retry_subs: Some(settings.retry_subs),
+    }
+}
+
 /// Start a new download for the given URL.
 ///
 /// Validates the URL, adds a job to the queue, builds a
@@ -257,6 +290,13 @@ pub async fn start_download(
         .ok()
         .map(|json| SavedDownloadOptions { json });
 
+    // Embed subtitles.
+    let embed_subtitles = options.embed_subtitles.unwrap_or(settings.embed_subtitles);
+
+    // Subtitle options (borrows `options`; must run before any `options`
+    // field with a non-`Copy` type is moved out below).
+    let subtitle_options = build_subtitle_options(&options, &settings, embed_subtitles);
+
     // Build the download request from options + settings
     let output_dir = options
         .output_dir
@@ -286,9 +326,6 @@ pub async fn start_download(
     let output_template = options
         .output_template
         .or_else(|| settings.output_template.clone());
-
-    // Embed subtitles.
-    let embed_subtitles = options.embed_subtitles.unwrap_or(settings.embed_subtitles);
 
     // Write thumbnail.
     let write_thumbnail_resolved = options.write_thumbnail.unwrap_or(settings.write_thumbnail);
@@ -321,16 +358,7 @@ pub async fn start_download(
             },
             ..FormatOptions::default()
         },
-        subtitles: SubtitleOptions {
-            write_subs: Some(options.subtitles || settings.write_subtitles),
-            write_auto_subs: Some(settings.write_auto_subtitles),
-            sub_langs: options.subtitle_langs,
-            sub_format: settings.default_subtitle_format,
-            embed_subs: embed_subtitles.then_some(true),
-            strict_subs: Some(settings.strict_subs),
-            verify_sub_urls: Some(settings.verify_sub_urls),
-            retry_subs: Some(settings.retry_subs),
-        },
+        subtitles: subtitle_options,
         postprocess: PostProcessOptions {
             remux,
             extract_audio,
@@ -946,6 +974,98 @@ mod tests {
         assert!(net.pool_idle_timeout_secs.is_none());
         assert!(net.download_timeout_secs.is_none());
         assert!(net.merge_timeout_secs.is_none());
+    }
+
+    // ------------------------------------------------------------------ //
+    // H. Subtitle options: settings -> SubtitleOptions bridge
+    // ------------------------------------------------------------------ //
+
+    /// `write_subs` MUST read the global `settings.write_subtitles` value
+    /// only. This is the regression guard for the misleading
+    /// `options.subtitles || settings.write_subtitles` OR that was removed:
+    /// `options.subtitles` has no per-download UI (hardcoded `false` in the
+    /// frontend; tracked in #606), so it must not influence the result.
+    #[test]
+    fn test_write_subs_follows_settings_only() {
+        let options = default_download_options();
+
+        let settings_on = AppSettings {
+            write_subtitles: true,
+            ..AppSettings::default()
+        };
+        let result_on = build_subtitle_options(&options, &settings_on, false);
+        assert_eq!(result_on.write_subs, Some(true));
+
+        let settings_off = AppSettings {
+            write_subtitles: false,
+            ..AppSettings::default()
+        };
+        let result_off = build_subtitle_options(&options, &settings_off, false);
+        assert_eq!(result_off.write_subs, Some(false));
+    }
+
+    /// Each of the 4 remaining settings-only subtitle bools MUST reach the
+    /// corresponding `SubtitleOptions` field verbatim.
+    #[test]
+    fn test_subtitle_settings_bools_propagate_to_dto() {
+        let options = default_download_options();
+        let settings = AppSettings {
+            write_auto_subtitles: true,
+            strict_subs: true,
+            verify_sub_urls: true,
+            retry_subs: true,
+            ..AppSettings::default()
+        };
+        let result = build_subtitle_options(&options, &settings, false);
+
+        assert_eq!(result.write_auto_subs, Some(true));
+        assert_eq!(result.strict_subs, Some(true));
+        assert_eq!(result.verify_sub_urls, Some(true));
+        assert_eq!(result.retry_subs, Some(true));
+    }
+
+    /// Default (all-false) settings MUST leave every subtitle bool field
+    /// `Some(false)` — negative counterpart of the previous test, proving
+    /// each field is independently wired rather than defaulting to `true`.
+    #[test]
+    fn test_subtitle_settings_bools_default_to_false() {
+        let options = default_download_options();
+        let settings = AppSettings::default();
+        let result = build_subtitle_options(&options, &settings, false);
+
+        assert_eq!(result.write_subs, Some(false));
+        assert_eq!(result.write_auto_subs, Some(false));
+        assert_eq!(result.strict_subs, Some(false));
+        assert_eq!(result.verify_sub_urls, Some(false));
+        assert_eq!(result.retry_subs, Some(false));
+    }
+
+    /// `sub_langs` MUST pass through from `options` and `sub_format` from
+    /// `settings`; `embed_subs` reflects the caller-resolved flag.
+    #[test]
+    fn test_subtitle_langs_and_format_pass_through() {
+        let options = DownloadOptions {
+            subtitle_langs: vec!["en".to_owned(), "sv".to_owned()],
+            ..default_download_options()
+        };
+        let settings = AppSettings {
+            default_subtitle_format: Some(rdlp_types::SubtitleFormat::Srt),
+            ..AppSettings::default()
+        };
+
+        let result_no_embed = build_subtitle_options(&options, &settings, false);
+        assert_eq!(
+            result_no_embed.sub_langs,
+            vec!["en".to_owned(), "sv".to_owned()]
+        );
+        assert_eq!(
+            result_no_embed.sub_format,
+            Some(rdlp_types::SubtitleFormat::Srt)
+        );
+        assert!(result_no_embed.embed_subs.is_none());
+
+        let result_embed = build_subtitle_options(&options, &settings, true);
+        assert_eq!(result_embed.embed_subs, Some(true));
     }
 }
 

--- a/crates/rdlp-desktop/src-tauri/src/state/app_settings.rs
+++ b/crates/rdlp-desktop/src-tauri/src/state/app_settings.rs
@@ -121,6 +121,21 @@ pub struct AppSettings {
     /// `Config::validate()`): must be 1..=86400.
     #[serde(default)]
     pub merge_timeout: Option<u64>,
+    /// Download subtitles by default.
+    #[serde(default)]
+    pub write_subtitles: bool,
+    /// Download auto-generated subtitles by default.
+    #[serde(default)]
+    pub write_auto_subtitles: bool,
+    /// Fail the download if requested subtitles are unavailable.
+    #[serde(default)]
+    pub strict_subs: bool,
+    /// Validate subtitle URLs before downloading.
+    #[serde(default)]
+    pub verify_sub_urls: bool,
+    /// Retry failed subtitle downloads.
+    #[serde(default)]
+    pub retry_subs: bool,
 }
 
 impl AppSettings {
@@ -240,6 +255,11 @@ impl Default for AppSettings {
             pool_idle_timeout: None,
             download_timeout: None,
             merge_timeout: None,
+            write_subtitles: false,
+            write_auto_subtitles: false,
+            strict_subs: false,
+            verify_sub_urls: false,
+            retry_subs: false,
         }
     }
 }
@@ -603,6 +623,11 @@ mod tests {
             pool_idle_timeout: None,
             download_timeout: None,
             merge_timeout: None,
+            write_subtitles: true,
+            write_auto_subtitles: true,
+            strict_subs: true,
+            verify_sub_urls: true,
+            retry_subs: true,
         };
 
         let json = serde_json::to_string(&settings).expect("serialization should succeed");
@@ -648,6 +673,11 @@ mod tests {
             Some("%(title)s.%(ext)s")
         );
         assert!(restored.embed_subtitles);
+        assert!(restored.write_subtitles);
+        assert!(restored.write_auto_subtitles);
+        assert!(restored.strict_subs);
+        assert!(restored.verify_sub_urls);
+        assert!(restored.retry_subs);
     }
 
     #[test]
@@ -681,5 +711,21 @@ mod tests {
         assert!(s.socket_timeout.is_none());
         assert!(s.read_timeout.is_none());
         assert!(s.pool_idle_timeout.is_none());
+    }
+
+    #[test]
+    fn legacy_json_without_subtitle_flags_defaults_false() {
+        // Minimal legacy settings.json predating the 5 subtitle flags. Mirrors the
+        // fixture shape in `test_legacy_settings_json_without_timeout_fields_loads`
+        // (the fields below are the only ones without `#[serde(default)]`).
+        let json = r#"{"output_dir":"/tmp","embed_thumbnail":true,"embed_metadata":false,"verbose":false,"default_subtitle_langs":[]}"#;
+        let s: AppSettings = serde_json::from_str(json).unwrap();
+        assert!(
+            !s.write_subtitles
+                && !s.write_auto_subtitles
+                && !s.strict_subs
+                && !s.verify_sub_urls
+                && !s.retry_subs
+        );
     }
 }

--- a/crates/rdlp-desktop/src/types/index.ts
+++ b/crates/rdlp-desktop/src/types/index.ts
@@ -437,6 +437,11 @@ export interface AppSettings {
     normalize_boost: boolean;
     normalize_boost_db: number | null;
     embed_subtitles: boolean;
+    write_subtitles: boolean;
+    write_auto_subtitles: boolean;
+    strict_subs: boolean;
+    verify_sub_urls: boolean;
+    retry_subs: boolean;
 }
 
 // ========== Error Types ==========

--- a/crates/rdlp-desktop/src/views/settings/SettingsNav.tsx
+++ b/crates/rdlp-desktop/src/views/settings/SettingsNav.tsx
@@ -14,6 +14,7 @@ const SECTIONS: SectionDef[] = [
     { id: "settings-formats", label: "Format Defaults" },
     { id: "settings-output", label: "Output & Templates" },
     { id: "settings-postprocess", label: "Media & Embedding" },
+    { id: "settings-subtitles", label: "Subtitles" },
     { id: "settings-normalization", label: "Audio Normalization" },
     { id: "settings-network", label: "Network" },
     { id: "settings-cookies", label: "Cookies" },

--- a/crates/rdlp-desktop/src/views/settings/SettingsView.tsx
+++ b/crates/rdlp-desktop/src/views/settings/SettingsView.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { GeneralSection } from "./sections/GeneralSection";
 import { OutputSection } from "./sections/OutputSection";
 import { PostProcessSection } from "./sections/PostProcessSection";
+import { SubtitlesSection } from "./sections/SubtitlesSection";
 import { NormalizationSection } from "./sections/NormalizationSection";
 import { NetworkSection } from "./sections/NetworkSection";
 import { SystemSection } from "./sections/SystemSection";
@@ -101,6 +102,7 @@ export function SettingsView() {
                 <GeneralSection draft={draft} onChange={handleChange} />
                 <OutputSection draft={draft} onChange={handleChange} />
                 <PostProcessSection draft={draft} onChange={handleChange} />
+                <SubtitlesSection draft={draft} onChange={handleChange} />
                 <NormalizationSection draft={draft} onChange={handleChange} />
                 <NetworkSection draft={draft} onChange={handleChange} />
                 <SystemSection />

--- a/crates/rdlp-desktop/src/views/settings/sections/NetworkSection.test.tsx
+++ b/crates/rdlp-desktop/src/views/settings/sections/NetworkSection.test.tsx
@@ -37,6 +37,11 @@ const baseDraft: AppSettings = {
     normalize_boost: false,
     normalize_boost_db: null,
     embed_subtitles: false,
+    write_subtitles: false,
+    write_auto_subtitles: false,
+    strict_subs: false,
+    verify_sub_urls: false,
+    retry_subs: false,
 };
 
 describe("NetworkSection — timeout controls", () => {

--- a/crates/rdlp-desktop/src/views/settings/sections/SubtitlesSection.tsx
+++ b/crates/rdlp-desktop/src/views/settings/sections/SubtitlesSection.tsx
@@ -1,0 +1,56 @@
+// SubtitlesSection: subtitle download/verification toggles.
+
+import { Captions } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { AppSettings } from "@/types";
+
+interface Props {
+    draft: AppSettings;
+    onChange: (update: Partial<AppSettings>) => void;
+}
+
+// Jolly Checkbox (React Aria) uses isSelected + children for label (no separate Label + id pairing)
+const toggleItems: { label: string; field: keyof AppSettings; help: string }[] = [
+    { label: "Download subtitles", field: "write_subtitles", help: "Fetch subtitle tracks for each download." },
+    {
+        label: "Download auto-generated subtitles",
+        field: "write_auto_subtitles",
+        help: "Include machine-generated captions when available.",
+    },
+    {
+        label: "Strict subtitles",
+        field: "strict_subs",
+        help: "Fail the download if requested subtitles are missing.",
+    },
+    {
+        label: "Verify subtitle URLs",
+        field: "verify_sub_urls",
+        help: "Check subtitle URLs are reachable before downloading.",
+    },
+    { label: "Retry failed subtitles", field: "retry_subs", help: "Retry subtitle downloads that fail." },
+];
+
+export function SubtitlesSection({ draft, onChange }: Props) {
+    return (
+        <section id="settings-subtitles" aria-labelledby="settings-subtitles-heading" className="settings-panel">
+            <h3 id="settings-subtitles-heading" className="settings-panel-title">
+                <Captions className="size-3.5" />
+                Subtitles
+            </h3>
+            <div className="flex flex-col gap-3">
+                {toggleItems.map(({ label, field, help }) => (
+                    <div key={field} className="flex flex-col gap-1">
+                        <Checkbox
+                            isSelected={draft[field] as boolean}
+                            onChange={(checked) => onChange({ [field]: checked })}
+                            className="flex items-center gap-2 text-sm font-medium text-muted-foreground cursor-pointer"
+                        >
+                            {label}
+                        </Checkbox>
+                        <p className="text-xs text-muted-foreground/70 pl-6">{help}</p>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+}


### PR DESCRIPTION
Closes #605
Refs #585

First GUI-control batch of PR 6 — building the ~60 desktop controls enumerated by the option registry (#602, PR 5). Adds the 5 subtitle settings, wired **end-to-end** so they affect downloads (not just persist — the #589 class this arc kills).

## What
5 subtitle settings → Jolly UI `Checkbox`es in a new **Subtitles** Settings section:
`write_subtitles`, `write_auto_subtitles`, `strict_subs`, `verify_sub_urls`, `retry_subs`.

## Wiring (all 5 reach a download)
- **rdlp-api** `SubtitleOptions` DTO extended with `verify_sub_urls`/`retry_subs` + merge (the other 3 already converted to Config).
- **rdlp-desktop** `AppSettings` +5 `bool` (`#[serde(default)]` — legacy `settings.json` still loads) → `build_subtitle_options` bridge (extracted + unit-tested) → DTO → Config.
- **TS** `AppSettings` + `SubtitlesSection.tsx` (Jolly Checkbox, no Radix; Save-gated form so checkbox not switch, per NN/g).
- **registry** 5 entries flipped `Missing("#602")` → `Control(...)`; buckets 31/5/60 → **36/5/55**. `check-gui-option-parity.sh` (PR 5) mechanically enforces the Control targets match the real AppSettings fields — so the whole chain can't silently drift.

## Design grounded in research
Control-type + a11y from cited research (NN/g, WCAG 2.2 AA, WAI-ARIA APG, an arXiv configurator-usability paper): checkbox (Save-gated), WCAG labels/focus/target-size. The `write_subtitles`↔settings override semantics were settled by a second research pass (layered-config precedence: git/curl/mpv/yt-dlp, figment merge = replace not union) → the per-invocation choice overrides the default, both directions — but investigation found `DownloadOptions.subtitles` has **no per-download UI** (hardcoded `false`; the visible "Subtitles" checkbox is `embedSubtitles`), so the correct fix here is `write_subs: Some(settings.write_subtitles)`. The real per-download tri-state control is fully spec'd in **follow-up #606**.

## Tests / gates
- rdlp-api merge tests (both new DTO fields, both directions); desktop round-trip + legacy-JSON default tests; `build_subtitle_options` unit tests incl. a **discriminating** regression guard (`options.subtitles=true` + setting off → `Some(false)`, which fails against the removed OR); registry exhaustiveness/bucket/parity tests.
- Full workspace gate green (fmt, clippy `-D warnings`, test, `cargo check -p rdlp-desktop`, `check-all.sh` incl. the parity gate); frontend `tsc` clean + 30/30 settings vitest.

## Reviews
Subagent-driven (per-task spec+quality gates, all clean). Whole-branch pre-push:
- **security-reviewer: Approve** — traced `verify_sub_urls`: the SSRF gate (`validate_url_security`) runs unconditionally, this setting only toggles a reachability pre-check; can't disable a security control.
- **code-reviewer: Approve-with-fixes** — field-name parity across all 5 surfaces + end-to-end wiring verified; 2 findings **fixed pre-push** (misleading OR → `Some(settings.write_subtitles)`; bridge extracted + tested with a discriminating guard).

## Follow-ups
- **#606** — per-download subtitle-fetch control (tri-state, Analyze dialog) with the full ux-designer spec.
- ~55 GUI controls remain in the #602 tracker for subsequent batches.