### PR TITLE
fix(ffmpeg): derive container audio defaults from the muxer, not a catch-all

### DIFF
--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
@@ -5,10 +5,9 @@
 //!
 //! When `libfdk_aac` is available (custom `FFmpeg` build with `--enable-nonfree`),
 //! it is automatically preferred over the built-in `aac` encoder for better
-//! quality at equivalent bitrates. Use [`preferred_aac_encoder()`] to resolve
-//! the best available AAC encoder at runtime.
-
-use super::audio_encoder_registry;
+//! quality at equivalent bitrates — resolved via
+//! [`super::audio_encoder_registry::preferred_audio_encoder`], the single
+//! source of truth for encoder preference.
 
 /// Audio codec configuration for extraction/conversion.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,31 +161,9 @@ pub fn get_audio_codec(name: &str) -> Option<&'static AudioCodecConfig> {
         .map(|(_, config)| config)
 }
 
-/// Returns the best available AAC encoder name.
-///
-/// Delegates to [`audio_encoder_registry::preferred_audio_encoder`] for a single
-/// source of truth. Returns `"libfdk_aac"` when the Fraunhofer FDK build is
-/// available, otherwise `"aac"` (built-in).
-///
-/// This function requires [`super::ensure_init`] to have been called first.
-#[must_use]
-pub fn preferred_aac_encoder() -> &'static str {
-    audio_encoder_registry::preferred_audio_encoder("aac").unwrap_or("aac")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_preferred_aac_encoder_returns_valid_name() {
-        // Must be one of the two known AAC encoders
-        let enc = preferred_aac_encoder();
-        assert!(
-            enc == "aac" || enc == "libfdk_aac",
-            "unexpected encoder: {enc}"
-        );
-    }
 
     #[test]
     fn test_get_audio_codec_aac() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_codecs.rs
@@ -3,11 +3,15 @@
 //! Provides `AudioCodecConfig` and `AUDIO_CODECS` for mapping codec names
 //! to encoder names, file extensions, quality scale ranges, and bitrate ranges.
 //!
-//! When `libfdk_aac` is available (custom `FFmpeg` build with `--enable-nonfree`),
-//! it is automatically preferred over the built-in `aac` encoder for better
-//! quality at equivalent bitrates — resolved via
-//! [`super::audio_encoder_registry::preferred_audio_encoder`], the single
-//! source of truth for encoder preference.
+//! This table is the audio-extraction path's own configuration
+//! (`AudioExtractStage` / `transcode::audio_extract`), which reads `encoder`
+//! as a literal `FFmpeg` encoder name and does NOT resolve it through
+//! [`super::audio_encoder_registry::preferred_audio_encoder`] — the "aac" row
+//! here always names the built-in `aac` encoder, even on a build that links
+//! `libfdk_aac`. Rerouting extraction through the preference registry would
+//! be a behaviour change and is out of this module's scope; see
+//! `audio_encoder_registry` for the encoder-preference logic actually used by
+//! recode/normalize.
 
 /// Audio codec configuration for extraction/conversion.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -19,7 +19,7 @@
 use rdlp_types::ContainerFormat;
 use serde::{Deserialize, Serialize};
 
-use crate::ffmpeg::codec_registry;
+use crate::ffmpeg::{codec_registry, muxer_defaults};
 
 /// Information about a specific audio encoder.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -316,34 +316,152 @@ pub fn container_supports_audio_codec(container: ContainerFormat, codec: &str) -
         .is_some_and(|entry| entry.supported_containers.contains(&container))
 }
 
-/// Returns the best default audio encoder for the given container format.
+/// What decides a container's default audio encoder.
+enum AudioDefault {
+    /// Defer to whatever the linked `FFmpeg` muxer declares.
+    FromMuxer,
+    /// rdlp overrides the muxer's declaration; the reason is on the arm.
+    Override(&'static str),
+    /// The container carries no audio stream at all.
+    NoAudio,
+}
+
+/// Policy for each container. Exhaustive with no `_` arm: a new
+/// [`ContainerFormat`] variant must be classified here or the build fails.
+const fn audio_default_for(container: ContainerFormat) -> AudioDefault {
+    match container {
+        // Mkv/Mka: Opus over the matroska muxer's historical `vorbis`
+        // declaration — better quality per bit, and Matroska carries Opus
+        // without caveat.
+        //
+        // Ogg: preserved as-is pending #623. `.ogg` conventionally means Ogg
+        // Vorbis (Xiph; RFC 7845 §9 recommends `.opus` for Opus), so this
+        // override is probably wrong for Ogg specifically — but changing it
+        // is a separate user-visible change.
+        ContainerFormat::Mkv | ContainerFormat::Mka | ContainerFormat::Ogg => {
+            AudioDefault::Override("opus")
+        }
+
+        // FFmpeg declares `amr_nb`: 8 kHz speech-only, and the native encoder
+        // is absent from most builds. 3GPP TS 26.244 permits AMR, AMR-WB and
+        // AAC, so AAC is spec-correct rather than a workaround.
+        ContainerFormat::ThreeGp => AudioDefault::Override("aac"),
+
+        // Raw VP8/VP9/AV1 elementary stream; the muxer declares no audio codec
+        // and refuses any audio stream outright.
+        ContainerFormat::Ivf => AudioDefault::NoAudio,
+
+        ContainerFormat::Mp4
+        | ContainerFormat::WebM
+        | ContainerFormat::Mov
+        | ContainerFormat::M4v
+        | ContainerFormat::Ts
+        | ContainerFormat::Flv
+        | ContainerFormat::Avi
+        | ContainerFormat::Mpg
+        | ContainerFormat::F4v
+        | ContainerFormat::Wmv
+        | ContainerFormat::Wma
+        | ContainerFormat::Asf
+        | ContainerFormat::Mxf
+        | ContainerFormat::Vob
+        | ContainerFormat::Dv
+        | ContainerFormat::Nut
+        | ContainerFormat::M4a
+        | ContainerFormat::Mp3
+        | ContainerFormat::Wav
+        | ContainerFormat::Flac
+        | ContainerFormat::Opus
+        | ContainerFormat::Aac
+        | ContainerFormat::Aiff
+        | ContainerFormat::Wv
+        | ContainerFormat::Caf
+        | ContainerFormat::Ac3 => AudioDefault::FromMuxer,
+    }
+}
+
+/// Returns the best default audio encoder for `container`.
 ///
-/// Selection is based on what is most universally compatible:
-/// - MP4, MOV, TS → AAC (best available)
-/// - `WebM` → Opus
-/// - OGG → Opus (if available) or Vorbis
-/// - MKV → Opus (quality/size efficiency)
-/// - AVI → MP3
-/// - Default fallback → AAC
+/// Returns `None` when no audio encoder could be determined for it: the
+/// container genuinely carries no audio stream, or the muxer/codec tables
+/// yielded no usable default (see `muxer_defaults::declared_codec` for the
+/// causes).
+///
+/// Most containers defer to what the linked `FFmpeg` muxer declares, so rdlp
+/// keeps no second copy of `FFmpeg`'s table. The handful of deliberate
+/// deviations are named in `audio_default_for` with their reasons.
 ///
 /// Requires [`super::ensure_init`] to have been called first.
 #[must_use]
-pub fn select_audio_encoder_for_container(container: ContainerFormat) -> &'static str {
-    match container {
-        ContainerFormat::WebM => preferred_audio_encoder("opus").unwrap_or("libopus"),
-        ContainerFormat::Ogg => preferred_audio_encoder("opus")
-            .or_else(|| preferred_audio_encoder("vorbis"))
-            .unwrap_or("libopus"),
-        ContainerFormat::Mkv => {
-            // MKV supports everything; prefer Opus for quality/size efficiency
-            preferred_audio_encoder("opus").unwrap_or("libopus")
+pub fn select_audio_encoder_for_container(container: ContainerFormat) -> Option<&'static str> {
+    let codec = match audio_default_for(container) {
+        AudioDefault::NoAudio => return None,
+        AudioDefault::Override(codec) => codec,
+        AudioDefault::FromMuxer => {
+            let Some(codec) =
+                muxer_defaults::declared_codec(container, codec_registry::MediaKind::Audio)
+            else {
+                // Every other `None` path logs (the ABI-skew warn inside
+                // `declared_codec`, the tier-4 AAC-fallback warn below) or is
+                // a declared policy (`NoAudio`). "No muxer claims this
+                // extension" is the one case that would otherwise pass
+                // through silently — the case an operator would most want to
+                // see (Minor-10, #618 fix wave 1).
+                log::warn!(
+                    "no muxer declares an audio codec for container {}; \
+                     no default audio encoder available",
+                    container.as_ext()
+                );
+                return None;
+            };
+            codec
         }
-        ContainerFormat::Avi => preferred_audio_encoder("mp3").unwrap_or("libmp3lame"),
-        _ => {
-            // MP4, MOV, TS, and everything else → AAC
-            preferred_audio_encoder("aac").unwrap_or("aac")
-        }
-    }
+    };
+
+    resolve_declared_codec(codec, container)
+}
+
+/// Resolves a declared codec-ID name to an available encoder, falling back
+/// to AAC-with-a-warning (tier 4) when nothing else works.
+///
+/// `codec` is `FFmpeg`'s codec-ID name (e.g. "`pcm_s16le`", "`wmav2`", "vorbis"),
+/// not necessarily a key in `AUDIO_CODEC_PREFERENCES`: aliased codecs like
+/// mp3/vorbis have a table row that maps to a differently-named lib encoder,
+/// but native single-encoder codecs like PCM/WMA have no row at all — for
+/// those, the codec-ID name IS the encoder name. Try the preference-table
+/// mapping first (it also picks the *best* of several encoders, e.g.
+/// `libfdk_aac` over `aac`), then fall back to treating the declared name as
+/// a literal encoder.
+///
+/// Split out of [`select_audio_encoder_for_container`] so tier 4 is
+/// testable with an arbitrary/bogus codec name, independent of what any
+/// particular linked `FFmpeg` build actually declares (Minor-12).
+///
+/// Caveat (Minor-7): `is_audio_encoder_available` is a bare
+/// `find_by_name(..).is_some()` — it does not check
+/// `AV_CODEC_CAP_EXPERIMENTAL`. `FFmpeg`'s native `vorbis`/`opus` encoders
+/// both carry that flag and fail to open without
+/// `strict_std_compliance = experimental`, so on a build lacking
+/// `libvorbis`/`libopus` this tier can resolve a codec-ID name (`vorbis`)
+/// that "is available" by this check yet won't actually open. Not filtered
+/// here: none of rdlp's transcode call sites set `strict_std_compliance`, so
+/// this is a real gap, but plumbing capability flags through this lookup is
+/// a materially bigger change than the rest of this fix wave — left for a
+/// follow-up rather than folded in here.
+fn resolve_declared_codec(codec: &'static str, container: ContainerFormat) -> Option<&'static str> {
+    preferred_audio_encoder(codec)
+        .or_else(|| is_audio_encoder_available(codec).then_some(codec))
+        .or_else(|| {
+            // Neither the preference table nor a direct name match resolved
+            // an available encoder. Fall back to AAC, but SAY SO — a silent
+            // fallback would recreate the invisible `_ => aac` this change
+            // exists to remove.
+            log::warn!(
+                "no encoder available for {codec} (default for {}); falling back to AAC",
+                container.as_ext()
+            );
+            preferred_audio_encoder("aac")
+        })
 }
 
 #[cfg(test)]
@@ -351,7 +469,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn preferred_aac_encoder_returns_valid() {
+    fn preferred_audio_encoder_aac_returns_valid() {
         let enc = preferred_audio_encoder("aac");
         assert!(enc.is_some(), "aac encoder should be available");
         let name = enc.unwrap();
@@ -440,21 +558,11 @@ mod tests {
 
     #[test]
     fn select_encoder_for_mp4_returns_aac() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
         let enc = select_audio_encoder_for_container(ContainerFormat::Mp4);
         assert!(
-            enc == "aac" || enc == "libfdk_aac",
-            "expected aac encoder for mp4, got {enc}"
-        );
-    }
-
-    #[test]
-    fn preferred_aac_encoder_wrapper_consistency() {
-        // The audio_codecs.rs preferred_aac_encoder() should match registry
-        let registry_result = preferred_audio_encoder("aac").unwrap_or("aac");
-        let legacy_result = crate::ffmpeg::audio_codecs::preferred_aac_encoder();
-        assert_eq!(
-            registry_result, legacy_result,
-            "registry and legacy preferred_aac_encoder must agree"
+            enc == Some("aac") || enc == Some("libfdk_aac"),
+            "expected aac encoder for mp4, got {enc:?}"
         );
     }
 
@@ -496,5 +604,150 @@ mod tests {
         } else {
             assert_eq!(resolve_audio_encoder("libfdk_aac"), None);
         }
+    }
+
+    /// Guarded against a thin build lacking `libmp3lame`: on a build with it,
+    /// this fails under the old `_ => "aac"` catch-all (mutation-verified,
+    /// see the module report). On a build WITHOUT it, tier 4's AAC-fallback
+    /// is correct by design, so a bare "must not be aac" would itself be a
+    /// false failure (Minor-6) — the honest form only asserts the exact
+    /// codec when it's actually available.
+    #[test]
+    fn audio_only_containers_get_their_own_codec_not_aac() {
+        ensure_init_for_test();
+        let mp3 = select_audio_encoder_for_container(ContainerFormat::Mp3);
+        assert!(
+            mp3 == Some("libmp3lame") || !is_audio_encoder_available("libmp3lame"),
+            "expected libmp3lame for .mp3 when available, got {mp3:?}"
+        );
+        assert_eq!(
+            select_audio_encoder_for_container(ContainerFormat::Flac),
+            Some("flac")
+        );
+        assert_eq!(
+            select_audio_encoder_for_container(ContainerFormat::Wav),
+            Some("pcm_s16le")
+        );
+    }
+
+    #[test]
+    fn asf_family_gets_wmav2() {
+        ensure_init_for_test();
+        for c in [
+            ContainerFormat::Wmv,
+            ContainerFormat::Wma,
+            ContainerFormat::Asf,
+        ] {
+            let enc = select_audio_encoder_for_container(c);
+            assert!(
+                enc == Some("wmav2") || !is_audio_encoder_available("wmav2"),
+                "{c:?}: expected wmav2 when available, got {enc:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ivf_carries_no_audio() {
+        ensure_init_for_test();
+        assert_eq!(
+            select_audio_encoder_for_container(ContainerFormat::Ivf),
+            None
+        );
+    }
+
+    /// The four overrides, asserted against literal encoder names — NOT
+    /// against `declared_codec(..)`, which would be a tautology that
+    /// survives mutating the override away. Guarded the same honest way as
+    /// `asf_family_gets_wmav2` (Minor-6): only asserted when the encoder is
+    /// actually available, since tier 4's AAC fallback is correct by design
+    /// otherwise.
+    #[test]
+    fn overrides_are_exactly_these_four() {
+        ensure_init_for_test();
+        for c in [
+            ContainerFormat::Mkv,
+            ContainerFormat::Mka,
+            ContainerFormat::Ogg,
+        ] {
+            let enc = select_audio_encoder_for_container(c);
+            assert!(
+                enc == Some("libopus") || !is_audio_encoder_available("libopus"),
+                "{c:?}: expected libopus when available, got {enc:?}"
+            );
+        }
+
+        let threegp = select_audio_encoder_for_container(ContainerFormat::ThreeGp);
+        assert!(
+            threegp == Some("aac") || threegp == Some("libfdk_aac"),
+            "expected an aac-family encoder for 3gp, got {threegp:?}"
+        );
+    }
+
+    /// Containers that defer to the muxer must NOT all be AAC — that was the
+    /// old catch-all's signature failure. Guarded the same honest way as
+    /// `asf_family_gets_wmav2` (Minor-6): on a thin build missing
+    /// `mp2`/`libvorbis`, tier 4's AAC fallback is correct by design, so
+    /// these only assert the exact codec when it's actually available.
+    #[test]
+    fn from_muxer_containers_are_not_uniformly_aac() {
+        ensure_init_for_test();
+
+        let ts = select_audio_encoder_for_container(ContainerFormat::Ts);
+        assert!(
+            ts == Some("mp2") || !is_audio_encoder_available("mp2"),
+            "expected mp2 for .ts when available, got {ts:?}"
+        );
+
+        let nut = select_audio_encoder_for_container(ContainerFormat::Nut);
+        assert!(
+            nut == Some("libvorbis") || !is_audio_encoder_available("libvorbis"),
+            "expected libvorbis for .nut when available, got {nut:?}"
+        );
+
+        assert_eq!(
+            select_audio_encoder_for_container(ContainerFormat::Ac3),
+            Some("ac3")
+        );
+        assert_eq!(
+            select_audio_encoder_for_container(ContainerFormat::Aiff),
+            Some("pcm_s16be")
+        );
+    }
+
+    #[test]
+    fn mp4_family_still_gets_aac() {
+        ensure_init_for_test();
+        for c in [
+            ContainerFormat::Mp4,
+            ContainerFormat::M4a,
+            ContainerFormat::M4v,
+            ContainerFormat::Mov,
+            ContainerFormat::F4v,
+        ] {
+            let enc = select_audio_encoder_for_container(c);
+            assert!(
+                enc == Some("aac") || enc == Some("libfdk_aac"),
+                "expected an aac-family encoder for {c:?}, got {enc:?}"
+            );
+        }
+    }
+
+    /// Minor-12: tier 4 (the AAC-with-warning fallback the whole design
+    /// hinges on being VISIBLE) had no test — tiers 1-3 were covered, tier 4
+    /// wasn't. A bogus codec name skips the preference table (tier 1) and
+    /// the direct-name check (tier 3) unconditionally, landing on tier 4
+    /// regardless of what any particular linked `FFmpeg` build declares.
+    #[test]
+    fn tier_four_falls_back_to_aac_for_an_unresolvable_codec() {
+        ensure_init_for_test();
+        let enc = resolve_declared_codec("definitely_not_a_real_codec_xyz", ContainerFormat::Mp4);
+        assert!(
+            enc == Some("aac") || enc == Some("libfdk_aac"),
+            "expected tier 4 to fall back to an aac-family encoder, got {enc:?}"
+        );
+    }
+
+    fn ensure_init_for_test() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -881,7 +881,7 @@ mod tests {
         }
     }
 
-    /// Tier 4 (the AAC-with-warning fallback the whole design hinges on
+    /// Tier 3 (the AAC-with-warning fallback the whole design hinges on
     /// being VISIBLE) had no test — tiers 1-2 were covered, tier 3 wasn't.
     /// A bogus codec name skips the preference table (tier 1) and the
     /// direct-name check (tier 2) unconditionally, landing on tier 3

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -64,6 +64,16 @@ impl codec_registry::CodecRow for AudioCodecEntry {
     fn encoders(&self) -> &'static [(&'static str, &'static str)] {
         self.encoders
     }
+    fn aliases(&self) -> &'static [&'static str] {
+        // "pcm" predates this row being keyed to its exact codec-ID name
+        // (`pcm_s16le`) and is a CLI vocabulary word a user may still type
+        // from muscle memory; the alias keeps it resolving without
+        // reintroducing the exact-key mismatch the rename fixes.
+        match self.codec {
+            "pcm_s16le" => &["pcm"],
+            _ => &[],
+        }
+    }
 }
 
 /// Static preference table for audio codecs.
@@ -85,6 +95,16 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mkv,
             ContainerFormat::Avi,
             ContainerFormat::Ts,
+            ContainerFormat::Aac,
+            ContainerFormat::M4a,
+            // ThreeGp: rdlp overrides the muxer's own `amr_nb` default to
+            // aac (see `audio_default_for`); the compatibility matrix must
+            // accept the codec it actually produces. M4v/F4v: their muxers
+            // declare aac as the default (verified against the linked
+            // FFmpeg build).
+            ContainerFormat::ThreeGp,
+            ContainerFormat::M4v,
+            ContainerFormat::F4v,
         ],
     },
     AudioCodecEntry {
@@ -97,6 +117,9 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mkv,
             ContainerFormat::Avi,
             ContainerFormat::Ts,
+            ContainerFormat::Mp3,
+            // Flv's muxer declares mp3 as its default audio codec.
+            ContainerFormat::Flv,
         ],
     },
     AudioCodecEntry {
@@ -106,8 +129,12 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
         supported_containers: &[
             ContainerFormat::Mp4,
             ContainerFormat::Mkv,
+            // Mka: rdlp overrides matroska's own default to opus (see
+            // `audio_default_for`); the matrix must accept it.
+            ContainerFormat::Mka,
             ContainerFormat::WebM,
             ContainerFormat::Ogg,
+            ContainerFormat::Opus,
         ],
     },
     AudioCodecEntry {
@@ -118,13 +145,18 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mkv,
             ContainerFormat::WebM,
             ContainerFormat::Ogg,
+            ContainerFormat::Nut,
         ],
     },
     AudioCodecEntry {
         codec: "flac",
         display_name: "FLAC",
         encoders: &[("flac", "FLAC (built-in)")],
-        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Ogg],
+        supported_containers: &[
+            ContainerFormat::Mkv,
+            ContainerFormat::Ogg,
+            ContainerFormat::Flac,
+        ],
     },
     AudioCodecEntry {
         codec: "alac",
@@ -146,6 +178,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mkv,
             ContainerFormat::Avi,
             ContainerFormat::Ts,
+            ContainerFormat::Ac3,
         ],
     },
     AudioCodecEntry {
@@ -169,19 +202,82 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
         codec: "mp2",
         display_name: "MP2",
         encoders: &[("mp2", "MP2 (built-in)")],
-        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Ts],
+        supported_containers: &[
+            ContainerFormat::Mkv,
+            ContainerFormat::Ts,
+            // Mpg/Vob's muxers both declare mp2 as their default audio codec.
+            ContainerFormat::Mpg,
+            ContainerFormat::Vob,
+        ],
     },
