### PR TITLE
chore(desktop): upgrade to pnpm 11, move build allowlist to allowBuilds, declare Node 22+ floor

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -204,9 +204,13 @@ The desktop crate at `crates/rdlp-desktop/` is a Tauri v2 app with a React/TypeS
 cd crates/rdlp-desktop
 
 # Frontend deps + build
-# This project uses pnpm (not npm). Install it with `corepack enable`
-# or see https://pnpm.io/installation. `pnpm-lock.yaml` is committed;
-# use --frozen-lockfile in CI so installs match it exactly.
+# This project uses pnpm (not npm), pinned via the `packageManager` field.
+# pnpm 11 requires Node.js 22 or newer.
+# Install pnpm standalone: curl -fsSL https://get.pnpm.io/install.sh | sh -
+# (see https://pnpm.io/installation). `corepack enable` also works on Node 24
+# and older, but corepack is no longer bundled from Node 25 on.
+# `pnpm-lock.yaml` is committed; use --frozen-lockfile in CI so installs
+# match it exactly.
 pnpm install
 pnpm exec vite build
 

--- a/crates/rdlp-desktop/package.json
+++ b/crates/rdlp-desktop/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "packageManager": "pnpm@11.15.1",
+  "engines": {
+    "node": ">=22"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/crates/rdlp-desktop/package.json
+++ b/crates/rdlp-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "rdlp-desktop",
   "private": true,
   "version": "0.1.0",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -61,11 +61,5 @@
     "typescript": "^5.4.5",
     "vite": "^7.3.0",
     "vitest": "^4.0.18"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "cypress",
-      "esbuild"
-    ]
   }
 }

--- a/crates/rdlp-desktop/pnpm-workspace.yaml
+++ b/crates/rdlp-desktop/pnpm-workspace.yaml
@@ -1,25 +1,31 @@
 # pnpm settings for the desktop frontend.
 #
-# strictDepBuilds makes an unreviewed postinstall script a HARD ERROR
+# pnpm reads settings ONLY from here (and from `.npmrc` for auth/registry). The
+# `pnpm` block in package.json is no longer read at all as of v11 — do not
+# "tidy" any of these keys back into package.json; they would be silently
+# ignored.
+#
+# allowBuilds is the allowlist of dependencies permitted to run install
+# scripts. pnpm refuses to run a dependency's build scripts unless it is listed
+# here, and Cypress downloads its actual binary in postinstall. Unlisted, the
+# install reports success and the binary silently never arrives — failing
+# later, somewhere unrelated. That is the trap that bit us during the
+# npm->pnpm migration.
+#
+# Keep entries UNPINNED (bare package names). A pinned entry like
+# `esbuild@0.27.4` stops matching after a version bump and is then silently
+# blocked (pnpm/pnpm#11219, pnpm/pnpm#10426).
+#
+# Replaced `onlyBuiltDependencies` on the v10 -> v11 upgrade (2026-07-21);
+# v11 consolidated onlyBuiltDependencies / neverBuiltDependencies /
+# ignoredBuiltDependencies / ignoreDepScripts into this one map.
+allowBuilds:
+  cypress: true
+  esbuild: true
+
+# strictDepBuilds makes an unreviewed install script a HARD ERROR
 # (ERR_PNPM_IGNORED_BUILDS, exit 1) instead of a warning that scrolls past.
