### PR TITLE
refactor(ffmpeg): extract shared encoder registry core

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -19,9 +19,10 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use log::info;
 use rdlp_types::ContainerFormat;
 use serde::{Deserialize, Serialize};
+
+use crate::ffmpeg::codec_registry;
 
 /// Information about a specific audio encoder.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,6 +59,19 @@ struct AudioCodecEntry {
     /// Container formats this codec is compatible with.
     supported_containers: &'static [ContainerFormat],
 }
+
+impl codec_registry::CodecRow for AudioCodecEntry {
+    fn codec(&self) -> &'static str {
+        self.codec
+    }
+    fn encoders(&self) -> &'static [(&'static str, &'static str)] {
+        self.encoders
+    }
+}
+
+/// Per-registry cache. Module-level, NOT inside a generic function — see
+/// `codec_registry::preferred_encoder`.
+static AUDIO_CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
 
 /// Static preference table for audio codecs.
 ///
@@ -189,7 +203,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn is_audio_encoder_available(encoder: &str) -> bool {
-    ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
+    codec_registry::is_encoder_available(encoder)
 }
 
 /// Returns the best available audio encoder for a given codec name.
@@ -200,30 +214,7 @@ pub fn is_audio_encoder_available(encoder: &str) -> bool {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn preferred_audio_encoder(codec: &str) -> Option<&'static str> {
-    static CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
-
-    let cache = CACHE.get_or_init(|| {
-        let mut map = HashMap::new();
-        for entry in AUDIO_CODEC_PREFERENCES {
-            let selected = entry
-                .encoders
-                .iter()
-                .find(|(enc, _)| is_audio_encoder_available(enc))
-                .map(|(enc, _)| *enc);
-
-            if let Some(enc) = selected {
-                info!("Using {enc} as {codec} audio encoder", codec = entry.codec);
-            }
-
-            map.insert(entry.codec, selected);
-        }
-        map
-    });
-
-    cache
-        .get(codec.to_ascii_lowercase().as_str())
-        .copied()
-        .flatten()
+    codec_registry::preferred_encoder(AUDIO_CODEC_PREFERENCES, &AUDIO_CACHE, codec, "audio")
 }
 
 /// Resolves an audio encoder name.
@@ -238,22 +229,7 @@ pub fn preferred_audio_encoder(codec: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn resolve_audio_encoder(input: &str) -> Option<&'static str> {
-    let lower = input.to_ascii_lowercase();
-
-    // Check if input is a known codec name first
-    if let Some(enc) = preferred_audio_encoder(&lower) {
-        return Some(enc);
-    }
-
-    // Otherwise treat as a direct encoder name — find the matching static str,
-    // then gate on availability. Short-circuits on the first name match exactly
-    // like the prior nested-loop search (duplicate names occur only across
-    // byte-identical codec-alias rows), so the verdict is unchanged.
-    AUDIO_CODEC_PREFERENCES
-        .iter()
-        .flat_map(|entry| entry.encoders)
-        .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
-        .and_then(|(enc, _)| is_audio_encoder_available(enc).then_some(*enc))
+    codec_registry::resolve(AUDIO_CODEC_PREFERENCES, &AUDIO_CACHE, input, "audio")
 }
 
 /// Returns all available encoders for a given audio codec name, in preference order.
