### PR TITLE
chore(scripts): harden the gate scripts — tool guards, C locale, one awk pass

### DIFF
--- a/scripts/audit-issues.sh
+++ b/scripts/audit-issues.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Issue-hygiene reconciliation report (read-only; makes no changes).
 #
 # Surfaces the rot patterns that let issues drift out of sync with the code,

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run every invariant gate. Referenced by CODING_RULES.md's Pre-Commit Checklist
 # so the gates have a committed local entry point, not only a CI one.
 #
@@ -6,16 +6,34 @@
 
 set -uo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# `|| exit` matters here (SC2164): this script runs with `set -uo pipefail` and
+# deliberately WITHOUT `-e`, so a failed cd would not abort -- it would run every
+# gate against whatever directory the caller happened to be in and report on the
+# wrong tree.
+cd "$(git rev-parse --show-toplevel)" || exit 2  # 2 = cannot run, 1 = a gate failed
 
 FAILED=0
+BLOCKED=0
+BLOCKED_GATES=""
 
 for script in scripts/check-*.sh; do
     # Don't recurse into this aggregate.
     [ "$(basename "$script")" = "check-all.sh" ] && continue
     printf '%-44s' "$(basename "$script")"
-    if output=$(bash "$script" 2>&1); then
+    # Distinguish the two non-zero cases rather than folding them together.
+    # A gate that CANNOT RUN (exit 2 -- a required tool is missing) is not the
+    # same news as an invariant being violated (exit 1), and telling an operator
+    # "invariants failed" when rg simply isn't installed sends them hunting for
+    # a defect that does not exist.
+    rc=0
+    output=$(bash "$script" 2>&1) || rc=$?
+    if [[ $rc -eq 0 ]]; then
         echo "OK"
+    elif [[ $rc -eq 2 ]]; then
+        echo "CANNOT RUN"
+        printf '%s\n' "$output" | sed 's/^/    /'
+        BLOCKED=1
+        BLOCKED_GATES="$BLOCKED_GATES $script"
     else
         echo "FAILED"
         printf '%s\n' "$output" | sed 's/^/    /'
@@ -44,8 +62,19 @@ for script in scripts/check-*.sh; do
     # a green canary that does not exist. Require the sentinel on stdout so
     # "a real canary ran" is observed rather than inferred, and so the failure
     # mode is loud rather than silent.
-    if output=$(bash "$script" --self-test 2>&1) \
-        && printf '%s\n' "$output" | grep -q '^SELF-TEST OK'; then
+    rc=0
+    output=$(bash "$script" --self-test 2>&1) || rc=$?
+    # A canary exiting 2 is only credible as CANNOT RUN if the GATE ITSELF was
+    # blocked above. Otherwise a script could mention `--self-test`, ignore it,
+    # exit 2, and skip the sentinel assertion entirely -- dodging the anti-spoof
+    # property this loop exists for while the gate demonstrably runs fine.
+    if [[ $rc -eq 2 ]] && [[ " $BLOCKED_GATES " == *" $script "* ]]; then
+        echo "CANNOT RUN"
+        printf '%s\n' "$output" | sed 's/^/    /'
+        BLOCKED=1
+        continue
+    fi
+    if [[ $rc -eq 0 ]] && printf '%s\n' "$output" | grep -q '^SELF-TEST OK'; then
         echo "OK"
     else
         echo "FAILED"
@@ -57,10 +86,19 @@ for script in scripts/check-*.sh; do
     fi
 done
 
+# A real failure outranks a blocked gate: if any invariant is actually violated,
+# that is the headline regardless of what else could not run.
 if [ "$FAILED" -eq 1 ]; then
     echo ""
     echo "One or more invariant gates failed."
     exit 1
+fi
+
+if [ "$BLOCKED" -eq 1 ]; then
+    echo ""
+    echo "One or more invariant gates COULD NOT RUN (missing tool). Nothing above"
+    echo "was reported as violated, but the suite did not fully execute."
+    exit 2
 fi
 
 echo ""