-#
-# This is the guard for the trap that bit us during the npm->pnpm migration:
-# pnpm 10 refuses to run a dependency's build scripts unless the package is
-# listed in `pnpm.onlyBuiltDependencies`, and Cypress downloads its actual
-# binary in postinstall. Unlisted, the install reports success and the binary
-# silently never arrives — failing later, somewhere unrelated.
-#
-# Verified empirically against pnpm 10.33.0 on 2026-07-21:
-#   - NOT on by default at this version (install warned and exited 0).
-#   - Honored ONLY here. The same key in package.json's `pnpm` block is
-#     silently ignored (exit 0) — do not "tidy" it into package.json next to
-#     onlyBuiltDependencies.
-#
-# Keep `onlyBuiltDependencies` entries UNPINNED (bare package names). Pinned
-# entries like `esbuild@0.27.4` stop matching after a version bump and are
-# silently blocked without tripping strictDepBuilds
-# (pnpm/pnpm#11219, pnpm/pnpm#10426).
-#
-# pnpm v11 replaces onlyBuiltDependencies/ignoredBuiltDependencies with a
-# unified `allowBuilds` map; revisit on that upgrade.
+# It became the default in v11 (it was NOT on by default in 10.33.0 — verified
+# empirically: the install warned and exited 0). Kept explicit so the guard
+# survives a future default flip and stays greppable.
 strictDepBuilds: true

--- a/crates/rdlp-desktop/pnpm-workspace.yaml
+++ b/crates/rdlp-desktop/pnpm-workspace.yaml
@@ -14,11 +14,15 @@
 #
 # Keep entries UNPINNED (bare package names). A pinned entry like
 # `esbuild@0.27.4` stops matching after a version bump and is then silently
-# blocked (pnpm/pnpm#11219, pnpm/pnpm#10426).
+# blocked — observed under the predecessor `onlyBuiltDependencies`
+# (pnpm/pnpm#11219, pnpm/pnpm#10426, both still open against the v10 key); the
+# same pin-matching design carries into `allowBuilds`.
 #
-# Replaced `onlyBuiltDependencies` on the v10 -> v11 upgrade (2026-07-21);
-# v11 consolidated onlyBuiltDependencies / neverBuiltDependencies /
-# ignoredBuiltDependencies / ignoreDepScripts into this one map.
+# Replaced `onlyBuiltDependencies` on the v10 -> v11 upgrade (2026-07-21).
+# v11 REMOVED all five predecessors — onlyBuiltDependencies,
+# onlyBuiltDependenciesFile, neverBuiltDependencies, ignoredBuiltDependencies
+# and ignoreDepScripts — in favour of this one map, where a `false` value is
+# what neverBuilt/ignoredBuilt used to express.
 allowBuilds:
   cypress: true
   esbuild: true

--- a/crates/rdlp-desktop/pnpm-workspace.yaml
+++ b/crates/rdlp-desktop/pnpm-workspace.yaml
@@ -1,0 +1,25 @@
+# pnpm settings for the desktop frontend.
+#
+# strictDepBuilds makes an unreviewed postinstall script a HARD ERROR
+# (ERR_PNPM_IGNORED_BUILDS, exit 1) instead of a warning that scrolls past.
+#
+# This is the guard for the trap that bit us during the npm->pnpm migration:
+# pnpm 10 refuses to run a dependency's build scripts unless the package is
+# listed in `pnpm.onlyBuiltDependencies`, and Cypress downloads its actual
+# binary in postinstall. Unlisted, the install reports success and the binary
+# silently never arrives — failing later, somewhere unrelated.
+#
+# Verified empirically against pnpm 10.33.0 on 2026-07-21:
+#   - NOT on by default at this version (install warned and exited 0).
+#   - Honored ONLY here. The same key in package.json's `pnpm` block is
+#     silently ignored (exit 0) — do not "tidy" it into package.json next to
+#     onlyBuiltDependencies.
+#
+# Keep `onlyBuiltDependencies` entries UNPINNED (bare package names). Pinned
+# entries like `esbuild@0.27.4` stop matching after a version bump and are
+# silently blocked without tripping strictDepBuilds
+# (pnpm/pnpm#11219, pnpm/pnpm#10426).
+#
+# pnpm v11 replaces onlyBuiltDependencies/ignoredBuiltDependencies with a
+# unified `allowBuilds` map; revisit on that upgrade.
+strictDepBuilds: true


### PR DESCRIPTION
Closes #616

## What