@@ -263,18 +239,12 @@ pub fn resolve_audio_encoder(input: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn available_audio_encoders_for_codec(codec: &str) -> Vec<AudioEncoderInfo> {
-    let lower = codec.to_ascii_lowercase();
-    AUDIO_CODEC_PREFERENCES
-        .iter()
-        .find(|e| e.codec == lower.as_str())
-        .map(|entry| {
-            entry
-                .encoders
-                .iter()
-                .filter(|(enc, _)| is_audio_encoder_available(enc))
+    codec_registry::find_row(AUDIO_CODEC_PREFERENCES, codec)
+        .map(|row| {
+            codec_registry::available_encoders(row)
                 .map(|(enc, display)| AudioEncoderInfo {
-                    encoder_name: (*enc).to_string(),
-                    display_name: (*display).to_string(),
+                    encoder_name: enc.to_string(),
+                    display_name: display.to_string(),
                 })
                 .collect()
         })
@@ -290,13 +260,10 @@ pub fn list_available_audio_codecs() -> Vec<AudioCodecInfo> {
     AUDIO_CODEC_PREFERENCES
         .iter()
         .filter_map(|entry| {
-            let encoders: Vec<AudioEncoderInfo> = entry
-                .encoders
-                .iter()
-                .filter(|(enc, _)| is_audio_encoder_available(enc))
+            let encoders: Vec<AudioEncoderInfo> = codec_registry::available_encoders(entry)
                 .map(|(enc, display)| AudioEncoderInfo {
-                    encoder_name: (*enc).to_string(),
-                    display_name: (*display).to_string(),
+                    encoder_name: enc.to_string(),
+                    display_name: display.to_string(),
                 })
                 .collect();
 

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -16,9 +16,6 @@
 //! - [`container_supports_audio_codec`] — point query for validation
 //! - [`select_audio_encoder_for_container`] — best default encoder for a container
 
-use std::collections::HashMap;
-use std::sync::OnceLock;
-
 use rdlp_types::ContainerFormat;
 use serde::{Deserialize, Serialize};
 
@@ -68,10 +65,6 @@ impl codec_registry::CodecRow for AudioCodecEntry {
         self.encoders
     }
 }
-
-/// Per-registry cache. Module-level, NOT inside a generic function — see
-/// `codec_registry::preferred_encoder`.
-static AUDIO_CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
 
 /// Static preference table for audio codecs.
 ///
@@ -198,6 +191,10 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
     },
 ];
 
+/// The audio codec registry, owning its own cache over [`AUDIO_CODEC_PREFERENCES`].
+static AUDIO_REGISTRY: codec_registry::Registry<AudioCodecEntry> =
+    codec_registry::Registry::new(AUDIO_CODEC_PREFERENCES, codec_registry::MediaKind::Audio);
+
 /// Returns `true` if the named audio encoder is available in the current `FFmpeg` build.
 ///
 /// Requires [`super::ensure_init`] to have been called first.
@@ -214,7 +211,7 @@ pub fn is_audio_encoder_available(encoder: &str) -> bool {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn preferred_audio_encoder(codec: &str) -> Option<&'static str> {
-    codec_registry::preferred_encoder(AUDIO_CODEC_PREFERENCES, &AUDIO_CACHE, codec, "audio")
+    AUDIO_REGISTRY.preferred_encoder(codec)
 }
 
 /// Resolves an audio encoder name.
@@ -229,7 +226,7 @@ pub fn preferred_audio_encoder(codec: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn resolve_audio_encoder(input: &str) -> Option<&'static str> {
-    codec_registry::resolve(AUDIO_CODEC_PREFERENCES, &AUDIO_CACHE, input, "audio")
+    AUDIO_REGISTRY.resolve(input)
 }
 
 /// Returns all available encoders for a given audio codec name, in preference order.
@@ -239,7 +236,8 @@ pub fn resolve_audio_encoder(input: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn available_audio_encoders_for_codec(codec: &str) -> Vec<AudioEncoderInfo> {
-    codec_registry::find_row(AUDIO_CODEC_PREFERENCES, codec)
+    AUDIO_REGISTRY
+        .find_row(codec)
         .map(|row| {
             codec_registry::available_encoders(row)
                 .map(|(enc, display)| AudioEncoderInfo {
@@ -313,10 +311,8 @@ pub fn audio_codecs_for_container(container: ContainerFormat) -> Vec<AudioCodecI
 /// ```
 #[must_use]
 pub fn container_supports_audio_codec(container: ContainerFormat, codec: &str) -> bool {
-    let lower = codec.to_ascii_lowercase();
-    AUDIO_CODEC_PREFERENCES
-        .iter()
-        .find(|e| e.codec == lower.as_str())
+    AUDIO_REGISTRY
+        .find_row(codec)
         .is_some_and(|entry| entry.supported_containers.contains(&container))
 }
 
@@ -373,9 +369,20 @@ mod tests {
 
     #[test]
     fn resolve_encoder_by_encoder_name() {
-        // Built-in "aac" encoder is always available
-        let enc = resolve_audio_encoder("aac");
-        assert!(enc.is_some());
+        // "libmp3lame" is an ENCODER name (the sole encoder under codec key
+        // "mp3"), not itself a codec key, so this exercises the
+        // direct-encoder-name branch of `resolve` rather than short-circuiting
+        // through `preferred_encoder` the way `resolve_encoder_by_codec_name`
+        // (which passes "aac", a codec key) does. Gated on availability so a
+        // build without libmp3lame still passes — either branch outcome
+        // proves the direct-name path was taken, since "libmp3lame" never
+        // matches a codec key.
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        if is_audio_encoder_available("libmp3lame") {
+            assert_eq!(resolve_audio_encoder("libmp3lame"), Some("libmp3lame"));
+        } else {
+            assert_eq!(resolve_audio_encoder("libmp3lame"), None);
+        }
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
@@ -5,6 +5,11 @@
 //! Those answers live here once; the per-media modules keep only their table
 //! and the `*Info` types they build, which genuinely differ.
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use log::info;
+
 /// The minimal view of a preference-table row the shared lookups need.
 ///
 /// Deliberately two methods: everything else about a row (audio's
@@ -26,9 +31,60 @@ pub fn is_encoder_available(encoder: &str) -> bool {
     ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
 }
 
+/// Finds the row for a codec name, case-insensitively.
+#[must_use]
+pub fn find_row<R: CodecRow>(table: &'static [R], codec: &str) -> Option<&'static R> {
+    table
+        .iter()
+        .find(|row| row.codec().eq_ignore_ascii_case(codec))
+}
+
+/// Best available encoder for a codec name, memoised in `cache`.
+///
+/// `cache` is a parameter, not a `static` inside this function: a static in a
+/// generic scope is NOT monomorphized, so an inner static would be shared by
+/// every registry that calls this. `label` distinguishes the registries in the
+/// log line (e.g. `"audio"` / `"video"`).
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn preferred_encoder<R: CodecRow>(
+    table: &'static [R],
+    cache: &'static OnceLock<HashMap<&'static str, Option<&'static str>>>,
+    codec: &str,
+    label: &str,
+) -> Option<&'static str> {
+    let map = cache.get_or_init(|| {
+        let mut map = HashMap::new();
+        for row in table {
+            let selected = row
+                .encoders()
+                .iter()
+                .find(|(enc, _)| is_encoder_available(enc))
+                .map(|(enc, _)| *enc);
+
+            if let Some(enc) = selected {
+                info!(
+                    "Using {enc} as {codec} {label} encoder",
+                    codec = row.codec()
+                );
+            }
+
+            map.insert(row.codec(), selected);
+        }
+        map
+    });
+
+    map.get(codec.to_ascii_lowercase().as_str())
+        .copied()
+        .flatten()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::OnceLock;
 
     struct FakeRow {
         codec: &'static str,
@@ -54,10 +110,7 @@ mod tests {
         let row = FAKE_TABLE.first().expect("fake table has one row");
         assert_eq!(row.codec(), "fakecodec");
         assert_eq!(row.encoders().len(), 1);
-        let encoder = row
-            .encoders()
-            .first()
-            .expect("encoders has one entry");
+        let encoder = row.encoders().first().expect("encoders has one entry");
         assert_eq!(encoder.0, "nonexistent_encoder_xyz");
     }
 
@@ -70,5 +123,54 @@ mod tests {
     fn is_encoder_available_true_for_builtin_aac() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
         assert!(is_encoder_available("aac"));
+    }
+
+    static FAKE_CACHE_A: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
+    static FAKE_CACHE_B: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
+
+    static TABLE_A: &[FakeRow] = &[FakeRow {
+        codec: "shared_name",
+        encoders: &[("aac", "AAC")],
+    }];
+    static TABLE_B: &[FakeRow] = &[FakeRow {
+        codec: "shared_name",
+        encoders: &[("pcm_s16le", "PCM")],
+    }];
+
+    #[test]
+    fn preferred_encoder_returns_first_available() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            preferred_encoder(TABLE_A, &FAKE_CACHE_A, "shared_name", "test-a"),
+            Some("aac")
+        );
+    }
+
+    #[test]
+    fn preferred_encoder_unknown_codec_is_none() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            preferred_encoder(TABLE_A, &FAKE_CACHE_A, "no_such_codec", "test-a"),
+            None
+        );
+    }
+
+    /// REGRESSION GUARD for the generic-static trap. Two tables share a codec
+    /// name but have different encoders. With one shared cache, whichever ran
+    /// first would win for both. Distinct caches must give distinct answers.
+    #[test]
+    fn distinct_caches_do_not_share_entries() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        let a = preferred_encoder(TABLE_A, &FAKE_CACHE_A, "shared_name", "test-a");
+        let b = preferred_encoder(TABLE_B, &FAKE_CACHE_B, "shared_name", "test-b");
+        assert_eq!(a, Some("aac"), "table A must resolve from its own table");
+        assert_eq!(b, Some("pcm_s16le"), "table B must NOT inherit A's cache");
+        assert_ne!(a, b, "caches leaked across registries");
+    }
+
+    #[test]
+    fn find_row_matches_case_insensitively() {
+        assert!(find_row(TABLE_A, "SHARED_NAME").is_some());
+        assert!(find_row(TABLE_A, "nope").is_none());
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
@@ -80,6 +80,44 @@ pub fn preferred_encoder<R: CodecRow>(
         .flatten()
 }
 
+/// Resolves either a codec name or a direct encoder name to an available encoder.
+///
+/// Codec names go through [`preferred_encoder`]; anything else is matched against
+/// the table's encoder names and then gated on availability.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn resolve<R: CodecRow>(
+    table: &'static [R],
+    cache: &'static OnceLock<HashMap<&'static str, Option<&'static str>>>,
+    input: &str,
+    label: &str,
+) -> Option<&'static str> {
+    let lower = input.to_ascii_lowercase();
+
+    if let Some(enc) = preferred_encoder(table, cache, &lower, label) {
+        return Some(enc);
+    }
+
+    // Short-circuits on the first name match: duplicate encoder names occur
+    // only across byte-identical codec-alias rows, so the verdict is unchanged.
+    table
+        .iter()
+        .flat_map(CodecRow::encoders)
+        .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
+        .and_then(|(enc, _)| is_encoder_available(enc).then_some(*enc))
+}
+
+/// The row's encoders that are present in this build, in preference order.
+pub fn available_encoders<R: CodecRow>(
+    row: &'static R,
+) -> impl Iterator<Item = (&'static str, &'static str)> {
+    row.encoders()
+        .iter()
+        .filter(|(enc, _)| is_encoder_available(enc))
+        .map(|(enc, display)| (*enc, *display))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,5 +210,47 @@ mod tests {
     fn find_row_matches_case_insensitively() {
         assert!(find_row(TABLE_A, "SHARED_NAME").is_some());
         assert!(find_row(TABLE_A, "nope").is_none());
+    }
+
+    #[test]
+    fn resolve_accepts_a_codec_name() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            resolve(TABLE_A, &FAKE_CACHE_A, "shared_name", "test-a"),
+            Some("aac")
+        );
+    }
+
+    #[test]
+    fn resolve_accepts_a_direct_encoder_name() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            resolve(TABLE_A, &FAKE_CACHE_A, "aac", "test-a"),
+            Some("aac")
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_an_unknown_name() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            resolve(TABLE_A, &FAKE_CACHE_A, "no_such_thing", "test-a"),
+            None
+        );
+    }
+
+    #[test]
+    fn available_encoders_filters_unavailable() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        // FAKE_TABLE's only encoder does not exist in any build.
+        assert!(
+            available_encoders(FAKE_TABLE.first().expect("row"))
+                .next()
+                .is_none(),
+            "unavailable encoder must be filtered out"
+        );
+
+        let got: Vec<_> = available_encoders(TABLE_A.first().expect("row")).collect();
+        assert_eq!(got, vec![("aac", "AAC")]);
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
@@ -12,14 +12,128 @@ use log::info;
 
 /// The minimal view of a preference-table row the shared lookups need.
 ///
-/// Deliberately two methods: everything else about a row (audio's
-/// `supported_containers`, video's speed-control derivation) is media-specific
-/// and stays in the owning module.
+/// The trait carries only what the shared lookups need. `display_name` is
+/// common to both row types too, but is read directly by each module's own
+/// `list_available_*`, which construct different `*Info` shapes and therefore
+/// remain per-media; audio's `supported_containers` and video's speed-control
+/// derivation are genuinely media-specific and stay in the owning module.
 pub trait CodecRow {
     /// Canonical codec name, e.g. `"aac"` / `"h264"`.
     fn codec(&self) -> &'static str;
     /// Ordered encoder preference list: `(encoder_name, display_name)`.
     fn encoders(&self) -> &'static [(&'static str, &'static str)];
+}
+
+/// Which media a registry serves. Also supplies the word used in the
+/// selection log line.
+#[derive(Debug, Clone, Copy)]
+pub enum MediaKind {
+    /// An audio codec/encoder registry.
+    Audio,
+    /// A video codec/encoder registry.
+    Video,
+}
+
+impl std::fmt::Display for MediaKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Audio => "audio",
+            Self::Video => "video",
+        })
+    }
+}
+
+/// A codec preference table with its own memoisation cache.
+///
+/// The cache is owned by the `Registry`, not borrowed from a module-level
+/// `static`: there is no longer a second value that could be mismatched
+/// against the table, so passing one registry's table with another
+/// registry's cache is not a shape the type system can even express.
+pub struct Registry<R: CodecRow + 'static> {
+    table: &'static [R],
+    cache: OnceLock<HashMap<&'static str, Option<&'static str>>>,
+    kind: MediaKind,
+}
+
+impl<R: CodecRow + 'static> Registry<R> {
+    /// Binds a preference table to a fresh cache and declares which media it serves.
+    #[must_use]
+    pub const fn new(table: &'static [R], kind: MediaKind) -> Self {
+        Self {
+            table,
+            cache: OnceLock::new(),
+            kind,
+        }
+    }
+
+    /// Finds the row for a codec name, case-insensitively.
+    #[must_use]
+    pub fn find_row(&self, codec: &str) -> Option<&'static R> {
+        self.table
+            .iter()
+            .find(|row| row.codec().eq_ignore_ascii_case(codec))
+    }
+
+    /// Best available encoder for a codec name, memoised in this registry's cache.
+    ///
+    /// Requires [`super::ensure_init`] to have been called first.
+    #[must_use]
+    pub fn preferred_encoder(&self, codec: &str) -> Option<&'static str> {
+        self.lookup_preferred(&codec.to_ascii_lowercase())
+    }
+
+    /// As [`Self::preferred_encoder`], but `lower` must already be lowercase.
+    ///
+    /// Lets [`Self::resolve`] lowercase its input once and reuse the same
+    /// lookup, instead of lowercasing again on the way in here.
+    fn lookup_preferred(&self, lower: &str) -> Option<&'static str> {
+        let map = self.cache.get_or_init(|| {
+            let mut map = HashMap::new();
+            for row in self.table {
+                let selected = row
+                    .encoders()
+                    .iter()
+                    .find(|(enc, _)| is_encoder_available(enc))
+                    .map(|(enc, _)| *enc);
+
+                if let Some(enc) = selected {
+                    info!(
+                        "Using {enc} as {codec} {kind} encoder",
+                        codec = row.codec(),
+                        kind = self.kind
+                    );
+                }
+
+                map.insert(row.codec(), selected);
+            }
+            map
+        });
+
+        map.get(lower).copied().flatten()
+    }
+
+    /// Resolves either a codec name or a direct encoder name to an available encoder.
+    ///
+    /// Codec names go through [`Self::preferred_encoder`]; anything else is
+    /// matched against the table's encoder names and then gated on availability.
+    ///
+    /// Requires [`super::ensure_init`] to have been called first.
+    #[must_use]
+    pub fn resolve(&self, input: &str) -> Option<&'static str> {
+        let lower = input.to_ascii_lowercase();
+
+        if let Some(enc) = self.lookup_preferred(&lower) {
+            return Some(enc);
+        }
+
+        // Short-circuits on the first name match: duplicate encoder names occur
+        // only across byte-identical codec-alias rows, so the verdict is unchanged.
+        self.table
+            .iter()
+            .flat_map(CodecRow::encoders)
+            .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
+            .and_then(|(enc, _)| is_encoder_available(enc).then_some(*enc))
+    }
 }
 
 /// Returns `true` if the named encoder is present in the linked `FFmpeg` build.