--- a/scripts/check-arg-blank-validation.sh
+++ b/scripts/check-arg-blank-validation.sh
@@ -26,10 +26,16 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
 # Anchor to the repo root: the target path below is relative, so running from
 # anywhere else would scan nothing and cheerfully report OK. A gate that passes
 # having scanned nothing is worse than no gate.
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 2
 
 TARGET="crates/rdlp-cli/src/args.rs"
 

--- a/scripts/check-dedup.sh
+++ b/scripts/check-dedup.sh
@@ -17,7 +17,7 @@
 # not here.
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 2
 
 echo "==> cargo dupes check --exclude-tests --min-lines 20 -p crates/"
 cargo dupes check --exclude-tests --min-lines 20 -p crates/

--- a/scripts/check-gui-option-parity.sh
+++ b/scripts/check-gui-option-parity.sh
@@ -9,7 +9,13 @@
 #
 # Usage: scripts/check-gui-option-parity.sh [--self-test]
 set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
+
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+cd "$(git rev-parse --show-toplevel)" || exit 2
 
 REGISTRY="crates/rdlp-api/src/options.rs"
 APPSETTINGS="crates/rdlp-desktop/src-tauri/src/state/app_settings.rs"

--- a/scripts/check-log-redaction.sh
+++ b/scripts/check-log-redaction.sh
@@ -11,6 +11,12 @@
 # runs fail-closed there (CI sets RDLP_REQUIRE_SEMGREP=1 to turn skip into failure).
 set -euo pipefail
 
+# Anchor to the repo root: every path below is relative, so without this the
+# gate scans NOTHING and reports success when run from any other directory --
+# the same fail-open class as the missing-tool guard. `|| exit 2` distinguishes
+# "cannot run" from "gate failed" (exit 1). See #621.
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
 RULE="scripts/semgrep/log-url-redaction.yml"
 SCAN="crates"
 

--- a/scripts/check-merge-exhaustive.sh
+++ b/scripts/check-merge-exhaustive.sh
@@ -9,7 +9,13 @@
 #                "canary-verified" stays true as the tree evolves.
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+cd "$(git rev-parse --show-toplevel)" || exit 2
 
 FILE="crates/rdlp-cli/src/config_tests.rs"
 FN="every_config_field_is_classified"

--- a/scripts/check-no-bare-response-text.sh
+++ b/scripts/check-no-bare-response-text.sh
@@ -32,6 +32,59 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+# Anchor to the repo root: every path below is relative, so without this the
+# gate scans NOTHING and reports success when run from any other directory --
+# the same fail-open class as the missing-tool guard. `|| exit 2` distinguishes
+# "cannot run" from "gate failed" (exit 1). See #621.
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+# The guard below is deliberately NOT covered by a self-test canary, unlike the
+# fixture-driven canaries in check-merge-exhaustive.sh and its siblings. Those
+# feed a pure matcher a synthetic violating fixture -- input in, verdict out, no
+# environment involved. A tool-presence guard has no fixture: proving it fires
+# means re-executing this script under a manipulated PATH, and that harness
+# produced four defects across four review rounds (it passed vacuously; it
+# exited 127 on external binaries missing from its own stub PATH; it inherited
+# the caller's cwd; it conflated cannot-run with failed) while the five lines
+# below were never once wrong. Same call the kubernetes hack/ scripts make for
+# their own tool-presence checks.
+#
+# ("self-test" is spelled without its dashes above on purpose: check-all.sh
+# discovers canaries by grepping for that literal, and a script that merely
+# MENTIONS it is reported FAILED for not implementing one.)
+#
+# The guard stays verifiable on demand. Seed a stub PATH with the binaries this
+# script needs EXCEPT rg -- bash included, or the pipeline below dies 127 before
+# reaching anything, which is the very trap that killed the canary:
+#
+#   stub=$(mktemp -d)
+#   for t in bash git grep sed; do ln -s "$(command -v "$t")" "$stub/$t"; done
+#   PATH="$stub" /bin/bash scripts/check-no-bare-response-text.sh            # expect: exit 2
+#   grep -v '^require_tool rg$' scripts/check-no-bare-response-text.sh \
+#       | PATH="$stub" /bin/bash -s                              # expect: PASS, exit 0
+#
+# The second form printing PASS is the silent false pass this guard prevents.
+# --- required external tools -------------------------------------------------
+# Verified failure mode (2026-07-21): with `rg` absent, `hits=$(rg ... || true)`
+# swallowed rg's 127 and this gate printed PASS while checking nothing. A
+# security gate that reports green when it cannot run is worse than no gate.
+#
+# Exit 2, not 1, so "tool missing" is distinguishable from "gate failed" by any
+# caller that reads the status.
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 && return 0
+    printf 'error: %s: required tool %s not found in PATH\n' "${0##*/}" "$1" >&2
+    printf '       This gate cannot run, and will NOT report a PASS it did not verify.\n' >&2
+    exit 2
+}
+require_tool rg
+
 TARGET="crates/rdlp-extractor/src"
 
 # 1. `rg -U --pcre2` matches `.text()` + `.await` across optional whitespace/newlines.