Upgrades `crates/rdlp-desktop` to pnpm 11 and moves the install-script allowlist to the only place v11 reads it.

- `packageManager`: `pnpm@10.33.0` → `pnpm@11.15.1`
- `package.json` `pnpm.onlyBuiltDependencies` → `allowBuilds` in `pnpm-workspace.yaml` (`cypress: true`, `esbuild: true`, entries unpinned)
- `strictDepBuilds: true` kept explicit even though it is now the v11 default — it is a security guard, so it should survive a default flip and stay greppable
- `engines.node: ">=22"` declared; `BUILDING.md` documents the floor and leads with the standalone pnpm installer

The first commit (`222517ae`) predates the upgrade and is what made an unreviewed install script a hard error under pnpm 10.

## Why it isn't cosmetic

pnpm 11 stops reading the `pnpm` field in `package.json` entirely, removes `onlyBuiltDependencies` (plus four sibling keys) in favour of `allowBuilds`, and defaults `strictDepBuilds` to `true`. On a naive version bump the allowlist is silently ignored and every install then hard-fails on Cypress' postinstall — which is where Cypress downloads its actual binary. Fail-closed, but only because the guard was already in place.

The Node floor was previously satisfied by luck: `node-version: lts/*` happens to resolve to v24. `engines` makes it a contract — and an enforced one, since pnpm hard-fails on an incompatible range declared by the root project regardless of `engineStrict`.

## Verification

- `pnpm install --frozen-lockfile` (the CI command) from a wiped `node_modules` under 11.15.1 → exit 0
- **`pnpm-lock.yaml` is unchanged** — still `lockfileVersion: '9.0'`, byte-identical, zero dependency drift across the major bump
- Guard **mutation-tested**: deleting `cypress: true` from `allowBuilds` makes the install exit 1 with `ERR_PNPM_IGNORED_BUILDS`; restored, the postinstall visibly runs and `pnpm exec cypress verify` passes
- `pnpm build`, 308 tests / 23 files
- `cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`, `cargo check -p rdlp-desktop`, `scripts/check-all.sh` — all green

CI needs no change: `pnpm/action-setup@v4` reads the version from `package_json_file:`, and `node-version: lts/*` clears the Node 22+ floor.

## Reviews

Both mandatory pre-push reviewers ran over the full `develop..HEAD` diff and **Approve**.

- **security-reviewer** — no blocking findings. Verified `allowBuilds` matches by exact package name and is non-transitive, so the move does not widen the allowlist; the new v11 defaults adopted here (`minimumReleaseAge=1440`, `blockExoticSubdeps=true`, `verifyDepsBeforeRun=install`) are net-positive hardening. Two LOW/INFO notes, no action: the `packageManager` pin carries no integrity hash (pre-existing, and tested — pnpm parses a `+sha512-…` suffix and ignores it, so adding one would assert a guarantee that isn't enforced), and 11.15.1 is a recent publish.
- **code-reviewer** — initially raised a Critical claiming the lockfile was never regenerated and `--frozen-lockfile` would hard-fail in CI. That rested on `pnpm --version` returning `command not found` in a non-login shell; the binary is installed standalone outside that PATH. Withdrawn on evidence after the frozen install was demonstrated green with no lockfile diff. Its other three findings (Node floor, an over-stated issue citation, an incomplete list of removed keys) are all fixed in `f9415de8`.

## Notes for reviewers

- pnpm 11 wants to purge a v10-built `node_modules` and prompts first, so a non-TTY run aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. Use `--config.confirmModulesPurge=false`; do **not** reach for `CI=true`, which also flips `install` to `--frozen-lockfile`.
- `pnpm-workspace.yaml` cites pnpm/pnpm#11219 and #10426 for the unpinned-entry rule. Both are open against the v10 `onlyBuiltDependencies` key; the comment now says so explicitly and marks the carry-forward to `allowBuilds` as design inference rather than verified fact.