@@ -29,83 +143,6 @@ pub trait CodecRow {
 #[must_use]
 pub fn is_encoder_available(encoder: &str) -> bool {
     ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
-}
-
-/// Finds the row for a codec name, case-insensitively.
-#[must_use]
-pub fn find_row<R: CodecRow>(table: &'static [R], codec: &str) -> Option<&'static R> {
-    table
-        .iter()
-        .find(|row| row.codec().eq_ignore_ascii_case(codec))
-}
-
-/// Best available encoder for a codec name, memoised in `cache`.
-///
-/// `cache` is a parameter, not a `static` inside this function: a static in a
-/// generic scope is NOT monomorphized, so an inner static would be shared by
-/// every registry that calls this. `label` distinguishes the registries in the
-/// log line (e.g. `"audio"` / `"video"`).
-///
-/// Requires [`super::ensure_init`] to have been called first.
-#[must_use]
-pub fn preferred_encoder<R: CodecRow>(
-    table: &'static [R],
-    cache: &'static OnceLock<HashMap<&'static str, Option<&'static str>>>,
-    codec: &str,
-    label: &str,
-) -> Option<&'static str> {
-    let map = cache.get_or_init(|| {
-        let mut map = HashMap::new();
-        for row in table {
-            let selected = row
-                .encoders()
-                .iter()
-                .find(|(enc, _)| is_encoder_available(enc))
-                .map(|(enc, _)| *enc);
-
-            if let Some(enc) = selected {
-                info!(
-                    "Using {enc} as {codec} {label} encoder",
-                    codec = row.codec()
-                );
-            }
-
-            map.insert(row.codec(), selected);
-        }
-        map
-    });
-
-    map.get(codec.to_ascii_lowercase().as_str())
-        .copied()
-        .flatten()
-}
-
-/// Resolves either a codec name or a direct encoder name to an available encoder.
-///
-/// Codec names go through [`preferred_encoder`]; anything else is matched against
-/// the table's encoder names and then gated on availability.
-///
-/// Requires [`super::ensure_init`] to have been called first.
-#[must_use]
-pub fn resolve<R: CodecRow>(
-    table: &'static [R],
-    cache: &'static OnceLock<HashMap<&'static str, Option<&'static str>>>,
-    input: &str,
-    label: &str,
-) -> Option<&'static str> {
-    let lower = input.to_ascii_lowercase();
-
-    if let Some(enc) = preferred_encoder(table, cache, &lower, label) {
-        return Some(enc);
-    }
-
-    // Short-circuits on the first name match: duplicate encoder names occur
-    // only across byte-identical codec-alias rows, so the verdict is unchanged.
-    table
-        .iter()
-        .flat_map(CodecRow::encoders)
-        .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
-        .and_then(|(enc, _)| is_encoder_available(enc).then_some(*enc))
 }
 
 /// The row's encoders that are present in this build, in preference order.