@@ -49,7 +102,7 @@ hits=$(
 
 if [[ -n "$hits" ]]; then
     echo "FAIL — bare (uncapped) response body read(s) found:"
-    echo "$hits" | sed 's/^/  /'
+    printf '%s\n' "  ${hits//$'\n'/$'\n'  }"
     echo ""
     echo "FIX: route the read through crate::base::common::fetch_capped_text(response, url)."
     echo "     For a genuinely-safe test-only loopback read, add an inline"

--- a/scripts/check-no-cli.sh
+++ b/scripts/check-no-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # CI guard: fail if any production code uses std::process::Command or
 # spawns external FFmpeg processes.  Test code is allowed to use
 # std::process for non-FFmpeg purposes (e.g. exit codes).
@@ -6,6 +6,18 @@
 # Usage: scripts/check-no-cli.sh
 
 set -euo pipefail
+
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+# Anchor to the repo root: every path below is relative, so without this the
+# gate scans NOTHING and reports success when run from any other directory --
+# the same fail-open class as the missing-tool guard. `|| exit 2` distinguishes
+# "cannot run" from "gate failed" (exit 1). See #621.
+cd "$(git rev-parse --show-toplevel)" || exit 2
 
 FOUND=0
 

--- a/scripts/check-no-dir-sweep-delete.sh
+++ b/scripts/check-no-dir-sweep-delete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # CI guard: fail if production code enumerates a directory and deletes what it
 # finds there.
 #
@@ -48,11 +48,17 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
 # Anchor to the repo root. `crates/*/src` is a relative glob: run from anywhere
 # else it expands to nothing, find scans zero files, and the script would
 # cheerfully report OK. A gate that passes having scanned nothing is worse than
 # no gate, so this is load-bearing, not tidiness.
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 2
 
 SELF_TEST=0
 [ "${1:-}" = "--self-test" ] && SELF_TEST=1

--- a/scripts/check-ts-enum-drift.sh
+++ b/scripts/check-ts-enum-drift.sh
@@ -26,6 +26,18 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+# Anchor to the repo root: every path below is relative, so without this the
+# gate scans NOTHING and reports success when run from any other directory --
+# the same fail-open class as the missing-tool guard. `|| exit 2` distinguishes
+# "cannot run" from "gate failed" (exit 1). See #621.
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
 TS_FILE="crates/rdlp-desktop/src/types/index.ts"
 
 # rust_file:rust_enum:ts_union — each enum's `rename_all = "lowercase"` is

--- a/scripts/check-url-redaction.sh
+++ b/scripts/check-url-redaction.sh
@@ -29,6 +29,59 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+# Anchor to the repo root: every path below is relative, so without this the
+# gate scans NOTHING and reports success when run from any other directory --
+# the same fail-open class as the missing-tool guard. `|| exit 2` distinguishes
+# "cannot run" from "gate failed" (exit 1). See #621.
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+# The guard below is deliberately NOT covered by a self-test canary, unlike the
+# fixture-driven canaries in check-merge-exhaustive.sh and its siblings. Those
+# feed a pure matcher a synthetic violating fixture -- input in, verdict out, no
+# environment involved. A tool-presence guard has no fixture: proving it fires
+# means re-executing this script under a manipulated PATH, and that harness
+# produced four defects across four review rounds (it passed vacuously; it
+# exited 127 on external binaries missing from its own stub PATH; it inherited
+# the caller's cwd; it conflated cannot-run with failed) while the five lines
+# below were never once wrong. Same call the kubernetes hack/ scripts make for
+# their own tool-presence checks.
+#
+# ("self-test" is spelled without its dashes above on purpose: check-all.sh
+# discovers canaries by grepping for that literal, and a script that merely
+# MENTIONS it is reported FAILED for not implementing one.)
+#
+# The guard stays verifiable on demand. Seed a stub PATH with the binaries this
+# script needs EXCEPT rg -- bash included, or the pipeline below dies 127 before
+# reaching anything, which is the very trap that killed the canary:
+#
+#   stub=$(mktemp -d)
+#   for t in bash git grep sed; do ln -s "$(command -v "$t")" "$stub/$t"; done
+#   PATH="$stub" /bin/bash scripts/check-url-redaction.sh            # expect: exit 2
+#   grep -v '^require_tool rg$' scripts/check-url-redaction.sh \
+#       | PATH="$stub" /bin/bash -s                              # expect: PASS, exit 0
+#
+# The second form printing PASS is the silent false pass this guard prevents.
+# --- required external tools -------------------------------------------------
+# Verified failure mode (2026-07-21): with `rg` absent, `hits=$(rg ... || true)`
+# swallowed rg's 127 and this gate printed PASS while checking nothing. A
+# security gate that reports green when it cannot run is worse than no gate.
+#
+# Exit 2, not 1, so "tool missing" is distinguishable from "gate failed" by any
+# caller that reads the status.
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 && return 0
+    printf 'error: %s: required tool %s not found in PATH\n' "${0##*/}" "$1" >&2
+    printf '       This gate cannot run, and will NOT report a PASS it did not verify.\n' >&2
+    exit 2
+}
+require_tool rg
+
 EXTRACTOR_TARGET="crates/rdlp-extractor/src"
 PIPELINE_TARGET="crates/rdlp-postprocess/src"
 API_TARGET="crates/rdlp-api/src"
