### PR TITLE
fix: correct pool-idle timeout default claims from 90s to 60s

### DIFF
--- a/crates/rdlp-desktop/src/views/settings/sections/NetworkSection.test.tsx
+++ b/crates/rdlp-desktop/src/views/settings/sections/NetworkSection.test.tsx
@@ -152,6 +152,17 @@ describe("NetworkSection — timeout controls", () => {
         expect(descriptionNode!.textContent).toMatch(/idle keep-alive connections/i);
     });
 
+    // #613 regression guard: the placeholder is the "inherit the backend default"
+    // hint, so it must state the value the app actually uses —
+    // `DEFAULT_POOL_IDLE_TIMEOUT_SECS` in rdlp-http/src/config.rs, which owns the
+    // rationale for that number. Pinning a literal against a literal is weak by
+    // construction; #611 replaces it by sourcing the value over IPC.
+    it("pool-idle placeholder states the real backend default (60, not 90)", () => {
+        render(<NetworkSection draft={baseDraft} onChange={vi.fn()} />);
+        const numeric = screen.getByRole("textbox", { name: /idle timeout/i });
+        expect(numeric).toHaveAttribute("placeholder", "60");
+    });
+
     it("out-of-range pool-idle value clamps to the upper bound", async () => {
         const user = userEvent.setup();
         const onChange = vi.fn();

--- a/crates/rdlp-desktop/src/views/settings/sections/NetworkSection.tsx
+++ b/crates/rdlp-desktop/src/views/settings/sections/NetworkSection.tsx
@@ -147,7 +147,7 @@ export function NetworkSection({ draft, onChange }: Props) {
                                     maxValue={3600}
                                     onCommit={handlePoolIdleChange}
                                     isDisabled={!poolIdleForm.evictIdle}
-                                    placeholder="90"
+                                    placeholder="60"
                                     suffix="s"
                                 />
                             </div>

--- a/crates/rdlp-types/src/config.rs
+++ b/crates/rdlp-types/src/config.rs
@@ -176,7 +176,12 @@ pub struct Config {
 
     /// Pool idle-connection timeout in seconds.
     ///
-    /// Default: 90. Range: 0..=3600.
+    /// Default: 60. Range: 0..=3600.
+    ///
+    /// The default is NOT stored here — this field is `None` in
+    /// `Config::default()`, and `HttpClientConfig::from_rdlp_config` supplies
+    /// `DEFAULT_POOL_IDLE_TIMEOUT_SECS` when it is unset. See
+    /// `rdlp-http/src/config.rs` for that const and why its value is what it is.
     ///
     /// `0` is a sentinel meaning "disable idle eviction entirely" — wired
     /// through to wreq/reqwest as `pool_idle_timeout(None)`. Any positive


### PR DESCRIPTION
## Resolves

Closes #613

## What

The effective HTTP connection-pool idle-eviction default is **60 seconds**. Two places claimed
**90**. This corrects both. No runtime behaviour changes.

| Site | Was | Now |
|---|---|---|
| `crates/rdlp-types/src/config.rs` — `Config::pool_idle_timeout` doc-comment | `Default: 90` | `Default: 60` + a note on where the default actually lives |
| `crates/rdlp-desktop/.../NetworkSection.tsx:150` — GUI placeholder | `"90"` | `"60"` |

## Why it mattered

This was wrong out of the box — no `config.toml`, no user action required.

`Config::default().pool_idle_timeout` is `None`. When unset,
`HttpClientConfig::from_rdlp_config` leaves the field at `DEFAULT_POOL_IDLE_TIMEOUT_SECS` (60,
`crates/rdlp-http/src/config.rs:23`). That value is deliberate: it sits below nginx's default 75s
`keepalive_timeout` to avoid the stale-connection race, and a compile-time
`const _: () = assert!(… < 75)` enforces it. `90` is the reqwest/Go value it was lowered from —
the doc-comment and the placeholder were never updated with it.

The wrong hint was not merely misinformative. A user "restoring the default" by entering 90 would
push the timeout **above** the server keep-alive and reopen the exact race the 60s default exists
to prevent — the GUI was steering toward the regression.

## Why the doc-comment grew

The root cause of the drift is that `Config` documents a default it does not store. The comment
now says so and points at the const that owns it, so the next reader has no reason to restate a
number from memory.

## Tests

Adds a frontend regression guard pinning the placeholder (fails against the unpatched code —
verified RED with `Received: placeholder="90"`).

It pins a literal against a literal, which is weak by construction and is called out as such
in-place. The structural fix is #611, which sources placeholders from the backend over IPC and
deletes the hardcoded value outright.

No Rust test was needed: `default_pool_idle_timeout_is_some_60` and
`from_rdlp_config_with_no_timeout_overrides_uses_defaults` already pin the runtime, and the diff
is comment-only in that crate.

## Verification

`cargo fmt --check` · `cargo check` · `cargo clippy --workspace --all-targets -- -D warnings` ·
`cargo test` (exit 0, 103 suites) · `cargo check -p rdlp-desktop` · `scripts/check-all.sh` (all
gates + self-tests) · `tsc --noEmit` · `vitest` (308 tests / 23 files). All green.

## Reviews

- **security-reviewer — Approve.** No security impact. Verified `git diff develop..HEAD --
  crates/rdlp-http/src/config.rs` is empty, so the const and its `< 75` assert are untouched;
  validation range `0..=3600` and the `0`-means-disable sentinel unchanged. Noted the fix
  *removes* a prior risk rather than introducing one.
- **code-reviewer — Approve.** Verified every factual clause of the new doc-comment against
  `Config::default()` and `from_rdlp_config`. Swept the repo for any surviving 90-as-default claim
  and found none (remaining `90`s are arbitrary test inputs; the CLI flag never stated a default).
  Also independently checked the sibling fields `socket_timeout` and `read_timeout` for the same
  drift class — both accurate, so no second bug is hiding next to this one.

One Low finding (rationale duplicated across three comment sites, itself a drift surface) was
accepted and fixed before push: the test comment and the Rust doc-comment were trimmed to point at
the authoritative const instead of restating its history.