+    // Keyed to the exact FFmpeg codec-ID name (rather than the historical
+    // "pcm" vocabulary word) so it matches `muxer_defaults::declared_codec`
+    // and stays in tier 1 — see `resolve_declared_codec`'s tiers. "pcm"
+    // still resolves via `CodecRow::aliases` below, for the CLI vocabulary a
+    // user may type from muscle memory.
+    //
+    // Aiff/Caf are listed here too, alongside the separate `pcm_s16be` row:
+    // this is a *compatibility* fact ("pcm_s16le can be muxed into AIFF/CAF",
+    // verified against the linked FFmpeg build), not a claim about either
+    // container's *default* (which is `pcm_s16be` — see the row below). The
+    // two facts coexist; neither row should be read as claiming the other.
     AudioCodecEntry {
-        codec: "pcm",
-        display_name: "WAV/PCM",
+        codec: "pcm_s16le",
+        display_name: "PCM 16-bit little-endian",
         encoders: &[("pcm_s16le", "PCM 16-bit (built-in)")],
-        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Avi],
+        supported_containers: &[
+            ContainerFormat::Mkv,
+            ContainerFormat::Avi,
+            ContainerFormat::Wav,
+            ContainerFormat::Aiff,
+            ContainerFormat::Caf,
+            // Mxf and Dv's muxers both declare pcm_s16le as their default
+            // audio codec (caught by the sweep test, not the review's table).
+            ContainerFormat::Mxf,
+            ContainerFormat::Dv,
+        ],
+    },
+    // Big-endian PCM is a distinct codec-ID from the little-endian
+    // `pcm_s16le` row above (AIFF/CAF declare `pcm_s16be`; WAV/AVI/MKV
+    // declare `pcm_s16le`). Keyed to the exact FFmpeg codec-ID name so it
+    // matches `muxer_defaults::declared_codec` and stays in tier 1 rather
+    // than silently falling through to tier 3's literal-encoder-name
+    // fallback in `resolve_declared_codec`.
+    //
+    // Behavioural neutrality of this row being in tier 1 rather than tier 3
+    // depends on `encoders` staying the singleton `[("pcm_s16be", _)]` where
+    // the encoder name equals the codec key — see `resolve_declared_codec`'s
+    // doc comment for the structural argument. Adding a second encoder here
+    // would need that argument re-checked.
+    AudioCodecEntry {
+        codec: "pcm_s16be",
+        display_name: "PCM 16-bit big-endian",
+        encoders: &[("pcm_s16be", "PCM 16-bit big-endian (built-in)")],
+        supported_containers: &[ContainerFormat::Aiff, ContainerFormat::Caf],
     },
     AudioCodecEntry {
         codec: "wavpack",
         display_name: "WavPack",
         encoders: &[("wavpack", "WavPack (built-in)")],
-        supported_containers: &[ContainerFormat::Mkv],
+        supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Wv],
+    },
+    // WMA had no compatibility-matrix row at all; `.wma`/`.wmv`/`.asf` all
+    // declare `wmav2` as their default audio codec (see `asf_family_gets_wmav2`).
+    // Keyed to the exact FFmpeg codec-ID name for the same reason as
+    // `pcm_s16be` above.
+    //
+    // Same singleton dependency as `pcm_s16be`: `encoders` must stay
+    // `[("wmav2", _)]` (key == encoder name) for tier 1 to be behaviourally
+    // identical to tier 3's fallback — see `resolve_declared_codec`.
+    AudioCodecEntry {
+        codec: "wmav2",
+        display_name: "WMA v2",
+        encoders: &[("wmav2", "Windows Media Audio 2 (built-in)")],
+        supported_containers: &[
+            ContainerFormat::Wma,
+            ContainerFormat::Wmv,
+            ContainerFormat::Asf,
+        ],
     },
     AudioCodecEntry {
         codec: "tta",
@@ -488,6 +584,18 @@ mod tests {
         assert!(enc.is_some(), "should resolve aac codec");
     }
 
+    /// CRITICAL-8 regression guard: `resolve_audio_encoder("pcm")` must
+    /// resolve via the `pcm_s16le` row's alias, not fall through to `None`.
+    /// `pcm_s16le` is a built-in `FFmpeg` encoder present in every build (the
+    /// same assumption `audio_only_containers_get_their_own_codec_not_aac`
+    /// already makes unguarded), so this is safe to assert unconditionally.
+    #[test]
+    fn resolve_encoder_by_alias_pcm() {
+        ensure_init_for_test();
+        assert_eq!(resolve_audio_encoder("pcm"), Some("pcm_s16le"));
+        assert_eq!(preferred_audio_encoder("pcm"), Some("pcm_s16le"));
+    }
+
     #[test]
     fn resolve_encoder_by_encoder_name() {
         // "libmp3lame" is an ENCODER name (the sole encoder under codec key
@@ -544,14 +652,6 @@ mod tests {
     }
 
     #[test]
-    fn container_does_not_support_mp4_vorbis() {
-        assert!(!container_supports_audio_codec(
-            ContainerFormat::Mp4,
-            "vorbis"
-        ));
-    }
-
-    #[test]
     fn container_does_not_support_mov_opus() {
         assert!(!container_supports_audio_codec(
             ContainerFormat::Mov,
@@ -567,14 +667,6 @@ mod tests {
             enc == Some("aac") || enc == Some("libfdk_aac"),
             "expected aac encoder for mp4, got {enc:?}"
         );
-    }
-
-    #[test]
-    fn compatibility_rejects_vorbis_mp4() {
-        assert!(!container_supports_audio_codec(
-            ContainerFormat::Mp4,
-            "vorbis"
-        ));
     }
 
     #[test]
@@ -752,5 +844,189 @@ mod tests {
 
     fn ensure_init_for_test() {
         crate::ffmpeg::ensure_init().expect("ffmpeg init");
+    }
+
+    /// Each codec whose own container exists as a variant must list it. The
+    /// registry not knowing that FLAC belongs in .flac made
+    /// `--recode-audio=flac` into .flac emit a bogus incompatibility warning.
+    #[test]
+    fn codecs_list_their_own_container() {
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Flac,
+            "flac"
+        ));
+        assert!(container_supports_audio_codec(ContainerFormat::Wav, "pcm"));
+        assert!(container_supports_audio_codec(ContainerFormat::Mp3, "mp3"));
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Opus,
+            "opus"
+        ));
+        assert!(container_supports_audio_codec(ContainerFormat::Ac3, "ac3"));
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Wv,
+            "wavpack"
+        ));
+    }
+
+    /// Negative control: the gap-closing must not make everything true. The
+    /// sole owner of the "mp4 does not accept vorbis" assertion — it used to
+    /// be duplicated verbatim across three tests
+    /// (`container_does_not_support_mp4_vorbis`, `compatibility_rejects_vorbis_mp4`,
+    /// and this one); the other two were removed.
+    #[test]
+    fn unrelated_container_codec_pairs_stay_false() {
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::WebM,
+            "flac"
+        ));
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mp4,
+            "vorbis"
+        ));
+    }
+
+    /// Big-endian PCM (AIFF/CAF declare `pcm_s16be`, distinct from the
+    /// little-endian `pcm` row's `pcm_s16le`) had no compatibility-matrix
+    /// row at all — `container_supports_audio_codec` returned `false` for a
+    /// combination `select_audio_encoder_for_container` already produces by
+    /// default via tier 3. Keyed to the exact muxer-declared codec-ID name so
+    /// it doesn't drift from `muxer_defaults::declared_codec`.
+    #[test]
+    fn big_endian_pcm_containers_recognized() {
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Aiff,
+            "pcm_s16be"
+        ));
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Caf,
+            "pcm_s16be"
+        ));
+    }
+
+    /// WMA had no compatibility-matrix row at all, even though `.wma`/`.wmv`/
+    /// `.asf` all declare `wmav2` as their default audio codec.
+    #[test]
+    fn wma_family_containers_recognized() {
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Wma,
+            "wmav2"
+        ));
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Wmv,
+            "wmav2"
+        ));
+        assert!(container_supports_audio_codec(
+            ContainerFormat::Asf,
+            "wmav2"
+        ));
+    }
+
+    /// Negative control for the two new rows: they must not leak into
+    /// unrelated containers.
+    #[test]
+    fn new_rows_do_not_leak_into_unrelated_containers() {
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mp4,
+            "pcm_s16be"
+        ));
+        assert!(!container_supports_audio_codec(
+            ContainerFormat::Mp4,
+            "wmav2"
+        ));
+    }
+
+    /// The falsifiable form of "the matrix must not disagree with a
+    /// container's own default audio codec". For every `ContainerFormat`,
+    /// derives the expected codec from `audio_default_for` — the same policy
+    /// `select_audio_encoder_for_container` uses — and cross-checks it
+    /// against `container_supports_audio_codec`, i.e. against the static
+    /// table read by a genuinely independent source
+    /// (`muxer_defaults::declared_codec`, which asks the linked `FFmpeg`
+    /// build's muxers directly) for the `FromMuxer` containers. A key typo,
+    /// or a container missing from a row, fails this test by naming the
+    /// exact container and codec — no hardcoded pair to keep in sync by
+    /// hand.
+    #[test]
+    fn every_containers_own_default_codec_is_accepted_by_the_matrix() {
+        use strum::IntoEnumIterator;
+        ensure_init_for_test();
+
+        for container in ContainerFormat::iter() {
+            let expected = match audio_default_for(container) {
+                AudioDefault::NoAudio => {
+                    // The sweep's one unguarded skip: nothing else pins the
+                    // `NoAudio` *classification* itself (only
+                    // `ivf_carries_no_audio` checks the one known instance).
+                    // A container wrongly classified `NoAudio` here would
+                    // otherwise be skipped by this sweep and caught by
+                    // nothing. Cross-check against an INDEPENDENT oracle —
+                    // FFmpeg's own muxer table via `muxer_defaults` — rather
+                    // than `select_audio_encoder_for_container`, which itself
+                    // returns `None` for `NoAudio` via this same
+                    // `audio_default_for` call: asserting against that would
+                    // be one classification read twice, not a cross-check.
+                    assert!(
+                        muxer_defaults::declared_codec(container, codec_registry::MediaKind::Audio)
+                            .is_none(),
+                        "{container:?} is classified NoAudio but its muxer \
+                         declares an audio codec"
+                    );
+                    continue;
+                }
+                AudioDefault::Override(codec) => codec,
+                AudioDefault::FromMuxer => {
+                    let Some(codec) =
+                        muxer_defaults::declared_codec(container, codec_registry::MediaKind::Audio)
+                    else {
+                        // No muxer claims the extension, or the declared id
+                        // is unrepresentable in this build — nothing to
+                        // cross-check against for this container.
+                        continue;
+                    };
+                    codec
+                }
+            };
+
+            assert!(
+                container_supports_audio_codec(container, expected),
+                "{container:?}'s own default audio codec {expected:?} is not \
+                 accepted by its own compatibility-matrix row"
+            );
+        }
+    }
+
+    /// Falsifiable, generalising form of the CRITICAL-8 regression guard:
+    /// for every row, every declared alias must resolve (via
+    /// `preferred_audio_encoder`) to the exact same encoder as the row's own
+    /// primary codec key. Catches not just today's `pcm` alias but any
+    /// future alias added to any row without per-alias test coverage.
+    #[test]
+    fn every_alias_resolves_to_its_rows_own_encoder() {
+        use codec_registry::CodecRow;
+        ensure_init_for_test();
+
+        for row in AUDIO_CODEC_PREFERENCES {
+            let primary = preferred_audio_encoder(row.codec());
+            for alias in row.aliases() {
+                // `assert_eq!` below passes vacuously when `primary` is
+                // `None` (e.g. a row whose encoders are all absent from this
+                // FFmpeg build) — guard against that so the equality check
+                // is only ever trusted when it had something to compare.
+                assert!(
+                    primary.is_some(),
+                    "alias {alias:?} is declared on codec {:?}, whose own \
+                     encoders are unavailable in this build — the equality \
+                     below would pass vacuously",
+                    row.codec()
+                );
+                assert_eq!(
+                    preferred_audio_encoder(alias),
+                    primary,
+                    "alias {alias:?} of codec {:?} must resolve to the same \
+                     encoder as the primary key",
+                    row.codec()
+                );
+            }
+        }
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -55,6 +55,12 @@ struct AudioCodecEntry {
     encoders: &'static [(&'static str, &'static str)],
     /// Container formats this codec is compatible with.
     supported_containers: &'static [ContainerFormat],
+    /// Alternate names that should also resolve to this row. Declared next
+    /// to the row it describes rather than in a separate `match self.codec`
+    /// keyed by string — that indirection let a rename of `codec` silently
+    /// drop the alias through the `CodecRow::aliases` trait default. Empty
+    /// for every row but `pcm_s16le`.
+    aliases: &'static [&'static str],
 }
 
 impl codec_registry::CodecRow for AudioCodecEntry {
@@ -65,14 +71,7 @@ impl codec_registry::CodecRow for AudioCodecEntry {
         self.encoders
     }
     fn aliases(&self) -> &'static [&'static str] {
-        // "pcm" predates this row being keyed to its exact codec-ID name
-        // (`pcm_s16le`) and is a CLI vocabulary word a user may still type
-        // from muscle memory; the alias keeps it resolving without
-        // reintroducing the exact-key mismatch the rename fixes.
-        match self.codec {
-            "pcm_s16le" => &["pcm"],
-            _ => &[],
-        }
+        self.aliases
     }
 }
 