@@ -121,8 +158,6 @@ pub fn available_encoders<R: CodecRow>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::OnceLock;
 
     struct FakeRow {
         codec: &'static str,
@@ -143,14 +178,7 @@ mod tests {
         encoders: &[("nonexistent_encoder_xyz", "Fake")],
     }];
 
-    #[test]
-    fn codec_row_exposes_codec_and_encoders() {
-        let row = FAKE_TABLE.first().expect("fake table has one row");
-        assert_eq!(row.codec(), "fakecodec");
-        assert_eq!(row.encoders().len(), 1);
-        let encoder = row.encoders().first().expect("encoders has one entry");
-        assert_eq!(encoder.0, "nonexistent_encoder_xyz");
-    }
+    static REGISTRY_FAKE: Registry<FakeRow> = Registry::new(FAKE_TABLE, MediaKind::Audio);
 
     #[test]
     fn is_encoder_available_false_for_nonsense_name() {
@@ -163,80 +191,87 @@ mod tests {
         assert!(is_encoder_available("aac"));
     }
 
-    static FAKE_CACHE_A: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
-    static FAKE_CACHE_B: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
+    /// Every encoder listed for `"fakecodec"` is absent from any real build,
+    /// so the registry must resolve to `None`, not silently fall through to
+    /// a permissive default. Guards the `.find(available)` +
+    /// `.copied().flatten()` chain in `lookup_preferred` against a mutation
+    /// that would return the first (unavailable) entry regardless.
+    #[test]
+    fn preferred_encoder_none_when_no_encoder_is_available() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(REGISTRY_FAKE.preferred_encoder("fakecodec"), None);
+    }
 
     static TABLE_A: &[FakeRow] = &[FakeRow {
         codec: "shared_name",
         encoders: &[("aac", "AAC")],
     }];