@@ -42,17 +95,21 @@ check() {
     local pattern="$2"
     local target="${3:-$EXTRACTOR_TARGET}"
     local hits
+    # One alternation, not six chained greps: the exclusion set is then a single
+    # auditable predicate rather than a conjunction the reader must assemble.
+    #
+    # The former chain also carried a `grep -v '^\s*//'` arm intended to drop
+    # commented-out code. It was dead: `rg -n` over a directory prefixes every
+    # line with `path:line:`, so `^\s*//` could never match (verified: 0 hits).
+    # Dropped rather than repaired -- a comment containing a raw URL in a format
+    # string is worth seeing, and the compliant-wrapper filters already cover
+    # the real false positives.
     hits=$(rg -U --type rust -n "$pattern" "$target" 2>/dev/null \
-        | grep -v 'RedactedUrl' \
-        | grep -v 'sanitize_for_logging' \
-        | grep -v 'safe_url' \
-        | grep -v '/tests/' \
-        | grep -v '#\[cfg(test)\]' \
-        | grep -v '^\s*//' \
+        | grep -Ev 'RedactedUrl|sanitize_for_logging|safe_url|/tests/|#\[cfg\(test\)\]' \
         || true)
     if [[ -n "$hits" ]]; then
         echo "FAIL [$label] — raw URL interpolation(s) found:"
-        echo "$hits" | sed 's/^/  /'
+        printf '%s\n' "  ${hits//$'\n'/$'\n'  }"
         FAIL=1
     fi
 }