@@ -106,6 +105,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::M4v,
             ContainerFormat::F4v,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "mp3",
@@ -121,6 +121,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             // Flv's muxer declares mp3 as its default audio codec.
             ContainerFormat::Flv,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "opus",
@@ -136,6 +137,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Ogg,
             ContainerFormat::Opus,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "vorbis",
@@ -147,6 +149,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Ogg,
             ContainerFormat::Nut,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "flac",
@@ -157,6 +160,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Ogg,
             ContainerFormat::Flac,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "alac",
@@ -167,6 +171,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mov,
             ContainerFormat::Mkv,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "ac3",
@@ -180,6 +185,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Ts,
             ContainerFormat::Ac3,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "eac3",
@@ -191,12 +197,14 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mkv,
             ContainerFormat::Ts,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "dts",
         display_name: "DTS",
         encoders: &[("dca", "DTS (built-in)")],
         supported_containers: &[ContainerFormat::Mkv],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "mp2",
@@ -209,6 +217,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mpg,
             ContainerFormat::Vob,
         ],
+        aliases: &[],
     },
     // Keyed to the exact FFmpeg codec-ID name (rather than the historical
     // "pcm" vocabulary word) so it matches `muxer_defaults::declared_codec`
@@ -236,15 +245,16 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Mxf,
             ContainerFormat::Dv,
         ],
+        aliases: &["pcm"],
     },
     // Big-endian PCM is a distinct codec-ID from the little-endian
     // `pcm_s16le` row above (AIFF/CAF declare `pcm_s16be`; WAV/AVI/MKV
     // declare `pcm_s16le`). Keyed to the exact FFmpeg codec-ID name so it
     // matches `muxer_defaults::declared_codec` and stays in tier 1 rather
-    // than silently falling through to tier 3's literal-encoder-name
+    // than silently falling through to tier 2's literal-encoder-name
     // fallback in `resolve_declared_codec`.
     //
-    // Behavioural neutrality of this row being in tier 1 rather than tier 3
+    // Behavioural neutrality of this row being in tier 1 rather than tier 2
     // depends on `encoders` staying the singleton `[("pcm_s16be", _)]` where
     // the encoder name equals the codec key — see `resolve_declared_codec`'s
     // doc comment for the structural argument. Adding a second encoder here
@@ -254,12 +264,14 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
         display_name: "PCM 16-bit big-endian",
         encoders: &[("pcm_s16be", "PCM 16-bit big-endian (built-in)")],
         supported_containers: &[ContainerFormat::Aiff, ContainerFormat::Caf],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "wavpack",
         display_name: "WavPack",
         encoders: &[("wavpack", "WavPack (built-in)")],
         supported_containers: &[ContainerFormat::Mkv, ContainerFormat::Wv],
+        aliases: &[],
     },
     // WMA had no compatibility-matrix row at all; `.wma`/`.wmv`/`.asf` all
     // declare `wmav2` as their default audio codec (see `asf_family_gets_wmav2`).
@@ -268,7 +280,7 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
     //
     // Same singleton dependency as `pcm_s16be`: `encoders` must stay
     // `[("wmav2", _)]` (key == encoder name) for tier 1 to be behaviourally
-    // identical to tier 3's fallback — see `resolve_declared_codec`.
+    // identical to tier 2's fallback — see `resolve_declared_codec`.
     AudioCodecEntry {
         codec: "wmav2",
         display_name: "WMA v2",
@@ -278,12 +290,14 @@ static AUDIO_CODEC_PREFERENCES: &[AudioCodecEntry] = &[
             ContainerFormat::Wmv,
             ContainerFormat::Asf,
         ],
+        aliases: &[],
     },
     AudioCodecEntry {
         codec: "tta",
         display_name: "TTA",
         encoders: &[("tta", "TTA (built-in)")],
         supported_containers: &[ContainerFormat::Mkv],
+        aliases: &[],
     },
 ];
 
@@ -498,7 +512,7 @@ pub fn select_audio_encoder_for_container(container: ContainerFormat) -> Option<
                 muxer_defaults::declared_codec(container, codec_registry::MediaKind::Audio)
             else {
                 // Every other `None` path logs (the ABI-skew warn inside
-                // `declared_codec`, the tier-4 AAC-fallback warn below) or is
+                // `declared_codec`, the tier-3 AAC-fallback warn below) or is
                 // a declared policy (`NoAudio`). "No muxer claims this
                 // extension" is the one case that would otherwise pass
                 // through silently — the case an operator would most want to
@@ -517,19 +531,23 @@ pub fn select_audio_encoder_for_container(container: ContainerFormat) -> Option<
     resolve_declared_codec(codec, container)
 }
 
-/// Resolves a declared codec-ID name to an available encoder, falling back
-/// to AAC-with-a-warning (tier 4) when nothing else works.
+/// Resolves a declared codec-ID name to an available encoder, in three tiers:
+///
+/// 1. **Preference-table match** — `codec` is an exact key in
+///    `AUDIO_CODEC_PREFERENCES` (or one of its aliases); use the best
+///    available encoder for that row (e.g. `libfdk_aac` over `aac`).
+/// 2. **Literal encoder-name fallback** — `codec` has no table row (native
+///    single-encoder codecs like PCM/WMA have none: the codec-ID name IS the
+///    encoder name), so accept it directly if it's available in this build.
+/// 3. **AAC-with-a-warning fallback** — neither tier resolved anything;
+///    substitute AAC, but only when `container` can actually carry it (see
+///    Important-2), and always log so this never becomes a silent
+///    catch-all.
 ///
 /// `codec` is `FFmpeg`'s codec-ID name (e.g. "`pcm_s16le`", "`wmav2`", "vorbis"),
-/// not necessarily a key in `AUDIO_CODEC_PREFERENCES`: aliased codecs like
-/// mp3/vorbis have a table row that maps to a differently-named lib encoder,
-/// but native single-encoder codecs like PCM/WMA have no row at all — for
-/// those, the codec-ID name IS the encoder name. Try the preference-table
-/// mapping first (it also picks the *best* of several encoders, e.g.
-/// `libfdk_aac` over `aac`), then fall back to treating the declared name as
-/// a literal encoder.
+/// not necessarily a key in `AUDIO_CODEC_PREFERENCES` — see tier 2 above.
 ///
-/// Split out of [`select_audio_encoder_for_container`] so tier 4 is
+/// Split out of [`select_audio_encoder_for_container`] so tier 3 is
 /// testable with an arbitrary/bogus codec name, independent of what any
 /// particular linked `FFmpeg` build actually declares.
 ///
@@ -537,7 +555,7 @@ pub fn select_audio_encoder_for_container(container: ContainerFormat) -> Option<
 /// — it does not check `AV_CODEC_CAP_EXPERIMENTAL`. `FFmpeg`'s native
 /// `vorbis`/`opus` encoders both carry that flag and fail to open without
 /// `strict_std_compliance = experimental`, so on a build lacking