-    static TABLE_B: &[FakeRow] = &[FakeRow {
-        codec: "shared_name",
-        encoders: &[("pcm_s16le", "PCM")],
+    static TABLE_C: &[FakeRow] = &[FakeRow {
+        codec: "ordered",
+        encoders: &[
+            ("nonexistent_encoder_first", "Missing 1"),
+            ("aac", "AAC"),
+            ("pcm_s16le", "PCM"),
+        ],
     }];
+
+    static REGISTRY_A: Registry<FakeRow> = Registry::new(TABLE_A, MediaKind::Audio);
+    static REGISTRY_C: Registry<FakeRow> = Registry::new(TABLE_C, MediaKind::Audio);
 
     #[test]
     fn preferred_encoder_returns_first_available() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        assert_eq!(
-            preferred_encoder(TABLE_A, &FAKE_CACHE_A, "shared_name", "test-a"),
-            Some("aac")
-        );
+        assert_eq!(REGISTRY_A.preferred_encoder("shared_name"), Some("aac"));
     }
 
     #[test]
     fn preferred_encoder_unknown_codec_is_none() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        assert_eq!(
-            preferred_encoder(TABLE_A, &FAKE_CACHE_A, "no_such_codec", "test-a"),
-            None
-        );
+        assert_eq!(REGISTRY_A.preferred_encoder("no_such_codec"), None);
     }
 
-    /// REGRESSION GUARD for the generic-static trap. Two tables share a codec
-    /// name but have different encoders. With one shared cache, whichever ran
-    /// first would win for both. Distinct caches must give distinct answers.
+    /// Preference order matters: the first entry is an unavailable encoder,
+    /// so the registry must skip it and land on `aac` — not `pcm_s16le`,
+    /// which is also available but listed later. A one-encoder fixture
+    /// (`TABLE_A`) cannot distinguish `.find(available)` from `.first()` or
+    /// `.last()`; this table can.
     #[test]
-    fn distinct_caches_do_not_share_entries() {
+    fn preferred_encoder_skips_unavailable_and_respects_order() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        let a = preferred_encoder(TABLE_A, &FAKE_CACHE_A, "shared_name", "test-a");
-        let b = preferred_encoder(TABLE_B, &FAKE_CACHE_B, "shared_name", "test-b");
-        assert_eq!(a, Some("aac"), "table A must resolve from its own table");
-        assert_eq!(b, Some("pcm_s16le"), "table B must NOT inherit A's cache");
-        assert_ne!(a, b, "caches leaked across registries");
+        assert_eq!(REGISTRY_C.preferred_encoder("ordered"), Some("aac"));
+    }
+
+    /// Pins both the availability filter AND the preservation of preference
+    /// order in `available_encoders`.
+    #[test]
+    fn available_encoders_filters_and_preserves_order() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        let got: Vec<_> = available_encoders(TABLE_C.first().expect("row")).collect();
+        assert_eq!(got, vec![("aac", "AAC"), ("pcm_s16le", "PCM")]);
     }
 
     #[test]
     fn find_row_matches_case_insensitively() {
-        assert!(find_row(TABLE_A, "SHARED_NAME").is_some());
-        assert!(find_row(TABLE_A, "nope").is_none());
+        assert!(REGISTRY_A.find_row("SHARED_NAME").is_some());
+        assert!(REGISTRY_A.find_row("nope").is_none());
     }
 
     #[test]
     fn resolve_accepts_a_codec_name() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        assert_eq!(
-            resolve(TABLE_A, &FAKE_CACHE_A, "shared_name", "test-a"),
-            Some("aac")
-        );
+        assert_eq!(REGISTRY_A.resolve("shared_name"), Some("aac"));
     }
 
     #[test]
     fn resolve_accepts_a_direct_encoder_name() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        assert_eq!(
-            resolve(TABLE_A, &FAKE_CACHE_A, "aac", "test-a"),
-            Some("aac")
-        );
+        assert_eq!(REGISTRY_A.resolve("aac"), Some("aac"));
     }
 
     #[test]
     fn resolve_rejects_an_unknown_name() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        assert_eq!(
-            resolve(TABLE_A, &FAKE_CACHE_A, "no_such_thing", "test-a"),
-            None
-        );
+        assert_eq!(REGISTRY_A.resolve("no_such_thing"), None);
     }
 
     #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