--- a/scripts/check-wit-drift.sh
+++ b/scripts/check-wit-drift.sh
@@ -16,6 +16,18 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+# Anchor to the repo root: every path below is relative, so without this the
+# gate scans NOTHING and reports success when run from any other directory --
+# the same fail-open class as the missing-tool guard. `|| exit 2` distinguishes
+# "cannot run" from "gate failed" (exit 1). See #621.
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
 HOST_DIR="crates/rdlp-plugin/wit"
 VENDORED_DIRS=(
     "examples/plugins/example-extractor/wit/deps/rdlp-plugin"
@@ -50,4 +62,13 @@ EOF
     fi
 done
 
-echo "WIT vendor parity OK ($(ls "$HOST_DIR" | wc -l) files × ${#VENDORED_DIRS[@]} vendored copies match)"
+# Count with a glob rather than `ls | wc -l` (SC2012): `ls` output is not a
+# reliable list for programmatic use, and this is two fewer processes.
+# `nullglob` so an empty directory counts 0 instead of matching the literal
+# pattern as one entry. Like `ls`, a bare `*` skips dotfiles, so the count is
+# unchanged.
+shopt -s nullglob
+host_files=("$HOST_DIR"/*)
+shopt -u nullglob
+
+echo "WIT vendor parity OK (${#host_files[@]} files × ${#VENDORED_DIRS[@]} vendored copies match)"

--- a/scripts/count-loc.sh
+++ b/scripts/count-loc.sh
@@ -16,12 +16,34 @@
 
 set -euo pipefail
 
+# Pin the C locale: GNU grep's manual says range expressions like the `[a-z_]`
+# classes used below are UNSPECIFIED outside the C locale -- they "might fail to
+# match any character". A correctness fix, NOT a speed one (measured: no
+# difference). Full quote and rationale in #621.
+export LC_ALL=C
+
+# gawk specifically: the awk program below uses BEGINFILE/ENDFILE, which are
+# gawk extensions. Any other awk would parse them as always-false patterns and
+# print `0  total` with exit 0. Exit 2 = cannot run, distinct from a real result.
+if ! command -v gawk >/dev/null 2>&1; then
+    echo "error: ${0##*/}: requires gawk (uses BEGINFILE/ENDFILE)" >&2
+    exit 2
+fi
+
 if [[ $# -lt 1 ]]; then
     echo "Usage: $0 <path>" >&2
     exit 1
 fi
 
 target="$1"
+
+# A path that does not exist is a caller error, not "zero lines of code". Without
+# this, `count-loc.sh /nonexistent` printed `0  total (non-test LOC)` and exited
+# 0 -- the same silently-wrong shape this suite exists to eliminate.
+if [[ ! -e "$target" ]]; then
+    echo "error: ${0##*/}: no such file or directory: $target" >&2
+    exit 2
+fi
 
 if [[ -f "$target" ]]; then
     files=( "$target" )
@@ -35,31 +57,62 @@ else
     )
 fi
 
-total=0
-for f in "${files[@]}"; do
-    # Strip #[cfg(test)] mod tests { ... } blocks via awk brace-balance.
-    lines=$(awk '
-        /#\[cfg\(test\)\][[:space:]]*$/ { in_attr=1; next }
-        in_attr && /^[[:space:]]*mod[[:space:]]+/ {
-            in_attr=0
-            if (/\{[[:space:]]*$/) { depth=1; in_block=1; next }
-        }
-        in_attr { in_attr=0 }
-        in_block {
-            n=gsub(/\{/, "{"); depth+=n
-            n=gsub(/\}/, "}"); depth-=n
-            if (depth==0) { in_block=0 }
-            next
-        }
-        { print }
-    ' "$f" | wc -l)
-    total=$((total + lines))
-    if [[ ${#files[@]} -gt 1 ]]; then
-        printf "%5d  %s\n" "$lines" "$f"
-    fi
-done
-
-if [[ ${#files[@]} -gt 1 ]]; then
-    echo "----"
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "0  total (non-test LOC)"
+    exit 0
 fi
-echo "$total  total (non-test LOC)"
+
+# ONE awk process over every file, rather than `awk | wc -l` per file.
+# Measured on crates/rdlp-extractor/src (128 files): 287ms -> 31ms, because
+# process-spawn cost dominates the scanning itself at this file count. Totals
+# verified identical before and after the change. (An isolated micro-benchmark
+# of the same two forms gave 300ms -> 26ms; the numbers above are the ones
+# reproducible by running this script, so they are the ones quoted.)
+#
+# The per-file invocation got its state reset for free by starting a fresh
+# process; a single pass must do it explicitly at FNR==1, which is also where
+# the previous file's tally is emitted.
+per_file=0
+[[ ${#files[@]} -gt 1 ]] && per_file=1
+
+gawk -v per_file="$per_file" '
+    function emit() {
+        if (per_file) printf "%5d  %s\n", count, fname
+        total += count
+    }
+
+    # BEGINFILE/ENDFILE rather than `FNR == 1`: awk never fires FNR==1 for a
+    # ZERO-BYTE file, so a `FNR==1 { emit(); reset }` form silently omits empty
+    # files from the per-file listing (the total is unaffected, since they
+    # contribute 0).
+    #
+    # These are GAWK-ONLY, which is why this calls `gawk` explicitly and guards
+    # for it above. Under another awk they would parse as ordinary (always
+    # false) variable patterns, so nothing would ever be emitted and the script
+    # would print `0  total` and exit 0 -- a silently wrong answer, the same
+    # fail-open shape this gate suite exists to eliminate.
+    BEGINFILE {
+        in_attr = 0; in_block = 0; depth = 0; count = 0
+        fname = FILENAME
+    }
+    ENDFILE { emit() }
+
+    /#\[cfg\(test\)\][[:space:]]*$/ { in_attr = 1; next }
+    in_attr && /^[[:space:]]*mod[[:space:]]+/ {
+        in_attr = 0
+        if (/\{[[:space:]]*$/) { depth = 1; in_block = 1; next }
+    }
+    in_attr { in_attr = 0 }
+    in_block {
+        n = gsub(/\{/, "{"); depth += n
+        n = gsub(/\}/, "}"); depth -= n
+        if (depth == 0) { in_block = 0 }
+        next
+    }
+    { count++ }
+
+    END {
+        if (per_file) print "----"
+        printf "%d  total (non-test LOC)\n", total
+    }
+' "${files[@]}"


### PR DESCRIPTION
Closes #621

## What

An audit of all 16 `scripts/*.sh` gate scripts. Tool choices measured on this repo (497 files / 157k lines); semantics checked against the installed manuals (`grep.info` 3.12, `gawk.info` 5.4.1) rather than recalled.

## The defects — gates reporting PASS while verifying nothing

| defect | before | after |
|---|---|---|
| `rg` unguarded in 2 gates | `PASS`, exit 0, no error output | exit 2, `required tool rg not found` |
| 6 gates unanchored to the repo root | scanned nothing, reported success | exit 2 |
| `check-all.sh` unguarded `cd` (SC2164) | uninformative failure, no gates run | exit 2 |
| `count-loc.sh` on a bad path | `0  total (non-test LOC)`, exit 0 | exit 2 |

The two `rg`-dependent gates are the ones enforcing **credential redaction in logs** (#328/#427) and **byte-capped HTTP body reads against OOM** (#438) — so a machine without ripgrep got a green light on both.

`2` now means "cannot run" and `1` means "a gate failed", uniformly. `check-all.sh` reports the former as `CANNOT RUN` instead of folding it into "invariants failed".

## Locale — correctness, not speed

Seven gates match with ranges like `[a-z_]*url`; none set `LC_ALL`. GNU grep 3.12's manual:

> In the default C locale, it matches any single character that appears between the two characters in ASCII order… **In other locales the behavior is unspecified**: `[a-d]` might be equivalent to `[abcd]` or `[aBbCcDd]` … **or it might fail to match any character**.

`LC_ALL=C` is pinned in the ten text-scanning gates — deliberately **not** in `check-log-redaction.sh` (semgrep/Python), `check-dedup.sh` (cargo), `audit-issues.sh` (gh), or `check-all.sh` (a runner; it would export into those children).

Measured: **no speed difference whatsoever** (10 ms either way). The comments say so, so it isn't stripped later as cargo-culted.

## Measured tool policy

Same job, output verified byte-identical before timing, 157k lines:

| tool | time |
|---|---|
| `grep` | **2 ms** |
| `sed -n '/…/p'` | 14 ms (7×) |
| `awk '/…/'` | 39 ms (20×) |

So grep for filtering; awk only for genuine state, which `check-ts-enum-drift.sh` legitimately needs. `-P` costs ~67% over `-F`/`-E` and returned identical results to `-E` with POSIX classes, so the PCRE dependency was not load-bearing.

`count-loc.sh` ran `awk | wc -l` **per file** — 287 ms on 128 files vs **31 ms** for one `gawk` pass. Now one pass via `BEGINFILE`/`ENDFILE` so zero-byte files aren't silently dropped (plain awk never fires `FNR==1` for them), with `gawk` called explicitly and guarded, since those are gawk extensions.

## Also

- The six chained `grep -v` in `check-url-redaction.sh` collapse to one `grep -Ev`. That's **reviewability, not speed** — measured at 1 ms. One of the six arms, `grep -v '^\s*//'`, was **dead**: `rg -n` prefixes every line with `path:line:`, so it could never match (0 hits). Dropped rather than repaired.
- Four `#!/bin/bash` shebangs normalised.
- `shellcheck scripts/*.sh` with **no severity filter** now exits 0 (was 3 findings).
- gawk's `> "/dev/stderr"` is **kept** — `gawk.info` calls it *"the proper way to write an error message"* and supports it even under `--traditional`.

## What this branch tried and reverted

The two `rg` guards originally shipped with `--self-test` canaries. Those canaries re-executed the script under a stubbed PATH and produced **four defects across four review rounds** — passing vacuously, exiting 127 on external binaries missing from their own stub, inheriting the caller's cwd, conflating cannot-run with failed — while the five-line guards they verified were never once wrong.

They're removed. Full rationale, including the research against bats-core/shunit2/shellspec and the Kubernetes precedent, is in [#621's comment](https://github.com/crippledgeek/rdlp/issues/621#issuecomment-5039543202); #621's Scope and Acceptance bullets are amended to match.

The repo's **four pre-existing canaries are untouched and still green**. They use a different mechanism — measured: re-exec 0, PATH-stub 0 — feeding a pure matcher a synthetic fixture. That isn't available for a tool-presence guard, which asserts something about the environment rather than being a function of its input.

## Verification

- **Every gate's output is byte-identical to its pre-change baseline** — this is a hardening pass, not a behaviour change. Re-checked at every review round.
- `check-all.sh` green with the four surviving canaries; every gate exits 2 from a non-repo directory.
- Guards mutation-tested with a correctly-seeded stub PATH: present → exit 2; removed → `PASS`, exit 0 (the silent false pass).
- `count-loc.sh` identical on the repo, correct on an empty-file fixture, exit 2 on a bad path.
- `shellcheck` clean unfiltered.

## Reviews

Four rounds of security + code review. **Both Approve.**

Worth stating plainly: in three of those rounds a fix I made introduced a new defect, and every one of those regressions was in the canary harness — never in a gate or a guard. The reviewers caught two; my own verification caught one. That record is why the harness was ultimately deleted rather than repaired, and why the final round's findings (a spliced comment, and a documented verification recipe that died 127 under the PATH it prescribed) were worth fixing rather than waving through.

The final security review ran positive controls — injecting a real raw-URL interpolation and a bare `.text().await` — and confirmed both gates still catch them at the correct `file:line`.