-/// `libvorbis`/`libopus` this tier can resolve a codec-ID name (`vorbis`)
+/// `libvorbis`/`libopus` tier 2 can resolve a codec-ID name (`vorbis`)
 /// that "is available" by this check yet won't actually open. Not filtered
 /// here: none of rdlp's transcode call sites set `strict_std_compliance`, so
 /// this is a real gap. It is deferred, not because filtering would require
@@ -552,9 +570,23 @@ fn resolve_declared_codec(codec: &'static str, container: ContainerFormat) -> Op
         .or_else(|| is_audio_encoder_available(codec).then_some(codec))
         .or_else(|| {
             // Neither the preference table nor a direct name match resolved
-            // an available encoder. Fall back to AAC, but SAY SO — a silent
-            // fallback would recreate the invisible `_ => aac` this change
-            // exists to remove.
+            // an available encoder. AAC is only a sane fallback when the
+            // container can actually carry it — substituting it into a
+            // container that provably cannot (e.g. `.mp3` on a build without
+            // libmp3lame) would recreate the #618 failure class in reduced
+            // form. Refuse truthfully instead; the caller already turns a
+            // `None` here into `RecodeStage`'s/normalize's honest refusal.
+            if !container_supports_audio_codec(container, "aac") {
+                log::warn!(
+                    "no encoder available for {codec} (default for {}), and that \
+                     container cannot carry AAC either; refusing rather than \
+                     producing a container-incompatible file",
+                    container.as_ext()
+                );
+                return None;
+            }
+            // Fall back to AAC, but SAY SO — a silent fallback would
+            // recreate the invisible `_ => aac` this change exists to remove.
             log::warn!(
                 "no encoder available for {codec} (default for {}); falling back to AAC",
                 container.as_ext()
@@ -703,7 +735,7 @@ mod tests {
 
     /// Guarded against a thin build lacking `libmp3lame`: on a build with it,
     /// this fails under the old `_ => "aac"` catch-all (mutation-verified,
-    /// see the module report). On a build WITHOUT it, tier 4's AAC-fallback
+    /// see the module report). On a build WITHOUT it, tier 3's AAC-fallback
     /// is correct by design, so a bare "must not be aac" would itself be a
     /// false failure — the honest form only asserts the exact
     /// codec when it's actually available.
@@ -754,10 +786,12 @@ mod tests {
     /// against `declared_codec(..)`, which would be a tautology that
     /// survives mutating the override away. Guarded the same honest way as
     /// `asf_family_gets_wmav2`: only asserted when the encoder is
-    /// actually available, since tier 4's AAC fallback is correct by design
+    /// actually available, since tier 3's AAC fallback is correct by design
     /// otherwise.
     #[test]
     fn overrides_are_exactly_these_four() {
+        use strum::IntoEnumIterator;
+
         ensure_init_for_test();
         for c in [
             ContainerFormat::Mkv,
@@ -776,12 +810,32 @@ mod tests {
             threegp == Some("aac") || threegp == Some("libfdk_aac"),
             "expected an aac-family encoder for 3gp, got {threegp:?}"
         );
+
+        // The "exactly" half: no OTHER container may be classified
+        // `AudioDefault::Override`. Without this, adding e.g.
+        // `Avi => Override("opus")` to `audio_default_for` would leave the
+        // assertions above green.
+        let known_overrides = [
+            ContainerFormat::Mkv,
+            ContainerFormat::Mka,
+            ContainerFormat::Ogg,
+            ContainerFormat::ThreeGp,
+        ];
+        for container in ContainerFormat::iter() {
+            let is_override = matches!(audio_default_for(container), AudioDefault::Override(_));
+            assert_eq!(
+                is_override,
+                known_overrides.contains(&container),
+                "{container:?}: AudioDefault::Override classification does not \
+                 match the known set of four overrides"
+            );
+        }
     }
 
     /// Containers that defer to the muxer must NOT all be AAC — that was the
     /// old catch-all's signature failure. Guarded the same honest way as
     /// `asf_family_gets_wmav2`: on a thin build missing
-    /// `mp2`/`libvorbis`, tier 4's AAC fallback is correct by design, so
+    /// `mp2`/`libvorbis`, tier 3's AAC fallback is correct by design, so
     /// these only assert the exact codec when it's actually available.
     #[test]
     fn from_muxer_containers_are_not_uniformly_aac() {
@@ -828,17 +882,37 @@ mod tests {
     }
 
     /// Tier 4 (the AAC-with-warning fallback the whole design hinges on
-    /// being VISIBLE) had no test — tiers 1-3 were covered, tier 4 wasn't.
+    /// being VISIBLE) had no test — tiers 1-2 were covered, tier 3 wasn't.
     /// A bogus codec name skips the preference table (tier 1) and the
-    /// direct-name check (tier 3) unconditionally, landing on tier 4
+    /// direct-name check (tier 2) unconditionally, landing on tier 3
     /// regardless of what any particular linked `FFmpeg` build declares.
     #[test]
-    fn tier_four_falls_back_to_aac_for_an_unresolvable_codec() {
+    fn tier_three_falls_back_to_aac_for_an_unresolvable_codec() {
         ensure_init_for_test();
         let enc = resolve_declared_codec("definitely_not_a_real_codec_xyz", ContainerFormat::Mp4);
         assert!(
             enc == Some("aac") || enc == Some("libfdk_aac"),
-            "expected tier 4 to fall back to an aac-family encoder, got {enc:?}"
+            "expected tier 3 to fall back to an aac-family encoder, got {enc:?}"
+        );
+    }
+
+    /// Important-2: tier 3 must NOT hand back AAC when the target container
+    /// provably cannot carry it — that would recreate the #618 failure class
+    /// in reduced form (a thin build without libmp3lame would still resolve
+    /// AAC for `.mp3`, which the mp3 muxer rejects). `Wav` is not in the
+    /// `aac` row's `supported_containers`, so this is a genuine mismatch, not
+    /// a build-availability accident.
+    #[test]
+    fn tier_three_refuses_rather_than_returning_aac_for_a_container_that_cannot_carry_it() {
+        ensure_init_for_test();
+        assert!(
+            !container_supports_audio_codec(ContainerFormat::Wav, "aac"),
+            "test premise: wav must not accept aac"
+        );
+        let enc = resolve_declared_codec("definitely_not_a_real_codec_xyz", ContainerFormat::Wav);
+        assert_eq!(
+            enc, None,
+            "wav cannot carry aac; tier 3 must refuse rather than substitute it"
         );
     }
 
@@ -889,7 +963,7 @@ mod tests {
     /// little-endian `pcm` row's `pcm_s16le`) had no compatibility-matrix
     /// row at all — `container_supports_audio_codec` returned `false` for a
     /// combination `select_audio_encoder_for_container` already produces by
-    /// default via tier 3. Keyed to the exact muxer-declared codec-ID name so
+    /// default via tier 2. Keyed to the exact muxer-declared codec-ID name so
     /// it doesn't drift from `muxer_defaults::declared_codec`.
     #[test]
     fn big_endian_pcm_containers_recognized() {
@@ -965,6 +1039,11 @@ mod tests {
                     // returns `None` for `NoAudio` via this same
                     // `audio_default_for` call: asserting against that would
                     // be one classification read twice, not a cross-check.
+                    // Residual gap: `declared_codec`'s own doc warns `None`
+                    // has three causes, only one of which is "no audio slot
+                    // at all" — an ABI-skew `None` (muxer declares a codec id
+                    // this build's libavcodec can't name) would let a
+                    // misclassified `NoAudio` through this cross-check too.
                     assert!(
                         muxer_defaults::declared_codec(container, codec_registry::MediaKind::Audio)
                             .is_none(),

--- a/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/audio_encoder_registry.rs
@@ -406,7 +406,7 @@ pub fn select_audio_encoder_for_container(container: ContainerFormat) -> Option<
                 // a declared policy (`NoAudio`). "No muxer claims this
                 // extension" is the one case that would otherwise pass
                 // through silently — the case an operator would most want to
-                // see (Minor-10, #618 fix wave 1).
+                // see (#618).
                 log::warn!(
                     "no muxer declares an audio codec for container {}; \
                      no default audio encoder available",
@@ -435,19 +435,22 @@ pub fn select_audio_encoder_for_container(container: ContainerFormat) -> Option<
 ///
 /// Split out of [`select_audio_encoder_for_container`] so tier 4 is
 /// testable with an arbitrary/bogus codec name, independent of what any
-/// particular linked `FFmpeg` build actually declares (Minor-12).
+/// particular linked `FFmpeg` build actually declares.
 ///
-/// Caveat (Minor-7): `is_audio_encoder_available` is a bare
-/// `find_by_name(..).is_some()` — it does not check
-/// `AV_CODEC_CAP_EXPERIMENTAL`. `FFmpeg`'s native `vorbis`/`opus` encoders
-/// both carry that flag and fail to open without
+/// Caveat: `is_audio_encoder_available` is a bare `find_by_name(..).is_some()`
+/// — it does not check `AV_CODEC_CAP_EXPERIMENTAL`. `FFmpeg`'s native
+/// `vorbis`/`opus` encoders both carry that flag and fail to open without
 /// `strict_std_compliance = experimental`, so on a build lacking
 /// `libvorbis`/`libopus` this tier can resolve a codec-ID name (`vorbis`)
 /// that "is available" by this check yet won't actually open. Not filtered
 /// here: none of rdlp's transcode call sites set `strict_std_compliance`, so
-/// this is a real gap, but plumbing capability flags through this lookup is
-/// a materially bigger change than the rest of this fix wave — left for a
-/// follow-up rather than folded in here.
+/// this is a real gap. It is deferred, not because filtering would require
+/// major plumbing — `ffmpeg-the-third` already exposes
+/// `Codec::capabilities()` / `Capabilities::EXPERIMENTAL`, so a self-filter
+/// here would be a few lines with no new plumbing — but because the failure
+/// mode this leaves in place is a loud encoder-open error at transcode time,
+/// not a silent wrong-codec substitution (the #618 bug class). Tracked as
+/// #625.
 fn resolve_declared_codec(codec: &'static str, container: ContainerFormat) -> Option<&'static str> {
     preferred_audio_encoder(codec)
         .or_else(|| is_audio_encoder_available(codec).then_some(codec))
@@ -610,7 +613,7 @@ mod tests {
     /// this fails under the old `_ => "aac"` catch-all (mutation-verified,
     /// see the module report). On a build WITHOUT it, tier 4's AAC-fallback
     /// is correct by design, so a bare "must not be aac" would itself be a
-    /// false failure (Minor-6) — the honest form only asserts the exact
+    /// false failure — the honest form only asserts the exact
     /// codec when it's actually available.
     #[test]
     fn audio_only_containers_get_their_own_codec_not_aac() {
@@ -658,7 +661,7 @@ mod tests {
     /// The four overrides, asserted against literal encoder names — NOT
     /// against `declared_codec(..)`, which would be a tautology that
     /// survives mutating the override away. Guarded the same honest way as
-    /// `asf_family_gets_wmav2` (Minor-6): only asserted when the encoder is
+    /// `asf_family_gets_wmav2`: only asserted when the encoder is
     /// actually available, since tier 4's AAC fallback is correct by design
     /// otherwise.
     #[test]
@@ -685,7 +688,7 @@ mod tests {
 
     /// Containers that defer to the muxer must NOT all be AAC — that was the
     /// old catch-all's signature failure. Guarded the same honest way as
-    /// `asf_family_gets_wmav2` (Minor-6): on a thin build missing
+    /// `asf_family_gets_wmav2`: on a thin build missing
     /// `mp2`/`libvorbis`, tier 4's AAC fallback is correct by design, so
     /// these only assert the exact codec when it's actually available.
     #[test]
@@ -732,10 +735,10 @@ mod tests {
         }
     }
 
-    /// Minor-12: tier 4 (the AAC-with-warning fallback the whole design
-    /// hinges on being VISIBLE) had no test — tiers 1-3 were covered, tier 4
-    /// wasn't. A bogus codec name skips the preference table (tier 1) and
-    /// the direct-name check (tier 3) unconditionally, landing on tier 4
+    /// Tier 4 (the AAC-with-warning fallback the whole design hinges on
+    /// being VISIBLE) had no test — tiers 1-3 were covered, tier 4 wasn't.
+    /// A bogus codec name skips the preference table (tier 1) and the
+    /// direct-name check (tier 3) unconditionally, landing on tier 4
     /// regardless of what any particular linked `FFmpeg` build declares.
     #[test]
     fn tier_four_falls_back_to_aac_for_an_unresolvable_codec() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/codec_registry.rs
@@ -22,6 +22,20 @@ pub trait CodecRow {
     fn codec(&self) -> &'static str;
     /// Ordered encoder preference list: `(encoder_name, display_name)`.
     fn encoders(&self) -> &'static [(&'static str, &'static str)];
+    /// Alternate names that should also resolve to this row, e.g. a
+    /// pre-existing CLI vocabulary word that predates the row being keyed to
+    /// its exact codec-ID name. Defaults to none so rows (and the video
+    /// registry, which has no aliases at all) need not opt in.
+    ///
+    /// Must be lowercase — [`Registry::lookup_preferred`]'s memoised map is
+    /// keyed on an already-lowercased needle (see [`Registry::preferred_encoder`]
+    /// / [`Registry::resolve`]) and does an exact-key lookup, so an
+    /// uppercase alias here would silently never match. [`Registry::find_row`]
+    /// case-folds both sides instead and has no such restriction — that
+    /// divergence is deliberate; don't "fix" `find_row` to match this map.
+    fn aliases(&self) -> &'static [&'static str] {
+        &[]
+    }
 }
 
 /// Which media a registry serves. Also supplies the word used in the
@@ -66,12 +80,17 @@ impl<R: CodecRow + 'static> Registry<R> {
         }
     }
 
-    /// Finds the row for a codec name, case-insensitively.
+    /// Finds the row for a codec name, case-insensitively. Matches either the
+    /// row's primary codec name or one of its [`CodecRow::aliases`].
     #[must_use]
     pub fn find_row(&self, codec: &str) -> Option<&'static R> {
-        self.table
-            .iter()
-            .find(|row| row.codec().eq_ignore_ascii_case(codec))
+        self.table.iter().find(|row| {
+            row.codec().eq_ignore_ascii_case(codec)
+                || row
+                    .aliases()
+                    .iter()
+                    .any(|alias| alias.eq_ignore_ascii_case(codec))
+        })
     }
 
     /// Best available encoder for a codec name, memoised in this registry's cache.
@@ -105,6 +124,31 @@ impl<R: CodecRow + 'static> Registry<R> {
                 }
 
                 map.insert(row.codec(), selected);
+
+                // Aliases resolve through this same map, not just through
+                // `find_row` — otherwise a codec reachable only by its alias
+                // (e.g. the CLI vocabulary word "pcm") resolves via
+                // `find_row`-based callers but returns `None` from
+                // `preferred_encoder`/`resolve`. See `CodecRow::aliases`'s
+                // doc comment for why this insert requires a lowercase
+                // alias and why that's a different contract from `find_row`.
+                //
+                // The `debug_assert_eq!` below is compiled out in release, so
+                // it is not what enforces that contract — the real guard is
+                // `audio_encoder_registry`'s
+                // `every_alias_resolves_to_its_rows_own_encoder`, which fails
+                // in any profile because an uppercase alias is inserted
+                // verbatim while the lookup needle arrives lowercased, so the
+                // map misses. Do not delete that test believing this assert
+                // covers release builds.
+                for alias in row.aliases() {
+                    debug_assert_eq!(
+                        *alias,
+                        alias.to_ascii_lowercase(),
+                        "CodecRow::aliases must be declared lowercase: {alias:?}"
+                    );
+                    map.insert(alias, selected);
+                }
             }
             map
         });
@@ -179,6 +223,83 @@ mod tests {
     }];
 
     static REGISTRY_FAKE: Registry<FakeRow> = Registry::new(FAKE_TABLE, MediaKind::Audio);
+
+    struct AliasedRow {
+        codec: &'static str,
+        aliases: &'static [&'static str],
+        encoders: &'static [(&'static str, &'static str)],
+    }
+
+    impl CodecRow for AliasedRow {
+        fn codec(&self) -> &'static str {
+            self.codec
+        }
+        fn encoders(&self) -> &'static [(&'static str, &'static str)] {
+            self.encoders
+        }
+        fn aliases(&self) -> &'static [&'static str] {
+            self.aliases
+        }
+    }
+
+    static ALIASED_TABLE: &[AliasedRow] = &[AliasedRow {
+        codec: "pcm_s16le",
+        aliases: &["pcm"],
+        encoders: &[("pcm_s16le", "PCM")],
+    }];
+
+    static REGISTRY_ALIASED: Registry<AliasedRow> = Registry::new(ALIASED_TABLE, MediaKind::Audio);
+
+    /// `find_row` must match a row by its declared alias, not just its
+    /// primary `codec()` name — the mechanism Important-4 restores.
+    #[test]
+    fn find_row_matches_by_alias() {
+        assert!(REGISTRY_ALIASED.find_row("pcm").is_some());
+        assert!(
+            REGISTRY_ALIASED.find_row("PCM").is_some(),
+            "case-insensitive"
+        );
+        assert_eq!(
+            REGISTRY_ALIASED.find_row("pcm").unwrap().codec(),
+            "pcm_s16le"
+        );
+    }
+
+    /// Negative control: an alias-shaped string that was never declared must
+    /// not accidentally match via the default `&[]` aliases.
+    #[test]
+    fn find_row_does_not_match_undeclared_alias() {
+        assert!(REGISTRY_ALIASED.find_row("pcm_s24le").is_none());
+        assert!(REGISTRY_FAKE.find_row("pcm").is_none());
+    }
+
+    /// `preferred_encoder` must resolve an alias too, not just `find_row` —
+    /// the CRITICAL-8 gap: aliases reached `find_row`-based callers
+    /// (`container_supports_audio_codec`) but not `lookup_preferred`-based
+    /// ones (`preferred_audio_encoder`, `resolve_audio_encoder`), so
+    /// `--recode-audio=pcm` silently fell through to a container default.
+    #[test]
+    fn preferred_encoder_resolves_via_alias() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(REGISTRY_ALIASED.preferred_encoder("pcm"), Some("pcm_s16le"));
+    }
+
+    /// Same gap through the `resolve` entry point (what
+    /// `resolve_audio_encoder` — and therefore the CLI/config `pcm` value —
+    /// actually calls).
+    #[test]
+    fn resolve_resolves_via_alias() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(REGISTRY_ALIASED.resolve("pcm"), Some("pcm_s16le"));
+    }
+
+    /// Negative control: an undeclared alias-shaped string must still miss
+    /// through the memoised-map path, same as it does through `find_row`.
+    #[test]
+    fn preferred_encoder_undeclared_alias_is_none() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(REGISTRY_ALIASED.preferred_encoder("pcm_s24le"), None);
+    }
 
     #[test]
     fn is_encoder_available_false_for_nonsense_name() {

--- a/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/encoding_tag.rs
@@ -98,6 +98,26 @@ pub unsafe fn set_encoding_tool_ffi_if_missing(
     }
 }
 
+/// Component string for the `encoding_tool` tag's audio segment.
+///
+/// `audio_copy` takes precedence over `audio_codec` — matches the documented
+/// contract on `VideoConvertOptions` (`audio_copy` wins when both are set: a
+/// stream copy happens even if `audio_codec` names an encoder). A resolved
+/// codec name is only consulted when `audio_copy` is `false`; otherwise
+/// `audio_copy` distinguishes a genuine stream copy (`"copy"`) from no audio
+/// stream at all (`"none"`) — a video-only source must resolve here, not
+/// stamp a false `"copy"`.
+#[must_use]
+pub const fn audio_tag_component(audio_copy: bool, audio_codec: Option<&str>) -> &str {
+    if audio_copy {
+        "copy"
+    } else if let Some(codec) = audio_codec {
+        codec
+    } else {
+        "none"
+    }
+}
+
 /// Set the `encoder` per-stream tag on a high-level output stream.
 pub fn set_stream_encoder(
     octx: &mut ffmpeg_the_third::format::context::Output,
@@ -134,5 +154,19 @@ mod tests {
     fn test_encoding_tool_tag_single_component() {
         let tag = encoding_tool_tag("libfdk_aac");
         assert!(tag.contains("(libfdk_aac)"), "tag: {tag}");
+    }
+
+    /// Pins the `encoding_tool` tag's audio component for the four
+    /// `(audio_copy, audio_codec)` combinations, including the video-only
+    /// case that used to stamp a false "copy" and the `(true, Some(_))`
+    /// case where `audio_copy` must win over a resolved codec name (matches
+    /// `VideoConvertOptions`'s documented precedence).
+    #[test]
+    fn audio_tag_component_matrix() {
+        assert_eq!(audio_tag_component(false, None), "none");
+        assert_eq!(audio_tag_component(true, None), "copy");
+        assert_eq!(audio_tag_component(false, Some("libopus")), "libopus");
+        // `audio_copy` wins even when a codec name is also present.
+        assert_eq!(audio_tag_component(true, Some("libopus")), "copy");
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -51,6 +51,7 @@ pub mod fixup;
 pub mod log_capture;
 mod merge;
 mod metadata;
+pub(crate) mod muxer_defaults;
 mod normalize;
 mod normalize_types;
 mod options;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/mod.rs
@@ -45,7 +45,7 @@ pub(crate) mod codec_registry;
 mod dts_synth;
 pub(crate) use dts_synth::DtsSynthesizer;
 mod encoding_tag;
-pub use encoding_tag::encoding_tool_tag;
+pub use encoding_tag::{audio_tag_component, encoding_tool_tag};
 mod ffi_helpers;
 pub mod fixup;
 pub mod log_capture;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/muxer_defaults.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/muxer_defaults.rs
@@ -23,6 +23,14 @@ impl MediaKind {
     }
 }
 
+// `declared_codec(_, MediaKind::Video)` has no production caller yet — it is
+// exercised only by `video_kind_answers_separately` below. The planned
+// consumer is deriving a container's default video codec the same
+// muxer-declared way `select_audio_encoder_for_container` does for audio,
+// wiring into `default_codec_for_container`/`validate_speed_controls`. Not
+// speculative surface: it is real, planned follow-up work landing in a later
+// PR, kept here now because the audio and video code paths share this module.
+
 /// The codec the linked build's muxer declares as its default for `container`.
 ///
 /// Returns `None` when the container carries no stream of that kind at all
@@ -95,9 +103,10 @@ pub fn declared_codec(container: ContainerFormat, kind: MediaKind) -> Option<&'s
         let name = CStr::from_ptr(name).to_str().ok()?;
         if name == "unknown_codec" {
             log::warn!(
-                "{container} muxer declared {kind} codec id {}, but the \
+                "{} muxer declared {kind} codec id {}, but the \
                  linked libavcodec has no name for it (descriptor table is \
                  behind the muxer table) — reporting no declared {kind} codec",
+                container.as_ext(),
                 id as u32
             );
             return None;
@@ -175,6 +184,14 @@ mod tests {
     /// each container declares; that per-container table is a later task's to
     /// pin (see the individual exact-pin tests above for the containers that
     /// already have one).
+    ///
+    /// This is a deliberate pin on a full-featured `FFmpeg` build: it asserts
+    /// the EXACT set of audio-less containers, so it fails on any build with
+    /// muxers disabled (`--disable-muxer=caf`, a `--disable-everything`
+    /// distro build, a minimal vendored build) where a container this test
+    /// expects to have audio no longer does. If it fires for that reason,
+    /// the fix is widening the expected set to match the linked build, not
+    /// treating it as a real regression.
     #[test]
     fn every_container_resolves_and_only_ivf_lacks_audio() {
         use strum::IntoEnumIterator;

--- a/crates/rdlp-ffmpeg/src/ffmpeg/muxer_defaults.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/muxer_defaults.rs
@@ -1,0 +1,206 @@
+//! What the linked `FFmpeg` build's muxers declare as their default codecs.
+//!
+//! `AVOutputFormat` carries `audio_codec` / `video_codec` fields — the muxer
+//! author's own answer to "what belongs in this container by default". Reading
+//! them here means rdlp does not keep a second copy of `FFmpeg`'s table that can
+//! drift from whichever build is actually linked.
+
+use std::ffi::{CStr, CString};
+
+use ffmpeg_the_third::ffi::{
+    AVCodecID, AVMediaType, av_guess_codec, av_guess_format, avcodec_get_name,
+};
+use rdlp_types::ContainerFormat;
+
+use super::codec_registry::MediaKind;
+
+impl MediaKind {
+    const fn as_av(self) -> AVMediaType {
+        match self {
+            Self::Audio => AVMediaType::AVMEDIA_TYPE_AUDIO,
+            Self::Video => AVMediaType::AVMEDIA_TYPE_VIDEO,
+        }
+    }
+}
+
+/// The codec the linked build's muxer declares as its default for `container`.
+///
+/// Returns `None` when the container carries no stream of that kind at all
+/// (e.g. `Ivf` has no audio), when no muxer claims the extension, or when the
+/// muxer declares a codec id the linked `libavcodec` cannot name (its
+/// descriptor table is older than the id the muxer produced — an ABI-skew
+/// case, logged as a warning when it happens).
+///
+/// `None` is therefore not proof the container carries no stream of that
+/// kind: the third cause above means a container that genuinely has a codec
+/// of that kind can still resolve to `None` here. Callers that need to
+/// distinguish "no slot of this kind" from "slot present but unrepresentable
+/// in this build" must not treat `None` as equivalent to the first two
+/// causes.
+///
+/// The probe filename is built from [`ContainerFormat::as_ext`] because that is
+/// the projection this code intends to probe with — the actual file extension,
+/// not an arbitrary alias. `Display` happens to equal `as_ext()` for every
+/// variant today (`rdlp-types` pins `to_string` to the extension as of #545,
+/// verified by `test_display_is_the_file_extension`), but that equality is an
+/// `rdlp-types` invariant, not one this module owns; keep using `as_ext()` so
+/// this code stays correct even if that invariant is ever relaxed.
+///
+/// `av_guess_format` scores every registered muxer against the probe name and
+/// returns the first strict-maximum match, so when more than one muxer claims
+/// the same extension the winner is decided by `FFmpeg`'s internal registration
+/// order, not by this code — worth knowing if a declared default ever looks
+/// surprising.
+///
+/// Requires [`super::ensure_init`] to have been called first.
+#[must_use]
+pub fn declared_codec(container: ContainerFormat, kind: MediaKind) -> Option<&'static str> {
+    let probe = CString::new(format!("x.{}", container.as_ext())).ok()?;
+
+    // SAFETY: `av_guess_format` and `av_guess_codec` are pure lookups over
+    // FFmpeg's static muxer tables; `probe` outlives both calls. `ofmt` (when
+    // non-null) points into FFmpeg's static muxer registry, never freed, and
+    // is null-checked below before `av_guess_codec` dereferences `fmt->name`
+    // internally. The returned name pointer is a 'static string literal owned
+    // by FFmpeg.
+    unsafe {
+        let ofmt = av_guess_format(std::ptr::null(), probe.as_ptr(), std::ptr::null());
+        if ofmt.is_null() {
+            return None;
+        }
+
+        let id = av_guess_codec(
+            ofmt,
+            std::ptr::null(),
+            probe.as_ptr(),
+            std::ptr::null(),
+            kind.as_av(),
+        );
+
+        if id == AVCodecID::AV_CODEC_ID_NONE {
+            return None;
+        }
+
+        // `avcodec_get_name` is documented to return a static, NUL-terminated
+        // string and never NULL — it falls back to the literal
+        // "unknown_codec" for any id absent from its descriptor table (see
+        // `FFmpegRunner::unrepresentable_codec_error` in
+        // `ffi_helpers/mod.rs` for the same guarantee cited against the same
+        // C API). The null check below is belt-and-braces; the sentinel is
+        // what we actually reject here.
+        let name = avcodec_get_name(id);
+        if name.is_null() {
+            return None;
+        }
+        let name = CStr::from_ptr(name).to_str().ok()?;
+        if name == "unknown_codec" {
+            log::warn!(
+                "{container} muxer declared {kind} codec id {}, but the \
+                 linked libavcodec has no name for it (descriptor table is \
+                 behind the muxer table) — reporting no declared {kind} codec",
+                id as u32
+            );
+            return None;
+        }
+        Some(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mp3_container_declares_mp3_not_aac() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            declared_codec(ContainerFormat::Mp3, MediaKind::Audio),
+            Some("mp3")
+        );
+    }
+
+    #[test]
+    fn flac_declares_flac_and_wav_declares_pcm() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            declared_codec(ContainerFormat::Flac, MediaKind::Audio),
+            Some("flac")
+        );
+        assert_eq!(
+            declared_codec(ContainerFormat::Wav, MediaKind::Audio),
+            Some("pcm_s16le")
+        );
+    }
+
+    #[test]
+    fn aiff_declares_big_endian_pcm() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            declared_codec(ContainerFormat::Aiff, MediaKind::Audio),
+            Some("pcm_s16be"),
+            "AIFF is big-endian; pcm_s16le would be wrong"
+        );
+    }
+
+    #[test]
+    fn ivf_declares_no_audio_codec() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            declared_codec(ContainerFormat::Ivf, MediaKind::Audio),
+            None,
+            "ivf is a raw video elementary stream and carries no audio"
+        );
+    }
+
+    /// Pins matroska's declared default audio codec. `libavformat/matroskaenc.c`
+    /// picks between vorbis and ac3 depending on whether the linked build
+    /// enables `CONFIG_LIBVORBIS_ENCODER`, so both are valid outcomes here —
+    /// this module intentionally does not keep a second, build-specific copy
+    /// of `FFmpeg`'s table (see the module doc).
+    #[test]
+    fn mkv_declares_vorbis_or_ac3_depending_on_build() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert!(
+            matches!(
+                declared_codec(ContainerFormat::Mkv, MediaKind::Audio),
+                Some("vorbis" | "ac3")
+            ),
+            "matroska declares vorbis when CONFIG_LIBVORBIS_ENCODER is on, else ac3"
+        );
+    }
+
+    /// Only observes which containers resolve NO audio codec at all — either
+    /// because no muxer claims the extension, or because the muxer that does
+    /// claim it declares no default audio codec. It does not pin the *value*
+    /// each container declares; that per-container table is a later task's to
+    /// pin (see the individual exact-pin tests above for the containers that
+    /// already have one).
+    #[test]
+    fn every_container_resolves_and_only_ivf_lacks_audio() {
+        use strum::IntoEnumIterator;
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+
+        let without_audio: Vec<ContainerFormat> = ContainerFormat::iter()
+            .filter(|c| declared_codec(*c, MediaKind::Audio).is_none())
+            .collect();
+
+        assert_eq!(
+            without_audio,
+            vec![ContainerFormat::Ivf],
+            "unexpected set of containers with no declared audio codec"
+        );
+    }
+
+    #[test]
+    fn video_kind_answers_separately() {
+        crate::ffmpeg::ensure_init().expect("ffmpeg init");
+        assert_eq!(
+            declared_codec(ContainerFormat::Dv, MediaKind::Video),
+            Some("dvvideo")
+        );
+        assert_eq!(
+            declared_codec(ContainerFormat::Ivf, MediaKind::Video),
+            Some("vp8")
+        );
+    }
+}

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/encode.rs
@@ -36,9 +36,7 @@ use super::super::ffi_helpers::set_single_thread_codec;
 use super::super::log_capture::LogSuppressGuard;
 use super::super::salvage::open_input_resilient;
 use super::super::transcode::MuxTimingState;