@@ -1,0 +1,74 @@
+//! Shared core for the audio and video encoder preference registries.
+//!
+//! Both registries hold a static table of codecs, each with an ordered
+//! encoder-preference list, and answer the same four questions against it.
+//! Those answers live here once; the per-media modules keep only their table
+//! and the `*Info` types they build, which genuinely differ.
+
+/// The minimal view of a preference-table row the shared lookups need.
+///
+/// Deliberately two methods: everything else about a row (audio's
+/// `supported_containers`, video's speed-control derivation) is media-specific
+/// and stays in the owning module.
+pub trait CodecRow {
+    /// Canonical codec name, e.g. `"aac"` / `"h264"`.
+    fn codec(&self) -> &'static str;
+    /// Ordered encoder preference list: `(encoder_name, display_name)`.
+    fn encoders(&self) -> &'static [(&'static str, &'static str)];
+}
+
+/// Returns `true` if the named encoder is present in the linked `FFmpeg` build.
+///
+/// Identical for audio and video — this is the single definition. Requires
+/// [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn is_encoder_available(encoder: &str) -> bool {
+    ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeRow {
+        codec: &'static str,
+        encoders: &'static [(&'static str, &'static str)],
+    }
+
+    impl CodecRow for FakeRow {
+        fn codec(&self) -> &'static str {
+            self.codec
+        }
+        fn encoders(&self) -> &'static [(&'static str, &'static str)] {
+            self.encoders
+        }
+    }
+
+    static FAKE_TABLE: &[FakeRow] = &[FakeRow {
+        codec: "fakecodec",
+        encoders: &[("nonexistent_encoder_xyz", "Fake")],
+    }];
+
+    #[test]
+    fn codec_row_exposes_codec_and_encoders() {
+        let row = FAKE_TABLE.first().expect("fake table has one row");
+        assert_eq!(row.codec(), "fakecodec");
+        assert_eq!(row.encoders().len(), 1);
+        let encoder = row
+            .encoders()
+            .first()
+            .expect("encoders has one entry");
+        assert_eq!(encoder.0, "nonexistent_encoder_xyz");
+    }
+
+    #[test]
+    fn is_encoder_available_false_for_nonsense_name() {
+        assert!(!is_encoder_available("nonexistent_encoder_xyz"));
+    }
+
+    #[test]
+    fn is_encoder_available_true_for_builtin_aac() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert!(is_encoder_available("aac"));
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -41,6 +41,7 @@
 
 mod audio_codecs;
 pub mod audio_encoder_registry;
+pub(crate) mod codec_registry;
 mod dts_synth;
 pub(crate) use dts_synth::DtsSynthesizer;
 mod encoding_tag;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -8,9 +8,6 @@
 //! given codec name. Use [`list_available_codecs()`] to enumerate all codecs with
 //! at least one available encoder (for UI population).
 
-use std::collections::HashMap;
-use std::sync::OnceLock;
-
 use serde::{Deserialize, Serialize};
 
 use crate::ffmpeg::codec_registry;
@@ -260,10 +257,6 @@ impl codec_registry::CodecRow for CodecEntry {
     }
 }
 
-/// Per-registry cache. Module-level, NOT inside a generic function — see
-/// `codec_registry::preferred_encoder`.
-static VIDEO_CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
-
 /// Static table mapping codec names to ordered encoder preference lists.
 ///
 /// Codecs are listed in preference order — the first available encoder
@@ -383,6 +376,10 @@ static CODEC_PREFERENCES: &[CodecEntry] = &[
     },
 ];
 
+/// The video codec registry, owning its own cache over [`CODEC_PREFERENCES`].
+static VIDEO_REGISTRY: codec_registry::Registry<CodecEntry> =
+    codec_registry::Registry::new(CODEC_PREFERENCES, codec_registry::MediaKind::Video);
+
 /// Returns `true` if `encoder` is available in the current `FFmpeg` build.
 ///
 /// Uses `ffmpeg_the_third::codec::encoder::find_by_name()` for detection.
@@ -403,7 +400,7 @@ pub fn is_encoder_available(encoder: &str) -> bool {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn preferred_video_encoder(codec: &str) -> Option<&'static str> {
-    codec_registry::preferred_encoder(CODEC_PREFERENCES, &VIDEO_CACHE, codec, "video")
+    VIDEO_REGISTRY.preferred_encoder(codec)
 }
 
 /// Resolves an encoder name.
@@ -418,7 +415,7 @@ pub fn preferred_video_encoder(codec: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn resolve_encoder(input: &str) -> Option<&'static str> {
-    codec_registry::resolve(CODEC_PREFERENCES, &VIDEO_CACHE, input, "video")
+    VIDEO_REGISTRY.resolve(input)
 }
 
 /// Returns all available encoders for a given codec name, in preference order.
