### PR TITLE
refactor: type the container decisions outside the thumbnail stage, and dedup the predicates it exposed

### DIFF
--- a/crates/rdlp-api/src/orchestrator/container_resolver.rs
+++ b/crates/rdlp-api/src/orchestrator/container_resolver.rs
@@ -56,8 +56,7 @@ impl ResolvedContainer {
 
         // Priority 3: infer from output file extension
         if let Some(path) = output_path
-            && let Some(ext) = path.extension().and_then(|e| e.to_str())
-            && let Ok(c) = ext.parse::<ContainerFormat>()
+            && let Some(c) = ContainerFormat::from_path(path)
         {
             // Skip .ts — raw MPEG-TS is an intermediate format
             if c != ContainerFormat::Ts {

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -377,10 +377,7 @@ impl Orchestrator {
         let final_path = crate::orchestrator::naming::finalize_survivor(survivor).await?;
 
         // HLS downloads produce .ts files that should be remuxed.
-        if is_hls
-            && rdlp_types::ContainerFormat::from_path(&final_path)
-                == Some(rdlp_types::ContainerFormat::Ts)
-        {
+        if is_hls && super::helpers::hls_remux_incomplete(&final_path) {
             return Err(OrchestratorError::DownloadFailed(
                 rdlp_core::RdlpError::Extraction {
                     message: format!(

--- a/crates/rdlp-api/src/orchestrator/playlist/episode.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/episode.rs
@@ -377,23 +377,20 @@ impl Orchestrator {
         let final_path = crate::orchestrator::naming::finalize_survivor(survivor).await?;
 
         // HLS downloads produce .ts files that should be remuxed.
-        if is_hls {
-            let ext = final_path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
-            if ext.eq_ignore_ascii_case("ts") {
-                return Err(OrchestratorError::DownloadFailed(
-                    rdlp_core::RdlpError::Extraction {
-                        message: format!(
-                            "Post-processing failed for '{}': \
+        if is_hls
+            && rdlp_types::ContainerFormat::from_path(&final_path)
+                == Some(rdlp_types::ContainerFormat::Ts)
+        {
+            return Err(OrchestratorError::DownloadFailed(
+                rdlp_core::RdlpError::Extraction {
+                    message: format!(
+                        "Post-processing failed for '{}': \
                              HLS container still .ts (FFmpeg remux did not complete)",
-                            final_info.title,
-                        ),
-                        url: None,
-                    },
-                ));
-            }
+                        final_info.title,
+                    ),
+                    url: None,
+                },
+            ));
         }
 
         Ok(Some(final_path))

--- a/crates/rdlp-api/src/orchestrator/playlist/helpers.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/helpers.rs
@@ -7,6 +7,20 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
+/// Whether `path` is still an un-remuxed MPEG-TS output, meaning an HLS
+/// download's remux never completed.
+///
+/// One definition shared by the two callers that ask it — the post-download
+/// check in `episode.rs` and the resume scan in `resume.rs` — which each
+/// compared `eq_ignore_ascii_case("ts")` on their own before.
+///
+/// Recognises `ContainerFormat`'s aliases, so `.mpegts` counts too. These are
+/// reject-guards, so widening the vocabulary makes them catch strictly more
+/// incomplete output; it cannot be sidestepped by using the alias spelling.
+pub(in crate::orchestrator) fn hls_remux_incomplete(path: &std::path::Path) -> bool {
+    rdlp_types::ContainerFormat::from_path(path) == Some(rdlp_types::ContainerFormat::Ts)
+}
+
 impl Orchestrator {
     /// Handle the case where all videos are already downloaded.
     ///
@@ -171,5 +185,36 @@ pub(super) fn filter_formats_by_language(infos: &mut [rdlp_types::InfoDict], lan
     for info in infos.iter_mut() {
         info.formats
             .retain(|f| f.language.as_deref() == Some(language));
+    }
+}
+
+#[cfg(test)]
+mod hls_remux_incomplete_tests {
+    use super::hls_remux_incomplete;
+    use std::path::Path;
+
+    #[test]
+    fn mpeg_ts_outputs_are_incomplete() {
+        for p in ["/tmp/Ep.ts", "/tmp/Ep.TS", "/tmp/Ep.mpegts"] {
+            assert!(hls_remux_incomplete(Path::new(p)), "{p} is un-remuxed TS");
+        }
+    }
+
+    /// The negative half: a completed remux, and the shapes that must not be
+    /// mistaken for one.
+    #[test]
+    fn remuxed_and_unknown_outputs_are_not_incomplete() {
+        for p in [
+            "/tmp/Ep.mp4",
+            "/tmp/Ep.mkv",
+            "/tmp/Ep",
+            "/tmp/Ep.rdlp-part",
+            "/tmp/ts",
+        ] {
+            assert!(
+                !hls_remux_incomplete(Path::new(p)),
+                "{p} must not be flagged"
+            );
+        }
     }
 }

--- a/crates/rdlp-api/src/orchestrator/playlist/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/resume.rs
@@ -145,9 +145,7 @@ impl Orchestrator {
                     }
 
                     // Reject .ts files -- HLS remux didn't complete
-                    if rdlp_types::ContainerFormat::from_path(file_path)
-                        == Some(rdlp_types::ContainerFormat::Ts)
-                    {
+                    if super::helpers::hls_remux_incomplete(file_path) {
                         debug!(
                             file:% = filename;
                             "Skipping .ts file (remux incomplete)"

--- a/crates/rdlp-api/src/orchestrator/playlist/resume.rs
+++ b/crates/rdlp-api/src/orchestrator/playlist/resume.rs
@@ -145,7 +145,9 @@ impl Orchestrator {
                     }
 
                     // Reject .ts files -- HLS remux didn't complete
-                    if ext.eq_ignore_ascii_case("ts") {
+                    if rdlp_types::ContainerFormat::from_path(file_path)
+                        == Some(rdlp_types::ContainerFormat::Ts)
+                    {
                         debug!(
                             file:% = filename;
                             "Skipping .ts file (remux incomplete)"

--- a/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/merge/mod.rs
@@ -98,9 +98,13 @@ impl FFmpegRunner {
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility.
         // The key is copying avg_frame_rate which sets Matroska's "Default duration" element.
-        let is_mkv = output
-            .extension()
-            .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
+        // Via ContainerFormat rather than a literal "mkv" compare, so this
+        // cannot drift from the rest of the container vocabulary. Slight
+        // widening: a `.matroska` output now takes the raw-FFI path too, which
+        // is correct — it is the same container under an alias, and it used to
+        // silently fall through to the generic muxer.
+        let is_mkv = rdlp_types::ContainerFormat::from_path(output)
+            == Some(rdlp_types::ContainerFormat::Mkv);
         if is_mkv {
             return Ok(Self::merge_mkv_raw_ffi(
                 video_input,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/metadata.rs
@@ -23,7 +23,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use log::debug;
 use rdlp_core::PostProcessCallback;
 
 use crate::error::{PostProcessError, Result};
@@ -183,16 +182,7 @@ impl FFmpegRunner {
         }
 
         // Build muxer options dictionary
-        let mut dict = ffmpeg_the_third::Dictionary::new();
-
-        // MKV: set cluster_time_limit for smoother playback/seeking in players like VLC
-        let is_mkv = output
-            .extension()
-            .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
-        if is_mkv {
-            dict.set("cluster_time_limit", "500");
-            debug!("MKV detected, setting cluster_time_limit=500ms via dictionary");
-        }
+        let dict = crate::ffmpeg::options::muxer_options_for(output);
 
         // Write header with options
         octx.write_header_with(dict)

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -465,10 +465,7 @@ mod audio_encoder_selection_tests {
     /// this change, and pinned here.
     #[test]
     fn wave_alias_resolves_like_wav() {
-        assert_eq!(
-            select_audio_encoder_for_container("wave"),
-            select_audio_encoder_for_container("wav"),
-        );
+        assert_eq!(select_audio_encoder_for_container("wave"), "pcm_s16le");
     }
 
     /// An extension that is not a container at all still falls back rather

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -232,23 +232,23 @@ pub(super) fn extract_json_value(text: &str, key: &str) -> Option<f64> {
 /// For video containers, delegates to [`audio_encoder_registry::select_audio_encoder_for_container`].
 /// Falls back to the best available AAC encoder for unknown extensions.
 pub(super) fn select_audio_encoder_for_container(ext: &str) -> &'static str {
-    // Audio-only output formats: these are not ContainerFormat variants but
-    // appear as extensions when normalizing standalone audio files.
-    if ext.eq_ignore_ascii_case("mp3") {
-        return "libmp3lame";
-    }
-    if ext.eq_ignore_ascii_case("flac") {
-        return "flac";
-    }
-    if ext.eq_ignore_ascii_case("wav") {
-        return "pcm_s16le";
-    }
+    let Ok(container) = ext.parse::<rdlp_types::ContainerFormat>() else {
+        return crate::ffmpeg::audio_codecs::preferred_aac_encoder();
+    };
 
-    // For proper container formats, delegate to the registry
-    if let Ok(container) = ext.parse::<rdlp_types::ContainerFormat>() {
-        crate::ffmpeg::audio_encoder_registry::select_audio_encoder_for_container(container)
-    } else {
-        crate::ffmpeg::audio_codecs::preferred_aac_encoder()
+    match container {
+        // Lossless/lossy audio-only containers whose own codec is the whole
+        // point: re-encoding a .mp3 to AAC-in-mp3 is not what the user asked
+        // for. The registry's fallback arm would do exactly that, so these are
+        // decided here before delegating.
+        //
+        // (These three WERE matched as raw strings with a comment claiming
+        // they "are not ContainerFormat variants". They are — Mp3, Flac and
+        // Wav have been variants throughout; the comment was simply wrong.)
+        rdlp_types::ContainerFormat::Mp3 => "libmp3lame",
+        rdlp_types::ContainerFormat::Flac => "flac",
+        rdlp_types::ContainerFormat::Wav => "pcm_s16le",
+        other => crate::ffmpeg::audio_encoder_registry::select_audio_encoder_for_container(other),
     }
 }
 
@@ -435,4 +435,51 @@ where
 /// [`parse_loudnorm_json`].
 pub(super) fn begin_loudnorm_capture() -> Result<LogCaptureGuard> {
     LogCaptureGuard::begin()
+}
+
+#[cfg(test)]
+mod audio_encoder_selection_tests {
+    use super::select_audio_encoder_for_container;
+
+    /// The three audio-only containers whose own codec is the point. These were
+    /// matched as raw strings before; the answers must not move.
+    #[test]
+    fn audio_only_containers_keep_their_native_encoder() {
+        assert_eq!(select_audio_encoder_for_container("mp3"), "libmp3lame");
+        assert_eq!(select_audio_encoder_for_container("flac"), "flac");
+        assert_eq!(select_audio_encoder_for_container("wav"), "pcm_s16le");
+    }
+
+    /// Case-insensitivity came free with `eq_ignore_ascii_case`; going through
+    /// `FromStr` must preserve it.
+    #[test]
+    fn audio_only_matching_stays_case_insensitive() {
+        assert_eq!(select_audio_encoder_for_container("MP3"), "libmp3lame");
+        assert_eq!(select_audio_encoder_for_container("Flac"), "flac");
+    }
+
+    /// The widening this conversion accepts: `"wave"` is a `ContainerFormat`
+    /// alias for Wav, so it now resolves to `pcm_s16le` where the literal
+    /// `eq_ignore_ascii_case("wav")` missed it and it fell through to the
+    /// registry's AAC fallback. Same class as the other alias widenings in
+    /// this change, and pinned here.
+    #[test]
+    fn wave_alias_resolves_like_wav() {
+        assert_eq!(
+            select_audio_encoder_for_container("wave"),
+            select_audio_encoder_for_container("wav"),
+        );
+    }
+
+    /// An extension that is not a container at all still falls back rather
+    /// than panicking or resolving to an audio-only encoder.
+    #[test]
+    fn unknown_extension_falls_back_to_aac() {
+        let fallback = crate::ffmpeg::audio_codecs::preferred_aac_encoder();
+        assert_eq!(
+            select_audio_encoder_for_container("not-a-container"),
+            fallback
+        );
+        assert_eq!(select_audio_encoder_for_container(""), fallback);
+    }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -22,6 +22,63 @@ pub fn faststart_for_output(path: &Path) -> bool {
     rdlp_types::ContainerFormat::from_path(path).is_some_and(|c| c.supports_faststart())
 }
 
+/// Matroska cluster duration limit, in milliseconds.
+///
+/// `FFmpeg`'s Matroska muxer otherwise emits clusters sized by its own
+/// heuristics, which produces coarse seek points; capping cluster duration
+/// gives players (VLC in particular) a seek granularity users expect.
+const MKV_CLUSTER_TIME_LIMIT_MS: &str = "500";
+
+/// Muxer options for writing to `output`, derived from its container.
+///
+/// The boundary form, like [`faststart_for_output`]: callers hold only a path.
+/// Both the metadata-embed and video-transcode header writes built this
+/// dictionary inline with an identical `eq_ignore_ascii_case("mkv")` check and
+/// their own copy of the 500 ms literal; this is the single place that decision
+/// and that number live.
+#[must_use]
+pub fn muxer_options_for(output: &Path) -> ffmpeg_the_third::Dictionary<'static> {
+    let mut dict = ffmpeg_the_third::Dictionary::new();
+    if rdlp_types::ContainerFormat::from_path(output) == Some(rdlp_types::ContainerFormat::Mkv) {
+        dict.set("cluster_time_limit", MKV_CLUSTER_TIME_LIMIT_MS);
+        log::debug!("MKV detected, setting cluster_time_limit={MKV_CLUSTER_TIME_LIMIT_MS}ms");
+    }
+    dict
+}
+
+#[cfg(test)]
+mod muxer_options_tests {
+    use super::*;
+
+    #[test]
+    fn mkv_output_gets_the_cluster_time_limit() {
+        for path in ["/tmp/Title.mkv", "/tmp/Title.MKV", "/tmp/Title.matroska"] {
+            let dict = muxer_options_for(Path::new(path));
+            assert_eq!(
+                dict.get("cluster_time_limit"),
+                Some(MKV_CLUSTER_TIME_LIMIT_MS),
+                "{path} is Matroska and needs the cluster cap"
+            );
+        }
+    }
+
+    /// The negative half: no other container may pick up a Matroska-only
+    /// option, and an unknown extension must not either.
+    #[test]
+    fn non_mkv_output_gets_no_matroska_options() {
+        for path in [
+            "/tmp/Title.mp4",
+            "/tmp/Title.webm",
+            "/tmp/Title.mka",
+            "/tmp/Title.xyz",
+            "/tmp/Title",
+        ] {
+            let dict = muxer_options_for(Path::new(path));
+            assert_eq!(dict.get("cluster_time_limit"), None, "{path}");
+        }
+    }
+}
+
 /// Options for remux and merge operations.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RemuxOptions {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/options.rs
@@ -19,10 +19,7 @@ use std::path::Path;
 /// An unrecognised extension answers `false` — matching the previous behaviour
 /// for unknown containers.
 pub fn faststart_for_output(path: &Path) -> bool {
-    path.extension()
-        .and_then(|e| e.to_str())
-        .and_then(|e| e.parse::<rdlp_types::ContainerFormat>().ok())
-        .is_some_and(|c| c.supports_faststart())
+    rdlp_types::ContainerFormat::from_path(path).is_some_and(|c| c.supports_faststart())
 }
 
 /// Options for remux and merge operations.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/remux.rs
@@ -86,9 +86,13 @@ impl FFmpegRunner {
 
         // MKV: use raw FFI with proper stream property copying for VLC compatibility.
         // The key is copying avg_frame_rate which sets Matroska's "Default duration" element.
-        let is_mkv = output
-            .extension()
-            .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
+        // Via ContainerFormat rather than a literal "mkv" compare, so this
+        // cannot drift from the rest of the container vocabulary. Slight
+        // widening: a `.matroska` output now takes the raw-FFI path too, which
+        // is correct — it is the same container under an alias, and it used to
+        // silently fall through to the generic muxer.
+        let is_mkv = rdlp_types::ContainerFormat::from_path(output)
+            == Some(rdlp_types::ContainerFormat::Mkv);
         if is_mkv {
             return Self::remux_mkv_raw_ffi(
                 input,

--- a/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
@@ -84,6 +84,13 @@ pub fn resolve_recode_encoder(
     // These arrive as raw config strings, so the parse is the boundary where
     // an unknown container becomes the default codec — the behaviour the old
     // `_` arm provided when the match itself was string-based.
+    //
+    // ONE deliberate widening rides along: the parse resolves ContainerFormat's
+    // aliases, so `"mpeg"` now reaches the Mpg arm ("mpeg2") where the old
+    // literal `"mpg" | "vob"` compare let it fall to h264. Every other alias
+    // (`mpegts`, `3gpp`, `matroska`, `quicktime`, ...) still lands on h264, so
+    // `"mpeg"` is the only string whose codec changes. Same class of widening
+    // as #537's, and pinned by `mpeg_alias_resolves_like_mpg` below.
     let codec = target
         .parse::<ContainerFormat>()
         .map_or(DEFAULT_VIDEO_CODEC, default_codec_for_container);
@@ -306,6 +313,32 @@ mod tests {
             default_codec_for_container("matroska".parse().expect("alias")),
             default_codec_for_container(ContainerFormat::Mkv)
         );
+    }
+
+    /// The one string whose resolved codec this conversion CHANGES: `"mpeg"`
+    /// is a `ContainerFormat` alias for `Mpg`, so it now resolves to mpeg2
+    /// where the old literal `"mpg" | "vob"` compare dropped it to h264.
+    /// Deliberate, documented at the parse site, and pinned here.
+    #[test]
+    fn mpeg_alias_resolves_like_mpg() {
+        assert_eq!(
+            resolve_recode_encoder(None, Some("mpeg"), None),
+            resolve_recode_encoder(None, Some("mpg"), None),
+            "the `mpeg` alias must resolve exactly as `mpg` does"
+        );
+    }
+
+    /// The aliases that do NOT change: each still lands on the h264 default,
+    /// so the widening above is genuinely confined to `"mpeg"`.
+    #[test]
+    fn other_aliases_still_resolve_to_the_default_codec() {
+        for alias in ["mpegts", "3gpp", "matroska", "quicktime"] {
+            assert_eq!(
+                resolve_recode_encoder(None, Some(alias), None),
+                resolve_recode_encoder(None, Some("mp4"), None),
+                "{alias} must still resolve to the h264 default"
+            );
+        }
     }
 
     /// `resolve_recode_encoder` still takes strings (config-supplied), so its

--- a/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/speed_controls.rs
@@ -3,23 +3,66 @@
 //! The validator and `RecodeStage` MUST resolve the target encoder identically;
 //! both go through [`resolve_recode_encoder`] so they cannot drift.
 
+use rdlp_types::ContainerFormat;
 use thiserror::Error;
 
 use super::video_codecs::{KnobField, KnobKindDef, resolve_encoder, speed_controls_def};
 
+/// The codec every container that isn't explicitly special-cased encodes
+/// toward, and the answer for a container string that doesn't parse at all.
+/// Named because it is now referenced from two places.
+const DEFAULT_VIDEO_CODEC: &str = "h264";
+
 /// Return the default video codec to encode toward for a given container
-/// extension (e.g. `"webm"` → `"vp9"`, `"mp4"` → `"h264"`).
+/// (e.g. [`ContainerFormat::WebM`] → `"vp9"`, [`ContainerFormat::Mp4`] →
+/// `"h264"`).
 ///
 /// This is the **single source of truth** for the container → codec mapping.
 /// Both the speed-control validator and `RecodeStage` delegate here so they
 /// can never resolve differently.
+///
+/// Takes a [`ContainerFormat`] rather than a `&str`: every caller already had
+/// one and was calling `.as_ext()` purely to satisfy this signature, so the
+/// "callers always pass a canonical extension" invariant was conventional.
+/// It is now structural — the same argument as #536. Matched exhaustively with
+/// no catch-all, so a new container variant fails to compile here instead of
+/// silently inheriting `"h264"`.
 #[must_use]
-pub fn default_codec_for_container(container: &str) -> &'static str {
-    match container.to_ascii_lowercase().as_str() {
-        "webm" | "ivf" => "vp9",
-        "ogg" => "theora",
-        "mpg" | "vob" => "mpeg2",
-        _ => "h264",
+pub const fn default_codec_for_container(container: ContainerFormat) -> &'static str {
+    match container {
+        ContainerFormat::WebM | ContainerFormat::Ivf => "vp9",
+        ContainerFormat::Ogg => "theora",
+        ContainerFormat::Mpg | ContainerFormat::Vob => "mpeg2",
+        // Video containers that took the old `_` arm.
+        ContainerFormat::Mp4
+        | ContainerFormat::Mkv
+        | ContainerFormat::Mov
+        | ContainerFormat::M4v
+        | ContainerFormat::Ts
+        | ContainerFormat::Flv
+        | ContainerFormat::Avi
+        | ContainerFormat::ThreeGp
+        | ContainerFormat::F4v
+        | ContainerFormat::Wmv
+        | ContainerFormat::Asf
+        | ContainerFormat::Mxf
+        | ContainerFormat::Dv
+        | ContainerFormat::Nut
+        // Audio-only containers. A *video* codec is meaningless for these and
+        // they are not recode-video targets, but they reached "h264" through
+        // the old default and this conversion changes no behaviour.
+        | ContainerFormat::M4a
+        | ContainerFormat::Mka
+        | ContainerFormat::Mp3
+        | ContainerFormat::Wav
+        | ContainerFormat::Flac
+        | ContainerFormat::Opus
+        | ContainerFormat::Aac
+        | ContainerFormat::Aiff
+        | ContainerFormat::Wma
+        | ContainerFormat::Wv
+        | ContainerFormat::Caf
+        | ContainerFormat::Ac3 => DEFAULT_VIDEO_CODEC,
     }
 }
 
@@ -38,7 +81,13 @@ pub fn resolve_recode_encoder(
         return resolve_encoder(ve);
     }
     let target = recode_container.or(recode_video)?;
-    resolve_encoder(default_codec_for_container(target))
+    // These arrive as raw config strings, so the parse is the boundary where
+    // an unknown container becomes the default codec — the behaviour the old
+    // `_` arm provided when the match itself was string-based.
+    let codec = target
+        .parse::<ContainerFormat>()
+        .map_or(DEFAULT_VIDEO_CODEC, default_codec_for_container);
+    resolve_encoder(codec)
 }
 
 /// Strict per-encoder speed-control validation error.
@@ -226,14 +275,48 @@ mod tests {
         }
     }
 
+    /// Behaviour parity across the string → `ContainerFormat` conversion:
+    /// every container that had a non-default codec keeps it, and the ones
+    /// that reached `"h264"` via the old `_` arm still do.
     #[test]
     fn resolver_matches_recode_stage_defaults() {
-        assert_eq!(default_codec_for_container("webm"), "vp9");
-        assert_eq!(default_codec_for_container("ivf"), "vp9");
-        assert_eq!(default_codec_for_container("ogg"), "theora");
-        assert_eq!(default_codec_for_container("mpg"), "mpeg2");
-        assert_eq!(default_codec_for_container("vob"), "mpeg2");
-        assert_eq!(default_codec_for_container("mp4"), "h264");
-        assert_eq!(default_codec_for_container("mkv"), "h264");
+        for (container, want) in [
+            (ContainerFormat::WebM, "vp9"),
+            (ContainerFormat::Ivf, "vp9"),
+            (ContainerFormat::Ogg, "theora"),
+            (ContainerFormat::Mpg, "mpeg2"),
+            (ContainerFormat::Vob, "mpeg2"),
+            (ContainerFormat::Mp4, "h264"),
+            (ContainerFormat::Mkv, "h264"),
+        ] {
+            assert_eq!(
+                default_codec_for_container(container),
+                want,
+                "{container:?}"
+            );
+        }
+    }
+
+    /// The typed signature is the point: a caller can no longer hand this an
+    /// arbitrary string. Aliases resolve to the same answer as the canonical
+    /// name, which the old `to_ascii_lowercase` compare did not do.
+    #[test]
+    fn aliases_resolve_to_the_same_codec() {
+        assert_eq!(
+            default_codec_for_container("matroska".parse().expect("alias")),
+            default_codec_for_container(ContainerFormat::Mkv)
+        );
+    }
+
+    /// `resolve_recode_encoder` still takes strings (config-supplied), so its
+    /// unparseable-input path must keep the old `_ => "h264"` behaviour rather
+    /// than silently resolving to nothing.
+    #[test]
+    fn unparseable_container_string_still_falls_back_to_h264() {
+        assert_eq!(
+            resolve_recode_encoder(None, Some("not-a-container"), None),
+            resolve_recode_encoder(None, Some("mp4"), None),
+            "an unknown container string must resolve exactly as the h264 default did"
+        );
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -487,16 +487,7 @@ impl FFmpegRunner {
         };
 
         // Build muxer options dictionary
-        let mut dict = ffmpeg_the_third::Dictionary::new();
-
-        // MKV: set cluster_time_limit for smoother playback/seeking in players like VLC
-        let is_mkv = output
-            .extension()
-            .is_some_and(|e| e.eq_ignore_ascii_case("mkv"));
-        if is_mkv {
-            dict.set("cluster_time_limit", "500");
-            debug!("MKV detected, setting cluster_time_limit=500ms via dictionary");
-        }
+        let dict = crate::ffmpeg::options::muxer_options_for(output);
 
         // Set format-level encoding_tool metadata
         {

--- a/crates/rdlp-postprocess/src/pipeline/stages/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/mod.rs
@@ -14,7 +14,7 @@ pub mod normalize;
 pub mod recode;
 pub mod remux;
 pub mod subtitle;
-pub mod subtitle_codec;
+mod subtitle_codec;
 pub mod thumbnail;
 
 pub use audio_extract::AudioExtractStage;

--- a/crates/rdlp-postprocess/src/pipeline/stages/mod.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/mod.rs
@@ -14,6 +14,7 @@ pub mod normalize;
 pub mod recode;
 pub mod remux;
 pub mod subtitle;
+pub mod subtitle_codec;
 pub mod thumbnail;
 
 pub use audio_extract::AudioExtractStage;

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -118,8 +118,8 @@ impl RecodeStage {
     /// Pick the default video codec to encode toward when no explicit
     /// encoder override is given. Delegates to the single source in `rdlp-ffmpeg`
     /// so the recode pipeline and `validate_speed_controls` never resolve differently.
-    fn default_codec_for(target: ContainerFormat) -> &'static str {
-        rdlp_ffmpeg::default_codec_for_container(target.as_ext())
+    const fn default_codec_for(target: ContainerFormat) -> &'static str {
+        rdlp_ffmpeg::default_codec_for_container(target)
     }
 
     /// Default `(preset, crf)` for a known target codec. Returns `(None, None)`

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle.rs
@@ -11,13 +11,17 @@ use log::{debug, warn};
 
 use rdlp_ffmpeg::FFmpegRunner;
 
+use rdlp_types::ContainerFormat;
+
+use super::subtitle_codec::SubtitleEmbedCodec;
 use crate::pipeline::{DiscoveredSidecar, PipelineMessage, PipelineStage, SidecarOwnership};
 
 /// Subtitle file extensions to search for.
 const SUBTITLE_EXTENSIONS: &[&str] = &["srt", "vtt", "ass", "ssa", "lrc"];
 
-/// Containers that support subtitle embedding.
-const SUBTITLE_CONTAINERS: &[&str] = &["mp4", "m4a", "m4v", "mov", "mkv", "mka", "webm"];
+// Which containers accept subtitles, and with which codec, is decided in
+// `super::subtitle_codec` by an exhaustive `ContainerFormat` match — never by
+// a string list here.
 
 /// Embeds subtitle streams into video containers.
 ///
@@ -34,30 +38,18 @@ impl SubtitleStage {
         Self { ffmpeg }
     }
 
-    /// Check if the container format supports subtitle embedding.
-    fn supports_subtitles(extension: &str) -> bool {
-        SUBTITLE_CONTAINERS
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(extension))
-    }
-
-    /// Get the `FFmpeg` subtitle codec for a container format.
-    fn subtitle_codec_for_container(container_ext: &str) -> &'static str {
-        if ["mp4", "m4a", "m4v", "mov"]
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(container_ext))
-        {
-            "mov_text"
-        } else if ["mkv", "mka"]
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(container_ext))
-        {
-            "srt"
-        } else if container_ext.eq_ignore_ascii_case("webm") {
-            "webvtt"
-        } else {
-            "srt"
-        }
+    /// Resolve the subtitle codec for a file extension, or `None` when the
+    /// container cannot carry subtitles.
+    ///
+    /// An unparseable extension is not a subtitle target, which is why this
+    /// swallows the parse error: `ContainerFormat` already owns the vocabulary
+    /// (including its aliases), so anything it rejects is not a container we
+    /// can embed into.
+    fn codec_for_extension(extension: &str) -> Option<SubtitleEmbedCodec> {
+        extension
+            .parse::<ContainerFormat>()
+            .ok()
+            .and_then(SubtitleEmbedCodec::for_container)
     }
 
     /// Find subtitle files alongside a media file using `original_stem` for discovery.
@@ -167,10 +159,10 @@ impl PipelineStage for SubtitleStage {
             .and_then(|e| e.to_str())
             .unwrap_or("");
 
-        if !Self::supports_subtitles(extension) {
+        let Some(codec) = Self::codec_for_extension(extension) else {
             debug!("SubtitleStage: container '{extension}' does not support subtitle embedding");
             return Ok(msg);
-        }
+        };
 
         let subtitle_files = Self::find_subtitle_files(&media_file, &msg.original_stem).await;
 
@@ -182,7 +174,7 @@ impl PipelineStage for SubtitleStage {
             return Ok(msg);
         }
 
-        let codec = Self::subtitle_codec_for_container(extension);
+        let codec = codec.as_ffmpeg_name();
         // FFmpeg subtitle embedding is not yet implemented in rdlp-ffmpeg.
         // Surface this LOUDLY: a user invoking --embed-subtitles must see a
         // warn-level message AND a structured warning on the pipeline so
@@ -301,34 +293,39 @@ mod tests {
         assert!(!stage.is_fatal());
     }
 
+    /// Same coverage the two string-based helpers had, now through the one
+    /// typed entry point that replaced them.
     #[test]
     fn supports_subtitle_containers() {
-        assert!(SubtitleStage::supports_subtitles("mp4"));
-        assert!(SubtitleStage::supports_subtitles("mkv"));
-        assert!(SubtitleStage::supports_subtitles("webm"));
-        assert!(!SubtitleStage::supports_subtitles("ts"));
-        assert!(!SubtitleStage::supports_subtitles("avi"));
+        assert!(SubtitleStage::codec_for_extension("mp4").is_some());
+        assert!(SubtitleStage::codec_for_extension("mkv").is_some());
+        assert!(SubtitleStage::codec_for_extension("webm").is_some());
+        assert!(SubtitleStage::codec_for_extension("ts").is_none());
+        assert!(SubtitleStage::codec_for_extension("avi").is_none());
     }
 
     #[test]
-    fn subtitle_codec_for_mp4() {
-        assert_eq!(
-            SubtitleStage::subtitle_codec_for_container("mp4"),
-            "mov_text"
-        );
+    fn subtitle_codec_per_container_family() {
+        for (ext, want) in [("mp4", "mov_text"), ("mkv", "srt"), ("webm", "webvtt")] {
+            assert_eq!(
+                SubtitleStage::codec_for_extension(ext).map(SubtitleEmbedCodec::as_ffmpeg_name),
+                Some(want),
+            );
+        }
     }
 
+    /// New negative coverage the string path never had: an extension that is
+    /// not a container at all, and a file with no extension, must both be
+    /// "no subtitle target" rather than falling through to the old `"srt"`
+    /// default.
     #[test]
-    fn subtitle_codec_for_mkv() {
-        assert_eq!(SubtitleStage::subtitle_codec_for_container("mkv"), "srt");
-    }
-
-    #[test]
-    fn subtitle_codec_for_webm() {
-        assert_eq!(
-            SubtitleStage::subtitle_codec_for_container("webm"),
-            "webvtt"
-        );
+    fn unknown_and_empty_extensions_are_not_subtitle_targets() {
+        for ext in ["", "part", "rdlp-tmp", "txt", "srt"] {
+            assert!(
+                SubtitleStage::codec_for_extension(ext).is_none(),
+                "{ext:?} must not resolve to a subtitle codec"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle_codec.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle_codec.rs
@@ -18,7 +18,7 @@ use rdlp_types::ContainerFormat;
 
 /// The `FFmpeg` subtitle codec used to embed into a given container.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SubtitleEmbedCodec {
+pub(super) enum SubtitleEmbedCodec {
     /// `MPEG-4` timed text — the MP4/`QuickTime` family's native subtitle codec.
     MovText,
     /// `SubRip` — Matroska's default text subtitle codec.
@@ -36,7 +36,7 @@ impl SubtitleEmbedCodec {
     /// here, forcing an explicit decision instead of silently inheriting the
     /// old `"srt"` fallback.
     #[must_use]
-    pub const fn for_container(format: ContainerFormat) -> Option<Self> {
+    pub(super) const fn for_container(format: ContainerFormat) -> Option<Self> {
         match format {
             ContainerFormat::Mp4
             | ContainerFormat::Mov
@@ -73,22 +73,13 @@ impl SubtitleEmbedCodec {
 
     /// The encoder name passed to `FFmpeg`.
     #[must_use]
-    pub const fn as_ffmpeg_name(self) -> &'static str {
+    pub(super) const fn as_ffmpeg_name(self) -> &'static str {
         match self {
             Self::MovText => "mov_text",
             Self::Srt => "srt",
             Self::WebVtt => "webvtt",
         }
     }
-}
-
-/// Whether `format` can carry embedded subtitles at all.
-///
-/// The gateway to [`SubtitleEmbedCodec::for_container`], so the stage's
-/// should-we-run check and its codec choice cannot drift apart.
-#[must_use]
-pub const fn supports_subtitle_embed(format: ContainerFormat) -> bool {
-    SubtitleEmbedCodec::for_container(format).is_some()
 }
 
 #[cfg(test)]
@@ -120,18 +111,32 @@ mod tests {
         }
     }
 
-    /// The negative half: containers that were rejected before are still
-    /// rejected, and they no longer fall through to the silent `"srt"` default.
+    /// The negative half, swept rather than sampled: EVERY variant outside the
+    /// supported set must resolve to `None`, so nothing falls through to the
+    /// old silent `"srt"` default.
+    ///
+    /// Iterating `ContainerFormat` pins the whole mapping. The exhaustive match
+    /// only makes an *unclassified* variant fail to compile; this catches a
+    /// *misclassified* one, which the compiler cannot see.
     #[test]
-    fn unsupported_containers_have_no_codec() {
-        for ext in [
-            "ts", "avi", "flv", "mpg", "wav", "ac3", "ogg", "flac", "mp3",
-        ] {
-            let format: ContainerFormat = ext.parse().expect("known container");
+    fn every_variant_matches_the_pinned_support_set() {
+        use strum::IntoEnumIterator as _;
+
+        const SUPPORTED: &[ContainerFormat] = &[
+            ContainerFormat::Mp4,
+            ContainerFormat::Mov,
+            ContainerFormat::M4v,
+            ContainerFormat::M4a,
+            ContainerFormat::Mkv,
+            ContainerFormat::Mka,
+            ContainerFormat::WebM,
+        ];
+
+        for format in ContainerFormat::iter() {
             assert_eq!(
-                SubtitleEmbedCodec::for_container(format),
-                None,
-                "{ext} must not resolve to a codec"
+                SubtitleEmbedCodec::for_container(format).is_some(),
+                SUPPORTED.contains(&format),
+                "{format:?} support must match the pinned set"
             );
         }
     }

--- a/crates/rdlp-postprocess/src/pipeline/stages/subtitle_codec.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/subtitle_codec.rs
@@ -1,0 +1,172 @@
+//! Which subtitle codec a given [`ContainerFormat`] can carry.
+//!
+//! `SubtitleStage` previously decided this with two raw-string lists and three
+//! inline `eq_ignore_ascii_case` arrays (`SUBTITLE_CONTAINERS`, plus
+//! `["mp4","m4a","m4v","mov"]` / `["mkv","mka"]` / `"webm"` inside
+//! `subtitle_codec_for_container`) — the same decision expressed twice, in
+//! strings, with an `else` arm that defaulted to `"srt"` for anything
+//! unrecognised. This module collapses both into one typed decision made from
+//! [`ContainerFormat`] (per the workspace convention: container formats are
+//! never raw strings — see `CLAUDE.md`), modelled directly on
+//! `rdlp_ffmpeg`'s `embed_strategy::ThumbnailEmbedStrategy` (#533/#537).
+//!
+//! The `"srt"` default is gone: a container either resolves to a codec or is
+//! not a subtitle target at all. Support and codec choice can no longer
+//! disagree, because both now come from the single match below.
+
+use rdlp_types::ContainerFormat;
+
+/// The `FFmpeg` subtitle codec used to embed into a given container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubtitleEmbedCodec {
+    /// `MPEG-4` timed text — the MP4/`QuickTime` family's native subtitle codec.
+    MovText,
+    /// `SubRip` — Matroska's default text subtitle codec.
+    Srt,
+    /// `WebVTT` — the only text subtitle codec `WebM` accepts.
+    WebVtt,
+}
+
+impl SubtitleEmbedCodec {
+    /// Resolve the subtitle codec for `format`, or `None` when `format` cannot
+    /// carry embedded subtitles at all.
+    ///
+    /// Matched exhaustively over every [`ContainerFormat`] variant (no
+    /// catch-all arm) so that a newly-added container format fails to compile
+    /// here, forcing an explicit decision instead of silently inheriting the
+    /// old `"srt"` fallback.
+    #[must_use]
+    pub const fn for_container(format: ContainerFormat) -> Option<Self> {
+        match format {
+            ContainerFormat::Mp4
+            | ContainerFormat::Mov
+            | ContainerFormat::M4v
+            | ContainerFormat::M4a => Some(Self::MovText),
+            ContainerFormat::Mkv | ContainerFormat::Mka => Some(Self::Srt),
+            ContainerFormat::WebM => Some(Self::WebVtt),
+            ContainerFormat::Ts
+            | ContainerFormat::Flv
+            | ContainerFormat::Avi
+            | ContainerFormat::ThreeGp
+            | ContainerFormat::Mpg
+            | ContainerFormat::F4v
+            | ContainerFormat::Wmv
+            | ContainerFormat::Wma
+            | ContainerFormat::Asf
+            | ContainerFormat::Mxf
+            | ContainerFormat::Vob
+            | ContainerFormat::Dv
+            | ContainerFormat::Nut
+            | ContainerFormat::Ivf
+            | ContainerFormat::Ogg
+            | ContainerFormat::Opus
+            | ContainerFormat::Mp3
+            | ContainerFormat::Wav
+            | ContainerFormat::Flac
+            | ContainerFormat::Aac
+            | ContainerFormat::Aiff
+            | ContainerFormat::Wv
+            | ContainerFormat::Caf
+            | ContainerFormat::Ac3 => None,
+        }
+    }
+
+    /// The encoder name passed to `FFmpeg`.
+    #[must_use]
+    pub const fn as_ffmpeg_name(self) -> &'static str {
+        match self {
+            Self::MovText => "mov_text",
+            Self::Srt => "srt",
+            Self::WebVtt => "webvtt",
+        }
+    }
+}
+
+/// Whether `format` can carry embedded subtitles at all.
+///
+/// The gateway to [`SubtitleEmbedCodec::for_container`], so the stage's
+/// should-we-run check and its codec choice cannot drift apart.
+#[must_use]
+pub const fn supports_subtitle_embed(format: ContainerFormat) -> bool {
+    SubtitleEmbedCodec::for_container(format).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rdlp_types::ContainerFormat;
+
+    /// Behaviour parity: every container supported before the conversion keeps
+    /// the exact codec it had, so this refactor changes nothing for anyone.
+    #[test]
+    fn supported_containers_keep_their_codec() {
+        for (ext, want) in [
+            ("mp4", "mov_text"),
+            ("m4a", "mov_text"),
+            ("m4v", "mov_text"),
+            ("mov", "mov_text"),
+            ("mkv", "srt"),
+            ("mka", "srt"),
+            ("webm", "webvtt"),
+        ] {
+            let format: ContainerFormat = ext.parse().expect("known container");
+            let codec = SubtitleEmbedCodec::for_container(format)
+                .unwrap_or_else(|| panic!("{ext} must still support subtitle embedding"));
+            assert_eq!(
+                codec.as_ffmpeg_name(),
+                want,
+                "codec for {ext} must not change"
+            );
+        }
+    }
+
+    /// The negative half: containers that were rejected before are still
+    /// rejected, and they no longer fall through to the silent `"srt"` default.
+    #[test]
+    fn unsupported_containers_have_no_codec() {
+        for ext in [
+            "ts", "avi", "flv", "mpg", "wav", "ac3", "ogg", "flac", "mp3",
+        ] {
+            let format: ContainerFormat = ext.parse().expect("known container");
+            assert_eq!(
+                SubtitleEmbedCodec::for_container(format),
+                None,
+                "{ext} must not resolve to a codec"
+            );
+        }
+    }
+
+    /// The widening this conversion accepts, pinned exactly as #537 pinned the
+    /// thumbnail one: the typed path recognises `ContainerFormat`'s aliases, so
+    /// a file named `.matroska` / `.quicktime` is now accepted where the raw
+    /// string list rejected it. Deliberate, and locked down here.
+    #[test]
+    fn strum_aliases_are_accepted_and_map_to_the_canonical_codec() {
+        let mkv: ContainerFormat = "matroska".parse().expect("alias");
+        let mov: ContainerFormat = "quicktime".parse().expect("alias");
+
+        assert_eq!(mkv, ContainerFormat::Mkv);
+        assert_eq!(mov, ContainerFormat::Mov);
+        assert_eq!(
+            SubtitleEmbedCodec::for_container(mkv).map(SubtitleEmbedCodec::as_ffmpeg_name),
+            Some("srt")
+        );
+        assert_eq!(
+            SubtitleEmbedCodec::for_container(mov).map(SubtitleEmbedCodec::as_ffmpeg_name),
+            Some("mov_text")
+        );
+    }
+
+    /// Case-insensitivity came free with the string compare
+    /// (`eq_ignore_ascii_case`); it must survive the move to `FromStr`.
+    #[test]
+    fn extension_matching_stays_case_insensitive() {
+        for ext in ["MP4", "Mkv", "WEBM"] {
+            let format: ContainerFormat = ext.parse().expect("case-insensitive parse");
+            assert!(
+                SubtitleEmbedCodec::for_container(format).is_some(),
+                "{ext} must still be recognised"
+            );
+        }
+    }
+}

--- a/crates/rdlp-types/src/container.rs
+++ b/crates/rdlp-types/src/container.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 
 use crate::parse_error::ParseEnumError;
 use serde_with::DeserializeFromStr;
+use std::path::Path;
+
 use strum_macros::{Display, EnumIter, EnumString};
 
 /// Builds the `FromStr` error for [`ContainerFormat`].
@@ -196,6 +198,25 @@ impl ContainerFormat {
             Self::Caf => "caf",
             Self::Ac3 => "ac3",
         }
+    }
+
+    /// Derive the container from a filesystem path's extension.
+    ///
+    /// The single place a path becomes a `ContainerFormat`. Honours everything
+    /// [`FromStr`](std::str::FromStr) does — the canonical extension, the
+    /// aliases (`matroska`, `quicktime`, ...), and ASCII case — so callers stop
+    /// hand-rolling `path.extension().and_then(str::parse)` chains that each
+    /// pick their own subset of that vocabulary. Answers `None` for a missing,
+    /// non-UTF-8, or unrecognised extension; deciding what `None` means is the
+    /// caller's job.
+    ///
+    /// Takes only the path's extension — no filesystem access, so this stays
+    /// within the crate's pure-data remit.
+    #[must_use]
+    pub fn from_path(path: &Path) -> Option<Self> {
+        path.extension()
+            .and_then(|e| e.to_str())
+            .and_then(|e| e.parse().ok())
     }
 
     /// Whether this container supports faststart (moov atom at beginning).
@@ -542,5 +563,47 @@ mod tests {
             !ContainerFormat::Asf.is_audio_only(),
             "asf is the general fallback and may carry video"
         );
+    }
+
+    /// `from_path` is the one place a filesystem path becomes a container, so
+    /// it must honour everything `FromStr` honours: the canonical extension,
+    /// the strum aliases, and ASCII case-insensitivity.
+    #[test]
+    fn from_path_accepts_canonical_aliases_and_any_case() {
+        for (path, want) in [
+            ("/tmp/Title.mkv", ContainerFormat::Mkv),
+            ("/tmp/Title.matroska", ContainerFormat::Mkv),
+            ("/tmp/Title.MKV", ContainerFormat::Mkv),
+            ("/tmp/Title.quicktime", ContainerFormat::Mov),
+            ("Title.mp4", ContainerFormat::Mp4),
+            ("/tmp/a.b.c/Title.with.dots.webm", ContainerFormat::WebM),
+        ] {
+            assert_eq!(
+                ContainerFormat::from_path(std::path::Path::new(path)),
+                Some(want),
+                "{path}"
+            );
+        }
+    }
+
+    /// The negative space: anything that is not a recognised container answers
+    /// `None` rather than guessing a default.
+    #[test]
+    fn from_path_rejects_missing_unknown_and_non_container_extensions() {
+        for path in [
+            "/tmp/Title",
+            "/tmp/Title.",
+            "/tmp/.hidden",
+            "/tmp/Title.rdlp-part",
+            "/tmp/Title.srt",
+            "/tmp/Title.xyz",
+            "",
+        ] {
+            assert_eq!(
+                ContainerFormat::from_path(std::path::Path::new(path)),
+                None,
+                "{path:?} must not resolve to a container"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #541

## What

Converts the container decisions that survived outside the thumbnail stage from raw strings to `ContainerFormat`, then deduplicates the predicates that conversion exposed.

**Issue items**

1. **Subtitle containers** — `SUBTITLE_CONTAINERS` plus the three inline `eq_ignore_ascii_case` arrays inside `subtitle_codec_for_container` collapse into one exhaustive match in the new `stages/subtitle_codec` module, modelled on `embed_strategy::ThumbnailEmbedStrategy`. Support and codec now come from a single `Option`, so they cannot drift apart, and the `else { "srt" }` fallback is gone.
2. **`audio_only_extension_for`** — no work needed. It was already converted to an exhaustive `ContainerFormat` match by `81119a6b`; the issue body describes a state that no longer exists.
3. **`default_codec_for_container`** — now takes `ContainerFormat`; the `_ => "h264"` catch-all is replaced by an exhaustive match with every previously-defaulting variant grouped and commented. The parse moved to `resolve_recode_encoder`, which still takes config strings, so unknown input maps to a named `DEFAULT_VIDEO_CODEC` exactly as before.

**Beyond the issue** — a dedup sweep found the same defect at sites the issue never enumerated:

- `ContainerFormat::from_path` in `rdlp-types` is now the single place a path becomes a container. Four hand-rolled extension-parse chains collapse onto it, including **two verbatim-identical `eq_ignore_ascii_case("mkv")` blocks** in `remux.rs` and `merge/mod.rs`.
- `options::muxer_options_for` replaces **two verbatim-identical eight-line blocks** in `metadata.rs` and `transcode/video_transcode_phases.rs` that each set `cluster_time_limit=500` for MKV. The literal became `MKV_CLUSTER_TIME_LIMIT_MS` with its rationale.
- `playlist::helpers::hls_remux_incomplete` replaces two copies of the "is the output still `.ts`" guard in `episode.rs` and `resume.rs`. Neither was previously covered by a test — both sat inside long private async fns.
- `normalize/helpers.rs` audio-encoder selection is typed. Its mp3/flac/wav arms carried a comment claiming *"these are not ContainerFormat variants"* — they are, and always have been.

## Deviations from the acceptance criteria (please read)

The issue says *"No behavior change for any container that works today."* Four deliberate deviations exist, each documented at the call site and pinned by a test:

| Input | Before | After |
|---|---|---|
| `.matroska` / `.quicktime` | rejected for subtitle embedding | accepted (the widening #537 set precedent for, and which the issue body instructed) |
| `.matroska` output | generic muxer, no cluster cap | raw-FFI MKV path + cluster cap, same as `.mkv` |
| `"mpeg"` as recode target | `h264` | `mpeg2` (it is a `ContainerFormat` alias for `Mpg`) |
| `"wave"` | AAC fallback | `pcm_s16le` |
| `.mpegts` output | passed the HLS remux-completion guard | correctly flagged as un-remuxed |

The `"mpeg"` flip is the one nobody anticipated when the criterion was written. `mpegts`/`3gpp`/`matroska`/`quicktime` all still resolve to `h264`, asserted, so that widening is confined to one input. The two `.ts` cases are **reject-guards**, so widening them makes them catch strictly more incomplete output — they cannot be sidestepped by using the alias spelling.

## Why the six exhaustive matches are not factored together

`embed_strategy`, `normalize/helpers`, `speed_controls`, `recode`, `thumbnail` and `subtitle_codec` each re-list all 31 `ContainerFormat` variants, which looks like the duplication to attack. It is the opposite. Each is a *different* mapping, and the repeated enumeration **is** the mechanism: a shared table or a generating macro would trade 31 compiler-checked arms for data the compiler cannot verify, destroying the `E0004` guarantee this issue exists to create. Same pattern, different data.

## Verification

- `cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`, `cargo check -p rdlp-desktop`, `scripts/check-all.sh` — all green
- `scripts/check-dedup.sh` — PASS, statistics **identical to the `develop` baseline** (25 exact groups, 18 near, 3 advisory pairs; all three advisory pairs pre-existing and outside this diff)
- **Exhaustiveness mutation-verified**: deleting one arm fails with `E0004: non-exhaustive patterns: ContainerFormat::Nut not covered`
- **Misclassification mutation-verified**: the `EnumIter` sweep over all 31 variants fails with `Avi support must match the pinned set` when `Avi` is moved into the `Srt` arm — the compiler catches an *unclassified* variant, this catches a *misclassified* one

## Reviews

Both mandatory reviewers ran over the full `develop..HEAD` and **Approve**, across two rounds each.

- **security-reviewer** — no findings above LOW. Verified `allowBuilds`-style tightening on the extension parse, that every alias resolves to the same variant as its canonical spelling, that the `.ts` guards are *strengthened* by widening, that no attacker-controlled data reaches the muxer dictionary (keys and values are hardcoded constants), and that `rdlp-types` gained no filesystem access — `from_path` calls only `.extension()`/`.to_str()`.
- **code-reviewer** — first round raised four findings (dead `supports_subtitle_embed`, over-broad visibility vs the stated model, the undocumented `"mpeg"` flip, sampled-not-swept negative space), all fixed in `a988db9b`. Second round raised four more (untested `.ts` widening, a false claim in `235d1a2a`'s message, the `RemuxStage` straggler, a relative assertion), two fixed in `975588c2` and two filed.

## Known-wrong commit message

`235d1a2a` claims `eq_ignore_ascii_case("mkv")` appears nowhere in the workspace but one doc comment. It also appears in two **test** files (`normalize/tests.rs:283`, `process_local_file_e2e.rs:121`), correctly left alone. The claim should have said "nowhere in production code". Corrected in `975588c2`'s message rather than by rebase — rebasing would have rewritten commits the reviewers had already signed off, breaking the correspondence between reviewed and merged SHAs.

## Follow-ups filed

- #618 — `audio_encoder_registry`'s `_` catch-all answers AAC for `Mp3`/`Flac`/`Wav` reaching it directly. Fixing it changes recode output, which does not belong in a typing refactor.
- #619 — `RemuxStage`/`RecodeStage` compare canonical extensions, so a `.matroska` input with `--remux=mkv` gets a pointless remux pass. The one-line fix also skips the alias→canonical *rename* that pass performs, leaving the user with a filename they did not ask for — a product decision, not a drive-by.