-use super::helpers::{
-    build_audio_filter_with_spec, default_bitrate_for_encoder, select_audio_encoder_for_container,
-};
+use super::helpers::{build_audio_filter_with_spec, default_bitrate_for_encoder};
 use super::io_diag::validate_mux_header_state;
 
 /// Recurring plumbing passed through the normalize encode helpers.
@@ -135,7 +133,7 @@ impl FFmpegRunner {
                 )
             })?;
 
-        let enc_name = select_audio_encoder_for_container(final_output_ext);
+        let enc_name = super::helpers::resolve_normalize_audio_encoder(final_output_ext, label)?;
         let enc_codec = ffmpeg_the_third::encoder::find_by_name(enc_name).ok_or_else(|| {
             PostProcessError::UnsupportedCodec {
                 codec: enc_name.to_string(),

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -225,33 +225,6 @@ pub(super) fn extract_json_value(text: &str, key: &str) -> Option<f64> {
     value_str.trim().parse::<f64>().ok()
 }
 
-/// Select the appropriate audio encoder for a container extension.
-///
-/// Handles both video containers and audio-only output formats (e.g., mp3, flac, wav).
-/// For recognized audio-only extensions, returns the canonical encoder directly.
-/// For video containers, delegates to [`audio_encoder_registry::select_audio_encoder_for_container`].
-/// Falls back to the best available AAC encoder for unknown extensions.
-pub(super) fn select_audio_encoder_for_container(ext: &str) -> &'static str {
-    let Ok(container) = ext.parse::<rdlp_types::ContainerFormat>() else {
-        return crate::ffmpeg::audio_codecs::preferred_aac_encoder();
-    };
-
-    match container {
-        // Lossless/lossy audio-only containers whose own codec is the whole
-        // point: re-encoding a .mp3 to AAC-in-mp3 is not what the user asked
-        // for. The registry's fallback arm would do exactly that, so these are
-        // decided here before delegating.
-        //
-        // (These three WERE matched as raw strings with a comment claiming
-        // they "are not ContainerFormat variants". They are — Mp3, Flac and
-        // Wav have been variants throughout; the comment was simply wrong.)
-        rdlp_types::ContainerFormat::Mp3 => "libmp3lame",
-        rdlp_types::ContainerFormat::Flac => "flac",
-        rdlp_types::ContainerFormat::Wav => "pcm_s16le",
-        other => crate::ffmpeg::audio_encoder_registry::select_audio_encoder_for_container(other),
-    }
-}
-
 /// Get a sensible default bitrate (in bps) for an encoder.
 pub(super) fn default_bitrate_for_encoder(encoder: &str) -> usize {
     match encoder {
@@ -329,6 +302,49 @@ pub(super) const fn audio_only_extension_for(container: ContainerFormat) -> &'st
 pub(super) fn audio_only_extension_for_ext(ext: &str) -> &'static str {
     ext.parse::<ContainerFormat>()
         .map_or(DEFAULT_AUDIO_ONLY.as_ext(), audio_only_extension_for)
+}
+
+/// Resolves the audio encoder for a normalize output extension.
+///
+/// `final_output_ext` is the USER's output path extension, so two distinct
+/// failure modes must stay distinct:
+///
+/// - The extension doesn't parse into a [`ContainerFormat`] at all. This
+///   degrades gracefully to AAC, exactly like the sibling
+///   [`audio_only_extension_for_ext`] — normalization is about container
+///   *defaults* (#618), not about rejecting extensions it doesn't recognise,
+///   and the prior behaviour (before #618) was this same AAC fallback.
+/// - The extension parses but the registry can't determine an encoder for
+///   it (container genuinely carries no audio, or the muxer/codec tables
+///   yielded nothing usable — see
+///   [`super::super::audio_encoder_registry::select_audio_encoder_for_container`]).
+///   This is a real refusal and is reported truthfully: the extension goes
+///   in `format`, never mislabelled as a codec name.
+pub(super) fn resolve_normalize_audio_encoder(
+    final_output_ext: &str,
+    label: &str,
+) -> Result<&'static str> {
+    if let Ok(container) = final_output_ext.parse::<ContainerFormat>() {
+        super::super::audio_encoder_registry::select_audio_encoder_for_container(container)
+            .ok_or_else(|| PostProcessError::UnsupportedFormat {
+                format: final_output_ext.to_string(),
+                operation: format!(
+                    "audio normalization ({label}): no audio encoder could be \
+                     determined for container '{final_output_ext}'"
+                ),
+            })
+    } else {
+        warn!(
+            "audio normalization ({label}): unrecognized output extension \
+             '{final_output_ext}'; falling back to AAC"
+        );
+        super::super::audio_encoder_registry::preferred_audio_encoder("aac").ok_or_else(|| {
+            PostProcessError::UnsupportedCodec {
+                codec: "aac".to_string(),
+                operation: format!("audio normalization ({label})"),
+            }
+        })
+    }
 }
 
 /// Three-tier recovery for mux failures during audio normalization.
@@ -435,48 +451,4 @@ where
 /// [`parse_loudnorm_json`].
 pub(super) fn begin_loudnorm_capture() -> Result<LogCaptureGuard> {
     LogCaptureGuard::begin()
-}
-
-#[cfg(test)]
-mod audio_encoder_selection_tests {
-    use super::select_audio_encoder_for_container;
-
-    /// The three audio-only containers whose own codec is the point. These were
-    /// matched as raw strings before; the answers must not move.
-    #[test]
-    fn audio_only_containers_keep_their_native_encoder() {
-        assert_eq!(select_audio_encoder_for_container("mp3"), "libmp3lame");
-        assert_eq!(select_audio_encoder_for_container("flac"), "flac");
-        assert_eq!(select_audio_encoder_for_container("wav"), "pcm_s16le");
-    }
-
-    /// Case-insensitivity came free with `eq_ignore_ascii_case`; going through
-    /// `FromStr` must preserve it.
-    #[test]
-    fn audio_only_matching_stays_case_insensitive() {
-        assert_eq!(select_audio_encoder_for_container("MP3"), "libmp3lame");
-        assert_eq!(select_audio_encoder_for_container("Flac"), "flac");
-    }
-
-    /// The widening this conversion accepts: `"wave"` is a `ContainerFormat`
-    /// alias for Wav, so it now resolves to `pcm_s16le` where the literal
-    /// `eq_ignore_ascii_case("wav")` missed it and it fell through to the
-    /// registry's AAC fallback. Same class as the other alias widenings in
-    /// this change, and pinned here.
-    #[test]
-    fn wave_alias_resolves_like_wav() {
-        assert_eq!(select_audio_encoder_for_container("wave"), "pcm_s16le");
-    }
-
-    /// An extension that is not a container at all still falls back rather
-    /// than panicking or resolving to an audio-only encoder.
-    #[test]
-    fn unknown_extension_falls_back_to_aac() {
-        let fallback = crate::ffmpeg::audio_codecs::preferred_aac_encoder();
-        assert_eq!(
-            select_audio_encoder_for_container("not-a-container"),
-            fallback
-        );
-        assert_eq!(select_audio_encoder_for_container(""), fallback);
-    }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/helpers.rs
@@ -226,12 +226,19 @@ pub(super) fn extract_json_value(text: &str, key: &str) -> Option<f64> {
 }
 
 /// Get a sensible default bitrate (in bps) for an encoder.
+///
+/// The `0` arm is the lossless sentinel: `bit_rate` is meaningless for these
+/// encoders (they ignore it), and `encode.rs:174` prefers a non-zero input
+/// bitrate when one is known anyway. Widened alongside the audio-default
+/// registry (#618) to cover every lossless encoder now reachable through
+/// `select_audio_encoder_for_container` (`.aiff`/`.caf` → `pcm_s16be`, `.wv`
+/// → `wavpack`), not just the two that were reachable before.
 pub(super) fn default_bitrate_for_encoder(encoder: &str) -> usize {
     match encoder {
         "aac" | "libfdk_aac" => 128_000,
         "libmp3lame" => 192_000,
         "libopus" => 128_000,
-        "flac" | "pcm_s16le" => 0,
+        "flac" | "pcm_s16le" | "pcm_s16be" | "alac" | "wavpack" | "tta" => 0,
         _ => 128_000,
     }
 }

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
@@ -93,6 +93,12 @@ fn test_default_bitrate_for_encoder() {
     assert_eq!(default_bitrate_for_encoder("libopus"), 128_000);
     assert_eq!(default_bitrate_for_encoder("flac"), 0);
     assert_eq!(default_bitrate_for_encoder("pcm_s16le"), 0);
+    // Lossless siblings newly reachable via the widened audio-default
+    // registry (#618): `.aiff`/`.caf` -> pcm_s16be, `.wv` -> wavpack.
+    assert_eq!(default_bitrate_for_encoder("pcm_s16be"), 0);
+    assert_eq!(default_bitrate_for_encoder("alac"), 0);
+    assert_eq!(default_bitrate_for_encoder("wavpack"), 0);
+    assert_eq!(default_bitrate_for_encoder("tta"), 0);
 }
 
 #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
@@ -5,23 +5,84 @@ use super::helpers::*;
 
 #[test]
 fn test_select_audio_encoder_for_container() {
-    // AAC-compatible containers return the preferred AAC encoder
-    // (libfdk_aac if available, built-in aac otherwise)
-    let aac = crate::ffmpeg::audio_codecs::preferred_aac_encoder();
-    assert_eq!(select_audio_encoder_for_container("mp4"), aac);
-    assert_eq!(select_audio_encoder_for_container("m4a"), aac);
-    assert_eq!(select_audio_encoder_for_container("mov"), aac);
-    assert_eq!(select_audio_encoder_for_container("webm"), "libopus");
-    // MKV supports everything; registry prefers Opus for quality/size efficiency
-    assert_eq!(select_audio_encoder_for_container("mkv"), "libopus");
-    assert_eq!(select_audio_encoder_for_container("avi"), "libmp3lame");
-    assert_eq!(select_audio_encoder_for_container("mp3"), "libmp3lame");
-    assert_eq!(select_audio_encoder_for_container("flac"), "flac");
-    assert_eq!(select_audio_encoder_for_container("wav"), "pcm_s16le");
-    assert_eq!(select_audio_encoder_for_container("ts"), aac);
-    assert_eq!(select_audio_encoder_for_container("ogg"), "libopus");
-    assert_eq!(select_audio_encoder_for_container("flv"), aac);
-    assert_eq!(select_audio_encoder_for_container("xyz"), aac);
+    use crate::ffmpeg::audio_encoder_registry::{
+        is_audio_encoder_available, select_audio_encoder_for_container as sel,
+    };
+    use rdlp_types::ContainerFormat as C;
+
+    crate::ffmpeg::ensure_init().expect("ffmpeg init");
+
+    // AAC-family assertions guarded: `preferred_audio_encoder("aac")` prefers
+    // `libfdk_aac` over the built-in `aac` when both are linked (see
+    // audio_encoder_registry's own `select_encoder_for_mp4_returns_aac`).
+    // Mp4/M4a/Mov declare `aac`; ffmpeg's mpegts muxer instead declares mp2,
+    // and avi/flv both declare mp3 — none of these three are aac-family
+    // (verified against the linked build's `av_guess_codec`, not assumed).
+    for c in [C::Mp4, C::M4a, C::Mov] {
+        let enc = sel(c);
+        assert!(
+            enc == Some("aac") || enc == Some("libfdk_aac"),
+            "expected an aac-family encoder for {c:?}, got {enc:?}"
+        );
+    }
+
+    if is_audio_encoder_available("libopus") {
+        assert_eq!(sel(C::WebM), Some("libopus"));
+        assert_eq!(sel(C::Mkv), Some("libopus"));
+        assert_eq!(sel(C::Ogg), Some("libopus"));
+    }
+    if is_audio_encoder_available("libmp3lame") {
+        // avi/flv/mp3 all declare (or, for .mp3, override to) the mp3 codec.
+        assert_eq!(sel(C::Avi), Some("libmp3lame"));
+        assert_eq!(sel(C::Flv), Some("libmp3lame"));
+        assert_eq!(sel(C::Mp3), Some("libmp3lame"));
+    }
+    if is_audio_encoder_available("mp2") {
+        assert_eq!(sel(C::Ts), Some("mp2"));
+    }
+    assert_eq!(sel(C::Flac), Some("flac"));
+    assert_eq!(sel(C::Wav), Some("pcm_s16le"));
+
+    // Behaviour CHANGES from the old `&str` shim, deliberately: IVF carries
+    // no audio stream at all, so it must be refused rather than defaulted.
+    assert_eq!(sel(C::Ivf), None, "was aac under the catch-all");
+}
+
+/// #618 fix-wave-1, Important-3: an output extension that isn't a
+/// `ContainerFormat` at all (`.m2ts`, `.oga`, `.3g2`, ...) must fall back to
+/// AAC exactly like the sibling `audio_only_extension_for_ext` does, not
+/// hard-fail normalization. Regression guard for the deleted
+/// `unknown_extension_falls_back_to_aac` test.
+#[test]
+fn unrecognized_extension_falls_back_to_aac_not_hard_failure() {
+    crate::ffmpeg::ensure_init().expect("ffmpeg init");
+    for ext in ["m2ts", "oga", "3g2", "mts", "divx"] {
+        let enc = resolve_normalize_audio_encoder(ext, "test")
+            .unwrap_or_else(|e| panic!("expected AAC fallback for '.{ext}', got error: {e}"));
+        assert!(
+            enc == "aac" || enc == "libfdk_aac",
+            "expected an aac-family encoder for unparseable ext '.{ext}', got {enc}"
+        );
+    }
+}
+
+/// #618 fix-wave-1, Important-2: a *recognised* container that genuinely has
+/// no resolvable audio encoder (e.g. `.ivf`, no audio stream at all) must
+/// report a truthful cause — never "container carries no audio" folded in
+/// with a parse failure, and never a codec name where an extension belongs.
+#[test]
+fn recognized_extension_with_no_encoder_reports_truthful_cause() {
+    crate::ffmpeg::ensure_init().expect("ffmpeg init");
+    let err = resolve_normalize_audio_encoder("ivf", "test").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no audio encoder could be determined"),
+        "error should name the real cause, got: {msg}"
+    );
+    assert!(
+        msg.contains("ivf"),
+        "error should name the container extension, got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/normalize/tests.rs
@@ -48,7 +48,7 @@ fn test_select_audio_encoder_for_container() {
     assert_eq!(sel(C::Ivf), None, "was aac under the catch-all");
 }
 
-/// #618 fix-wave-1, Important-3: an output extension that isn't a
+/// #618: an output extension that isn't a
 /// `ContainerFormat` at all (`.m2ts`, `.oga`, `.3g2`, ...) must fall back to
 /// AAC exactly like the sibling `audio_only_extension_for_ext` does, not
 /// hard-fail normalization. Regression guard for the deleted
@@ -66,7 +66,7 @@ fn unrecognized_extension_falls_back_to_aac_not_hard_failure() {
     }
 }
 
-/// #618 fix-wave-1, Important-2: a *recognised* container that genuinely has
+/// #618: a *recognised* container that genuinely has
 /// no resolvable audio encoder (e.g. `.ivf`, no audio stream at all) must
 /// report a truthful cause — never "container carries no audio" folded in
 /// with a parse failure, and never a codec name where an extension belongs.

--- a/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
+++ b/crates/rdlp-ffmpeg/src/ffmpeg/transcode/video_transcode_phases.rs
@@ -491,13 +491,10 @@ impl FFmpegRunner {
 
         // Set format-level encoding_tool metadata
         {
-            let audio_component = if let Some(enc_name) = audio_encode_codec {
-                enc_name
-            } else if opts.audio_copy {
-                "copy"
-            } else {
-                "none"
-            };
+            let audio_component = crate::ffmpeg::encoding_tag::audio_tag_component(
+                opts.audio_copy,
+                audio_encode_codec,
+            );
             let tool_components = format!("{video_codec_name} + {audio_component}");
             crate::ffmpeg::encoding_tag::set_encoding_tool(&mut ctx.octx, &tool_components);
         }

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -203,6 +203,80 @@ impl RecodeStage {
         })
     }
 
+    /// Resolves `(audio_copy, audio_codec)` for a transcode (never called on
+    /// the remux fast path, which always copies audio unconditionally).
+    ///
+    /// `has_audio` gates everything else: `setup_audio_pipeline` only creates
+    /// an audio output stream when the input actually has an audio stream
+    /// (`transcode/video_transcode_phases.rs`), so a video-only source has
+    /// always made the resolved encoder irrelevant. Refusing before this
+    /// check (Important-4, #618 fix wave 1) was a regression — a video-only
+    /// `.ivf` recode used to succeed and started hard-failing.
+    fn resolve_audio_params(
+        recode_audio: &RecodeAudioMode,
+        target: ContainerFormat,
+        has_audio: bool,
+    ) -> Result<(bool, Option<String>), PostProcessError> {
+        if !has_audio {
+            return Ok((true, None));
+        }
+
+        let target_ext = target.as_ext();
+        match recode_audio {
+            RecodeAudioMode::Copy => Ok((true, None)),
+            RecodeAudioMode::Auto => {
+                // `None` does not strictly mean "this container cannot carry
+                // audio" — see `muxer_defaults::declared_codec`'s doc for the
+                // other two causes (no muxer claims the extension; ABI skew
+                // between the muxer and libavcodec tables). Refuse truthfully
+                // rather than guessing which cause applies, and rather than
+                // silently dropping the audio track or defaulting to AAC
+                // (FFmpeg itself would refuse with a cryptic "Invalid
+                // argument" if we didn't).
+                let Some(encoder) =
+                    audio_encoder_registry::select_audio_encoder_for_container(target)
+                else {
+                    return Err(PostProcessError::UnsupportedFormat {
+                        format: target_ext.to_string(),
+                        operation: format!(
+                            "no audio encoder could be determined for container \
+                             '{target_ext}'; use --recode-audio=copy with a \
+                             video-only source, or choose a different container"
+                        ),
+                    });
+                };
+                debug!("RecodeStage: auto audio encoder for {target_ext}: {encoder}");
+                Ok((false, Some(encoder.to_string())))
+            }
+            RecodeAudioMode::Encoder { name } => {
+                if !audio_encoder_registry::container_supports_audio_codec(target, name) {
+                    warn!(
+                        "RecodeStage: audio codec '{name}' may not be compatible with \
+                         container '{target_ext}'; proceeding anyway"
+                    );
+                }
+                let resolved = audio_encoder_registry::resolve_audio_encoder(name).or_else(|| {
+                    warn!(
+                        "RecodeStage: audio encoder '{name}' not available; \
+                         falling back to container default"
+                    );
+                    audio_encoder_registry::select_audio_encoder_for_container(target)
+                });
+                let Some(resolved) = resolved else {
+                    return Err(PostProcessError::UnsupportedFormat {
+                        format: target_ext.to_string(),
+                        operation: format!(
+                            "audio encoder '{name}' is unavailable and no audio \
+                             encoder could be determined for container '{target_ext}'"
+                        ),
+                    });
+                };
+                debug!("RecodeStage: using audio encoder: {resolved}");
+                Ok((false, Some(resolved.to_string())))
+            }
+        }
+    }
+
     fn default_preset_crf(encoder: &str) -> (Option<String>, Option<u32>) {
         // Explicit per-encoder match (not substring): x265's default crf is 28,
         // not x264's 23; and libopenh264/kvazaar (substring "264"/"kvazaar") are
@@ -295,38 +369,13 @@ impl PipelineStage for RecodeStage {
             msg.config.recode_audio.clone()
         };
 
-        // Derive audio_copy / audio_codec from the resolved mode
+        // Derive audio_copy / audio_codec from the resolved mode. Remux
+        // always copies audio (no re-encoding needed); otherwise resolution
+        // depends on whether the input has an audio stream at all (Important-4).
         let (audio_copy, audio_codec) = if can_remux {
-            // Remux path always copies audio — no re-encoding needed
             (true, None)
         } else {
-            match recode_audio {
-                RecodeAudioMode::Copy => (true, None),
-                RecodeAudioMode::Auto => {
-                    let encoder =
-                        audio_encoder_registry::select_audio_encoder_for_container(target);
-                    debug!("RecodeStage: auto audio encoder for {target_ext}: {encoder}");
-                    (false, Some(encoder.to_string()))
-                }
-                RecodeAudioMode::Encoder { ref name } => {
-                    if !audio_encoder_registry::container_supports_audio_codec(target, name) {
-                        warn!(
-                            "RecodeStage: audio codec '{name}' may not be compatible with \
-                             container '{target_ext}'; proceeding anyway"
-                        );
-                    }
-                    let resolved = audio_encoder_registry::resolve_audio_encoder(name)
-                        .unwrap_or_else(|| {
-                            warn!(
-                                "RecodeStage: audio encoder '{name}' not available; \
-                                 falling back to container default"
-                            );
-                            audio_encoder_registry::select_audio_encoder_for_container(target)
-                        });
-                    debug!("RecodeStage: using audio encoder: {resolved}");
-                    (false, Some(resolved.to_string()))
-                }
-            }
+            Self::resolve_audio_params(&recode_audio, target, media_info.audio_codec.is_some())?
         };
 
         let output_path = msg.tracker.temp_path(&input_file, target_ext);
@@ -493,6 +542,63 @@ mod tests {
             RecodeStage::default_preset_crf("libx264"),
             (Some("medium".into()), Some(23))
         );
+    }
+
+    /// #618 fix-wave-1, Important-5: exercises `resolve_audio_params` itself
+    /// (real `rdlp-postprocess` code), not just the registry it wraps.
+    #[test]
+    fn resolve_audio_params_auto_ivf_with_audio_is_refused_truthfully() {
+        rdlp_ffmpeg::ffmpeg::ensure_init().expect("ffmpeg init");
+        let err =
+            RecodeStage::resolve_audio_params(&RecodeAudioMode::Auto, ContainerFormat::Ivf, true)
+                .expect_err("ivf has no audio encoder to resolve");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no audio encoder could be determined"),
+            "error should name the real cause, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_audio_params_auto_mp4_with_audio_resolves_aac_family() {
+        rdlp_ffmpeg::ffmpeg::ensure_init().expect("ffmpeg init");
+        let (audio_copy, audio_codec) =
+            RecodeStage::resolve_audio_params(&RecodeAudioMode::Auto, ContainerFormat::Mp4, true)
+                .expect("mp4 always resolves an aac-family encoder");
+        assert!(!audio_copy);
+        let codec = audio_codec.expect("mp4 auto mode must pick an encoder");
+        assert!(
+            codec == "aac" || codec == "libfdk_aac",
+            "expected an aac-family encoder for mp4, got {codec}"
+        );
+    }
+
+    #[test]
+    fn resolve_audio_params_bogus_encoder_on_ivf_with_audio_is_refused() {
+        rdlp_ffmpeg::ffmpeg::ensure_init().expect("ffmpeg init");
+        let mode = RecodeAudioMode::Encoder {
+            name: "definitely_not_a_real_encoder_xyz".to_string(),
+        };
+        let err = RecodeStage::resolve_audio_params(&mode, ContainerFormat::Ivf, true)
+            .expect_err("bogus encoder + no container default on ivf must refuse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unavailable") && msg.contains("no audio"),
+            "error should explain both causes, got: {msg}"
+        );
+    }
+
+    /// #618 fix-wave-1, Important-4 regression guard: a video-only source
+    /// recoding to a container with no resolvable audio default (e.g.
+    /// `.ivf`) must NOT be refused — `setup_audio_pipeline` only creates an
+    /// audio stream when the input actually has one
+    /// (`transcode/video_transcode_phases.rs`), so the chosen/default
+    /// encoder was always irrelevant for video-only sources.
+    #[test]
+    fn resolve_audio_params_auto_ivf_without_audio_succeeds_as_copy() {
+        let result =
+            RecodeStage::resolve_audio_params(&RecodeAudioMode::Auto, ContainerFormat::Ivf, false);
+        assert_eq!(result.unwrap(), (true, None));
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -159,7 +159,7 @@ impl RecodeStage {
         if can_remux {
             return Some(VideoConvertOptions {
                 remux_only: true,
-                audio_copy: true,
+                audio_copy: params.audio_copy,
                 ..Default::default()
             });
         }
@@ -376,11 +376,15 @@ impl PipelineStage for RecodeStage {
         };
 
         // Derive audio_copy / audio_codec from the resolved mode. Remux
-        // always copies audio (no re-encoding needed); otherwise resolution
-        // depends on whether the input has an audio stream at all — see
-        // `resolve_audio_params`.
+        // stream-copies unconditionally when there IS an audio stream to
+        // copy (no re-encoding needed); a video-only source has no audio
+        // stream to copy, so `audio_copy` must be `false`, not a true claim
+        // with nothing behind it — the same "+ none" truthfulness fix
+        // `resolve_audio_params` already applies to the transcode path
+        // (`23c344a7`), extended to remux so `encoding_tool` never stamps a
+        // false "+ copy" for a video-only remux.
         let (audio_copy, audio_codec) = if can_remux {
-            (true, None)
+            (media_info.has_audio, None)
         } else {
             Self::resolve_audio_params(&recode_audio, target, media_info.has_audio)?
         };
@@ -760,6 +764,29 @@ mod tests {
         let opts = RecodeStage::build_convert_options(&params, true).unwrap();
         assert!(opts.remux_only);
         assert!(opts.audio_copy);
+    }
+
+    /// Minor-7 regression guard: a video-only remux (`params.audio_copy ==
+    /// false`, no audio stream present) must NOT stamp `audio_copy: true` —
+    /// that would claim an audio "copy" that never happened. Pins that
+    /// `build_convert_options` reads `params.audio_copy` on the remux path
+    /// rather than hardcoding `true`.
+    #[test]
+    fn build_convert_options_remux_video_only_does_not_claim_audio_copy() {
+        let params = RecodeParams {
+            target: ContainerFormat::Mp4,
+            encoder_override: None,
+            audio_copy: false,
+            audio_codec: None,
+            threads: None,
+            preset_override: None,
+            deadline: None,
+            cpu_used: None,
+            speed_level: None,
+        };
+        let opts = RecodeStage::build_convert_options(&params, true).unwrap();
+        assert!(opts.remux_only);
+        assert!(!opts.audio_copy);
     }
 
     #[test]

--- a/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
+++ b/crates/rdlp-postprocess/src/pipeline/stages/recode.rs
@@ -210,15 +210,21 @@ impl RecodeStage {
     /// an audio output stream when the input actually has an audio stream
     /// (`transcode/video_transcode_phases.rs`), so a video-only source has
     /// always made the resolved encoder irrelevant. Refusing before this
-    /// check (Important-4, #618 fix wave 1) was a regression — a video-only
-    /// `.ivf` recode used to succeed and started hard-failing.
+    /// check (#618) was a regression — a video-only `.ivf` recode used to
+    /// succeed and started hard-failing.
+    ///
+    /// A video-only source returns `(false, None)`, not `(true, None)`: there
+    /// is no audio stream to copy, so claiming `audio_copy = true` would
+    /// stamp a false "copy" into the `encoding_tool` metadata tag (both
+    /// branches are otherwise inert — `setup_audio_pipeline` only opens an
+    /// audio output when `ctx.audio_transcode`/an input audio stream exists).
     fn resolve_audio_params(
         recode_audio: &RecodeAudioMode,
         target: ContainerFormat,
         has_audio: bool,
     ) -> Result<(bool, Option<String>), PostProcessError> {
         if !has_audio {
-            return Ok((true, None));
+            return Ok((false, None));
         }
 
         let target_ext = target.as_ext();
@@ -371,11 +377,12 @@ impl PipelineStage for RecodeStage {
 
         // Derive audio_copy / audio_codec from the resolved mode. Remux
         // always copies audio (no re-encoding needed); otherwise resolution
-        // depends on whether the input has an audio stream at all (Important-4).
+        // depends on whether the input has an audio stream at all — see
+        // `resolve_audio_params`.
         let (audio_copy, audio_codec) = if can_remux {
             (true, None)
         } else {
-            Self::resolve_audio_params(&recode_audio, target, media_info.audio_codec.is_some())?
+            Self::resolve_audio_params(&recode_audio, target, media_info.has_audio)?
         };
 
         let output_path = msg.tracker.temp_path(&input_file, target_ext);
@@ -476,13 +483,10 @@ impl PipelineStage for RecodeStage {
 
         // Capture the encoding_tool for downstream pass-through stages.
         {
-            let audio_part = if let Some(ref ac) = opts.audio_codec {
-                ac.as_str()
-            } else if opts.audio_copy {
-                "copy"
-            } else {
-                "none"
-            };
+            let audio_part = rdlp_ffmpeg::ffmpeg::audio_tag_component(
+                opts.audio_copy,
+                opts.audio_codec.as_deref(),
+            );
             let video_part = opts.video_codec.as_deref().unwrap_or("libx264");
             msg.encoding_tool = Some(format!("{video_part} + {audio_part}"));
         }
@@ -544,8 +548,8 @@ mod tests {
         );
     }
 
-    /// #618 fix-wave-1, Important-5: exercises `resolve_audio_params` itself
-    /// (real `rdlp-postprocess` code), not just the registry it wraps.
+    /// Exercises `resolve_audio_params` itself (real `rdlp-postprocess`
+    /// code), not just the registry it wraps.
     #[test]
     fn resolve_audio_params_auto_ivf_with_audio_is_refused_truthfully() {
         rdlp_ffmpeg::ffmpeg::ensure_init().expect("ffmpeg init");
@@ -588,17 +592,55 @@ mod tests {
         );
     }
 
-    /// #618 fix-wave-1, Important-4 regression guard: a video-only source
-    /// recoding to a container with no resolvable audio default (e.g.
-    /// `.ivf`) must NOT be refused — `setup_audio_pipeline` only creates an
-    /// audio stream when the input actually has one
-    /// (`transcode/video_transcode_phases.rs`), so the chosen/default
-    /// encoder was always irrelevant for video-only sources.
+    /// Regression guard (#618): a video-only source recoding to a container
+    /// with no resolvable audio default (e.g. `.ivf`) must NOT be refused —
+    /// `setup_audio_pipeline` only creates an audio stream when the input
+    /// actually has one (`transcode/video_transcode_phases.rs`), so the
+    /// chosen/default encoder was always irrelevant for video-only sources.
+    /// Resolves to `(false, None)`, not `(true, None)` — there is no audio
+    /// stream to copy.
     #[test]
-    fn resolve_audio_params_auto_ivf_without_audio_succeeds_as_copy() {
+    fn resolve_audio_params_auto_ivf_without_audio_omits_audio() {
         let result =
             RecodeStage::resolve_audio_params(&RecodeAudioMode::Auto, ContainerFormat::Ivf, false);
+        assert_eq!(result.unwrap(), (false, None));
+    }
+
+    /// `RecodeAudioMode::Copy` with an actual audio stream present was
+    /// untested — only the `has_audio == false` early-return path (which
+    /// also short-circuits `Copy`) had coverage.
+    #[test]
+    fn resolve_audio_params_copy_mode_with_audio_copies() {
+        let result =
+            RecodeStage::resolve_audio_params(&RecodeAudioMode::Copy, ContainerFormat::Mp4, true);
         assert_eq!(result.unwrap(), (true, None));
+    }
+
+    /// The `Encoder` arm's SUCCESS path was untested — only its `Err` path
+    /// (`resolve_audio_params_bogus_encoder_on_ivf_with_audio_is_refused`)
+    /// had coverage. Pins that a valid-but-container-mismatched encoder name
+    /// still resolves to `(false, Some(name))` rather than aborting — the
+    /// container mismatch only warns (see `container_supports_audio_codec`).
+    /// Uses `"flac"` (always built in, and its table row maps `flac -> flac`
+    /// so `resolve_audio_encoder` is identity-stable on every build) rather
+    /// than picking from a candidate list keyed on availability: `"aac"` is
+    /// always available too, but `resolve_audio_encoder("aac")` resolves
+    /// through the *preferred*-encoder table and returns `"libfdk_aac"` on a
+    /// build that links it — an assertion pinned to the literal `"aac"`
+    /// would then fail only on richer builds.
+    #[test]
+    fn resolve_audio_params_encoder_arm_succeeds_despite_container_mismatch() {
+        rdlp_ffmpeg::ffmpeg::ensure_init().expect("ffmpeg init");
+        // flac does not support Wav, so this exercises the warn-then-proceed
+        // branch rather than the compatible-encoder path.
+        let mode = RecodeAudioMode::Encoder {
+            name: "flac".to_string(),
+        };
+        let (audio_copy, audio_codec) =
+            RecodeStage::resolve_audio_params(&mode, ContainerFormat::Wav, true)
+                .expect("an available encoder must resolve despite a container mismatch warning");
+        assert!(!audio_copy);
+        assert_eq!(audio_codec.as_deref(), Some("flac"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`select_audio_encoder_for_container` ended in `_ => "aac"`, so **20 of 31 containers silently
got AAC**. `--recode-video=mp3` produced AAC-in-mp3; `--recode-video=wav` produced AAC-in-wav.

It now classifies every `ContainerFormat` into a policy — `FromMuxer`, `Override(codec)`, or
`NoAudio` — through an **exhaustive match with no `_` arm**, so a new container variant fails
the build rather than silently inheriting a wrong default. `FromMuxer` resolves against what
the linked FFmpeg build's own muxer declares, so rdlp keeps no second copy of FFmpeg's table.

Closes #618

## How the default is decided

`muxer_defaults::declared_codec` asks the linked build via `av_guess_format` + `av_guess_codec`.
The four deliberate overrides carry their reasons on the arm; `Ivf` is the one `NoAudio`.

The declared codec then resolves in three tiers, because `declared_codec` returns FFmpeg
*codec-ID* names and several are not preference-table keys:

1. exact match in `AUDIO_CODEC_PREFERENCES` → best available encoder for that row
2. the declared name treated as a literal encoder name
3. AAC with a warning — **gated on `container_supports_audio_codec`**, so it never substitutes
   AAC into a container that provably cannot carry it

Tier 2 exists because `pcm_s16le`, `pcm_s16be` and `wmav2` have no table row; without it,
`wav`/`aiff`/`wma`/`asf` fell through to AAC — the very bug being fixed. Tier 3's gate is what
stops the fallback from being a quieter version of the same defect.

## Behaviour changes beyond the fix

- **A video-only recode no longer stamps `encoding_tool` as `"+ copy"`**, claiming to copy audio
  into a file that has none. Now `"+ none"`. This also changes the pre-existing `Copy`-mode
  video-only case — deliberate; the old value was false.
- **`list_available_audio_codecs()` emits `codec: "pcm_s16le"`** where it emitted `"pcm"`.
  `"pcm"` still resolves, as a declared alias.
- **The desktop's container-filtered codec dropdown becomes non-empty** for `Mka`, `Flv`, `Mpg`,
  `Vob`, `M4v`, `F4v`, `ThreeGp`, `Mxf`, `Dv`, and gains "PCM 16-bit big-endian" and "WMA v2"
  in the unfiltered list. That is the matrix fix, below.
- **`RecodeStage` and audio normalization refuse with a truthful error** where a container
  yields no usable audio encoder, instead of silently dropping or substituting. Both are gated
  so they cannot fire on a source that has no audio to begin with, and an output extension that
  is not a `ContainerFormat` still degrades to AAC with a warning, as before.

## The compatibility matrix disagreed with the defaults

Separately, `supported_containers` was incomplete enough that
`container_supports_audio_codec` **contradicted the container's own default for nine
containers** — including `Mka` and `ThreeGp`, whose defaults rdlp *deliberately overrides*. So
`--recode-audio=flac` into `.flac` warned that FLAC might not be compatible with FLAC.

The guard is a sweep that derives its expectation from `audio_default_for` and `declared_codec`
rather than a hand-written table. That matters: a curated list was wrong twice, by two
independent careful passes — the sweep caught `Mxf` and `Dv` that a hand enumeration missed.
It cross-checks the static table against FFmpeg's muxer table, so it is not a tautology.

## Verification

```
cargo fmt --check && cargo check && cargo clippy --workspace --all-targets -- -D warnings \
  && cargo test && cargo check -p rdlp-desktop && bash scripts/check-all.sh
```

Exit 0. **4006 tests**, 113 suites, 15 invariant gates.

⚠️ **Built against system FFmpeg 62.28.102, not the custom build** — `~/.local/mediaforge` is
currently absent, so the linked build has `libmp3lame`/`libopus`/`libvorbis` but **no
`libfdk_aac`**. Every encoder-name assertion here is either guarded on
`is_audio_encoder_available` or targets an encoder built into every FFmpeg, specifically so
this suite stays honest when mediaforge is rebuilt. Worth re-running the gate then.

### Bisect note

Two intermediate commits leave `clippy -D warnings` red on `dead_code`: `muxer_defaults` lands
one commit before its consumer, and project policy forbids `#[allow(dead_code)]` to defer work.
The commits are the probe primitive (`1698da7a`) and — until its consumer arrives — nothing
after. `git bisect run` with a gate that includes clippy should skip those; manual bisect and a
clippy-free gate both work normally. The alternative was merging the primitive with its
consumer, which would have destroyed the commit story for a weak benefit on a 9-commit branch.

## Reviews

- **security-reviewer** (whole branch) — **Approve**, 0 Critical / 0 HIGH / 0 MEDIUM. Two LOW,
  both inherited properties of the FFmpeg bindings and already documented in-code. Confirmed no
  attacker-controlled input reaches the new `unsafe` FFI block (the probe filename is built from
  `const fn as_ext()`, entirely compile-time), that `--recode-audio` never reaches FFmpeg's
  `find_by_name` (which would `unwrap` a `CString`), and that the memoisation cache stays
  bounded by the compile-time table now that aliases add a second key class.
- **code-reviewer** (whole branch, 2 rounds) — Approve-with-fixes → all 12 findings fixed →
  **Approve**. The load-bearing one: tier 3 still fell back to AAC for containers that cannot
  carry it, which is the #618 failure class surviving in reduced form inside the PR named for
  removing it.

Per-task review preceded these: 43 findings across 8 rounds on Tasks 7–9, none disputed.

## Follow-ups filed

- #623 — whether `.ogg` should default to Vorbis rather than Opus (the code's own comment cites
  Xiph and RFC 7845 §9 that it should; changing it is user-visible, so it is split out)
- #625 — tier 2 can select an `AV_CODEC_CAP_EXPERIMENTAL` encoder, which fails at open
- #626 — remux stamps `libx264` into `encoding_tool` regardless of the input's real codec
- #627 — the matrix omits `Flv`/`Nut` from codecs those containers accept; tier 3's new gate
  makes matrix gaps load-bearing rather than advisory