@@ -428,7 +425,8 @@ pub fn resolve_encoder(input: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn available_encoders_for_codec(codec: &str) -> Vec<VideoEncoderInfo> {
-    codec_registry::find_row(CODEC_PREFERENCES, codec)
+    VIDEO_REGISTRY
+        .find_row(codec)
         .map(|row| {
             codec_registry::available_encoders(row)
                 .map(|(enc, display)| VideoEncoderInfo {
@@ -641,12 +639,14 @@ mod tests {
         }
     }
 
-    /// REGRESSION GUARD: the audio and video registries must not share a cache.
+    /// REGRESSION GUARD: the audio and video tables are disjoint.
     ///
-    /// The two codec tables are disjoint, so a codec belonging to one registry
-    /// must resolve to `None` through the other. A shared cache would leak the
-    /// first registry's entry and return `Some(..)` instead. Resolve through
-    /// each registry FIRST so both caches are populated before the cross checks.
+    /// `Registry` now owns its cache, so cross-registry cache leakage is not
+    /// representable — this test instead pins the real invariant that
+    /// remains: `CODEC_PREFERENCES` and `AUDIO_CODEC_PREFERENCES` share no
+    /// codec name, so a codec that belongs to one registry must resolve to
+    /// `None` through the other. Resolve through each registry FIRST so both
+    /// caches are populated before the cross checks.
     #[test]
     fn audio_and_video_registries_have_independent_caches() {
         use crate::ffmpeg::audio_encoder_registry::preferred_audio_encoder;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -641,19 +641,38 @@ mod tests {
         }
     }
 
-    /// The audio and video registries must not share a cache. Resolving a
-    /// video codec first must not change what the audio registry answers.
+    /// REGRESSION GUARD: the audio and video registries must not share a cache.
+    ///
+    /// The two codec tables are disjoint, so a codec belonging to one registry
+    /// must resolve to `None` through the other. A shared cache would leak the
+    /// first registry's entry and return `Some(..)` instead. Resolve through
+    /// each registry FIRST so both caches are populated before the cross checks.
     #[test]
     fn audio_and_video_registries_have_independent_caches() {
-        crate::ffmpeg::ensure_init().expect("ffmpeg init");
-        let video_h264 = preferred_video_encoder("h264");
-        let audio_aac = crate::ffmpeg::audio_encoder_registry::preferred_audio_encoder("aac");
+        use crate::ffmpeg::audio_encoder_registry::preferred_audio_encoder;
 
-        assert!(video_h264.is_some(), "h264 encoder should resolve");
-        assert!(audio_aac.is_some(), "aac encoder should resolve");
-        assert_ne!(
-            video_h264, audio_aac,
-            "audio registry returned the video registry's answer — caches are shared"
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+
+        // Populate both caches.
+        assert!(
+            preferred_video_encoder("h264").is_some(),
+            "h264 is a video codec"
+        );
+        assert!(
+            preferred_audio_encoder("aac").is_some(),
+            "aac is an audio codec"
+        );
+
+        // Cross checks — these are what a shared cache would break.
+        assert_eq!(
+            preferred_video_encoder("aac"),
+            None,
+            "video registry returned an answer for an audio-only codec — caches are shared"
+        );
+        assert_eq!(
+            preferred_audio_encoder("h264"),
+            None,
+            "audio registry returned an answer for a video-only codec — caches are shared"
         );
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/video_codecs.rs
@@ -11,8 +11,9 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use log::info;
 use serde::{Deserialize, Serialize};
+
+use crate::ffmpeg::codec_registry;
 
 /// Information about a specific video encoder.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -250,6 +251,19 @@ struct CodecEntry {
     encoders: &'static [(&'static str, &'static str)],
 }
 
+impl codec_registry::CodecRow for CodecEntry {
+    fn codec(&self) -> &'static str {
+        self.codec
+    }
+    fn encoders(&self) -> &'static [(&'static str, &'static str)] {
+        self.encoders
+    }
+}
+
+/// Per-registry cache. Module-level, NOT inside a generic function — see
+/// `codec_registry::preferred_encoder`.
+static VIDEO_CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
+
 /// Static table mapping codec names to ordered encoder preference lists.
 ///
 /// Codecs are listed in preference order — the first available encoder
@@ -375,7 +389,7 @@ static CODEC_PREFERENCES: &[CodecEntry] = &[
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn is_encoder_available(encoder: &str) -> bool {
-    ffmpeg_the_third::codec::encoder::find_by_name(encoder).is_some()
+    codec_registry::is_encoder_available(encoder)
 }
 
 /// Returns the best available video encoder for a given codec name.
@@ -389,31 +403,7 @@ pub fn is_encoder_available(encoder: &str) -> bool {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn preferred_video_encoder(codec: &str) -> Option<&'static str> {
-    static CACHE: OnceLock<HashMap<&'static str, Option<&'static str>>> = OnceLock::new();
-
-    let cache = CACHE.get_or_init(|| {
-        let mut map = HashMap::new();
-        for entry in CODEC_PREFERENCES {
-            let selected = entry
-                .encoders
-                .iter()
-                .find(|(enc, _)| is_encoder_available(enc))
-                .map(|(enc, _)| *enc);
-
-            if let Some(enc) = selected {
-                info!("Using {enc} as {codec} encoder", codec = entry.codec);
-            }
-
-            map.insert(entry.codec, selected);
-        }
-        map
-    });
-
-    // Only canonically-known codecs are in the cache; unknown codec names return None
-    cache
-        .get(codec.to_ascii_lowercase().as_str())
-        .copied()
-        .flatten()
+    codec_registry::preferred_encoder(CODEC_PREFERENCES, &VIDEO_CACHE, codec, "video")
 }
 
 /// Resolves an encoder name.
@@ -428,23 +418,7 @@ pub fn preferred_video_encoder(codec: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn resolve_encoder(input: &str) -> Option<&'static str> {
-    let lower = input.to_ascii_lowercase();
-
-    // Check if input is a known codec name first
-    if let Some(enc) = preferred_video_encoder(&lower) {
-        return Some(enc);
-    }
-
-    // Otherwise treat as a direct encoder name — find the matching static str
-    // in our table, then gate on availability. Short-circuits on the first
-    // name match exactly like the prior nested-loop search: duplicate encoder
-    // names occur only across byte-identical codec-alias rows, so the verdict
-    // (available → Some, unavailable → None) is unchanged.
-    CODEC_PREFERENCES
-        .iter()
-        .flat_map(|entry| entry.encoders)
-        .find(|(enc, _)| enc.eq_ignore_ascii_case(input))
-        .and_then(|(enc, _)| is_encoder_available(enc).then_some(*enc))
+    codec_registry::resolve(CODEC_PREFERENCES, &VIDEO_CACHE, input, "video")
 }
 
 /// Returns all available encoders for a given codec name, in preference order.
@@ -454,18 +428,12 @@ pub fn resolve_encoder(input: &str) -> Option<&'static str> {
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
 pub fn available_encoders_for_codec(codec: &str) -> Vec<VideoEncoderInfo> {
-    let lower = codec.to_ascii_lowercase();
-    CODEC_PREFERENCES
-        .iter()
-        .find(|e| e.codec == lower.as_str())
-        .map(|entry| {
-            entry
-                .encoders
-                .iter()
-                .filter(|(enc, _)| is_encoder_available(enc))
+    codec_registry::find_row(CODEC_PREFERENCES, codec)
+        .map(|row| {
+            codec_registry::available_encoders(row)
                 .map(|(enc, display)| VideoEncoderInfo {
-                    encoder_name: (*enc).to_string(),
-                    display_name: (*display).to_string(),
+                    encoder_name: enc.to_string(),
+                    display_name: display.to_string(),
                     speed_controls: speed_controls_def(enc)
                         .iter()
                         .map(SpeedKnob::from_def)
@@ -489,13 +457,10 @@ pub fn list_available_codecs() -> Vec<VideoCodecInfo> {
     CODEC_PREFERENCES
         .iter()
         .filter_map(|entry| {
-            let encoders: Vec<VideoEncoderInfo> = entry
-                .encoders
-                .iter()
-                .filter(|(enc, _)| is_encoder_available(enc))
+            let encoders: Vec<VideoEncoderInfo> = codec_registry::available_encoders(entry)
                 .map(|(enc, display)| VideoEncoderInfo {
-                    encoder_name: (*enc).to_string(),
-                    display_name: (*display).to_string(),
+                    encoder_name: enc.to_string(),
+                    display_name: display.to_string(),
                     speed_controls: speed_controls_def(enc)
                         .iter()
                         .map(SpeedKnob::from_def)
@@ -674,5 +639,21 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The audio and video registries must not share a cache. Resolving a
+    /// video codec first must not change what the audio registry answers.
+    #[test]
+    fn audio_and_video_registries_have_independent_caches() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        let video_h264 = preferred_video_encoder("h264");
+        let audio_aac = crate::ffmpeg::audio_encoder_registry::preferred_audio_encoder("aac");
+
+        assert!(video_h264.is_some(), "h264 encoder should resolve");
+        assert!(audio_aac.is_some(), "aac encoder should resolve");
+        assert_ne!(
+            video_h264, audio_aac,
+            "audio registry returned the video registry's answer — caches are shared"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Extracts the genuinely-duplicated logic shared by the audio and video encoder
registries in `rdlp-ffmpeg` into one `codec_registry` core, behind a two-method
`CodecRow` trait plus a `Registry<R>` parameter object that owns its own cache.

This is groundwork for #618 (container-aware audio defaults). It lands against
**unchanged behaviour** so the subsequent policy change is reviewable on its own.

Refs #618

## What moved

Five previously-duplicated function pairs now have a single implementation:

- `is_encoder_available`
- `preferred_encoder`
- `resolve_encoder`
- `available_encoders`
- the codec→encoder availability cache

`Registry<R>` **owns** an inline `OnceLock` cache rather than borrowing one, so a
table can no longer be paired with the wrong cache — the hazard is unrepresentable
rather than merely privacy-gated. `MediaKind` replaces a `&str` label.

`list_available_audio_encoders` / `list_available_video_codecs` deliberately stay
per-media: they return different `*Info` shapes and share no logic worth unifying.

## Behaviour

Behaviour-neutral **except one log string**: the video selection log line gains the
word "video" — `Using {enc} as {codec} encoder` becomes `Using {enc} as {codec} video
encoder`. Audio's wording is byte-identical. This is a deliberate symmetry fix from
unifying the two format strings, not an accidental regression.

Both registries' log **target** also moves to `rdlp_ffmpeg::ffmpeg::codec_registry`.

Neutrality was verified by **enumeration, not inspection**: the old code lowercased
then compared exactly, the new code uses `eq_ignore_ascii_case`. All 32 codec-table
name literals are lowercase ASCII, so the substitution is provably a no-op.

## Tests

New coverage for the extracted core, each mutation-verified to actually fail:

- preference order is honoured (three-entry fixture — a one-entry fixture cannot
  distinguish `.find(available)` from `.first()`/`.last()`/reversed)
- known codec with every encoder unavailable returns `None`
- resolution by direct encoder name (uses `libmp3lame`, an encoder name — testing
  `"aac"` never reaches that branch, since it is a codec key)
- the audio and video registries do not share cache entries, exploiting the two
  tables being disjoint

Two tests that could not fail under the regression they were named for were removed
rather than left as fake guards.

## Verification

```
cargo fmt --check && cargo check && cargo clippy --workspace --all-targets -- -D warnings \
  && cargo test && cargo check -p rdlp-desktop && bash scripts/check-all.sh
```

Exit 0. Full workspace suite green; `check-all.sh` = 11 gates + 4 self-tests.

## Reviews

- **security-reviewer** — Approve, **0 findings**. Confirmed the caches are bounded by
  the compile-time table (caller strings are lookup keys only, never inserted), so no
  attacker-controlled string can cause an unlisted encoder to be returned. No new
  `unsafe`, no new dependencies.
- **code-reviewer** (whole branch, 2 rounds) — 2 Important + 4 Minor each round, **all
  fixed**. Round 1 replaced a call-site mispairing trap with the `Registry` object and
  fixed an under-powered test fixture; round 2 made `Registry` own its cache outright
  and rewired the last hand-rolled copy of the extracted search.
